### PR TITLE
feat: support multithreaded building raw_forward_input.

### DIFF
--- a/xllm/core/framework/batch/batch.cpp
+++ b/xllm/core/framework/batch/batch.cpp
@@ -82,7 +82,8 @@ ForwardInput Batch::prepare_forward_input(uint32_t num_decoding_tokens,
 }
 
 RawForwardInput Batch::prepare_forward_input(uint32_t start_idx,
-                                             uint32_t end_idx) {
+                                             uint32_t end_idx,
+                                             ThreadPool* thread_pool) {
   BatchInputBuilder builder(sequences_,
                             allowed_max_tokens_,
                             input_embeddings_vec_,
@@ -90,7 +91,8 @@ RawForwardInput Batch::prepare_forward_input(uint32_t start_idx,
                             copy_in_cache_block_infos_,
                             copy_out_cache_block_infos_,
                             swap_cache_block_infos_,
-                            nullptr);
+                            nullptr,
+                            thread_pool);
   return builder.build_raw_forward_input(start_idx, end_idx);
 }
 

--- a/xllm/core/framework/batch/batch.h
+++ b/xllm/core/framework/batch/batch.h
@@ -26,6 +26,7 @@ limitations under the License.
 #include "framework/request/sequence.h"
 #include "framework/request/sequences_group.h"
 #include "runtime/forward_params.h"
+#include "util/threadpool.h"
 
 namespace xllm {
 
@@ -74,7 +75,9 @@ class Batch {
                                      const ModelArgs& args);
 
   // Convert Batch to pb type, which will be pass to remote worker.
-  RawForwardInput prepare_forward_input(uint32_t start_idx, uint32_t end_idx);
+  RawForwardInput prepare_forward_input(uint32_t start_idx,
+                                        uint32_t end_idx,
+                                        ThreadPool* thread_pool = nullptr);
 
   // process output
   void process_sample_output(const SampleOutput& sample_output,

--- a/xllm/core/runtime/llm_engine.h
+++ b/xllm/core/runtime/llm_engine.h
@@ -145,7 +145,7 @@ class LLMEngine : public Engine {
   void process_eplb_data(
       const std::vector<folly::Try<std::optional<RawForwardOutput>>>& results);
 
-  ThreadPool threadpool_;
+  std::unique_ptr<ThreadPool> threadpool_ = nullptr;
 };
 
 }  // namespace xllm


### PR DESCRIPTION
Add process_sequences_multithreaded function to accelerate processing sequences when building raw_forward_input, reducing execution time from ~10ms to under 2ms (tested on Qwen2-7B-Instruct with intention benchmark, current bench = 500, enable_schedule_overlap = false).