### PR TITLE
feat: add onerec worker impl  for rec framework[5/8].

### DIFF
--- a/xllm/core/common/CMakeLists.txt
+++ b/xllm/core/common/CMakeLists.txt
@@ -15,6 +15,7 @@ cc_library(
     $<$<BOOL:${USE_NPU}>:mspti_helper.h>
     options.h
     rate_limiter.h
+    rec_model_utils.h
     types.h
     device_monitor.h
     version_singleton.h
@@ -66,5 +67,4 @@ cc_test(
 )
 target_link_libraries(common PRIVATE OpenSSL::SSL OpenSSL::Crypto protobuf::libprotobuf)
 add_dependencies(common brpc-static)
-
 

--- a/xllm/core/common/rec_model_utils.h
+++ b/xllm/core/common/rec_model_utils.h
@@ -1,0 +1,47 @@
+/* Copyright 2025 The xLLM Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://github.com/jd-opensource/xllm/blob/main/LICENSE
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#pragma once
+
+#include <cstdint>
+#include <string_view>
+
+namespace xllm {
+
+enum class RecModelKind : int8_t {
+  kNone = 0,
+  kOneRec = 1,
+  kLlmRec = 2,
+};
+
+inline constexpr bool is_onerec_model_type(std::string_view model_type) {
+  return model_type == "onerec";
+}
+
+inline constexpr bool is_llmrec_model_type(std::string_view model_type) {
+  return model_type == "qwen2" || model_type == "qwen3";
+}
+
+inline constexpr RecModelKind get_rec_model_kind(std::string_view model_type) {
+  if (is_onerec_model_type(model_type)) {
+    return RecModelKind::kOneRec;
+  }
+  if (is_llmrec_model_type(model_type)) {
+    return RecModelKind::kLlmRec;
+  }
+  return RecModelKind::kNone;
+}
+
+}  // namespace xllm

--- a/xllm/core/distributed_runtime/rec_master.cpp
+++ b/xllm/core/distributed_runtime/rec_master.cpp
@@ -25,6 +25,7 @@ limitations under the License.
 
 #include "common/macros.h"
 #include "common/metrics.h"
+#include "common/rec_model_utils.h"
 #include "common/types.h"
 #include "framework/request/mm_data.h"
 #include "models/model_registry.h"
@@ -42,12 +43,14 @@ namespace {
 constexpr int32_t kDefaultPlaceholderToken = 20152019;
 
 RecType get_rec_type(const ModelArgs& model_args) {
-  const auto& model_type = model_args.model_type();
-  if (model_type == "onerec") {
-    return RecType::kOneRec;
-  }
-  if (model_type == "qwen2" || model_type == "qwen3") {
-    return RecType::kLlmRec;
+  const auto kind = get_rec_model_kind(model_args.model_type());
+  switch (kind) {
+    case RecModelKind::kOneRec:
+      return RecType::kOneRec;
+    case RecModelKind::kLlmRec:
+      return RecType::kLlmRec;
+    case RecModelKind::kNone:
+      return RecType::kNone;
   }
   return RecType::kNone;
 }

--- a/xllm/core/runtime/CMakeLists.txt
+++ b/xllm/core/runtime/CMakeLists.txt
@@ -22,6 +22,7 @@ cc_library(
     dit_worker.h
     embed_worker_impl.h
     embed_vlm_worker_impl.h
+    rec_worker_impl.h
     worker_client.h
     xservice_client.h
     speculative_worker_impl.h
@@ -38,6 +39,7 @@ cc_library(
     dit_worker.cpp
     embed_worker_impl.cpp
     embed_vlm_worker_impl.cpp
+    rec_worker_impl.cpp
     worker_client.cpp
     xservice_client.cpp
     params_utils.cpp

--- a/xllm/core/runtime/rec_worker_impl.cpp
+++ b/xllm/core/runtime/rec_worker_impl.cpp
@@ -1,0 +1,316 @@
+/* Copyright 2025 The xLLM Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://github.com/jd-opensource/xllm/blob/main/LICENSE
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include "rec_worker_impl.h"
+
+#include <glog/logging.h>
+
+#include <algorithm>
+#include <memory>
+#include <vector>
+
+#include "common/device_monitor.h"
+#include "common/metrics.h"
+#include "common/types.h"
+#include "framework/model/model_input_params.h"
+#include "util/env_var.h"
+#include "util/timer.h"
+
+namespace xllm {
+
+RecWorkerImpl::LlmRecWorkPipeline::LlmRecWorkPipeline(RecWorkerImpl& worker)
+    : worker_(worker) {}
+
+ForwardInput RecWorkerImpl::LlmRecWorkPipeline::prepare_inputs(Batch& batch) {
+  return worker_.WorkerImpl::prepare_inputs(batch);
+}
+
+void RecWorkerImpl::LlmRecWorkPipeline::prepare_work_before_execute(
+    const ForwardInput& inputs,
+    ForwardInput& processed_inputs) {
+  worker_.WorkerImpl::prepare_work_before_execute(inputs, processed_inputs);
+
+  if (!inputs.input_params.mm_data.valid()) {
+    return;
+  }
+
+  torch::Tensor input_embedding;
+  torch::Tensor input_tokens_tensor;
+  torch::Tensor input_indices_tensor;
+
+  const auto& mm_data = inputs.input_params.mm_data;
+  const auto& processed_mm_data = processed_inputs.input_params.mm_data;
+
+  if (auto res = processed_mm_data.get<torch::Tensor>(LLM_REC_INPUT_TOKENS)) {
+    input_tokens_tensor = res.value();
+  }
+
+  // Input indices are generated on host side.
+  if (auto res = mm_data.get<torch::Tensor>(LLM_REC_INPUT_INDICES)) {
+    input_indices_tensor = res.value();
+  }
+
+  if (auto res =
+          processed_mm_data.get<torch::Tensor>(LLM_REC_INPUT_EMBEDDING)) {
+    input_embedding = res.value();
+  }
+
+  if (input_embedding.defined()) {
+    input_embedding = input_embedding.to(worker_.dtype());
+  }
+
+  if (input_indices_tensor.defined()) {
+    CHECK(input_tokens_tensor.defined())
+        << "LLM_REC_INPUT_TOKENS is required when LLM_REC_INPUT_INDICES is "
+           "set.";
+
+    layer::WordEmbedding word_embedding = worker_.get_word_embedding();
+    torch::Tensor input_tokens_embedding =
+        word_embedding(input_tokens_tensor, 0);
+
+    if (input_embedding.defined()) {
+      torch::Tensor input_indices_cpu =
+          input_indices_tensor.to(torch::kCPU).to(torch::kInt64).contiguous();
+      const auto* input_indices_ptr = input_indices_cpu.data_ptr<int64_t>();
+      std::vector<int64_t> input_indices(
+          input_indices_ptr, input_indices_ptr + input_indices_cpu.numel());
+
+      processed_inputs.input_params.input_embedding =
+          worker_.merge_embeddings_by_indices(
+              input_tokens_embedding, input_embedding, input_indices);
+    } else {
+      processed_inputs.input_params.input_embedding = input_tokens_embedding;
+    }
+  } else if (input_embedding.defined()) {
+    processed_inputs.input_params.input_embedding = input_embedding;
+  }
+}
+
+std::optional<ForwardOutput> RecWorkerImpl::LlmRecWorkPipeline::step(
+    const ForwardInput& input) {
+  return worker_.LLMWorkerImpl::step(input);
+}
+
+RecWorkerImpl::OneRecWorkPipeline::OneRecWorkPipeline(RecWorkerImpl& worker)
+    : worker_(worker) {}
+
+ForwardInput RecWorkerImpl::OneRecWorkPipeline::prepare_inputs(Batch& batch) {
+  ThreadPool* thread_pool = worker_.input_builder_thread_pool_
+                                ? worker_.input_builder_thread_pool_.get()
+                                : nullptr;
+
+  return batch.prepare_rec_forward_input(worker_.options_.num_decoding_tokens(),
+                                         /*min_decoding_batch_size=*/0,
+                                         worker_.context_.get_model_args(),
+                                         thread_pool);
+}
+
+void RecWorkerImpl::OneRecWorkPipeline::prepare_work_before_execute(
+    const ForwardInput& inputs,
+    ForwardInput& processed_inputs) {
+  worker_.WorkerImpl::prepare_work_before_execute(inputs, processed_inputs);
+}
+
+std::optional<ForwardOutput> RecWorkerImpl::OneRecWorkPipeline::step(
+    const ForwardInput& input) {
+  Timer timer;
+  worker_.device_.set_device();
+
+  const auto& sampling_params = input.sampling_params;
+  const auto& input_params = input.input_params;
+
+  const auto* onerec_params = input_params.onerec_params();
+  CHECK(onerec_params != nullptr) << "OneRec requires rec_params.";
+
+  const OneRecModelInputParams& rec_params = *onerec_params;
+
+  torch::Tensor hidden_states;
+  if (rec_params.rec_stage == OneRecModelInputParams::RecStage::PREFILL) {
+    if (!rec_params.is_first_prefill) {
+      ModelInputParams decoder_params = input_params;
+      decoder_params.mutable_onerec_params().is_encoder_forward = false;
+      hidden_states = worker_.model_executor_->forward(
+          input.token_ids, input.positions, worker_.kv_caches_, decoder_params);
+    } else {
+      const bool has_sparse_embedding =
+          rec_params.encoder_sparse_embedding.defined();
+      const bool has_encoder_tokens = rec_params.encoder_token_ids.defined() &&
+                                      rec_params.encoder_positions.defined();
+
+      if (!has_sparse_embedding && !has_encoder_tokens) {
+        LOG(ERROR) << "OneRec first prefill requires encoder inputs.";
+        return std::nullopt;
+      }
+
+      ModelInputParams encoder_params = input_params;
+      auto& mutable_onerec_params = encoder_params.mutable_onerec_params();
+      mutable_onerec_params.is_encoder_forward = true;
+
+      torch::Tensor encoder_tokens;
+      if (has_sparse_embedding) {
+        mutable_onerec_params.is_hybrid_mode = true;
+        encoder_tokens = rec_params.encoder_sparse_embedding;
+      } else {
+        encoder_tokens = rec_params.encoder_token_ids;
+      }
+
+      worker_.model_executor_->forward(encoder_tokens,
+                                       rec_params.encoder_positions,
+                                       worker_.kv_caches_,
+                                       encoder_params);
+
+      ModelInputParams decoder_params = input_params;
+      decoder_params.mutable_onerec_params().is_encoder_forward = false;
+      hidden_states = worker_.model_executor_->forward(
+          input.token_ids, input.positions, worker_.kv_caches_, decoder_params);
+    }
+  } else {
+    ModelInputParams decoder_params = input_params;
+    decoder_params.mutable_onerec_params().is_encoder_forward = false;
+    hidden_states = worker_.model_executor_->forward(
+        input.token_ids, input.positions, worker_.kv_caches_, decoder_params);
+  }
+
+  if (!hidden_states.defined()) {
+    return std::nullopt;
+  }
+
+  if (!worker_.enable_schedule_overlap() && !worker_.driver_ &&
+      !worker_.dp_driver_ && !worker_.options_.enable_speculative_decode()) {
+    worker_.device_.synchronize_default_stream();
+    COUNTER_ADD(execution_latency_seconds_model, timer.elapsed_seconds());
+    DeviceMonitor::get_instance().update_active_activation_memory(
+        worker_.device_.index());
+    return std::nullopt;
+  }
+
+  torch::Tensor logits;
+  if (sampling_params.selected_token_idxes.defined()) {
+    logits = worker_.model_->logits(hidden_states,
+                                    sampling_params.selected_token_idxes);
+  }
+
+  ForwardOutput output;
+
+  if (sampling_params.selected_token_idxes.defined()) {
+    auto sample_output = worker_.sampler_->forward(logits, sampling_params);
+    output.logits = logits;
+    output.sample_output = sample_output;
+    output.do_sample = sampling_params.do_sample;
+    output.logprobs = sampling_params.logprobs;
+    output.max_top_logprobs = sampling_params.max_top_logprobs;
+  }
+
+  worker_.device_.synchronize_default_stream();
+  COUNTER_ADD(execution_latency_seconds_model, timer.elapsed_seconds());
+  DeviceMonitor::get_instance().update_active_activation_memory(
+      worker_.device_.index());
+
+  return output;
+}
+
+RecWorkerImpl::RecWorkerImpl(const ParallelArgs& parallel_args,
+                             const torch::Device& device,
+                             const runtime::Options& options)
+    : LLMWorkerImpl(parallel_args, device, options) {
+  if (!is_driver()) {
+    return;
+  }
+
+  const int64_t num_threads = std::max<int64_t>(
+      1, util::get_int_env("XLLM_REC_INPUT_BUILDER_THREADS", 16));
+  input_builder_thread_pool_ =
+      std::make_shared<ThreadPool>(static_cast<size_t>(num_threads));
+}
+
+bool RecWorkerImpl::init_model(ModelContext& context) {
+  const bool ok = LLMWorkerImpl::init_model(context);
+  if (!ok) {
+    return false;
+  }
+
+  const auto& model_type = context.get_model_args().model_type();
+  rec_model_kind_ = get_rec_model_kind(model_type);
+  CHECK(rec_model_kind_ != RecModelKind::kNone)
+      << "Unsupported rec model_type: " << model_type;
+
+  if (rec_model_kind_ == RecModelKind::kLlmRec) {
+    work_pipeline_ = std::make_unique<LlmRecWorkPipeline>(*this);
+  } else if (rec_model_kind_ == RecModelKind::kOneRec) {
+    work_pipeline_ = std::make_unique<OneRecWorkPipeline>(*this);
+  }
+
+  return true;
+}
+
+ForwardInput RecWorkerImpl::prepare_inputs(Batch& batch) {
+  CHECK(work_pipeline_ != nullptr) << "RecWorkerImpl is not initialized.";
+  return work_pipeline_->prepare_inputs(batch);
+}
+
+void RecWorkerImpl::prepare_work_before_execute(
+    const ForwardInput& inputs,
+    ForwardInput& processed_inputs) {
+  CHECK(work_pipeline_ != nullptr) << "RecWorkerImpl is not initialized.";
+  work_pipeline_->prepare_work_before_execute(inputs, processed_inputs);
+}
+
+torch::Tensor RecWorkerImpl::merge_embeddings_by_indices(
+    const torch::Tensor& input_tokens_embedding,
+    const torch::Tensor& input_embedding,
+    const std::vector<int64_t>& input_indices) {
+  CHECK_EQ(input_embedding.dim(), 2);
+  CHECK_EQ(input_tokens_embedding.dim(), 2);
+  CHECK_EQ(input_tokens_embedding.size(1), input_embedding.size(1));
+  CHECK_EQ(input_tokens_embedding.dtype(), input_embedding.dtype());
+  CHECK_EQ(input_tokens_embedding.device(), input_embedding.device());
+
+  const int64_t total_rows =
+      input_tokens_embedding.size(0) + input_embedding.size(0);
+  const int64_t cols = input_embedding.size(1);
+
+  torch::Device device = input_embedding.device();
+  torch::Tensor merged = torch::empty(
+      {total_rows, cols}, torch::dtype(input_embedding.dtype()).device(device));
+
+  std::vector<int64_t> input_embedding_indices;
+  for (int64_t i = 0; i < total_rows; ++i) {
+    if (std::find(input_indices.begin(), input_indices.end(), i) ==
+        input_indices.end()) {
+      input_embedding_indices.push_back(i);
+    }
+  }
+
+  CHECK_EQ(input_embedding_indices.size(), input_embedding.size(0));
+
+  torch::Tensor input_embedding_indices_tensor =
+      torch::tensor(input_embedding_indices, torch::kInt64).to(device);
+  merged.index_put_({input_embedding_indices_tensor, torch::indexing::Ellipsis},
+                    input_embedding);
+
+  torch::Tensor input_indices_tensor =
+      torch::tensor(input_indices, torch::kInt64).to(device);
+  merged.index_put_({input_indices_tensor, torch::indexing::Ellipsis},
+                    input_tokens_embedding);
+
+  return merged;
+}
+
+std::optional<ForwardOutput> RecWorkerImpl::step(const ForwardInput& input) {
+  CHECK(work_pipeline_ != nullptr) << "RecWorkerImpl is not initialized.";
+  return work_pipeline_->step(input);
+}
+
+}  // namespace xllm

--- a/xllm/core/runtime/rec_worker_impl.h
+++ b/xllm/core/runtime/rec_worker_impl.h
@@ -1,0 +1,104 @@
+/* Copyright 2025 The xLLM Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://github.com/jd-opensource/xllm/blob/main/LICENSE
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#pragma once
+
+#include <torch/torch.h>
+
+#include <cstdint>
+#include <memory>
+#include <optional>
+#include <vector>
+
+#include "common/rec_model_utils.h"
+#include "runtime/llm_worker_impl.h"
+
+namespace xllm {
+
+class RecWorkerImpl : public LLMWorkerImpl {
+ public:
+  RecWorkerImpl(const ParallelArgs& parallel_args,
+                const torch::Device& device,
+                const runtime::Options& options);
+
+  ~RecWorkerImpl() override = default;
+
+  bool init_model(ModelContext& context) override;
+
+  ForwardInput prepare_inputs(Batch& batch) override;
+
+  void prepare_work_before_execute(const ForwardInput& inputs,
+                                   ForwardInput& processed_inputs) override;
+
+  std::optional<ForwardOutput> step(const ForwardInput& input) override;
+
+ protected:
+  std::shared_ptr<ThreadPool> input_builder_thread_pool_;
+
+ private:
+  class RecWorkPipeline {
+   public:
+    virtual ~RecWorkPipeline() = default;
+
+    virtual ForwardInput prepare_inputs(Batch& batch) = 0;
+
+    virtual void prepare_work_before_execute(
+        const ForwardInput& inputs,
+        ForwardInput& processed_inputs) = 0;
+
+    virtual std::optional<ForwardOutput> step(const ForwardInput& input) = 0;
+  };
+
+  class LlmRecWorkPipeline final : public RecWorkPipeline {
+   public:
+    explicit LlmRecWorkPipeline(RecWorkerImpl& worker);
+
+    ForwardInput prepare_inputs(Batch& batch) override;
+
+    void prepare_work_before_execute(const ForwardInput& inputs,
+                                     ForwardInput& processed_inputs) override;
+
+    std::optional<ForwardOutput> step(const ForwardInput& input) override;
+
+   private:
+    RecWorkerImpl& worker_;
+  };
+
+  class OneRecWorkPipeline final : public RecWorkPipeline {
+   public:
+    explicit OneRecWorkPipeline(RecWorkerImpl& worker);
+
+    ForwardInput prepare_inputs(Batch& batch) override;
+
+    void prepare_work_before_execute(const ForwardInput& inputs,
+                                     ForwardInput& processed_inputs) override;
+
+    std::optional<ForwardOutput> step(const ForwardInput& input) override;
+
+   private:
+    RecWorkerImpl& worker_;
+  };
+
+  torch::Tensor merge_embeddings_by_indices(
+      const torch::Tensor& input_tokens_embedding,
+      const torch::Tensor& input_embedding,
+      const std::vector<int64_t>& input_indices);
+
+  std::unique_ptr<RecWorkPipeline> work_pipeline_;
+
+  RecModelKind rec_model_kind_ = RecModelKind::kNone;
+};
+
+}  // namespace xllm

--- a/xllm/core/runtime/worker.cpp
+++ b/xllm/core/runtime/worker.cpp
@@ -32,6 +32,7 @@ limitations under the License.
 #include "runtime/embed_vlm_worker_impl.h"
 #include "runtime/embed_worker_impl.h"
 #include "runtime/llm_worker_impl.h"
+#include "runtime/rec_worker_impl.h"
 #include "runtime/speculative_worker_impl.h"
 #include "runtime/vlm_worker_impl.h"
 #include "util/timer.h"
@@ -52,10 +53,7 @@ Worker::Worker(const ParallelArgs& parallel_args,
   } else if (worker_type == WorkerType::EVLM) {
     impl_ = new EmbedVLMWorkerImpl(parallel_args, device, options);
   } else if (worker_type == WorkerType::REC) {
-    // TODO. add following when next pr (use RecWorkerImpl).
-    // impl_ = new RecWorkerImpl(parallel_args, device, options);
-    // TODO. delete this when next pr.
-    impl_ = new LLMWorkerImpl(parallel_args, device, options);
+    impl_ = new RecWorkerImpl(parallel_args, device, options);
   } else {
     LOG(ERROR) << "Unknown worker type, please check logic";
   }


### PR DESCRIPTION
  This PR is a follow-up to #565 and continues the generative recommendation work by introducing the runtime rec worker
  layer for the OneRec execution path.

  ## What’s included
  - Runtime worker implementation for rec requests:
    - `RecWorkerImpl` (abstract base): shared model init + rec input preparation via
  `Batch::prepare_rec_forward_input(...)`
    - `OneRecWorkerImpl` (concrete): executes the OneRec prefill flow
  - `WorkerType::REC` wiring: `Worker` now instantiates `OneRecWorkerImpl` (removes the temporary `LLMWorkerImpl` fallback)
  - Two-stage first-prefill execution:
    - encoder forward (from `rec_params.encoder_sparse_embedding` or `rec_params.encoder_token_ids`)
    - decoder forward
    - subsequent steps run decoder-only
  - Driver-only sampling/output: non-driver ranks return `std::nullopt` (same contract as the LLM path)
  - Tunable input-builder thread pool via `XLLM_REC_INPUT_BUILDER_THREADS` (driver only)

  ## Out of scope (planned follow-ups)
  - Input/output processors (request ingestion and result emission)
  - Concrete `kLlmRec` implementation (enum value reserved only)
  - ValidPathFilter / rec decode constraint integration for the runtime worker (if needed)
  - OneRec model implementation + ATB graph building/integration
  - Pure NPU inference path

  ## Roadmap checklist
  - [x] Rec tokenizer #317
  - [x] Rec decoder constrain #480
  - [x] Rec proto and service #440
  - [x] Rec engine master #557
  - [x] Scheduler #557
  - [x] `RecType` plumbing + rec batch input builder layering #565
  - [x] Rec worker #567
  - [ ] request+sampler
  - [ ] OneRec model + ATB graph integration
  - [ ] Pure NPU inference