### PR TITLE
feat: add control to enable customized mla operation.

### DIFF
--- a/xllm/core/common/global_flags.cpp
+++ b/xllm/core/common/global_flags.cpp
@@ -79,6 +79,8 @@ DEFINE_bool(enable_mla,
             false,
             "Whether to enable multi-head latent attention.");
 
+DEFINE_bool(enable_customize_mla_kernel, false, "enable customize mla kernel");
+
 // --- graph mode execution config ---
 
 DEFINE_bool(enable_acl_graph,

--- a/xllm/core/common/global_flags.h
+++ b/xllm/core/common/global_flags.h
@@ -125,6 +125,8 @@ DECLARE_int32(expert_parallel_degree);
 
 DECLARE_int32(max_reconnect_count);
 
+DECLARE_bool(enable_customize_mla_kernel);
+
 DECLARE_bool(enable_atb_comm_multiprocess);
 
 DECLARE_string(tool_call_parser);

--- a/xllm/core/layers/npu/npu_deepseek_v2_decoder_layer_impl.h
+++ b/xllm/core/layers/npu/npu_deepseek_v2_decoder_layer_impl.h
@@ -313,9 +313,11 @@ class NpuDeepseekV2DecoderLayerImpl : public NpuBaseLayer {
 
   atb_speed::deepseekV2::DecoderLayerParam prefill_param_;
   atb_speed::deepseekV2::DecoderLayerParam decode_param_;
+  atb_speed::deepseekV2::DecoderLayerParam decode_mla_param_;
 
   atb_speed::Model::Node prefill_node_;
   atb_speed::Model::Node decode_node_;
+  atb_speed::Model::Node decode_mla_node_;
 
   atb::Tensor internal_tensor_;
   atb::Tensor internal_tensor_auxiliary_;

--- a/xllm/core/runtime/llm_engine.cpp
+++ b/xllm/core/runtime/llm_engine.cpp
@@ -664,7 +664,22 @@ ForwardOutput LLMEngine::step(std::vector<Batch>& batch) {
       << "The processed raw forward inputs size "
       << batched_raw_forward_inputs.size() << " is not equal to dp size "
       << dp_size_ << ".";
-
+  static bool set_enable_mla = FLAGS_enable_customize_mla_kernel;
+  // decode phase with tokens more than this limit will lead to error in
+  // customize mla kernel. once detect any input exceed the limit, fall back to
+  // default kernel.
+  const int num_tokens_limit = 230;
+  if (set_enable_mla) {
+    FLAGS_enable_customize_mla_kernel = std::all_of(
+        batched_raw_forward_inputs.begin(),
+        batched_raw_forward_inputs.end(),
+        [](const std::vector<RawForwardInput>& inputs) {
+          return std::all_of(
+              inputs.begin(), inputs.end(), [](const RawForwardInput& input) {
+                return input.flatten_tokens_vec.size() < num_tokens_limit;
+              });
+        });
+  }
   std::vector<folly::SemiFuture<std::optional<RawForwardOutput>>> futures;
   futures.reserve(worker_clients_num_);
 


### PR DESCRIPTION
xLLM launch script：
```bash
export PYTHON_INCLUDE_PATH="$(python3 -c 'from sysconfig import get_paths; print(get_paths()["include"])')"
export PYTHON_LIB_PATH="$(python3 -c 'from sysconfig import get_paths; print(get_paths()["include"])')"
export PYTORCH_NPU_INSTALL_PATH=/usr/local/libtorch_npu/
export PYTORCH_INSTALL_PATH="$(python3 -c 'import torch, os; print(os.path.dirname(os.path.abspath(torch.__file__)))')"
export LIBTORCH_ROOT="$(python3 -c 'import torch, os; print(os.path.dirname(os.path.abspath(torch.__file__)))')"
export LD_LIBRARY_PATH=/usr/local/libtorch_npu/lib:$LD_LIBRARY_PATH

source /usr/local/Ascend/ascend-toolkit/set_env.sh
source /usr/local/Ascend/nnal/atb/set_env.sh
# export ASCEND_RT_VISIBLE_DEVICES=0
#export ASCEND_RT_VISIBLE_DEVICES=4,5
export ASDOPS_LOG_TO_STDOUT=1
export ASDOPS_LOG_LEVEL=ERROR
export ATB_LOG_TO_STDOUT=1
# export ASDOPS_LOG_TO_FILE=1 
# export HCCL_BUFFSIZE=1024
export PYTORCH_NPU_ALLOC_CONF=expandable_segments:True
export NPU_MEMORY_FRACTION=0.98
export ATB_WORKSPACE_MEM_ALLOC_ALG_TYPE=3
export ATB_WORKSPACE_MEM_ALLOC_GLOBAL=1

export OMP_NUM_THREADS=12

export HCCL_CONNECT_TIMEOUT=7200

\rm -rf /root/atb/log/
\rm -rf /root/ascend/log/
\rm -rf core.*

MODEL_PATH="/export/home/lanliwei.1/models/models/DeepSeek-V3"
MASTER_NODE_ADDR="11.87.49.111:9590"
START_PORT=18999
START_DEVICE=0
LOG_DIR="log"
NNODES=16
WORLD_SIZE=16

export HCCL_IF_BASE_PORT=43439


for (( i=0; i<$NNODES; i++ ))
do
  PORT=$((START_PORT + i))
  DEVICE=$((START_DEVICE + i))
  LOG_FILE="$LOG_DIR/node_$i.log"
    /export/home/lanliwei.1/code/mla_xllm_customize/xllm/build/xllm/core/server/xllm \
    --model $MODEL_PATH \
    --port $PORT \
    --devices="npu:$DEVICE" \
    --master_node_addr=$MASTER_NODE_ADDR \
    --nnodes=$WORLD_SIZE \
    --node_rank=$i \
    --max_memory_utilization=0.8 \
    --max_tokens_per_batch=20000 \
    --max_seqs_per_batch=2000 \
    --block_size=128 \
    --enable_prefix_cache=false \
    --enable_chunked_prefill=false \
    --communication_backend="hccl" \
    --enable_schedule_overlap=true \
    --enable_mla=true \
    --ep_size=16 \
    --dp_size=4 \
    --enable_customize_mla_kernel \
    > $LOG_FILE 2>&1 &
done
```
The benchmark code used is as follow:
[benchmark.py](https://github.com/user-attachments/files/23413383/benchmark.py)

The corresponding parameters are：
```bash
python3 benchmark.py \
 --backend xllm \
 --model /export/home/lanliwei.1/models/models/DeepSeek-V3 \
 --dataset-name random \
 --random-range-ratio 1 \
 --num-prompt 420 \
 --request-rate 2 \
 --max-concurrency 100 \
 --random-input 2048 \
 --random-output 2048 \
 --host 127.0.0.1 \
 --port 18999 \
 --dataset-path /export/home/lanliwei.1/dataset/ShareGPT_V3_unfiltered_cleaned_split.json \
```

Performance comparision：
<img width="963" height="276" alt="image" src="https://github.com/user-attachments/assets/5e1a1c8a-ce24-4ded-b1b6-5ea54e07f3f8" />
