### PR TITLE
refactor: change default value of enable_schedule_overlap flag from false to true.

### DIFF
--- a/docs/en/features/async_schedule.md
+++ b/docs/en/features/async_schedule.md
@@ -13,16 +13,17 @@ In the overall architecture, stages 1 and 3 on the CPU side are handled by diffe
 
 ## Usage
 
-xLLM provides the gflags parameter enable_schedule_overlap, which defaults to false. To enable this feature, simply set it to true in xLLM’s service startup script, as
+xLLM provides the gflags parameter enable_schedule_overlap, which defaults to true. To disable this feature, simply set it to false in xLLM's service startup script, as
 ```shell
---enable_schedule_overlap=true
+--enable_schedule_overlap=false
 ```
 
 ## Performance
 
-- With asynchronous scheduling enabled, the device idle time between two steps is approximately 200μs - comparable to a single kernel launch duration.
+- With asynchronous scheduling enabled, the device idle time between two steps is approximately 200us - comparable to a single kernel launch duration.
 - On the DeepSeek-R1-Distill-Qwen-1.5B model with TPOT constrained to 50ms, this achieves 17% throughput improvement.
 
 
 ## Notice
-The asynchronous scheduling feature requires the server to compute one additional step. For use cases involving limited output tokens (e.g., few-token generation) or single-output scenarios like embedding models, enabling this feature is not recommended as it may reduce server-side throughput.
+The asynchronous scheduling feature requires the server to compute one additional step. For use cases involving limited output tokens (e.g., few-token generation) or single-output scenarios like embedding models, enabling this feature is not recommended as it may reduce server-side throughput, thus hard-disabled internally.
+The VLM model is currently being adapted, will be temporarily disabled.

--- a/docs/zh/features/async_schedule.md
+++ b/docs/zh/features/async_schedule.md
@@ -17,9 +17,9 @@ xLLM在框架层支持了异步调度功能，在device执行 step-i 计算的�
 
 ## 使用方式
 
-xLLM中提供了gflags参数`enable_schedule_overlap`，默认false，如需开启在xLLM的服务启动脚本中设置为true即可，示例如下：
+xLLM中提供了gflags参数`enable_schedule_overlap`，默认true，如需关闭在xLLM的服务启动脚本中设置为false即可，示例如下：
 ```shell
---enable_schedule_overlap=true
+--enable_schedule_overlap=false
 ```
 
 
@@ -29,4 +29,5 @@ xLLM中提供了gflags参数`enable_schedule_overlap`，默认false，如需开�
 
 
 !!! warning "注意"
-    - 异步调度功能会在服务端额外计算一个step，当使用场景中输出token数量较少，或是类似embedding模型只一次性输出的场景，不建议开启，会影响服务端吞吐。
+    - 异步调度功能会在服务端额外计算一个step，当使用场景中输出token数量较少，或是类似embedding模型只一次性输出的场景，会影响服务端吞吐，所以强制关闭异步调度。
+    - VLM模型正在适配中，暂时会强制关闭异步调度。

--- a/xllm/core/common/global_flags.cpp
+++ b/xllm/core/common/global_flags.cpp
@@ -112,7 +112,7 @@ DEFINE_int32(dp_size, 1, "Data parallel size for MLA attention.");
 DEFINE_int32(ep_size, 1, "Expert parallel size for MoE model.");
 
 DEFINE_bool(enable_schedule_overlap,
-            false,
+            true,
             "Whether to enable schedule overlap.");
 
 DEFINE_double(prefill_scheduling_memory_usage_threshold,

--- a/xllm/core/common/options.h
+++ b/xllm/core/common/options.h
@@ -109,7 +109,7 @@ class Options {
 
   PROPERTY(bool, enable_disagg_pd) = false;
 
-  PROPERTY(bool, enable_schedule_overlap) = false;
+  PROPERTY(bool, enable_schedule_overlap) = true;
 
   PROPERTY(InstanceRole, instance_role) = InstanceRole::DEFAULT;
 

--- a/xllm/core/runtime/options.h
+++ b/xllm/core/runtime/options.h
@@ -86,7 +86,7 @@ struct Options {
   PROPERTY(int32_t, ep_size) = 1;
 
   // enable enable_schedule_overlap to improve runtime execution efficiency.
-  PROPERTY(bool, enable_schedule_overlap) = false;
+  PROPERTY(bool, enable_schedule_overlap) = true;
 
   // enable chunked prefill.
   PROPERTY(bool, enable_chunked_prefill) = true;

--- a/xllm/core/scheduler/continuous_scheduler.h
+++ b/xllm/core/scheduler/continuous_scheduler.h
@@ -83,7 +83,7 @@ class ContinuousScheduler : public Scheduler {
     // default value is 1.
     PROPERTY(int32_t, max_reqs_p2d_once) = 1;
 
-    PROPERTY(bool, enable_schedule_overlap) = false;
+    PROPERTY(bool, enable_schedule_overlap) = true;
 
     PROPERTY(bool, enable_chunked_prefill) = true;
 

--- a/xllm/models/model_registry.cpp
+++ b/xllm/models/model_registry.cpp
@@ -93,7 +93,7 @@ void ModelRegistry::register_model_args_loader(const std::string& name,
   ModelRegistry* instance = get_instance();
 
   if (instance->model_registry_[name].model_args_loader != nullptr) {
-    LOG(WARNING) << "model args loader for " << name << "already registered.";
+    LOG(WARNING) << "model args loader for " << name << " already registered.";
   } else {
     instance->model_registry_[name].model_args_loader = loader;
   }


### PR DESCRIPTION
For LLM generation task, enable schedule overlap as default.
For LLM embedding task, disable schedule overlap mandatorily, which is transparent to users.
For VLM model, disable schedule overlap temporarily, will support later.