### PR TITLE
feat: add profiler for latency prediction and initial latency-aware scheduler.

### DIFF
--- a/vcpkg.json
+++ b/vcpkg.json
@@ -121,6 +121,10 @@
       "name": "pybind11",
       "version>=": "2.11.1",
       "default-features": false
+    },
+    {
+      "name": "eigen3",
+      "version>=": "3.4.0"
     }
   ],
   "builtin-baseline": "fba75d09065fcc76a25dcf386b1d00d33f5175af"

--- a/xllm/core/common/global_flags.cpp
+++ b/xllm/core/common/global_flags.cpp
@@ -15,6 +15,8 @@ limitations under the License.
 
 #include "global_flags.h"
 
+#include <limits>
+
 #include "brpc/reloadable_flags.h"
 
 // NOTE: related flags should be placed together.
@@ -168,6 +170,10 @@ DEFINE_bool(enable_profile_step_time,
             false,
             "Whether to enable profile step time.");
 
+DEFINE_bool(enable_profile_token_budget,
+            false,
+            "Whether to enable profile token budget.");
+
 DEFINE_bool(enable_latency_aware_schedule,
             false,
             "use predicted latency for latency aware schedule.");
@@ -176,15 +182,15 @@ DEFINE_int32(profile_max_prompt_length,
              2048,
              "The max prompt length for profile.");
 
-DEFINE_bool(if_profile_kv_blocks,
+DEFINE_bool(enable_profile_kv_blocks,
             true,
             "true if generate kv cache for profile");
 
-DEFINE_int32(global_ttft_ms,
+DEFINE_int32(max_global_ttft_ms,
              std::numeric_limits<int32_t>::max(),
              "all requests use single global ttft");
 
-DEFINE_int32(global_tpot_ms,
+DEFINE_int32(max_global_tpot_ms,
              std::numeric_limits<int32_t>::max(),
              "all requests use single global ttft");
 

--- a/xllm/core/common/global_flags.cpp
+++ b/xllm/core/common/global_flags.cpp
@@ -162,6 +162,32 @@ DEFINE_string(rank_tablefile, "", "ATB HCCL rank table file.");
 
 DEFINE_int32(expert_parallel_degree, 0, "Expert parallel degree.");
 
+// --- profile config ---
+
+DEFINE_bool(enable_profile_step_time,
+            false,
+            "Whether to enable profile step time.");
+
+DEFINE_bool(enable_latency_aware_schedule,
+            false,
+            "use predicted latency for latency aware schedule.");
+
+DEFINE_int32(profile_max_prompt_length,
+             2048,
+             "The max prompt length for profile.");
+
+DEFINE_bool(if_profile_kv_blocks,
+            true,
+            "true if generate kv cache for profile");
+
+DEFINE_int32(global_ttft_ms,
+             std::numeric_limits<int32_t>::max(),
+             "all requests use single global ttft");
+
+DEFINE_int32(global_tpot_ms,
+             std::numeric_limits<int32_t>::max(),
+             "all requests use single global ttft");
+
 // --- prefix cache config ---
 
 DEFINE_bool(enable_prefix_cache,

--- a/xllm/core/common/global_flags.h
+++ b/xllm/core/common/global_flags.h
@@ -161,12 +161,14 @@ DECLARE_string(store_metadata_connstring);
 
 DECLARE_bool(enable_profile_step_time);
 
+DECLARE_bool(enable_profile_token_budget);
+
 DECLARE_bool(enable_latency_aware_schedule);
 
 DECLARE_int32(profile_max_prompt_length);
 
-DECLARE_bool(if_profile_kv_blocks);
+DECLARE_bool(enable_profile_kv_blocks);
 
-DECLARE_int32(global_ttft_ms);
+DECLARE_int32(max_global_ttft_ms);
 
-DECLARE_int32(global_tpot_ms);
+DECLARE_int32(max_global_tpot_ms);

--- a/xllm/core/common/global_flags.h
+++ b/xllm/core/common/global_flags.h
@@ -158,3 +158,15 @@ DECLARE_string(store_protocol);
 DECLARE_string(store_master_server_entry);
 
 DECLARE_string(store_metadata_connstring);
+
+DECLARE_bool(enable_profile_step_time);
+
+DECLARE_bool(enable_latency_aware_schedule);
+
+DECLARE_int32(profile_max_prompt_length);
+
+DECLARE_bool(if_profile_kv_blocks);
+
+DECLARE_int32(global_ttft_ms);
+
+DECLARE_int32(global_tpot_ms);

--- a/xllm/core/common/options.h
+++ b/xllm/core/common/options.h
@@ -143,15 +143,17 @@ class Options {
 
   PROPERTY(bool, enable_profile_step_time) = false;
 
+  PROPERTY(bool, enable_profile_token_budget) = false;
+
   PROPERTY(bool, enable_latency_aware_schedule) = false;
   // the max prompt length for profile
   PROPERTY(int32_t, profile_max_prompt_length) = 2048;
   // true if generate kv cache for profile
-  PROPERTY(bool, if_profile_kv_blocks) = true;
+  PROPERTY(bool, enable_profile_kv_blocks) = true;
   // all requests use single global ttft
-  PROPERTY(int32_t, global_ttft_ms) = std::numeric_limits<int32_t>::max();
+  PROPERTY(int32_t, max_global_ttft_ms) = std::numeric_limits<int32_t>::max();
   // all requests use single global tpot
-  PROPERTY(int32_t, global_tpot_ms) = std::numeric_limits<int32_t>::max();
+  PROPERTY(int32_t, max_global_tpot_ms) = std::numeric_limits<int32_t>::max();
 };
 
 }  // namespace xllm

--- a/xllm/core/common/options.h
+++ b/xllm/core/common/options.h
@@ -140,6 +140,18 @@ class Options {
   PROPERTY(std::string, store_master_server_entry) = "";
 
   PROPERTY(std::string, store_metadata_connstring) = "";
+
+  PROPERTY(bool, enable_profile_step_time) = false;
+
+  PROPERTY(bool, enable_latency_aware_schedule) = false;
+  // the max prompt length for profile
+  PROPERTY(int32_t, profile_max_prompt_length) = 2048;
+  // true if generate kv cache for profile
+  PROPERTY(bool, if_profile_kv_blocks) = true;
+  // all requests use single global ttft
+  PROPERTY(int32_t, global_ttft_ms) = std::numeric_limits<int32_t>::max();
+  // all requests use single global tpot
+  PROPERTY(int32_t, global_tpot_ms) = std::numeric_limits<int32_t>::max();
 };
 
 }  // namespace xllm

--- a/xllm/core/framework/request/priority_comparator.cpp
+++ b/xllm/core/framework/request/priority_comparator.cpp
@@ -1,3 +1,18 @@
+/* Copyright 2025 The xLLM Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://github.com/jd-opensource/xllm/blob/main/LICENSE
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
 #include "priority_comparator.h"
 
 #include "glog/logging.h"

--- a/xllm/core/framework/request/priority_comparator.h
+++ b/xllm/core/framework/request/priority_comparator.h
@@ -1,3 +1,18 @@
+/* Copyright 2025 The xLLM Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://github.com/jd-opensource/xllm/blob/main/LICENSE
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
 #pragma once
 #include <functional>
 #include <memory>

--- a/xllm/core/runtime/llm_master.cpp
+++ b/xllm/core/runtime/llm_master.cpp
@@ -84,7 +84,15 @@ LLMMaster::LLMMaster(const Options& options)
       .instance_role(options_.instance_role())
       .kv_cache_transfer_mode(options_.kv_cache_transfer_mode())
       .enable_service_routing(options_.enable_service_routing())
-      .enable_decode_response_to_service(enable_decode_response_to_service);
+      .enable_decode_response_to_service(enable_decode_response_to_service)
+      .priority_strategy(options_.priority_strategy())
+      .enable_online_preempt_offline(options_.enable_online_preempt_offline())
+      .enable_profile_step_time(options_.enable_profile_step_time())
+      .enable_latency_aware_schedule(options_.enable_latency_aware_schedule())
+      .profile_max_prompt_length(options_.profile_max_prompt_length())
+      .if_profile_kv_blocks(options_.if_profile_kv_blocks())
+      .global_ttft_ms(options_.global_ttft_ms())
+      .global_tpot_ms(options_.global_tpot_ms());
   scheduler_ = create_continuous_scheduler(engine_.get(), scheduler_options);
 
   if (options_.enable_service_routing()) {

--- a/xllm/core/runtime/llm_master.cpp
+++ b/xllm/core/runtime/llm_master.cpp
@@ -88,11 +88,12 @@ LLMMaster::LLMMaster(const Options& options)
       .priority_strategy(options_.priority_strategy())
       .enable_online_preempt_offline(options_.enable_online_preempt_offline())
       .enable_profile_step_time(options_.enable_profile_step_time())
+      .enable_profile_token_budget(options_.enable_profile_token_budget())
       .enable_latency_aware_schedule(options_.enable_latency_aware_schedule())
       .profile_max_prompt_length(options_.profile_max_prompt_length())
-      .if_profile_kv_blocks(options_.if_profile_kv_blocks())
-      .global_ttft_ms(options_.global_ttft_ms())
-      .global_tpot_ms(options_.global_tpot_ms());
+      .enable_profile_kv_blocks(options_.enable_profile_kv_blocks())
+      .max_global_ttft_ms(options_.max_global_ttft_ms())
+      .max_global_tpot_ms(options_.max_global_tpot_ms());
   scheduler_ = create_continuous_scheduler(engine_.get(), scheduler_options);
 
   if (options_.enable_service_routing()) {

--- a/xllm/core/scheduler/CMakeLists.txt
+++ b/xllm/core/scheduler/CMakeLists.txt
@@ -1,6 +1,9 @@
 include(cc_library)
 include(cc_test)
 
+
+add_subdirectory(profile)
+
 cc_library(
   NAME 
     scheduler
@@ -24,6 +27,7 @@ cc_library(
     :batch
     :request
     :runtime
+    :profile
     glog::glog
     Folly::folly
     absl::time

--- a/xllm/core/scheduler/chunked_prefill_scheduler.cpp
+++ b/xllm/core/scheduler/chunked_prefill_scheduler.cpp
@@ -16,6 +16,8 @@ limitations under the License.
 
 #include "scheduler/chunked_prefill_scheduler.h"
 
+#include <limits>
+
 #include "common/metrics.h"
 #include "framework/batch/batch_factory.h"
 #include "util/timer.h"
@@ -41,6 +43,8 @@ ChunkedPrefillScheduler::~ChunkedPrefillScheduler() {
 
 void ChunkedPrefillScheduler::handle_running_queue_requests(
     const size_t max_tokens_per_chunk_for_prefill,
+    size_t& latency_budget,
+    size_t& estimate_latency,
     size_t& remaining_token_budget,
     size_t& remaining_seq_budget,
     size_t& num_preempted_requests,
@@ -50,7 +54,7 @@ void ChunkedPrefillScheduler::handle_running_queue_requests(
     bool& blocks_exhausted) {
   while (!running_queue->empty() &&
          remaining_token_budget > options_.num_speculative_tokens() &&
-         remaining_seq_budget > 0) {
+         latency_budget > estimate_latency && remaining_seq_budget > 0) {
     std::shared_ptr<Request> request(running_queue->top());
     // TODO: check if request is timeout
 
@@ -64,6 +68,7 @@ void ChunkedPrefillScheduler::handle_running_queue_requests(
     bool has_enough_blocks = true;
     size_t allocated_tokens = 0;
     size_t allocated_seqs = 0;
+    size_t allocated_estimate_latency = 0;
 
     for (auto& sequence : request->sequences()) {
       // skip finished sequence.
@@ -72,6 +77,9 @@ void ChunkedPrefillScheduler::handle_running_queue_requests(
       }
 
       // no budget left
+      // FIXME: Incorrect conditional judgment. it does not consider the
+      // sequence in the prefill stage and enable prefix cache. need to refactor
+      // to seperate counting actual token and allocating blocks
       if (allocated_seqs >= remaining_seq_budget ||
           allocated_tokens + options_.num_speculative_tokens() >=
               remaining_token_budget) {
@@ -94,6 +102,25 @@ void ChunkedPrefillScheduler::handle_running_queue_requests(
         break;
       }
 
+      // for chunked prefill, we need to estimate latency according to
+      // current_step_handle_tokens TO IMPROVE and REFACTOR: seperate allocate
+      // prefix cache blocks and compute prefix cache match to estimate latency
+      // before acctually allocating blocks
+      // TODO:
+      size_t seq_estimate_latency = 0;
+      if (options_.enable_latency_aware_schedule()) {
+        size_t kv_cache_tokens_num = sequence->kv_state().kv_cache_tokens_num();
+        seq_estimate_latency = profile_manager_->predict_step_time(
+            current_step_handle_tokens + kv_cache_tokens_num,
+            kv_cache_tokens_num);
+        if (estimate_latency + allocated_estimate_latency +
+                seq_estimate_latency >
+            latency_budget) {
+          has_enough_budget = false;
+          break;
+        }
+      }
+
       // if (sequence->if_cache_block_for_prefill()) {
       //   block_manager_pool_->cache(sequence.get());
       // }
@@ -107,6 +134,7 @@ void ChunkedPrefillScheduler::handle_running_queue_requests(
       // update the allocated tokens for the sequence
       allocated_tokens += current_step_handle_tokens;
       allocated_seqs += 1;
+      allocated_estimate_latency += seq_estimate_latency;
       candidate_sequences.emplace_back(sequence.get());
       candidate_token_budgets.emplace_back(current_step_handle_tokens);
     }
@@ -126,6 +154,7 @@ void ChunkedPrefillScheduler::handle_running_queue_requests(
                                         candidate_token_budgets.end());
       remaining_token_budget -= allocated_tokens;
       remaining_seq_budget -= allocated_seqs;
+      estimate_latency += allocated_estimate_latency;
       continue;
     }
 
@@ -136,8 +165,10 @@ void ChunkedPrefillScheduler::handle_running_queue_requests(
                               candidate_token_budgets,
                               allocated_tokens,
                               allocated_seqs,
+                              allocated_estimate_latency,
                               remaining_token_budget,
                               remaining_seq_budget,
+                              estimate_latency,
                               true, /*budget_exhausted*/
                               false /*blocks_exhausted*/);
       budget_exhausted = true;
@@ -187,8 +218,10 @@ void ChunkedPrefillScheduler::handle_running_queue_requests(
                             candidate_token_budgets,
                             allocated_tokens,
                             allocated_seqs,
+                            allocated_estimate_latency,
                             remaining_token_budget,
                             remaining_seq_budget,
+                            estimate_latency,
                             false, /*budget_exhausted*/
                             true /*blocks_exhausted*/);
     blocks_exhausted = true;
@@ -198,6 +231,8 @@ void ChunkedPrefillScheduler::handle_running_queue_requests(
 
 void ChunkedPrefillScheduler::handle_prefill_requests(
     const size_t max_tokens_per_chunk_for_prefill,
+    size_t& latency_budget,
+    size_t& estimate_latency,
     size_t& remaining_token_budget,
     size_t& remaining_seq_budget,
     size_t& num_preempted_requests,
@@ -209,7 +244,7 @@ void ChunkedPrefillScheduler::handle_prefill_requests(
   // NOTE: preempted requests will be pushed in waiting_priority_queue,
   // they may contian many sequences, so we should check here.
   while (!waiting_priority_queue.empty() && remaining_token_budget > 0 &&
-         remaining_seq_budget > 0) {
+         latency_budget > estimate_latency && remaining_seq_budget > 0) {
     std::shared_ptr<Request> request(waiting_priority_queue.top());
     if (request->finished() || request->cancelled()) {
       block_manager_pool_->deallocate(request.get());
@@ -230,6 +265,7 @@ void ChunkedPrefillScheduler::handle_prefill_requests(
     // Optimization of the scheduling algorithm under multiple sequences
     size_t allocated_tokens = 0;
     size_t allocated_seqs = 0;
+    size_t allocated_estimate_latency = 0;
     bool can_schedule = true;
     std::vector<Sequence*> prefill_sequences;
     std::vector<size_t> prefill_sequences_budget;
@@ -245,7 +281,9 @@ void ChunkedPrefillScheduler::handle_prefill_requests(
       const size_t assume_max_tokens =
           std::min(max_tokens_per_chunk_for_prefill,
                    remaining_token_budget - allocated_tokens);
+
       num_tokens = std::min(assume_max_tokens, num_tokens);
+
       if (remaining_token_budget < allocated_tokens + num_tokens ||
           remaining_seq_budget < allocated_seqs + 1) {
         can_schedule = false;
@@ -299,10 +337,33 @@ void ChunkedPrefillScheduler::handle_prefill_requests(
           break;
         }
       }
+
+      // check latency budget
+      // for prefill requests, check latency after prefix cache match
+      size_t seq_estimate_latency = 0;
+      if (options_.enable_latency_aware_schedule()) {
+        // use current_step_handle_tokens to predict for chunked prefill
+        // sequence
+        size_t kv_cache_tokens_num =
+            prefill_sequence->kv_state().kv_cache_tokens_num();
+        seq_estimate_latency = profile_manager_->predict_step_time(
+            current_step_handle_tokens + kv_cache_tokens_num,
+            kv_cache_tokens_num);
+        if (estimate_latency + allocated_estimate_latency +
+                seq_estimate_latency >
+            latency_budget) {
+          block_manager_pool_->deallocate(prefill_sequence.get());
+          can_schedule = false;
+          budget_exhausted = true;
+          break;
+        }
+      }
+
       prefill_sequences_budget.emplace_back(current_step_handle_tokens);
       prefill_sequences.emplace_back(prefill_sequence.get());
       allocated_tokens += current_step_handle_tokens;
       allocated_seqs += 1;
+      allocated_estimate_latency += seq_estimate_latency;
     }
 
     if (!can_schedule) {
@@ -318,6 +379,7 @@ void ChunkedPrefillScheduler::handle_prefill_requests(
                                    prefill_sequences.end());
     remaining_token_budget -= allocated_tokens;
     remaining_seq_budget -= allocated_seqs;
+    estimate_latency += allocated_estimate_latency;
     waiting_priority_queue.pop();
     running_requests_.emplace_back(request);
     running_sequences_.insert(running_sequences_.end(),
@@ -330,20 +392,35 @@ void ChunkedPrefillScheduler::handle_prefill_requests(
   // maybe can pre-compute if prompt beyond length
   if (running_sequences_.empty() && !waiting_priority_queue.empty() &&
       running_queue_->empty()) {
-    LOG(ERROR) << "Request prompt is too long, no enough memory to schedule "
-                  "a single sequence";
-    // no enough memory to schedule single sequence, just finish the request
     std::shared_ptr<Request> request(waiting_priority_queue.top());
     waiting_priority_queue.pop();
     block_manager_pool_->deallocate(request.get());
-    response_processor_->process_failed_request(
-        request,
-        {StatusCode::RESOURCE_EXHAUSTED,
-         "No enough memory to schedule single sequence"});
+    if (blocks_exhausted) {
+      LOG(ERROR) << "Request prompt is too long, no enough memory to schedule "
+                    "a single sequence.";
+      // no enough memory to schedule single sequence, just finish the request
+      response_processor_->process_failed_request(
+          request,
+          {StatusCode::RESOURCE_EXHAUSTED,
+           "No enough memory to schedule single sequence"});
+    } else if (budget_exhausted) {
+      LOG(ERROR) << "Request prompt is too long, no enough budget to schedule "
+                    "a single sequence. Please set a larger budegt.";
+      // no enough memory to schedule single sequence, just finish the request
+      response_processor_->process_failed_request(
+          request,
+          {StatusCode::RESOURCE_EXHAUSTED,
+           "No enough budget to schedule single sequence."});
+    } else {
+      LOG(FATAL) << "Unexpected error: blocks and budget are enough but can "
+                    "not schedule.";
+    }
   }
 }
 
 void ChunkedPrefillScheduler::handle_remaining_budget(
+    size_t& latency_budget,
+    size_t& estimate_latency,
     size_t& remaining_token_budget,
     std::vector<Sequence*>& prefill_stage_sequences,
     bool& blocks_exhausted) {
@@ -361,6 +438,22 @@ void ChunkedPrefillScheduler::handle_remaining_budget(
 
     // add previous allocated tokens back
     remaining_token_budget += token_budget;
+    if (options_.enable_latency_aware_schedule()) {
+      auto origin_estimate_seq_latency =
+          profile_manager_->predict_step_time(sequence);
+      // subtract the allocated latency back
+      estimate_latency -= origin_estimate_seq_latency;
+
+      // check latency budget
+      auto cur_estimate_seq_latency = profile_manager_->predict_step_time(
+          remaining_token_budget, sequence->kv_state().kv_cache_tokens_num());
+      if (estimate_latency + cur_estimate_seq_latency > latency_budget) {
+        // beyond latency budget, break
+        break;
+      }
+      estimate_latency += cur_estimate_seq_latency;
+    }
+
     size_t current_step_handle_tokens = 0;
     // no memory left
     if (!allocate_blocks_for(
@@ -368,6 +461,7 @@ void ChunkedPrefillScheduler::handle_remaining_budget(
       blocks_exhausted = true;
       break;
     }
+
     // update the allocated tokens for the sequence
     token_budget = current_step_handle_tokens;
     CHECK(remaining_token_budget >= current_step_handle_tokens);
@@ -463,10 +557,16 @@ std::vector<Batch> ChunkedPrefillScheduler::prepare_batch() {
   // for execution, thereby preventing subsequent requests from being
   // blocked by the first extremely long request.
   //
-  // NOTE: MagicNum 64 here, avoid users setting small value.
-  const size_t max_tokens_per_chunk_for_prefill =
-      std::max(options_.max_tokens_per_chunk_for_prefill(), 64);
 
+  const size_t max_tokens_per_chunk_for_prefill =
+      options_.max_tokens_per_chunk_for_prefill();
+
+  // maintain estimate_latency for current batch for support requests with
+  // different tpot and ttft only support one unified tpot for ChunkedPrefill TO
+  // IMPROVE: use min remaining time (i.e. tpot_slo - elapsed_time) of the
+  // reuquest in current decode queue to replace.
+  size_t latency_budget = options_.global_tpot_ms();
+  size_t estimate_latency = 0;
   // Max tokens be handled in once chunked prefill schedule.
   size_t remaining_token_budget = options_.max_tokens_per_batch();
   size_t remaining_seq_budget = options_.max_seqs_per_batch();
@@ -485,6 +585,8 @@ std::vector<Batch> ChunkedPrefillScheduler::prepare_batch() {
   //  add them to the batch.
   //
   handle_running_queue_requests(max_tokens_per_chunk_for_prefill,
+                                latency_budget,
+                                estimate_latency,
                                 remaining_token_budget,
                                 remaining_seq_budget,
                                 num_preempted_requests,
@@ -499,7 +601,14 @@ std::vector<Batch> ChunkedPrefillScheduler::prepare_batch() {
   // condition Otherwise, fragmentation may occur due to processing some long
   // requests first
   if (!budget_exhausted && !blocks_exhausted) {
+    // NOTE: for latency schedule, currently only consider tpot for chunked
+    // prefill. when no decode requests, not consider latency_budget.
+    if (running_sequences_.empty()) {
+      latency_budget = std::numeric_limits<int32_t>::max();
+    }
     handle_prefill_requests(max_tokens_per_chunk_for_prefill,
+                            latency_budget,
+                            estimate_latency,
                             remaining_token_budget,
                             remaining_seq_budget,
                             num_preempted_requests,
@@ -514,6 +623,8 @@ std::vector<Batch> ChunkedPrefillScheduler::prepare_batch() {
   // num_speculative_tokens+1 token per step
   if (remaining_token_budget > 0) {
     handle_running_queue_requests(max_tokens_per_chunk_for_prefill,
+                                  latency_budget,
+                                  estimate_latency,
                                   remaining_token_budget,
                                   remaining_seq_budget,
                                   num_preempted_requests,
@@ -523,7 +634,12 @@ std::vector<Batch> ChunkedPrefillScheduler::prepare_batch() {
                                   blocks_exhausted);
   }
   if (!budget_exhausted && !blocks_exhausted) {
+    if (running_sequences_.empty()) {
+      latency_budget = std::numeric_limits<int32_t>::max();
+    }
     handle_prefill_requests(max_tokens_per_chunk_for_prefill,
+                            latency_budget,
+                            estimate_latency,
                             remaining_token_budget,
                             remaining_seq_budget,
                             num_preempted_requests,
@@ -536,9 +652,12 @@ std::vector<Batch> ChunkedPrefillScheduler::prepare_batch() {
 
   // step-3. remaining_token_budget > 0, try to allocate more tokens to
   // prefill stage reuquests.
-  if (remaining_token_budget > 0) {
-    handle_remaining_budget(
-        remaining_token_budget, prefill_stage_sequences, blocks_exhausted);
+  if (remaining_token_budget > 0 && latency_budget > estimate_latency) {
+    handle_remaining_budget(latency_budget,
+                            estimate_latency,
+                            remaining_token_budget,
+                            prefill_stage_sequences,
+                            blocks_exhausted);
   }
 
   if (!finished_requests.empty()) {
@@ -580,10 +699,6 @@ bool ChunkedPrefillScheduler::allocate_blocks_for(
   // token budget should be large enough for one speculative decoding step
   CHECK_GT(token_budget, options_.num_speculative_tokens());
 
-  if (sequence->kv_state().num_kv_blocks() == 0) {
-    // allocate shared blocks
-    block_manager_pool_->allocate_shared(sequence);
-  }
   allocate_shared_blocks_for(sequence);
 
   // number of tokens in the kv cache, which are already processed

--- a/xllm/core/scheduler/chunked_prefill_scheduler.h
+++ b/xllm/core/scheduler/chunked_prefill_scheduler.h
@@ -41,6 +41,8 @@ class ChunkedPrefillScheduler final : public ContinuousScheduler {
   virtual std::vector<Batch> prepare_batch() override;
   void handle_running_queue_requests(
       const size_t max_tokens_per_chunk_for_prefill,
+      size_t& latency_budget,
+      size_t& estimate_latency,
       size_t& remaining_token_budget,
       size_t& remaining_seq_budget,
       size_t& num_preempted_requests,
@@ -50,6 +52,8 @@ class ChunkedPrefillScheduler final : public ContinuousScheduler {
       bool& blocks_exhausted);
   void handle_prefill_requests(
       const size_t max_tokens_per_chunk_for_prefill,
+      size_t& latency_budget,
+      size_t& estimate_latency,
       size_t& remaining_token_budget,
       size_t& remaining_seq_budget,
       size_t& num_preempted_requests,
@@ -58,7 +62,9 @@ class ChunkedPrefillScheduler final : public ContinuousScheduler {
       bool& budget_exhausted,
       bool& blocks_exhausted,
       std::vector<std::shared_ptr<Request>>& finished_requests);
-  void handle_remaining_budget(size_t& remaining_token_budget,
+  void handle_remaining_budget(size_t& latency_budget,
+                               size_t& estimate_latency,
+                               size_t& remaining_token_budget,
                                std::vector<Sequence*>& prefill_stage_sequences,
                                bool& blocks_exhausted);
 

--- a/xllm/core/scheduler/chunked_prefill_scheduler_test.cpp
+++ b/xllm/core/scheduler/chunked_prefill_scheduler_test.cpp
@@ -18,6 +18,8 @@ limitations under the License.
 #include <absl/time/clock.h>
 #include <gtest/gtest.h>
 
+#include <optional>
+
 #include "runtime/engine.h"
 #include "util/utils.h"
 
@@ -83,7 +85,11 @@ ContinuousScheduler::Options create_scheduler_options(
     int32_t num_speculative_tokens,
     int32_t max_tokens_per_chunk_for_prefill,
     int32_t dp_size,
-    const std::string& priority_strategy = "FCFS") {
+    const std::string& priority_strategy = "FCFS",
+    bool if_profile_kv_blocks = true,
+    bool enable_latency_aware_schedule = false,
+    int32_t global_ttft_ms = std::numeric_limits<int32_t>::max(),
+    int32_t global_tpot_ms = std::numeric_limits<int32_t>::max()) {
   ContinuousScheduler::Options opt;
   opt.num_speculative_tokens_ = num_speculative_tokens;
   opt.max_tokens_per_chunk_for_prefill_ = max_tokens_per_chunk_for_prefill;
@@ -91,55 +97,39 @@ ContinuousScheduler::Options create_scheduler_options(
   opt.max_seqs_per_batch_ = max_seqs_per_batch;
   opt.dp_size_ = dp_size;
   opt.priority_strategy_ = priority_strategy;
-
+  opt.if_profile_kv_blocks_ = if_profile_kv_blocks;
+  opt.enable_latency_aware_schedule_ = enable_latency_aware_schedule;
+  opt.global_ttft_ms_ = global_ttft_ms;
+  opt.global_tpot_ms_ = global_tpot_ms;
   return opt;
 }
 
 std::vector<std::shared_ptr<Request>> generate_request(
     const std::vector<int32_t>& prompt_lens,
     const std::vector<int32_t>& max_tokens,
+    std::optional<std::vector<bool>> offlines,
+    std::optional<std::vector<int32_t>> priorities,
     int32_t max_context_len) {
   std::vector<std::shared_ptr<Request>> requests;
   EXPECT_TRUE(prompt_lens.size() == max_tokens.size());
-  for (size_t i = 0; i < prompt_lens.size(); ++i) {
-    std::vector<int32_t> prompt_token_ids;
-    prompt_token_ids.resize(prompt_lens[i]);
-    RequestSamplingParam sampling_param;
-    StoppingChecker stopping_checker;
-    stopping_checker.set_max_generated_tokens(max_tokens[i]);
-    stopping_checker.set_max_context_len(max_context_len);
-    stopping_checker.set_ignore_eos(true);
-    RequestState req_state("x",
-                           prompt_token_ids,
-                           sampling_param,
-                           stopping_checker,
-                           prompt_lens[i] + 30000,
-                           1,
-                           1,
-                           false,
-                           false,
-                           false,
-                           false,
-                           false,
-                           nullptr,
-                           nullptr);
-    auto request =
-        std::make_shared<Request>("1", "1", "1", std::move(req_state), "1");
-    requests.emplace_back(request);
+
+  size_t batch_size = prompt_lens.size();
+  std::vector<bool> offline_vec;
+  std::vector<int32_t> priority_vec;
+  if (offlines.has_value()) {
+    offline_vec = *offlines;
+  } else {
+    offline_vec = std::vector<bool>(batch_size, false);
   }
 
-  return requests;
-}
+  if (priorities.has_value()) {
+    priority_vec = priorities.value();
+  } else {
+    priority_vec = std::vector<int32_t>(
+        batch_size, static_cast<int32_t>(RequestPriority::NORMAL));
+  }
 
-std::vector<std::shared_ptr<Request>> generate_priority_request(
-    const std::vector<int32_t>& prompt_lens,
-    const std::vector<int32_t>& max_tokens,
-    const std::vector<bool>& offlines,
-    const std::vector<int32_t>& priorities,
-    int32_t max_context_len) {
-  std::vector<std::shared_ptr<Request>> requests;
-  EXPECT_TRUE(prompt_lens.size() == max_tokens.size());
-  for (size_t i = 0; i < prompt_lens.size(); ++i) {
+  for (size_t i = 0; i < batch_size; ++i) {
     std::vector<int32_t> prompt_token_ids;
     prompt_token_ids.resize(prompt_lens[i]);
     RequestSamplingParam sampling_param;
@@ -147,6 +137,7 @@ std::vector<std::shared_ptr<Request>> generate_priority_request(
     stopping_checker.set_max_generated_tokens(max_tokens[i]);
     stopping_checker.set_max_context_len(max_context_len);
     stopping_checker.set_ignore_eos(true);
+
     RequestState req_state("x",
                            prompt_token_ids,
                            sampling_param,
@@ -161,15 +152,16 @@ std::vector<std::shared_ptr<Request>> generate_priority_request(
                            false,
                            nullptr,
                            nullptr);
-    auto request =
-        std::make_shared<Request>("1",
-                                  "1",
-                                  "1",
-                                  std::move(req_state),
-                                  "1",
-                                  offlines[i],
-                                  0,
-                                  static_cast<RequestPriority>(priorities[i]));
+
+    auto request = std::make_shared<Request>(
+        "1",
+        "1",
+        "1",
+        std::move(req_state),
+        "1",
+        offline_vec[i],
+        0,
+        static_cast<RequestPriority>(priority_vec[i]));
     requests.emplace_back(request);
   }
 
@@ -211,7 +203,8 @@ TEST(ChunkedPrefillSchedulerTest, AddNewRequestBase) {
     EXPECT_TRUE(scheduler != nullptr);
 
     // create requests
-    auto requests = generate_request({prompt_len[idx]}, {10}, 10000);
+    auto requests = generate_request(
+        {prompt_len[idx]}, {10}, std::nullopt, std::nullopt, 10000);
     for (auto req : requests) {
       scheduler->add_request(req);
     }
@@ -241,7 +234,8 @@ TEST(ChunkedPrefillSchedulerTest, ResourceNotEnough) {
     EXPECT_TRUE(scheduler != nullptr);
 
     // request prompt len: 100
-    auto requests = generate_request({1, 100}, {1, 10}, 10000);
+    auto requests =
+        generate_request({1, 100}, {1, 10}, std::nullopt, std::nullopt, 10000);
     scheduler->add_request(requests[0]);
     scheduler->add_request(requests[1]);
 
@@ -261,7 +255,8 @@ TEST(ChunkedPrefillSchedulerTest, ResourceNotEnough) {
     EXPECT_TRUE(scheduler != nullptr);
 
     // request prompt len: 1000
-    auto requests = generate_request({1, 1000}, {1, 100}, 10000);
+    auto requests = generate_request(
+        {1, 1000}, {1, 100}, std::nullopt, std::nullopt, 10000);
     scheduler->add_request(requests[0]);
     scheduler->add_request(requests[1]);
 
@@ -286,7 +281,8 @@ TEST(ChunkedPrefillSchedulerTest, NormalSchedule) {
   EXPECT_TRUE(scheduler != nullptr);
 
   // 1. schedule some new prefill requests
-  auto requests = generate_request({100, 200, 300}, {10, 20, 30}, 30000);
+  auto requests = generate_request(
+      {100, 200, 300}, {10, 20, 30}, std::nullopt, std::nullopt, 30000);
   for (auto req : requests) {
     scheduler->add_request(req);
   }
@@ -308,7 +304,8 @@ TEST(ChunkedPrefillSchedulerTest, NormalSchedule) {
   update_requests(requests);
 
   // 3. add new prefill requests
-  auto requests1 = generate_request({400, 500}, {40, 50}, 30000);
+  auto requests1 =
+      generate_request({400, 500}, {40, 50}, std::nullopt, std::nullopt, 30000);
   for (auto req : requests1) {
     scheduler->add_request(req);
   }
@@ -321,7 +318,8 @@ TEST(ChunkedPrefillSchedulerTest, NormalSchedule) {
   // 4. add long new prefill requests,
   // memory is enough, can handled tokens from
   // max_tokens_per_chunk_for_prefill(1024) -> remain_max_tokens_budget
-  auto requests2 = generate_request({10000}, {10}, 30000);
+  auto requests2 =
+      generate_request({10000}, {10}, std::nullopt, std::nullopt, 30000);
   for (auto req : requests2) {
     scheduler->add_request(req);
   }
@@ -339,7 +337,8 @@ TEST(ChunkedPrefillSchedulerTest, NormalSchedule) {
   // 5. add long new prefill requests,
   // memory is not enough, only handled `max_tokens_per_chunk_for_prefill`(1024)
   // tokens
-  auto requests3 = generate_request({10000}, {10}, 30000);
+  auto requests3 =
+      generate_request({10000}, {10}, std::nullopt, std::nullopt, 30000);
   for (auto req : requests3) {
     scheduler->add_request(req);
   }
@@ -371,7 +370,8 @@ TEST(ChunkedPrefillSchedulerTest, PreemptSchedule) {
 
   // 1. schedule some new prefill requests
   // request-1 has higher priority than request-2
-  auto requests = generate_request({127, 127}, {10, 10}, 30000);
+  auto requests =
+      generate_request({127, 127}, {10, 10}, std::nullopt, std::nullopt, 30000);
   running_requests = requests;
   for (auto req : requests) {
     scheduler->add_request(req);
@@ -430,8 +430,11 @@ TEST(ChunkedPrefillSchedulerTest, OnDecodePreemptOffDecode) {
   std::vector<std::shared_ptr<Request>> running_requests;
 
   // 1. schedule one online and one prefill prefill requests
-  auto requests = generate_priority_request(
-      {127, 127}, {10, 10}, {true, false}, {2, 2}, 30000);
+  auto requests = generate_request({127, 127},
+                                   {10, 10},
+                                   std::vector<bool>{true, false},
+                                   std::vector<int32_t>{2, 2},
+                                   30000);
   running_requests = requests;
   for (auto req : requests) {
     scheduler->add_request(req);
@@ -486,8 +489,11 @@ TEST(ChunkedPrefillSchedulerTest, OnPrefillPreemptOffDecode) {
 
     std::vector<std::shared_ptr<Request>> running_requests;
 
-    auto requests = generate_priority_request(
-        {100, 100}, {10, 10}, {true, true}, {2, 2}, 30000);
+    auto requests = generate_request({100, 100},
+                                     {10, 10},
+                                     std::vector<bool>{true, true},
+                                     std::vector<int32_t>{2, 2},
+                                     30000);
     running_requests = requests;
     for (auto req : requests) {
       scheduler->add_request(req);
@@ -504,8 +510,11 @@ TEST(ChunkedPrefillSchedulerTest, OnPrefillPreemptOffDecode) {
     EXPECT_TRUE(util::max(block_manager_pool->num_free_blocks()) == 0);
     update_requests(running_requests);
 
-    auto new_requests = generate_priority_request(
-        {80}, {10}, {false}, {2}, 30000);  // use 3 blocks
+    auto new_requests = generate_request({80},
+                                         {10},
+                                         std::vector<bool>{false},
+                                         std::vector<int32_t>{2},
+                                         30000);  // use 3 blocks
     scheduler->add_request(new_requests[0]);
     batch = scheduler->prepare_batch_test();
     EXPECT_TRUE(batch.size() == 1);
@@ -531,8 +540,11 @@ TEST(ChunkedPrefillSchedulerTest, OnPrefillPreemptOffDecode) {
 
     std::vector<std::shared_ptr<Request>> running_requests;
     // 1. schedule one online and one offline
-    auto requests = generate_priority_request(
-        {100, 100}, {10, 10}, {true, false}, {2, 2}, 30000);
+    auto requests = generate_request({100, 100},
+                                     {10, 10},
+                                     std::vector<bool>{true, false},
+                                     std::vector<int32_t>{2, 2},
+                                     30000);
     running_requests = requests;
     for (auto req : requests) {
       scheduler->add_request(req);
@@ -543,8 +555,8 @@ TEST(ChunkedPrefillSchedulerTest, OnPrefillPreemptOffDecode) {
     EXPECT_TRUE(util::max(block_manager_pool->num_free_blocks()) == 0);
     update_requests(running_requests);
 
-    auto new_requests =
-        generate_priority_request({200}, {10}, {false}, {2}, 30000);
+    auto new_requests = generate_request(
+        {200}, {10}, std::vector<bool>{false}, std::vector<int32_t>{2}, 30000);
     scheduler->add_request(new_requests[0]);
     batch = scheduler->prepare_batch_test();
 
@@ -575,8 +587,11 @@ TEST(ChunkedPrefillSchedulerTest, PrioritySchedule) {
   std::vector<std::shared_ptr<Request>> running_requests;
 
   // 1: HIGH, 2: NORMAL, 3: LOW
-  auto requests = generate_priority_request(
-      {127, 127, 127}, {10, 10, 10}, {false, false, false}, {3, 3, 2}, 30000);
+  auto requests = generate_request({127, 127, 127},
+                                   {10, 10, 10},
+                                   std::vector<bool>{false, false, false},
+                                   std::vector<int32_t>{3, 3, 2},
+                                   30000);
   for (auto req : requests) {
     scheduler->add_request(req);
   }
@@ -593,8 +608,11 @@ TEST(ChunkedPrefillSchedulerTest, PrioritySchedule) {
   update_requests(running_requests);
 
   // new HIGH priority request arrives, its prefill starts
-  auto new_requests = generate_priority_request(
-      {32}, {10}, {false}, {1}, 30000);  // use 1 blocks
+  auto new_requests = generate_request({32},
+                                       {10},
+                                       std::vector<bool>{false},
+                                       std::vector<int32_t>{1},
+                                       30000);  // use 1 blocks
   scheduler->add_request(new_requests[0]);
   batch = scheduler->prepare_batch_test();
   // check there are 3 running requests owing to decode-maximal
@@ -612,6 +630,73 @@ TEST(ChunkedPrefillSchedulerTest, PrioritySchedule) {
               RequestPriority::HIGH /*HIGH*/);
   EXPECT_TRUE(scheduler->get_running_requests()[1]->priority() ==
               RequestPriority::NORMAL /*NORMAL*/);
+}
+
+// TEST-8:
+// test latency budget
+TEST(ChunkedPrefillSchedulerTest, LatencySchedule) {
+  // set max free blocks: 3
+  // actually only 2 free blocks , because default 1 block is for padding
+  int block_num = 12;
+  int block_size = 32;
+  int max_tokens_per_chunk_for_prefill = 4;
+  // set chunked max_tokens budgets 10000 per step
+  ContinuousScheduler::Options opt =
+      create_scheduler_options(10000,
+                               256,
+                               0,
+                               max_tokens_per_chunk_for_prefill,
+                               1,
+                               "FCFS",
+                               false,
+                               true,
+                               350,
+                               150);
+  auto engine = std::make_unique<FakeEngine>(block_num, block_size);
+  auto scheduler = std::make_unique<ChunkedPrefillScheduler>(engine.get(), opt);
+  EXPECT_TRUE(scheduler != nullptr);
+
+  // mannuly created profile data for y=0.5x^2+10x
+  std::vector<std::pair<int32_t, int32_t>> created_profile_data = {
+      {2, 22}, {4, 48}, {6, 78}, {8, 112}};
+  auto profile_manager = scheduler->get_profile_manager();
+  // fit y=0.5x^2+10x
+  profile_manager->train_time_predictor(created_profile_data);
+
+  auto requests = generate_request(
+      {10, 10, 10}, {10, 10, 10}, std::nullopt, std::nullopt, 30000);
+  // check if time equation fits well
+  EXPECT_TRUE(profile_manager->predict_step_time(
+                  requests[0]->sequences()[0].get()) == 150);
+  EXPECT_TRUE(profile_manager->predict_step_time(1, 0) == 10);
+
+  std::vector<std::shared_ptr<Request>> running_requests;
+
+  // 1. three requests enter prefill
+  for (auto req : requests) {
+    scheduler->add_request(req);
+  }
+  auto batch = scheduler->prepare_batch_test();
+  EXPECT_TRUE(batch.size() == 1);
+  EXPECT_TRUE(batch[0].size() == 3);
+  EXPECT_TRUE(scheduler->get_running_requests().size() == 3);
+  running_requests = scheduler->get_running_requests();
+  update_requests(running_requests);
+
+  // 2. three requests enter decode, one new request chunked prefill
+  auto new_requests = generate_request(
+      {10}, {10}, std::nullopt, std::nullopt, 30000);  // use 1 blocks
+  scheduler->add_request(new_requests[0]);
+  batch = scheduler->prepare_batch_test();
+  auto running_sequences_budgets = scheduler->get_running_sequences_budgets();
+
+  EXPECT_TRUE(batch.size() == 1);
+  // tpot = 150 > 3 * 10 , all requests enter decode. But not enough for extra
+  // whole prefill, then do chunked
+  EXPECT_TRUE(batch[0].size() == 4);
+  EXPECT_TRUE(scheduler->get_running_requests().size() == 4);
+  EXPECT_TRUE(running_sequences_budgets.size() == 4);
+  EXPECT_TRUE(running_sequences_budgets[3] == max_tokens_per_chunk_for_prefill);
 }
 
 }  // namespace xllm

--- a/xllm/core/scheduler/chunked_prefill_scheduler_test.cpp
+++ b/xllm/core/scheduler/chunked_prefill_scheduler_test.cpp
@@ -86,10 +86,10 @@ ContinuousScheduler::Options create_scheduler_options(
     int32_t max_tokens_per_chunk_for_prefill,
     int32_t dp_size,
     const std::string& priority_strategy = "FCFS",
-    bool if_profile_kv_blocks = true,
+    bool enable_profile_kv_blocks = true,
     bool enable_latency_aware_schedule = false,
-    int32_t global_ttft_ms = std::numeric_limits<int32_t>::max(),
-    int32_t global_tpot_ms = std::numeric_limits<int32_t>::max()) {
+    int32_t max_global_ttft_ms = std::numeric_limits<int32_t>::max(),
+    int32_t max_global_tpot_ms = std::numeric_limits<int32_t>::max()) {
   ContinuousScheduler::Options opt;
   opt.num_speculative_tokens_ = num_speculative_tokens;
   opt.max_tokens_per_chunk_for_prefill_ = max_tokens_per_chunk_for_prefill;
@@ -97,10 +97,10 @@ ContinuousScheduler::Options create_scheduler_options(
   opt.max_seqs_per_batch_ = max_seqs_per_batch;
   opt.dp_size_ = dp_size;
   opt.priority_strategy_ = priority_strategy;
-  opt.if_profile_kv_blocks_ = if_profile_kv_blocks;
+  opt.enable_profile_kv_blocks_ = enable_profile_kv_blocks;
   opt.enable_latency_aware_schedule_ = enable_latency_aware_schedule;
-  opt.global_ttft_ms_ = global_ttft_ms;
-  opt.global_tpot_ms_ = global_tpot_ms;
+  opt.max_global_ttft_ms_ = max_global_ttft_ms;
+  opt.max_global_tpot_ms_ = max_global_tpot_ms;
   return opt;
 }
 

--- a/xllm/core/scheduler/continuous_scheduler.cpp
+++ b/xllm/core/scheduler/continuous_scheduler.cpp
@@ -48,9 +48,19 @@ ContinuousScheduler::ContinuousScheduler(Engine* engine, const Options& options)
   CHECK(engine_ != nullptr);
   block_manager_pool_ = engine_->block_manager_pool();
   CHECK(block_manager_pool_ != nullptr);
+
   enable_prefix_cache_ = block_manager_pool_->options().enable_prefix_cache();
 
   last_batch_.resize(options_.dp_size());
+
+  ProfileManager::Options profile_manager_options;
+  profile_manager_options.dp_size(options.dp_size())
+      .enable_schedule_overlap(options.enable_schedule_overlap())
+      .enable_profile_step_time(options.enable_profile_step_time())
+      .profile_max_prompt_length(options.profile_max_prompt_length())
+      .if_profile_kv_blocks(options.if_profile_kv_blocks());
+  profile_manager_ =
+      std::make_unique<ProfileManager>(engine, profile_manager_options);
 
   response_processor_ = std::make_unique<AsyncResponseProcessor>(
       engine_->tokenizer(),
@@ -141,6 +151,8 @@ bool ContinuousScheduler::check_if_enough_to_evict(
 }
 
 void ContinuousScheduler::handle_prefill_requests(
+    size_t& latency_budget,
+    size_t& estimate_latency,
     size_t& remaining_token_budget,
     size_t& remaining_seq_budget,
     RequestPriorityQueue& waiting_priority_queue,
@@ -156,8 +168,10 @@ void ContinuousScheduler::handle_prefill_requests(
   //
   // NOTE: preempted requests will be pushed in waiting_priority_queue,
   // they may contian many sequences, so we should check here.
+  bool budget_exhausted = false;
+  bool blocks_exhausted = false;
   while (!waiting_priority_queue.empty() && remaining_seq_budget > 0 &&
-         remaining_token_budget > 0 &&
+         remaining_token_budget > 0 && latency_budget > estimate_latency &&
          block_manager_pool_->kv_cache_utilization() <
              FLAGS_prefill_scheduling_memory_usage_threshold) {
     std::shared_ptr<Request> request(waiting_priority_queue.top());
@@ -182,6 +196,7 @@ void ContinuousScheduler::handle_prefill_requests(
     // long sequences may stuck when n>1
     size_t allocated_tokens = 0;
     size_t allocated_seqs = 0;
+    size_t allocated_estimate_latency = 0;
     bool can_schedule = true;
     std::vector<Sequence*> prefill_sequences;
     std::vector<size_t> prefill_sequences_budget;
@@ -193,11 +208,14 @@ void ContinuousScheduler::handle_prefill_requests(
       }
 
       prefill_sequence->sync_result();
-
+      // FIXME: use actual num_tokens to handle
+      // Currently overestimating the number of tokens actually processed when
+      // enable prefix cache
       size_t num_tokens = prefill_sequence->num_need_compute_tokens();
       if (remaining_token_budget < allocated_tokens + num_tokens ||
           remaining_seq_budget < allocated_seqs + 1) {
         can_schedule = false;
+        budget_exhausted = true;
         break;
       }
 
@@ -238,14 +256,35 @@ void ContinuousScheduler::handle_prefill_requests(
           }
         }
         if (!can_schedule) {
+          // release shared prefix blocks
           block_manager_pool_->deallocate(prefill_sequence.get());
+          blocks_exhausted = true;
           break;
         }
       }
+
+      // OPTIMIZE for multi-slo requests
+      // for prefill requests, check latency after prefix cache match
+      size_t seq_estimate_latency = 0;
+      if (options_.enable_latency_aware_schedule()) {
+        seq_estimate_latency =
+            profile_manager_->predict_step_time(prefill_sequence.get());
+        if (estimate_latency + allocated_estimate_latency +
+                seq_estimate_latency >
+            latency_budget) {
+          // release shared prefix blocks
+          block_manager_pool_->deallocate(prefill_sequence.get());
+          can_schedule = false;
+          budget_exhausted = true;
+          break;
+        }
+      }
+
       prefill_sequences_budget.emplace_back(num_tokens);
       prefill_sequences.emplace_back(prefill_sequence.get());
       allocated_tokens += num_tokens;
       allocated_seqs += 1;
+      allocated_estimate_latency += seq_estimate_latency;
     }
 
     if (!can_schedule) {
@@ -258,6 +297,7 @@ void ContinuousScheduler::handle_prefill_requests(
 
     remaining_token_budget -= allocated_tokens;
     remaining_seq_budget -= allocated_seqs;
+    estimate_latency += allocated_estimate_latency;
     waiting_priority_queue.pop();
     running_requests_.emplace_back(request);
     running_sequences_.insert(running_sequences_.end(),
@@ -270,16 +310,29 @@ void ContinuousScheduler::handle_prefill_requests(
   // maybe can pre-compute if prompt beyond length
   if (running_sequences_.empty() && !waiting_priority_queue.empty() &&
       running_queue_->empty()) {
-    LOG(ERROR) << "Request prompt is too long, no enough memory to schedule "
-                  "a single sequence.";
-    // no enough memory to schedule single sequence, just finish the request
     std::shared_ptr<Request> request(waiting_priority_queue.top());
     waiting_priority_queue.pop();
     block_manager_pool_->deallocate(request.get());
-    response_processor_->process_failed_request(
-        request,
-        {StatusCode::RESOURCE_EXHAUSTED,
-         "No enough memory to schedule single sequence"});
+    if (blocks_exhausted) {
+      LOG(ERROR) << "Request prompt is too long, no enough memory to schedule "
+                    "a single sequence.";
+      // no enough memory to schedule single sequence, just finish the request
+      response_processor_->process_failed_request(
+          request,
+          {StatusCode::RESOURCE_EXHAUSTED,
+           "No enough memory to schedule single sequence"});
+    } else if (budget_exhausted) {
+      LOG(ERROR) << "Request prompt is too long, no enough budget to schedule "
+                    "a single sequence. Please set a larger budegt.";
+      // no enough memory to schedule single sequence, just finish the request
+      response_processor_->process_failed_request(
+          request,
+          {StatusCode::RESOURCE_EXHAUSTED,
+           "No enough budget to schedule single sequence."});
+    } else {
+      LOG(FATAL) << "Unexpected error: blocks and budget are enough but can "
+                    "not schedule.";
+    }
   }
 
   if (!running_sequences_.empty()) {
@@ -288,6 +341,8 @@ void ContinuousScheduler::handle_prefill_requests(
 }
 
 void ContinuousScheduler::handle_decode_requests(
+    size_t& latency_budget,
+    size_t& estimate_latency,
     size_t& remaining_token_budget,
     size_t& remaining_seq_budget,
     size_t& num_offline_decode_preempt_offline_requests,
@@ -296,7 +351,7 @@ void ContinuousScheduler::handle_decode_requests(
     std::unique_ptr<DecodePriorityQueue>& running_queue) {
   while (!running_queue->empty() &&
          remaining_token_budget > options_.num_speculative_tokens() &&
-         remaining_seq_budget > 0) {
+         latency_budget > estimate_latency && remaining_seq_budget > 0) {
     std::shared_ptr<Request> request = running_queue->top();
     // TODO: check if request is timeout
 
@@ -310,12 +365,24 @@ void ContinuousScheduler::handle_decode_requests(
     bool has_enough_blocks = true;
     size_t allocated_tokens = 0;
     size_t allocated_seqs = 0;
+    size_t allocated_estimate_latency = 0;
     for (auto& sequence : request->sequences()) {
       // skip finished sequence.
       if (sequence->finished()) {
         continue;
       }
       // no budget left
+      size_t seq_estimate_latency = 0;
+      if (options_.enable_latency_aware_schedule()) {
+        seq_estimate_latency =
+            profile_manager_->predict_step_time(sequence.get());
+        if (estimate_latency + allocated_estimate_latency +
+                seq_estimate_latency >
+            latency_budget) {
+          has_enough_budget = false;
+          break;
+        }
+      }
       if (allocated_tokens + options_.num_speculative_tokens() >=
               remaining_token_budget ||
           allocated_seqs >= remaining_seq_budget) {
@@ -338,6 +405,7 @@ void ContinuousScheduler::handle_decode_requests(
       // update the allocated tokens for the sequence
       allocated_tokens += options_.num_speculative_tokens() + 1;
       allocated_seqs += 1;
+      allocated_estimate_latency += seq_estimate_latency;
       candidate_sequences.emplace_back(sequence.get());
       candidate_token_budgets.emplace_back(options_.num_speculative_tokens() +
                                            1);
@@ -359,6 +427,7 @@ void ContinuousScheduler::handle_decode_requests(
                                         candidate_token_budgets.end());
       remaining_token_budget -= allocated_tokens;
       remaining_seq_budget -= allocated_seqs;
+      estimate_latency += allocated_estimate_latency;
 
       continue;
     }
@@ -370,8 +439,10 @@ void ContinuousScheduler::handle_decode_requests(
                               candidate_token_budgets,
                               allocated_tokens,
                               allocated_seqs,
+                              allocated_estimate_latency,
                               remaining_token_budget,
                               remaining_seq_budget,
+                              estimate_latency,
                               true, /*budget_exhausted*/
                               false /*blocks_exhausted*/);
       break;
@@ -420,8 +491,10 @@ void ContinuousScheduler::handle_decode_requests(
                             candidate_token_budgets,
                             allocated_tokens,
                             allocated_seqs,
+                            allocated_estimate_latency,
                             remaining_token_budget,
                             remaining_seq_budget,
+                            estimate_latency,
                             false, /*budget_exhausted*/
                             true /*blocks_exhausted*/);
     break;
@@ -435,8 +508,10 @@ void ContinuousScheduler::handle_abnormal_request(
     const std::vector<size_t>& candidate_token_budgets,
     const size_t& allocated_tokens,
     const size_t& allocated_seqs,
+    size_t& allocated_estimate_latency,
     size_t& remaining_token_budget,
     size_t& remaining_seq_budget,
+    size_t& estimate_latency,
     bool budget_exhausted,
     bool blocks_exhausted) {
   std::shared_ptr<Request> request = running_queue->top();
@@ -495,6 +570,7 @@ void ContinuousScheduler::handle_abnormal_request(
                                       candidate_token_budgets.end());
     remaining_token_budget -= allocated_tokens;
     remaining_seq_budget -= allocated_seqs;
+    estimate_latency += allocated_estimate_latency;
   }
 }
 
@@ -632,6 +708,11 @@ std::vector<Batch> ContinuousScheduler::prepare_batch() {
   running_sequences_.clear();
   running_sequences_budgets_.clear();
 
+  // maintain estimate_latency for current batch for support requests with
+  // different ttft TO IMPROVE: use min remaining time (i.e. slo - elapsed_time)
+  // of the reuquest in current decode queue to replace.
+  size_t latency_budget = options_.global_ttft_ms();
+  size_t estimate_latency = 0;
   // remaining budget for the current batch
   size_t remaining_token_budget = options_.max_tokens_per_batch();
   size_t remaining_seq_budget = std::max(options_.max_seqs_per_batch(), 1);
@@ -641,28 +722,37 @@ std::vector<Batch> ContinuousScheduler::prepare_batch() {
   size_t num_online_prefill_preempt_offline_requests = 0;
   size_t num_online_decode_preempt_offline_requests = 0;
   // TO IMPROVE?: handle online decode request before prefill offline request
-  handle_prefill_requests(remaining_token_budget,
+  handle_prefill_requests(latency_budget,
+                          estimate_latency,
+                          remaining_token_budget,
                           remaining_seq_budget,
                           waiting_priority_queue_,
                           num_online_prefill_preempt_offline_requests,
                           finished_requests);
-  handle_prefill_requests(remaining_token_budget,
+  handle_prefill_requests(latency_budget,
+                          estimate_latency,
+                          remaining_token_budget,
                           remaining_seq_budget,
                           waiting_priority_queue_offline_,
                           num_online_prefill_preempt_offline_requests,
                           finished_requests);
 
   if (running_sequences_.empty()) {
+    latency_budget = options_.global_tpot_ms();
     // Handle decoding requests.
     // no prefill request, schedule the decode requests in the running priority
     // queue
-    handle_decode_requests(remaining_token_budget,
+    handle_decode_requests(latency_budget,
+                           estimate_latency,
+                           remaining_token_budget,
                            remaining_seq_budget,
                            num_offline_decode_preempt_offline_requests,
                            num_online_decode_preempt_online_requests,
                            num_online_decode_preempt_offline_requests,
                            running_queue_);
-    handle_decode_requests(remaining_token_budget,
+    handle_decode_requests(latency_budget,
+                           estimate_latency,
+                           remaining_token_budget,
                            remaining_seq_budget,
                            num_offline_decode_preempt_offline_requests,
                            num_online_decode_preempt_online_requests,

--- a/xllm/core/scheduler/continuous_scheduler.h
+++ b/xllm/core/scheduler/continuous_scheduler.h
@@ -96,15 +96,17 @@ class ContinuousScheduler : public Scheduler {
 
     PROPERTY(bool, enable_profile_step_time) = false;
     // use predicted latency for latency aware schedule
+    PROPERTY(bool, enable_profile_token_budget) = false;
+
     PROPERTY(bool, enable_latency_aware_schedule) = false;
     // the max prompt length for profile
     PROPERTY(int32_t, profile_max_prompt_length) = 2048;
     // true if generate kv cache for profile
-    PROPERTY(bool, if_profile_kv_blocks) = true;
+    PROPERTY(bool, enable_profile_kv_blocks) = true;
     // all requests use single global ttft
-    PROPERTY(int32_t, global_ttft_ms) = std::numeric_limits<int32_t>::max();
+    PROPERTY(int32_t, max_global_ttft_ms) = std::numeric_limits<int32_t>::max();
     // all requests use single global tpot
-    PROPERTY(int32_t, global_tpot_ms) = std::numeric_limits<int32_t>::max();
+    PROPERTY(int32_t, max_global_tpot_ms) = std::numeric_limits<int32_t>::max();
   };
 
   ContinuousScheduler(Engine* engine, const Options& options);

--- a/xllm/core/scheduler/continuous_scheduler.h
+++ b/xllm/core/scheduler/continuous_scheduler.h
@@ -35,6 +35,7 @@ limitations under the License.
 #include "runtime/xservice_client.h"
 #include "scheduler.h"
 #include "scheduler/decode_priority_queue.h"
+#include "scheduler/profile/profile_manager.h"
 
 namespace xllm {
 class Engine;
@@ -92,6 +93,18 @@ class ContinuousScheduler : public Scheduler {
     PROPERTY(std::string,
              priority_strategy) = "FCFS";  // priority, deadline, FCFS
     PROPERTY(bool, enable_online_preempt_offline) = true;
+
+    PROPERTY(bool, enable_profile_step_time) = false;
+    // use predicted latency for latency aware schedule
+    PROPERTY(bool, enable_latency_aware_schedule) = false;
+    // the max prompt length for profile
+    PROPERTY(int32_t, profile_max_prompt_length) = 2048;
+    // true if generate kv cache for profile
+    PROPERTY(bool, if_profile_kv_blocks) = true;
+    // all requests use single global ttft
+    PROPERTY(int32_t, global_ttft_ms) = std::numeric_limits<int32_t>::max();
+    // all requests use single global tpot
+    PROPERTY(int32_t, global_tpot_ms) = std::numeric_limits<int32_t>::max();
   };
 
   ContinuousScheduler(Engine* engine, const Options& options);
@@ -121,10 +134,14 @@ class ContinuousScheduler : public Scheduler {
     return waiting_priority_queue_.size() +
            waiting_priority_queue_offline_.size();
   }
+
   // for test only
   std::vector<Batch> prepare_batch_test() { return prepare_batch(); }
   std::vector<std::shared_ptr<Request>> get_running_requests() {
     return running_requests_;
+  }
+  std::vector<size_t> get_running_sequences_budgets() {
+    return running_sequences_budgets_;
   }
   std::vector<std::shared_ptr<Request>> get_waiting_requests() {
     std::vector<std::shared_ptr<Request>> result;
@@ -138,6 +155,8 @@ class ContinuousScheduler : public Scheduler {
 
     return result;
   }
+
+  ProfileManager* get_profile_manager() { return profile_manager_.get(); }
 
   virtual void get_latency_metrics(std::vector<int64_t>& ttft,
                                    std::vector<int64_t>& tbt) {}
@@ -177,6 +196,8 @@ class ContinuousScheduler : public Scheduler {
 
   std::unique_ptr<AsyncResponseProcessor> response_processor_;
 
+  std::unique_ptr<ProfileManager> profile_manager_;
+
   bool enable_prefix_cache_ = false;
 
   // the number of requests that are waiting to be scheduled
@@ -213,12 +234,16 @@ class ContinuousScheduler : public Scheduler {
   InstanceInfo instance_info_;
 
   void handle_prefill_requests(
+      size_t& latency_budget,
+      size_t& estimate_latency,
       size_t& remaining_token_budget,
       size_t& remaining_seq_budget,
       RequestPriorityQueue& waiting_priority_queue,
       size_t& num_online_prefill_preempt_offline_requests,
       std::vector<std::shared_ptr<Request>>& finished_requests);
   void handle_decode_requests(
+      size_t& latency_budget,
+      size_t& estimate_latency,
       size_t& remaining_token_budget,
       size_t& remaining_seq_budget,
       size_t& num_offline_decode_preempt_offline_requests,
@@ -234,8 +259,10 @@ class ContinuousScheduler : public Scheduler {
       const std::vector<size_t>& candidate_token_budgets,
       const size_t& allocated_tokens,
       const size_t& allocated_seqs,
+      size_t& allocated_estimate_latency,
       size_t& remaining_token_budget,
       size_t& remaining_seq_budget,
+      size_t& estimate_latency,
       bool budget_exhausted,
       bool block_exhausted);
   void handle_running_requests(std::shared_ptr<Request> request);

--- a/xllm/core/scheduler/continuous_scheduler_test.cpp
+++ b/xllm/core/scheduler/continuous_scheduler_test.cpp
@@ -73,10 +73,10 @@ ContinuousScheduler::Options create_scheduler_options(
     int32_t max_tokens_per_chunk_for_prefill,
     int32_t dp_size,
     const std::string& priority_strategy = "FCFS",
-    bool if_profile_kv_blocks = true,
+    bool enable_profile_kv_blocks = true,
     bool enable_latency_aware_schedule = false,
-    int32_t global_ttft_ms = std::numeric_limits<int32_t>::max(),
-    int32_t global_tpot_ms = std::numeric_limits<int32_t>::max()) {
+    int32_t max_global_ttft_ms = std::numeric_limits<int32_t>::max(),
+    int32_t max_global_tpot_ms = std::numeric_limits<int32_t>::max()) {
   ContinuousScheduler::Options opt;
   opt.num_speculative_tokens_ = num_speculative_tokens;
   opt.max_tokens_per_chunk_for_prefill_ = max_tokens_per_chunk_for_prefill;
@@ -84,10 +84,10 @@ ContinuousScheduler::Options create_scheduler_options(
   opt.max_seqs_per_batch_ = max_seqs_per_batch;
   opt.dp_size_ = dp_size;
   opt.priority_strategy_ = priority_strategy;
-  opt.if_profile_kv_blocks_ = if_profile_kv_blocks;
+  opt.enable_profile_kv_blocks_ = enable_profile_kv_blocks;
   opt.enable_latency_aware_schedule_ = enable_latency_aware_schedule;
-  opt.global_ttft_ms_ = global_ttft_ms;
-  opt.global_tpot_ms_ = global_tpot_ms;
+  opt.max_global_ttft_ms_ = max_global_ttft_ms;
+  opt.max_global_tpot_ms_ = max_global_tpot_ms;
   return opt;
 }
 

--- a/xllm/core/scheduler/continuous_scheduler_test.cpp
+++ b/xllm/core/scheduler/continuous_scheduler_test.cpp
@@ -3,6 +3,9 @@
 #include <absl/time/clock.h>
 #include <gtest/gtest.h>
 
+#include <limits>
+#include <optional>
+
 #include "chunked_prefill_scheduler.h"
 #include "runtime/engine.h"
 #include "util/utils.h"
@@ -69,7 +72,11 @@ ContinuousScheduler::Options create_scheduler_options(
     int32_t num_speculative_tokens,
     int32_t max_tokens_per_chunk_for_prefill,
     int32_t dp_size,
-    const std::string& priority_strategy = "FCFS") {
+    const std::string& priority_strategy = "FCFS",
+    bool if_profile_kv_blocks = true,
+    bool enable_latency_aware_schedule = false,
+    int32_t global_ttft_ms = std::numeric_limits<int32_t>::max(),
+    int32_t global_tpot_ms = std::numeric_limits<int32_t>::max()) {
   ContinuousScheduler::Options opt;
   opt.num_speculative_tokens_ = num_speculative_tokens;
   opt.max_tokens_per_chunk_for_prefill_ = max_tokens_per_chunk_for_prefill;
@@ -77,19 +84,39 @@ ContinuousScheduler::Options create_scheduler_options(
   opt.max_seqs_per_batch_ = max_seqs_per_batch;
   opt.dp_size_ = dp_size;
   opt.priority_strategy_ = priority_strategy;
-
+  opt.if_profile_kv_blocks_ = if_profile_kv_blocks;
+  opt.enable_latency_aware_schedule_ = enable_latency_aware_schedule;
+  opt.global_ttft_ms_ = global_ttft_ms;
+  opt.global_tpot_ms_ = global_tpot_ms;
   return opt;
 }
 
 std::vector<std::shared_ptr<Request>> generate_request(
     const std::vector<int32_t>& prompt_lens,
     const std::vector<int32_t>& max_tokens,
-    const std::vector<bool>& offlines,
-    const std::vector<int32_t>& priorities,
+    std::optional<std::vector<bool>> offlines,
+    std::optional<std::vector<int32_t>> priorities,
     int32_t max_context_len) {
   std::vector<std::shared_ptr<Request>> requests;
   EXPECT_TRUE(prompt_lens.size() == max_tokens.size());
-  for (size_t i = 0; i < prompt_lens.size(); ++i) {
+
+  size_t batch_size = prompt_lens.size();
+  std::vector<bool> offline_vec;
+  std::vector<int32_t> priority_vec;
+  if (offlines.has_value()) {
+    offline_vec = *offlines;
+  } else {
+    offline_vec = std::vector<bool>(batch_size, false);
+  }
+
+  if (priorities.has_value()) {
+    priority_vec = priorities.value();
+  } else {
+    priority_vec = std::vector<int32_t>(
+        batch_size, static_cast<int32_t>(RequestPriority::NORMAL));
+  }
+
+  for (size_t i = 0; i < batch_size; ++i) {
     std::vector<int32_t> prompt_token_ids;
     prompt_token_ids.resize(prompt_lens[i]);
     RequestSamplingParam sampling_param;
@@ -97,6 +124,7 @@ std::vector<std::shared_ptr<Request>> generate_request(
     stopping_checker.set_max_generated_tokens(max_tokens[i]);
     stopping_checker.set_max_context_len(max_context_len);
     stopping_checker.set_ignore_eos(true);
+
     RequestState req_state("x",
                            prompt_token_ids,
                            sampling_param,
@@ -111,15 +139,16 @@ std::vector<std::shared_ptr<Request>> generate_request(
                            false,
                            nullptr,
                            nullptr);
-    auto request =
-        std::make_shared<Request>("1",
-                                  "1",
-                                  "1",
-                                  std::move(req_state),
-                                  "1",
-                                  offlines[i],
-                                  0,
-                                  static_cast<RequestPriority>(priorities[i]));
+
+    auto request = std::make_shared<Request>(
+        "1",
+        "1",
+        "1",
+        std::move(req_state),
+        "1",
+        offline_vec[i],
+        0,
+        static_cast<RequestPriority>(priority_vec[i]));
     requests.emplace_back(request);
   }
 
@@ -162,8 +191,11 @@ TEST(ContinuousSchedulerTest, OnDecodePreemptOffDecode) {
   std::vector<std::shared_ptr<Request>> running_requests;
 
   // 1. schedule two new online prefill requests
-  auto requests =
-      generate_request({127, 127}, {10, 10}, {true, false}, {2, 2}, 30000);
+  auto requests = generate_request({127, 127},
+                                   {10, 10},
+                                   std::vector<bool>{true, false},
+                                   std::vector<int32_t>{2, 2},
+                                   30000);
   running_requests = requests;
   for (auto req : requests) {
     scheduler->add_request(req);
@@ -217,8 +249,11 @@ TEST(ContinuousSchedulerTest, OnPrefillPreemptOffDecode) {
 
     std::vector<std::shared_ptr<Request>> running_requests;
 
-    auto requests =
-        generate_request({100, 100}, {10, 10}, {true, true}, {2, 2}, 30000);
+    auto requests = generate_request({100, 100},
+                                     {10, 10},
+                                     std::vector<bool>{true, true},
+                                     std::vector<int32_t>{2, 2},
+                                     30000);
     running_requests = requests;
     for (auto req : requests) {
       scheduler->add_request(req);
@@ -235,8 +270,11 @@ TEST(ContinuousSchedulerTest, OnPrefillPreemptOffDecode) {
     EXPECT_TRUE(util::max(block_manager_pool->num_free_blocks()) == 0);
     update_requests(running_requests);
 
-    auto new_requests =
-        generate_request({80}, {10}, {false}, {2}, 30000);  // use 3 blocks
+    auto new_requests = generate_request({80},
+                                         {10},
+                                         std::vector<bool>{false},
+                                         std::vector<int32_t>{2},
+                                         30000);  // use 3 blocks
     scheduler->add_request(new_requests[0]);
     batch = scheduler->prepare_batch_test();
     EXPECT_TRUE(batch.size() == 1);
@@ -261,8 +299,11 @@ TEST(ContinuousSchedulerTest, OnPrefillPreemptOffDecode) {
 
     std::vector<std::shared_ptr<Request>> running_requests;
     // one online, one offline
-    auto requests =
-        generate_request({100, 100}, {10, 10}, {true, false}, {2, 2}, 30000);
+    auto requests = generate_request({100, 100},
+                                     {10, 10},
+                                     std::vector<bool>{true, false},
+                                     std::vector<int32_t>{2, 2},
+                                     30000);
     running_requests = requests;
     for (auto req : requests) {
       scheduler->add_request(req);
@@ -273,7 +314,8 @@ TEST(ContinuousSchedulerTest, OnPrefillPreemptOffDecode) {
     EXPECT_TRUE(util::max(block_manager_pool->num_free_blocks()) == 0);
     update_requests(running_requests);
 
-    auto new_requests = generate_request({200}, {10}, {false}, {2}, 30000);
+    auto new_requests = generate_request(
+        {200}, {10}, std::vector<bool>{false}, std::vector<int32_t>{2}, 30000);
     scheduler->add_request(new_requests[0]);
     batch = scheduler->prepare_batch_test();
     // online is still waiting
@@ -303,8 +345,11 @@ TEST(ContinuousSchedulerTest, PrioritySchedule) {
   std::vector<std::shared_ptr<Request>> running_requests;
 
   // 1: HIGH, 2: NORMAL, 3: LOW
-  auto requests = generate_request(
-      {128, 128, 128}, {10, 10, 10}, {false, false, false}, {3, 3, 2}, 30000);
+  auto requests = generate_request({128, 128, 128},
+                                   {10, 10, 10},
+                                   std::vector<bool>{false, false, false},
+                                   std::vector<int32_t>{3, 3, 2},
+                                   30000);
   for (auto req : requests) {
     scheduler->add_request(req);
   }
@@ -320,8 +365,11 @@ TEST(ContinuousSchedulerTest, PrioritySchedule) {
   update_requests(running_requests);
 
   // new HIGH priority request arrives, its prefill starts
-  auto new_requests =
-      generate_request({32}, {10}, {false}, {1}, 30000);  // use 1 blocks
+  auto new_requests = generate_request({32},
+                                       {10},
+                                       std::vector<bool>{false},
+                                       std::vector<int32_t>{1},
+                                       30000);  // use 1 blocks
   scheduler->add_request(new_requests[0]);
   batch = scheduler->prepare_batch_test();
   EXPECT_TRUE(batch.size() == 1);
@@ -338,6 +386,75 @@ TEST(ContinuousSchedulerTest, PrioritySchedule) {
               RequestPriority::HIGH /*HIGH*/);
   EXPECT_TRUE(scheduler->get_running_requests()[1]->priority() ==
               RequestPriority::NORMAL /*NORMAL*/);
+}
+
+// TEST-4:
+// test latency budget
+TEST(ContinuousSchedulerTest, LatencySchedule) {
+  // block is enough
+  int block_num = 12;
+  int block_size = 32;
+  int max_tokens_per_chunk_for_prefill = 1024;
+  // set chunked max_tokens budgets 10000 per step
+  ContinuousScheduler::Options opt =
+      create_scheduler_options(10000,
+                               256,
+                               0,
+                               max_tokens_per_chunk_for_prefill,
+                               1,
+                               "FCFS",
+                               false,
+                               true,
+                               350,
+                               25);
+  auto engine = std::make_unique<FakeEngine>(block_num, block_size);
+  auto scheduler = std::make_unique<ContinuousScheduler>(engine.get(), opt);
+  EXPECT_TRUE(scheduler != nullptr);
+
+  // mannuly created profile data for y=0.5x^2+10x
+  std::vector<std::pair<int32_t, int32_t>> created_profile_data = {
+      {2, 22}, {4, 48}, {6, 78}, {8, 112}};
+  auto profile_manager = scheduler->get_profile_manager();
+  // fit y=0.5x^2+10x
+  profile_manager->train_time_predictor(created_profile_data);
+
+  auto requests = generate_request(
+      {10, 10, 10}, {10, 10, 10}, std::nullopt, std::nullopt, 30000);
+  // check if time equation fits well
+  EXPECT_TRUE(profile_manager->predict_step_time(
+                  requests[0]->sequences()[0].get()) == 150);
+  EXPECT_TRUE(profile_manager->predict_step_time(1, 0) == 10);
+
+  std::vector<std::shared_ptr<Request>> running_requests;
+
+  // 1. two requests enter prefill
+  for (auto req : requests) {
+    scheduler->add_request(req);
+  }
+  auto batch = scheduler->prepare_batch_test();
+  std::cout << batch[0].size() << std::endl;
+
+  EXPECT_TRUE(batch.size() == 1);
+  // 2*150 < ttft_slo=350 < 3 * 150, only two requests enter prefill
+  EXPECT_TRUE(batch[0].size() == 2);
+  EXPECT_TRUE(scheduler->get_running_requests().size() == 2);
+  running_requests = scheduler->get_running_requests();
+  update_requests(running_requests);
+
+  // 2. one request enter prefill
+  batch = scheduler->prepare_batch_test();
+  EXPECT_TRUE(batch.size() == 1);
+  EXPECT_TRUE(batch[0].size() == 1);
+  EXPECT_TRUE(scheduler->get_running_requests().size() == 1);
+  running_requests = scheduler->get_running_requests();
+  update_requests(running_requests);
+
+  // 3. two requests start decode
+  batch = scheduler->prepare_batch_test();
+  EXPECT_TRUE(batch.size() == 1);
+  // 2*10 < tpot_slo=25 < 3 * 10, only two requests enter decode
+  EXPECT_TRUE(batch[0].size() == 2);
+  EXPECT_TRUE(scheduler->get_running_requests().size() == 2);
 }
 
 }  // namespace xllm

--- a/xllm/core/scheduler/decode_priority_queue.h
+++ b/xllm/core/scheduler/decode_priority_queue.h
@@ -1,3 +1,18 @@
+/* Copyright 2025 The xLLM Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://github.com/jd-opensource/xllm/blob/main/LICENSE
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
 #pragma once
 #include <functional>
 #include <memory>

--- a/xllm/core/scheduler/disagg_pd_scheduler.h
+++ b/xllm/core/scheduler/disagg_pd_scheduler.h
@@ -91,10 +91,6 @@ class DisaggPDScheduler : public ContinuousScheduler {
   // corresponding TTFT for calculating the estimated TTFT of requests.
   void profile_ttft();
 
-  // Generate a prefill request of token_length and execute inference, finally
-  // returning the inference time.
-  int64_t run_prefill_request(int32_t token_length, int32_t vocab_size);
-
   // check remote instance info, if not exist, get from master service
   bool check_remote_instance_info(const std::string& instance_name);
 

--- a/xllm/core/scheduler/profile/CMakeLists.txt
+++ b/xllm/core/scheduler/profile/CMakeLists.txt
@@ -1,0 +1,20 @@
+
+include(cc_library)
+include(cc_test)
+
+cc_library(
+  NAME 
+    profile
+  HDRS
+    profile_manager.h
+    time_predictor.h
+  SRCS
+    profile_manager.cpp
+    time_predictor.cpp
+  DEPS
+    :batch
+    :request
+    :runtime
+    glog::glog
+    absl::time
+)

--- a/xllm/core/scheduler/profile/profile_manager.cpp
+++ b/xllm/core/scheduler/profile/profile_manager.cpp
@@ -36,13 +36,99 @@ ProfileManager::ProfileManager(Engine* engine, const Options& options)
   block_manager_pool_ = engine_->block_manager_pool();
   CHECK(block_manager_pool_ != nullptr);
   time_predictor_ =
-      std::make_unique<TimePredictor>(options.if_profile_kv_blocks());
+      std::make_unique<TimePredictor>(options.enable_profile_kv_blocks());
   if (options.enable_profile_step_time()) {
     LOG(INFO) << "Starting profiliing step time.";
     profile_step_time(true);
+    eval_sequence_latency_prediction();
+    eval_batch_latency_prediction();
+  }
+  if (options.enable_profile_token_budget()) {
+    LOG(INFO) << "Starting profiliing token budget.";
+    profile_token_budget();
   }
   // more profile here, such as token_budget profile and decode length
   // prediction.
+}
+
+// currently only for test debug
+void ProfileManager::eval_sequence_latency_prediction() {
+  auto& model_args = engine_->model_args();
+  int32_t vocab_size = model_args.vocab_size();
+  std::vector<int32_t> pred_vec;
+  std::vector<int32_t> target_vec;
+  int32_t token_step = 80;
+  int32_t prefix_step = 400;
+  int32_t upper_bound = 4000;
+
+  LOG(INFO) << "Starting testing sequence latency prediction.";
+  for (int32_t token_length = token_step; token_length < upper_bound;
+       token_length += token_step) {
+    for (int32_t prefix_length = 0; prefix_length < token_length;
+         prefix_length += prefix_step) {
+      target_vec.emplace_back(
+          run_request(token_length, prefix_length, vocab_size));
+      pred_vec.emplace_back(predict_step_time(token_length, prefix_length));
+    }
+  }
+
+  // print
+  for (const auto& element : pred_vec) {
+    std::cout << element << " ";
+  }
+  std::cout << std::endl;
+  for (const auto& element : target_vec) {
+    std::cout << element << " ";
+  }
+  std::cout << std::endl;
+
+  double sum_error = 0.0;
+  for (size_t i = 0; i < pred_vec.size(); ++i) {
+    sum_error += std::abs(pred_vec[i] - target_vec[i]);
+  }
+  double mae = sum_error / pred_vec.size();
+
+  LOG(INFO) << "Mean Absolute Error (MAE) of latency prediction: " << mae;
+}
+void ProfileManager::eval_batch_latency_prediction() {
+  auto& model_args = engine_->model_args();
+  int32_t vocab_size = model_args.vocab_size();
+  std::vector<int32_t> pred_vec;
+  std::vector<int32_t> target_vec;
+  int32_t token_step = 400;
+  int32_t prefix_step = 400;
+  int32_t upper_bound = 4000;
+  int32_t batch_size = 10;
+
+  LOG(INFO) << "Starting testing batch latency prediction.";
+  for (int32_t token_length = token_step; token_length < upper_bound;
+       token_length += token_step) {
+    for (int32_t prefix_length = 0; prefix_length < token_length;
+         prefix_length += prefix_step) {
+      target_vec.emplace_back(
+          run_request(token_length, prefix_length, vocab_size, batch_size));
+      pred_vec.emplace_back(
+          predict_step_time(token_length, prefix_length, batch_size));
+    }
+  }
+
+  // print
+  for (const auto& element : pred_vec) {
+    std::cout << element << " ";
+  }
+  std::cout << std::endl;
+  for (const auto& element : target_vec) {
+    std::cout << element << " ";
+  }
+  std::cout << std::endl;
+
+  double sum_error = 0.0;
+  for (size_t i = 0; i < pred_vec.size(); ++i) {
+    sum_error += std::abs(pred_vec[i] - target_vec[i]);
+  }
+  double mae = sum_error / pred_vec.size();
+
+  LOG(INFO) << "Mean Absolute Error (MAE) of latency prediction: " << mae;
 }
 
 std::string ProfileManager::generate_filename(const std::string& file_suffix) {
@@ -99,17 +185,15 @@ void ProfileManager::profile_step_time(bool if_dump_to_file) {
   int32_t vocab_size = model_args.vocab_size();
 
   // TODO: support length for decode request profile
-  int32_t profile_length_step = 128;
   int32_t profile_max_prompt_length =
       std::min(max_context_len, options_.profile_max_prompt_length());
-  int32_t profile_count_per_step = 3;
   auto block_size = block_manager_pool_->options().block_size();
-  bool if_profile_kv_blocks = options_.if_profile_kv_blocks();
+  bool enable_profile_kv_blocks = options_.enable_profile_kv_blocks();
 
   // warm up
   run_request(profile_max_prompt_length, 0, vocab_size);
 
-  if (options_.if_profile_kv_blocks()) {
+  if (options_.enable_profile_kv_blocks()) {
     // starting from max_context_len, dividing the token length by 2 in
     // each loop iteration
     // consider to generate kv blocks for prompt
@@ -117,7 +201,7 @@ void ProfileManager::profile_step_time(bool if_dump_to_file) {
     for (int32_t token_length = profile_max_prompt_length; token_length > 1;
          token_length >>= 1) {
       // increase prefix length according to block size
-      auto block_step = (profile_length_step + block_size - 1) / block_size;
+      auto block_step = (profile_length_step_ + block_size - 1) / block_size;
       for (int32_t prefix_length = 0;
            prefix_length < token_length - 1 + (block_step * block_size);
            prefix_length += (block_step * block_size)) {
@@ -127,10 +211,10 @@ void ProfileManager::profile_step_time(bool if_dump_to_file) {
         }
         float latency_mean = 0;
 
-        for (int32_t k = 0; k < profile_count_per_step; k++) {
+        for (int32_t k = 0; k < profile_count_per_step_; k++) {
           latency_mean += run_request(token_length, prefix_length, vocab_size);
         }
-        latency_mean /= profile_count_per_step;
+        latency_mean /= profile_count_per_step_;
         // use token_length and prefix_length to predict
         time_profiling_data.emplace_back(
             token_length, prefix_length, static_cast<int32_t>(latency_mean));
@@ -146,10 +230,10 @@ void ProfileManager::profile_step_time(bool if_dump_to_file) {
     for (int32_t token_length = profile_max_prompt_length; token_length > 1;
          token_length >>= 1) {
       float latency_mean = 0;
-      for (int32_t k = 0; k < profile_count_per_step; k++) {
+      for (int32_t k = 0; k < profile_count_per_step_; k++) {
         latency_mean += run_request(token_length, 0, vocab_size);
       }
-      latency_mean /= profile_count_per_step;
+      latency_mean /= profile_count_per_step_;
       time_profiling_data.emplace_back(token_length,
                                        static_cast<int32_t>(latency_mean));
     }
@@ -168,76 +252,167 @@ void ProfileManager::train_time_predictor(
     std::vector<std::pair<int32_t, int32_t>> time_profiling_data) {
   time_predictor_->fit(time_profiling_data);
 }
-
+// for single sequence
 int32_t ProfileManager::predict_step_time(int32_t length,
-                                          int32_t prefix_length) {
-  return time_predictor_->predict_time(length, prefix_length);
+                                          int32_t prefix_length,
+                                          bool if_need_add_constant_term) {
+  return time_predictor_->predict_time(
+      length, prefix_length, if_need_add_constant_term);
 }
 
-int32_t ProfileManager::predict_step_time(Sequence* sequence) {
+int32_t ProfileManager::predict_step_time(Sequence* sequence,
+                                          bool if_need_add_constant_term) {
   auto length = sequence->num_tokens();
   auto prefix_length = sequence->kv_state().kv_cache_tokens_num();
-  int32_t latency = predict_step_time(length, prefix_length);
+  int32_t latency =
+      predict_step_time(length, prefix_length, if_need_add_constant_term);
   return latency;
 }
-
-int32_t ProfileManager::predict_step_time(std::vector<Sequence*>& sequences) {
-  // TODO: OPTIMIZE for multi-node, dp_size > 1
+// for single batch or sequences
+// seq in batch with the same token and prefix length
+int32_t ProfileManager::predict_step_time(int32_t length,
+                                          int32_t prefix_length,
+                                          int32_t batch_size) {
+  // int32_t total_latency = time_predictor_->get_constant_overhead();
+  // for (int32_t i = 0; i < batch_size; i++) {
+  //   // predict for each sequence
+  //   total_latency += predict_step_time(length, prefix_length, false);
+  // }
+  // return total_latency;
   int32_t total_latency = 0;
-  for (auto* sequence : sequences) {
-    total_latency += predict_step_time(sequence);
+  for (int32_t i = 0; i < batch_size; i++) {
+    total_latency += predict_step_time(length, prefix_length, true);
   }
   return total_latency;
 }
 
-void ProfileManager::profile_token_budget(int32_t tpot_slo_ms) {
-  // TODO: support adaptively token budget
+int32_t ProfileManager::predict_step_time(std::vector<Sequence*>& sequences) {
+  // TODO: OPTIMIZE for multi-node, dp_size > 1
+  int32_t total_latency = time_predictor_->get_constant_overhead();
+  for (auto* sequence : sequences) {
+    total_latency += predict_step_time(sequence, false);
+  }
+  return total_latency;
+}
+
+void ProfileManager::profile_token_budget() {
   // use token budget means defaultly ignoring prefix cache and decode request's
   // kv cache load overhead
-  ;
+  profile_token_budget_ = binary_search_max_tokens(
+      options_.max_global_tpot_ms(), 1, options_.max_tokens_per_batch());
+  LOG(INFO) << "Profile token budget: " << profile_token_budget_
+            << "for TPOT SLO: " << options_.max_global_tpot_ms();
 }
-int32_t ProfileManager::get_token_budget(int32_t tpot_slo_ms) {}
 
-// collect the latency of each step
-int32_t ProfileManager::run_request(int32_t token_length,
-                                    int32_t prefix_length,
-                                    int32_t vocab_size) {
-  // generate random token ids and request
+bool ProfileManager::check_if_satisfy_slo(int32_t num_tokens,
+                                          int32_t tpot_slo_ms) {
+  auto& model_args = engine_->model_args();
+  int32_t vocab_size = model_args.vocab_size();
+  int32_t prompt_tokens_per_batch = 1024;
+
+  auto batch_size = num_tokens / prompt_tokens_per_batch;
+  int32_t extra_token_length = num_tokens % prompt_tokens_per_batch;
+  int32_t batch_latency = 0;
+  for (int32_t k = 0; k < profile_count_per_step_; k++) {
+    batch_latency += run_request(
+        prompt_tokens_per_batch, 0, vocab_size, batch_size, extra_token_length);
+  }
+  batch_latency /= profile_count_per_step_;
+  if (batch_latency <= tpot_slo_ms) {
+    return true;
+  } else {
+    return false;
+  }
+}
+
+int32_t ProfileManager::binary_search_max_tokens(int32_t tpot_slo_ms,
+                                                 int32_t lower_bound,
+                                                 int32_t upper_bound) {
+  int32_t left = lower_bound;
+  int32_t right = upper_bound;
+  // [left, right)
+  while (left < right) {
+    int32_t mid = left + (right - left) / 2;
+    if (check_if_satisfy_slo(mid, tpot_slo_ms)) {
+      left = mid + 1;
+    } else {
+      right = mid;
+    }
+  }
+  return left - 1;
+}
+
+int32_t ProfileManager::get_token_budget() { return profile_token_budget_; }
+
+std::shared_ptr<Request> ProfileManager::generate_single_request(
+    int32_t token_length,
+    int32_t prefix_length,
+    int32_t vocab_size) {
   std::random_device rd;
   std::mt19937_64 gen(rd());
-  // generate token id within the range [0, vocab_size - 1]
   std::uniform_int_distribution<int32_t> dis(0, vocab_size - 1);
   std::vector<int32_t> token_ids(token_length);
   std::generate(token_ids.begin(), token_ids.end(), [&]() { return dis(gen); });
 
-  // generate request
+  // 直接构造 shared_ptr<Request>
   RequestState req_state(token_ids);
-  Request request(/*request_id=*/"",
-                  /*x_request_id=*/"",
-                  /*x_request_time=*/"",
-                  req_state);
+  auto request = std::make_shared<Request>(
+      /*request_id=*/"",
+      /*x_request_id=*/"",
+      /*x_request_time=*/"",
+      req_state);
 
   // TODO: better disable prefix cache
-  // pre-allocate for sequence to get initail kv cache
   if (prefix_length > 0) {
-    if (!block_manager_pool_->allocate(request.sequences()[0].get(),
+    if (!block_manager_pool_->allocate(request->sequences()[0].get(),
                                        prefix_length)) {
-      LOG(FATAL) << "Profiling TTFT failed! Not enough blocks, token length : "
+      LOG(FATAL) << "Profiling time failed! Not enough blocks, prefix length : "
                  << prefix_length;
     }
-    request.sequences()[0]->kv_state().incr_kv_cache_tokens_num(prefix_length);
+    request->sequences()[0]->kv_state().incr_kv_cache_tokens_num(prefix_length);
   }
 
-  // allocate blocks
-  if (!block_manager_pool_->allocate(request.sequences()[0].get())) {
-    LOG(FATAL) << "Profiling TTFT failed! Not enough blocks, token length : "
+  if (!block_manager_pool_->allocate(request->sequences()[0].get())) {
+    LOG(FATAL) << "Profiling time failed! Not enough blocks, token length : "
                << token_length;
+  }
+
+  return request;
+}
+
+// collect the latency of each step
+int32_t ProfileManager::run_request(int32_t token_length,
+                                    int32_t prefix_length,
+                                    int32_t vocab_size,
+                                    int32_t batch_size,
+                                    int32_t extra_token_length) {
+  CHECK(token_length >= prefix_length);
+  std::vector<Sequence*> sequences;
+  std::vector<size_t> sequences_budget;
+  std::vector<std::shared_ptr<Request>> requests;
+
+  // batch sequences with the same kv cahce and token length
+  for (int32_t i = 0; i < batch_size; i++) {
+    // generate random token ids and request
+    std::shared_ptr<Request> request =
+        generate_single_request(token_length, prefix_length, vocab_size);
+    requests.emplace_back(request);
+    sequences.emplace_back(request->sequences()[0].get());
+    sequences_budget.emplace_back(token_length - prefix_length);
+  }
+  // maybe another sequence for extra token length (< token_length) for token
+  // budget profiling
+  if (extra_token_length > 0) {
+    std::shared_ptr<Request> request =
+        generate_single_request(token_length, prefix_length, vocab_size);
+    requests.emplace_back(request);
+    sequences.emplace_back(request->sequences()[0].get());
+    sequences_budget.emplace_back(token_length - prefix_length);
   }
   // build batch
   auto batches =
       BatchFactory::get_instance(options_.dp_size())
-          ->create_batches(
-              {request.sequences()[0].get()}, {token_length}, nullptr, nullptr);
+          ->create_batches(sequences, sequences_budget, nullptr, nullptr);
 
   absl::Time start_time = absl::Now();
   engine_->step(batches);
@@ -245,7 +420,9 @@ int32_t ProfileManager::run_request(int32_t token_length,
     engine_->update_last_step_result(batches);
   }
   const int32_t latency = absl::ToInt64Milliseconds(absl::Now() - start_time);
-  block_manager_pool_->deallocate(&request);
+  for (auto& request : requests) {
+    block_manager_pool_->deallocate(request.get());
+  }
 
   return latency;
 }

--- a/xllm/core/scheduler/profile/profile_manager.cpp
+++ b/xllm/core/scheduler/profile/profile_manager.cpp
@@ -1,0 +1,253 @@
+/* Copyright 2025 The xLLM Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://github.com/jd-opensource/xllm/blob/main/LICENSE
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include "profile_manager.h"
+
+#include <absl/time/time.h>
+#include <glog/logging.h>
+
+#include <chrono>
+#include <filesystem>
+#include <fstream>
+#include <iomanip>
+#include <random>
+#include <sstream>
+
+#include "framework/batch/batch_factory.h"
+#include "framework/request/request_state.h"
+
+namespace xllm {
+
+ProfileManager::ProfileManager(Engine* engine, const Options& options)
+    : options_(options), engine_(engine) {
+  CHECK(engine_ != nullptr);
+  block_manager_pool_ = engine_->block_manager_pool();
+  CHECK(block_manager_pool_ != nullptr);
+  time_predictor_ =
+      std::make_unique<TimePredictor>(options.if_profile_kv_blocks());
+  if (options.enable_profile_step_time()) {
+    LOG(INFO) << "Starting profiliing step time.";
+    profile_step_time(true);
+  }
+  // more profile here, such as token_budget profile and decode length
+  // prediction.
+}
+
+std::string ProfileManager::generate_filename(const std::string& file_suffix) {
+  auto now = std::chrono::system_clock::now();
+  auto in_time_t = std::chrono::system_clock::to_time_t(now);
+
+  std::stringstream ss;
+  ss << std::put_time(std::localtime(&in_time_t), "%Y%m%d_%H%M%S");
+
+  std::string filename;
+  filename = ss.str() + "_" + file_suffix + ".txt";
+
+  return filename;
+}
+
+void ProfileManager::dump_step_time_profile_to_file(
+    const std::vector<std::pair<int32_t, int32_t>>& time_profiling_data) {
+  std::string filename = generate_filename("profile_step_time");
+  std::ofstream outfile(filename);
+  if (!outfile.is_open()) {
+    LOG(FATAL) << "Could not open file " << filename << " for writing.";
+    return;
+  }
+  // write data
+  for (const auto& data : time_profiling_data) {
+    outfile << data.first << "," << data.second << std::endl;
+  }
+  outfile.close();
+  LOG(INFO) << "Profile data saved to: " << filename;
+}
+
+void ProfileManager::dump_step_time_profile_to_file(
+    const std::vector<std::tuple<int32_t, int32_t, int32_t>>&
+        time_profiling_data) {
+  std::string filename = generate_filename("profile_step_time");
+  std::ofstream outfile(filename);
+  if (!outfile.is_open()) {
+    LOG(FATAL) << "Could not open file " << filename << " for writing.";
+    return;
+  }
+  // write data
+  for (const auto& data : time_profiling_data) {
+    outfile << std::get<0>(data) << "," << std::get<1>(data) << ","
+            << std::get<2>(data) << std::endl;
+  }
+  outfile.close();
+  LOG(INFO) << "Profile data saved to: " << filename;
+}
+
+void ProfileManager::profile_step_time(bool if_dump_to_file) {
+  // get the maximum prefill token length
+  auto& model_args = engine_->model_args();
+  int32_t max_context_len = model_args.max_position_embeddings();
+  int32_t vocab_size = model_args.vocab_size();
+
+  // TODO: support length for decode request profile
+  int32_t profile_length_step = 128;
+  int32_t profile_max_prompt_length =
+      std::min(max_context_len, options_.profile_max_prompt_length());
+  int32_t profile_count_per_step = 3;
+  auto block_size = block_manager_pool_->options().block_size();
+  bool if_profile_kv_blocks = options_.if_profile_kv_blocks();
+
+  // warm up
+  run_request(profile_max_prompt_length, 0, vocab_size);
+
+  if (options_.if_profile_kv_blocks()) {
+    // starting from max_context_len, dividing the token length by 2 in
+    // each loop iteration
+    // consider to generate kv blocks for prompt
+    std::vector<std::tuple<int32_t, int32_t, int32_t>> time_profiling_data;
+    for (int32_t token_length = profile_max_prompt_length; token_length > 1;
+         token_length >>= 1) {
+      // increase prefix length according to block size
+      auto block_step = (profile_length_step + block_size - 1) / block_size;
+      for (int32_t prefix_length = 0;
+           prefix_length < token_length - 1 + (block_step * block_size);
+           prefix_length += (block_step * block_size)) {
+        if (prefix_length > token_length - 1) {
+          // avoid kv_cache_token_num == token_length
+          prefix_length = token_length - 1;
+        }
+        float latency_mean = 0;
+
+        for (int32_t k = 0; k < profile_count_per_step; k++) {
+          latency_mean += run_request(token_length, prefix_length, vocab_size);
+        }
+        latency_mean /= profile_count_per_step;
+        // use token_length and prefix_length to predict
+        time_profiling_data.emplace_back(
+            token_length, prefix_length, static_cast<int32_t>(latency_mean));
+      }
+    }
+    if (if_dump_to_file) {
+      dump_step_time_profile_to_file(time_profiling_data);
+    }
+    train_time_predictor(time_profiling_data);
+  } else {
+    // not consider kv cache
+    std::vector<std::pair<int32_t, int32_t>> time_profiling_data;
+    for (int32_t token_length = profile_max_prompt_length; token_length > 1;
+         token_length >>= 1) {
+      float latency_mean = 0;
+      for (int32_t k = 0; k < profile_count_per_step; k++) {
+        latency_mean += run_request(token_length, 0, vocab_size);
+      }
+      latency_mean /= profile_count_per_step;
+      time_profiling_data.emplace_back(token_length,
+                                       static_cast<int32_t>(latency_mean));
+    }
+    if (if_dump_to_file) {
+      dump_step_time_profile_to_file(time_profiling_data);
+    }
+    train_time_predictor(time_profiling_data);
+  }
+}
+
+void ProfileManager::train_time_predictor(
+    std::vector<std::tuple<int32_t, int32_t, int32_t>> time_profiling_data) {
+  time_predictor_->fit(time_profiling_data);
+}
+void ProfileManager::train_time_predictor(
+    std::vector<std::pair<int32_t, int32_t>> time_profiling_data) {
+  time_predictor_->fit(time_profiling_data);
+}
+
+int32_t ProfileManager::predict_step_time(int32_t length,
+                                          int32_t prefix_length) {
+  return time_predictor_->predict_time(length, prefix_length);
+}
+
+int32_t ProfileManager::predict_step_time(Sequence* sequence) {
+  auto length = sequence->num_tokens();
+  auto prefix_length = sequence->kv_state().kv_cache_tokens_num();
+  int32_t latency = predict_step_time(length, prefix_length);
+  return latency;
+}
+
+int32_t ProfileManager::predict_step_time(std::vector<Sequence*>& sequences) {
+  // TODO: OPTIMIZE for multi-node, dp_size > 1
+  int32_t total_latency = 0;
+  for (auto* sequence : sequences) {
+    total_latency += predict_step_time(sequence);
+  }
+  return total_latency;
+}
+
+void ProfileManager::profile_token_budget(int32_t tpot_slo_ms) {
+  // TODO: support adaptively token budget
+  // use token budget means defaultly ignoring prefix cache and decode request's
+  // kv cache load overhead
+  ;
+}
+int32_t ProfileManager::get_token_budget(int32_t tpot_slo_ms) {}
+
+// collect the latency of each step
+int32_t ProfileManager::run_request(int32_t token_length,
+                                    int32_t prefix_length,
+                                    int32_t vocab_size) {
+  // generate random token ids and request
+  std::random_device rd;
+  std::mt19937_64 gen(rd());
+  // generate token id within the range [0, vocab_size - 1]
+  std::uniform_int_distribution<int32_t> dis(0, vocab_size - 1);
+  std::vector<int32_t> token_ids(token_length);
+  std::generate(token_ids.begin(), token_ids.end(), [&]() { return dis(gen); });
+
+  // generate request
+  RequestState req_state(token_ids);
+  Request request(/*request_id=*/"",
+                  /*x_request_id=*/"",
+                  /*x_request_time=*/"",
+                  req_state);
+
+  // TODO: better disable prefix cache
+  // pre-allocate for sequence to get initail kv cache
+  if (prefix_length > 0) {
+    if (!block_manager_pool_->allocate(request.sequences()[0].get(),
+                                       prefix_length)) {
+      LOG(FATAL) << "Profiling TTFT failed! Not enough blocks, token length : "
+                 << prefix_length;
+    }
+    request.sequences()[0]->kv_state().incr_kv_cache_tokens_num(prefix_length);
+  }
+
+  // allocate blocks
+  if (!block_manager_pool_->allocate(request.sequences()[0].get())) {
+    LOG(FATAL) << "Profiling TTFT failed! Not enough blocks, token length : "
+               << token_length;
+  }
+  // build batch
+  auto batches =
+      BatchFactory::get_instance(options_.dp_size())
+          ->create_batches(
+              {request.sequences()[0].get()}, {token_length}, nullptr, nullptr);
+
+  absl::Time start_time = absl::Now();
+  engine_->step(batches);
+  if (options_.enable_schedule_overlap()) {
+    engine_->update_last_step_result(batches);
+  }
+  const int32_t latency = absl::ToInt64Milliseconds(absl::Now() - start_time);
+  block_manager_pool_->deallocate(&request);
+
+  return latency;
+}
+
+}  // namespace xllm

--- a/xllm/core/scheduler/profile/profile_manager.h
+++ b/xllm/core/scheduler/profile/profile_manager.h
@@ -1,0 +1,89 @@
+/* Copyright 2025 The xLLM Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://github.com/jd-opensource/xllm/blob/main/LICENSE
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#pragma once
+
+#include <memory>
+#include <vector>
+
+#include "common/macros.h"
+#include "common/types.h"
+#include "framework/block/block_manager_pool.h"
+#include "framework/request/request.h"
+#include "framework/request/sequence.h"
+#include "runtime/engine.h"
+#include "runtime/xservice_client.h"
+#include "time_predictor.h"
+
+namespace xllm {
+class Engine;
+class ProfileManager {
+ public:
+  struct Options {
+    PROPERTY(bool, enable_schedule_overlap) = false;
+
+    PROPERTY(int32_t, dp_size) = 1;
+    // config for profile
+    PROPERTY(bool, enable_profile_step_time) = false;
+
+    PROPERTY(int32_t, profile_max_prompt_length) = 2048;
+
+    PROPERTY(bool, if_profile_kv_blocks) = true;
+  };
+  ProfileManager(Engine* engine, const Options& options);
+
+  int32_t get_token_budget(int32_t tpot_slo_ms);
+
+  int32_t predict_step_time(int32_t length, int32_t prefix_length);
+
+  int32_t predict_step_time(Sequence* sequence);
+
+  int32_t predict_step_time(std::vector<Sequence*>& sequences);
+  // Generate a request of token_length and prefix_length, finally
+  // executing and returning the inference time.
+  int32_t run_request(int32_t token_length,
+                      int32_t prefix_length,
+                      int32_t vocab_size);
+
+  void train_time_predictor(
+      std::vector<std::tuple<int32_t, int32_t, int32_t>> time_profiling_data);
+
+  void train_time_predictor(
+      std::vector<std::pair<int32_t, int32_t>> time_profiling_data);
+
+ private:
+  void dump_step_time_profile_to_file(
+      const std::vector<std::pair<int32_t, int32_t>>& time_profiling_data);
+
+  void dump_step_time_profile_to_file(
+      const std::vector<std::tuple<int32_t, int32_t, int32_t>>&
+          time_profiling_data);
+
+  std::string generate_filename(const std::string& file_suffix);
+
+  void profile_step_time(bool if_dump_to_file);
+
+  void profile_token_budget(int32_t tpot_slo_ms);
+
+  std::unique_ptr<TimePredictor> time_predictor_;
+
+  const Options options_;
+
+  Engine* engine_;
+
+  BlockManagerPool* block_manager_pool_;
+};
+
+}  // namespace xllm

--- a/xllm/core/scheduler/profile/time_predictor.cpp
+++ b/xllm/core/scheduler/profile/time_predictor.cpp
@@ -1,0 +1,123 @@
+/* Copyright 2025 The xLLM Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://github.com/jd-opensource/xllm/blob/main/LICENSE
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include "time_predictor.h"
+
+#include <glog/logging.h>
+
+#include <vector>
+
+namespace xllm {
+
+TimePredictor::TimePredictor(bool if_profile_prefix)
+    : if_profile_prefix_(if_profile_prefix) {
+  if (!if_profile_prefix) {
+    coefficients_ = Eigen::VectorXd::Zero(3);
+  } else {
+    coefficients_ = Eigen::VectorXd::Zero(5);
+  }
+}
+
+void TimePredictor::fit(
+    const std::vector<std::pair<int32_t, int32_t>>& time_profiling_data) {
+  // construct Vandermonde matrix
+  int32_t m = time_profiling_data.size();
+  int32_t n = 3;  // use 2-degree polynomial
+  Eigen::MatrixXd matrix(m, n);
+  for (int32_t i = 0; i < m; ++i) {
+    for (int32_t j = 0; j < n; ++j) {
+      matrix(i, j) = std::pow(time_profiling_data[i].first, j);
+    }
+  }
+  // construct target vector
+  Eigen::VectorXd target(m);
+  for (int32_t i = 0; i < m; ++i) {
+    target(i) = time_profiling_data[i].second;
+  }
+  // get coefficients
+  coefficients_ = matrix.colPivHouseholderQr().solve(target);
+
+  // Output equation
+  std::stringstream equation;
+  equation << "Fitted equation: time = ";
+  for (int32_t i = 0; i < coefficients_.size(); ++i) {
+    if (i > 0) equation << " + ";
+    equation << coefficients_(i);
+    if (i == 1)
+      equation << " * x";
+    else if (i > 1)
+      equation << " * x^" << i;
+  }
+  LOG(INFO) << equation.str();
+}
+
+void TimePredictor::fit(
+    const std::vector<std::tuple<int32_t, int32_t, int32_t>>&
+        time_profiling_data) {
+  int32_t m = time_profiling_data.size();
+  int32_t n = 5;
+  Eigen::MatrixXd matrix(m, n);
+
+  for (int32_t i = 0; i < m; ++i) {
+    int32_t token_length = std::get<0>(time_profiling_data[i]);
+    int32_t prefix_length = std::get<1>(time_profiling_data[i]);
+    int32_t diff = token_length - prefix_length;
+
+    matrix(i, 0) = diff * diff;           // (token_length-prefix_length)^2
+    matrix(i, 1) = diff;                  // (token_length-prefix_length)
+    matrix(i, 2) = diff * prefix_length;  // prefix_length
+    matrix(i, 3) = prefix_length;         // (token_length-prefix_length)
+    matrix(i, 4) = 1.0;                   // constant
+  }
+  // construct target vector
+  Eigen::VectorXd target(m);
+  for (int32_t i = 0; i < m; ++i) {
+    target(i) = std::get<2>(time_profiling_data[i]);
+  }
+  // get coefficients
+  coefficients_ = matrix.colPivHouseholderQr().solve(target);
+  // output equation
+  LOG(INFO) << "Fitted equation: time = " << coefficients_(0) << " * diff^2 + "
+            << coefficients_(1) << " * diff + " << coefficients_(2)
+            << " * (diff * prefix_length) + " << coefficients_(3)
+            << " * prefix_length + " << coefficients_(4);
+}
+
+int32_t TimePredictor::predict_time(int32_t length, int32_t prefix_length) {
+  double result = 0.0;
+  if (!if_profile_prefix_) {
+    // use prefix-free profile
+    int32_t effective_length = length - prefix_length;
+    double power = 1.0;
+    for (int32_t i = 0; i < coefficients_.size(); ++i) {
+      result += coefficients_(i) * power;
+      power *= effective_length;
+    }
+
+  } else {
+    // prefix profile
+    int32_t diff = length - prefix_length;
+    result = coefficients_(0) * diff * diff + coefficients_(1) * diff +
+             coefficients_(2) * diff * prefix_length +
+             coefficients_(3) * prefix_length + coefficients_(4);
+  }
+  if (result < 0) {
+    LOG(WARNING) << "Negative time prediction: " << result;
+    result = 0;
+  }
+  return static_cast<int32_t>(result);
+}
+
+}  // namespace xllm

--- a/xllm/core/scheduler/profile/time_predictor.h
+++ b/xllm/core/scheduler/profile/time_predictor.h
@@ -1,0 +1,41 @@
+/* Copyright 2025 The xLLM Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://github.com/jd-opensource/xllm/blob/main/LICENSE
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#pragma once
+
+#include <Eigen/Dense>
+
+namespace xllm {
+
+// Predictor for predicting TTFT based on input length
+class TimePredictor final {
+ public:
+  TimePredictor(bool if_profile_prefix);
+
+  void fit(const std::vector<std::pair<int32_t, int32_t>>& time_profiling_data);
+
+  void fit(const std::vector<std::tuple<int32_t, int32_t, int32_t>>&
+               time_profiling_data);
+
+  ~TimePredictor() = default;
+
+  int32_t predict_time(int32_t length, int32_t prefix_length = 0);
+
+ private:
+  Eigen::VectorXd coefficients_;
+  bool if_profile_prefix_ = false;
+};
+
+}  // namespace xllm

--- a/xllm/core/scheduler/profile/time_predictor.h
+++ b/xllm/core/scheduler/profile/time_predictor.h
@@ -19,10 +19,10 @@ limitations under the License.
 
 namespace xllm {
 
-// Predictor for predicting TTFT based on input length
+// Predictor for predicting time based on input length
 class TimePredictor final {
  public:
-  TimePredictor(bool if_profile_prefix);
+  explicit TimePredictor(bool if_profile_prefix);
 
   void fit(const std::vector<std::pair<int32_t, int32_t>>& time_profiling_data);
 
@@ -31,7 +31,11 @@ class TimePredictor final {
 
   ~TimePredictor() = default;
 
-  int32_t predict_time(int32_t length, int32_t prefix_length = 0);
+  int32_t predict_time(int32_t length,
+                       int32_t prefix_length = 0,
+                       bool if_need_add_constant_term = true);
+
+  int32_t get_constant_overhead();
 
  private:
   Eigen::VectorXd coefficients_;

--- a/xllm/xllm.cpp
+++ b/xllm/xllm.cpp
@@ -149,8 +149,13 @@ int run() {
                             (FLAGS_host_blocks_factor > 0.0))
       .store_protocol(FLAGS_store_protocol)
       .store_master_server_entry(FLAGS_store_master_server_entry)
-      .store_metadata_connstring(FLAGS_store_metadata_connstring);
-
+      .store_metadata_connstring(FLAGS_store_metadata_connstring)
+      .enable_profile_step_time(FLAGS_enable_profile_step_time)
+      .enable_latency_aware_schedule(FLAGS_enable_latency_aware_schedule)
+      .profile_max_prompt_length(FLAGS_profile_max_prompt_length)
+      .if_profile_kv_blocks(FLAGS_if_profile_kv_blocks)
+      .global_ttft_ms(FLAGS_global_ttft_ms)
+      .global_tpot_ms(FLAGS_global_tpot_ms);
   InstanceName::name()->set_name(options.instance_name().value_or(""));
 
   // working node

--- a/xllm/xllm.cpp
+++ b/xllm/xllm.cpp
@@ -151,11 +151,12 @@ int run() {
       .store_master_server_entry(FLAGS_store_master_server_entry)
       .store_metadata_connstring(FLAGS_store_metadata_connstring)
       .enable_profile_step_time(FLAGS_enable_profile_step_time)
+      .enable_profile_token_budget(FLAGS_enable_profile_token_budget)
       .enable_latency_aware_schedule(FLAGS_enable_latency_aware_schedule)
       .profile_max_prompt_length(FLAGS_profile_max_prompt_length)
-      .if_profile_kv_blocks(FLAGS_if_profile_kv_blocks)
-      .global_ttft_ms(FLAGS_global_ttft_ms)
-      .global_tpot_ms(FLAGS_global_tpot_ms);
+      .enable_profile_kv_blocks(FLAGS_enable_profile_kv_blocks)
+      .max_global_ttft_ms(FLAGS_max_global_ttft_ms)
+      .max_global_tpot_ms(FLAGS_max_global_tpot_ms);
   InstanceName::name()->set_name(options.instance_name().value_or(""));
 
   // working node


### PR DESCRIPTION
- Add profiling and time prediction modules for the continuous scheduler (mainly for chunkedprefill). 
- Initial process logic added into  build batch based on estimated latency.
- test scripts.
- token budget profile based on tpot for chunkedprefill (refer to Sarathi-Serve)

To add:
- seperate allocate prefix cache blocks and compute prefix cache match to estimate latency before acctually allocating blocks

