### PR TITLE
feat: optimize the groupmatmul operator.

### DIFF
--- a/xllm/core/kernels/ascend/a2/atb_layers/operations/aclnn/ops/grouped_matmul_operation.h
+++ b/xllm/core/kernels/ascend/a2/atb_layers/operations/aclnn/ops/grouped_matmul_operation.h
@@ -105,6 +105,7 @@ private:
     int CreateA16(AclNNVariantPack &aclnnVariantPack);
     int CreateW8A8Token(AclNNVariantPack &aclnnVariantPack);
     int CreateW4A8(AclNNVariantPack &aclnnVariantPack);
+    int IndexGmmQuant(AclNNVariantPack &aclnnVariantPack);
 
     std::vector<aclTensor *> yTensorVector;
     std::vector<std::vector<aclTensor *>> inputVectorOfTensor;

--- a/xllm/core/layers/ascend/deepseek_v2_decoder_layer.cpp
+++ b/xllm/core/layers/ascend/deepseek_v2_decoder_layer.cpp
@@ -1067,11 +1067,11 @@ void DeepseekV2DecoderImpl::merge_experts_weights() {
 
   torch::Tensor mlp_down_weight =
       merge_experts_weights(experts_weights_["down_proj.weight"],
-                            /*transpose=*/false);
-  // at_weight_tensors_[IN_MLP_DOWN_WEIGHT_EXPERT] =
-  //     at_npu::native::npu_format_cast(mlp_down_weight, 29);
+                            /*transpose=*/true);
   at_weight_tensors_[IN_MLP_DOWN_WEIGHT_EXPERT] =
-      at_npu::native::npu_format_cast(mlp_down_weight, 2).contiguous();
+      at_npu::native::npu_format_cast(mlp_down_weight, 29);
+  // at_weight_tensors_[IN_MLP_DOWN_WEIGHT_EXPERT] =
+  //     at_npu::native::npu_format_cast(mlp_down_weight, 2).contiguous();
   if (quantize_type_ == "w8a8_dynamic") {
     at_weight_tensors_[IN_MLP_DOWN_OFFSET_EXPERT] =
         merge_experts_weights(experts_weights_["down_proj.weight_offset"]);


### PR DESCRIPTION
* Change 1: Modify the down weight in deepseek_v2_decoder_layer.cpp to NZ format.
* Change 2: In the ATB plugin, activate the shape based on the input to select different operators.
* Performance:


When using groupmatmul with dp=1 and ep=1, tpop decreased by 5%, ttft decreased by 5%, and throughput improved by 5%.
<img width="2060" height="842" alt="image" src="https://github.com/user-attachments/assets/0f8f769d-dca9-47aa-b19f-55bc0586c850" />

