### PR TITLE
feat: support beam search for llm model [1/N].

### DIFF
--- a/xllm/core/framework/batch/CMakeLists.txt
+++ b/xllm/core/framework/batch/CMakeLists.txt
@@ -15,6 +15,7 @@ cc_library(
     batch_factory.cpp
     batch_input_builder.cpp
     mposition.cpp
+    beam_search.h
   DEPS
     :request
     :runtime

--- a/xllm/core/framework/batch/batch.h
+++ b/xllm/core/framework/batch/batch.h
@@ -22,7 +22,9 @@ limitations under the License.
 #include <vector>
 
 #include "framework/request/mm_data.h"
+#include "framework/request/request.h"
 #include "framework/request/sequence.h"
+#include "framework/request/sequences_group.h"
 #include "runtime/forward_params.h"
 
 namespace xllm {
@@ -41,6 +43,10 @@ class Batch {
 
   void add(const std::vector<Sequence*>& sequences);
 
+  void add(SequencesGroup* sequence_group) {
+    sequence_groups_.push_back(sequence_group);
+  };
+
   void set_copy_in_cache_block_infos(
       std::vector<CacheBlockInfo>* copy_in_cache_block_infos) {
     copy_in_cache_block_infos_ = copy_in_cache_block_infos;
@@ -49,6 +55,11 @@ class Batch {
   void set_copy_out_cache_block_infos(
       std::vector<CacheBlockInfo>* copy_out_cache_block_infos) {
     copy_out_cache_block_infos_ = copy_out_cache_block_infos;
+  }
+
+  void set_swap_cache_block_infos(
+      std::vector<CacheBlockInfo>* swap_cache_block_infos) {
+    swap_cache_block_infos_ = swap_cache_block_infos;
   }
 
   // get the number of sequences in the batch
@@ -93,9 +104,13 @@ class Batch {
                                  int token_idx,
                                  bool enable_schedule_overlap);
 
+  void process_beam_search();
+
   std::vector<Sequence*> sequences_;
+  std::vector<SequencesGroup*> sequence_groups_;
   std::vector<CacheBlockInfo>* copy_in_cache_block_infos_ = nullptr;
   std::vector<CacheBlockInfo>* copy_out_cache_block_infos_ = nullptr;
+  std::vector<CacheBlockInfo>* swap_cache_block_infos_ = nullptr;
 
   // max number of tokens to process for each sequence
   // default to max value

--- a/xllm/core/framework/batch/batch_factory.h
+++ b/xllm/core/framework/batch/batch_factory.h
@@ -28,11 +28,14 @@ class BatchFactory {
   }
 
   std::vector<Batch> create_batches(
+      const std::vector<std::shared_ptr<Request>>& running_requests,
       const std::vector<Sequence*>& running_sequences,
       const std::vector<size_t>& running_sequences_budgets,
       std::vector<std::vector<CacheBlockInfo>>* copy_in_cache_block_infos =
           nullptr,
       std::vector<std::vector<CacheBlockInfo>>* copy_out_cache_block_infos =
+          nullptr,
+      std::vector<std::vector<CacheBlockInfo>>* swap_cache_block_infos =
           nullptr);
 
  private:

--- a/xllm/core/framework/batch/batch_input_builder.h
+++ b/xllm/core/framework/batch/batch_input_builder.h
@@ -38,6 +38,7 @@ class BatchInputBuilder {
       const std::vector<MMData>& mm_data_vec,
       const std::vector<CacheBlockInfo>* copy_in_cache_block_infos,
       const std::vector<CacheBlockInfo>* copy_out_cache_block_infos,
+      const std::vector<CacheBlockInfo>* swap_cache_block_infos,
       const ModelArgs* args);
 
   ForwardInput build_forward_input(uint32_t num_decoding_tokens,
@@ -125,6 +126,7 @@ class BatchInputBuilder {
   std::unordered_set<int32_t> write_block_ids_;
   const std::vector<CacheBlockInfo>* copy_in_cache_block_infos_ = nullptr;
   const std::vector<CacheBlockInfo>* copy_out_cache_block_infos_ = nullptr;
+  const std::vector<CacheBlockInfo>* swap_cache_block_infos_ = nullptr;
 };
 
 }  // namespace xllm

--- a/xllm/core/framework/batch/beam_search.h
+++ b/xllm/core/framework/batch/beam_search.h
@@ -1,0 +1,130 @@
+/* Copyright 2025 The xLLM Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://github.com/jd-opensource/xllm/blob/main/LICENSE
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#pragma once
+
+namespace xllm {
+
+// BeamCandidate structure for beam search sorting
+struct BeamCandidate {
+  size_t seq_index;
+  float logprob_sum;
+  std::vector<int32_t> token_ids;
+  std::vector<std::optional<float>> logprobs;
+
+  BeamCandidate() = default;
+
+  BeamCandidate(size_t seq_idx,
+                float logprob,
+                std::vector<int32_t>& token_ids,
+                std::vector<std::optional<float>>& logprobs)
+      : seq_index(seq_idx),
+        logprob_sum(logprob),
+        token_ids(std::move(token_ids)),
+        logprobs(std::move(logprobs)) {}
+
+  bool operator<(const BeamCandidate& other) const {
+    return logprob_sum > other.logprob_sum;
+  }
+};
+
+template <typename CandidateType>
+class SimpleTopKOptimizer {
+ private:
+  std::priority_queue<CandidateType> min_heap_;
+  size_t k_;
+
+ public:
+  explicit SimpleTopKOptimizer(size_t k) : k_(k) {}
+
+  void clear() {
+    while (!min_heap_.empty()) {
+      min_heap_.pop();
+    }
+  }
+
+  void insert(const CandidateType& candidate) {
+    if (min_heap_.size() < k_) {
+      min_heap_.push(candidate);
+    } else if (candidate.logprob_sum > min_heap_.top().logprob_sum) {
+      min_heap_.pop();
+      min_heap_.push(candidate);
+    }
+  }
+
+  void insert(CandidateType&& candidate) {
+    if (min_heap_.size() < k_) {
+      min_heap_.push(std::move(candidate));
+    } else if (candidate.logprob_sum > min_heap_.top().logprob_sum) {
+      min_heap_.pop();
+      min_heap_.push(std::move(candidate));
+    }
+  }
+
+  void insert_batch(const std::vector<CandidateType>& candidates) {
+    for (const auto& candidate : candidates) {
+      insert(candidate);
+    }
+  }
+
+  std::vector<CandidateType> getTopK() {
+    std::vector<CandidateType> result;
+    result.reserve(min_heap_.size());
+
+    while (!min_heap_.empty()) {
+      result.emplace_back(
+          std::move(const_cast<CandidateType&>(min_heap_.top())));
+      min_heap_.pop();
+    }
+
+    return result;
+  }
+
+  std::vector<CandidateType>&& getTopKMove() {
+    std::vector<CandidateType> result;
+    result.reserve(min_heap_.size());
+
+    while (!min_heap_.empty()) {
+      result.emplace_back(
+          std::move(const_cast<CandidateType&>(min_heap_.top())));
+      min_heap_.pop();
+    }
+
+    return std::move(result);
+  }
+
+  std::vector<CandidateType> getTopKSorted() {
+    std::vector<CandidateType> result = getTopK();
+    std::reverse(result.begin(), result.end());
+    return result;
+  }
+
+  size_t size() const { return min_heap_.size(); }
+
+  bool empty() const { return min_heap_.empty(); }
+
+  bool worthInserting(float logprob_sum) const {
+    return min_heap_.size() < k_ || logprob_sum > min_heap_.top().logprob_sum;
+  }
+
+  float getMinLogprob() const {
+    return min_heap_.empty() ? -std::numeric_limits<float>::infinity()
+                             : min_heap_.top().logprob_sum;
+  }
+};
+
+using SimpleTopKOptimizerBeamCandidate = SimpleTopKOptimizer<BeamCandidate>;
+
+}  // namespace xllm

--- a/xllm/core/framework/block/block_manager_pool.h
+++ b/xllm/core/framework/block/block_manager_pool.h
@@ -61,6 +61,7 @@ class BlockManagerPool {
 
   std::vector<std::vector<CacheBlockInfo>>* get_copy_in_cache_block_infos();
   std::vector<std::vector<CacheBlockInfo>>* get_copy_out_cache_block_infos();
+  std::vector<std::vector<CacheBlockInfo>>* get_swap_cache_block_infos();
   void reset_copy_content();
 
   void get_merged_kvcache_event(KvCacheEvent* event) const;
@@ -81,6 +82,8 @@ class BlockManagerPool {
   void allocate_host_shared(Sequence* sequence);
   void cache_host(Sequence* sequence);
 
+  void process_beam_search(Sequence* sequence, bool need_swap = false);
+
  private:
   std::vector<std::unique_ptr<BlockManager>> block_managers_;
   std::vector<std::unique_ptr<BlockManager>> host_block_managers_;
@@ -91,6 +94,7 @@ class BlockManagerPool {
   // CacheBlockInfo per step
   std::vector<std::vector<CacheBlockInfo>> copy_in_cache_block_infos_;
   std::vector<std::vector<CacheBlockInfo>> copy_out_cache_block_infos_;
+  std::vector<std::vector<CacheBlockInfo>> swap_cache_block_infos_;
   std::vector<std::vector<Block>> evict_host_blocks_;
 };
 

--- a/xllm/core/framework/kv_cache/kv_cache.cpp
+++ b/xllm/core/framework/kv_cache/kv_cache.cpp
@@ -23,4 +23,34 @@ KVCache::KVCache(torch::Tensor key_cache, torch::Tensor value_cache)
 torch::Tensor KVCache::get_k_cache() const { return key_cache_; }
 torch::Tensor KVCache::get_v_cache() const { return value_cache_; }
 
+void KVCache::swap_blocks(const std::vector<CacheBlockInfo>& swap_blocks) {
+  if (swap_blocks.empty()) {
+    return;
+  }
+
+  // collect src and dst indices
+  std::vector<int64_t> src_indices, dst_indices;
+  src_indices.reserve(swap_blocks.size());
+  dst_indices.reserve(swap_blocks.size());
+
+  for (const auto& block : swap_blocks) {
+    src_indices.push_back(block.device_block_id);
+    dst_indices.push_back(block.host_block_id);
+  }
+
+  // batch select keys and values
+  auto src_tensor = torch::tensor(
+      src_indices, torch::dtype(torch::kLong).device(key_cache_.device()));
+  auto dst_tensor = torch::tensor(
+      dst_indices, torch::dtype(torch::kLong).device(key_cache_.device()));
+
+  // batch select keys and values
+  auto selected_keys = torch::index_select(key_cache_, 0, src_tensor);
+  auto selected_values = torch::index_select(value_cache_, 0, src_tensor);
+
+  // batch copy keys and values to dst indices
+  key_cache_.index_copy_(0, dst_tensor, selected_keys);
+  value_cache_.index_copy_(0, dst_tensor, selected_values);
+}
+
 }  // namespace xllm

--- a/xllm/core/framework/kv_cache/kv_cache.h
+++ b/xllm/core/framework/kv_cache/kv_cache.h
@@ -19,6 +19,8 @@ limitations under the License.
 #include <cstdint>
 #include <vector>
 
+#include "framework/model/model_input_params.h"
+
 namespace xllm {
 class KVCache final {
  public:
@@ -33,6 +35,8 @@ class KVCache final {
   bool empty() const {
     return !key_cache_.defined() || !value_cache_.defined();
   }
+
+  void swap_blocks(const std::vector<CacheBlockInfo>& swap_blocks);
 
  private:
   torch::Tensor key_cache_;

--- a/xllm/core/framework/model/model_input_params.h
+++ b/xllm/core/framework/model/model_input_params.h
@@ -80,6 +80,7 @@ struct ModelInputParams {
     params.async_copy_out_blocks = std::move(async_copy_out_blocks);
     params.copy_out_blocks = std::move(copy_out_blocks);
     params.copy_in_blocks = std::move(copy_in_blocks);
+    params.swap_blocks = std::move(swap_blocks);
     return params;
   }
 
@@ -143,6 +144,7 @@ struct ModelInputParams {
   std::vector<CacheBlockInfo> async_copy_out_blocks;
   std::vector<CacheBlockInfo> copy_out_blocks;
   std::vector<CacheBlockInfo> copy_in_blocks;
+  std::vector<CacheBlockInfo> swap_blocks;
 
   std::shared_ptr<NPULayerSynchronizerImpl> layer_synchronizer = nullptr;
 #endif

--- a/xllm/core/framework/request/request.h
+++ b/xllm/core/framework/request/request.h
@@ -51,6 +51,8 @@ class Request {
   }
   bool expand_sequences(bool share_prefix = true);
 
+  SequencesGroup* sequence_group() { return sequences_group_.get(); }
+
   void set_cancel() { cancelled_.store(true, std::memory_order_relaxed); }
 
   bool cancelled() const { return cancelled_.load(std::memory_order_relaxed); }
@@ -93,6 +95,10 @@ class Request {
   RequestState& state() { return state_; }
 
   void update_connection_status();
+
+  bool check_beam_search() const {
+    return state_.sampling_param.beam_width > 1;
+  }
 
  private:
   // request create time

--- a/xllm/core/framework/request/request_params.cpp
+++ b/xllm/core/framework/request/request_params.cpp
@@ -116,6 +116,13 @@ RequestParams::RequestParams(const proto::CompletionRequest& request,
       streaming = false;
     }
   }
+  // beam search
+  if (request.has_beam_width()) {
+    beam_width = request.beam_width();
+    if (beam_width > 1) {
+      ignore_eos = true;
+    }
+  }
 }
 
 namespace {
@@ -276,6 +283,14 @@ void InitFromChatRequest(RequestParams& params, const ChatRequest& request) {
     }
   }
 
+  // beam search
+  if (request.has_beam_width()) {
+    params.beam_width = request.beam_width();
+    if (params.beam_width > 1) {
+      params.ignore_eos = true;
+    }
+  }
+
   if (request.has_chat_template_kwargs()) {
     params.chat_template_kwargs =
         proto_struct_to_json(request.chat_template_kwargs());
@@ -357,9 +372,9 @@ bool RequestParams::verify_params(OutputCallback callback) const {
                           "logprobs is not supported with echo");
       return false;
     }
-    if (top_logprobs < 0 || top_logprobs > 20) {
+    if (top_logprobs < 0 || top_logprobs > 2000) {
       CALLBACK_WITH_ERROR(StatusCode::INVALID_ARGUMENT,
-                          "logprobs must be between 0 and 20");
+                          "logprobs must be between 0 and 2000");
       return false;
     }
   }

--- a/xllm/core/framework/request/request_params.h
+++ b/xllm/core/framework/request/request_params.h
@@ -133,6 +133,9 @@ struct RequestParams {
 
   RequestPriority priority = RequestPriority::NORMAL;
 
+  // beam search
+  int32_t beam_width = 0;
+
   nlohmann::json chat_template_kwargs = nlohmann::json::object();
 };
 

--- a/xllm/core/framework/request/sequence.h
+++ b/xllm/core/framework/request/sequence.h
@@ -83,6 +83,8 @@ class Sequence final {
            const IncrementalDecoder& incremental_decoder,
            const SequenceParams& seq_params);
 
+  Sequence(const Sequence& other);
+
   // get mm data
   const MMData& get_mm_data() const { return mm_data_; }
   void set_mrope_position_delta(int val) { mrope_position_delta_ = val; }
@@ -138,6 +140,7 @@ class Sequence final {
   // the token would be discarded if the sequence is still in prefill stage
   void append_token(const Token& token);
   void append_token(int64_t token_id) { append_token(Token(token_id)); }
+  void update_token(size_t index, const Token& token);
   void update_last_step_token(const Token& token, size_t token_offset = 0);
   bool has_new_tokens_generated() const {
     return num_tokens_ > decoder_.output_offset();
@@ -246,6 +249,12 @@ class Sequence final {
   }
 
   void reset();
+
+  bool check_beam_search() {
+    return sequence_params_.sampling_param->beam_width > 1;
+  }
+
+  LogprobState* logprob_state() { return logprob_state_.get(); }
 
  private:
   // the index of the sequence in the request

--- a/xllm/core/framework/request/sequence_kv_state.cpp
+++ b/xllm/core/framework/request/sequence_kv_state.cpp
@@ -140,4 +140,15 @@ void KVCacheState::reset() {
   transfer_kv_info_.reset();
 }
 
+void KVCacheState::process_beam_search(const std::vector<Block>& new_blocks) {
+  blocks_.clear();
+  blocks_ = std::move(src_blocks_);
+
+  if (!new_blocks.empty()) {
+    CHECK_EQ(new_blocks.size(), 1);
+    blocks_.pop_back();
+    blocks_.insert(blocks_.end(), new_blocks.begin(), new_blocks.end());
+  }
+}
+
 }  // namespace xllm

--- a/xllm/core/framework/request/sequence_kv_state.h
+++ b/xllm/core/framework/request/sequence_kv_state.h
@@ -42,6 +42,17 @@ class KVCacheState {
   // returns allocated cache blocks
   Slice<Block> kv_blocks() const;
   std::vector<Block>* mutable_kv_blocks();
+
+  Slice<Block> src_blocks() const { return src_blocks_; };
+
+  void set_src_blocks(const std::vector<Block>& src_blocks,
+                      bool need_swap = false) {
+    src_blocks_ = std::move(src_blocks);
+    need_swap_ = need_swap;
+  };
+
+  bool need_swap() const { return need_swap_; }
+
   // get the number of blocks
   size_t num_kv_blocks() const;
   std::vector<int32_t> kv_cache_slots(int32_t pos_start, int32_t pos_end);
@@ -51,12 +62,20 @@ class KVCacheState {
 
   void reset();
 
+  void process_beam_search(const std::vector<Block>& new_blocks);
+
  private:
   // number of tokens in kv cache
   size_t kv_cache_tokens_num_ = 0;
 
   // kv cache blocks.
   std::vector<Block> blocks_;
+
+  // source kv cache blocks for swap
+  std::vector<Block> src_blocks_;
+
+  // if need to swap last block
+  bool need_swap_ = false;
 
   // transfer kv info for disaggregated PD mode.
   std::optional<TransferKVInfo> transfer_kv_info_;

--- a/xllm/core/framework/request/sequence_logprob_state.cpp
+++ b/xllm/core/framework/request/sequence_logprob_state.cpp
@@ -131,11 +131,11 @@ void LogprobState::generate_output_tokens_logprobs(
 void LogprobState::update_logprob(size_t index,
                                   const Token& token,
                                   int64_t num_top_tokens) {
-  CHECK(!logprobs_[index].has_value())
-      << "logprob at index " << index << " is already set";
+  // CHECK(!logprobs_[index].has_value())
+  //     << "logprob at index " << index << " is already set";
   logprobs_[index] = token.logprob;
 
-  if (num_top_tokens > 0) {
+  if (num_top_tokens > 0 && token.top_tokens.size() > 0) {
     DCHECK_EQ(token.top_tokens.size(), token.top_logprobs.size());
     if (token.top_tokens.size() > num_top_tokens) {
       top_tokens_[index] = token.top_tokens.slice(0, num_top_tokens);

--- a/xllm/core/framework/request/sequence_logprob_state.h
+++ b/xllm/core/framework/request/sequence_logprob_state.h
@@ -45,6 +45,18 @@ class LogprobState {
 
   void update_logprob(size_t index, const Token& token, int64_t num_top_tokens);
 
+  const std::vector<std::vector<float>>& get_top_logprobs() const {
+    return top_logprobs_;
+  }
+
+  const std::vector<std::vector<int64_t>>& get_top_tokens() const {
+    return top_tokens_;
+  }
+
+  const std::vector<std::optional<float>>& get_logprobs() const {
+    return logprobs_;
+  }
+
  private:
   int64_t num_prompt_tokens_;
   std::vector<std::optional<float>> logprobs_;

--- a/xllm/core/framework/request/sequences_group.h
+++ b/xllm/core/framework/request/sequences_group.h
@@ -46,7 +46,11 @@ class SequencesGroup {
   void generate_outputs(std::vector<SequenceOutput>& outputs,
                         const Tokenizer& tokenizer);
 
+  void process_beam_search();
+
   std::vector<std::unique_ptr<Sequence>>& sequences() { return sequences_; }
+
+  int32_t dp_rank() { return sequences_[0]->dp_rank(); }
 
  private:
   void add();

--- a/xllm/core/framework/sampling/sampling_params.h
+++ b/xllm/core/framework/sampling/sampling_params.h
@@ -35,6 +35,7 @@ struct RequestSamplingParam {
   int64_t top_logprobs = 0;
   bool do_sample = false;
   bool is_embeddings = false;
+  int32_t beam_width = 0;
 };
 
 struct SamplingParameters {

--- a/xllm/core/runtime/forward_params.h
+++ b/xllm/core/runtime/forward_params.h
@@ -154,6 +154,7 @@ struct RawForwardInput {
   std::vector<CacheBlockInfo> async_copy_out_blocks;
   std::vector<CacheBlockInfo> copy_out_blocks;
   std::vector<CacheBlockInfo> copy_in_blocks;
+  std::vector<CacheBlockInfo> swap_blocks;
 };
 
 struct RawSampleOutput {

--- a/xllm/core/runtime/llm_master.cpp
+++ b/xllm/core/runtime/llm_master.cpp
@@ -342,6 +342,7 @@ std::shared_ptr<Request> LLMMaster::generate_request(
   sampling_param.logprobs = sp.logprobs;
   sampling_param.top_logprobs = sp.top_logprobs;
   sampling_param.is_embeddings = sp.is_embeddings;
+  sampling_param.beam_width = sp.beam_width;
   if (best_of > sp.n) {
     // enable logprobs for best_of to generate sequence logprob
     sampling_param.logprobs = true;

--- a/xllm/core/runtime/worker_impl.cpp
+++ b/xllm/core/runtime/worker_impl.cpp
@@ -393,6 +393,13 @@ void WorkerImpl::prepare_work_before_execute(const ForwardInput& inputs,
     offload_kv_blocks_to_store_async(inputs.input_params.copy_out_blocks);
   }
 
+  if (input_params.swap_blocks.size() > 0) {
+    const int64_t num_layers = context_.get_model_args().n_layers();
+    for (int layer_id = 0; layer_id < num_layers; layer_id++) {
+      kv_caches_[layer_id].swap_blocks(input_params.swap_blocks);
+    }
+  }
+
   if (!context_.get_parallel_args().mapping_data().empty()) {
     torch::Tensor token_size_per_dp_group =
         torch::tensor(processed_inputs.input_params.dp_global_token_nums,

--- a/xllm/core/scheduler/chunked_prefill_scheduler.cpp
+++ b/xllm/core/scheduler/chunked_prefill_scheduler.cpp
@@ -684,9 +684,10 @@ std::vector<Batch> ChunkedPrefillScheduler::prepare_batch() {
     response_processor_->process_completed_requests(finished_requests);
   }
 
-  auto batches =
-      BatchFactory::get_instance(options_.dp_size())
-          ->create_batches(running_sequences_, running_sequences_budgets_);
+  auto batches = BatchFactory::get_instance(options_.dp_size())
+                     ->create_batches(running_requests_,
+                                      running_sequences_,
+                                      running_sequences_budgets_);
 
   if (!batches[0].empty()) {
     // only update the scheduling latency when there are requests to process

--- a/xllm/core/scheduler/profile/profile_manager.cpp
+++ b/xllm/core/scheduler/profile/profile_manager.cpp
@@ -412,7 +412,8 @@ int32_t ProfileManager::run_request(int32_t token_length,
   // build batch
   auto batches =
       BatchFactory::get_instance(options_.dp_size())
-          ->create_batches(sequences, sequences_budget, nullptr, nullptr);
+          ->create_batches(
+              requests, sequences, sequences_budget, nullptr, nullptr);
 
   absl::Time start_time = absl::Now();
   engine_->step(batches);

--- a/xllm/proto/chat.proto
+++ b/xllm/proto/chat.proto
@@ -124,8 +124,9 @@ message ChatRequest {
   // request priority. default = DEFAULT
   optional Priority priority = 32;
 
+  optional int32 beam_width = 33;
 
-  optional google.protobuf.Struct chat_template_kwargs = 33;
+  optional google.protobuf.Struct chat_template_kwargs = 34;
 }
 
 message ChatLogProbData {

--- a/xllm/proto/completion.proto
+++ b/xllm/proto/completion.proto
@@ -93,6 +93,8 @@ message CompletionRequest {
 
   // request priority. default = DEFAULT
   optional Priority priority = 28;
+
+  optional int32 beam_width = 29;
 }
 
 message LogProbs {

--- a/xllm/proto/multimodal.proto
+++ b/xllm/proto/multimodal.proto
@@ -138,5 +138,7 @@ message MMChatRequest {
   // request priority. default = DEFAULT
   optional Priority priority = 31;
 
-  optional google.protobuf.Struct chat_template_kwargs = 32;
+  optional int32 beam_width = 32;
+
+  optional google.protobuf.Struct chat_template_kwargs = 33;
 }

--- a/xllm/proto/worker.proto
+++ b/xllm/proto/worker.proto
@@ -184,6 +184,7 @@ message ForwardInput {
   repeated CacheBlockInfo async_copy_out_blocks = 27;
   repeated CacheBlockInfo copy_out_blocks = 28;
   repeated CacheBlockInfo copy_in_blocks = 29;
+  repeated CacheBlockInfo swap_blocks = 30;
 }
 
 message Embeddings {


### PR DESCRIPTION
## Background

basic beam search support for llm model and generative recommendation.

## Usage

```

curl http://127.0.0.1:13222/v1/completions
	-H 'accept: application/json' -H 'Content-Type: application/json'
	-X 'POST'
	-d '{
		"model": "Qwen3-8B",
		"prompt": "hello xllm",
		"stream": false,
		"max_tokens": 30,
		"temperature": 0.0,
		"beam_width": 5,
		"logprobs": 5
  	}'

```

## More Work

* copy blocks kernel.
* optimize cpu cost of beam search.
* beam search kernel.
* paged attention kernel for beam search.
