### PR TITLE
feat: support multi_stream_parallel and modify model. [4/4]

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -28,20 +28,20 @@ if(USE_NPU)
     if(DEVICE_TYPE STREQUAL "USE_A3")
         message("downloading a3 arm xllm kernels")
         file(DOWNLOAD 
-            "https://9n-das-tools.s3.cn-north-1.jdcloud-oss.com/xllm-ai/xllm_kernels/0.6.0/xllm_kernels-1.2.1-Linux.a3.arm.rpm"
+            "https://9n-das-tools.s3.cn-north-1.jdcloud-oss.com/xllm-ai/xllm_kernels/0.6.0/xllm_kernels-1.3.0-Linux.a3.arm.rpm"
             "${CMAKE_BINARY_DIR}/xllm_kernels.rpm"
         )
     else()  
       if(DEVICE_ARCH STREQUAL "ARM")
           message("downloading a2 arm xllm_kernels")
           file(DOWNLOAD 
-              "https://9n-das-tools.s3.cn-north-1.jdcloud-oss.com/xllm-ai/xllm_kernels/0.6.0/xllm_kernels-1.2.1-Linux.a2.arm.rpm"
+              "https://9n-das-tools.s3.cn-north-1.jdcloud-oss.com/xllm-ai/xllm_kernels/0.6.0/xllm_kernels-1.3.0-Linux.a2.arm.rpm"
               "${CMAKE_BINARY_DIR}/xllm_kernels.rpm"
           )
       else()
-          message("downloading a3 x86 xllm_kernels")
+          message("downloading a2 x86 xllm_kernels")
           file(DOWNLOAD 
-              "https://9n-das-tools.s3.cn-north-1.jdcloud-oss.com/xllm-ai/xllm_kernels/0.6.0/xllm_kernels-1.2.1-Linux.a2.x86.rpm"
+              "https://9n-das-tools.s3.cn-north-1.jdcloud-oss.com/xllm-ai/xllm_kernels/0.6.0/xllm_kernels-1.3.0-Linux.rpm"
               "${CMAKE_BINARY_DIR}/xllm_kernels.rpm"
           )
       endif()

--- a/docs/en/features/multi_streams.md
+++ b/docs/en/features/multi_streams.md
@@ -28,3 +28,4 @@ On the DeepSeek-R1 model, when generating just 1 token, this achieves:
 
 ## Notice
 The dual-stream parallelism currently only supports the prefill phase, with greater performance benefits observed for longer input requests.
+Only Support DeepSeek, Qwen3 dense(non-MoE) models.

--- a/docs/zh/features/multi_streams.md
+++ b/docs/zh/features/multi_streams.md
@@ -26,3 +26,4 @@ prefill双流并行开启后，基本可掩盖75以上的通信开销，在DeepS
 
 !!! warning "注意"
     双流并行目前只支持prefill阶段，请求输入越长，收益越大。
+    目前仅支持DeepSeek、Qwen3 dense（非MoE）模型。

--- a/xllm/core/common/global_flags.cpp
+++ b/xllm/core/common/global_flags.cpp
@@ -330,6 +330,10 @@ DEFINE_bool(
     "Whether to enable computation communication parallel by two streams "
     "and two micro batches in prefill stage.");
 
+DEFINE_int32(default_micro_batch_num,
+             2,
+             "Default use two micro batches for multi-stream parallel.");
+
 // --- for dit ---
 DEFINE_int32(max_requests_per_batch, 1, "Max number of request per batch.");
 

--- a/xllm/core/common/global_flags.h
+++ b/xllm/core/common/global_flags.h
@@ -163,6 +163,8 @@ DECLARE_string(store_metadata_connstring);
 
 DECLARE_bool(enable_multi_stream_parallel);
 
+DECLARE_int32(default_micro_batch_num);
+
 DECLARE_bool(enable_profile_step_time);
 
 DECLARE_bool(enable_profile_token_budget);

--- a/xllm/core/framework/batch/batch.h
+++ b/xllm/core/framework/batch/batch.h
@@ -122,7 +122,7 @@ class Batch {
   std::vector<MMData> mm_data_vec_;
 
   // all sequences in this batch are in prefill stage
-  bool all_seqs_in_prefill_ = true;
+  bool all_seqs_in_prefill_ = false;
 };
 
 }  // namespace xllm

--- a/xllm/core/framework/batch/batch_factory.cpp
+++ b/xllm/core/framework/batch/batch_factory.cpp
@@ -58,9 +58,9 @@ std::vector<Batch> BatchFactory::create_batches(
     // if dp enabled, each sequence is required to
     // dispatch to the same rank in the whole lifetime
     batches[sequence->dp_rank()].add(sequence, token_budget);
-    if (sequence->stage() == SequenceStage::DECODE &&
-        sequence->kv_state().kv_cache_tokens_num() > 0) {
-      batches[sequence->dp_rank()].set_batch_prefill_status(false);
+    if (!((sequence->stage() == SequenceStage::DECODE) &&
+          (sequence->kv_state().kv_cache_tokens_num() > 0))) {
+      batches[sequence->dp_rank()].set_batch_prefill_status(true);
     }
   }
 

--- a/xllm/core/framework/model/causal_lm.h
+++ b/xllm/core/framework/model/causal_lm.h
@@ -44,10 +44,11 @@ class CausalLM : public torch::nn::Module {
   // tokens: [num_tokens]
   // positions: [num_tokens]
   // returns: [num_tokens, hidden_size]
-  virtual torch::Tensor forward(const torch::Tensor& tokens,
-                                const torch::Tensor& positions,
-                                std::vector<KVCache>& kv_caches,
-                                const ModelInputParams& parameters) = 0;
+  virtual torch::Tensor forward(
+      const std::vector<torch::Tensor>& tokens,
+      const std::vector<torch::Tensor>& positions,
+      std::vector<KVCache>& kv_caches,
+      const std::vector<ModelInputParams>& parameters) = 0;
 
   // hidden_states: [num_tokens, hidden_size]
   // seleted_idxes: [num_tokens]
@@ -69,8 +70,9 @@ class CausalLM : public torch::nn::Module {
 #if defined(USE_NPU)
   virtual layer::LmHead get_lm_head() = 0;
   virtual void set_lm_head(layer::LmHead& head) = 0;
-  virtual layer::WordEmbedding get_word_embedding() = 0;
-  virtual void set_word_embedding(layer::WordEmbedding& embedding) = 0;
+  virtual std::vector<layer::WordEmbedding> get_word_embedding() = 0;
+  virtual void set_word_embedding(
+      std::vector<layer::WordEmbedding>& embedding) = 0;
 #endif
 };
 
@@ -80,10 +82,11 @@ class CausalLMImpl : public CausalLM {
   CausalLMImpl(Model model, const torch::TensorOptions& options)
       : model_(std::move(model)), options_(options) {}
 
-  torch::Tensor forward(const torch::Tensor& tokens,
-                        const torch::Tensor& positions,
-                        std::vector<KVCache>& kv_caches,
-                        const ModelInputParams& parameters) override {
+  torch::Tensor forward(
+      const std::vector<torch::Tensor>& tokens,
+      const std::vector<torch::Tensor>& positions,
+      std::vector<KVCache>& kv_caches,
+      const std::vector<ModelInputParams>& parameters) override {
     return model_->forward(tokens, positions, kv_caches, parameters);
   }
 
@@ -110,11 +113,12 @@ class CausalLMImpl : public CausalLM {
 
   void set_lm_head(layer::LmHead& head) override { model_->set_lm_head(head); };
 
-  layer::WordEmbedding get_word_embedding() override {
+  std::vector<layer::WordEmbedding> get_word_embedding() override {
     return model_->get_word_embedding();
   };
 
-  void set_word_embedding(layer::WordEmbedding& embedding) override {
+  void set_word_embedding(
+      std::vector<layer::WordEmbedding>& embedding) override {
     model_->set_word_embedding(embedding);
   };
 #endif

--- a/xllm/core/framework/model/causal_vlm.h
+++ b/xllm/core/framework/model/causal_vlm.h
@@ -41,10 +41,11 @@ class CausalVLMImpl : public CausalVLM {
   CausalVLMImpl(Model model, const torch::TensorOptions& options)
       : model_(std::move(model)), options_(options) {}
 
-  torch::Tensor forward(const torch::Tensor& tokens,
-                        const torch::Tensor& positions,
-                        std::vector<KVCache>& kv_caches,
-                        const ModelInputParams& parameters) override {
+  torch::Tensor forward(
+      const std::vector<torch::Tensor>& tokens,
+      const std::vector<torch::Tensor>& positions,
+      std::vector<KVCache>& kv_caches,
+      const std::vector<ModelInputParams>& parameters) override {
     return model_->forward(tokens, positions, kv_caches, parameters);
   }
 
@@ -69,11 +70,12 @@ class CausalVLMImpl : public CausalVLM {
 
   void set_lm_head(layer::LmHead& head) override { model_->set_lm_head(head); };
 
-  layer::WordEmbedding get_word_embedding() override {
+  std::vector<layer::WordEmbedding> get_word_embedding() override {
     return model_->get_word_embedding();
   };
 
-  void set_word_embedding(layer::WordEmbedding& embedding) override {
+  void set_word_embedding(
+      std::vector<layer::WordEmbedding>& embedding) override {
     model_->set_word_embedding(embedding);
   };
 #endif

--- a/xllm/core/framework/model_context.cpp
+++ b/xllm/core/framework/model_context.cpp
@@ -38,9 +38,19 @@ ModelContext::ModelContext(const ParallelArgs& input_parallel_args,
       tensor_options_(tensor_options) {
 #if defined(USE_NPU)
   int32_t device_id = tensor_options.device().index();
-  void* stream = c10_npu::getCurrentNPUStream(device_id).stream();
+  aclError ret = aclrtSetDevice(device_id);
   atb::CreateContext(&context_);
-  context_->SetExecuteStream(stream);
+  std::vector<aclrtStream> streams;
+  streams.push_back(c10_npu::getCurrentNPUStream(device_id).stream());
+  for (int i = 0; i < 1; ++i) {
+    aclrtStream sub_stream;
+    aclError ret = aclrtCreateStream(&sub_stream);
+    if (ret != ACL_ERROR_NONE) {
+      ATB_SPEED_LOG_ERROR("Failed to create aclrtStream: " << ret);
+    }
+    streams.push_back(sub_stream);
+  }
+  context_->SetExecuteStreams(streams);
   context_->SetAsyncTilingCopyStatus(true);
 #endif
 }

--- a/xllm/core/layers/npu/buffer/atb_buffer.cpp
+++ b/xllm/core/layers/npu/buffer/atb_buffer.cpp
@@ -46,12 +46,9 @@ void* AtbBuffer::get_buffer(uint64_t buffer_size) {
     return at_tensor_.data_ptr();
   }
 
-  if (aclrtSynchronizeDevice() != 0) {
-    return nullptr;
-  }
+  aclrtSynchronizeStream(
+      c10_npu::getCurrentNPUStream(device_.index()).stream());
 
-  int device_id = device_.index();
-  torch::npu::synchronize(device_id);
   at_tensor_.reset();
   at_tensor_ = create_attensor(buffer_size);
   buffer_size_ = uint64_t(at_tensor_.numel());

--- a/xllm/core/layers/npu/npu_base_layer.h
+++ b/xllm/core/layers/npu/npu_base_layer.h
@@ -61,13 +61,15 @@ class NpuBaseLayer : public BaseLayer {
 
   atb::Status execute_node(atb_speed::Model::Node& node,
                            int nodeId = 0,
-                           aclrtEvent* event = nullptr,
-                           std::atomic<bool>* event_flag = nullptr);
+                           std::vector<aclrtEvent*> event = {nullptr, nullptr},
+                           std::vector<std::atomic<bool>*> event_flag = {
+                               nullptr,
+                               nullptr});
 
   atb::Status execute_plan(const atb_speed::Model::Node& node,
                            const std::string& op_name,
-                           aclrtEvent* event,
-                           std::atomic<bool>* event_flag);
+                           std::vector<aclrtEvent*> event,
+                           std::vector<std::atomic<bool>*> event_flag);
 
   virtual void run_task(std::string taskName,
                         std::function<int()> task) const override;

--- a/xllm/core/layers/npu/npu_deepseek_v2_decoder_layer_impl.cpp
+++ b/xllm/core/layers/npu/npu_deepseek_v2_decoder_layer_impl.cpp
@@ -21,11 +21,6 @@ limitations under the License.
 
 #include "common/global_flags.h"
 
-DECLARE_string(rank_tablefile);
-DECLARE_string(communication_backend);
-DECLARE_int32(expert_parallel_degree);
-DECLARE_bool(enable_continuous_kvcache);
-
 namespace xllm {
 namespace layer {
 
@@ -1464,6 +1459,11 @@ int64_t NpuDeepseekV2DecoderLayerImpl::init_layer() {
 int64_t NpuDeepseekV2DecoderLayerImpl::init_node(
     atb_speed::Model::Node& node,
     atb_speed::deepseekV2::DecoderLayerParam& param) {
+  bool eplb_enabled = FLAGS_enable_eplb &&
+                      layer_id_ >= decode_param_.firstKDenseReplace &&
+                      !param.isPrefill;
+  bool multi_stream_parallel_enabled =
+      param.isPrefill && FLAGS_enable_multi_stream_parallel;
   atb::Operation* operation = nullptr;
   atb_speed::deepseekV2::DecoderLayer(param, &operation);
   node.operation.reset(operation);
@@ -1477,8 +1477,7 @@ int64_t NpuDeepseekV2DecoderLayerImpl::init_node(
   }
   node.inTensors.resize(node.operation->GetInputNum());
 
-  if (FLAGS_enable_eplb && layer_id_ >= decode_param_.firstKDenseReplace &&
-      !param.isPrefill) {
+  if (eplb_enabled || multi_stream_parallel_enabled) {
     node.outTensors.resize(2);
   } else {
     node.outTensors.resize(1);
@@ -1494,8 +1493,9 @@ int64_t NpuDeepseekV2DecoderLayerImpl::init_node(
   node.variantPack.inTensors.reserve(node.inTensors.size());
   node.variantPack.inTensors.resize(node.inTensors.size());
 
-  if (FLAGS_enable_eplb && layer_id_ >= decode_param_.firstKDenseReplace &&
-      !param.isPrefill) {
+  // eplb used in decode stage, while multi stream parallel used in prefill
+  // stage
+  if (eplb_enabled || multi_stream_parallel_enabled) {
     node.variantPack.outTensors.reserve(2);
     node.variantPack.outTensors.resize(2);  // TODO
   } else {
@@ -1506,18 +1506,19 @@ int64_t NpuDeepseekV2DecoderLayerImpl::init_node(
 }
 
 torch::Tensor NpuDeepseekV2DecoderLayerImpl::forward(
-    torch::Tensor& x,
-    torch::Tensor& cos_pos,
-    torch::Tensor& sin_pos,
-    torch::Tensor& attn_mask,
+    std::vector<torch::Tensor>& x,
+    std::vector<torch::Tensor>& cos_pos,
+    std::vector<torch::Tensor>& sin_pos,
+    std::vector<torch::Tensor>& attn_mask,
     KVCache& kv_cache,
-    const ModelInputParams& input_params,
-    aclrtEvent* event,
-    std::atomic<bool>* event_flag,
+    const std::vector<ModelInputParams>& input_params,
+    std::vector<aclrtEvent*> event,
+    std::vector<std::atomic<bool>*> event_flag,
     int node_id) {
   atb::Status st;
-
-  if (input_params.global_empty_kv_cache) {
+  // all micro batches are in same prefill/decode stage,
+  //  so, to judge empty_kv_cache, use input_params[0] here
+  if (input_params[0].global_empty_kv_cache) {
     build_node_variant_pack(prefill_node_,
                             x,
                             cos_pos,
@@ -1530,11 +1531,13 @@ torch::Tensor NpuDeepseekV2DecoderLayerImpl::forward(
     LOG_IF(FATAL, st != 0) << model_name_
                            << "excute prefill layer fail, error code: " << st;
   } else {
+    std::vector<torch::Tensor> attn_mask{tensor_placeholder_,
+                                         tensor_placeholder_};
     build_node_variant_pack(decode_node_,
                             x,
                             cos_pos,
                             sin_pos,
-                            /*attn_mask*/ tensor_placeholder_,
+                            attn_mask,
                             kv_cache,
                             input_params,
                             false);
@@ -1547,18 +1550,19 @@ torch::Tensor NpuDeepseekV2DecoderLayerImpl::forward(
 
 void NpuDeepseekV2DecoderLayerImpl::build_node_variant_pack(
     atb_speed::Model::Node& node,
-    torch::Tensor& x,
-    torch::Tensor& cos_pos,
-    torch::Tensor& sin_pos,
-    torch::Tensor& attn_mask,
+    std::vector<torch::Tensor>& x,
+    std::vector<torch::Tensor>& cos_pos,
+    std::vector<torch::Tensor>& sin_pos,
+    std::vector<torch::Tensor>& attn_mask,
     KVCache& kv_cache,
-    const ModelInputParams& input_params,
+    const std::vector<ModelInputParams>& input_params,
     bool is_prefill) {
-  internal_tensor_ = atb_speed::Utils::AtTensor2Tensor(x);
+  internal_tensor_ = atb_speed::Utils::AtTensor2Tensor(x[0]);
   // final_hidden_states_ = torch::zeros_like(x);
   int32_t input_idx = 0;
-  auto& dp_ep_padding = input_params.dp_ep_padding_data;
+  auto& dp_ep_padding = input_params[0].dp_ep_padding_data;
 
+  // set micro batch 0 input part
   node.variantPack.inTensors.at(WEIGHT_COUNT_PER_LAYER) = internal_tensor_;
   node.variantPack.inTensors.at(WEIGHT_COUNT_PER_LAYER + 1) =
       atb_speed::Utils::AtTensor2Tensor(dp_ep_padding.expert_array());
@@ -1571,11 +1575,11 @@ void NpuDeepseekV2DecoderLayerImpl::build_node_variant_pack(
   node.variantPack.inTensors.at(WEIGHT_COUNT_PER_LAYER + 5) =
       atb_speed::Utils::AtTensor2Tensor(tensor_placeholder_);
   node.variantPack.inTensors.at(WEIGHT_COUNT_PER_LAYER + 6) =
-      atb_speed::Utils::AtTensor2Tensor(cos_pos);
+      atb_speed::Utils::AtTensor2Tensor(cos_pos[0]);
   node.variantPack.inTensors.at(WEIGHT_COUNT_PER_LAYER + 7) =
-      atb_speed::Utils::AtTensor2Tensor(sin_pos);
+      atb_speed::Utils::AtTensor2Tensor(sin_pos[0]);
   node.variantPack.inTensors.at(WEIGHT_COUNT_PER_LAYER + 8) =
-      atb_speed::Utils::AtTensor2Tensor(attn_mask);
+      atb_speed::Utils::AtTensor2Tensor(attn_mask[0]);
 
   if (!FLAGS_enable_continuous_kvcache) {
     node.variantPack.inTensors.at(WEIGHT_COUNT_PER_LAYER + 9) =
@@ -1589,8 +1593,8 @@ void NpuDeepseekV2DecoderLayerImpl::build_node_variant_pack(
         XTensor2Tensor(kv_cache.get_v_xtensor());
   }
 
-  if ((!input_params.block_tables.defined() ||
-       input_params.block_tables.storage().data() == nullptr) &&
+  if ((!input_params[0].block_tables.defined() ||
+       input_params[0].block_tables.storage().data() == nullptr) &&
       !FLAGS_enable_continuous_kvcache) {
     node.variantPack.inTensors.at(WEIGHT_COUNT_PER_LAYER + 11) =
         atb_speed::Utils::AtTensor2Tensor(int_tensor_placeholder_);
@@ -1598,9 +1602,9 @@ void NpuDeepseekV2DecoderLayerImpl::build_node_variant_pack(
         const_cast<int32_t*>(placeholder_vec_.data());
   } else {
     node.variantPack.inTensors.at(WEIGHT_COUNT_PER_LAYER + 11) =
-        atb_speed::Utils::AtTensor2Tensor(input_params.kv_seq_lens);
+        atb_speed::Utils::AtTensor2Tensor(input_params[0].kv_seq_lens);
     node.variantPack.inTensors.at(WEIGHT_COUNT_PER_LAYER + 11).hostData =
-        const_cast<int32_t*>(input_params.kv_seq_lens_vec.data());
+        const_cast<int32_t*>(input_params[0].kv_seq_lens_vec.data());
   }
 
   node.variantPack.inTensors.at(WEIGHT_COUNT_PER_LAYER + 12) =
@@ -1613,28 +1617,30 @@ void NpuDeepseekV2DecoderLayerImpl::build_node_variant_pack(
       atb_speed::Utils::AtTensor2Tensor(tensor_placeholder_);
 
   if (!FLAGS_enable_continuous_kvcache) {
-    if (!input_params.block_tables.defined() ||
-        input_params.block_tables.storage().data() == nullptr) {
+    if (!input_params[0].block_tables.defined() ||
+        input_params[0].block_tables.storage().data() == nullptr) {
       node.variantPack.inTensors.at(WEIGHT_COUNT_PER_LAYER + 15) =
           atb_speed::Utils::AtTensor2Tensor(block_tables_placeholder_);
       node.variantPack.inTensors.at(WEIGHT_COUNT_PER_LAYER + 16) =
           atb_speed::Utils::AtTensor2Tensor(slot_tensor_placeholder_);
     } else {
       node.variantPack.inTensors.at(WEIGHT_COUNT_PER_LAYER + 15) =
-          atb_speed::Utils::AtTensor2Tensor(input_params.block_tables);
+          atb_speed::Utils::AtTensor2Tensor(input_params[0].block_tables);
       node.variantPack.inTensors.at(WEIGHT_COUNT_PER_LAYER + 16) =
-          atb_speed::Utils::AtTensor2Tensor(input_params.new_cache_slots);
+          atb_speed::Utils::AtTensor2Tensor(input_params[0].new_cache_slots);
     }
   } else {
     node.variantPack.inTensors.at(WEIGHT_COUNT_PER_LAYER + 15) =
-        atb_speed::Utils::AtTensor2Tensor(input_params.kv_cache_start_offsets);
+        atb_speed::Utils::AtTensor2Tensor(
+            input_params[0].kv_cache_start_offsets);
     node.variantPack.inTensors.at(WEIGHT_COUNT_PER_LAYER + 16) =
-        atb_speed::Utils::AtTensor2Tensor(input_params.new_cache_slot_offsets);
+        atb_speed::Utils::AtTensor2Tensor(
+            input_params[0].new_cache_slot_offsets);
   }
 
   if (num_speculative_tokens_ > 0 && !is_prefill) {
-    if ((!input_params.block_tables.defined() ||
-         input_params.block_tables.storage().data() == nullptr) &&
+    if ((!input_params[0].block_tables.defined() ||
+         input_params[0].block_tables.storage().data() == nullptr) &&
         !FLAGS_enable_continuous_kvcache) {
       node.variantPack.inTensors.at(WEIGHT_COUNT_PER_LAYER + 17) =
           atb_speed::Utils::AtTensor2Tensor(int_tensor_placeholder_);
@@ -1642,40 +1648,226 @@ void NpuDeepseekV2DecoderLayerImpl::build_node_variant_pack(
           const_cast<int32_t*>(placeholder_vec_.data());
     } else {
       node.variantPack.inTensors.at(WEIGHT_COUNT_PER_LAYER + 17) =
-          atb_speed::Utils::AtTensor2Tensor(input_params.q_seq_lens);
+          atb_speed::Utils::AtTensor2Tensor(input_params[0].q_seq_lens);
       node.variantPack.inTensors.at(WEIGHT_COUNT_PER_LAYER + 17).hostData =
-          const_cast<int32_t*>(input_params.q_seq_lens_vec.data());
+          const_cast<int32_t*>(input_params[0].q_seq_lens_vec.data());
     }
   } else {
     node.variantPack.inTensors.at(WEIGHT_COUNT_PER_LAYER + 17) =
         atb_speed::Utils::AtTensor2Tensor(tensor_placeholder_);
   }
 
-  node.variantPack.inTensors.at(WEIGHT_COUNT_PER_LAYER + 18) =
-      atb_speed::Utils::AtTensor2Tensor(dp_ep_padding.attn_padding_idx());
-  node.variantPack.inTensors.at(WEIGHT_COUNT_PER_LAYER + 19) =
-      atb_speed::Utils::AtTensor2Tensor(dp_ep_padding.attn_unpadding_idx());
-  node.variantPack.inTensors.at(WEIGHT_COUNT_PER_LAYER + 20) =
-      atb_speed::Utils::AtTensor2Tensor(dp_ep_padding.ffn_padding_idx());
-  node.variantPack.inTensors.at(WEIGHT_COUNT_PER_LAYER + 21) =
-      atb_speed::Utils::AtTensor2Tensor(dp_ep_padding.ffn_unpadding_idx());
-  node.variantPack.inTensors.at(WEIGHT_COUNT_PER_LAYER + 22) =
-      atb_speed::Utils::AtTensor2Tensor(
-          dp_ep_padding.lm_head_skip_padding_token_indices());
-  node.variantPack.inTensors.at(WEIGHT_COUNT_PER_LAYER + 23) =
-      atb_speed::Utils::AtTensor2Tensor(dp_ep_padding.gather_prenorm_idx());
-  node.variantPack.inTensors.at(WEIGHT_COUNT_PER_LAYER + 24) =
-      atb_speed::Utils::AtTensor2Tensor(at_start_expert_id_);
-  node.variantPack.inTensors.at(WEIGHT_COUNT_PER_LAYER + 25) =
-      atb_speed::Utils::AtTensor2Tensor(at_in_device_expert_count_);
-  node.variantPack.inTensors.at(WEIGHT_COUNT_PER_LAYER + 26) =
-      atb_speed::Utils::AtTensor2Tensor(dp_ep_padding.padding_idx());
-  node.variantPack.inTensors.at(WEIGHT_COUNT_PER_LAYER + 27) =
-      atb_speed::Utils::AtTensor2Tensor(dp_ep_padding.un_padding_idx());
-  node.variantPack.inTensors.at(WEIGHT_COUNT_PER_LAYER + 28) =
-      atb_speed::Utils::AtTensor2Tensor(dp_ep_padding.dynamic_ep_idx());
-  node.variantPack.inTensors.at(WEIGHT_COUNT_PER_LAYER + 29) =
-      atb_speed::Utils::AtTensor2Tensor(dp_ep_padding.moe_idx());
+  if (is_prefill && FLAGS_enable_multi_stream_parallel) {
+    internal_tensor_auxiliary_ = atb_speed::Utils::AtTensor2Tensor(x[1]);
+    auto& dp_ep_padding_auxiliary = input_params[1].dp_ep_padding_data;
+
+    // set micro batch 1 input part
+    auto offset = 18;
+    node.variantPack.inTensors.at(WEIGHT_COUNT_PER_LAYER + offset) =
+        internal_tensor_auxiliary_;
+    node.variantPack.inTensors.at(WEIGHT_COUNT_PER_LAYER + 1 + offset) =
+        atb_speed::Utils::AtTensor2Tensor(
+            dp_ep_padding_auxiliary.expert_array());
+    node.variantPack.inTensors.at(WEIGHT_COUNT_PER_LAYER + 2 + offset) =
+        atb_speed::Utils::AtTensor2Tensor(expert_group_);
+    node.variantPack.inTensors.at(WEIGHT_COUNT_PER_LAYER + 3 + offset) =
+        atb_speed::Utils::AtTensor2Tensor(one_hot_);
+    node.variantPack.inTensors.at(WEIGHT_COUNT_PER_LAYER + 4 + offset) =
+        atb_speed::Utils::AtTensor2Tensor(zero_hot_);
+    node.variantPack.inTensors.at(WEIGHT_COUNT_PER_LAYER + 5 + offset) =
+        atb_speed::Utils::AtTensor2Tensor(tensor_placeholder_);
+    node.variantPack.inTensors.at(WEIGHT_COUNT_PER_LAYER + 6 + offset) =
+        atb_speed::Utils::AtTensor2Tensor(cos_pos[1]);
+    node.variantPack.inTensors.at(WEIGHT_COUNT_PER_LAYER + 7 + offset) =
+        atb_speed::Utils::AtTensor2Tensor(sin_pos[1]);
+    node.variantPack.inTensors.at(WEIGHT_COUNT_PER_LAYER + 8 + offset) =
+        atb_speed::Utils::AtTensor2Tensor(attn_mask[1]);
+
+    if (!FLAGS_enable_continuous_kvcache) {
+      node.variantPack.inTensors.at(WEIGHT_COUNT_PER_LAYER + 9 + offset) =
+          atb_speed::Utils::AtTensor2Tensor(kv_cache.get_k_cache());
+      node.variantPack.inTensors.at(WEIGHT_COUNT_PER_LAYER + 10 + offset) =
+          atb_speed::Utils::AtTensor2Tensor(kv_cache.get_v_cache());
+    } else {
+      node.variantPack.inTensors.at(WEIGHT_COUNT_PER_LAYER + 9 + offset) =
+          XTensor2Tensor(kv_cache.get_k_xtensor());
+      node.variantPack.inTensors.at(WEIGHT_COUNT_PER_LAYER + 10 + offset) =
+          XTensor2Tensor(kv_cache.get_v_xtensor());
+    }
+
+    if ((!input_params[1].block_tables.defined() ||
+         input_params[1].block_tables.storage().data() == nullptr) &&
+        !FLAGS_enable_continuous_kvcache) {
+      node.variantPack.inTensors.at(WEIGHT_COUNT_PER_LAYER + 11 + offset) =
+          atb_speed::Utils::AtTensor2Tensor(int_tensor_placeholder_);
+      node.variantPack.inTensors.at(WEIGHT_COUNT_PER_LAYER + 11 + offset)
+          .hostData = const_cast<int32_t*>(placeholder_vec_.data());
+    } else {
+      node.variantPack.inTensors.at(WEIGHT_COUNT_PER_LAYER + 11 + offset) =
+          atb_speed::Utils::AtTensor2Tensor(input_params[1].kv_seq_lens);
+      node.variantPack.inTensors.at(WEIGHT_COUNT_PER_LAYER + 11 + offset)
+          .hostData =
+          const_cast<int32_t*>(input_params[1].kv_seq_lens_vec.data());
+    }
+
+    node.variantPack.inTensors.at(WEIGHT_COUNT_PER_LAYER + 12 + offset) =
+        atb_speed::Utils::AtTensor2Tensor(tensor_placeholder_);
+    node.variantPack.inTensors.at(WEIGHT_COUNT_PER_LAYER + 13 + offset) =
+        atb_speed::Utils::AtTensor2Tensor(tensor_placeholder_);
+    node.variantPack.inTensors.at(WEIGHT_COUNT_PER_LAYER + 13 + offset)
+        .hostData = const_cast<int32_t*>(placeholder_vec_.data());
+    node.variantPack.inTensors.at(WEIGHT_COUNT_PER_LAYER + 14 + offset) =
+        atb_speed::Utils::AtTensor2Tensor(tensor_placeholder_);
+
+    if (!FLAGS_enable_continuous_kvcache) {
+      if (!input_params[1].block_tables.defined() ||
+          input_params[1].block_tables.storage().data() == nullptr) {
+        node.variantPack.inTensors.at(WEIGHT_COUNT_PER_LAYER + 15 + offset) =
+            atb_speed::Utils::AtTensor2Tensor(block_tables_placeholder_);
+        node.variantPack.inTensors.at(WEIGHT_COUNT_PER_LAYER + 16 + offset) =
+            atb_speed::Utils::AtTensor2Tensor(slot_tensor_placeholder_);
+      } else {
+        node.variantPack.inTensors.at(WEIGHT_COUNT_PER_LAYER + 15 + offset) =
+            atb_speed::Utils::AtTensor2Tensor(input_params[1].block_tables);
+        node.variantPack.inTensors.at(WEIGHT_COUNT_PER_LAYER + 16 + offset) =
+            atb_speed::Utils::AtTensor2Tensor(input_params[1].new_cache_slots);
+      }
+    } else {
+      node.variantPack.inTensors.at(WEIGHT_COUNT_PER_LAYER + 15 + offset) =
+          atb_speed::Utils::AtTensor2Tensor(
+              input_params[1].kv_cache_start_offsets);
+      node.variantPack.inTensors.at(WEIGHT_COUNT_PER_LAYER + 16 + offset) =
+          atb_speed::Utils::AtTensor2Tensor(
+              input_params[1].new_cache_slot_offsets);
+    }
+
+    if (num_speculative_tokens_ > 0 && !is_prefill) {
+      if ((!input_params[1].block_tables.defined() ||
+           input_params[1].block_tables.storage().data() == nullptr) &&
+          !FLAGS_enable_continuous_kvcache) {
+        node.variantPack.inTensors.at(WEIGHT_COUNT_PER_LAYER + 17 + offset) =
+            atb_speed::Utils::AtTensor2Tensor(int_tensor_placeholder_);
+        node.variantPack.inTensors.at(WEIGHT_COUNT_PER_LAYER + 17 + offset)
+            .hostData = const_cast<int32_t*>(placeholder_vec_.data());
+      } else {
+        node.variantPack.inTensors.at(WEIGHT_COUNT_PER_LAYER + 17 + offset) =
+            atb_speed::Utils::AtTensor2Tensor(input_params[1].q_seq_lens);
+        node.variantPack.inTensors.at(WEIGHT_COUNT_PER_LAYER + 17 + offset)
+            .hostData =
+            const_cast<int32_t*>(input_params[1].q_seq_lens_vec.data());
+      }
+    } else {
+      node.variantPack.inTensors.at(WEIGHT_COUNT_PER_LAYER + 17 + offset) =
+          atb_speed::Utils::AtTensor2Tensor(tensor_placeholder_);
+    }
+
+    // set micro batch 0 dp_ep_padding part
+    node.variantPack.inTensors.at(WEIGHT_COUNT_PER_LAYER + 18 + offset) =
+        atb_speed::Utils::AtTensor2Tensor(dp_ep_padding.attn_padding_idx());
+    node.variantPack.inTensors.at(WEIGHT_COUNT_PER_LAYER + 19 + offset) =
+        atb_speed::Utils::AtTensor2Tensor(dp_ep_padding.attn_unpadding_idx());
+    node.variantPack.inTensors.at(WEIGHT_COUNT_PER_LAYER + 20 + offset) =
+        atb_speed::Utils::AtTensor2Tensor(dp_ep_padding.ffn_padding_idx());
+    node.variantPack.inTensors.at(WEIGHT_COUNT_PER_LAYER + 21 + offset) =
+        atb_speed::Utils::AtTensor2Tensor(dp_ep_padding.ffn_unpadding_idx());
+    node.variantPack.inTensors.at(WEIGHT_COUNT_PER_LAYER + 22 + offset) =
+        atb_speed::Utils::AtTensor2Tensor(
+            dp_ep_padding.lm_head_skip_padding_token_indices());
+    node.variantPack.inTensors.at(WEIGHT_COUNT_PER_LAYER + 23 + offset) =
+        atb_speed::Utils::AtTensor2Tensor(dp_ep_padding.gather_prenorm_idx());
+    node.variantPack.inTensors.at(WEIGHT_COUNT_PER_LAYER + 24 + offset) =
+        atb_speed::Utils::AtTensor2Tensor(at_start_expert_id_);
+    node.variantPack.inTensors.at(WEIGHT_COUNT_PER_LAYER + 25 + offset) =
+        atb_speed::Utils::AtTensor2Tensor(at_in_device_expert_count_);
+    node.variantPack.inTensors.at(WEIGHT_COUNT_PER_LAYER + 26 + offset) =
+        atb_speed::Utils::AtTensor2Tensor(dp_ep_padding.padding_idx());
+    node.variantPack.inTensors.at(WEIGHT_COUNT_PER_LAYER + 27 + offset) =
+        atb_speed::Utils::AtTensor2Tensor(dp_ep_padding.un_padding_idx());
+    node.variantPack.inTensors.at(WEIGHT_COUNT_PER_LAYER + 28 + offset) =
+        atb_speed::Utils::AtTensor2Tensor(dp_ep_padding.dynamic_ep_idx());
+    node.variantPack.inTensors.at(WEIGHT_COUNT_PER_LAYER + 29 + offset) =
+        atb_speed::Utils::AtTensor2Tensor(dp_ep_padding.moe_idx());
+
+    // set micro batch 1 dp_ep_padding part
+    offset = 30;
+    node.variantPack.inTensors.at(WEIGHT_COUNT_PER_LAYER + 18 + offset) =
+        atb_speed::Utils::AtTensor2Tensor(
+            dp_ep_padding_auxiliary.attn_padding_idx());
+    node.variantPack.inTensors.at(WEIGHT_COUNT_PER_LAYER + 19 + offset) =
+        atb_speed::Utils::AtTensor2Tensor(
+            dp_ep_padding_auxiliary.attn_unpadding_idx());
+    node.variantPack.inTensors.at(WEIGHT_COUNT_PER_LAYER + 20 + offset) =
+        atb_speed::Utils::AtTensor2Tensor(
+            dp_ep_padding_auxiliary.ffn_padding_idx());
+    node.variantPack.inTensors.at(WEIGHT_COUNT_PER_LAYER + 21 + offset) =
+        atb_speed::Utils::AtTensor2Tensor(
+            dp_ep_padding_auxiliary.ffn_unpadding_idx());
+    node.variantPack.inTensors.at(WEIGHT_COUNT_PER_LAYER + 22 + offset) =
+        atb_speed::Utils::AtTensor2Tensor(
+            dp_ep_padding_auxiliary.lm_head_skip_padding_token_indices());
+    node.variantPack.inTensors.at(WEIGHT_COUNT_PER_LAYER + 23 + offset) =
+        atb_speed::Utils::AtTensor2Tensor(
+            dp_ep_padding_auxiliary.gather_prenorm_idx());
+    node.variantPack.inTensors.at(WEIGHT_COUNT_PER_LAYER + 24 + offset) =
+        atb_speed::Utils::AtTensor2Tensor(at_start_expert_id_);
+    node.variantPack.inTensors.at(WEIGHT_COUNT_PER_LAYER + 25 + offset) =
+        atb_speed::Utils::AtTensor2Tensor(at_in_device_expert_count_);
+    node.variantPack.inTensors.at(WEIGHT_COUNT_PER_LAYER + 26 + offset) =
+        atb_speed::Utils::AtTensor2Tensor(
+            dp_ep_padding_auxiliary.padding_idx());
+    node.variantPack.inTensors.at(WEIGHT_COUNT_PER_LAYER + 27 + offset) =
+        atb_speed::Utils::AtTensor2Tensor(
+            dp_ep_padding_auxiliary.un_padding_idx());
+    node.variantPack.inTensors.at(WEIGHT_COUNT_PER_LAYER + 28 + offset) =
+        atb_speed::Utils::AtTensor2Tensor(
+            dp_ep_padding_auxiliary.dynamic_ep_idx());
+    node.variantPack.inTensors.at(WEIGHT_COUNT_PER_LAYER + 29 + offset) =
+        atb_speed::Utils::AtTensor2Tensor(dp_ep_padding_auxiliary.moe_idx());
+
+    if (FLAGS_enable_eplb && layer_id_ >= decode_param_.firstKDenseReplace) {
+      // set micro batch 0 eplb part
+      node.variantPack.inTensors.at(WEIGHT_COUNT_PER_LAYER + 30 + offset) =
+          atb_speed::Utils::AtTensor2Tensor(expert_routing_map_);
+      // set micro batch 1 eplb part
+      node.variantPack.inTensors.at(WEIGHT_COUNT_PER_LAYER + 31 + offset) =
+          atb_speed::Utils::AtTensor2Tensor(expert_routing_map_);
+    }
+  } else {
+    node.variantPack.inTensors.at(WEIGHT_COUNT_PER_LAYER + 18) =
+        atb_speed::Utils::AtTensor2Tensor(dp_ep_padding.attn_padding_idx());
+    node.variantPack.inTensors.at(WEIGHT_COUNT_PER_LAYER + 19) =
+        atb_speed::Utils::AtTensor2Tensor(dp_ep_padding.attn_unpadding_idx());
+    node.variantPack.inTensors.at(WEIGHT_COUNT_PER_LAYER + 20) =
+        atb_speed::Utils::AtTensor2Tensor(dp_ep_padding.ffn_padding_idx());
+    node.variantPack.inTensors.at(WEIGHT_COUNT_PER_LAYER + 21) =
+        atb_speed::Utils::AtTensor2Tensor(dp_ep_padding.ffn_unpadding_idx());
+    node.variantPack.inTensors.at(WEIGHT_COUNT_PER_LAYER + 22) =
+        atb_speed::Utils::AtTensor2Tensor(
+            dp_ep_padding.lm_head_skip_padding_token_indices());
+    node.variantPack.inTensors.at(WEIGHT_COUNT_PER_LAYER + 23) =
+        atb_speed::Utils::AtTensor2Tensor(dp_ep_padding.gather_prenorm_idx());
+    node.variantPack.inTensors.at(WEIGHT_COUNT_PER_LAYER + 24) =
+        atb_speed::Utils::AtTensor2Tensor(at_start_expert_id_);
+    node.variantPack.inTensors.at(WEIGHT_COUNT_PER_LAYER + 25) =
+        atb_speed::Utils::AtTensor2Tensor(at_in_device_expert_count_);
+    node.variantPack.inTensors.at(WEIGHT_COUNT_PER_LAYER + 26) =
+        atb_speed::Utils::AtTensor2Tensor(dp_ep_padding.padding_idx());
+    node.variantPack.inTensors.at(WEIGHT_COUNT_PER_LAYER + 27) =
+        atb_speed::Utils::AtTensor2Tensor(dp_ep_padding.un_padding_idx());
+    node.variantPack.inTensors.at(WEIGHT_COUNT_PER_LAYER + 28) =
+        atb_speed::Utils::AtTensor2Tensor(dp_ep_padding.dynamic_ep_idx());
+    node.variantPack.inTensors.at(WEIGHT_COUNT_PER_LAYER + 29) =
+        atb_speed::Utils::AtTensor2Tensor(dp_ep_padding.moe_idx());
+    if (FLAGS_enable_eplb && layer_id_ >= decode_param_.firstKDenseReplace) {
+      node.variantPack.inTensors.at(WEIGHT_COUNT_PER_LAYER + 30) =
+          atb_speed::Utils::AtTensor2Tensor(expert_routing_map_);
+      if (!is_prefill) {
+        node.variantPack.outTensors.at(1) = atb_speed::Utils::AtTensor2Tensor(
+            input_params[0].expert_load_data[layer_id_ -
+                                             decode_param_.firstKDenseReplace]);
+      }
+    }
+  }
 
   for (size_t i = 0; i < WEIGHT_COUNT_PER_LAYER; ++i) {
     CHECK_THROW(node.inTensors.at(i) == nullptr,
@@ -1684,15 +1876,8 @@ void NpuDeepseekV2DecoderLayerImpl::build_node_variant_pack(
   }
 
   node.variantPack.outTensors.at(0) = internal_tensor_;
-
-  if (FLAGS_enable_eplb && layer_id_ >= decode_param_.firstKDenseReplace) {
-    node.variantPack.inTensors.at(WEIGHT_COUNT_PER_LAYER + 30) =
-        atb_speed::Utils::AtTensor2Tensor(expert_routing_map_);
-    if (!is_prefill) {
-      node.variantPack.outTensors.at(1) = atb_speed::Utils::AtTensor2Tensor(
-          input_params
-              .expert_load_data[layer_id_ - decode_param_.firstKDenseReplace]);
-    }
+  if (is_prefill && FLAGS_enable_multi_stream_parallel) {
+    node.variantPack.outTensors.at(1) = internal_tensor_auxiliary_;
   }
 }
 

--- a/xllm/core/layers/npu/npu_deepseek_v2_decoder_layer_impl.h
+++ b/xllm/core/layers/npu/npu_deepseek_v2_decoder_layer_impl.h
@@ -127,14 +127,15 @@ class NpuDeepseekV2DecoderLayerImpl : public NpuBaseLayer {
 
   virtual int64_t init_layer() override;
 
-  torch::Tensor forward(torch::Tensor& x,
-                        torch::Tensor& cos_pos,
-                        torch::Tensor& sin_pos,
-                        torch::Tensor& attn_mask,
+  torch::Tensor forward(std::vector<torch::Tensor>& x,
+                        std::vector<torch::Tensor>& cos_pos,
+                        std::vector<torch::Tensor>& sin_pos,
+                        std::vector<torch::Tensor>& attn_mask,
                         KVCache& kv_cache,
-                        const ModelInputParams& input_params,
-                        aclrtEvent* event = nullptr,
-                        std::atomic<bool>* event_flag = nullptr,
+                        const std::vector<ModelInputParams>& input_params,
+                        std::vector<aclrtEvent*> event = {nullptr, nullptr},
+                        std::vector<std::atomic<bool>*> event_flag = {nullptr,
+                                                                      nullptr},
                         int node_id = 0);
 
  private:
@@ -268,14 +269,15 @@ class NpuDeepseekV2DecoderLayerImpl : public NpuBaseLayer {
   int64_t init_node(atb_speed::Model::Node& node,
                     atb_speed::deepseekV2::DecoderLayerParam& param);
 
-  void build_node_variant_pack(atb_speed::Model::Node& node,
-                               torch::Tensor& x,
-                               torch::Tensor& cos_pos,
-                               torch::Tensor& sin_pos,
-                               torch::Tensor& attn_mask,
-                               KVCache& kv_cache,
-                               const ModelInputParams& input_params,
-                               bool is_prefill);
+  void build_node_variant_pack(
+      atb_speed::Model::Node& node,
+      std::vector<torch::Tensor>& x,
+      std::vector<torch::Tensor>& cos_pos,
+      std::vector<torch::Tensor>& sin_pos,
+      std::vector<torch::Tensor>& attn_mask,
+      KVCache& kv_cache,
+      const std::vector<ModelInputParams>& input_params,
+      bool is_prefill);
 
   torch::Tensor block_tables_placeholder_;
   std::string model_name_;
@@ -317,6 +319,7 @@ class NpuDeepseekV2DecoderLayerImpl : public NpuBaseLayer {
   atb_speed::Model::Node decode_node_;
 
   atb::Tensor internal_tensor_;
+  atb::Tensor internal_tensor_auxiliary_;
 
   torch::Tensor at_cumsum_;
   torch::Tensor tensor_placeholder_;

--- a/xllm/core/layers/npu/npu_qwen2_decoder_layer_impl.cpp
+++ b/xllm/core/layers/npu/npu_qwen2_decoder_layer_impl.cpp
@@ -21,11 +21,11 @@ limitations under the License.
 
 #include <map>
 
+#include "common/global_flags.h"
+
 // #include "attn_mask.h"
 #include "torch_npu/csrc/core/npu/NPUCachingAllocator.h"
 #include "torch_npu/csrc/core/npu/NPUException.h"
-
-DECLARE_bool(enable_chunked_prefill);
 
 namespace xllm {
 namespace layer {
@@ -394,26 +394,27 @@ int64_t NpuQwen2DecoderLayerImpl::init_node(
   return atb::NO_ERROR;
 }
 
-torch::Tensor NpuQwen2DecoderLayerImpl::forward(torch::Tensor& x,
-                                                torch::Tensor& cos_pos,
-                                                torch::Tensor& sin_pos,
-                                                torch::Tensor& attn_mask,
-                                                KVCache& kv_cache,
-                                                ModelInputParams& input_params,
-                                                aclrtEvent* event,
-                                                std::atomic<bool>* event_flag,
-                                                int node_id) {
+torch::Tensor NpuQwen2DecoderLayerImpl::forward(
+    std::vector<torch::Tensor>& x,
+    std::vector<torch::Tensor>& cos_pos,
+    std::vector<torch::Tensor>& sin_pos,
+    std::vector<torch::Tensor>& attn_mask,
+    KVCache& kv_cache,
+    std::vector<ModelInputParams>& input_params,
+    std::vector<aclrtEvent*> event,
+    std::vector<std::atomic<bool>*> event_flag,
+    int node_id) {
   atb::Status st;
-  if (input_params.prefill_indices.second !=
-      input_params.q_seq_lens.size(0) - 1) {
+  if (input_params[0].prefill_indices.second !=
+      input_params[0].q_seq_lens.size(0) - 1) {
     // mstxRangeId id = mstxRangeStartA("prefill build variant", nullptr);
     build_node_variant_pack(prefill_node_,
-                            x,
-                            cos_pos,
-                            sin_pos,
-                            attn_mask,
+                            x[0],
+                            cos_pos[0],
+                            sin_pos[0],
+                            attn_mask[0],
                             kv_cache,
-                            input_params,
+                            input_params[0],
                             true);
     // mstxRangeEnd(id);
     st = execute_node(prefill_node_, node_id, event, event_flag);
@@ -421,12 +422,12 @@ torch::Tensor NpuQwen2DecoderLayerImpl::forward(torch::Tensor& x,
                            << "excute prefill layer fail, error code: " << st;
   } else {
     build_node_variant_pack(decode_node_,
-                            x,
-                            cos_pos,
-                            sin_pos,
+                            x[0],
+                            cos_pos[0],
+                            sin_pos[0],
                             decode_attn_mask_,
                             kv_cache,
-                            input_params,
+                            input_params[0],
                             false);
     st = execute_node(decode_node_, node_id + 1000, event, event_flag);
     LOG_IF(FATAL, st != 0) << model_name_

--- a/xllm/core/layers/npu/npu_qwen2_decoder_layer_impl.h
+++ b/xllm/core/layers/npu/npu_qwen2_decoder_layer_impl.h
@@ -120,14 +120,15 @@ class NpuQwen2DecoderLayerImpl : public NpuBaseLayer {
 
   virtual int64_t init_layer() override;
 
-  torch::Tensor forward(torch::Tensor& x,
-                        torch::Tensor& cos_pos,
-                        torch::Tensor& sin_pos,
-                        torch::Tensor& attn_mask,
+  torch::Tensor forward(std::vector<torch::Tensor>& x,
+                        std::vector<torch::Tensor>& cos_pos,
+                        std::vector<torch::Tensor>& sin_pos,
+                        std::vector<torch::Tensor>& attn_mask,
                         KVCache& kv_cache,
-                        ModelInputParams& input_params,
-                        aclrtEvent* event = nullptr,
-                        std::atomic<bool>* event_flag = nullptr,
+                        std::vector<ModelInputParams>& input_params,
+                        std::vector<aclrtEvent*> event = {nullptr, nullptr},
+                        std::vector<std::atomic<bool>*> event_flag = {nullptr,
+                                                                      nullptr},
                         int node_id = 0);
 
  private:

--- a/xllm/core/layers/npu/npu_qwen3_decoder_layer_impl.h
+++ b/xllm/core/layers/npu/npu_qwen3_decoder_layer_impl.h
@@ -57,14 +57,15 @@ class NpuQwen3DecoderLayerImpl : public NpuBaseLayer {
 
   virtual int64_t init_layer() override;
 
-  torch::Tensor forward(torch::Tensor& x,
-                        torch::Tensor& cos_pos,
-                        torch::Tensor& sin_pos,
-                        torch::Tensor& attn_mask,
+  torch::Tensor forward(std::vector<torch::Tensor>& x,
+                        std::vector<torch::Tensor>& cos_pos,
+                        std::vector<torch::Tensor>& sin_pos,
+                        std::vector<torch::Tensor>& attn_mask,
                         KVCache& kv_cache,
-                        ModelInputParams& input_params,
-                        aclrtEvent* event = nullptr,
-                        std::atomic<bool>* event_flag = nullptr,
+                        std::vector<ModelInputParams>& input_params,
+                        std::vector<aclrtEvent*> event = {nullptr, nullptr},
+                        std::vector<std::atomic<bool>*> event_flag = {nullptr,
+                                                                      nullptr},
                         int node_id = 0);
 
  private:
@@ -74,12 +75,12 @@ class NpuQwen3DecoderLayerImpl : public NpuBaseLayer {
                        bool isPrefill);
 
   void build_node_variant_pack(atb_speed::Model::Node& node,
-                               torch::Tensor& x,
-                               torch::Tensor& cos_pos,
-                               torch::Tensor& sin_pos,
-                               torch::Tensor& attn_mask,
+                               std::vector<torch::Tensor>& x,
+                               std::vector<torch::Tensor>& cos_pos,
+                               std::vector<torch::Tensor>& sin_pos,
+                               std::vector<torch::Tensor>& attn_mask,
                                KVCache& kv_cache,
-                               ModelInputParams& input_params,
+                               std::vector<ModelInputParams>& input_params,
                                bool is_prefill);
 
   void initialize_quantization_parameters(
@@ -96,7 +97,11 @@ class NpuQwen3DecoderLayerImpl : public NpuBaseLayer {
   atb_speed::qwen::QwenLayerParam prefill_param_;
   atb_speed::qwen::QwenLayerParam decode_param_;
   atb::Tensor internal_tensors_;
+  atb::Tensor internal_tensors_auxiliary;
   atb::Tensor placeholder_;
+  torch::Tensor int_tensor_placeholder_;
+  torch::Tensor block_tables_placeholder_;
+  torch::Tensor slot_tensor_placeholder_;
 
   at::Tensor decode_attn_mask_;
 

--- a/xllm/core/layers/npu/npu_qwen3_moe_decoder_layer_impl.cpp
+++ b/xllm/core/layers/npu/npu_qwen3_moe_decoder_layer_impl.cpp
@@ -17,9 +17,7 @@ limitations under the License.
 
 #include <gflags/gflags.h>
 
-DECLARE_string(rank_tablefile);
-DECLARE_string(communication_backend);
-DECLARE_int32(expert_parallel_degree);
+#include "common/global_flags.h"
 
 namespace xllm {
 namespace layer {
@@ -881,7 +879,7 @@ torch::Tensor NpuQwen3MoeDecoderLayerImpl::forward(
                             input_params,
                             expert_array,
                             true);
-    st = execute_node(prefill_node_, node_id, event, event_flag);
+    st = execute_node(prefill_node_, node_id, {event}, {event_flag});
     LOG_IF(FATAL, st != 0) << model_name_
                            << "excute prefill layer fail, error code: " << st;
   } else {
@@ -894,7 +892,7 @@ torch::Tensor NpuQwen3MoeDecoderLayerImpl::forward(
                             input_params,
                             expert_array,
                             false);
-    st = execute_node(decode_node_, node_id + 1000, event, event_flag);
+    st = execute_node(decode_node_, node_id + 1000, {event}, {event_flag});
     LOG_IF(FATAL, st != 0) << model_name_
                            << "excute decode layer fail, error code: " << st;
   }

--- a/xllm/core/runtime/embed_vlm_worker_impl.cpp
+++ b/xllm/core/runtime/embed_vlm_worker_impl.cpp
@@ -82,7 +82,7 @@ std::optional<ForwardOutput> EmbedVLMWorkerImpl::step(
 
   // call model executor forward to get hidden states
   auto hidden_states = model_executor_->forward(
-      flatten_tokens, flatten_positions, kv_caches_, params);
+      {flatten_tokens}, {flatten_positions}, kv_caches_, {params});
 
 #if defined(USE_NPU)
   torch::npu::synchronize();

--- a/xllm/core/runtime/embed_worker_impl.cpp
+++ b/xllm/core/runtime/embed_worker_impl.cpp
@@ -76,7 +76,7 @@ std::optional<ForwardOutput> EmbedWorkerImpl::step(
 
   // call model executor forward to get hidden states
   auto hidden_states = model_executor_->forward(
-      flatten_tokens, flatten_positions, kv_caches_, params);
+      {flatten_tokens}, {flatten_positions}, kv_caches_, {params});
 
   COUNTER_ADD(execution_latency_seconds_model, timer.elapsed_seconds());
 

--- a/xllm/core/runtime/executor.cpp
+++ b/xllm/core/runtime/executor.cpp
@@ -35,10 +35,10 @@ ForwardInput Executor::prepare_inputs(Batch& batch) {
   return impl_->prepare_inputs(batch);
 }
 
-torch::Tensor Executor::forward(const torch::Tensor& tokens,
-                                const torch::Tensor& positions,
+torch::Tensor Executor::forward(const std::vector<torch::Tensor>& tokens,
+                                const std::vector<torch::Tensor>& positions,
                                 std::vector<KVCache>& kv_caches,
-                                const ModelInputParams& params) {
+                                const std::vector<ModelInputParams>& params) {
   COUNTER_INC(num_model_execution_total_eager);
   return impl_->run(tokens, positions, kv_caches, params);
 }

--- a/xllm/core/runtime/executor.h
+++ b/xllm/core/runtime/executor.h
@@ -44,10 +44,10 @@ class Executor final {
   // tokens: [num_tokens]
   // positions: [num_tokens] token pos in the sequence
   // returns: [num_tokens, hidden_size]
-  torch::Tensor forward(const torch::Tensor& tokens,
-                        const torch::Tensor& positions,
+  torch::Tensor forward(const std::vector<torch::Tensor>& tokens,
+                        const std::vector<torch::Tensor>& positions,
                         std::vector<KVCache>& kv_caches,
-                        const ModelInputParams& params);
+                        const std::vector<ModelInputParams>& params);
 
  private:
   std::unique_ptr<ExecutorImpl> impl_;

--- a/xllm/core/runtime/executor_impl.h
+++ b/xllm/core/runtime/executor_impl.h
@@ -35,10 +35,10 @@ class ExecutorImpl {
 
   virtual ForwardInput prepare_inputs(Batch& batch) = 0;
 
-  virtual torch::Tensor run(const torch::Tensor& tokens,
-                            const torch::Tensor& positions,
+  virtual torch::Tensor run(const std::vector<torch::Tensor>& tokens,
+                            const std::vector<torch::Tensor>& positions,
                             std::vector<KVCache>& kv_caches,
-                            const ModelInputParams& params) = 0;
+                            const std::vector<ModelInputParams>& params) = 0;
 };
 
 }  // namespace xllm

--- a/xllm/core/runtime/llm_engine.cpp
+++ b/xllm/core/runtime/llm_engine.cpp
@@ -736,11 +736,11 @@ void LLMEngine::process_eplb_data(
 }
 
 uint32_t determine_micro_batches_num(const std::vector<Batch>& batch) {
-  bool is_all_prefill =
-      std::all_of(batch.begin(), batch.end(), [](const Batch& one_batch) {
+  bool not_all_in_decode =
+      std::any_of(batch.begin(), batch.end(), [](const Batch& one_batch) {
         return one_batch.get_batch_prefill_status();
       });
-  if (is_all_prefill && FLAGS_enable_multi_stream_parallel) {
+  if (not_all_in_decode && FLAGS_enable_multi_stream_parallel) {
     return 2;
   } else {
     return 1;

--- a/xllm/core/runtime/llm_worker_impl.cpp
+++ b/xllm/core/runtime/llm_worker_impl.cpp
@@ -125,11 +125,10 @@ std::optional<ForwardOutput> LLMWorkerImpl::step(
 
   // temporarily use [0], will be adapted in next pr
   // call model executor forward to get hidden states
-  auto hidden_states =
-      model_executor_->forward(flatten_tokens_micro_batches[0],
-                               flatten_positions_micro_batches[0],
-                               kv_caches_,
-                               input_params_micro_batches[0]);
+  auto hidden_states = model_executor_->forward(flatten_tokens_micro_batches,
+                                                flatten_positions_micro_batches,
+                                                kv_caches_,
+                                                input_params_micro_batches);
 
   torch::Tensor logits;
   if (concated_sampling_params.selected_token_idxes.defined()) {

--- a/xllm/core/runtime/llm_worker_impl.h
+++ b/xllm/core/runtime/llm_worker_impl.h
@@ -51,11 +51,11 @@ class LLMWorkerImpl : public WorkerImpl {
 
   void set_lm_head(layer::LmHead& head) { model_->set_lm_head(head); };
 
-  layer::WordEmbedding get_word_embedding() {
+  std::vector<layer::WordEmbedding> get_word_embedding() {
     return model_->get_word_embedding();
   };
 
-  void set_word_embedding(layer::WordEmbedding& embedding) {
+  void set_word_embedding(std::vector<layer::WordEmbedding>& embedding) {
     model_->set_word_embedding(embedding);
   };
 #elif defined(USE_MLU)

--- a/xllm/core/runtime/master.cpp
+++ b/xllm/core/runtime/master.cpp
@@ -78,6 +78,8 @@ Master::Master(const Options& options, EngineType type) : options_(options) {
     FLAGS_eplb_update_threshold = options.eplb_update_threshold().value();
   }
 #endif
+  FLAGS_enable_multi_stream_parallel =
+      options.enable_multi_stream_parallel() && (options.nnodes() > 1);
 
   // construct engine
   const auto devices =

--- a/xllm/core/runtime/npu_executor_impl.cpp
+++ b/xllm/core/runtime/npu_executor_impl.cpp
@@ -34,10 +34,11 @@ ForwardInput NpuExecutorImpl::prepare_inputs(Batch& batch) {
 // tokens: [num_tokens]
 // positions: [num_tokens] token pos in the sequence
 // returns: [num_tokens, hidden_size]
-torch::Tensor NpuExecutorImpl::run(const torch::Tensor& tokens,
-                                   const torch::Tensor& positions,
-                                   std::vector<KVCache>& kv_caches,
-                                   const ModelInputParams& params) {
+torch::Tensor NpuExecutorImpl::run(
+    const std::vector<torch::Tensor>& tokens,
+    const std::vector<torch::Tensor>& positions,
+    std::vector<KVCache>& kv_caches,
+    const std::vector<ModelInputParams>& params) {
   return model_->forward(tokens, positions, kv_caches, params);
 }
 

--- a/xllm/core/runtime/npu_executor_impl.h
+++ b/xllm/core/runtime/npu_executor_impl.h
@@ -40,10 +40,10 @@ class NpuExecutorImpl : public ExecutorImpl {
 
   ForwardInput prepare_inputs(Batch& batch) override;
 
-  torch::Tensor run(const torch::Tensor& tokens,
-                    const torch::Tensor& positions,
+  torch::Tensor run(const std::vector<torch::Tensor>& tokens,
+                    const std::vector<torch::Tensor>& positions,
                     std::vector<KVCache>& kv_caches,
-                    const ModelInputParams& params) override;
+                    const std::vector<ModelInputParams>& params) override;
 
  private:
   // not own

--- a/xllm/core/runtime/vlm_engine.cpp
+++ b/xllm/core/runtime/vlm_engine.cpp
@@ -275,10 +275,10 @@ ForwardOutput VLMEngine::step(std::vector<Batch>& batches) {
 
   std::vector<folly::SemiFuture<std::optional<ForwardOutput>>> futures;
   futures.reserve(workers_.size());
+  // TODO to adapt multi stream parallel later
+  BatchedForwardInputs batched_fwd_inputs;
+  batched_fwd_inputs.micro_inputs = {std::move(forward_inputs)};
   for (auto& worker : workers_) {
-    // TODO to adapt multi stream parallel later
-    BatchedForwardInputs batched_fwd_inputs;
-    batched_fwd_inputs.micro_inputs = {forward_inputs};
     futures.emplace_back(worker->step_async(batched_fwd_inputs));
   }
   // wait for the all future to complete

--- a/xllm/core/runtime/vlm_worker_impl.cpp
+++ b/xllm/core/runtime/vlm_worker_impl.cpp
@@ -90,7 +90,7 @@ std::optional<ForwardOutput> VLMWorkerImpl::step(
 
   // call model executor forward to get hidden states
   auto hidden_states = model_executor_->forward(
-      flatten_tokens, flatten_positions, kv_caches_, params);
+      {flatten_tokens}, {flatten_positions}, kv_caches_, {params});
 
   torch::Tensor logits;
   if (sampling_params.selected_token_idxes.defined()) {

--- a/xllm/models/llm/deepseek_v2.h
+++ b/xllm/models/llm/deepseek_v2.h
@@ -54,14 +54,14 @@ class DeepseekV2DecoderLayerImpl : public torch::nn::Module {
         "decoder_layer", layer::DeepseekV2DecoderLayer(context, i, sm_scale));
   }
 
-  torch::Tensor forward(torch::Tensor x,
-                        torch::Tensor cos_pos,
-                        torch::Tensor sin_pos,
-                        torch::Tensor attn_mask,
+  torch::Tensor forward(std::vector<torch::Tensor>& x,
+                        std::vector<torch::Tensor>& cos_pos,
+                        std::vector<torch::Tensor>& sin_pos,
+                        std::vector<torch::Tensor>& attn_mask,
                         KVCache& kv_cache,
-                        const ModelInputParams& input_params,
-                        aclrtEvent* event = nullptr,
-                        std::atomic<bool>* event_flag = nullptr) {
+                        const std::vector<ModelInputParams>& input_params,
+                        std::vector<aclrtEvent*> event,
+                        std::vector<std::atomic<bool>*> event_flag) {
     return decoder_layer_(x,
                           cos_pos,
                           sin_pos,
@@ -107,8 +107,6 @@ class DeepseekV2ModelImpl : public torch::nn::Module {
     device_ = options.device();
     dtype_ = options.dtype().toScalarType();
     num_speculative_tokens_ = model_args.num_speculative_tokens();
-    embed_tokens_ =
-        register_module("embed_tokens", layer::WordEmbedding(context));
 
     // rotary positional embedding
     auto inv_freq = rotary::apply_deepseek_yarn_rope_scaling(
@@ -120,13 +118,16 @@ class DeepseekV2ModelImpl : public torch::nn::Module {
         model_args.rope_theta(),
         model_args.rope_scaling_original_max_position_embeddings());
     float sm_scale = 1.0f;
-    pos_emb_ = create_rotary_embedding(model_args,
-                                       model_args.rotary_dim(),
-                                       inv_freq,
-                                       /*interleaved=*/false,
-                                       sm_scale,
-                                       options);
-    atb_pos_emb_ = layer::PosEmbedding(context);
+    for (auto i = 0; i < FLAGS_default_micro_batch_num; i++) {
+      embed_tokens_.push_back(layer::WordEmbedding(context));
+      pos_embs_.push_back(create_rotary_embedding(model_args,
+                                                  model_args.rotary_dim(),
+                                                  inv_freq,
+                                                  /*interleaved=*/false,
+                                                  sm_scale,
+                                                  options));
+      atb_pos_embs_.push_back(layer::PosEmbedding(context));
+    }
     max_seq_len_ = model_args.max_position_embeddings();
     int32_t mask_value = model_args.dtype() == "bfloat16" ? 1 : -9984;
     attn_mask_ = layer::AttentionMask(options.device(),
@@ -153,55 +154,78 @@ class DeepseekV2ModelImpl : public torch::nn::Module {
     }
   }
 
-  torch::Tensor forward(torch::Tensor tokens,
-                        torch::Tensor positions,
+  torch::Tensor forward(std::vector<torch::Tensor> tokens,
+                        std::vector<torch::Tensor> positions,
                         std::vector<KVCache>& kv_caches,
-                        const ModelInputParams& input_params) {
-    if (dp_size_ > 1) {
-      if (tokens.sizes() == 0) {
-        tokens = torch::tensor({1}).to(torch::kInt32).to(device_);
-        positions = torch::tensor({0}).to(torch::kInt32).to(device_);
+                        const std::vector<ModelInputParams>& input_params) {
+    auto micro_batch_num = tokens.size();
+    std::vector<torch::Tensor> hs;
+    hs.reserve(micro_batch_num);
+    std::vector<torch::Tensor> cos_poss;
+    cos_poss.reserve(micro_batch_num);
+    std::vector<torch::Tensor> sin_poss;
+    sin_poss.reserve(micro_batch_num);
+    std::vector<torch::Tensor> attn_masks;
+    attn_masks.reserve(micro_batch_num);
+
+    for (auto i = 0; i < micro_batch_num; ++i) {
+      if (dp_size_ > 1) {
+        if (tokens[i].sizes() == 0) {
+          tokens[i] = torch::tensor({1}).to(torch::kInt32).to(device_);
+          positions[i] = torch::tensor({0}).to(torch::kInt32).to(device_);
+        }
       }
-    }
 
-    auto h = embed_tokens_(tokens, 0);
-    auto cos_sin = atb_pos_emb_(pos_emb_->get_cos_sin_cache(), positions, 0);
-    auto cos_sin_chunks = cos_sin.chunk(/*chunks=*/2, /*dim=*/-1);
-    auto cos_pos = cos_sin_chunks[0].contiguous();
-    auto sin_pos = cos_sin_chunks[1].contiguous();
+      hs.push_back(std::move(embed_tokens_[i](tokens[i], i)));
+      auto cos_sin =
+          atb_pos_embs_[i](pos_embs_[i]->get_cos_sin_cache(), positions[i], 0);
+      auto cos_sin_chunks = cos_sin.chunk(/*chunks=*/2, /*dim=*/-1);
+      auto cos_pos = cos_sin_chunks[0].contiguous();
+      auto sin_pos = cos_sin_chunks[1].contiguous();
 
-    torch::Tensor attn_mask;
-    if (num_speculative_tokens_ == 0 || input_params.global_empty_kv_cache) {
-      attn_mask = attn_mask_.get_attn_mask(128, dtype_, device_);
-    } else {
-      attn_mask = attn_mask_.gen_free_mask(
-          num_speculative_tokens_ + 1, dtype_, device_);
+      torch::Tensor attn_mask;
+      if (num_speculative_tokens_ == 0 ||
+          input_params[i].global_empty_kv_cache) {
+        attn_mask = attn_mask_.get_attn_mask(128, dtype_, device_);
+      } else {
+        attn_mask = attn_mask_.gen_free_mask(
+            num_speculative_tokens_ + 1, dtype_, device_);
+      }
+      cos_poss.push_back(std::move(cos_pos));
+      sin_poss.push_back(std::move(sin_pos));
+      attn_masks.push_back(std::move(attn_mask));
     }
 
     for (size_t i = 0; i < layers_.size(); i++) {
-      aclrtEvent* event = nullptr;
-      std::atomic<bool>* event_flag = nullptr;
-      if (input_params.layer_synchronizer != nullptr) {
-        event = input_params.layer_synchronizer->get_event(i);
-        event_flag = input_params.layer_synchronizer->get_event_flag(i);
+      std::vector<aclrtEvent*> events(micro_batch_num, nullptr);
+      std::vector<std::atomic<bool>*> event_flags(micro_batch_num, nullptr);
+      for (auto j = 0; j < micro_batch_num; ++j) {
+        if (input_params[j].layer_synchronizer != nullptr) {
+          events[j] = input_params[j].layer_synchronizer->get_event(i);
+          event_flags[j] =
+              input_params[j].layer_synchronizer->get_event_flag(i);
+        }
       }
       auto& layer = layers_[i];
-      layer(h,
-            cos_pos,
-            sin_pos,
-            attn_mask,
+      layer(hs,
+            cos_poss,
+            sin_poss,
+            attn_masks,
             kv_caches[i],
             input_params,
-            event,
-            event_flag);
+            events,
+            event_flags);
     }
-    return norm_(h, 0);
+    auto cancated_h = torch::cat(hs, 0);
+    return norm_(cancated_h, 0);
   }
 
   // load the weight from the checkpoint
   void load_state_dict(const StateDict& state_dict) {
-    embed_tokens_->load_state_dict(
-        state_dict.get_dict_with_prefix("embed_tokens."));
+    for (auto i = 0; i < FLAGS_default_micro_batch_num; i++) {
+      embed_tokens_[i]->load_state_dict(
+          state_dict.get_dict_with_prefix("embed_tokens."));
+    }
     // call each layer's load_state_dict function
     for (int i = 0; i < layers_.size(); i++) {
       layers_[i]->load_state_dict(
@@ -211,7 +235,9 @@ class DeepseekV2ModelImpl : public torch::nn::Module {
   }
 
   void verify_loaded_weights(const std::string& prefix) const {
-    embed_tokens_->verify_loaded_weights(prefix + "embed_tokens.");
+    for (auto i = 0; i < FLAGS_default_micro_batch_num; i++) {
+      embed_tokens_[i]->verify_loaded_weights(prefix + "embed_tokens.");
+    }
     for (int i = 0; i < layers_.size(); i++) {
       layers_[i]->verify_loaded_weights(prefix + "layers." + std::to_string(i) +
                                         ".");
@@ -220,7 +246,9 @@ class DeepseekV2ModelImpl : public torch::nn::Module {
   }
 
   void merge_loaded_weights() {
-    embed_tokens_->merge_loaded_weights();
+    for (auto i = 0; i < FLAGS_default_micro_batch_num; i++) {
+      embed_tokens_[i]->merge_loaded_weights();
+    }
     for (int i = 0; i < layers_.size(); i++) {
       layers_[i]->merge_loaded_weights();
     }
@@ -236,9 +264,11 @@ class DeepseekV2ModelImpl : public torch::nn::Module {
     layers_[layer_id]->update_expert_weight();
   }
 
-  layer::WordEmbedding get_word_embedding() { return embed_tokens_; }
+  std::vector<layer::WordEmbedding> get_word_embedding() {
+    return embed_tokens_;
+  }
 
-  void set_word_embedding(layer::WordEmbedding& word_embedding) {
+  void set_word_embedding(std::vector<layer::WordEmbedding>& word_embedding) {
     embed_tokens_ = word_embedding;
   }
 
@@ -255,9 +285,9 @@ class DeepseekV2ModelImpl : public torch::nn::Module {
   int32_t num_speculative_tokens_ = 0;
   at::Device device_;
   torch::Dtype dtype_;
-  layer::WordEmbedding embed_tokens_{nullptr};
-  std::shared_ptr<RotaryEmbedding> pos_emb_{nullptr};
-  layer::PosEmbedding atb_pos_emb_{nullptr};
+  std::vector<layer::WordEmbedding> embed_tokens_;
+  std::vector<std::shared_ptr<RotaryEmbedding>> pos_embs_;
+  std::vector<layer::PosEmbedding> atb_pos_embs_;
   layer::AttentionMask attn_mask_;
   layer::RmsNorm norm_{nullptr};
 };
@@ -274,10 +304,10 @@ class DeepseekV2ForCausalLMImpl : public torch::nn::Module {
   // tokens: [num_tokens]
   // positions: [num_tokens] token pos in the sequence
   // returns: [num_tokens, hidden_size]
-  torch::Tensor forward(const torch::Tensor& tokens,
-                        const torch::Tensor& positions,
+  torch::Tensor forward(const std::vector<torch::Tensor>& tokens,
+                        const std::vector<torch::Tensor>& positions,
                         std::vector<KVCache>& kv_caches,
-                        const ModelInputParams& input_params) {
+                        const std::vector<ModelInputParams>& input_params) {
     return model_(tokens, positions, kv_caches, input_params);
   }
 
@@ -317,11 +347,11 @@ class DeepseekV2ForCausalLMImpl : public torch::nn::Module {
 
   void set_lm_head(layer::LmHead& head) { lm_head_ = head; }
 
-  layer::WordEmbedding get_word_embedding() {
+  std::vector<layer::WordEmbedding> get_word_embedding() {
     return model_->get_word_embedding();
   }
 
-  void set_word_embedding(layer::WordEmbedding& word_embedding) {
+  void set_word_embedding(std::vector<layer::WordEmbedding>& word_embedding) {
     model_->set_word_embedding(word_embedding);
   }
 

--- a/xllm/models/llm/deepseek_v2_mtp.h
+++ b/xllm/models/llm/deepseek_v2_mtp.h
@@ -55,11 +55,6 @@ class DeepseekV2MtpModelImpl : public torch::nn::Module {
 
     layers_.reserve(model_args.n_layers());
 
-    // register submodules
-    // embed_tokens_ = register_module(
-    //     "embed_tokens",
-    //     layer::WordEmbedding(context));
-
     // rotary positional embedding
     auto inv_freq = rotary::apply_deepseek_yarn_rope_scaling(
         model_args.rope_scaling_factor(),
@@ -70,13 +65,6 @@ class DeepseekV2MtpModelImpl : public torch::nn::Module {
         model_args.rope_theta(),
         model_args.rope_scaling_original_max_position_embeddings());
     float sm_scale = 1.0f;
-    pos_emb_ = create_rotary_embedding(model_args,
-                                       model_args.rotary_dim(),
-                                       inv_freq,
-                                       /*interleaved=*/false,
-                                       sm_scale,
-                                       options);
-    atb_pos_emb_ = layer::PosEmbedding(context);
     max_seq_len_ = model_args.max_position_embeddings();
     attn_mask_ = layer::AttentionMask(
         options.device(), options.dtype().toScalarType(), /*mask_value=*/1);
@@ -86,8 +74,16 @@ class DeepseekV2MtpModelImpl : public torch::nn::Module {
       layers_.push_back(block);
       blocks_->push_back(block);
     }
-
-    eh_proj_ = register_module("eh_proj", layer::ColumnParallelLinear(context));
+    for (auto i = 0; i < FLAGS_default_micro_batch_num; i++) {
+      pos_embs_.push_back(create_rotary_embedding(model_args,
+                                                  model_args.rotary_dim(),
+                                                  inv_freq,
+                                                  /*interleaved=*/false,
+                                                  sm_scale,
+                                                  options));
+      atb_pos_embs_.push_back(layer::PosEmbedding(context));
+      eh_projs_.push_back(layer::ColumnParallelLinear(context));
+    }
     enorm_ = register_module("enorm", layer::RmsNorm(context));
     hnorm_ = register_module("hnorm", layer::RmsNorm(context));
     final_norm_ = register_module("final_norm", layer::RmsNorm(context));
@@ -107,69 +103,91 @@ class DeepseekV2MtpModelImpl : public torch::nn::Module {
 
   // tokens: [num_tokens]
   // positions: [num_tokens] token pos in the sequence
-  torch::Tensor forward(torch::Tensor tokens,
-                        torch::Tensor positions,
+  torch::Tensor forward(std::vector<torch::Tensor> tokens,
+                        std::vector<torch::Tensor> positions,
                         std::vector<KVCache>& kv_caches,
-                        const ModelInputParams& input_params) {
-    if (dp_size_ > 1) {
-      if (tokens.sizes() == 0) {
-        tokens = torch::tensor({1}).to(torch::kInt32).to(device_);
-        positions = torch::tensor({0}).to(torch::kInt32).to(device_);
+                        const std::vector<ModelInputParams>& input_params) {
+    auto micro_batch_num = tokens.size();
+    std::vector<torch::Tensor> hs;
+    hs.reserve(micro_batch_num);
+    std::vector<torch::Tensor> cos_poss;
+    cos_poss.reserve(micro_batch_num);
+    std::vector<torch::Tensor> sin_poss;
+    sin_poss.reserve(micro_batch_num);
+    std::vector<torch::Tensor> attn_masks;
+    attn_masks.reserve(micro_batch_num);
+
+    for (auto i = 0; i < micro_batch_num; ++i) {
+      if (dp_size_ > 1) {
+        if (tokens[i].sizes() == 0) {
+          tokens[i] = torch::tensor({1}).to(torch::kInt32).to(device_);
+          positions[i] = torch::tensor({0}).to(torch::kInt32).to(device_);
+        }
       }
+
+      hs.push_back(std::move(embed_tokens_[i](tokens[i], 0)));
+      torch::Tensor enorm = enorm_(hs[i], 0);
+      const auto& res = input_params[i].mm_data.get<torch::Tensor>("embedding");
+      if (res) {
+        hs[i] = res.value();
+      } else {
+        LOG(WARNING) << "hnorm use embedding from tokens.";
+      }
+
+      torch::Tensor hnorm = hnorm_(hs[i], 0);
+      CHECK_EQ(enorm.dim(), hnorm.dim());
+      CHECK_EQ(enorm.size(0), hnorm.size(0));
+      hs[i] = torch::cat({enorm, hnorm}, /*dim=*/-1);
+      hs[i] = eh_projs_[i](hs[i], 0);
+
+      auto cos_sin =
+          atb_pos_embs_[i](pos_embs_[i]->get_cos_sin_cache(), positions[i], 0);
+      auto cos_sin_chunks = cos_sin.chunk(/*chunks=*/2, /*dim=*/-1);
+      auto cos_pos = cos_sin_chunks[0].contiguous();
+      auto sin_pos = cos_sin_chunks[1].contiguous();
+
+      auto attn_mask = attn_mask_.get_attn_mask(
+          128, cos_pos.dtype().toScalarType(), cos_pos.device());
+      cos_poss.push_back(std::move(cos_pos));
+      sin_poss.push_back(std::move(sin_pos));
+      attn_masks.push_back(std::move(attn_mask));
     }
-
-    torch::Tensor h = embed_tokens_(tokens, 0);
-    torch::Tensor enorm = enorm_(h, 0);
-    const auto& res = input_params.mm_data.get<torch::Tensor>("embedding");
-    if (res) {
-      h = res.value();
-    } else {
-      LOG(WARNING) << "hnorm use embedding from tokens.";
-    }
-
-    torch::Tensor hnorm = hnorm_(h, 0);
-    CHECK_EQ(enorm.dim(), hnorm.dim());
-    CHECK_EQ(enorm.size(0), hnorm.size(0));
-    h = torch::cat({enorm, hnorm}, /*dim=*/-1);
-    h = eh_proj_(h, 0);
-
-    auto cos_sin = atb_pos_emb_(pos_emb_->get_cos_sin_cache(), positions, 0);
-    auto cos_sin_chunks = cos_sin.chunk(/*chunks=*/2, /*dim=*/-1);
-    auto cos_pos = cos_sin_chunks[0].contiguous();
-    auto sin_pos = cos_sin_chunks[1].contiguous();
-
-    auto attn_mask = attn_mask_.get_attn_mask(
-        128, cos_pos.dtype().toScalarType(), cos_pos.device());
 
     for (size_t i = 0; i < layers_.size(); i++) {
-      aclrtEvent* event = nullptr;
-      std::atomic<bool>* event_flag = nullptr;
-      if (input_params.layer_synchronizer != nullptr) {
-        event = input_params.layer_synchronizer->get_event(i);
-        event_flag = input_params.layer_synchronizer->get_event_flag(i);
+      std::vector<aclrtEvent*> events(micro_batch_num, nullptr);
+      std::vector<std::atomic<bool>*> event_flags(micro_batch_num, nullptr);
+      for (auto j = 0; j < micro_batch_num; ++j) {
+        if (input_params[j].layer_synchronizer != nullptr) {
+          events[j] = input_params[j].layer_synchronizer->get_event(i);
+          event_flags[j] =
+              input_params[j].layer_synchronizer->get_event_flag(i);
+        }
       }
       auto& layer = layers_[i];
-      layer(h,
-            cos_pos,
-            sin_pos,
-            attn_mask,
+      layer(hs,
+            cos_poss,
+            sin_poss,
+            attn_masks,
             kv_caches[i],
             input_params,
-            event,
-            event_flag);
+            events,
+            event_flags);
     }
-    return final_norm_(h, 0);
+    auto cancated_h = torch::cat(hs, 0);
+    return final_norm_(cancated_h, 0);
   }
 
   // load the weight from the checkpoint
   void load_state_dict(const StateDict& state_dict) {
-    // embed_tokens_->load_state_dict(state_dict.get_dict_with_prefix("embed_tokens."));
     // call each layer's load_state_dict function
     for (int i = 0; i < layers_.size(); i++) {
       layers_[i]->load_state_dict(
           state_dict.get_dict_with_prefix("layers." + std::to_string(i) + "."));
     }
-    eh_proj_->load_state_dict(state_dict.get_dict_with_prefix("eh_proj."));
+    for (auto i = 0; i < FLAGS_default_micro_batch_num; i++) {
+      eh_projs_[i]->load_state_dict(
+          state_dict.get_dict_with_prefix("eh_proj."));
+    }
     enorm_->load_state_dict(state_dict.get_dict_with_prefix("enorm."));
     hnorm_->load_state_dict(state_dict.get_dict_with_prefix("hnorm."));
     final_norm_->load_state_dict(
@@ -177,31 +195,35 @@ class DeepseekV2MtpModelImpl : public torch::nn::Module {
   }
 
   void verify_loaded_weights(const std::string& prefix) const {
-    // embed_tokens_->verify_loaded_weights(prefix + "embed_tokens.");
     for (int i = 0; i < layers_.size(); i++) {
       layers_[i]->verify_loaded_weights(prefix + "layers." + std::to_string(i) +
                                         ".");
     }
-    eh_proj_->verify_loaded_weights(prefix + "eh_proj.");
+    for (auto i = 0; i < FLAGS_default_micro_batch_num; i++) {
+      eh_projs_[i]->verify_loaded_weights(prefix + "eh_proj.");
+    }
     enorm_->verify_loaded_weights(prefix + "enorm.");
     hnorm_->verify_loaded_weights(prefix + "hnorm.");
     final_norm_->verify_loaded_weights(prefix + "shared_head.norm.");
   }
 
   void merge_loaded_weights() {
-    // embed_tokens_->merge_loaded_weights();
     for (int i = 0; i < layers_.size(); i++) {
       layers_[i]->merge_loaded_weights();
     }
-    eh_proj_->merge_loaded_weights();
+    for (auto i = 0; i < FLAGS_default_micro_batch_num; i++) {
+      eh_projs_[i]->merge_loaded_weights();
+    }
     enorm_->merge_loaded_weights();
     hnorm_->merge_loaded_weights();
     final_norm_->merge_loaded_weights();
   }
 
-  layer::WordEmbedding get_word_embedding() { return embed_tokens_; }
+  std::vector<layer::WordEmbedding> get_word_embedding() {
+    return embed_tokens_;
+  }
 
-  void set_word_embedding(layer::WordEmbedding& word_embedding) {
+  void set_word_embedding(std::vector<layer::WordEmbedding>& word_embedding) {
     embed_tokens_ = word_embedding;
   }
 
@@ -216,11 +238,11 @@ class DeepseekV2MtpModelImpl : public torch::nn::Module {
   nlohmann::json mapping_data_;
   int32_t num_experts_per_tok_;
   at::Device device_;
-  layer::WordEmbedding embed_tokens_{nullptr};
-  std::shared_ptr<RotaryEmbedding> pos_emb_{nullptr};
-  layer::PosEmbedding atb_pos_emb_{nullptr};
+  std::vector<layer::WordEmbedding> embed_tokens_;
+  std::vector<std::shared_ptr<RotaryEmbedding>> pos_embs_;
+  std::vector<layer::PosEmbedding> atb_pos_embs_;
   layer::AttentionMask attn_mask_;
-  layer::ColumnParallelLinear eh_proj_{nullptr};
+  std::vector<layer::ColumnParallelLinear> eh_projs_;
   layer::RmsNorm enorm_{nullptr};
   layer::RmsNorm hnorm_{nullptr};
   layer::RmsNorm final_norm_{nullptr};
@@ -238,10 +260,10 @@ class DeepseekV2MtpForCausalLMImpl : public torch::nn::Module {
   // tokens: [num_tokens]
   // positions: [num_tokens] token pos in the sequence
   // returns: [num_tokens, hidden_size]
-  torch::Tensor forward(const torch::Tensor& tokens,
-                        const torch::Tensor& positions,
+  torch::Tensor forward(const std::vector<torch::Tensor>& tokens,
+                        const std::vector<torch::Tensor>& positions,
                         std::vector<KVCache>& kv_caches,
-                        const ModelInputParams& input_params) {
+                        const std::vector<ModelInputParams>& input_params) {
     return model_(tokens, positions, kv_caches, input_params);
   }
 
@@ -278,11 +300,11 @@ class DeepseekV2MtpForCausalLMImpl : public torch::nn::Module {
 
   void set_lm_head(layer::LmHead& head) { lm_head_ = head; }
 
-  layer::WordEmbedding get_word_embedding() {
+  std::vector<layer::WordEmbedding> get_word_embedding() {
     return model_->get_word_embedding();
   }
 
-  void set_word_embedding(layer::WordEmbedding& word_embedding) {
+  void set_word_embedding(std::vector<layer::WordEmbedding>& word_embedding) {
     model_->set_word_embedding(word_embedding);
   }
 

--- a/xllm/models/llm/llama.h
+++ b/xllm/models/llm/llama.h
@@ -216,10 +216,12 @@ class LlamaModelImpl : public torch::nn::Module {
     norm_->merge_loaded_weights();
   }
 
-  layer::WordEmbedding get_word_embedding() { return embed_tokens_; }
+  std::vector<layer::WordEmbedding> get_word_embedding() {
+    return {embed_tokens_};
+  }
 
-  void set_word_embedding(layer::WordEmbedding& word_embedding) {
-    embed_tokens_ = word_embedding;
+  void set_word_embedding(std::vector<layer::WordEmbedding>& word_embedding) {
+    embed_tokens_ = word_embedding[0];
   }
 
  private:
@@ -250,11 +252,11 @@ class LlamaForCausalLMImpl : public torch::nn::Module {
   // tokens: [num_tokens]
   // positions: [num_tokens] token pos in the sequence
   // returns: [num_tokens, hidden_size]
-  torch::Tensor forward(const torch::Tensor& tokens,
-                        const torch::Tensor& positions,
+  torch::Tensor forward(const std::vector<torch::Tensor>& tokens,
+                        const std::vector<torch::Tensor>& positions,
                         std::vector<KVCache>& kv_caches,
-                        const ModelInputParams& input_params) {
-    return model_(tokens, positions, kv_caches, input_params);
+                        const std::vector<ModelInputParams>& input_params) {
+    return model_(tokens[0], positions[0], kv_caches, input_params[0]);
   }
 
   // hidden_states: [num_tokens, hidden_size]
@@ -289,11 +291,11 @@ class LlamaForCausalLMImpl : public torch::nn::Module {
 
   void set_lm_head(layer::LmHead& head) { lm_head_ = head; }
 
-  layer::WordEmbedding get_word_embedding() {
+  std::vector<layer::WordEmbedding> get_word_embedding() {
     return model_->get_word_embedding();
   }
 
-  void set_word_embedding(layer::WordEmbedding& word_embedding) {
+  void set_word_embedding(std::vector<layer::WordEmbedding>& word_embedding) {
     model_->set_word_embedding(word_embedding);
   }
 

--- a/xllm/models/llm/qwen2.h
+++ b/xllm/models/llm/qwen2.h
@@ -50,11 +50,11 @@ class QWen2ModelImpl : public QWenModelImplBase<QWen2DecoderLayer> {
 
     blocks_ = register_module("layers", torch::nn::ModuleList());
     layers_.reserve(model_args.n_layers());
-    embed_tokens_ =
-        register_module("embed_tokens", layer::WordEmbedding(context));
     norm_ = register_module("norm", layer::RmsNorm(context));
-
-    atb_pos_emb_ = layer::PosEmbedding(context);
+    for (auto i = 0; i < FLAGS_default_micro_batch_num; i++) {
+      embed_tokens_.push_back(layer::WordEmbedding(context));
+      atb_pos_embeds_.push_back(layer::PosEmbedding(context));
+    }
     cos_sin_ = get_qwen2_rotary_embedding(
         model_args.hidden_size() / model_args.n_heads(),
         model_args.max_position_embeddings(),

--- a/xllm/models/llm/qwen3.h
+++ b/xllm/models/llm/qwen3.h
@@ -46,11 +46,11 @@ class QWen3ModelImpl : public QWenModelImplBase<QWen3DecoderLayer> {
 
     blocks_ = register_module("layers", torch::nn::ModuleList());
     layers_.reserve(model_args.n_layers());
-    embed_tokens_ =
-        register_module("embed_tokens", layer::WordEmbedding(context));
     norm_ = register_module("norm", layer::RmsNorm(context));
-
-    atb_pos_emb_ = layer::PosEmbedding(context);
+    for (auto i = 0; i < FLAGS_default_micro_batch_num; i++) {
+      embed_tokens_.push_back(layer::WordEmbedding(context));
+      atb_pos_embeds_.push_back(layer::PosEmbedding(context));
+    }
     cos_sin_ = get_qwen3_rotary_embedding(128,
                                           model_args.max_position_embeddings(),
                                           model_args.rope_theta(),

--- a/xllm/models/llm/qwen3_embedding.h
+++ b/xllm/models/llm/qwen3_embedding.h
@@ -43,10 +43,11 @@ class EmbeddingLMImpl<xllm::QWen3ForEmbedding> : public EmbeddingLM {
                   const torch::TensorOptions& options)
       : model_(std::move(model)), options_(options) {}
 
-  torch::Tensor forward(const torch::Tensor& tokens,
-                        const torch::Tensor& positions,
-                        std::vector<KVCache>& kv_caches,
-                        const ModelInputParams& parameters) override {
+  torch::Tensor forward(
+      const std::vector<torch::Tensor>& tokens,
+      const std::vector<torch::Tensor>& positions,
+      std::vector<KVCache>& kv_caches,
+      const std::vector<ModelInputParams>& parameters) override {
     return model_->forward(tokens, positions, kv_caches, parameters);
   }
 
@@ -79,10 +80,11 @@ class EmbeddingLMImpl<xllm::QWen3ForEmbedding> : public EmbeddingLM {
   // Delegate head/embedding accessors to underlying model implementation.
   layer::LmHead get_lm_head() override { return model_->get_lm_head(); }
   void set_lm_head(layer::LmHead& head) override { model_->set_lm_head(head); }
-  layer::WordEmbedding get_word_embedding() override {
+  std::vector<layer::WordEmbedding> get_word_embedding() override {
     return model_->get_word_embedding();
   }
-  void set_word_embedding(layer::WordEmbedding& embedding) override {
+  void set_word_embedding(
+      std::vector<layer::WordEmbedding>& embedding) override {
     model_->set_word_embedding(embedding);
   }
 

--- a/xllm/models/llm/qwen3_moe.h
+++ b/xllm/models/llm/qwen3_moe.h
@@ -209,10 +209,12 @@ class Qwen3MoeModelImpl : public torch::nn::Module {
     norm_->merge_loaded_weights();
   }
 
-  layer::WordEmbedding get_word_embedding() { return embed_tokens_; }
+  std::vector<layer::WordEmbedding> get_word_embedding() {
+    return {embed_tokens_};
+  }
 
-  void set_word_embedding(layer::WordEmbedding& word_embedding) {
-    embed_tokens_ = word_embedding;
+  void set_word_embedding(std::vector<layer::WordEmbedding>& word_embedding) {
+    embed_tokens_ = word_embedding[0];
   }
 
  private:
@@ -246,11 +248,11 @@ class Qwen3MoeForCausalLMImpl : public torch::nn::Module {
   // tokens: [num_tokens]
   // positions: [num_tokens] token pos in the sequence
   // returns: [num_tokens, hidden_size]
-  torch::Tensor forward(const torch::Tensor& tokens,
-                        const torch::Tensor& positions,
+  torch::Tensor forward(const std::vector<torch::Tensor>& tokens,
+                        const std::vector<torch::Tensor>& positions,
                         std::vector<KVCache>& kv_caches,
-                        const ModelInputParams& input_params) {
-    return model_(tokens, positions, kv_caches, input_params);
+                        const std::vector<ModelInputParams>& input_params) {
+    return model_(tokens[0], positions[0], kv_caches, input_params[0]);
   }
 
   // hidden_states: [num_tokens, hidden_size]
@@ -287,11 +289,11 @@ class Qwen3MoeForCausalLMImpl : public torch::nn::Module {
 
   void set_lm_head(layer::LmHead& head) { lm_head_ = head; }
 
-  layer::WordEmbedding get_word_embedding() {
+  std::vector<layer::WordEmbedding> get_word_embedding() {
     return model_->get_word_embedding();
   }
 
-  void set_word_embedding(layer::WordEmbedding& word_embedding) {
+  void set_word_embedding(std::vector<layer::WordEmbedding>& word_embedding) {
     model_->set_word_embedding(word_embedding);
   }
 


### PR DESCRIPTION
1. Main changes:

- change the model forward input into vector format.
- duplicate the operations in decoder layer graph in `layers/npu`  to run two micro batches.
- duplicate the inputs/outputs in decoder layer graph in `layers/npu` .

----------------------------------------- test cases ---------------------------------------
2. when multi_stream_parallel is enabled, tested with qwen-3(8b), Deepseek-R1 model.

- chunked prefill:             on/off
- prefix cache:                 on/off
- schedule_overlap:        on/off
- expert-level:                 0/2
- eplb:                              on/off
- PD disaggeration: 
- mtp:                              (looks like some bug in branch main, to be confirmed).

3. when multi_stream_parallel is disenabled, regression test the follow case.

- qwen-embedding, Qwen3-embedding
- vlm model, Qwen2.5-VL

All the above cases are passed.


----------------------------------------- Notices ---------------------------------------
A part of file changes are caused by clang-format adjustments, primarily in two scenarios: 

- function input parameters being extended with std::vector, making them more verbose.
- The addition of for-loops that altered the original code indentation.