### PR TITLE
bugfix: fix incorrect parsing of float32 dtype in parse_dtype.

### DIFF
--- a/xllm/core/util/utils.cpp
+++ b/xllm/core/util/utils.cpp
@@ -80,7 +80,7 @@ torch::ScalarType parse_dtype(const std::string& dtype_str,
   }
   if ((boost::iequals(dtype_str, "float") ||
        boost::iequals(dtype_str, "float32"))) {
-    return torch::kFloat16;
+    return torch::kFloat;
   }
 
   if (dtype_str.empty() || boost::iequals(dtype_str, "auto")) {


### PR DESCRIPTION
bugfix: fix incorrect parsing of float32 dtype in parse_dtype.