### PR TITLE
bugfix: fix VLM runtime error when enable tensor parallel.

### DIFF
--- a/xllm/core/runtime/vlm_engine.cpp
+++ b/xllm/core/runtime/vlm_engine.cpp
@@ -278,7 +278,7 @@ ForwardOutput VLMEngine::step(std::vector<Batch>& batches) {
   for (auto& worker : workers_) {
     // TODO to adapt multi stream parallel later
     BatchedForwardInputs batched_fwd_inputs;
-    batched_fwd_inputs.micro_inputs = {std::move(forward_inputs)};
+    batched_fwd_inputs.micro_inputs = {forward_inputs};
     futures.emplace_back(worker->step_async(batched_fwd_inputs));
   }
   // wait for the all future to complete


### PR DESCRIPTION
修复单进程多卡运行VLM时出现的错误：
```
terminate called after throwing an instance of 'c10::Error' 
what(): tensor does not have a device
```
