### PR TITLE
add WAN2.1-I2V model modules

### DIFF
--- a/xllm/models/dit/autoencoder_kl_wan.h
+++ b/xllm/models/dit/autoencoder_kl_wan.h
@@ -1,0 +1,1552 @@
+#pragma once
+#include <torch/nn/modules/conv.h>
+#include <torch/nn/modules/dropout.h>
+#include <torch/nn/modules/linear.h>
+#include <torch/nn/modules/normalization.h>
+#include <torch/torch.h>
+
+#include <iostream>
+#include <memory>
+#include <optional>
+#include <stdexcept>
+#include <string>
+#include <vector>
+
+#include "autoencoder_kl.h"
+#include "core/framework/dit_model_loader.h"
+#include "core/framework/model/model_input_params.h"
+#include "core/framework/state_dict/state_dict.h"
+#include "dit_linear.h"
+#include "framework/model_context.h"
+#include "models/model_registry.h"
+#include "processors/input_processor.h"
+#include "processors/pywarpper_image_processor.h"
+
+namespace xllm {
+
+class AvgDown3DImpl : public torch::nn::Module {
+ public:
+  AvgDown3DImpl(int64_t in_channels,
+                int64_t out_channels,
+                int64_t factor_t,
+                int64_t factor_s = 1)
+      : in_channels_(in_channels),
+        out_channels_(out_channels),
+        factor_t_(factor_t),
+        factor_s_(factor_s) {
+    factor_ = factor_t_ * factor_s_ * factor_s_;
+    TORCH_CHECK(in_channels_ * factor_ % out_channels_ == 0,
+                "in_channels * factor must be divisible by out_channels");
+    group_size_ = in_channels_ * factor_ / out_channels_;
+  }
+
+  torch::Tensor forward(torch::Tensor x) {
+    int64_t pad_t = (factor_t_ - x.size(2) % factor_t_) % factor_t_;
+    std::vector<int64_t> pad = {0, 0, 0, 0, pad_t, 0};
+    x = torch::nn::functional::pad(x,
+                                   torch::nn::functional::PadFuncOptions(pad));
+    auto sizes = x.sizes();
+    int64_t B = sizes[0], C = sizes[1], T = sizes[2], H = sizes[3],
+            W = sizes[4];
+    x = x.view({B,
+                C,
+                T / factor_t_,
+                factor_t_,
+                H / factor_s_,
+                factor_s_,
+                W / factor_s_,
+                factor_s_});
+    x = x.permute({0, 1, 3, 5, 7, 2, 4, 6}).contiguous();
+    x = x.view({B, C * factor_, T / factor_t_, H / factor_s_, W / factor_s_});
+    x = x.view({B,
+                out_channels_,
+                group_size_,
+                T / factor_t_,
+                H / factor_s_,
+                W / factor_s_});
+    x = x.mean(2);
+    return x;
+  }
+
+ private:
+  int64_t in_channels_, out_channels_, factor_t_, factor_s_, factor_,
+      group_size_;
+};
+TORCH_MODULE(AvgDown3D);
+
+class DupUp3DImpl : public torch::nn::Module {
+ public:
+  DupUp3DImpl(int64_t in_channels,
+              int64_t out_channels,
+              int64_t factor_t,
+              int64_t factor_s = 1)
+      : in_channels_(in_channels),
+        out_channels_(out_channels),
+        factor_t_(factor_t),
+        factor_s_(factor_s) {
+    factor_ = factor_t_ * factor_s_ * factor_s_;
+    TORCH_CHECK(out_channels_ * factor_ % in_channels_ == 0,
+                "out_channels * factor must be divisible by in_channels");
+    repeats_ = out_channels_ * factor_ / in_channels_;
+  }
+
+  torch::Tensor forward(torch::Tensor x, bool first_chunk = false) {
+    x = x.repeat_interleave(repeats_, 1);
+    x = x.view({x.size(0),
+                out_channels_,
+                factor_t_,
+                factor_s_,
+                factor_s_,
+                x.size(2),
+                x.size(3),
+                x.size(4)});
+    x = x.permute({0, 1, 5, 2, 6, 3, 7, 4}).contiguous();
+    x = x.view({x.size(0),
+                out_channels_,
+                x.size(2) * factor_t_,
+                x.size(4) * factor_s_,
+                x.size(6) * factor_s_});
+    if (first_chunk) {
+      x = x.index({torch::indexing::Slice(),
+                   torch::indexing::Slice(),
+                   torch::indexing::Slice(factor_t_ - 1, torch::indexing::None),
+                   torch::indexing::Slice(),
+                   torch::indexing::Slice()});
+    }
+    return x;
+  }
+
+ private:
+  int64_t in_channels_, out_channels_, factor_t_, factor_s_, factor_, repeats_;
+};
+TORCH_MODULE(DupUp3D);
+
+class WanCausalConv3DImpl : public torch::nn::Module {
+ public:
+  WanCausalConv3DImpl(int64_t in_channels,
+                      int64_t out_channels,
+                      std::vector<int64_t> kernel_size,
+                      std::vector<int64_t> stride = {1, 1, 1},
+                      std::vector<int64_t> padding = {0, 0, 0})
+      : in_channels_(in_channels),
+        out_channels_(out_channels),
+        kernel_size_(kernel_size),
+        stride_(stride),
+        padding_(padding) {
+    conv_ = register_module(
+        "conv",
+        torch::nn::Conv3d(
+            torch::nn::Conv3dOptions(in_channels, out_channels, kernel_size)
+                .stride(stride)
+                .padding(0)
+                .bias(true)));
+    _padding_ = {
+        padding[2], padding[2], padding[1], padding[1], 2 * padding[0], 0};
+  }
+
+  torch::Tensor forward(
+      const torch::Tensor& x,
+      const torch::optional<torch::Tensor>& cache_x = torch::nullopt) {
+    std::vector<int64_t> padding = _padding_;
+    torch::Tensor input = x;
+    if (cache_x.has_value() && padding[4] > 0) {
+      torch::Tensor cache = cache_x.value().to(x.device());
+      input = torch::cat({cache, input}, 2);
+      padding[4] -= cache.size(2);
+    }
+    input = torch::nn::functional::pad(
+        input, torch::nn::functional::PadFuncOptions(padding));
+    return conv_->forward(input);
+  }
+
+  void load_state_dict(const StateDict& state_dict) {
+    const auto weight = state_dict.get_tensor("conv.weight");
+    if (weight.defined()) {
+      DCHECK_EQ(conv_->weight.sizes(), weight.sizes())
+          << "conv weight size mismatch";
+      conv_->weight.data().copy_(weight);
+    }
+    const auto bias = state_dict.get_tensor("conv.bias");
+    if (bias.defined() && conv_->bias.defined()) {
+      DCHECK_EQ(conv_->bias.sizes(), bias.sizes()) << "conv bias size mismatch";
+      conv_->bias.data().copy_(bias);
+    }
+  }
+
+ private:
+  int64_t in_channels_, out_channels_;
+  std::vector<int64_t> kernel_size_, stride_, padding_, _padding_;
+  torch::nn::Conv3d conv_{nullptr};
+};
+TORCH_MODULE(WanCausalConv3D);
+
+class WanRMSNormImpl : public torch::nn::Module {
+ public:
+  WanRMSNormImpl(int64_t dim,
+                 bool channel_first = true,
+                 bool images = true,
+                 bool bias = false)
+      : channel_first_(channel_first), images_(images), bias_enabled_(bias) {
+    std::vector<int64_t> broadcastable_dims;
+    if (!images) {
+      broadcastable_dims = {1, 1, 1};
+    } else {
+      broadcastable_dims = {1, 1};
+    }
+    std::vector<int64_t> shape;
+    if (channel_first) {
+      shape.push_back(dim);
+      shape.insert(
+          shape.end(), broadcastable_dims.begin(), broadcastable_dims.end());
+    } else {
+      shape.push_back(dim);
+    }
+    scale_ = std::sqrt(static_cast<double>(dim));
+    gamma_ = register_parameter("gamma", torch::ones(shape));
+    if (bias_enabled_) {
+      bias_ = register_parameter("bias", torch::zeros(shape));
+    }
+  }
+
+  torch::Tensor forward(const torch::Tensor& x) {
+    int64_t norm_dim = channel_first_ ? 1 : -1;
+    auto normed = torch::nn::functional::normalize(
+        x, torch::nn::functional::NormalizeFuncOptions().dim(norm_dim));
+    auto out = normed * scale_ * gamma_;
+    if (bias_enabled_) {
+      out = out + bias_;
+    }
+    return out;
+  }
+
+  void load_state_dict(const StateDict& state_dict) {
+    const auto gamma_weight = state_dict.get_tensor("gamma");
+    if (gamma_weight.defined()) {
+      gamma_.data().copy_(gamma_weight);
+    }
+    if (bias_enabled_) {
+      const auto bias_weight = state_dict.get_tensor("bias");
+      if (bias_weight.defined()) {
+        bias_.data().copy_(bias_weight);
+      }
+    }
+  }
+
+ private:
+  bool channel_first_;
+  bool images_;
+  bool bias_enabled_;
+  double scale_;
+  torch::Tensor gamma_;
+  torch::Tensor bias_;
+};
+TORCH_MODULE(WanRMSNorm);
+
+class WanResampleImpl : public torch::nn::Module {
+ public:
+  WanResampleImpl(int64_t dim,
+                  const std::string& mode,
+                  int64_t upsample_out_dim = -1)
+      : dim_(dim), mode_(mode) {
+    if (upsample_out_dim == -1) {
+      upsample_out_dim = dim / 2;
+    }
+
+    if (mode == "upsample2d") {
+      auto resample = torch::nn::Sequential(
+          torch::nn::Upsample(torch::nn::UpsampleOptions()
+                                  .scale_factor(std::vector<double>{2.0, 2.0})
+                                  .mode("nearest")),
+          torch::nn::Conv2d(
+              torch::nn::Conv2dOptions(dim, upsample_out_dim, 3).padding(1)));
+    } else if (mode == "upsample3d") {
+      auto resample = torch::nn::Sequential(
+          torch::nn::Upsample(torch::nn::UpsampleOptions()
+                                  .scale_factor(std::vector<double>{2.0, 2.0})
+                                  .mode("nearest")),
+          torch::nn::Conv2d(
+              torch::nn::Conv2dOptions(dim, upsample_out_dim, 3).padding(1)));
+      time_conv_ =
+          register_module("time_conv",
+                          WanCausalConv3D(dim,
+                                          dim,
+                                          std::vector<int64_t>{3, 1, 1},
+                                          std::vector<int64_t>{1, 1, 1},
+                                          std::vector<int64_t>{1, 0, 0}));
+    } else if (mode == "downsample2d") {
+      resample = torch::nn::Sequential(
+          torch::nn::ZeroPad2d(torch::nn::ZeroPad2dOptions({0, 1, 0, 1})),
+          torch::nn::Conv2d(torch::nn::Conv2dOptions(dim, dim, 3)
+                                .stride(std::vector<int64_t>{2, 2})));
+    } else if (mode == "downsample3d") {
+      auto resample = torch::nn::Sequential(
+          torch::nn::ZeroPad2d(torch::nn::ZeroPad2dOptions({0, 1, 0, 1})),
+          torch::nn::Conv2d(torch::nn::Conv2dOptions(dim, dim, 3)
+                                .stride(std::vector<int64_t>{2, 2})));
+      time_conv_ =
+          register_module("time_conv",
+                          WanCausalConv3D(dim,
+                                          dim,
+                                          std::vector<int64_t>{3, 1, 1},
+                                          std::vector<int64_t>{2, 1, 1},
+                                          std::vector<int64_t>{0, 0, 0}));
+    } else {
+      auto resample = torch::nn::Sequential(torch::nn::Identity());
+    }
+    resample_ = register_module("resample", resample);
+  }
+
+  torch::Tensor forward(torch::Tensor x,
+                        std::vector<torch::Tensor>* feat_cache = nullptr,
+                        std::vector<int>* feat_idx = std::vector<int>{0}) {
+    auto sizes = x.sizes();
+    int64_t b = sizes[0], c = sizes[1], t = sizes[2], h = sizes[3],
+            w = sizes[4];
+
+    if (mode == "upsample3d" && feat_cache) {
+      int idx = (*feat_idx)[0];
+      if ((*feat_cache)[idx].numel() == 0) {
+        (*feat_cache)[idx] = torch::full({1}, -1, x.options());  // Rep flag
+        (*feat_idx)[0] += 1;
+      } else {
+        auto cache_x =
+            x.index({torch::indexing::Slice(),
+                     torch::indexing::Slice(),
+                     torch::indexing::Slice(-CACHE_T, torch::indexing::None),
+                     torch::indexing::Slice(),
+                     torch::indexing::Slice()})
+                .clone();
+        if (cache_x.size(2) < 2 && (*feat_cache)[idx].numel() > 0 &&
+            (*feat_cache)[idx].item<int>() != -1) {
+          cache_x = torch::cat({(*feat_cache)[idx]
+                                    .index({torch::indexing::Slice(),
+                                            torch::indexing::Slice(),
+                                            -1,
+                                            torch::indexing::Slice(),
+                                            torch::indexing::Slice()})
+                                    .unsqueeze(2)
+                                    .to(cache_x.device()),
+                                cache_x},
+                               2);
+        }
+        if (cache_x.size(2) < 2 && (*feat_cache)[idx].numel() > 0 &&
+            (*feat_cache)[idx].item<int>() == -1) {
+          cache_x = torch::cat(
+              {torch::zeros_like(cache_x).to(cache_x.device()), cache_x}, 2);
+        }
+        if ((*feat_cache)[idx].item<int>() == -1) {
+          x = time_conv->forward(x);
+        } else {
+          x = time_conv->forward(x, (*feat_cache)[idx]);
+        }
+        (*feat_cache)[idx] = cache_x;
+        (*feat_idx)[0] += 1;
+
+        x = x.view({b, 2, c, t, h, w});
+        x = torch::stack({x.index({torch::indexing::Slice(),
+                                   0,
+                                   torch::indexing::Slice(),
+                                   torch::indexing::Slice(),
+                                   torch::indexing::Slice(),
+                                   torch::indexing::Slice()}),
+                          x.index({torch::indexing::Slice(),
+                                   1,
+                                   torch::indexing::Slice(),
+                                   torch::indexing::Slice(),
+                                   torch::indexing::Slice(),
+                                   torch::indexing::Slice()})},
+                         3);
+        x = x.view({b, c, t * 2, h, w});
+      }
+    }
+    t = x.size(2);
+    x = x.permute({0, 2, 1, 3, 4}).reshape({b * t, c, h, w});
+    x = resample->forward(x);
+    x = x.view({b, t, x.size(1), x.size(2), x.size(3)})
+            .permute({0, 2, 1, 3, 4});
+
+    if (mode == "downsample3d" && feat_cache) {
+      int idx = (*feat_idx)[0];
+      if ((*feat_cache)[idx].numel() == 0) {
+        (*feat_cache)[idx] = x.clone();
+        (*feat_idx)[0] += 1;
+      } else {
+        auto cache_x =
+            x.index({torch::indexing::Slice(),
+                     torch::indexing::Slice(),
+                     torch::indexing::Slice(-1, torch::indexing::None),
+                     torch::indexing::Slice(),
+                     torch::indexing::Slice()})
+                .clone();
+        x = time_conv->forward(
+            torch::cat({(*feat_cache)[idx].index(
+                            {torch::indexing::Slice(),
+                             torch::indexing::Slice(),
+                             torch::indexing::Slice(-1, torch::indexing::None),
+                             torch::indexing::Slice(),
+                             torch::indexing::Slice()}),
+                        x},
+                       2));
+        (*feat_cache)[idx] = cache_x;
+        (*feat_idx)[0] += 1;
+      }
+    }
+    return x;
+  }
+
+  void load_state_dict(const StateDict& state_dict) {
+    for (size_t i = 0; i < resample->size(); ++i) {
+      auto module = resample[i];
+      if (auto conv =
+              std::dynamic_pointer_cast<torch::nn::Conv2dImpl>(module)) {
+        const auto weight =
+            state_dict.get_tensor("resample." + std::to_string(i) + ".weight");
+        if (weight.defined()) {
+          DCHECK_EQ(conv->weight.sizes(), weight.sizes())
+              << "resample conv weight size mismatch: expected "
+              << conv->weight.sizes() << " but got " << weight.sizes();
+          conv->weight.data().copy_(weight);
+        }
+        const auto bias =
+            state_dict.get_tensor("resample." + std::to_string(i) + ".bias");
+        if (bias.defined() && conv->bias.defined()) {
+          DCHECK_EQ(conv->bias.sizes(), bias.sizes())
+              << "resample conv bias size mismatch: expected "
+              << conv->bias.sizes() << " but got " << bias.sizes();
+          conv->bias.data().copy_(bias);
+        }
+      }
+    }
+    if (time_conv) {
+      time_conv->load_state_dict(state_dict.get_dict_with_prefix("time_conv."));
+    }
+  }
+
+ private:
+  int64_t dim_;
+  std::string mode_;
+  torch::nn::Sequential resample_{nullptr};
+  WanCausalConv3D time_conv_{nullptr};
+  const int CACHE_T = 2;
+};
+TORCH_MODULE(WanResample);
+
+class WanResidualBlockImpl : public torch::nn::Module {
+ public:
+  WanResidualBlockImpl(int64_t in_dim, int64_t out_dim, float dropout = 0.0f)
+      : in_dim_(in_dim), out_dim_(out_dim) {
+    nonlinearity_ = torch::nn::Functional(torch::silu);
+    norm1_ = register_module("norm1", WanRMSNorm(in_dim, true, false, false));
+    conv1_ = register_module("conv1",
+                             WanCausalConv3D(dim,
+                                             dim,
+                                             std::vector<int64_t>{3, 3, 3},
+                                             std::vector<int64_t>{1, 1, 1},
+                                             std::vector<int64_t>{1, 1, 1}));
+    norm2_ = register_module("norm2", WanRMSNorm(out_dim, true, false, false));
+    dropout_layer_ = register_module("dropout", torch::nn::Dropout(dropout));
+    conv2_ = register_module("conv2",
+                             WanCausalConv3D(dim,
+                                             dim,
+                                             std::vector<int64_t>{3, 3, 3},
+                                             std::vector<int64_t>{1, 1, 1},
+                                             std::vector<int64_t>{1, 1, 1}));
+    if in_dim_
+      != out_dim_ {
+        conv_shortcut_ =
+            register_module("conv_shortcut",
+                            WanCausalConv3D(dim,
+                                            dim,
+                                            std::vector<int64_t>{1, 1, 1},
+                                            std::vector<int64_t>{1, 1, 1},
+                                            std::vector<int64_t>{0, 0, 0}));
+      }
+    else {
+      conv_shortcut_ = register_module("conv_shortcut", torch::nn::Identity());
+    }
+  }
+
+  torch::Tensor forward(torch::Tensor x,
+                        std::vector<torch::Tensor>* feat_cache = nullptr,
+                        std::vector<int>* feat_idx = std::vector<int>{0}) {
+    torch::Tensor h;
+    h = conv_shortcut_->forward(x);
+    x = norm1_->forward(x);
+    x = nonlinearity_(x);
+
+    if (feat_cache) {
+      int idx = (*feat_idx)[0];
+      auto cache_x =
+          x.index({torch::indexing::Slice(),
+                   torch::indexing::Slice(),
+                   torch::indexing::Slice(-CACHE_T, torch::indexing::None),
+                   torch::indexing::Slice(),
+                   torch::indexing::Slice()})
+              .clone();
+      if (cache_x.size(2) < 2 && (*feat_cache)[idx].numel() > 0) {
+        cache_x = torch::cat({(*feat_cache)[idx]
+                                  .index({torch::indexing::Slice(),
+                                          torch::indexing::Slice(),
+                                          -1,
+                                          torch::indexing::Slice(),
+                                          torch::indexing::Slice()})
+                                  .unsqueeze(2)
+                                  .to(cache_x.device()),
+                              cache_x},
+                             2);
+      }
+      x = conv1_->forward(x, (*feat_cache)[idx]);
+      (*feat_cache)[idx] = cache_x;
+      (*feat_idx)[0] += 1;
+    } else {
+      x = conv1->forward(x);
+    }
+
+    x = norm2_->forward(x);
+    x = nonlinearity_(x);
+    x = dropout_layer_->forward(x);
+
+    if (feat_cache) {
+      int idx = (*feat_idx)[0];
+      auto cache_x =
+          x.index({torch::indexing::Slice(),
+                   torch::indexing::Slice(),
+                   torch::indexing::Slice(-CACHE_T, torch::indexing::None),
+                   torch::indexing::Slice(),
+                   torch::indexing::Slice()})
+              .clone();
+      if (cache_x.size(2) < 2 && (*feat_cache)[idx].numel() > 0) {
+        cache_x = torch::cat({(*feat_cache)[idx]
+                                  .index({torch::indexing::Slice(),
+                                          torch::indexing::Slice(),
+                                          -1,
+                                          torch::indexing::Slice(),
+                                          torch::indexing::Slice()})
+                                  .unsqueeze(2)
+                                  .to(cache_x.device()),
+                              cache_x},
+                             2);
+      }
+      x = conv2_->forward(x, (*feat_cache)[idx]);
+      (*feat_cache)[idx] = cache_x;
+      (*feat_idx)[0] += 1;
+    } else {
+      x = conv2_->forward(x);
+    }
+
+    return x + h;
+  }
+
+  void load_state_dict(const StateDict& state_dict) {
+    norm1_->load_state_dict(state_dict.get_dict_with_prefix("norm1."));
+    conv1_->load_state_dict(state_dict.get_dict_with_prefix("conv1."));
+    norm2_->load_state_dict(state_dict.get_dict_with_prefix("norm2."));
+    conv2_->load_state_dict(state_dict.get_dict_with_prefix("conv2."));
+    conv_shortcut_->load_state_dict(
+        state_dict.get_dict_with_prefix("conv_shortcut."));
+  }
+
+ private:
+  int64_t in_dim_, out_dim_;
+  std::string non_linearity_;
+  const int CACHE_T = 2;
+
+  torch::nn::Functional nonlinearity_{nullptr};
+  WanRMSNorm norm1_{nullptr}, norm2_{nullptr};
+  WanCausalConv3D conv1_{nullptr}, conv2_{nullptr}, conv_shortcut_{nullptr};
+  torch::nn::Dropout dropout_layer_{nullptr};
+};
+TORCH_MODULE(WanResidualBlock);
+
+class WanAttentionBlockImpl : public torch::nn::Module {
+ public:
+  WanAttentionBlockImpl(int64_t dim) : dim_(dim) {
+    norm_ = register_module("norm", WanRMSNorm(dim, true, true, false));
+    to_qkv_ = register_module(
+        "to_qkv", torch::nn::Conv2d(torch::nn::Conv2dOptions(dim, dim * 3, 1)));
+    proj_ = register_module(
+        "proj", torch::nn::Conv2d(torch::nn::Conv2dOptions(dim, dim, 1)));
+  }
+
+  torch::Tensor forward(torch::Tensor x) {
+    torch::Tensor identity = x;
+    auto sizes = x.sizes();
+    int64_t batch_size = sizes[0];
+    int64_t channels = sizes[1];
+    int64_t time = sizes[2];
+    int64_t height = sizes[3];
+    int64_t width = sizes[4];
+
+    x = x.permute({0, 2, 1, 3, 4})
+            .reshape({batch_size * time, channels, height, width});
+    x = norm_->forward(x);
+
+    auto qkv = to_qkv_->forward(x);
+    qkv = qkv.reshape({batch_size * time, 1, channels * 3, height * width});
+    qkv = qkv.permute({0, 1, 3, 2}).contiguous();
+    auto chunks = qkv.chunk(3, -1);
+    torch::Tensor q = chunks[0];
+    torch::Tensor k = chunks[1];
+    torch::Tensor v = chunks[2];
+
+    torch::Tensor attn_out =
+        torch::nn::functional::scaled_dot_product_attention(q, k, v);
+
+    attn_out = attn_out.squeeze(1).permute({0, 2, 1}).reshape(
+        {batch_size * time, channels, height, width});
+    attn_out = proj_->forward(attn_out);
+
+    attn_out = attn_out.view({batch_size, time, channels, height, width})
+                   .permute({0, 2, 1, 3, 4});
+    return attn_out + identity;
+  }
+
+  void load_state_dict(const StateDict& state_dict) {
+    norm_->load_state_dict(state_dict.get_dict_with_prefix("norm."));
+    const auto to_qkv_weight = state_dict.get_tensor("to_qkv.weight");
+    if (to_qkv_weight.defined()) {
+      DCHECK_EQ(to_qkv_->weight.sizes(), to_qkv_weight.sizes())
+          << "to_qkv weight size mismatch";
+      to_qkv_->weight.data().copy_(to_qkv_weight);
+    }
+    const auto to_qkv_bias = state_dict.get_tensor("to_qkv.bias");
+    if (to_qkv_bias.defined() && to_qkv_->bias.defined()) {
+      DCHECK_EQ(to_qkv_->bias.sizes(), to_qkv_bias.sizes())
+          << "to_qkv bias size mismatch";
+      to_qkv_->bias.data().copy_(to_qkv_bias);
+    }
+    const auto proj_weight = state_dict.get_tensor("proj.weight");
+    if (proj_weight.defined()) {
+      DCHECK_EQ(proj_->weight.sizes(), proj_weight.sizes())
+          << "proj weight size mismatch";
+      proj_->weight.data().copy_(proj_weight);
+    }
+    const auto proj_bias = state_dict.get_tensor("proj.bias");
+    if (proj_bias.defined() && proj_->bias.defined()) {
+      DCHECK_EQ(proj_->bias.sizes(), proj_bias.sizes())
+          << "proj bias size mismatch";
+      proj_->bias.data().copy_(proj_bias);
+    }
+  }
+
+ private:
+  int64_t dim_;
+  WanRMSNorm norm_{nullptr};
+  torch::nn::Conv2d to_qkv_{nullptr};
+  torch::nn::Conv2d proj_{nullptr};
+};
+TORCH_MODULE(WanAttentionBlock);
+
+class WanMidBlockImpl : public torch::nn::Module {
+ public:
+  WanMidBlockImpl(int64_t dim, float dropout = 0.0f, int num_layers = 1)
+      : dim_(dim) {
+    resnets_ = register_module("resnets", torch::nn::ModuleList());
+    attentions_ = register_module("attentions", torch::nn::ModuleList());
+    resnets_->push_back(WanResidualBlock(dim, dim, dropout));
+    for (int i = 0; i < num_layers; ++i) {
+      attentions_->push_back(WanAttentionBlock(dim));
+      resnets_->push_back(WanResidualBlock(dim, dim, dropout));
+    }
+  }
+
+  torch::Tensor forward(torch::Tensor x,
+                        std::vector<torch::Tensor>* feat_cache = nullptr,
+                        std::vector<int>* feat_idx = std::vector<int>{0}) {
+    x = resnets_[0]->as<WanResidualBlock>()->forward(x, feat_cache, feat_idx);
+    for (size_t i = 0; i < attentions_->size(); ++i) {
+      auto attn = attentions_[i]->as<WanAttentionBlock>();
+      if (attn) {
+        x = attn->forward(x);
+      }
+      auto resnet = resnets_[i + 1]->as<WanResidualBlock>();
+      x = resnet->forward(x, feat_cache, feat_idx);
+    }
+    return x;
+  }
+
+  void load_state_dict(const StateDict& state_dict) {
+    for (size_t i = 0; i < resnets_->size(); ++i) {
+      resnets_[i]->as<WanResidualBlock>()->load_state_dict(
+          state_dict.get_dict_with_prefix("resnets." + std::to_string(i) +
+                                          "."));
+    }
+    for (size_t i = 0; i < attentions_->size(); ++i) {
+      attentions_[i]->as<WanAttentionBlock>()->load_state_dict(
+          state_dict.get_dict_with_prefix("attentions." + std::to_string(i) +
+                                          "."));
+    }
+  }
+
+ private:
+  int64_t dim_;
+  torch::nn::ModuleList resnets_{nullptr};
+  torch::nn::ModuleList attentions_{nullptr};
+};
+TORCH_MODULE(WanMidBlock);
+
+class WanResidualDownBlockImpl : public torch::nn::Module {
+ public:
+  WanResidualDownBlockImpl(int64_t in_dim,
+                           int64_t out_dim,
+                           float dropout,
+                           int num_res_blocks,
+                           bool temperal_downsample = false,
+                           bool down_flag = false)
+      : in_dim_(in_dim),
+        out_dim_(out_dim),
+        dropout_(dropout),
+        num_res_blocks_(num_res_blocks),
+        temperal_downsample_(temperal_downsample),
+        down_flag_(down_flag) {
+    int factor_t = temperal_downsample ? 2 : 1;
+    int factor_s = down_flag ? 2 : 1;
+    avg_shortcut_ = register_module(
+        "avg_shortcut", AvgDown3D(in_dim, out_dim, factor_t, factor_s));
+    resnets_ = register_module("resnets", torch::nn::ModuleList());
+    int cur_in_dim = in_dim;
+    for (int i = 0; i < num_res_blocks; ++i) {
+      resnets_->push_back(WanResidualBlock(cur_in_dim, out_dim, dropout));
+      cur_in_dim = out_dim;
+    }
+    if (down_flag) {
+      std::string mode = temperal_downsample ? "downsample3d" : "downsample2d";
+      downsampler_ =
+          register_module("downsampler", WanResample(out_dim, mode, -1));
+    } else {
+      downsampler_ = nullptr;
+    }
+  }
+
+  torch::Tensor forward(torch::Tensor x,
+                        std::vector<torch::Tensor>* feat_cache = nullptr,
+                        std::vector<int>* feat_idx = std::vector<int>{0}) {
+    torch::Tensor x_copy = x.clone();
+    for (size_t i = 0; i < resnets_->size(); ++i) {
+      x = resnets_[i]->as<WanResidualBlock>()->forward(x, feat_cache, feat_idx);
+    }
+    if (downsampler_) {
+      x = downsampler_->as<WanResample>()->forward(x, feat_cache, feat_idx);
+    }
+    return x + avg_shortcut_->forward(x_copy);
+  }
+
+  void load_state_dict(const StateDict& state_dict) {
+    avg_shortcut_->as<AvgDown3D>()->load_state_dict(
+        state_dict.get_dict_with_prefix("avg_shortcut."));
+    for (size_t i = 0; i < resnets_->size(); ++i) {
+      resnets_[i]->as<WanResidualBlock>()->load_state_dict(
+          state_dict.get_dict_with_prefix("resnets." + std::to_string(i) +
+                                          "."));
+    }
+    if (downsampler_) {
+      downsampler_->as<WanResample>()->load_state_dict(
+          state_dict.get_dict_with_prefix("downsampler."));
+    }
+  }
+
+ private:
+  int64_t in_dim_, out_dim_;
+  float dropout_;
+  int num_res_blocks_;
+  bool temperal_downsample_, down_flag_;
+  torch::nn::Module avg_shortcut_{nullptr};
+  torch::nn::ModuleList resnets_{nullptr};
+  torch::nn::Module downsampler_{nullptr};
+};
+TORCH_MODULE(WanResidualDownBlock);
+
+class WanVAEEncoder3DImpl : public torch::nn::Module {
+ public:
+  WanVAEEncoder3DImpl(int64_t in_channels = 3,
+                      int64_t dim = 128,
+                      int64_t z_dim = 4,
+                      std::vector<int64_t> dim_mult = {1, 2, 4, 4},
+                      int num_res_blocks = 2,
+                      std::vector<float> attn_scales = {},
+                      std::vector<bool> temperal_downsample = {true,
+                                                               true,
+                                                               false},
+                      float dropout = 0.0f,
+                      bool is_residual = false) {
+    nonlinearity_ = torch::nn::Functional(torch::silu);
+    std::vector<int64_t> dims;
+    dims.push_back(dim);
+    for (auto u : dim_mult) dims.push_back(dim * u);
+    double scale = 1.0;
+    conv_in_ = register_module("conv_in",
+                               WanCausalConv3D(in_channels,
+                                               dims[0],
+                                               std::vector<int64_t>{3, 3, 3},
+                                               std::vector<int64_t>{1, 1, 1},
+                                               std::vector<int64_t>{1, 1, 1}));
+    down_blocks_ = register_module("down_blocks", torch::nn::ModuleList());
+    for (size_t i = 0; i < dims.size() - 1; ++i) {
+      int64_t in_dim = dims[i];
+      int64_t out_dim = dims[i + 1];
+      if (is_residual) {
+        down_blocks_->push_back(WanResidualDownBlock(
+            in_dim,
+            out_dim,
+            dropout,
+            num_res_blocks,
+            (i != dim_mult.size() - 1) ? temperal_downsample[i] : false,
+            (i != dim_mult.size() - 1)));
+      } else {
+        for (int j = 0; j < num_res_blocks; ++j) {
+          int current_dim = in_dim;
+          down_blocks_->push_back(
+              WanResidualBlock(current_dim, out_dim, dropout));
+          if (std::find(attn_scales.begin(), attn_scales.end(), scale) !=
+              attn_scales.end()) {
+            down_blocks_->push_back(WanAttentionBlock(out_dim));
+          }
+          current_dim = out_dim;
+        }
+        if (i != dim_mult.size() - 1) {
+          std::string mode =
+              temperal_downsample[i] ? "downsample3d" : "downsample2d";
+          down_blocks_->push_back(WanResample(out_dim, mode, -1));
+          scale /= 2.0;
+        }
+      }
+    }
+    mid_block_ =
+        register_module("mid_block", WanMidBlock(dims.back(), dropout, 1));
+    norm_out_ = register_module("norm_out",
+                                WanRMSNorm(dims.back(), true, false, false));
+    conv_out_ = register_module("conv_out",
+                                WanCausalConv3D(dims.back(),
+                                                z_dim,
+                                                std::vector<int64_t>{3, 3, 3},
+                                                std::vector<int64_t>{1, 1, 1},
+                                                std::vector<int64_t>{1, 1, 1}));
+  }
+
+  torch::Tensor forward(torch::Tensor x,
+                        std::vector<torch::Tensor>* feat_cache = nullptr,
+                        std::vector<int>* feat_idx = std::vector<int>{0}) {
+    if (feat_cache) {
+      int idx = (*feat_idx)[0];
+      auto cache_x =
+          x.index({torch::indexing::Slice(),
+                   torch::indexing::Slice(),
+                   torch::indexing::Slice(-CACHE_T, torch::indexing::None),
+                   torch::indexing::Slice(),
+                   torch::indexing::Slice()})
+              .clone();
+      if (cache_x.size(2) < 2 && (*feat_cache)[idx].numel() > 0) {
+        cache_x = torch::cat({(*feat_cache)[idx]
+                                  .index({torch::indexing::Slice(),
+                                          torch::indexing::Slice(),
+                                          -1,
+                                          torch::indexing::Slice(),
+                                          torch::indexing::Slice()})
+                                  .unsqueeze(2)
+                                  .to(cache_x.device()),
+                              cache_x},
+                             2);
+      }
+      x = conv_in_->forward(x, (*feat_cache)[idx]);
+      (*feat_cache)[idx] = cache_x;
+      (*feat_idx)[0] += 1;
+    } else {
+      x = conv_in_->forward(x);
+    }
+    for (size_t i = 0; i < down_blocks_->size(); ++i) {
+      if (feat_cache) {
+        x = down_blocks_[i]->forward(x, feat_cache, feat_idx);
+      } else {
+        x = down_blocks_[i]->forward(x);
+      }
+    }
+    x = mid_block_->forward(x, feat_cache, feat_idx);
+    x = norm_out_->forward(x);
+    x = nonlinearity_(x);
+    if (feat_cache) {
+      int idx = (*feat_idx)[0];
+      auto cache_x =
+          x.index({torch::indexing::Slice(),
+                   torch::indexing::Slice(),
+                   torch::indexing::Slice(-CACHE_T, torch::indexing::None),
+                   torch::indexing::Slice(),
+                   torch::indexing::Slice()})
+              .clone();
+      if (cache_x.size(2) < 2 && (*feat_cache)[idx].numel() > 0) {
+        cache_x = torch::cat({(*feat_cache)[idx]
+                                  .index({torch::indexing::Slice(),
+                                          torch::indexing::Slice(),
+                                          -1,
+                                          torch::indexing::Slice(),
+                                          torch::indexing::Slice()})
+                                  .unsqueeze(2)
+                                  .to(cache_x.device()),
+                              cache_x},
+                             2);
+      }
+      x = conv_out_->forward(x, (*feat_cache)[idx]);
+      (*feat_cache)[idx] = cache_x;
+      (*feat_idx)[0] += 1;
+    } else {
+      x = conv_out_->forward(x);
+    }
+    return x;
+  }
+
+  void load_state_dict(const StateDict& state_dict) {
+    conv_in_->load_state_dict(state_dict.get_dict_with_prefix("conv_in."));
+    for (size_t i = 0; i < down_blocks_->size(); ++i) {
+      down_blocks_[i]->load_state_dict(state_dict.get_dict_with_prefix(
+          "down_blocks." + std::to_string(i) + "."));
+    }
+    mid_block_->load_state_dict(state_dict.get_dict_with_prefix("mid_block."));
+    norm_out_->load_state_dict(state_dict.get_dict_with_prefix("norm_out."));
+    conv_out_->load_state_dict(state_dict.get_dict_with_prefix("conv_out."));
+  }
+
+ private:
+  torch::nn::Functional nonlinearity_{nullptr};
+  torch::nn::Module conv_in_{nullptr};
+  torch::nn::ModuleList down_blocks_{nullptr};
+  WanMidBlock mid_block_{nullptr};
+  WanRMSNorm norm_out_{nullptr};
+  WanCausalConv3D conv_out_{nullptr};
+  const int CACHE_T = 2;
+};
+TORCH_MODULE(WanVAEEncoder3D);
+
+class WanResidualUpBlockImpl : public torch::nn::Module {
+ public:
+  WanResidualUpBlockImpl(int64_t in_dim,
+                         int64_t out_dim,
+                         int num_res_blocks,
+                         float dropout = 0.0f,
+                         bool temperal_upsample = false,
+                         bool up_flag = false)
+      : in_dim_(in_dim), out_dim_(out_dim), num_res_blocks_(num_res_blocks) {
+    if (up_flag_) {
+      int factor_t = temperal_upsample ? 2 : 1;
+      int factor_s = 2;
+      avg_shortcut_ = register_module(
+          "avg_shortcut", DupUp3D(in_dim, out_dim, factor_t, factor_s));
+    } else {
+      avg_shortcut_ = nullptr;
+    }
+    resnets_ = register_module("resnets", torch::nn::ModuleList());
+    int current_dim = in_dim;
+    for (int i = 0; i < num_res_blocks + 1; ++i) {
+      resnets_->push_back(WanResidualBlock(current_dim, out_dim, dropout));
+      current_dim = out_dim;
+    }
+    if (up_flag) {
+      std::string upsample_mode =
+          temperal_upsample ? "upsample3d" : "upsample2d";
+      upsampler_ = register_module(
+          "upsampler", WanResample(out_dim, upsample_mode, out_dim));
+    } else {
+      upsampler_ = nullptr;
+    }
+  }
+
+  torch::Tensor forward(torch::Tensor x,
+                        std::vector<torch::Tensor>* feat_cache = nullptr,
+                        std::vector<int>* feat_idx = std::vector<int>({0}),
+                        bool first_chunk = false) {
+    torch::Tensor x_copy = x.clone();
+    for (size_t i = 0; i < resnets_->size(); ++i) {
+      if (feat_cache) {
+        x = resnets_[i]->as<WanResidualBlock>()->forward(
+            x, feat_cache, feat_idx);
+      } else {
+        x = resnets_[i]->as<WanResidualBlock>()->forward(x);
+      }
+    }
+    if (upsampler_) {
+      if (feat_cache) {
+        x = upsampler_->as<WanResample>()->forward(x, feat_cache, feat_idx);
+      } else {
+        x = upsampler_->as<WanResample>()->forward(x);
+      }
+    }
+    if (avg_shortcut_) {
+      x = x + avg_shortcut_->as<DupUp3D>()->forward(x_copy, first_chunk);
+    }
+    return x;
+  }
+
+  void load_state_dict(const StateDict& state_dict) {
+    if (avg_shortcut_) {
+      avg_shortcut_->as<DupUp3D>()->load_state_dict(
+          state_dict.get_dict_with_prefix("avg_shortcut."));
+    }
+    for (size_t i = 0; i < resnets_->size(); ++i) {
+      resnets_[i]->as<WanResidualBlock>()->load_state_dict(
+          state_dict.get_dict_with_prefix("resnets." + std::to_string(i) +
+                                          "."));
+    }
+    if (upsampler_) {
+      upsampler_->as<WanResample>()->load_state_dict(
+          state_dict.get_dict_with_prefix("upsampler."));
+    }
+  }
+
+ private:
+  int64_t in_dim_, out_dim_;
+  int num_res_blocks_;
+  torch::nn::Module avg_shortcut_{nullptr};
+  torch::nn::ModuleList resnets_{nullptr};
+  torch::nn::Module upsampler_{nullptr};
+};
+TORCH_MODULE(WanResidualUpBlock);
+
+class WanUpBlockImpl : public torch::nn::Module {
+ public:
+  WanUpBlockImpl(int64_t in_dim,
+                 int64_t out_dim,
+                 int num_res_blocks,
+                 float dropout = 0.0f,
+                 const std::optional<std::string>& upsample_mode = std::nullopt)
+      : in_dim_(in_dim), out_dim_(out_dim), num_res_blocks_(num_res_blocks) {
+    resnets_ = register_module("resnets", torch::nn::ModuleList());
+    int current_dim = in_dim;
+    for (int i = 0; i < num_res_blocks + 1; ++i) {
+      resnets_->push_back(WanResidualBlock(current_dim, out_dim, dropout));
+      current_dim = out_dim;
+    }
+    if (upsample_mode.has_value()) {
+      upsamplers_ = register_module("upsamplers", torch::nn::ModuleList());
+      upsamplers_->push_back(WanResample(out_dim, upsample_mode.value()));
+    }
+  }
+
+  torch::Tensor forward(const torch::Tensor& x,
+                        std::vector<torch::Tensor>* feat_cache = nullptr,
+                        std::vector<int>* feat_idx = std::vector<int>{0},
+                        torch::Tensor* first_chunk = nullptr) {
+    torch::Tensor h = x;
+    for (size_t i = 0; i < resnets_->size(); ++i) {
+      auto resnet = resnets_[i]->as<WanResidualBlock>();
+      if (feat_cache) {
+        h = resnet->forward(h, *feat_cache, *feat_idx, first_chunk);
+      } else {
+        h = resnet->forward(h);
+      }
+    }
+    if (upsamplers_ && upsamplers_->size() > 0) {
+      auto upsampler = upsamplers_[0]->as<WanResample>();
+      if (feat_cache) {
+        h = upsampler->forward(h, *feat_cache, *feat_idx, first_chunk);
+      } else {
+        h = upsampler->forward(h);
+      }
+    }
+    return h;
+  }
+
+  void load_state_dict(const StateDict& state_dict) {
+    for (size_t i = 0; i < resnets_->size(); ++i) {
+      resnets_[i]->as<WanResidualBlock>()->load_state_dict(
+          state_dict.get_dict_with_prefix("resnets." + std::to_string(i) +
+                                          "."));
+    }
+    if (upsamplers_) {
+      for (size_t i = 0; i < upsamplers_->size(); ++i) {
+        upsamplers_[i]->as<WanResample>()->load_state_dict(
+            state_dict.get_dict_with_prefix("upsamplers." + std::to_string(i) +
+                                            "."));
+      }
+    }
+  }
+
+ private:
+  int64_t in_dim_;
+  int64_t out_dim_;
+  int num_res_blocks_;
+  torch::nn::ModuleList resnets_{nullptr};
+  torch::nn::ModuleList upsamplers_{nullptr};
+};
+TORCH_MODULE(WanUpBlock);
+
+class WanVAEDecoder3DImpl : public torch::nn::Module {
+ public:
+  WanVAEDecoder3DImpl(int64_t dim = 128,
+                      int64_t z_dim = 4,
+                      const std::vector<int64_t>& dim_mult = {1, 2, 4, 4},
+                      int num_res_blocks = 2,
+                      const std::vector<float>& attn_scales = {},
+                      const std::vector<bool>& temperal_upsample = {false,
+                                                                    true,
+                                                                    true},
+                      float dropout = 0.0f,
+                      int64_t out_channels = 3,
+                      bool is_residual = false) {
+    std::vector<int64_t> dims;
+    dims.push_back(dim * dim_mult.back());
+    for (auto it = dim_mult.rbegin(); it != dim_mult.rend(); ++it) {
+      dims.push_back(dim * (*it));
+    }
+    dims.erase(dims.begin());
+    conv_in_ = register_module("conv_in",
+                               WanCausalConv3d(z_dim,
+                                               dims[0],
+                                               std::vector<int64_t>{3, 3, 3},
+                                               std::vector<int64_t>{1, 1, 1},
+                                               std::vector<int64_t>{1, 1, 1}));
+    mid_block_ =
+        register_module("mid_block", WanMidBlock(dims[0], dropout_, 1));
+    up_blocks_ = register_module("up_blocks", torch::nn::ModuleList());
+    for (size_t i = 0; i < dims.size() - 1; ++i) {
+      int64_t in_dim = dims[i];
+      int64_t out_dim = dims[i + 1];
+      if (i > 0 && !is_residual) {
+        in_dim = in_dim / 2;
+      }
+      bool up_flag = (i != dim_mult.size() - 1);
+      std::string upsample_mode;
+      if (up_flag && temperal_upsample[i]) {
+        upsample_mode = "upsample3d";
+      } else if (up_flag) {
+        upsample_mode = "upsample2d";
+      }
+      if (is_residual) {
+        up_blocks_->push_back(
+            WanResidualUpBlock(in_dim,
+                               out_dim,
+                               num_res_blocks,
+                               dropout,
+                               (up_flag ? temperal_upsample[i] : false),
+                               up_flag));
+      } else {
+        up_blocks_->push_back(
+            WanUpBlock(in_dim,
+                       out_dim,
+                       num_res_blocks,
+                       dropout,
+                       up_flag ? std::optional<std::string>(upsample_mode)
+                               : std::nullopt));
+      }
+    }
+    nonlinearity_ = torch::nn::Functional(torch::silu);
+    norm_out_ = register_module("norm_out",
+                                WanRMSNorm(dims.back(), true, false, false));
+    conv_out_ = register_module("conv_out",
+                                WanCausalConv3d(dims.back(),
+                                                out_channels_,
+                                                std::vector<int64_t>{3, 3, 3},
+                                                std::vector<int64_t>{1, 1, 1},
+                                                std::vector<int64_t>{1, 1, 1}));
+  }
+
+  torch::Tensor forward(torch::Tensor x,
+                        std::vector<torch::Tensor>* feat_cache = nullptr,
+                        std::vector<int>* feat_idx = std::vector<int>{0},
+                        bool first_chunk = false) {
+    // conv_in
+    if (feat_cache) {
+      int idx = (*feat_idx)[0];
+      torch::Tensor cache_x =
+          x.index({torch::indexing::Slice(),
+                   torch::indexing::Slice(),
+                   torch::indexing::Slice(-CACHE_T, torch::indexing::None),
+                   torch::indexing::Slice(),
+                   torch::indexing::Slice()})
+              .clone();
+      if (cache_x.size(2) < 2 && (*feat_cache)[idx].defined()) {
+        cache_x = torch::cat(
+            {(*feat_cache)[idx]
+                 .index({torch::indexing::Slice(),
+                         torch::indexing::Slice(),
+                         torch::indexing::Slice(-1, torch::indexing::None),
+                         torch::indexing::Slice(),
+                         torch::indexing::Slice()})
+                 .unsqueeze(2)
+                 .to(cache_x.device()),
+             cache_x},
+            2);
+      }
+      x = conv_in_->forward(x, (*feat_cache)[idx]);
+      (*feat_cache)[idx] = cache_x;
+      (*feat_idx)[0] += 1;
+    } else {
+      x = conv_in_->forward(x);
+    }
+
+    // mid_block
+    x = mid_block_->forward(x, feat_cache, feat_idx);
+
+    // up_blocks
+    for (size_t i = 0; i < up_blocks_->size(); ++i) {
+      auto up_block = up_blocks_[i];
+      x = up_block->as<WanUpBlock>()->forward(
+          x, feat_cache, feat_idx, &first_chunk);
+    }
+
+    x = norm_out_->forward(x);
+    x = nonlinearity_(x);
+
+    // conv_out
+    if (feat_cache) {
+      int idx = (*feat_idx)[0];
+      torch::Tensor cache_x =
+          x.index({torch::indexing::Slice(),
+                   torch::indexing::Slice(),
+                   torch::indexing::Slice(-CACHE_T, torch::indexing::None),
+                   torch::indexing::Slice(),
+                   torch::indexing::Slice()})
+              .clone();
+      if (cache_x.size(2) < 2 && (*feat_cache)[idx].defined()) {
+        cache_x = torch::cat(
+            {(*feat_cache)[idx]
+                 .index({torch::indexing::Slice(),
+                         torch::indexing::Slice(),
+                         torch::indexing::Slice(-1, torch::indexing::None),
+                         torch::indexing::Slice(),
+                         torch::indexing::Slice()})
+                 .unsqueeze(2)
+                 .to(cache_x.device()),
+             cache_x},
+            2);
+      }
+      x = conv_out_->forward(x, (*feat_cache)[idx]);
+      (*feat_cache)[idx] = cache_x;
+      (*feat_idx)[0] += 1;
+    } else {
+      x = conv_out_->forward(x);
+    }
+    return x;
+  }
+
+  void load_state_dict(const StateDict& state_dict) {
+    conv_in_->load_state_dict(state_dict.get_dict_with_prefix("conv_in."));
+    mid_block_->load_state_dict(state_dict.get_dict_with_prefix("mid_block."));
+    for (size_t i = 0; i < up_blocks_->size(); ++i) {
+      up_blocks_[i]->as<WanUpBlock>()->load_state_dict(
+          state_dict.get_dict_with_prefix("up_blocks." + std::to_string(i) +
+                                          "."));
+    }
+    norm_out_->load_state_dict(state_dict.get_dict_with_prefix("norm_out."));
+    conv_out_->load_state_dict(state_dict.get_dict_with_prefix("conv_out."));
+  }
+
+ private:
+  WanCausalConv3d conv_in_{nullptr};
+  WanMidBlock mid_block_{nullptr};
+  torch::nn::ModuleList up_blocks_{nullptr};
+  WanRMSNorm norm_out_{nullptr};
+  WanCausalConv3d conv_out_{nullptr};
+  torch::nn::Functional nonlinearity_{nullptr};
+  const int CACHE_T = 2;
+};
+TORCH_MODULE(WanVAEDecoder3D);
+
+class WANVAEImpl : public torch::nn::Module {
+ public:
+  WANVAEImpl(const ModelContext& context,
+             torch::Device device,
+             torch::ScalarType dtype)
+      : args_(context.get_model_args()), device_(device), dtype_(dtype) {
+    encoder_ = register_module("encoder",
+                               WanVAEEncoder3D(args_.vae_in_channels(),
+                                               args_.vae_base_dim(),
+                                               args_.vae_z_dim() * 2,
+                                               args_.vae_dim_mult(),
+                                               args_.vae_num_res_blocks(),
+                                               args_.vae_attn_scales(),
+                                               args_.vae_temperal_downsample(),
+                                               args_.vae_dropout(),
+                                               args_.vae_is_residual()));
+
+    decoder_ = register_module("decoder",
+                               WanVAEDecoder3D(args_.vae_base_dim(),
+                                               args_.vae_z_dim(),
+                                               args_.vae_dim_mult(),
+                                               args_.vae_num_res_blocks(),
+                                               args_.vae_attn_scales(),
+                                               args_.vae_temperal_downsample(),
+                                               args_.vae_dropout(),
+                                               args_.vae_is_residual()));
+
+    quant_conv_ =
+        register_module("quant_conv",
+                        WanCausalConv3D(2 * args_.z_dim(),
+                                        2 * args_.z_dim(),
+                                        std::vector<int64_t>{1, 1, 1}));
+
+    post_quant_conv_ = register_module(
+        "post_quant_conv",
+        WanCausalConv3D(
+            args_.z_dim(), args_.z_dim(), std::vector<int64_t>{1, 1, 1}));
+    init_cached_conv_count();
+
+    encoder_->to(dtype_);
+    decoder_->to(dtype_);
+    quant_conv_->to(dtype_);
+    post_quant_conv_->to(dtype_);
+  }
+
+  void enable_slicing(bool enable) { use_slicing_ = enable; }
+  void disable_slicing() { use_slicing_ = false; }
+
+  void clear_cache() {
+    conv_num_ = cached_conv_count_["decoder"];
+    conv_idx_ = {0};
+    feat_map_.assign(conv_num_, nullptr);
+
+    enc_conv_num_ = cached_conv_count_["encoder"];
+    enc_conv_idx_ = {0};
+    enc_feat_map_.assign(enc_conv_num_, nullptr);
+  }
+
+  // Encode video into latent representations
+  torch::Tensor encode_(const torch::Tensor& videos) {
+    int64_t num_frame = videos.size(2);
+    int64_t height = videos.size(3);
+    int64_t width = videos.size(4);
+    int64_t iter_ = 1 + (num_frame - 1) / 4;
+    clear_cache();
+    torch::Tensor out;
+    for (int64_t i = 0; i < iter_; ++i) {
+      enc_conv_idx_ = {0};
+      if (i == 0) {
+        auto x_slice = videos.index({torch::indexing::Slice(),
+                                     torch::indexing::Slice(),
+                                     torch::indexing::Slice(0, 1),
+                                     torch::indexing::Slice(),
+                                     torch::indexing::Slice()});
+        out = encoder_(x_slice, &enc_feat_map_, &enc_conv_idx_);
+      } else {
+        int64_t start = 1 + 4 * (i - 1);
+        int64_t end = std::min(1 + 4 * i, num_frame);
+        auto x_slice = videos.index({torch::indexing::Slice(),
+                                     torch::indexing::Slice(),
+                                     torch::indexing::Slice(start, end),
+                                     torch::indexing::Slice(),
+                                     torch::indexing::Slice()});
+        auto out_ = encoder_(x_slice, &enc_feat_map_, &enc_conv_idx_);
+        out = torch::cat({out, out_}, 2);
+      }
+    }
+    out = quant_conv_(out);
+    clear_cache();
+    return out;
+  }
+
+  AutoencoderKLOutput encode(const torch::Tensor& videos) {
+    torch::Tensor hidden_states;
+    if (use_slicing_) {
+      std::vector<torch::Tensor> latent_slices;
+      for (const auto& x_slice : videos.split(1)) {
+        latent_slices.push_back(encode_(x_slice));
+      }
+      hidden_states = torch::cat(latent_slices, 0);
+    } else {
+      hidden_states = encode_(videos);
+    }
+    auto posterior = DiagonalGaussianDistribution(hidden_states);
+    return AutoencoderKLOutput(posterior);
+  }
+
+  // Decode latent representations into videos
+  DecoderOutput decode_(const torch::Tensor& latents) {
+    torch::Tensor processed_latents = latents;
+    int64_t num_frame = latents.size(2);
+    int64_t height = latents.size(3);
+    int64_t width = latents.size(4);
+    clear_cache();
+    torch::Tensor out;
+    processed_latents = post_quant_conv_(processed_latents);
+    for (int64_t i = 0; i < iter_; ++i) {
+      enc_conv_idx_ = {0};
+      if (i == 0) {
+        auto x_slice =
+            processed_latents.index({torch::indexing::Slice(),
+                                     torch::indexing::Slice(),
+                                     torch::indexing::Slice(i, i + 1),
+                                     torch::indexing::Slice(),
+                                     torch::indexing::Slice()});
+        out = decoder_(x_slice, &enc_feat_map_, &enc_conv_idx_, true);
+      } else {
+        auto x_slice =
+            processed_latents.index({torch::indexing::Slice(),
+                                     torch::indexing::Slice(),
+                                     torch::indexing::Slice(i, i + 1),
+                                     torch::indexing::Slice(),
+                                     torch::indexing::Slice()});
+        auto out_ = decoder_(x_slice, &enc_feat_map_, &enc_conv_idx_);
+        out = torch::cat({out, out_}, 2);
+      }
+    }
+    auto dec = torch::clamp(out, -1.0f, 1.0f);
+    clear_cache();
+    return DecoderOutput(dec);
+  }
+
+  DecoderOutput decode(
+      const torch::Tensor& latents,
+      const std::optional<torch::Generator>& generator = std::nullopt) {
+    torch::Tensor videos;
+    if (use_slicing_ && latents.size(0) > 1) {
+      std::vector<torch::Tensor> video_slices;
+      for (const auto& latent_slice : latents.split(1)) {
+        video_slices.push_back(decode_(latent_slice).sample);
+      }
+      videos = torch::cat(video_slices, 0);
+    } else {
+      videos = decode_(latents).sample;
+    }
+    return DecoderOutput(videos);
+  }
+
+  DecoderOutput forward_(torch::Tensor sample, bool sample_posterior = false) {
+    torch::Tensor x = sample;
+    DiagonalGaussianDistribution posterior = encode(x).latent_dist;
+
+    if (sample_posterior) {
+      x = posterior.sample();
+    } else {
+      x = posterior.mode();
+    }
+
+    return decode(x);
+  }
+
+  void load_model(std::unique_ptr<DiTFolderLoader> loader) {
+    for (const auto& state_dict : loader->get_state_dicts()) {
+      encoder_->load_state_dict(state_dict->get_dict_with_prefix("encoder."));
+      decoder_->load_state_dict(state_dict->get_dict_with_prefix("decoder."));
+
+      if (args_.vae_use_quant_conv()) {
+        const auto weight = state_dict->get_tensor("quant_conv.weight");
+        if (weight.defined()) {
+          DCHECK_EQ(quant_conv_->weight.sizes(), weight.sizes())
+              << "quant_conv weight size mismatch";
+          quant_conv_->weight.data().copy_(weight);
+          is_quant_conv_loaded = true;
+        }
+
+        const auto bias = state_dict->get_tensor("quant_conv.bias");
+        if (bias.defined() && quant_conv_->bias.defined()) {
+          DCHECK_EQ(quant_conv_->bias.sizes(), bias.sizes())
+              << "quant_conv bias size mismatch";
+          quant_conv_->bias.data().copy_(bias);
+        }
+      }
+
+      if (args_.vae_use_post_quant_conv()) {
+        const auto weight = state_dict->get_tensor("post_quant_conv.weight");
+        if (weight.defined()) {
+          DCHECK_EQ(post_quant_conv_->weight.sizes(), weight.sizes())
+              << "post_quant_conv weight size mismatch";
+          post_quant_conv_->weight.data().copy_(weight);
+          is_post_quant_conv_loaded = true;
+        }
+
+        const auto bias = state_dict->get_tensor("post_quant_conv.bias");
+        if (bias.defined() && post_quant_conv_->bias.defined()) {
+          DCHECK_EQ(post_quant_conv_->bias.sizes(), bias.sizes())
+              << "post_quant_conv bias size mismatch";
+          post_quant_conv_->bias.data().copy_(bias);
+        }
+      }
+    }
+    LOG(INFO) << "WAN VAE model loaded successfully.";
+  }
+
+ private:
+  WanVAEEncoder3D encoder_{nullptr};
+  WanVAEDecoder3D decoder_{nullptr};
+  torch::nn::Conv3d quant_conv_{nullptr};
+  torch::nn::Conv3d post_quant_conv_{nullptr};
+  bool use_slicing_{false};
+  ModelArgs args_;
+  torch::Device device_;
+  torch::ScalarType dtype_;
+  int64_t tile_sample_min_height_ = 256;
+  int64_t tile_sample_min_width_ = 256;
+  int64_t tile_sample_stride_height_ = 192;
+  int64_t tile_sample_stride_width_ = 192;
+  std::map<std::string, int> cached_conv_count_;
+  int conv_num_ = 0;
+  std::vector<int> conv_idx_{0};
+  std::vector<torch::Tensor> feat_map_;
+  int enc_conv_num_ = 0;
+  std::vector<int> enc_conv_idx_{0};
+  std::vector<torch::Tensor> enc_feat_map_;
+
+  void init_cached_conv_count() {
+    int decoder_count = 0;
+    int encoder_count = 0;
+    if (decoder_ != nullptr) {
+      for (const auto& m : decoder_->modules(/*include_self=*/false)) {
+        if (dynamic_cast<WanCausalConv3DImpl*>(m.get()) != nullptr) {
+          ++decoder_count;
+        }
+      }
+    }
+    if (encoder_ != nullptr) {
+      for (const auto& m : encoder_->modules(/*include_self=*/false)) {
+        if (dynamic_cast<WanCausalConv3DImpl*>(m.get()) != nullptr) {
+          ++encoder_count;
+        }
+      }
+    }
+    cached_conv_count_["decoder"] = decoder_count;
+    cached_conv_count_["encoder"] = encoder_count;
+  }
+};
+TORCH_MODULE(WANVAE);
+
+REGISTER_MODEL_ARGS(WANVAE, [&] {
+  LOAD_ARG_OR(vae_z_dim, "z_dim", 16);
+  LOAD_ARG_OR(vae_base_dim, "base_dim", 96);
+  LOAD_ARG_OR(vae_num_res_blocks, "num_res_blocks", 2);
+  LOAD_ARG_OR(vae_temperal_downsample,
+              "temporal_downsample",
+              std::vector<bool>{false, true, true});
+  LOAD_ARG_OR(vae_attn_scale, "attn_scale", std::vector<float>{});
+  LOAD_ARG_OR(vae_dim_mults, "dim_mults", std::vector<int>{1, 2, 4, 4});
+  LOAD_ARG_OR(vae_dropout, "dropout", 0.0f);
+  LOAD_ARG_OR(vae_in_channels, "in_channels", 3);
+  LOAD_ARG_OR(vae_out_channels, "out_channels", 3);
+  LOAD_ARG_OR(vae_is_residual, "is_residual", false);
+  LOAD_ARG_OR(vae_scale_factor_temporal, "scale_factor_temporal", 4);
+  LOAD_ARG_OR(vae_scale_factor_spatial, "scale_factor_spatial", 8);
+  LOAD_ARG_OR(vae_latents_mean,
+              "latents_mean",
+              std::vector<float>{-0.7571,
+                                 -0.7089,
+                                 -0.9113,
+                                 0.1075,
+                                 -0.1745,
+                                 0.9653,
+                                 -0.1517,
+                                 1.5508,
+                                 0.4134,
+                                 -0.0715,
+                                 0.5517,
+                                 -0.3632,
+                                 -0.1922,
+                                 -0.9497,
+                                 0.2503,
+                                 -0.2921});
+  LOAD_ARG_OR(vae_latents_std,
+              "latents_std",
+              std::vector<float>{2.8184,
+                                 1.4541,
+                                 2.3275,
+                                 2.6558,
+                                 1.2196,
+                                 1.7708,
+                                 2.6052,
+                                 2.0743,
+                                 3.2687,
+                                 2.1526,
+                                 2.8652,
+                                 1.5579,
+                                 1.6382,
+                                 1.1253,
+                                 2.8251,
+                                 1.916});
+});
+
+}  // namespace xllm

--- a/xllm/models/dit/clip_vision_model.h
+++ b/xllm/models/dit/clip_vision_model.h
@@ -1,0 +1,266 @@
+#pragma once
+
+#include <atb/atb_infer.h>
+#include <c10/core/ScalarType.h>
+#include <torch/torch.h>
+
+#include <regex>
+#include <unordered_map>
+
+#include "clip_text_model.h"
+#include "core/framework/dit_model_loader.h"
+#include "core/framework/kv_cache/kv_cache.h"
+#include "core/framework/model/model_input_params.h"
+#include "core/framework/model_context.h"
+#include "core/layers/siglip_encoder_layer.h"
+#include "dit_linear.h"
+#include "models/model_registry.h"
+#include "processors/clip_image_processor.h"
+#include "processors/input_processor.h"
+#include "processors/pywarpper_image_processor.h"
+#include "xllm_kernels/core/include/atb_speed/log.h"
+
+namespace xllm {
+
+class CLIPVisionEmbeddingImpl : public torch::nn::Module {
+ public:
+  explicit CLIPVisionEmbeddingImpl(const ModelContext& context) {
+    auto model_args = context.get_model_args();
+    auto options = context.get_tensor_options();
+    embed_dim_ = model_args.mm_hidden_size();
+    image_size_ = model_args.mm_image_size();
+    class_embedding_ = register_parameter("class_embedding",
+                                          torch::randn({embed_dim_}, options));
+    patch_embedding_ = register_module(
+        "patch_embedding",
+        torch::nn::Conv2d(torch::nn::Conv2dOptions(model_args.mm_num_channels(),
+                                                   embed_dim_,
+                                                   model_args.mm_patch_size())
+                              .stride(model_args.mm_patch_size())
+                              .bias(false)));
+    patch_embedding_->weight.set_data(patch_embedding_->weight.to(options));
+
+    auto num_patches =
+        (model_args.mm_image_size() / model_args.mm_patch_size()) *
+        (model_args.mm_image_size() / model_args.mm_patch_size());
+    auto num_positions = num_patches + 1;
+    position_embedding_ =
+        register_parameter("position_embedding",
+                           torch::randn({num_positions, embed_dim_}, options));
+    position_ids_ = register_buffer(
+        "position_ids",
+        torch::arange(0, num_positions, torch::kLong).unsqueeze(0));
+  }
+
+  torch::Tensor forward(const torch::Tensor& pixel_values) {
+    int64_t batch_size = pixel_values.size(0);
+    auto patch_embeds =
+        patch_embedding_->forward(pixel_values).flatten(2).transpose(1, 2);
+    auto class_embeds = class_embedding_.expand({batch_size, 1, -1});
+    auto embeddings = torch::cat({class_embeds, patch_embeds}, 1);
+    embeddings += position_embedding_.index({position_ids_});
+    return embeddings;
+  }
+
+  // load the weight from the checkpoint
+  void load_state_dict(const StateDict& state_dict) {
+    const auto cls = state_dict.get_tensor("class_embedding");
+    if (cls.defined()) {
+      DCHECK_EQ(cls.sizes(), class_embedding_.sizes())
+          << "class_embedding size mismatch for " << name();
+      class_embedding_.data().copy_(cls);
+      is_class_embedding_loaded = true;
+    }
+
+    const auto pos = state_dict.get_tensor("position_embedding.weight");
+    if (pos.defined()) {
+      CHECK_EQ(pos.sizes(), position_embedding_.sizes())
+          << "position_embedding weight size mismatch for " << name();
+      position_embedding_.data().copy_(pos);
+      is_position_embedding_loaded = true;
+    }
+
+    const auto weight = state_dict.get_tensor("patch_embedding.weight");
+    if (weight.defined()) {
+      DCHECK_EQ(patch_embedding_->weight.sizes(), weight.sizes())
+          << "patch_embedding weight size mismatch for " << name();
+      patch_embedding_->weight.data().copy_(weight);
+      is_patch_embedding_loaded = true;
+    }
+  }
+
+  void verify_loaded_weights(const std::string& prefix) const {
+    CHECK(is_class_embedding_loaded)
+        << "weight is not loaded for " << prefix + "class_embedding";
+    CHECK(is_position_embedding_loaded)
+        << "weight is not loaded for " << prefix + "position_embedding.weight";
+    CHECK(is_patch_embedding_loaded)
+        << "weight is not loaded for " << prefix + "patch_embedding.weight";
+  }
+
+ private:
+  int64_t embed_dim_;
+  int64_t image_size_;
+  bool is_class_embedding_loaded{false};
+  bool is_position_embedding_loaded{false};
+  bool is_patch_embedding_loaded{false};
+
+  torch::Tensor class_embedding_;
+  torch::Tensor position_ids_;
+  torch::nn::Conv2d patch_embedding_{nullptr};
+  torch::Tensor position_embedding_{nullptr};
+};
+TORCH_MODULE(CLIPVisionEmbedding);
+
+class CLIPVisionTransformerImpl : public torch::nn::Module {
+ public:
+  explicit CLIPVisionTransformerImpl(const ModelContext& context) {
+    auto model_args = context.get_model_args();
+    auto options = context.get_tensor_options();
+    embeddings_ = register_module("embeddings", CLIPVisionEmbedding(context));
+    pre_layernorm_ = register_module(
+        "pre_layernorm",
+        torch::nn::LayerNorm(
+            torch::nn::LayerNormOptions({model_args.mm_hidden_size()})
+                .elementwise_affine(true)
+                .eps(model_args.mm_layer_norm_eps())));
+
+    encoder_ = register_module("encoder", CLIPEncoder(context));
+    post_layernorm_ = register_module(
+        "post_layernorm",
+        torch::nn::LayerNorm(
+            torch::nn::LayerNormOptions({model_args.mm_hidden_size()})
+                .elementwise_affine(true)
+                .eps(model_args.mm_layer_norm_eps())));
+  }
+
+  // std::vector<torch::Tensor> forward(const torch::Tensor& pixel_values) {
+  torch::Tensor forward(const torch::Tensor& pixel_values) {
+    auto hidden_states = embeddings_->forward(pixel_values);
+    hidden_states = pre_layernorm_->forward(hidden_states);
+
+    auto last_hidden_state = encoder_->forward(hidden_states, torch::Tensor());
+    auto pool_output = last_hidden_state.select(1, 0);
+    pool_output = post_layernorm_->forward(pool_output);
+    // auto pool_output = post_layernorm_->forward(last_hidden_state);
+    return pool_output;
+  }
+
+  // load the weight from the checkpoint
+  void load_state_dict(const StateDict& state_dict) {
+    embeddings_->load_state_dict(
+        state_dict.get_dict_with_prefix("embeddings."));
+    encoder_->load_state_dict(state_dict.get_dict_with_prefix("encoder."));
+    weight::load_weight(state_dict,
+                        "pre_layernorm.weight",
+                        pre_layernorm_->weight,
+                        pre_layernorm_weight_loaded_);
+    weight::load_weight(state_dict,
+                        "pre_layernorm.bias",
+                        pre_layernorm_->bias,
+                        pre_layernorm_bias_loaded_);
+    weight::load_weight(state_dict,
+                        "post_layernorm.weight",
+                        post_layernorm_->weight,
+                        post_layernorm_weight_loaded_);
+    weight::load_weight(state_dict,
+                        "post_layernorm.bias",
+                        post_layernorm_->bias,
+                        post_layernorm_bias_loaded_);
+  }
+
+  void verify_loaded_weights(const std::string& prefix) const {
+    embeddings_->verify_loaded_weights(prefix + "embeddings.");
+    encoder_->verify_loaded_weights(prefix + "encoder.");
+    CHECK(pre_layernorm_weight_loaded_)
+        << "weight is not loaded for " << prefix + "pre_layernorm.weight";
+    CHECK(pre_layernorm_bias_loaded_)
+        << "weight is not loaded for " << prefix + "pre_layernorm.bias";
+    CHECK(post_layernorm_weight_loaded_)
+        << "weight is not loaded for " << prefix + "post_layernorm.weight";
+    CHECK(post_layernorm_bias_loaded_)
+        << "weight is not loaded for " << prefix + "post_layernorm.bias";
+  }
+
+ private:
+  CLIPVisionEmbedding embeddings_{nullptr};
+  torch::nn::LayerNorm pre_layernorm_{nullptr};
+  CLIPEncoder encoder_{nullptr};
+  torch::nn::LayerNorm post_layernorm_{nullptr};
+  bool pre_layernorm_weight_loaded_ = false;
+  bool pre_layernorm_bias_loaded_ = false;
+  bool post_layernorm_weight_loaded_ = false;
+  bool post_layernorm_bias_loaded_ = false;
+};
+TORCH_MODULE(CLIPVisionTransformer);
+
+class CLIPVisionModelWithProjectionImpl : public torch::nn::Module {
+ public:
+  explicit CLIPVisionModelWithProjectionImpl(const ModelContext& context) {
+    auto model_args = context.get_model_args();
+    auto options = context.get_tensor_options();
+    transformer_ =
+        register_module("transformer", CLIPVisionTransformer(context));
+    projection_ = register_parameter(
+        "projection",
+        torch::randn(
+            {model_args.mm_hidden_size(), model_args.mm_projection_dim()},
+            options));
+  }
+
+  torch::Tensor forward(const torch::Tensor& input_ids) {
+    auto last_hidden_states = transformer_->forward(input_ids);
+    auto projected_output = torch::matmul(last_hidden_states, projection_);
+    return projected_output;
+  }
+
+  // load the weight from the checkpoint
+  void load_state_dict(const StateDict& state_dict) {
+    transformer_->load_state_dict(
+        state_dict.get_dict_with_prefix("vision_model."));
+    const auto proj_weight = state_dict.get_tensor("projection");
+    if (proj_weight.defined()) {
+      DCHECK_EQ(projection_.sizes(), proj_weight.sizes())
+          << "projection size mismatch for " << name();
+      projection_.data().copy_(proj_weight);
+    }
+  }
+
+  void verify_loaded_weights(const std::string& prefix) const {
+    transformer_->verify_loaded_weights(prefix + "vision_model.");
+    DCHECK(projection_.defined())
+        << "projection parameter not loaded for " << prefix + "projection";
+  }
+
+  void load_model(std::unique_ptr<DiTFolderLoader> loader) {
+    for (const auto& state_dict : loader->get_state_dicts()) {
+      transformer_->load_state_dict(
+          state_dict->get_dict_with_prefix("vision_model."));
+    }
+
+    // verify
+    transformer_->verify_loaded_weights("vision_model.");
+    LOG(INFO) << "clip_vision_model loaded successfully.";
+  }
+
+ private:
+  CLIPVisionTransformer transformer_{nullptr};
+  torch::Tensor projection_;
+};
+TORCH_MODULE(CLIPVisionModelWithProjection);
+
+REGISTER_MODEL_ARGS(CLIPVisionModelWithProjection, [&] {
+  LOAD_ARG_OR(dtype, "torch_dtype", "float32");
+  LOAD_ARG_OR(model_type, "model_type", "clip_vision_model");
+  LOAD_ARG_OR(mm_hidden_size, "hidden_size", 1280);
+  LOAD_ARG_OR(mm_intermediate_size, "intermediate_size", 5120);
+  LOAD_ARG_OR(mm_projection_dim, "projection_dim", 1024);
+  LOAD_ARG_OR(mm_num_hidden_layers, "num_hidden_layers", 32);
+  LOAD_ARG_OR(mm_num_attention_heads, "num_attention_heads", 16);
+  LOAD_ARG_OR(mm_hidden_act, "hidden_act", "gelu");
+  LOAD_ARG_OR(mm_layer_norm_eps, "layer_norm_eps", 1e-5f);
+  LOAD_ARG_OR(mm_image_size, "image_size", 224);
+  LOAD_ARG_OR(mm_patch_size, "patch_size", 14);
+  LOAD_ARG_OR(mm_num_channels, "num_channels", 3);
+});
+}  // namespace xllm

--- a/xllm/models/dit/dit_wan.h
+++ b/xllm/models/dit/dit_wan.h
@@ -1,0 +1,775 @@
+#pragma once
+#include <torch/torch.h>
+
+#include <cmath>
+#include <iostream>
+#include <memory>
+#include <optional>
+#include <stdexcept>
+#include <string>
+#include <vector>
+
+#include "core/framework/dit_model_loader.h"
+#include "core/framework/model/model_input_params.h"
+#include "core/framework/state_dict/state_dict.h"
+#include "dit.h"
+#include "dit_linear.h"
+#include "framework/model_context.h"
+#include "models/model_registry.h"
+#include "processors/input_processor.h"
+#include "processors/pywarpper_image_processor.h"
+
+namespace xllm {
+inline torch::Tensor apply_rotary_emb_wan(const torch::Tensor& x,
+                                          const torch::Tensor& freqs_cis) {
+  auto cos_full = freqs_cis[0].unsqueeze(0).unsqueeze(1);  // [1, 1, S, D]
+  auto sin_full = freqs_cis[1].unsqueeze(0).unsqueeze(1);  // [1, 1, S, D]
+
+  int64_t D = x.size(-1);
+
+  // Extract cos[0::2] and sin[1::2]
+  auto cos_reshaped = cos_full.view({1, 1, -1, D / 2, 2});
+  auto sin_reshaped = sin_full.view({1, 1, -1, D / 2, 2});
+  auto cos = cos_reshaped.select(-1, 0);  // [1, 1, S, D//2]
+  auto sin = sin_reshaped.select(-1, 1);  // [1, 1, S, D//2]
+
+  // Split x into even/odd
+  auto x_reshaped = x.view({x.size(0), x.size(1), x.size(2), D / 2, 2});
+  auto x1 = x_reshaped.select(-1, 0);  // even indices
+  auto x2 = x_reshaped.select(-1, 1);  // odd indices
+
+  // Rotate
+  auto out_even = x1.to(torch::kFloat32) * cos.to(torch::kFloat32) -
+                  x2.to(torch::kFloat32) * sin.to(torch::kFloat32);
+  auto out_odd = x1.to(torch::kFloat32) * sin.to(torch::kFloat32) +
+                 x2.to(torch::kFloat32) * cos.to(torch::kFloat32);
+
+  // Interleave
+  auto out = torch::stack({out_even, out_odd}, -1)
+                 .view({x.size(0), x.size(1), x.size(2), D});
+
+  return out.to(x.dtype());
+}
+
+namespace F = torch::nn::functional;
+class FP32LayerNormImpl : public torch::nn::Module {
+ public:
+  torch::Tensor weight;
+  torch::Tensor bias;
+  FP32LayerNormImpl(const std::vector<int64_t>& normalized_shape,
+                    double eps = 1e-6,
+                    bool with_bias = true) {
+    weight = register_parameter("weight", torch::ones(normalized_shape));
+    if (with_bias) {
+      bias = register_parameter("bias", torch::zeros(normalized_shape));
+    } else {
+      bias = register_parameter("bias", {}, false);
+    }
+  }
+
+  torch::Tensor forward(const torch::Tensor& x) {
+    auto origin_dtype = x.dtype();
+    auto weight_fp32 =
+        weight.defined() ? weight.to(torch::kFloat32) : torch::Tensor();
+    auto bias_fp32 =
+        bias.defined() ? bias.to(torch::kFloat32) : torch::Tensor();
+    auto out =
+        F::layer_norm(x.to(torch::kFloat32),
+                      normalized_shape,
+                      weight_fp32.defined() ? weight_fp32 : torch::Tensor(),
+                      bias_fp32.defined() ? bias_fp32 : torch::Tensor(),
+                      eps);
+    return out.to(origin_dtype);
+  }
+};
+TORCH_MODULE(FP32LayerNorm);
+
+class WanAttentionImpl : public torch::nn::Module {
+ public:
+  WanAttentionImpl(int64_t dim,
+                   int64_t heads,
+                   int64_t dim_head,
+                   double eps,
+                   int64_t cross_attention_dim_head,
+                   at::Device device,
+                   const at::ScalarType& dtype = torch::kBFloat16)
+      : heads_(heads), device_(device), dtype_(dtype) {
+    int64_t inner_dim = dim_head * heads_;
+    is_cross_attention_ = cross_attention_dim_head > 0;
+    int64_t kv_inner_dim =
+        is_cross_attention_ ? cross_attention_dim_head * heads_ : inner_dim;
+    // QKV projections
+    to_q_ = register_module("to_q", DiTLinear(dim, inner_dim_, true));
+    to_k_ = register_module("to_k", DiTLinear(dim, kv_inner_dim, true));
+    to_v_ = register_module("to_v", DiTLinear(dim, kv_inner_dim, true));
+    to_out_ = register_module("to_out", DiTLinear(inner_dim, dim, true));
+    dropout_ = register_module("dropout", torch::nn::Dropout(0.0));
+    norm_q_ = register_module(
+        "norm_q",
+        DiTRMSNorm(head_dim * heads_, eps, true, false, device_, dtype_));
+    norm_k_ = register_module(
+        "norm_k",
+        DiTRMSNorm(head_dim * heads_, eps, true, false, device_, dtype_));
+  }
+
+  torch::Tensor forward(
+      const torch::Tensor& hidden_states,
+      const torch::optional<torch::Tensor>& encoder_hidden_states,
+      const torch::optional<std::vector<torch::Tensor>>& rotary_emb) {
+    const torch::Tensor& enc_states =
+        encoder_hidden_states.defined() ? encoder_hidden_states : hidden_states;
+
+    torch::Tensor hidden_states_reshaped = hidden_states;
+    if (input_ndim == 4) {
+      auto shape = hidden_states.sizes();
+      int64_t batch_size = shape[0];
+      int64_t channel = shape[1];
+      int64_t height = shape[2];
+      int64_t width = shape[3];
+      hidden_states_reshaped =
+          hidden_states.view({batch_size, channel, height * width})
+              .transpose(1, 2);
+    }
+    int64_t context_input_ndim = enc_states.dim();
+    torch::Tensor encoder_hidden_states_reshaped = enc_states;
+    if (context_input_ndim == 4) {
+      auto shape = enc_states.sizes();
+      int64_t batch_size = shape[0];
+      int64_t channel = shape[1];
+      int64_t height = shape[2];
+      int64_t width = shape[3];
+      encoder_hidden_states_reshaped =
+          enc_states.view({batch_size, channel, height * width})
+              .transpose(1, 2);
+    }
+
+    // QKV
+    torch::Tensor query = to_q_->forward(hidden_states_reshaped);
+    torch::Tensor key = to_k_->forward(encoder_hidden_states_reshaped);
+    torch::Tensor value = to_v_->forward(encoder_hidden_states_reshaped);
+
+    query = norm_q_->forward(query);
+    key = norm_k_->forward(key);
+
+    // unflatten heads
+    query = query.view({query.size(0), query.size(1), heads_, -1});
+    key = key.view({key.size(0), key.size(1), heads_, -1});
+    value = value.view({value.size(0), value.size(1), heads_, -1});
+
+    // rotary embedding
+    if (rotary_emb.has_value()) {
+      query = apply_rotary_emb_wan(query, rotary_emb.value());
+      key = apply_rotary_emb_wan(key, rotary_emb.value());
+    }
+
+    torch::Tensor attn_out = torch::scaled_dot_product_attention(
+        query, key, value, torch::nullopt, 0.0, false);
+    attn_out = attn_out.flatten(2, 3).type_as(query);
+
+    attn_out = to_out_->forward(attn_out);
+    return attn_out;
+  }
+
+  void load_state_dict(const StateDict& state_dict) {
+    // device management
+    to_q_->to(device_);
+    to_k_->to(device_);
+    to_v_->to(device_);
+    to_out_->to(device_);
+    //  to_q
+    const auto to_q_state_weight = state_dict.get_tensor("to_q.weight");
+    if (to_q_state_weight.defined()) {
+      DCHECK_EQ(to_q_->weight.sizes(), to_q_state_weight.sizes())
+          << "to_q weight size mismatch: expected " << to_q_->weight.sizes()
+          << " but got " << to_q_state_weight.sizes();
+      to_q_->weight.data().copy_(to_q_state_weight);
+      to_q_->weight.data().to(dtype_).to(device_);
+    }
+    const auto to_q_state_bias = state_dict.get_tensor("to_q.bias");
+    if (to_q_state_bias.defined()) {
+      DCHECK_EQ(to_q_->bias.sizes(), to_q_state_bias.sizes())
+          << "to_q bias size mismatch: expected " << to_q_->bias.sizes()
+          << " but got " << to_q_state_bias.sizes();
+      to_q_->bias.data().copy_(to_q_state_bias);
+      to_q_->bias.data().to(dtype_).to(device_);
+    }
+    // to_k
+    const auto to_k_state_weight = state_dict.get_tensor("to_k.weight");
+    if (to_k_state_weight.defined()) {
+      DCHECK_EQ(to_k_->weight.sizes(), to_k_state_weight.sizes())
+          << "to_k weight size mismatch: expected " << to_k_->weight.sizes()
+          << " but got " << to_k_state_weight.sizes();
+      to_k_->weight.data().copy_(to_k_state_weight);
+      to_k_->weight.data().to(dtype_).to(device_);
+    }
+    const auto to_k_state_bias = state_dict.get_tensor("to_k.bias");
+    if (to_k_state_bias.defined()) {
+      DCHECK_EQ(to_k_->bias.sizes(), to_k_state_bias.sizes())
+          << "to_k bias size mismatch: expected " << to_k_->bias.sizes()
+          << " but got " << to_k_state_bias.sizes();
+      to_k_->bias.data().copy_(to_k_state_bias);
+      to_k_->bias.data().to(dtype_).to(device_);
+    }
+    // to_v
+    const auto to_v_state_weight = state_dict.get_tensor("to_v.weight");
+    if (to_v_state_weight.defined()) {
+      DCHECK_EQ(to_v_->weight.sizes(), to_v_state_weight.sizes())
+          << "to_v weight size mismatch: expected " << to_v_->weight.sizes()
+          << " but got " << to_v_state_weight.sizes();
+      to_v_->weight.data().copy_(to_v_state_weight);
+      to_v_->weight.data().to(dtype_).to(device_);
+    }
+    const auto to_v_state_bias = state_dict.get_tensor("to_v.bias");
+    if (to_v_state_bias.defined()) {
+      DCHECK_EQ(to_v_->bias.sizes(), to_v_state_bias.sizes())
+          << "to_v bias size mismatch: expected " << to_v_->bias.sizes()
+          << " but got " << to_v_state_bias.sizes();
+      to_v_->bias.data().copy_(to_v_state_bias);
+      to_v_->bias.data().to(dtype_).to(device_);
+    }
+    // to_out
+    const auto to_out_state_weight = state_dict.get_tensor("to_out.0.weight");
+    if (to_out_state_weight.defined()) {
+      DCHECK_EQ(to_out_->weight.sizes(), to_out_state_weight.sizes())
+          << "to_out weight size mismatch: expected " << to_out_->weight.sizes()
+          << " but got " << to_out_state_weight.sizes();
+      to_out_->weight.data().copy_(to_out_state_weight);
+      to_out_->weight.data().to(dtype_).to(device_);
+    }
+    const auto to_out_state_bias = state_dict.get_tensor("to_out.0.bias");
+    if (to_out_state_bias.defined()) {
+      DCHECK_EQ(to_out_->bias.sizes(), to_out_state_bias.sizes())
+          << "to_out bias size mismatch: expected " << to_out_->bias.sizes()
+          << " but got " << to_out_state_bias.sizes();
+      to_out_->bias.data().copy_(to_out_state_bias);
+      to_out_->bias.data().to(dtype_).to(device_);
+    }
+    // norm_q
+    norm_q_->load_state_dict(state_dict.get_dict_with_prefix("norm_q."));
+    // norm_k
+    norm_k_->load_state_dict(state_dict.get_dict_with_prefix("norm_k."));
+  }
+
+ private:
+  int64_t heads_;
+  at::Device device_;
+  at::ScalarType dtype_;
+  bool is_cross_attention_;
+  DiTLinear to_q_{nullptr}, to_k_{nullptr}, to_v_{nullptr}, to_out_{nullptr};
+  torch::nn::Dropout dropout_{nullptr};
+  DiTRMSNorm norm_q_{nullptr}, norm_k_{nullptr};
+};
+TORCH_MODULE(WanAttention);
+
+class WanTimeTextImageEmbeddingImpl : public torch::nn::Module {
+ public:
+  WanTimeTextImageEmbeddingImpl(int64_t dim,
+                                int64_t time_freq_dim,
+                                int64_t time_proj_dim,
+                                int64_t text_embed_dim) {
+    timesteps_proj_ =
+        register_module("timesteps_proj", Timesteps(time_freq_dim, true, 0));
+    time_embedder_ =
+        register_module("time_embedder", TimestepEmbedding(time_freq_dim, dim));
+    act_fn_ = register_module("act_fn", torch::nn::SiLU());
+    time_proj_ =
+        register_module("time_proj", torch::nn::Linear(dim, time_proj_dim));
+    text_embedder_ = register_module(
+        "text_embedder",
+        PixArtAlphaTextProjection(text_embed_dim, dim, -1, "gelu_tanh"));
+  }
+
+  std::tuple<torch::Tensor, torch::Tensor, torch::Tensor> forward(
+      const torch::Tensor& timestep,
+      const torch::Tensor& encoder_hidden_states,
+      c10::optional<int64_t> timestep_seq_len = c10::nullopt) {
+    torch::Tensor timestep_proj_tensor = timesteps_proj->forward(timestep);
+    if (timestep_seq_len.has_value()) {
+      int64_t seq_len = timestep_seq_len.value();
+      int64_t batch = timestep_proj_tensor.size(0) / seq_len;
+      timestep_proj_tensor =
+          timestep_proj_tensor.unflatten(0, {batch, seq_len});
+    }
+    auto time_embedder_dtype = time_embedder->parameters().front().dtype();
+    if (timestep_proj_tensor.dtype() != time_embedder_dtype &&
+        time_embedder_dtype != torch::kInt8) {
+      timestep_proj_tensor = timestep_proj_tensor.to(time_embedder_dtype);
+    }
+    torch::Tensor temb = time_embedder->forward(timestep_proj_tensor)
+                             .to(encoder_hidden_states.dtype());
+    torch::Tensor timestep_proj_out = time_proj->forward(act_fn->forward(temb));
+    torch::Tensor encoder_hidden_states_out =
+        text_embedder->forward(encoder_hidden_states);
+    return std::make_tuple(temb, timestep_proj_out, encoder_hidden_states_out);
+  }
+
+  void load_state_dict(const StateDict& state_dict) {
+    // timesteps_proj
+    timesteps_proj_->load_state_dict(
+        state_dict.get_dict_with_prefix("timesteps_proj."));
+    // time_embedder
+    time_embedder_->load_state_dict(
+        state_dict.get_dict_with_prefix("time_embedder."));
+    // act_fn (SiLU has no parameters)
+    // time_proj
+    time_proj_->to(device_);
+    auto time_proj_weight = state_dict.get_tensor("time_proj.weight");
+    if (time_proj_weight.defined()) {
+      DCHECK_EQ(time_proj_weight.sizes(), time_proj_->weight.sizes())
+          << "time_proj weight size mismatch";
+      time_proj_->weight.data().copy_(time_proj_weight);
+      time_proj_->weight.data().to(dtype_).to(device_);
+    }
+    auto time_proj_bias = state_dict.get_tensor("time_proj.bias");
+    if (time_proj_bias.defined()) {
+      DCHECK_EQ(time_proj_bias.sizes(), time_proj_->bias.sizes())
+          << "time_proj bias size mismatch";
+      time_proj_->bias.data().copy_(time_proj_bias);
+      time_proj_->bias.data().to(dtype_).to(device_);
+    }
+    // text_embedder
+    text_embedder_->load_state_dict(
+        state_dict.get_dict_with_prefix("text_embedder."));
+  }
+
+ private:
+  Timesteps timesteps_proj_{nullptr};
+  TimestepEmbedding time_embedder_{nullptr};
+  torch::nn::SiLU act_fn_{nullptr};
+  torch::nn::Linear time_proj_{nullptr};
+  PixArtAlphaTextProjection text_embedder_{nullptr};
+};
+TORCH_MODULE(WanTimeTextImageEmbedding);
+
+class WanTransformerBlockImpl : public torch::nn::Module {
+ public:
+  WanTransformerBlockImpl(int64_t dim,
+                          int64_t ffn_dim,
+                          int64_t num_heads,
+                          bool cross_attn_norm = false,
+                          double eps = 1e-6,
+                          at::Device device = torch::kCPU,
+                          at::ScalarType dtype = torch::kFloat32)
+      : cross_attn_norm_(cross_attn_norm), device_(device), dtype_(dtype) {
+    norm1_ = register_module("norm1", FP32LayerNorm({dim}, eps, false));
+    attn1_ = register_module(
+        "attn1",
+        WanAttention(dim, num_heads, dim / num_heads, eps, 0, device, dtype));
+    attn2_ = register_module("attn2",
+                             WanAttention(dim,
+                                          num_heads,
+                                          dim / num_heads,
+                                          eps,
+                                          dim / num_heads,
+                                          device,
+                                          dtype));
+    if (cross_attn_norm_) {
+      norm2_ = register_module("norm2", FP32LayerNorm({dim}, eps, true));
+    } else {
+      norm2_ = nullptr;
+    }
+    ffn_ =
+        register_module("ffn", FeedForward(dim, ffn_dim, "gelu-approximate"));
+    norm3_ = register_module("norm3", FP32LayerNorm({dim}, eps, false));
+    scale_shift_table_ = register_parameter(
+        "scale_shift_table", torch::randn({1, 6, dim}) / std::sqrt(dim));
+  }
+
+  torch::Tensor forward(const torch::Tensor& hidden_states,
+                        const torch::Tensor& encoder_hidden_states,
+                        const torch::Tensor& temb,
+                        const torch::Tensor& rotary_emb) {
+    torch::Tensor shift_msa, scale_msa, gate_msa, c_shift_msa, c_scale_msa,
+        c_gate_msa;
+    if (temb.dim() == 4) {
+      // temb: batch_size, seq_len, 6, inner_dim
+      auto scale_shift =
+          scale_shift_table_.unsqueeze(0) + temb.to(torch::kFloat32);
+      auto chunks = scale_shift.chunk(6, 2);
+      shift_msa = chunks[0].squeeze(2);
+      scale_msa = chunks[1].squeeze(2);
+      gate_msa = chunks[2].squeeze(2);
+      c_shift_msa = chunks[3].squeeze(2);
+      c_scale_msa = chunks[4].squeeze(2);
+      c_gate_msa = chunks[5].squeeze(2);
+    } else {
+      // temb: batch_size, 6, inner_dim
+      auto scale_shift = scale_shift_table_ + temb.to(torch::kFloat32);
+      auto chunks = scale_shift.chunk(6, 1);
+      shift_msa = chunks[0];
+      scale_msa = chunks[1];
+      gate_msa = chunks[2];
+      c_shift_msa = chunks[3];
+      c_scale_msa = chunks[4];
+      c_gate_msa = chunks[5];
+    }
+    // 1. Self-attention
+    auto norm_hidden_states =
+        norm1_->forward(hidden_states.to(torch::kFloat32)) * (1 + scale_msa) +
+        shift_msa;
+    norm_hidden_states = norm_hidden_states.to(hidden_states.dtype());
+    auto attn_output =
+        attn1_->forward(norm_hidden_states, torch::nullopt, rotary_emb);
+    hidden_states = hidden_states.to(torch::kFloat32) + attn_output * gate_msa;
+    hidden_states = hidden_states.to(attn_output.dtype());
+
+    // 2. Cross-attention
+    if (cross_attn_norm_ && norm2_ != nullptr) {
+      norm_hidden_states = norm2_->forward(hidden_states.to(torch::kFloat32));
+      norm_hidden_states = norm_hidden_states.to(hidden_states.dtype());
+    } else {
+      norm_hidden_states = hidden_states;
+    }
+    attn_output = attn2_->forward(
+        norm_hidden_states, encoder_hidden_states, torch::nullopt);
+    hidden_states = hidden_states + attn_output;
+
+    // 3. Feed-forward
+    norm_hidden_states =
+        norm3_->forward(hidden_states.to(torch::kFloat32)) * (1 + c_scale_msa) +
+        c_shift_msa;
+    norm_hidden_states = norm_hidden_states.to(hidden_states.dtype());
+    auto ff_output = ffn_->forward(norm_hidden_states);
+    hidden_states = hidden_states.to(torch::kFloat32) +
+                    ff_output.to(torch::kFloat32) * c_gate_msa;
+    hidden_states = hidden_states.to(ff_output.dtype());
+
+    return hidden_states;
+  }
+
+  void load_state_dict(const StateDict& state_dict) {
+    // norm1
+    norm1_->load_state_dict(state_dict.get_dict_with_prefix("norm1."));
+    // attn1
+    attn1_->load_state_dict(state_dict.get_dict_with_prefix("attn1."));
+    // attn2
+    attn2_->load_state_dict(state_dict.get_dict_with_prefix("attn2."));
+    // norm2
+    if (cross_attn_norm_ && norm2_ != nullptr) {
+      norm2_->load_state_dict(state_dict.get_dict_with_prefix("norm2."));
+    }
+    // ffn
+    ffn_->load_state_dict(state_dict.get_dict_with_prefix("ffn."));
+    // norm3
+    norm3_->load_state_dict(state_dict.get_dict_with_prefix("norm3."));
+    // scale_shift_table
+    scale_shift_table_->to(device_);
+    auto scale_shift_table_weight = state_dict.get_tensor("scale_shift_table");
+    if (scale_shift_table_weight.defined()) {
+      DCHECK_EQ(scale_shift_table_weight.sizes(), scale_shift_table_.sizes())
+          << "scale_shift_table size mismatch";
+      scale_shift_table_.data().copy_(scale_shift_table_weight);
+      scale_shift_table_.data().to(dtype_).to(device_);
+    }
+  }
+
+ private:
+  FP32LayerNorm norm1_{nullptr};
+  WanAttention attn1_{nullptr};
+  WanAttention attn2_{nullptr};
+  FP32LayerNorm norm2_{nullptr};
+  FeedForward ffn_{nullptr};
+  FP32LayerNorm norm3_{nullptr};
+  torch::Tensor scale_shift_table_;
+  bool cross_attn_norm_;
+};
+TORCH_MODULE(WanTransformerBlock);
+
+class WanTransformer3DModelImpl : public torch::nn::Module {
+ public:
+  WanTransformer3DModelImpl(const ModelContext& context)
+      : args_(context.get_model_args()),
+        device_(context.get_device()),
+        dtype_(context.get_dtype()) {
+    int64_t dim =
+        args_.wan_num_attention_heads() * args_.wan_attention_head_dim();
+
+    // Patch embedding (3D)
+    patch_embed_ = register_module(
+        "patch_embed",
+        torch::nn::Conv3d(torch::nn::Conv3dOptions(args_.wan_in_channels(),
+                                                   dim,
+                                                   args_.wan_patch_size())
+                              .stride(args_.wan_patch_size())
+                              .padding(0)));
+
+    // Text projection
+    text_proj_ = register_module("text_proj",
+                                 DiTLinear(args_.wan_text_dim(), dim, true));
+
+    text_proj_->weight.set_data(text_proj_->weight.to(device_).to(dtype_));
+
+    // Timestep embedding
+    time_embed_ = register_module(
+        "time_embed",
+        torch::nn::Sequential(DiTLinear(args_.wan_freq_dim(), dim, true),
+                              torch::nn::SiLU(),
+                              DiTLinear(dim, dim, true)));
+
+    // Transformer blocks
+    blocks_ = register_module("blocks", torch::nn::ModuleList());
+    for (int64_t i = 0; i < args_.wan_num_layers(); ++i) {
+      blocks_->push_back(WanTransformerBlock(dim,
+                                             args_.wan_num_attention_heads(),
+                                             args_.wan_attention_head_dim(),
+                                             args_.wan_ffn_dim(),
+                                             args_.wan_cross_attn_norm(),
+                                             args_.wan_qk_norm(),
+                                             args_.wan_eps(),
+                                             device_,
+                                             dtype_));
+    }
+
+    // Final norm and projection
+    norm_out_ = register_module(
+        "norm_out",
+        torch::nn::LayerNorm(
+            torch::nn::LayerNormOptions({dim}).elementwise_affine(true).eps(
+                args_.wan_eps())));
+
+    proj_out_ = register_module(
+        "proj_out",
+        torch::nn::ConvTranspose3d(
+            torch::nn::ConvTranspose3dOptions(
+                dim, args_.wan_out_channels(), args_.wan_patch_size())
+                .stride(args_.wan_patch_size())
+                .padding(0)));
+  }
+
+  torch::Tensor forward(const torch::Tensor& hidden_states,
+                        const torch::Tensor& encoder_hidden_states,
+                        const torch::Tensor& timestep,
+                        const torch::Tensor& rotary_emb) {
+    // Patch embedding
+    // hidden_states: [B, C, T, H, W]
+    auto x = patch_embed_->forward(hidden_states.to(device_));
+
+    // Reshape to [B, seq_len, dim]
+    int64_t batch_size = x.size(0);
+    int64_t dim = x.size(1);
+    int64_t t = x.size(2);
+    int64_t h = x.size(3);
+    int64_t w = x.size(4);
+
+    x = x.permute({0, 2, 3, 4, 1}).contiguous();  // [B, T, H, W, dim]
+    x = x.view({batch_size, t * h * w, dim});     // [B, seq_len, dim]
+
+    // Timestep embedding
+    auto t_emb = get_timestep_embedding(timestep,
+                                        args_.wan_freq_dim(),
+                                        false,
+                                        0.0f,
+                                        1.0f,
+                                        10000,
+                                        device_,
+                                        dtype_);
+    t_emb = time_embed_->forward(t_emb);
+
+    // Add timestep embedding
+    x = x + t_emb.unsqueeze(1);
+
+    // Project text embeddings
+    auto context = text_proj_->forward(encoder_hidden_states.to(device_));
+
+    // Transformer blocks
+    for (int64_t i = 0; i < blocks_->size(); ++i) {
+      auto block = blocks_[i]->as<WanTransformerBlock>();
+      x = block->forward(x, context, rotary_emb);
+    }
+
+    // Final norm
+    x = norm_out_->forward(x);
+
+    // Reshape back to 3D
+    x = x.view({batch_size, t, h, w, dim});
+    x = x.permute({0, 4, 1, 2, 3}).contiguous();  // [B, dim, T, H, W]
+
+    // Project to output channels
+    auto output = proj_out_->forward(x);
+
+    return output;
+  }
+
+  void load_model(std::unique_ptr<DiTFolderLoader> loader) {
+    for (const auto& state_dict : loader->get_state_dicts()) {
+      // patch_embed
+      auto patch_weight = state_dict->get_tensor("patch_embed.weight");
+      if (patch_weight.defined()) {
+        patch_embed_->named_parameters()["weight"].data().copy_(
+            patch_weight.to(dtype_).to(device_));
+      }
+      auto patch_bias = state_dict->get_tensor("patch_embed.bias");
+      if (patch_bias.defined()) {
+        patch_embed_->named_parameters()["bias"].data().copy_(
+            patch_bias.to(dtype_).to(device_));
+      }
+
+      // text_proj
+      auto text_weight = state_dict->get_tensor("text_proj.weight");
+      if (text_weight.defined()) {
+        text_proj_->weight.data().copy_(text_weight.to(dtype_).to(device_));
+      }
+      auto text_bias = state_dict->get_tensor("text_proj.bias");
+      if (text_bias.defined()) {
+        text_proj_->bias.data().copy_(text_bias.to(dtype_).to(device_));
+      }
+
+      // time_embed (Sequential with two Linear layers)
+      auto time_0_weight = state_dict->get_tensor("time_embed.0.weight");
+      if (time_0_weight.defined()) {
+        time_embed_->named_modules()["0"]->as<DiTLinear>()->weight.data().copy_(
+            time_0_weight.to(dtype_).to(device_));
+      }
+      auto time_2_weight = state_dict->get_tensor("time_embed.2.weight");
+      if (time_2_weight.defined()) {
+        time_embed_->named_modules()["2"]->as<DiTLinear>()->weight.data().copy_(
+            time_2_weight.to(dtype_).to(device_));
+      }
+
+      // blocks
+      for (int64_t i = 0; i < blocks_->size(); ++i) {
+        auto block = blocks_[i]->as<WanTransformerBlock>();
+        block->load_state_dict(state_dict->get_dict_with_prefix(
+            "blocks." + std::to_string(i) + "."));
+      }
+
+      // norm_out
+      auto norm_weight = state_dict->get_tensor("norm_out.weight");
+      if (norm_weight.defined()) {
+        norm_out_->named_parameters()["weight"].data().copy_(norm_weight);
+      }
+      auto norm_bias = state_dict->get_tensor("norm_out.bias");
+      if (norm_bias.defined()) {
+        norm_out_->named_parameters()["bias"].data().copy_(norm_bias);
+      }
+
+      // proj_out
+      auto proj_weight = state_dict->get_tensor("proj_out.weight");
+      if (proj_weight.defined()) {
+        proj_out_->named_parameters()["weight"].data().copy_(
+            proj_weight.to(dtype_).to(device_));
+      }
+      auto proj_bias = state_dict->get_tensor("proj_out.bias");
+      if (proj_bias.defined()) {
+        proj_out_->named_parameters()["bias"].data().copy_(
+            proj_bias.to(dtype_).to(device_));
+      }
+    }
+
+    LOG(INFO) << "WanTransformer3DModel loaded successfully.";
+  }
+
+  // Generate 3D RoPE embeddings
+  torch::Tensor get_3d_rotary_emb(int64_t t_len, int64_t h_len, int64_t w_len) {
+    int64_t head_dim = args_.wan_attention_head_dim();
+    int64_t dim_per_axis = head_dim / 3;  // Split across T, H, W
+
+    auto options = torch::TensorOptions().dtype(dtype_).device(device_);
+
+    // Temporal frequencies
+    auto t_freqs = get_1d_rotary_freqs(t_len, dim_per_axis, options);
+    // Height frequencies
+    auto h_freqs = get_1d_rotary_freqs(h_len, dim_per_axis, options);
+    // Width frequencies
+    auto w_freqs = get_1d_rotary_freqs(w_len, dim_per_axis, options);
+
+    // Combine into 3D grid
+    auto freqs = torch::cat({t_freqs, h_freqs, w_freqs}, -1);
+
+    // Create cos and sin
+    auto cos_freqs = torch::cos(freqs);
+    auto sin_freqs = torch::sin(freqs);
+
+    return torch::stack({cos_freqs, sin_freqs}, 0);
+  }
+
+ private:
+  torch::Tensor get_1d_rotary_freqs(int64_t length,
+                                    int64_t dim,
+                                    torch::TensorOptions options) {
+    auto positions = torch::arange(length, options).unsqueeze(1);
+    auto inv_freq =
+        1.0 /
+        torch::pow(10000.0,
+                   torch::arange(0, dim, 2, options).to(torch::kFloat) / dim);
+
+    auto freqs = positions * inv_freq.unsqueeze(0);
+    return freqs;
+  }
+
+  ModelArgs args_;
+  torch::nn::Conv3d patch_embed_{nullptr};
+  DiTLinear text_proj_{nullptr};
+  torch::nn::Sequential time_embed_{nullptr};
+  torch::nn::ModuleList blocks_{nullptr};
+  torch::nn::LayerNorm norm_out_{nullptr};
+  torch::nn::ConvTranspose3d proj_out_{nullptr};
+  at::Device device_;
+  at::ScalarType dtype_;
+};
+TORCH_MODULE(WanTransformer3DModel);
+
+// ==================== WAN DiT Model Wrapper ====================
+class WanDiTModelImpl : public torch::nn::Module {
+ public:
+  WanDiTModelImpl(const ModelContext& context)
+      : args_(context.get_model_args()),
+        device_(context.get_device()),
+        dtype_(context.get_dtype()) {
+    wan_transformer_ =
+        register_module("wan_transformer", WanTransformer3DModel(context));
+  }
+
+  torch::Tensor forward(const torch::Tensor& latents,
+                        const torch::Tensor& encoder_hidden_states,
+                        const torch::Tensor& timestep,
+                        int64_t num_frames = 1,
+                        int64_t height = 64,
+                        int64_t width = 64) {
+    // Generate 3D rotary embeddings
+    auto patch_size = args_.wan_patch_size();
+    int64_t t_patches = num_frames / patch_size[0];
+    int64_t h_patches = height / patch_size[1];
+    int64_t w_patches = width / patch_size[2];
+
+    auto rotary_emb =
+        wan_transformer_->get_3d_rotary_emb(t_patches, h_patches, w_patches);
+
+    // Forward pass
+    auto output = wan_transformer_->forward(
+        latents, encoder_hidden_states, timestep, rotary_emb);
+
+    return output;
+  }
+
+  void load_model(std::unique_ptr<DiTFolderLoader> loader) {
+    wan_transformer_->load_model(std::move(loader));
+  }
+
+  int64_t in_channels() { return args_.wan_in_channels(); }
+  int64_t out_channels() { return args_.wan_out_channels(); }
+
+ private:
+  WanTransformer3DModel wan_transformer_{nullptr};
+  ModelArgs args_;
+  at::Device device_;
+  at::ScalarType dtype_;
+};
+TORCH_MODULE(WanDiTModel);
+REGISTER_MODEL_ARGS(WanTransformer3DModel, [&] {
+  LOAD_ARG_OR(wan_in_channels, "in_channels", 16);
+  LOAD_ARG_OR(wan_out_channels, "out_channels", 16);
+  LOAD_ARG_OR(wan_num_layers, "num_layers", 30);
+  LOAD_ARG_OR(wan_num_attention_heads, "num_attention_heads", 40);
+  LOAD_ARG_OR(wan_attention_head_dim, "attention_head_dim", 128);
+  LOAD_ARG_OR(wan_ffn_dim, "ffn_dim", 13824);
+  LOAD_ARG_OR(wan_text_dim, "text_dim", 4096);
+  LOAD_ARG_OR(wan_freq_dim, "freq_dim", 256);
+  LOAD_ARG_OR(wan_cross_attn_norm, "cross_attn_norm", true);
+  LOAD_ARG_OR(wan_qk_norm, "qk_norm", "rms_norm_across_heads");
+  LOAD_ARG_OR(wan_eps, "eps", 1e-6f);
+  LOAD_ARG_OR(wan_rope_max_seq_len, "rope_max_seq_len", 1024);
+  LOAD_ARG_OR(wan_patch_size, "patch_size", std::vector<int64_t>({1, 2, 2}));
+});
+
+}  // namespace xllm

--- a/xllm/models/dit/umt5_encoder.h
+++ b/xllm/models/dit/umt5_encoder.h
@@ -1,0 +1,681 @@
+#pragma once
+#include <torch/torch.h>
+
+#include <algorithm>
+#include <cmath>
+#include <iostream>
+#include <memory>
+#include <optional>
+#include <stdexcept>
+#include <string>
+#include <unordered_set>
+#include <vector>
+
+#include "core/framework/dit_model_loader.h"
+#include "core/framework/model/model_input_params.h"
+#include "core/framework/state_dict/state_dict.h"
+#include "dit_linear.h"
+#include "framework/model_context.h"
+#include "models/model_registry.h"
+#include "processors/input_processor.h"
+#include "processors/pywarpper_image_processor.h"
+#include "t5_encoder.h"
+
+namespace xllm {
+// UMT5 model compatible with huggingface weights
+// ref to:
+// https://github.com/huggingface/transformers/tree/main/src/transformers/models/umt5
+class UMT5LayerNormImpl : public torch::nn::Module {
+ public:
+  explicit UMT5LayerNormImpl(ModelContext context)
+      : device_(context.get_tensor_options().device()),
+        dtype_(context.get_tensor_options().dtype().toScalarType()) {
+    ModelArgs model_args = context.get_model_args();
+    int64_t hidden_size = model_args.d_model();
+    variance_epsilon_ = model_args.layer_norm_eps();
+    weight_ = register_parameter(
+        "weight", torch::ones({hidden_size}).to(device_).to(dtype_));
+  }
+
+  torch::Tensor forward(torch::Tensor hidden_states) {
+    auto variance = hidden_states.to(dtype_).pow(2).mean(-1, true);
+    hidden_states = hidden_states * torch::rsqrt(variance + variance_epsilon_);
+    if (weight_.dtype() == torch::kFloat16 ||
+        weight_.dtype() == torch::kBFloat16) {
+      hidden_states = hidden_states.to(weight_.dtype());
+    }
+    return weight_ * hidden_states;
+  }
+
+  void load_state_dict(const StateDict& state_dict) { LOAD_WEIGHT(weight); }
+
+  void verify_loaded_weights(const std::string& prefix) const {
+    CHECK(weight_is_loaded_)
+        << "weight is not loaded for " << prefix + "weight";
+  }
+
+ private:
+  torch::Tensor weight_;
+  bool weight_is_loaded_ = false;
+  double variance_epsilon_;
+  torch::Device device_;
+  torch::ScalarType dtype_;
+};
+TORCH_MODULE(UMT5LayerNorm);
+
+class UMT5DenseInterface : public torch::nn::Module {
+ public:
+  virtual torch::Tensor forward(const torch::Tensor& hidden_states) = 0;
+  virtual void load_state_dict(const StateDict& state_dict) = 0;
+  virtual void verify_loaded_weights(const std::string& prefix) const = 0;
+};
+
+class UMT5DenseActDenseImpl : public UMT5DenseInterface {
+ public:
+  explicit UMT5DenseActDenseImpl(const ModelContext& context) {
+    auto model_args = context.get_model_args();
+    auto options = context.get_tensor_options();
+    wi_ = register_module(
+        "wi", DiTLinear(model_args.d_model(), model_args.d_ff(), false));
+    wo_ = register_module(
+        "wo", DiTLinear(model_args.d_ff(), model_args.d_model(), false));
+
+    wi_->to(options);
+    wo_->to(options);
+    if (model_args.act_fn() == "relu") {
+      act_ = register_module("act", torch::nn::Functional(torch::relu));
+    } else if (model_args.act_fn() == "gelu_new") {
+      act_ = register_module("act", torch::nn::Functional(gelu_new));
+    } else {
+      LOG(FATAL) << "Unsupported activation function: " << model_args.act_fn();
+    }
+  }
+
+  torch::Tensor forward(const torch::Tensor& hidden_states) {
+    torch::Tensor hidden = wi_->forward(hidden_states);
+    hidden = act_(hidden);
+    if (wo_->weight.dtype() != torch::kInt8 &&
+        hidden.dtype() != wo_->weight.dtype()) {
+      hidden = hidden.to(wo_->weight.dtype());
+    }
+    hidden = wo_->forward(hidden);
+    return hidden;
+  }
+
+  void load_state_dict(const StateDict& state_dict) {
+    // wi
+    wi_->load_state_dict(state_dict.get_dict_with_prefix("wi."));
+    // wo
+    wo_->load_state_dict(state_dict.get_dict_with_prefix("wo."));
+  }
+
+  void verify_loaded_weights(const std::string& prefix) const {
+    wi_->verify_loaded_weights(prefix + "wi.");
+    wo_->verify_loaded_weights(prefix + "wo.");
+  }
+
+ private:
+  DiTLinear wi_ = nullptr;
+  DiTLinear wo_ = nullptr;
+  torch::nn::Functional act_ = nullptr;
+};
+
+class UMT5DenseGatedActDenseImpl : public UMT5DenseInterface {
+ public:
+  explicit UMT5DenseGatedActDenseImpl(const ModelContext& context) {
+    auto model_args = context.get_model_args();
+    auto options = context.get_tensor_options();
+    wi_0_ = register_module(
+        "wi_0", DiTLinear(model_args.d_model(), model_args.d_ff(), false));
+    wi_1_ = register_module(
+        "wi_1", DiTLinear(model_args.d_model(), model_args.d_ff(), false));
+    wo_ = register_module(
+        "wo", DiTLinear(model_args.d_ff(), model_args.d_model(), false));
+
+    wi_0_->to(options);
+    wi_1_->to(options);
+    wo_->to(options);
+    if (model_args.act_fn() == "relu") {
+      act_ = register_module("act", torch::nn::Functional(torch::relu));
+    } else if (model_args.act_fn() == "gelu_new") {
+      act_ = register_module("act", torch::nn::Functional(gelu_new));
+    } else {
+      LOG(FATAL) << "Unsupported activation function: " << model_args.act_fn();
+    }
+  }
+
+  torch::Tensor forward(const torch::Tensor& hidden_states) {
+    torch::Tensor hidden_gelu = act_(wi_0_->forward(hidden_states));
+    torch::Tensor hidden_linear = wi_1_->forward(hidden_states);
+    torch::Tensor new_hidden_states = hidden_gelu * hidden_linear;
+    if (wo_->weight.dtype() != torch::kInt8 &&
+        new_hidden_states.dtype() != wo_->weight.dtype()) {
+      new_hidden_states = new_hidden_states.to(wo_->weight.dtype());
+    }
+    new_hidden_states = wo_->forward(new_hidden_states);
+    return new_hidden_states;
+  }
+
+  void load_state_dict(const StateDict& state_dict) {
+    // wi_0
+    wi_0_->load_state_dict(state_dict.get_dict_with_prefix("wi_0."));
+    // wi_1
+    wi_1_->load_state_dict(state_dict.get_dict_with_prefix("wi_1."));
+    // wo
+    wo_->load_state_dict(state_dict.get_dict_with_prefix("wo."));
+  }
+
+  void verify_loaded_weights(const std::string& prefix) const {
+    wi_0_->verify_loaded_weights(prefix + "wi_0.");
+    wi_1_->verify_loaded_weights(prefix + "wi_1.");
+    wo_->verify_loaded_weights(prefix + "wo.");
+  }
+
+ private:
+  DiTLinear wi_0_ = nullptr;
+  DiTLinear wi_1_ = nullptr;
+  DiTLinear wo_ = nullptr;
+  torch::nn::Functional act_ = nullptr;
+};
+
+class UMT5LayerFFNImpl : public torch::nn::Module {
+ public:
+  explicit UMT5LayerFFNImpl(const ModelContext& context) {
+    auto model_args = context.get_model_args();
+    auto options = context.get_tensor_options();
+    layer_norm_ = register_module("layer_norm", UMT5LayerNorm(context));
+    if (model_args.is_gated_act()) {
+      dense_relu_dense_ = register_module(
+          "DenseReluDense",
+          std::make_shared<UMT5DenseGatedActDenseImpl>(context));
+    } else {
+      dense_relu_dense_ = register_module(
+          "DenseReluDense", std::make_shared<UMT5DenseActDenseImpl>(context));
+    }
+  }
+
+  torch::Tensor forward(const torch::Tensor& hidden_states) {
+    torch::Tensor forwarded_states = layer_norm_->forward(hidden_states);
+    forwarded_states = dense_relu_dense_->forward(forwarded_states);
+    torch::Tensor output = hidden_states + forwarded_states;
+    return output;
+  }
+
+  void load_state_dict(const StateDict& state_dict) {
+    dense_relu_dense_->load_state_dict(
+        state_dict.get_dict_with_prefix("DenseReluDense."));
+    layer_norm_->load_state_dict(
+        state_dict.get_dict_with_prefix("layer_norm."));
+  }
+
+  void verify_loaded_weights(const std::string& prefix) const {
+    dense_relu_dense_->verify_loaded_weights(prefix + "DenseReluDense.");
+    layer_norm_->verify_loaded_weights(prefix + "layer_norm.");
+  }
+
+ private:
+  std::shared_ptr<UMT5DenseInterface> dense_relu_dense_ = nullptr;
+  UMT5LayerNorm layer_norm_ = nullptr;
+};
+TORCH_MODULE(UMT5LayerFFN);
+
+class UMT5AttentionImpl : public torch::nn::Module {
+ public:
+  UMT5AttentionImpl(const ModelContext& context,
+                    bool has_relative_attention_bias) {
+    auto model_args = context.get_model_args();
+    auto options = context.get_tensor_options();
+    has_relative_attention_bias_ = has_relative_attention_bias;
+    inner_dim_ = model_args.n_heads() * model_args.d_kv();
+
+    n_heads_ = model_args.n_heads();
+    key_value_proj_dim_ = model_args.d_kv();
+    d_model_ = model_args.d_model();
+    relative_attention_num_buckets_ =
+        model_args.relative_attention_num_buckets();
+    relative_attention_max_distance_ =
+        model_args.relative_attention_max_distance();
+
+    q_ = register_module("q", DiTLinear(d_model_, inner_dim_, false));
+    k_ = register_module("k", DiTLinear(d_model_, inner_dim_, false));
+    v_ = register_module("v", DiTLinear(d_model_, inner_dim_, false));
+    o_ = register_module("o", DiTLinear(inner_dim_, d_model_, false));
+
+    q_->to(options);
+    k_->to(options);
+    v_->to(options);
+    o_->to(options);
+
+    if (has_relative_attention_bias_) {
+      relative_attention_bias_ = register_module(
+          "relative_attention_bias",
+          torch::nn::Embedding(relative_attention_num_buckets_, n_heads_));
+    }
+  }
+
+  std::vector<torch::Tensor> forward(
+      const torch::Tensor& hidden_states,
+      const std::optional<torch::Tensor>& mask = std::nullopt,
+      const std::optional<torch::Tensor>& key_value_states = std::nullopt,
+      const std::optional<torch::Tensor>& position_bias = std::nullopt,
+      const std::optional<torch::Tensor>& layer_head_mask = std::nullopt) {
+    int64_t batch_size = hidden_states.size(0);
+    int64_t seq_length = hidden_states.size(1);
+    bool is_cross_attention = key_value_states.has_value();
+    torch::Tensor query_states = q_->forward(hidden_states);
+    query_states =
+        query_states.view({batch_size, -1, n_heads_, key_value_proj_dim_})
+            .transpose(1, 2);  // (batch_size, n_heads, seq_len, head_dim)
+
+    torch::Tensor current_states =
+        is_cross_attention ? key_value_states.value() : hidden_states;
+    torch::Tensor key_states = k_->forward(current_states);
+    torch::Tensor value_states = v_->forward(current_states);
+    key_states =
+        key_states.view({batch_size, -1, n_heads_, key_value_proj_dim_})
+            .transpose(1, 2);  // (batch_size, n_heads, key_len, head_dim)
+    value_states =
+        value_states.view({batch_size, -1, n_heads_, key_value_proj_dim_})
+            .transpose(1, 2);  // (batch_size, n_heads, key_len, head_dim)
+    torch::Tensor scores = torch::matmul(
+        query_states,
+        key_states.transpose(3, 2));  // (batch, n_heads, seq_len, key_len)
+    torch::Tensor curr_position_bias;
+    if (position_bias.has_value() && position_bias.value().numel() > 0) {
+      curr_position_bias = position_bias.value();
+    } else {
+      int64_t key_length = key_states.size(-2);
+      if (!has_relative_attention_bias_) {
+        curr_position_bias =
+            torch::zeros({1, n_heads_, seq_length, key_length},
+                         torch::dtype(scores.dtype()).device(scores.device()));
+      } else {
+        torch::Tensor bias =
+            compute_bias(seq_length, key_length, scores.device());
+        curr_position_bias = bias.index(
+            {torch::indexing::Slice(),
+             torch::indexing::Slice(),
+             torch::indexing::Slice(-seq_length, torch::indexing::None),
+             torch::indexing::Slice()});
+      }
+      if (mask.has_value() && mask.value().numel() > 0) {
+        torch::Tensor causal_mask = mask.value().index(
+            {torch::indexing::Slice(),
+             torch::indexing::Slice(),
+             torch::indexing::Slice(),
+             torch::indexing::Slice(0, key_states.size(-2))});
+        curr_position_bias = curr_position_bias + causal_mask;
+      }
+    }
+    if (!pruned_heads_.empty()) {
+      torch::Tensor head_mask =
+          torch::ones(n_heads_ + pruned_heads_.size(), torch::kBool)
+              .to(scores.device());
+      for (int64_t pruned : pruned_heads_) {
+        head_mask[pruned] = false;
+      }
+      curr_position_bias = curr_position_bias.index({torch::indexing::Slice(),
+                                                     head_mask,
+                                                     torch::indexing::Slice(),
+                                                     torch::indexing::Slice()});
+    }
+    scores += curr_position_bias;
+    torch::Tensor attn_weights =
+        torch::softmax(scores.to(torch::kFloat), -1).to(scores.dtype());
+    if (layer_head_mask.has_value() && layer_head_mask.value().numel() > 0) {
+      attn_weights = attn_weights * layer_head_mask.value();
+    }
+    torch::Tensor attn_output = torch::matmul(
+        attn_weights, value_states);  // (batch, n_heads, seq_len, head_dim)
+    attn_output = attn_output.transpose(1, 2)
+                      .contiguous();  // (batch, seq_len, n_heads, head_dim)
+    attn_output = attn_output.view({batch_size, -1, inner_dim_});
+    attn_output = o_->forward(attn_output);
+    std::vector<torch::Tensor> outputs = {attn_output, attn_weights};
+    return outputs;
+  }
+
+  void load_state_dict(const StateDict& state_dict) {
+    q_->load_state_dict(state_dict.get_dict_with_prefix("q."));
+    k_->load_state_dict(state_dict.get_dict_with_prefix("k."));
+    v_->load_state_dict(state_dict.get_dict_with_prefix("v."));
+    o_->load_state_dict(state_dict.get_dict_with_prefix("o."));
+    if (has_relative_attention_bias_) {
+      weight::load_weight(state_dict,
+                          "relative_attention_bias.weight",
+                          relative_attention_bias_->weight,
+                          is_relative_attention_bias_loaded_);
+    }
+  }
+
+  void verify_loaded_weights(const std::string& prefix) const {
+    q_->verify_loaded_weights(prefix + "q.");
+    k_->verify_loaded_weights(prefix + "k.");
+    v_->verify_loaded_weights(prefix + "v.");
+    o_->verify_loaded_weights(prefix + "o.");
+    if (has_relative_attention_bias_) {
+      CHECK(is_relative_attention_bias_loaded_)
+          << "weight is not loaded for "
+          << prefix + "relative_attention_bias.weight";
+    }
+  }
+
+ private:
+  torch::Tensor _relative_position_bucket(torch::Tensor& relative_position,
+                                          bool bidirectional = true,
+                                          int64_t num_buckets = 32,
+                                          int64_t max_distance = 128) const {
+    torch::Tensor relative_buckets =
+        torch::zeros_like(relative_position, torch::kLong);
+    if (bidirectional) {
+      num_buckets /= 2;
+      relative_buckets +=
+          (relative_position > 0).to(torch::kLong) * num_buckets;
+      auto abs_relative_position = torch::abs(relative_position);
+      relative_position = abs_relative_position;
+    } else {
+      relative_position =
+          -torch::min(relative_position, torch::zeros_like(relative_position));
+    }
+    int64_t max_exact = num_buckets / 2;
+    torch::Tensor is_small = relative_position < max_exact;
+    auto relative_position_float = relative_position.to(torch::kFloat);
+    auto max_exact_float = static_cast<float>(max_exact);
+    auto max_distance_float = static_cast<float>(max_distance);
+    torch::Tensor relative_position_if_large =
+        max_exact + (torch::log(relative_position_float / max_exact_float) /
+                     std::log(max_distance_float / max_exact_float) *
+                     (num_buckets - max_exact))
+                        .to(torch::kLong);
+    relative_position_if_large = torch::min(
+        relative_position_if_large,
+        torch::full_like(
+            relative_position_if_large, num_buckets - 1, torch::kLong));
+    relative_buckets +=
+        torch::where(is_small, relative_position, relative_position_if_large);
+    return relative_buckets;
+  }
+
+  torch::Tensor compute_bias(
+      int64_t query_length,
+      int64_t key_length,
+      std::optional<torch::Device> device = std::nullopt) const {
+    if (!has_relative_attention_bias_) {
+      return torch::zeros(
+          {1, n_heads_, query_length, key_length},
+          torch::dtype(torch::kFloat).device(device.value_or(torch::kCPU)));
+    }
+
+    torch::Device dev =
+        device.value_or(relative_attention_bias_->weight.device());
+
+    torch::Tensor context_position;
+    context_position =
+        torch::arange(query_length, torch::dtype(torch::kLong).device(dev))
+            .unsqueeze(1);
+
+    torch::Tensor memory_position =
+        torch::arange(key_length, torch::dtype(torch::kLong).device(dev))
+            .unsqueeze(0);
+    torch::Tensor relative_position = memory_position - context_position;
+    torch::Tensor relative_position_bucket =
+        _relative_position_bucket(relative_position,
+                                  true,
+                                  relative_attention_num_buckets_,
+                                  relative_attention_max_distance_);
+    torch::Tensor values =
+        const_cast<torch::nn::EmbeddingImpl*>(relative_attention_bias_.get())
+            ->forward(relative_position_bucket);
+    values = values.permute({2, 0, 1}).unsqueeze(0);
+
+    return values;
+  }
+
+ private:
+  bool has_relative_attention_bias_;
+  int64_t relative_attention_num_buckets_;
+  int64_t relative_attention_max_distance_;
+  int64_t d_model_;
+  int64_t key_value_proj_dim_;
+  int64_t n_heads_;
+  int64_t inner_dim_;
+  std::optional<int64_t> layer_idx_;
+  DiTLinear q_ = nullptr;
+  DiTLinear k_ = nullptr;
+  DiTLinear v_ = nullptr;
+  DiTLinear o_ = nullptr;
+  torch::nn::Embedding relative_attention_bias_ = nullptr;
+  bool is_relative_attention_bias_loaded_ = false;
+  std::unordered_set<int64_t> pruned_heads_;
+};
+TORCH_MODULE(UMT5Attention);
+
+class UMT5LayerSelfAttentionImpl : public torch::nn::Module {
+ public:
+  UMT5LayerSelfAttentionImpl(const ModelContext& context,
+                             bool has_relative_attention_bias) {
+    auto model_args = context.get_model_args();
+    auto options = context.get_tensor_options();
+    self_attention_ = register_module(
+        "SelfAttention", UMT5Attention(context, has_relative_attention_bias));
+    layer_norm_ = register_module("layer_norm", UMT5LayerNorm(context));
+  }
+
+  std::vector<torch::Tensor> forward(
+      const torch::Tensor& hidden_states,
+      const std::optional<torch::Tensor>& attention_mask = std::nullopt,
+      const std::optional<torch::Tensor>& position_bias = std::nullopt,
+      const std::optional<torch::Tensor>& layer_head_mask = std::nullopt) {
+    torch::Tensor normed_hidden_states = layer_norm_->forward(hidden_states);
+    auto attention_output = self_attention_->forward(normed_hidden_states,
+                                                     attention_mask,
+                                                     std::nullopt,
+                                                     position_bias,
+                                                     layer_head_mask);
+
+    torch::Tensor updated_hidden_states = hidden_states + attention_output[0];
+
+    std::vector<torch::Tensor> outputs = {updated_hidden_states};
+    outputs.push_back(attention_output[1]);
+    return outputs;
+  }
+
+  void load_state_dict(const StateDict& state_dict) {
+    self_attention_->load_state_dict(
+        state_dict.get_dict_with_prefix("SelfAttention."));
+    layer_norm_->load_state_dict(
+        state_dict.get_dict_with_prefix("layer_norm."));
+  }
+
+  void verify_loaded_weights(const std::string& prefix) const {
+    self_attention_->verify_loaded_weights(prefix + "SelfAttention.");
+    layer_norm_->verify_loaded_weights(prefix + "layer_norm.");
+  }
+
+ private:
+  UMT5Attention self_attention_ = nullptr;
+  UMT5LayerNorm layer_norm_ = nullptr;
+};
+TORCH_MODULE(UMT5LayerSelfAttention);
+
+class UMT5BlockImpl : public torch::nn::Module {
+ public:
+  UMT5BlockImpl(const ModelContext& context, bool has_relative_attention_bias) {
+    auto model_args = context.get_model_args();
+    auto options = context.get_tensor_options();
+    self_attention_ = register_module(
+        "SelfAttention",
+        UMT5LayerSelfAttention(context, has_relative_attention_bias));
+    ff_layer_ = register_module("LayerFFN", UMT5LayerFFN(context));
+  }
+
+  std::vector<torch::Tensor> forward(
+      const torch::Tensor& hidden_states,
+      const std::optional<torch::Tensor>& attention_mask = std::nullopt,
+      const std::optional<torch::Tensor>& position_bias = std::nullopt,
+      const std::optional<torch::Tensor>& layer_head_mask = std::nullopt) {
+    auto self_attention_outputs = self_attention_->forward(
+        hidden_states, attention_mask, position_bias, layer_head_mask);
+    torch::Tensor curr_hidden_states = self_attention_outputs[0];
+    std::vector<torch::Tensor> attention_outputs;
+    for (size_t i = 1; i < self_attention_outputs.size(); ++i) {
+      attention_outputs.push_back(self_attention_outputs[i]);
+    }
+
+    if (curr_hidden_states.dtype() == torch::kFloat16) {
+      curr_hidden_states = clamp_inf_values(curr_hidden_states);
+    }
+
+    curr_hidden_states = ff_layer_->forward(curr_hidden_states);
+
+    if (curr_hidden_states.dtype() == torch::kFloat16) {
+      curr_hidden_states = clamp_inf_values(curr_hidden_states);
+    }
+
+    std::vector<torch::Tensor> outputs = {curr_hidden_states};
+    // outputs.insert(
+    //     outputs.end(), attention_outputs.begin(), attention_outputs.end());
+
+    return outputs;
+  }
+
+  void load_state_dict(const StateDict& state_dict) {
+    self_attention_->load_state_dict(
+        state_dict.get_dict_with_prefix("layer.0."));
+    ff_layer_->load_state_dict(state_dict.get_dict_with_prefix("layer.1."));
+  }
+
+  void verify_loaded_weights(const std::string& prefix) const {
+    self_attention_->verify_loaded_weights(prefix + "layer.0.");
+    ff_layer_->verify_loaded_weights(prefix + "layer.1.");
+  }
+
+ private:
+  torch::Tensor clamp_inf_values(const torch::Tensor& x) const {
+    float max_val;
+    if (x.scalar_type() == torch::kFloat16) {
+      max_val = 65504.0f;
+    } else if (x.scalar_type() == torch::kFloat32) {
+      max_val = std::numeric_limits<float>::max();
+    } else if (x.scalar_type() == torch::kBFloat16) {
+      max_val = 3.3895313892515355e+38f;
+    } else {
+      max_val = std::numeric_limits<float>::max();
+    }
+    torch::Tensor clamp_value =
+        torch::where(torch::isinf(x).any(),
+                     torch::tensor(max_val - 1000.0f, x.options()),
+                     torch::tensor(max_val, x.options()));
+
+    return torch::clamp(x, -clamp_value, clamp_value);
+  }
+
+  UMT5LayerSelfAttention self_attention_ = nullptr;
+  UMT5LayerFFN ff_layer_ = nullptr;
+};
+TORCH_MODULE(UMT5Block);
+
+class UMT5EncoderModelImpl : public torch::nn::Module {
+ public:
+  explicit UMT5EncoderModelImpl(const ModelContext& context) {
+    auto model_args = context.get_model_args();
+    auto options = context.get_tensor_options();
+    embed_tokens_ = register_module(
+        "embed_tokens",
+        torch::nn::Embedding(model_args.vocab_size(), model_args.d_model()));
+    embed_tokens_->weight.set_data(embed_tokens_->weight.to(options));
+    blocks_ = register_module("blocks", torch::nn::ModuleList{});
+    layers_.reserve(model_args.num_layers());
+    for (int64_t i = 0; i < model_args.num_layers(); ++i) {
+      bool has_relative_bias = true;
+      auto block = UMT5Block(context, has_relative_bias);
+      blocks_->push_back(block);
+      layers_.push_back(block);
+    }
+    final_layer_norm_ =
+        register_module("final_layer_norm", UMT5LayerNorm(context));
+  }
+
+  torch::Tensor forward(const torch::Tensor& input_ids) {
+    // Prepare input parameters
+    auto options = torch::TensorOptions()
+                       .dtype(torch::typeMetaToScalarType(input_ids.dtype()))
+                       .device(input_ids.device());
+
+    torch::Tensor hidden_states = embed_tokens_->forward(input_ids);
+    auto input_shape =
+        hidden_states.sizes();  // (batch_size, seq_length, d_model)
+    int64_t batch_size = input_shape[0];
+    int64_t seq_length = input_shape[1];
+    torch::Tensor causal_mask = torch::Tensor();
+    std::vector<torch::Tensor> all_hidden_states;
+    std::vector<torch::Tensor> all_attentions;
+    torch::Tensor position_bias = torch::Tensor();
+    for (size_t i = 0; i < layers_.size(); ++i) {
+      torch::Tensor layer_head_mask = torch::Tensor();
+      auto layer_outputs = layers_[i]->forward(
+          hidden_states, causal_mask, position_bias, layer_head_mask);
+      hidden_states = layer_outputs[0];
+      // position_bias = layer_outputs[1];
+      layer_outputs.clear();
+    }
+    hidden_states = final_layer_norm_->forward(hidden_states);
+    return hidden_states;
+  }
+
+  void load_model(std::unique_ptr<DiTFolderLoader> loader) {
+    for (const auto& state_dict : loader->get_state_dicts()) {
+      weight::load_weight(*state_dict,
+                          "shared.weight",
+                          embed_tokens_->weight,
+                          is_embed_tokens_loaded_);
+      final_layer_norm_->load_state_dict(
+          state_dict->get_dict_with_prefix("encoder.final_layer_norm."));
+      for (int64_t i = 0; i < layers_.size(); ++i) {
+        const auto block_prefix = "encoder.block." + std::to_string(i) + ".";
+        layers_[i]->load_state_dict(
+            state_dict->get_dict_with_prefix(block_prefix));
+      }
+    }
+    verify_loaded_weights();
+    LOG(INFO) << "UMT5EncoderModel loaded successfully.";
+  }
+
+  void verify_loaded_weights() const {
+    CHECK(is_embed_tokens_loaded_)
+        << "weight is not loaded for embed_tokens.weight";
+    final_layer_norm_->verify_loaded_weights("encoder.final_layer_norm.");
+    for (int64_t i = 0; i < layers_.size(); ++i) {
+      const auto block_prefix = "encoder.block." + std::to_string(i) + ".";
+      layers_[i]->verify_loaded_weights(block_prefix);
+    }
+  }
+
+ private:
+  UMT5LayerNorm final_layer_norm_ = nullptr;
+  torch::nn::Embedding embed_tokens_ = nullptr;
+  bool is_embed_tokens_loaded_ = false;
+  std::vector<UMT5Block> layers_;
+  torch::nn::ModuleList blocks_ = nullptr;
+};
+TORCH_MODULE(UMT5EncoderModel);
+
+REGISTER_MODEL_ARGS(UMT5EncoderModel, [&] {
+  LOAD_ARG_OR(dtype, "torch_dtype", "float32");
+  LOAD_ARG_OR(model_type, "model_type", "umt5encoder");
+  LOAD_ARG_OR(vocab_size, "vocab_size", 256384);
+  LOAD_ARG_OR(d_model, "d_model", 4096);
+  LOAD_ARG_OR(num_layers, "num_layers", 24);
+  LOAD_ARG_OR(d_kv, "d_kv", 64);
+  LOAD_ARG_OR(n_heads, "num_heads", 64);
+  LOAD_ARG_OR(d_ff, "d_ff", 10240);
+  LOAD_ARG_OR(act_fn, "dense_act_fn", "gelu_new");
+  LOAD_ARG_OR(is_gated_act, "is_gated_act", true);
+  LOAD_ARG_OR(
+      relative_attention_num_buckets, "relative_attention_num_buckets", 32);
+  LOAD_ARG_OR(
+      relative_attention_max_distance, "relative_attention_max_distance", 128);
+  LOAD_ARG_OR(layer_norm_eps, "layer_norm_epsilon", 1e-6f);
+});
+
+}  // namespace xllm

--- a/xllm/models/dit/unipc_multistep_scheduler.h
+++ b/xllm/models/dit/unipc_multistep_scheduler.h
@@ -1,0 +1,877 @@
+#pragma once
+#include <torch/torch.h>
+
+#include <algorithm>
+#include <cmath>
+#include <iostream>
+#include <memory>
+#include <optional>
+#include <stdexcept>
+#include <string>
+#include <vector>
+
+#include "core/framework/model/model_input_params.h"
+#include "core/framework/state_dict/state_dict.h"
+#include "models/model_registry.h"
+#include "processors/input_processor.h"
+#include "processors/pywarpper_image_processor.h"
+namespace xllm {
+struct UniPCMultistepSchedulerOutput {
+  torch::Tensor prev_sample;
+  explicit UniPCMultistepSchedulerOutput(torch::Tensor sample)
+      : prev_sample(std::move(sample)) {}
+};
+class UniPCMultistepSchedulerImpl : public torch::nn::Module {
+ private:
+  int num_train_timesteps_;
+  float beta_start_;
+  float beta_end_;
+  std::string beta_schedule_;
+  std::optional<std::vector<float>> trained_betas_;
+
+  int solver_order_;
+  std::string prediction_type_;
+  bool thresholding_;
+  float dynamic_thresholding_ratio_;
+  float sample_max_value_;
+  bool predict_x0_;
+  std::string solver_type_;
+  bool lower_order_final_;
+  std::vector<int> disable_corrector_;
+
+  std::string timestep_spacing_;
+  int steps_offset_;
+  bool rescale_betas_zero_snr_;
+  std::string final_sigmas_type_;
+
+  bool use_karras_sigmas_;
+  bool use_exponential_sigmas_;
+  bool use_beta_sigmas_;
+  bool use_flow_sigmas_;
+  float flow_shift_;
+  bool use_dynamic_shifting_;
+  std::string time_shift_type_;
+
+  torch::Tensor timesteps_;
+  torch::Tensor sigmas_;
+  torch::Tensor betas_;
+  torch::Tensor alphas_;
+  torch::Tensor alphas_cumprod_;
+
+  std::vector<torch::Tensor> model_outputs_;
+  std::vector<torch::Tensor> timestep_list_;
+  torch::Tensor last_sample_;
+  std::optional<int> step_index_;
+  std::optional<int> begin_index_;
+  int num_inference_steps_;
+  int lower_order_nums_;
+  int this_order_;
+
+  torch::Tensor lambda_t_;
+  torch::Tensor alpha_t_;
+  torch::Tensor sigma_t_;
+
+  torch::Tensor betas_for_alpha_bar(int num_diffusion_timesteps,
+                                    float max_beta = 0.999f) {
+    auto alpha_bar_fn = [](float t) {
+      return std::pow(std::cos((t + 0.008f) / 1.008f * M_PI / 2.0f), 2);
+    };
+
+    std::vector<float> betas_vec;
+    for (int i = 0; i < num_diffusion_timesteps; ++i) {
+      float t1 = static_cast<float>(i) / num_diffusion_timesteps;
+      float t2 = static_cast<float>(i + 1) / num_diffusion_timesteps;
+      float beta =
+          std::min(1.0f - alpha_bar_fn(t2) / alpha_bar_fn(t1), max_beta);
+      betas_vec.push_back(beta);
+    }
+    return torch::tensor(betas_vec);
+  }
+
+  torch::Tensor rescale_zero_terminal_snr(const torch::Tensor& betas) {
+    torch::Tensor alphas = 1.0f - betas;
+    torch::Tensor alphas_cumprod = torch::cumprod(alphas, 0);
+    torch::Tensor alphas_bar_sqrt = torch::sqrt(alphas_cumprod);
+
+    torch::Tensor alphas_bar_sqrt_0 = alphas_bar_sqrt[0].clone();
+    torch::Tensor alphas_bar_sqrt_T = alphas_bar_sqrt[-1].clone();
+
+    alphas_bar_sqrt = alphas_bar_sqrt - alphas_bar_sqrt_T;
+    alphas_bar_sqrt = alphas_bar_sqrt * alphas_bar_sqrt_0 /
+                      (alphas_bar_sqrt_0 - alphas_bar_sqrt_T);
+
+    torch::Tensor alphas_bar = torch::pow(alphas_bar_sqrt, 2);
+    alphas = torch::cat({alphas_bar.slice(0, 0, 1),
+                         alphas_bar.slice(0, 1) / alphas_bar.slice(0, 0, -1)});
+    return 1.0f - alphas;
+  }
+
+  void init_betas() {
+    if (trained_betas_.has_value()) {
+      betas_ = torch::tensor(trained_betas_.value());
+    } else if (beta_schedule_ == "linear") {
+      betas_ = torch::linspace(beta_start_, beta_end_, num_train_timesteps_);
+    } else if (beta_schedule_ == "scaled_linear") {
+      float start = std::sqrt(beta_start_);
+      float end = std::sqrt(beta_end_);
+      betas_ = torch::pow(torch::linspace(start, end, num_train_timesteps_), 2);
+    } else if (beta_schedule_ == "squaredcos_cap_v2") {
+      betas_ = betas_for_alpha_bar(num_train_timesteps_);
+    } else {
+      throw std::invalid_argument("Unknown beta_schedule: " + beta_schedule_);
+    }
+
+    if (rescale_betas_zero_snr_) {
+      betas_ = rescale_zero_terminal_snr(betas_);
+    }
+
+    alphas_ = 1.0f - betas_;
+    alphas_cumprod_ = torch::cumprod(alphas_, 0);
+
+    if (rescale_betas_zero_snr_) {
+      alphas_cumprod_[-1] = std::pow(2.0f, -24);
+    }
+
+    alpha_t_ = torch::sqrt(alphas_cumprod_);
+    sigma_t_ = torch::sqrt(1.0 - alphas_cumprod_);
+    lambda_t_ = torch::log(alpha_t_) - torch::log(sigma_t_);
+    sigmas_ = torch::sqrt((1.0 - alphas_cumprod_) / alphas_cumprod_);
+  }
+
+  // private tool function
+  torch::Tensor convert_to_karras(const torch::Tensor& in_sigmas,
+                                  int num_inference_steps) {
+    float sigma_min = sigma_min_;
+    float sigma_max = sigma_max_;
+    if (in_sigmas.numel() > 0) {
+      sigma_min = in_sigmas[-1].item<float>();
+      sigma_max = in_sigmas[0].item<float>();
+    }
+
+    const float rho = 7.0f;
+    std::vector<float> ramp(num_inference_steps);
+    for (int i = 0; i < num_inference_steps; ++i) {
+      ramp[i] = static_cast<float>(i) / (num_inference_steps - 1);
+    }
+    torch::Tensor ramp_tensor =
+        torch::from_blob(ramp.data(), {num_inference_steps}, torch::kFloat32);
+
+    float min_inv_rho = std::pow(sigma_min, 1.0f / rho);
+    float max_inv_rho = std::pow(sigma_max, 1.0f / rho);
+    return torch::pow(max_inv_rho + ramp_tensor * (min_inv_rho - max_inv_rho),
+                      rho);
+  }
+
+  torch::Tensor convert_to_exponential(const torch::Tensor& in_sigmas,
+                                       int num_inference_steps) {
+    float sigma_min = sigma_min_;
+    float sigma_max = sigma_max_;
+    if (in_sigmas.numel() > 0) {
+      sigma_min = in_sigmas[-1].item<float>();
+      sigma_max = in_sigmas[0].item<float>();
+    }
+
+    std::vector<float> exp_sigmas(num_inference_steps);
+    float log_sigma_max = std::log(sigma_max);
+    float log_sigma_min = std::log(sigma_min);
+    for (int i = 0; i < num_inference_steps; ++i) {
+      float t = static_cast<float>(i) / (num_inference_steps - 1);
+      exp_sigmas[i] =
+          std::exp(log_sigma_max + t * (log_sigma_min - log_sigma_max));
+    }
+    return torch::from_blob(
+               exp_sigmas.data(), {num_inference_steps}, torch::kFloat32)
+        .clone();
+  }
+
+  torch::Tensor convert_to_beta(const torch::Tensor& in_sigmas,
+                                int num_inference_steps,
+                                float alpha = 0.6f,
+                                float beta = 0.6f) {
+    // NOTE: Actual usage requires the `beta distribution` implementation from
+    // scipy, this is just for illustration.
+    throw std::runtime_error(
+        "Beta sigmas implementation requires scipy integration");
+  }
+
+  int sigma_to_t(float sigma, const std::vector<float>& log_sigmas) {
+    float log_sigma = std::log(std::max(sigma, 1e-10f));
+
+    std::vector<float> dists;
+    for (float ls : log_sigmas) {
+      dists.push_back(std::abs(log_sigma - ls));
+    }
+
+    int low_idx = std::min_element(dists.begin(), dists.end()) - dists.begin();
+    low_idx = std::min(low_idx, static_cast<int>(log_sigmas.size()) - 2);
+    int high_idx = low_idx + 1;
+
+    float low = log_sigmas[low_idx];
+    float high = log_sigmas[high_idx];
+    float w = (low - log_sigma) / (low - high);
+    w = std::clamp(w, 0.0f, 1.0f);
+
+    return static_cast<int>((1.0f - w) * low_idx + w * high_idx);
+  }
+
+  std::tuple<torch::Tensor, torch::Tensor> sigma_to_alpha_sigma_t(
+      const torch::Tensor& sigma) {
+    if (use_flow_sigmas_) {
+      return {1.0f - sigma, sigma};
+    } else {
+      torch::Tensor alpha_t = 1.0f / torch::sqrt(sigma.pow(2) + 1.0f);
+      torch::Tensor sigma_t = sigma * alpha_t;
+      return {alpha_t, sigma_t};
+    }
+  }
+
+  int index_for_timestep(const torch::Tensor& timestep,
+                         const torch::Tensor& schedule_timesteps = {}) {
+    torch::Tensor sched =
+        schedule_timesteps.defined() ? schedule_timesteps : timesteps_;
+    torch::Tensor indices = (sched == timestep).nonzero();
+
+    if (indices.size(0) == 0) {
+      return timesteps_.size(0) - 1;
+    }
+
+    int pos = indices.size(0) > 1 ? 1 : 0;
+    return indices.index({pos, 0}).item<int>();
+  }
+
+  void init_step_index(const torch::Tensor& timestep) {
+    if (!begin_index_.has_value()) {
+      torch::Tensor ts = timestep.to(timesteps_.device());
+      step_index_ = index_for_timestep(ts);
+    } else {
+      step_index_ = begin_index_.value();
+    }
+  }
+
+  torch::Tensor threshold_sample(const torch::Tensor& sample) {
+    auto dtype = sample.dtype();
+    int64_t batch_size = sample.size(0);
+    int64_t channels = sample.size(1);
+
+    std::vector<int64_t> remaining_dims(sample.sizes().begin() + 2,
+                                        sample.sizes().end());
+    int64_t prod = 1;
+    for (auto d : remaining_dims) prod *= d;
+
+    torch::Tensor sample_float = sample.to(torch::kFloat32);
+    torch::Tensor sample_flat =
+        sample_float.reshape({batch_size, channels * prod});
+    torch::Tensor abs_sample = sample_flat.abs();
+
+    torch::Tensor s =
+        std::get<0>(abs_sample.quantile(dynamic_thresholding_ratio_, 1));
+    s = torch::clamp(s, 1, sample_max_value_);
+    s = s.unsqueeze(1);
+
+    sample_flat = torch::clamp(sample_flat, -s, s) / s;
+
+    std::vector<int64_t> new_shape = {batch_size, channels};
+    new_shape.insert(
+        new_shape.end(), remaining_dims.begin(), remaining_dims.end());
+
+    return sample_flat.reshape(new_shape).to(dtype);
+  }
+
+  torch::Tensor convert_model_output(const torch::Tensor& model_output,
+                                     const torch::Tensor& sample) {
+    torch::Tensor sigma = sigmas_[step_index_.value()];
+    auto [alpha_t, sigma_t] = sigma_to_alpha_sigma_t(sigma);
+
+    torch::Tensor x0_pred;
+    if (predict_x0_) {
+      if (prediction_type_ == "epsilon") {
+        x0_pred = (sample - sigma_t * model_output) / alpha_t;
+      } else if (prediction_type_ == "sample") {
+        x0_pred = model_output;
+      } else if (prediction_type_ == "v_prediction") {
+        x0_pred = alpha_t * sample - sigma_t * model_output;
+      } else if (prediction_type_ == "flow_prediction") {
+        sigma_t = sigmas_[step_index_.value()];
+        x0_pred = sample - sigma_t * model_output;
+      } else {
+        throw std::invalid_argument("Unknown prediction_type: " +
+                                    prediction_type_);
+      }
+
+      if (thresholding_) {
+        x0_pred = threshold_sample(x0_pred);
+      }
+      return x0_pred;
+    } else {
+      if (prediction_type_ == "epsilon") {
+        return model_output;
+      } else if (prediction_type_ == "sample") {
+        return (sample - alpha_t * model_output) / sigma_t;
+      } else if (prediction_type_ == "v_prediction") {
+        return alpha_t * model_output + sigma_t * sample;
+      } else {
+        throw std::invalid_argument("Unknown prediction_type: " +
+                                    prediction_type_);
+      }
+    }
+  }
+
+  torch::Tensor multistep_uni_p_bh_update(const torch::Tensor& model_output,
+                                          const torch::Tensor& sample,
+                                          int order) {
+    torch::Tensor sigma_t = sigmas_[step_index_.value() + 1];
+    torch::Tensor sigma_s0 = sigmas_[step_index_.value()];
+
+    auto [alpha_t, sigma_t_val] = sigma_to_alpha_sigma_t(sigma_t);
+    auto [alpha_s0, sigma_s0_val] = sigma_to_alpha_sigma_t(sigma_s0);
+
+    torch::Tensor lambda_t = torch::log(alpha_t) - torch::log(sigma_t_val);
+    torch::Tensor lambda_s0 = torch::log(alpha_s0) - torch::log(sigma_s0_val);
+    torch::Tensor h = lambda_t - lambda_s0;
+
+    torch::Tensor m0 = model_outputs_[model_outputs_.size() - 1];
+    torch::Tensor x = sample;
+
+    torch::Device device = sample.device();
+    std::vector<float> rks_vec;
+    std::vector<torch::Tensor> D1s;
+
+    for (int i = 1; i < order; ++i) {
+      int si = step_index_.value() - i;
+      torch::Tensor mi = model_outputs_[model_outputs_.size() - (i + 1)];
+      torch::Tensor sigma_si = sigmas_[si];
+      auto [alpha_si, sigma_si_val] = sigma_to_alpha_sigma_t(sigma_si);
+      torch::Tensor lambda_si = torch::log(alpha_si) - torch::log(sigma_si_val);
+      float rk = ((lambda_si - lambda_s0) / h).item<float>();
+      rks_vec.push_back(rk);
+      D1s.push_back((mi - m0) / rk);
+    }
+
+    rks_vec.push_back(1.0f);
+    torch::Tensor rks =
+        torch::tensor(rks_vec, torch::TensorOptions().device(device));
+
+    torch::Tensor hh = predict_x0_ ? -h : h;
+    torch::Tensor h_phi_1 = torch::expm1(hh);
+    torch::Tensor h_phi_k = h_phi_1 / hh - 1.0f;
+
+    torch::Tensor B_h = solver_type_ == "bh1" ? hh : torch::expm1(hh);
+
+    std::vector<torch::Tensor> R_list;
+    std::vector<float> b_vec;
+    int factorial_i = 1;
+
+    for (int i = 1; i <= order; ++i) {
+      R_list.push_back(torch::pow(rks, i - 1));
+      b_vec.push_back((h_phi_k / B_h).item<float>() * factorial_i);
+      factorial_i *= (i + 1);
+      h_phi_k = h_phi_k / hh - 1.0f / factorial_i;
+    }
+
+    torch::Tensor R = torch::stack(R_list);
+    torch::Tensor b =
+        torch::tensor(b_vec, torch::TensorOptions().device(device));
+
+    torch::Tensor rhos_p;
+    if (!D1s.empty()) {
+      torch::Tensor D1s_stacked = torch::stack(D1s, 1);
+      if (order == 2) {
+        rhos_p = torch::tensor(
+            {0.5f},
+            torch::TensorOptions().dtype(sample.dtype()).device(device));
+      } else {
+        rhos_p = torch::linalg_solve(R.slice(0, 0, -1).slice(1, 0, -1),
+                                     b.slice(0, 0, -1))
+                     .to(device)
+                     .to(sample.dtype());
+      }
+    }
+
+    torch::Tensor x_t_;
+    if (predict_x0_) {
+      x_t_ = sigma_t_val / sigma_s0_val * x - alpha_t * h_phi_1 * m0;
+    } else {
+      x_t_ = alpha_t / alpha_s0 * x - sigma_t_val * h_phi_1 * m0;
+    }
+
+    torch::Tensor x_t = x_t_;
+    if (!D1s.empty()) {
+      torch::Tensor D1s_stacked = torch::stack(D1s, 1);
+      torch::Tensor pred_res =
+          torch::einsum("k,bkc...->bc...", {rhos_p, D1s_stacked});
+      if (predict_x0_) {
+        x_t = x_t_ - alpha_t * B_h * pred_res;
+      } else {
+        x_t = x_t_ - sigma_t_val * B_h * pred_res;
+      }
+    }
+
+    return x_t.to(sample.dtype());
+  }
+
+  torch::Tensor multistep_uni_c_bh_update(
+      const torch::Tensor& this_model_output,
+      const torch::Tensor& last_sample,
+      const torch::Tensor& this_sample,
+      int order) {
+    torch::Tensor sigma_t = sigmas_[step_index_.value()];
+    torch::Tensor sigma_s0 = sigmas_[step_index_.value() - 1];
+
+    auto [alpha_t, sigma_t_val] = sigma_to_alpha_sigma_t(sigma_t);
+    auto [alpha_s0, sigma_s0_val] = sigma_to_alpha_sigma_t(sigma_s0);
+
+    torch::Tensor lambda_t = torch::log(alpha_t) - torch::log(sigma_t_val);
+    torch::Tensor lambda_s0 = torch::log(alpha_s0) - torch::log(sigma_s0_val);
+    torch::Tensor h = lambda_t - lambda_s0;
+
+    torch::Tensor m0 = model_outputs_[model_outputs_.size() - 1];
+    torch::Tensor x = last_sample;
+    torch::Tensor model_t = this_model_output;
+
+    torch::Device device = this_sample.device();
+    std::vector<float> rks_vec;
+    std::vector<torch::Tensor> D1s;
+
+    for (int i = 1; i < order; ++i) {
+      int si = step_index_.value() - (i + 1);
+      torch::Tensor mi = model_outputs_[model_outputs_.size() - (i + 1)];
+      torch::Tensor sigma_si = sigmas_[si];
+      auto [alpha_si, sigma_si_val] = sigma_to_alpha_sigma_t(sigma_si);
+      torch::Tensor lambda_si = torch::log(alpha_si) - torch::log(sigma_si_val);
+      float rk = ((lambda_si - lambda_s0) / h).item<float>();
+      rks_vec.push_back(rk);
+      D1s.push_back((mi - m0) / rk);
+    }
+
+    rks_vec.push_back(1.0f);
+    torch::Tensor rks =
+        torch::tensor(rks_vec, torch::TensorOptions().device(device));
+
+    torch::Tensor hh = predict_x0_ ? -h : h;
+    torch::Tensor h_phi_1 = torch::expm1(hh);
+    torch::Tensor h_phi_k = h_phi_1 / hh - 1.0f;
+
+    torch::Tensor B_h = solver_type_ == "bh1" ? hh : torch::expm1(hh);
+
+    std::vector<torch::Tensor> R_list;
+    std::vector<float> b_vec;
+    int factorial_i = 1;
+
+    for (int i = 1; i <= order; ++i) {
+      R_list.push_back(torch::pow(rks, i - 1));
+      b_vec.push_back((h_phi_k / B_h).item<float>() * factorial_i);
+      factorial_i *= (i + 1);
+      h_phi_k = h_phi_k / hh - 1.0f / factorial_i;
+    }
+
+    torch::Tensor R = torch::stack(R_list);
+    torch::Tensor b =
+        torch::tensor(b_vec, torch::TensorOptions().device(device));
+
+    torch::Tensor rhos_c;
+    if (order == 1) {
+      rhos_c = torch::tensor(
+          {0.5f}, torch::TensorOptions().dtype(x.dtype()).device(device));
+    } else {
+      rhos_c = torch::linalg_solve(R, b).to(device).to(x.dtype());
+    }
+
+    torch::Tensor x_t_;
+    if (predict_x0_) {
+      x_t_ = sigma_t_val / sigma_s0_val * x - alpha_t * h_phi_1 * m0;
+    } else {
+      x_t_ = alpha_t / alpha_s0 * x - sigma_t_val * h_phi_1 * m0;
+    }
+
+    torch::Tensor corr_res = torch::zeros_like(x_t_);
+    if (!D1s.empty()) {
+      torch::Tensor D1s_stacked = torch::stack(D1s, 1);
+      corr_res = torch::einsum("k,bkc...->bc...",
+                               {rhos_c.slice(0, 0, -1), D1s_stacked});
+    }
+
+    torch::Tensor D1_t = model_t - m0;
+    torch::Tensor x_t;
+    if (predict_x0_) {
+      x_t = x_t_ - alpha_t * B_h * (corr_res + rhos_c[-1] * D1_t);
+    } else {
+      x_t = x_t_ - sigma_t_val * B_h * (corr_res + rhos_c[-1] * D1_t);
+    }
+
+    return x_t.to(x.dtype());
+  }
+
+ public:
+  int64_t order = 1;
+  ModelArgs args;
+
+  UniPCMultistepSchedulerImpl(const ModelContext& context)
+      : args(context.get_model_args()) {
+    num_train_timesteps_ = args.scheduler_num_train_timesteps();
+    beta_start_ = args.scheduler_beta_start();
+    beta_end_ = args.scheduler_beta_end();
+    beta_schedule_ = args.scheduler_beta_schedule();
+
+    solver_order_ = args.scheduler_solver_order();
+    prediction_type_ = args.scheduler_prediction_type();
+    thresholding_ = args.scheduler_thresholding();
+    dynamic_thresholding_ratio_ = args.scheduler_dynamic_thresholding_ratio();
+    sample_max_value_ = args.scheduler_sample_max_value();
+    predict_x0_ = args.scheduler_predict_x0();
+    solver_type_ = args.scheduler_solver_type();
+    lower_order_final_ = args.scheduler_lower_order_final();
+
+    timestep_spacing_ = args.scheduler_timestep_spacing();
+    steps_offset_ = args.scheduler_steps_offset();
+    rescale_betas_zero_snr_ = args.scheduler_rescale_betas_zero_snr();
+    final_sigmas_type_ = args.scheduler_final_sigmas_type();
+
+    use_karras_sigmas_ = args.scheduler_use_karras_sigmas();
+    use_exponential_sigmas_ = args.scheduler_use_exponential_sigmas();
+    use_beta_sigmas_ = args.scheduler_use_beta_sigmas();
+    use_flow_sigmas_ = args.scheduler_use_flow_sigmas();
+    flow_shift_ = args.scheduler_flow_shift();
+    use_dynamic_shifting_ = args.scheduler_use_dynamic_shifting();
+    time_shift_type_ = args.scheduler_time_shift_type();
+    disable_corrector_ = args.scheduler_disable_corrector();
+
+    init_betas();
+
+    std::vector<float> timesteps_vec(num_train_timesteps_);
+    for (int i = 0; i < num_train_timesteps_; ++i) {
+      timesteps_vec[i] = num_train_timesteps_ - 1 - i;
+    }
+    timesteps_ = torch::tensor(timesteps_vec);
+
+    model_outputs_.resize(solver_order_, torch::Tensor());
+    timestep_list_.resize(solver_order_, torch::Tensor());
+    lower_order_nums_ = 0;
+    last_frame_ = std::nullopt;
+    step_index_ = std::nullopt;
+    begin_index_ = std::nullopt;
+    num_inference_steps_ = 0;
+  }
+
+  void set_begin_index(int begin_index) { begin_index_ = begin_index; }
+
+  void set_timesteps(int num_inference_steps,
+                     const torch::Device& device = torch::kCPU,
+                     const std::optional<float>& mu = std::nullopt) {
+    if (mu.has_value() && use_dynamic_shifting_ &&
+        time_shift_type_ == "exponential") {
+      flow_shift_ = std::exp(mu.value());
+    }
+
+    std::vector<int64_t> timesteps_vec;
+    if (timestep_spacing_ == "linspace") {
+      torch::Tensor ts =
+          torch::linspace(0, num_train_timesteps_ - 1, num_inference_steps + 1);
+      ts = ts.round().flip(0).slice(0, 0, -1);
+      timesteps_vec = std::vector<int64_t>(ts.data_ptr<float>(),
+                                           ts.data_ptr<float>() + ts.numel());
+    } else if (timestep_spacing_ == "leading") {
+      int step_ratio = num_train_timesteps_ / (num_inference_steps + 1);
+      torch::Tensor ts = torch::arange(0, num_inference_steps + 1) * step_ratio;
+      ts = (ts.round().flip(0).slice(0, 0, -1) + steps_offset_);
+      timesteps_vec = std::vector<int64_t>(ts.data_ptr<float>(),
+                                           ts.data_ptr<float>() + ts.numel());
+    } else if (timestep_spacing_ == "trailing") {
+      float step_ratio =
+          static_cast<float>(num_train_timesteps_) / num_inference_steps;
+      torch::Tensor ts =
+          torch::arange(num_train_timesteps_, 0, -step_ratio).round() - 1;
+      timesteps_vec = std::vector<int64_t>(ts.data_ptr<float>(),
+                                           ts.data_ptr<float>() + ts.numel());
+    }
+
+    torch::Tensor sigmas =
+        torch::sqrt((1.0f - alphas_cumprod_) / alphas_cumprod_);
+
+    if (use_flow_sigmas_) {
+      torch::Tensor alphas = torch::linspace(
+          1, 1.0f / num_train_timesteps_, num_inference_steps + 1);
+      sigmas = 1.0f - alphas;
+      sigmas = sigmas.flip(0).slice(0, 0, -1);
+      sigmas = flow_shift_ * sigmas / (1.0f + (flow_shift_ - 1.0f) * sigmas);
+
+      std::vector<float> timesteps_float_vec(sigmas.numel());
+      auto sigmas_acc = sigmas.accessor<float, 1>();
+      for (int i = 0; i < sigmas.numel(); ++i) {
+        timesteps_float_vec[i] = sigmas_acc[i] * num_train_timesteps_;
+      }
+      timesteps_ = torch::tensor(timesteps_float_vec, torch::kInt64);
+
+      float sigma_last;
+      if (final_sigmas_type_ == "sigma_min") {
+        sigma_last = sigmas[-1].item<float>();
+      } else if (final_sigmas_type_ == "zero") {
+        sigma_last = 0.0f;
+      } else {
+        throw std::invalid_argument(
+            "final_sigmas_type must be one of 'zero' or 'sigma_min'");
+      }
+      sigmas = torch::cat({sigmas, torch::tensor({sigma_last})});
+    } else if (use_karras_sigmas_ || use_exponential_sigmas_ ||
+               use_beta_sigmas_) {
+      std::vector<float> log_sigmas_vec;
+      auto sigmas_acc = sigmas.accessor<float, 1>();
+      for (int i = 0; i < sigmas.numel(); ++i) {
+        log_sigmas_vec.push_back(std::log(sigmas_acc[i]));
+      }
+
+      sigmas = sigmas.flip(0);
+      if (use_karras_sigmas_) {
+        sigmas = convert_to_karras(sigmas, num_inference_steps);
+      } else if (use_beta_sigmas_) {
+        sigmas = convert_to_beta(sigmas, num_inference_steps);
+      } else {
+        sigmas = convert_to_exponential(sigmas, num_inference_steps);
+      }
+
+      std::vector<int64_t> new_timesteps;
+      auto sigmas_acc2 = sigmas.accessor<float, 1>();
+      for (int i = 0; i < sigmas.numel(); ++i) {
+        new_timesteps.push_back(sigma_to_t(sigmas_acc2[i], log_sigmas_vec));
+      }
+      timesteps_vec = new_timesteps;
+
+      float sigma_last;
+      if (final_sigmas_type_ == "sigma_min") {
+        sigma_last = sigmas[-1].item<float>();
+      } else if (final_sigmas_type_ == "zero") {
+        sigma_last = 0.0f;
+      } else {
+        throw std::invalid_argument(
+            "final_sigmas_type must be one of 'zero' or 'sigma_min'");
+      }
+      sigmas = torch::cat({sigmas, torch::tensor({sigma_last})});
+      timesteps_ = torch::tensor(timesteps_vec, torch::kInt64);
+    } else {
+      torch::Tensor timesteps_tensor =
+          torch::tensor(timesteps_vec, torch::kFloat32);
+      torch::Tensor arange_tensor =
+          torch::arange(0, sigmas.numel(), torch::kFloat32);
+      sigmas = torch::from_blob(
+          torch::numpy_t<float>(sigmas.data_ptr<float>(), {sigmas.numel()}),
+          {sigmas.numel()},
+          torch::kFloat32);
+      sigmas = torch::nn::functional::interpolate(
+                   sigmas.unsqueeze(0).unsqueeze(0),
+                   torch::nn::functional::InterpolateFuncOptions()
+                       .size(std::vector<int64_t>{
+                           static_cast<int64_t>(timesteps_vec.size())})
+                       .mode(torch::kLinear)
+                       .align_corners(false))
+                   .squeeze();
+
+      float sigma_last;
+      if (final_sigmas_type_ == "sigma_min") {
+        sigma_last =
+            torch::sqrt((1.0f - alphas_cumprod_[0]) / alphas_cumprod_[0])
+                .item<float>();
+      } else if (final_sigmas_type_ == "zero") {
+        sigma_last = 0.0f;
+      } else {
+        throw std::invalid_argument(
+            "final_sigmas_type must be one of 'zero' or 'sigma_min'");
+      }
+      sigmas = torch::cat({sigmas, torch::tensor({sigma_last})});
+      timesteps_ = torch::tensor(timesteps_vec, torch::kInt64);
+    }
+
+    sigmas_ = sigmas.to(torch::kCPU);
+    timesteps_ = timesteps_.to(device).to(torch::kInt64);
+
+    num_inference_steps_ = timesteps_vec.size();
+    model_outputs_ = std::vector<torch::Tensor>(solver_order_, torch::Tensor());
+    timestep_list_ = std::vector<torch::Tensor>(solver_order_, torch::Tensor());
+    lower_order_nums_ = 0;
+    last_sample_ = torch::Tensor();
+    step_index_ = std::nullopt;
+    begin_index_ = std::nullopt;
+  }
+
+  torch::Tensor scale_model_input(const torch::Tensor& sample) {
+    return sample;
+  }
+
+  UniPCMultistepSchedulerOutput step(const torch::Tensor& model_output,
+                                     const torch::Tensor& timestep,
+                                     const torch::Tensor& sample,
+                                     bool return_dict = true) {
+    if (!num_inference_steps_) {
+      throw std::runtime_error(
+          "Number of inference steps is None, run set_timesteps first");
+    }
+
+    if (!step_index_.has_value()) {
+      init_step_index(timestep);
+    }
+
+    bool use_corrector =
+        (step_index_.value() > 0 &&
+         std::find(disable_corrector_.begin(),
+                   disable_corrector_.end(),
+                   step_index_.value() - 1) == disable_corrector_.end() &&
+         last_sample_.defined());
+
+    torch::Tensor model_output_convert =
+        convert_model_output(model_output, sample);
+
+    torch::Tensor current_sample = sample;
+    if (use_corrector) {
+      current_sample = multistep_uni_c_bh_update(
+          model_output_convert, last_sample_, sample, this_order_);
+    }
+
+    for (int i = 0; i < solver_order_ - 1; ++i) {
+      model_outputs_[i] = model_outputs_[i + 1];
+      timestep_list_[i] = timestep_list_[i + 1];
+    }
+
+    model_outputs_[solver_order_ - 1] = model_output_convert;
+    timestep_list_[solver_order_ - 1] = timestep;
+
+    int order;
+    if (lower_order_final_) {
+      order =
+          std::min(solver_order_,
+                   static_cast<int>(timesteps_.size(0)) - step_index_.value());
+    } else {
+      order = solver_order_;
+    }
+
+    this_order_ = std::min(order, lower_order_nums_ + 1);
+
+    last_sample_ = current_sample;
+    torch::Tensor prev_sample =
+        multistep_uni_p_bh_update(model_output, current_sample, this_order_);
+
+    if (lower_order_nums_ < solver_order_) {
+      lower_order_nums_ += 1;
+    }
+
+    step_index_ = step_index_.value() + 1;
+
+    return UniPCMultistepSchedulerOutput(prev_sample);
+  }
+
+  torch::Tensor add_noise(const torch::Tensor& original_samples,
+                          const torch::Tensor& noise,
+                          const torch::Tensor& timesteps) {
+    torch::Tensor sigmas =
+        sigmas_.to(original_samples.device()).to(original_samples.dtype());
+    torch::Tensor schedule_timesteps = timesteps_.to(original_samples.device());
+    torch::Tensor ts = timesteps.to(original_samples.device());
+
+    std::vector<int> step_indices;
+    if (!begin_index_.has_value()) {
+      for (int i = 0; i < ts.size(0); ++i) {
+        step_indices.push_back(index_for_timestep(ts[i], schedule_timesteps));
+      }
+    } else if (step_index_.has_value()) {
+      step_indices = std::vector<int>(ts.size(0), step_index_.value());
+    } else {
+      step_indices = std::vector<int>(ts.size(0), begin_index_.value());
+    }
+
+    torch::Tensor sigma_indices = torch::tensor(
+        step_indices,
+        torch::TensorOptions().dtype(torch::kLong).device(sigmas.device()));
+    torch::Tensor sigma = sigmas.index_select(0, sigma_indices).flatten();
+
+    while (sigma.dim() < original_samples.dim()) {
+      sigma = sigma.unsqueeze(-1);
+    }
+
+    auto [alpha_t, sigma_t] = sigma_to_alpha_sigma_t(sigma);
+    torch::Tensor noisy_samples = alpha_t * original_samples + sigma_t * noise;
+    return noisy_samples;
+  }
+
+  std::optional<int> step_index() const { return step_index_; }
+  std::optional<int> begin_index() const { return begin_index_; }
+  const torch::Tensor& timesteps() const { return timesteps_; }
+  const torch::Tensor& sigmas() const { return sigmas_; }
+  int size() const { return num_train_timesteps_; }
+
+  torch::Tensor forward(const torch::Tensor& tokens,
+                        const torch::Tensor& positions,
+                        std::vector<KVCache>& kv_caches,
+                        const ModelInputParams& input_params) {
+    // 1. Test params (can be passed in via input_params, or hard-coded for
+    // debugging purposes.)
+    const int num_inference_steps = 50;
+    const float mu = 0.5f;              // Dynamic offset parameter
+    const bool use_stochastic = false;  // Test the deterministic mode first.
+
+    // 2. config the scheduler
+    this->set_timesteps(
+        num_inference_steps, tokens.device(), /*sigmas=*/std::nullopt, mu);
+    this->set_begin_index(0);
+
+    // 3. Generate test inputs (with fixed random seed to ensure
+    // reproducibility)
+    torch::manual_seed(42);  // Fixed random seed for reproducibility
+    torch::Tensor sample = torch::randn(
+        {1, 3, 32, 32}, torch::dtype(torch::kFloat32));  // Mock sample
+    torch::Tensor model_output =
+        torch::randn_like(sample);                  // Mock model output
+    torch::Tensor timestep = this->timesteps()[0];  // Initial timestep
+    model_output =
+        model_output.to(timestep.device())
+            .to(torch::kFloat32);  // Ensure same device and dtype as sample
+    sample =
+        sample.to(timestep.device())
+            .to(torch::kFloat32);  // Ensure same device and dtype as timestep
+    // 4. Execute one step of the scheduler calculation
+    auto output = this->step(model_output,
+                             timestep,
+                             sample,
+                             0.0f,
+                             0.0f,
+                             std::numeric_limits<float>::infinity(),
+                             1.0f,
+                             /*generator=*/std::nullopt,
+                             /*per_token_timesteps=*/std::nullopt);
+
+    return output.prev_sample;
+  }
+};
+
+TORCH_MODULE(UniPCMultistepScheduler);
+REGISTER_MODEL_ARGS(UniPCMultistepScheduler, [&] {
+  LOAD_ARG_OR(scheduler_num_train_timesteps, "num_train_timesteps", 1000);
+  LOAD_ARG_OR(scheduler_beta_start, "beta_start", 0.0001f);
+  LOAD_ARG_OR(scheduler_beta_end, "beta_end", 0.02f);
+  LOAD_ARG_OR(scheduler_beta_schedule, "beta_schedule", "linear");
+
+  LOAD_ARG_OR(scheduler_solver_order, "solver_order", 2);
+  LOAD_ARG_OR(scheduler_prediction_type, "prediction_type", "flow_prediction");
+  LOAD_ARG_OR(scheduler_thresholding, "thresholding", false);
+  LOAD_ARG_OR(scheduler_dynamic_thresholding_ratio,
+              "dynamic_thresholding_ratio",
+              0.995f);
+  LOAD_ARG_OR(scheduler_sample_max_value, "sample_max_value", 1.0f);
+  LOAD_ARG_OR(scheduler_predict_x0, "predict_x0", true);
+  LOAD_ARG_OR(scheduler_solver_type, "solver_type", "bh2");
+  LOAD_ARG_OR(scheduler_lower_order_final, "lower_order_final", true);
+
+  LOAD_ARG_OR(scheduler_timestep_spacing, "timestep_spacing", "linspace");
+  LOAD_ARG_OR(scheduler_steps_offset, "steps_offset", 0);
+  LOAD_ARG_OR(
+      scheduler_rescale_betas_zero_snr, "rescale_betas_zero_snr", false);
+  LOAD_ARG_OR(scheduler_final_sigmas_type, "final_sigmas_type", "zero");
+
+  LOAD_ARG_OR(scheduler_use_karras_sigmas, "use_karras_sigmas", false);
+  LOAD_ARG_OR(
+      scheduler_use_exponential_sigmas, "use_exponential_sigmas", false);
+  LOAD_ARG_OR(scheduler_use_beta_sigmas, "use_beta_sigmas", false);
+  LOAD_ARG_OR(scheduler_use_flow_sigmas, "use_flow_sigmas", true);
+  LOAD_ARG_OR(scheduler_flow_shift, "flow_shift", 3.0f);
+  LOAD_ARG_OR(scheduler_use_dynamic_shifting, "use_dynamic_shifting", false);
+  LOAD_ARG_OR(scheduler_time_shift_type, "time_shift_type", "exponential");
+  LOAD_ARG_OR(
+      scheduler_disable_corrector, "disable_corrector", std::vector<int>{});
+});
+}  // namespace xllm


### PR DESCRIPTION
The umt5_encoder.h and clip_vision_model.h modules have been registered as VLM models and tested, but issues were encountered during testing:
umt5_encoder.h error: engine.h:47 kv_cache_manager_ is not BlockManagerPool type!
clip_vision_model.h error: utils.cpp:32 Check failed: weight.sizes() == tensor.sizes() ([0, 1280] vs. [1280, 1280]) weight size mismatch for vision_model.encoder.layers.0.self_attn.q_proj.weight
The other three modules (autoencoder_kl_wan.h, dit_wan.h, and unipc_multistep_scheduler.h) have not been tested yet. Additionally, the overall pipeline for the WAN model has not been implemented.