### PR TITLE
feat: support dp load balance associated with custom mla op implementation.

### DIFF
--- a/xllm/core/common/global_flags.cpp
+++ b/xllm/core/common/global_flags.cpp
@@ -413,3 +413,11 @@ DEFINE_bool(
     "Whether to enable prefetch weight,only applicable to Qwen3-dense model."
     "The default prefetching ratio for gateup weight is 40%."
     "If adjustments are needed, e.g. export PREFETCH_COEFFOCIENT=0.5");
+
+// --- dp load balance ---
+
+DEFINE_bool(
+    enable_dp_balance,
+    false,
+    "Whether to enable dp load balance, if true, sequences within a single "
+    "dp batch will be shuffled.");

--- a/xllm/core/common/global_flags.h
+++ b/xllm/core/common/global_flags.h
@@ -208,3 +208,5 @@ DECLARE_bool(enable_shm);
 DECLARE_bool(enable_prefetch_weight);
 
 DECLARE_int32(flashinfer_workspace_buffer_size);
+
+DECLARE_bool(enable_dp_balance);

--- a/xllm/core/framework/batch/batch.cpp
+++ b/xllm/core/framework/batch/batch.cpp
@@ -81,9 +81,98 @@ ForwardInput Batch::prepare_forward_input(uint32_t num_decoding_tokens,
                                      min_decoding_batch_size);
 }
 
+void Batch::dp_balance_shuffle_seqs() {
+  // this shuffle operation is mainly used for npu with 24 cores
+  // and specific mla op implementation
+  const auto num_npu_cores = 24;  // npu cube core num
+  if (FLAGS_enable_customize_mla_kernel && FLAGS_enable_dp_balance &&
+      sequences_.size() > num_npu_cores) {
+    std::vector<uint32_t> kv_cache_tokens_num;
+    kv_cache_tokens_num.reserve(sequences_.size());
+    for (auto& seq : sequences_) {
+      kv_cache_tokens_num.push_back(seq->kv_state().kv_cache_tokens_num());
+    }
+    auto seq_index_shift = cal_seq_exchange_index(kv_cache_tokens_num);
+
+    std::vector<Sequence*> balanced_sequences;
+    std::vector<uint32_t> balanced_allowed_max_tokens;
+    balanced_sequences.resize(sequences_.size());
+    balanced_allowed_max_tokens.resize(allowed_max_tokens_.size());
+    for (auto& ele : seq_index_shift) {
+      balanced_sequences[ele.second] = sequences_[ele.first];
+      balanced_allowed_max_tokens[ele.second] = allowed_max_tokens_[ele.first];
+    }
+
+    CHECK_EQ(sequences_.size(), balanced_sequences.size());
+    sequences_ = std::move(balanced_sequences);
+    allowed_max_tokens_ = std::move(balanced_allowed_max_tokens);
+  }
+}
+
+std::map<uint32_t, uint32_t> Batch::cal_seq_exchange_index(
+    std::vector<uint32_t>& kv_cache_tokens_num) {
+  const auto num_npu_cores = 24;  // npu cube core num
+  const auto num_seqs = kv_cache_tokens_num.size();
+  const auto base_per_core = num_seqs / num_npu_cores;
+  const auto remainder = num_seqs % num_npu_cores;
+
+  // find the indices of the remainder biggest elements
+  std::vector<uint32_t> indices(num_seqs);
+  std::iota(indices.begin(), indices.end(), 0);
+  if (remainder > 0) {
+    std::nth_element(indices.begin(),
+                     indices.end() - remainder,
+                     indices.end(),
+                     [&kv_cache_tokens_num](uint32_t a, uint32_t b) {
+                       return kv_cache_tokens_num[a] < kv_cache_tokens_num[b];
+                     });
+  }
+
+  std::vector<uint32_t> base_indices(indices.begin(),
+                                     indices.end() - remainder);
+  std::vector<uint32_t> remainder_indices(indices.end() - remainder,
+                                          indices.end());
+
+  // sort base_indices in descending order
+  std::sort(base_indices.begin(),
+            base_indices.end(),
+            [&kv_cache_tokens_num](uint32_t a, uint32_t b) {
+              return kv_cache_tokens_num[a] > kv_cache_tokens_num[b];
+            });
+
+  // allocate a long and a short request to each core, to ensuring
+  // load balance among all cores
+  std::vector<std::vector<uint32_t>> base_assignment(
+      num_npu_cores, std::vector<uint32_t>(base_per_core));
+  for (auto i = 0; i < base_indices.size(); ++i) {
+    auto col = i / num_npu_cores;
+    auto row = (col % 2 == 0) ? (i % num_npu_cores)
+                              : (num_npu_cores - 1 - (i % num_npu_cores));
+    base_assignment[row][col] = base_indices[i];
+  }
+
+  // record the index map, first one is original index,
+  // second one is the target index to be exchanged to
+  std::map<uint32_t, uint32_t> index_shift;
+  // add base part data
+  for (auto i = 0; i < num_npu_cores; ++i) {
+    for (auto j = 0; j < base_per_core; ++j) {
+      auto idx = base_assignment[i][j];
+      index_shift[idx] = i + j * num_npu_cores;
+    }
+  }
+  // add remainder part data
+  for (auto i = 0; i < remainder; ++i) {
+    index_shift[remainder_indices[i]] = i + num_npu_cores * base_per_core;
+  }
+
+  return index_shift;
+}
+
 RawForwardInput Batch::prepare_forward_input(uint32_t start_idx,
                                              uint32_t end_idx,
                                              ThreadPool* thread_pool) {
+  dp_balance_shuffle_seqs();
   BatchInputBuilder builder(sequences_,
                             allowed_max_tokens_,
                             input_embeddings_vec_,

--- a/xllm/core/framework/batch/batch.h
+++ b/xllm/core/framework/batch/batch.h
@@ -111,6 +111,11 @@ class Batch {
 
   bool get_batch_prefill_status() const { return all_seqs_in_prefill_; }
 
+  std::map<uint32_t, uint32_t> cal_seq_exchange_index_test(
+      std::vector<uint32_t>& kv_cache_tokens_num) {
+    return cal_seq_exchange_index(kv_cache_tokens_num);
+  }
+
  private:
   bool update_sequence_state(Sequence* seq, bool replace_fake_token);
 
@@ -120,6 +125,11 @@ class Batch {
                                  bool replace_fake_token);
 
   void process_beam_search();
+
+  std::map<uint32_t, uint32_t> cal_seq_exchange_index(
+      std::vector<uint32_t>& kv_cache_tokens_num);
+
+  void dp_balance_shuffle_seqs();
 
   std::vector<Sequence*> sequences_;
   std::vector<SequencesGroup*> sequence_groups_;

--- a/xllm/core/framework/batch/batch_test.cpp
+++ b/xllm/core/framework/batch/batch_test.cpp
@@ -217,4 +217,22 @@ TEST(BatchTest, Basic) {
   // clang-format on
 }
 
+TEST(BatchTest, DPBalanceShuffle) {
+  Batch batch;
+  std::vector<uint32_t> kv_cache_tokens_num = {
+      99, 1,  2,  3,  4,  5,  6,  7,  8,  9,  10, 11, 12, 13, 14, 15, 16,
+      17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33,
+      34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48};
+  auto shifted_indices = batch.cal_seq_exchange_index_test(kv_cache_tokens_num);
+  // shifted_indices are expected as
+  // {48, 47, 46, 45, 44, 43, 42, 41, 40, 39, 38, 37, 36, 35, 34, 33, 32, 31,
+  //  30, 29, 28, 27, 26, 25,  1,  2,  3,  4,  5,  6,  7,  8,  9, 10, 11, 12,
+  //  13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 99}
+  EXPECT_EQ(shifted_indices[0], 48);
+  EXPECT_EQ(shifted_indices[48], 0);
+  EXPECT_EQ(shifted_indices[1], 24);
+  EXPECT_EQ(shifted_indices[47], 1);
+  EXPECT_EQ(shifted_indices[2], 25);
+}
+
 }  // namespace xllm

--- a/xllm/core/scheduler/chunked_prefill_scheduler.cpp
+++ b/xllm/core/scheduler/chunked_prefill_scheduler.cpp
@@ -688,7 +688,11 @@ std::vector<Batch> ChunkedPrefillScheduler::prepare_batch() {
                                       running_sequences_,
                                       running_sequences_budgets_);
 
-  if (!batches[0].empty()) {
+  bool is_batches_empty =
+      (std::all_of(batches.begin(), batches.end(), [](const Batch& one_batch) {
+        return one_batch.empty();
+      }));
+  if (!is_batches_empty) {
     // only update the scheduling latency when there are requests to process
     COUNTER_ADD(scheduling_latency_seconds, timer.elapsed_seconds());
   }

--- a/xllm/core/scheduler/continuous_scheduler.cpp
+++ b/xllm/core/scheduler/continuous_scheduler.cpp
@@ -799,7 +799,11 @@ std::vector<Batch> ContinuousScheduler::prepare_batch() {
                            kv_cache_manager_->get_copy_out_cache_block_infos(),
                            kv_cache_manager_->get_swap_cache_block_infos());
 
-  if (!batches[0].empty()) {
+  bool is_batches_empty =
+      (std::all_of(batches.begin(), batches.end(), [](const Batch& one_batch) {
+        return one_batch.empty();
+      }));
+  if (!is_batches_empty) {
     // only update the scheduling latency when there are requests to process
     COUNTER_ADD(scheduling_latency_seconds, timer.elapsed_seconds());
   }

--- a/xllm/core/scheduler/pd_ooc_scheduler.cpp
+++ b/xllm/core/scheduler/pd_ooc_scheduler.cpp
@@ -375,7 +375,11 @@ std::vector<Batch> PDOOCScheduler::prepare_batch() {
                            kv_cache_manager_->get_copy_in_cache_block_infos(),
                            kv_cache_manager_->get_copy_out_cache_block_infos());
 
-  if (!batches[0].empty()) {
+  bool is_batches_empty =
+      (std::all_of(batches.begin(), batches.end(), [](const Batch& one_batch) {
+        return one_batch.empty();
+      }));
+  if (!is_batches_empty) {
     // only update the scheduling latency when there are requests to process
     COUNTER_ADD(scheduling_latency_seconds, timer.elapsed_seconds());
   }

--- a/xllm/core/scheduler/prefill_only_scheduler.cpp
+++ b/xllm/core/scheduler/prefill_only_scheduler.cpp
@@ -633,7 +633,11 @@ std::vector<Batch> PrefillOnlyScheduler::prepare_batch() {
                            kv_cache_manager_->get_copy_out_cache_block_infos(),
                            kv_cache_manager_->get_swap_cache_block_infos());
 
-  if (!batches[0].empty()) {
+  bool is_batches_empty =
+      (std::all_of(batches.begin(), batches.end(), [](const Batch& one_batch) {
+        return one_batch.empty();
+      }));
+  if (!is_batches_empty) {
     // only update the scheduling latency when there are requests to process
     COUNTER_ADD(scheduling_latency_seconds, timer.elapsed_seconds());
   }


### PR DESCRIPTION
This pr introduces a gflag `enable_dp_balance`, would be truly enabled with `--enable_dp_balance=true` and `--enable_customize_mla_kernel=true`. 
The idea of this pr is to balance the load of all npu cube cores by adjusting the order of sequences within a dp batch, leave the most longest sequences to the remainder(of 24 cores) part to be optimized by custom mla op, and collocate a long + a short sequences to a single cube core.

If the kvcache len of 49 (24+24+1) input sequences within a batch as this,  
```
 { 99, 1,  2,  3,  4,  5,  6,  7,  8,  9,  10, 11, 12, 13, 14, 15, 16, 17, 
   18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33,
   34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48};
```
the shuffle result is 
```
{48, 47, 46, 45, 44, 43, 42, 41, 40, 39, 38, 37, 36, 35, 34, 33, 
  32, 31, 30, 29, 28, 27, 26, 25,  1,  2,  3,  4,  5,  6,  7,  8,  9, 10,
  11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 99}
```

Beside, fix a bug  in scheduler when recording the “scheduling_latency_seconds” metric.

