### PR TITLE
feat: support FLUX.1-Redux-dev model on npu device.

### DIFF
--- a/xllm/core/framework/dit_model_loader.cpp
+++ b/xllm/core/framework/dit_model_loader.cpp
@@ -81,6 +81,12 @@ bool DiTFolderLoader::load_args(const std::string& model_weights_path) {
     return false;
   }
 
+  if (!load_image_preprocessor_args(model_weights_path)) {
+    LOG(ERROR) << "Failed to load image preprocess args from "
+               << model_weights_path;
+    return false;
+  }
+
   return true;
 }
 
@@ -214,6 +220,96 @@ bool DiTFolderLoader::load_tokenizer_args(
     } else if (auto v = tokenizer_reader.value<std::string>("pad_token")) {
       tokenizer_args_.pad_token() = v.value();
     }
+  }
+
+  return true;
+}
+
+bool DiTFolderLoader::load_image_preprocessor_args(
+    const std::string& model_weights_path) {
+  // image preprocessor args
+  JsonReader image_preprocess_reader;
+  const std::string image_preprocess_file_path =
+      model_weights_path + "/preprocessor_config.json";
+  if (image_preprocess_reader.parse(image_preprocess_file_path)) {
+    LOG(INFO) << "Success to parse image preprocess args file: "
+              << image_preprocess_file_path;
+    args_.mm_image_do_center_crop() =
+        image_preprocess_reader.value_or<bool>("do_center_crop", false);
+    args_.mm_image_crop_height_size() =
+        image_preprocess_reader.value_or<int>("crop_size.height", 335);
+    args_.mm_image_crop_width_size() =
+        image_preprocess_reader.value_or<int>("crop_size.width", 335);
+
+    args_.mm_image_size_height() =
+        image_preprocess_reader.value_or<int>("size.height", 384);
+
+    args_.mm_image_size_width() =
+        image_preprocess_reader.value_or<int>("size.width", 384);
+
+    args_.mm_image_do_resize() =
+        image_preprocess_reader.value_or<bool>("do_resize", false);
+    args_.mm_image_resize_shortest_edge() =
+        image_preprocess_reader.value_or<int>("size.shortest_edge", 335);
+    args_.mm_image_resample() =
+        image_preprocess_reader.value_or<int>("resample", 335);
+
+    args_.mm_image_do_rescale() =
+        image_preprocess_reader.value_or<bool>("do_rescale", false);
+    args_.mm_image_rescale_factor() =
+        image_preprocess_reader.value_or<double>("rescale_factor", 0);
+
+    args_.mm_image_do_normalize() =
+        image_preprocess_reader.value_or<bool>("do_normalize", false);
+
+    const auto& image_prerocess_data = image_preprocess_reader.data();
+    if (image_preprocess_reader.contains("image_mean")) {
+      args_.mm_image_normalize_mean() =
+          image_prerocess_data["image_mean"].get<std::vector<double>>();
+    } else if (image_preprocess_reader.contains("norm_mean")) {
+      args_.mm_image_normalize_mean() =
+          image_prerocess_data["norm_mean"].get<std::vector<double>>();
+    }
+    if (image_preprocess_reader.contains("image_std")) {
+      args_.mm_image_normalize_std() =
+          image_prerocess_data["image_std"].get<std::vector<double>>();
+    } else if (image_preprocess_reader.contains("norm_std")) {
+      args_.mm_image_normalize_std() =
+          image_prerocess_data["norm_std"].get<std::vector<double>>();
+    }
+
+    args_.mm_image_shortest_edge() =
+        image_preprocess_reader.value_or<int>("size.shortest_edge", 0);
+
+    args_.mm_image_longest_edge() =
+        image_preprocess_reader.value_or<int>("size.longest_edge", 0);
+
+    args_.mm_image_min_pixels() =
+        image_preprocess_reader.value_or<int>("min_pixels", 0);
+
+    args_.mm_image_max_pixels() =
+        image_preprocess_reader.value_or<int>("max_pixels", 0);
+
+    args_.mm_image_patch_size() =
+        image_preprocess_reader.value_or<int>("patch_size", 0);
+
+    args_.mm_image_temporal_patch_size() =
+        image_preprocess_reader.value_or<int>("temporal_patch_size", 0);
+
+    args_.mm_image_merge_size() =
+        image_preprocess_reader.value_or<int>("merge_size", 0);
+
+    args_.mm_image_feature_size() =
+        image_preprocess_reader.value_or<int>("image_feature_size", 0);
+
+    args_.mm_scale_resolution() =
+        image_preprocess_reader.value_or<int>("scale_resolution", 0);
+
+    args_.mm_slice_mode() =
+        image_preprocess_reader.value_or<bool>("slice_mode", false);
+
+    args_.mm_use_image_id() =
+        image_preprocess_reader.value_or<bool>("use_image_id", false);
   }
 
   return true;

--- a/xllm/core/framework/dit_model_loader.h
+++ b/xllm/core/framework/dit_model_loader.h
@@ -42,6 +42,7 @@ class DiTFolderLoader : public ModelLoader {
   bool load_args(const std::string& model_weights_path);
   bool load_model_args(const std::string& model_weights_path);
   bool load_tokenizer_args(const std::string& model_weights_path);
+  bool load_image_preprocessor_args(const std::string& model_weights_path);
 
   std::string model_weights_path_;
 

--- a/xllm/core/framework/model/model_args.h
+++ b/xllm/core/framework/model/model_args.h
@@ -289,6 +289,8 @@ struct ModelArgs {
   // VLM image preprocessor resize
   PROPERTY(bool, mm_image_do_resize) = false;
   PROPERTY(int, mm_image_resize_shortest_edge) = 336;
+  PROPERTY(int64_t, mm_image_size_height) = 384;
+  PROPERTY(int64_t, mm_image_size_width) = 384;
 
   PROPERTY(int, mm_image_resample) = 0;
 

--- a/xllm/core/framework/request/dit_request_state.h
+++ b/xllm/core/framework/request/dit_request_state.h
@@ -43,7 +43,9 @@ struct DiTGenerationParams {
            max_sequence_length == other.max_sequence_length &&
            strength == other.strength &&
            enable_cfg_renorm == other.enable_cfg_renorm &&
-           cfg_renorm_min == other.cfg_renorm_min;
+           cfg_renorm_min == other.cfg_renorm_min &&
+           prompt_embeds_scale == other.prompt_embeds_scale &&
+           pooled_prompt_embeds_scale == other.pooled_prompt_embeds_scale;
   }
 
   bool operator!=(const DiTGenerationParams& other) const {
@@ -71,6 +73,10 @@ struct DiTGenerationParams {
   bool enable_cfg_renorm = true;
 
   float cfg_renorm_min = 0.0f;
+
+  float prompt_embeds_scale = 1.0;
+
+  float pooled_prompt_embeds_scale = 1.0;
 };
 
 struct DiTInputParams {

--- a/xllm/models/dit/pipeline_flux_prior_redux.h
+++ b/xllm/models/dit/pipeline_flux_prior_redux.h
@@ -1,0 +1,182 @@
+/* Copyright 2026 The xLLM Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://github.com/jd-opensource/xllm/blob/main/LICENSE
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#pragma once
+#include "pipeline_flux_base.h"
+#include "processors/siglip_image_processor.h"
+#include "siglip_vision_model.h"
+// pipeline_flux_prior_redux compatible with huggingface weights
+// ref to:
+// https://github.com/huggingface/diffusers/blob/main/src/diffusers/pipelines/flux/pipeline_flux_prior_redux.py
+
+namespace xllm {
+
+class ReduxImageEncoderImpl : public torch::nn::Module {
+ public:
+  explicit ReduxImageEncoderImpl(const ModelContext& context) {
+    auto model_args = context.get_model_args();
+    auto options = context.get_tensor_options();
+    act_ = register_module("act", torch::nn::Functional(torch::silu));
+
+    redux_up_ =
+        register_module("redux_up",
+                        layer::AddMatmul(model_args.mm_hidden_size(),
+                                         model_args.mm_intermediate_size() * 3,
+                                         true,
+                                         options));
+    redux_down_ =
+        register_module("redux_down",
+                        layer::AddMatmul(model_args.mm_intermediate_size() * 3,
+                                         model_args.mm_intermediate_size(),
+                                         true,
+                                         options));
+  }
+
+  torch::Tensor forward(const torch::Tensor& hidden_states) {
+    return redux_down_(act_(redux_up_(hidden_states)));
+  }
+
+  void load_model(std::unique_ptr<DiTFolderLoader> loader) {
+    for (const auto& state_dict : loader->get_state_dicts()) {
+      redux_up_->load_state_dict(state_dict->get_dict_with_prefix("redux_up."));
+      redux_down_->load_state_dict(
+          state_dict->get_dict_with_prefix("redux_down."));
+    }
+  }
+
+  void verify_loaded_weights(const std::string& prefix) const {
+    redux_up_->verify_loaded_weights(prefix + "redux_up.");
+    redux_up_->verify_loaded_weights(prefix + "redux_down.");
+  }
+
+ private:
+  layer::AddMatmul redux_up_{nullptr};
+  layer::AddMatmul redux_down_{nullptr};
+
+  torch::nn::Functional act_ = nullptr;
+};
+TORCH_MODULE(ReduxImageEncoder);
+
+REGISTER_MODEL_ARGS(ReduxImageEncoder, [&] {
+  LOAD_ARG_OR(dtype, "torch_dtype", "bfloat16");
+  LOAD_ARG_OR(mm_hidden_size, "redux_dim", 1152);
+  LOAD_ARG_OR(mm_intermediate_size, "txt_in_features", 4096);
+});
+
+class FluxPriorReduxPipelineImpl : public FluxPipelineBaseImpl {
+ public:
+  explicit FluxPriorReduxPipelineImpl(const DiTModelContext& context) {
+    auto model_args = context.get_model_args("feature_extractor");
+    options_ = context.get_tensor_options();
+    image_encoder_ =
+        SiglipVisionModel(context.get_model_context("image_encoder"));
+    image_embedder_ =
+        ReduxImageEncoder(context.get_model_context("image_embedder"));
+    feature_extractor_ = std::make_unique<SiglipImageProcessor>(model_args);
+  }
+
+  void load_model(std::unique_ptr<DiTModelLoader> loader) {
+    std::string model_path = loader->model_root_path();
+    auto image_encoder_loader = loader->take_component_loader("image_encoder");
+    auto image_embedder_loader =
+        loader->take_component_loader("image_embedder");
+    image_encoder_->load_model(std::move(image_encoder_loader));
+    image_encoder_->to(options_.device());
+    image_embedder_->load_model(std::move(image_embedder_loader));
+    image_embedder_->to(options_.device());
+  }
+
+  torch::Tensor encode_image(const torch::Tensor& image,
+                             int64_t num_images_per_prompt) {
+    auto imgs = feature_extractor_->preprocess(image).to(options_);
+    auto image_enc_hidden_states = image_encoder_->forward(imgs);
+    image_enc_hidden_states =
+        image_enc_hidden_states.repeat_interleave(num_images_per_prompt, 0);
+    return image_enc_hidden_states;
+  }
+
+  DiTForwardOutput forward(const DiTForwardInput& input) {
+    const auto& generation_params = input.generation_params;
+    auto image = input.images.defined() ? std::make_optional(input.images)
+                                        : std::nullopt;
+    auto prompt_embeds = input.prompt_embeds.defined()
+                             ? std::make_optional(input.prompt_embeds)
+                             : std::nullopt;
+    auto pooled_prompt_embeds =
+        input.pooled_prompt_embeds.defined()
+            ? std::make_optional(input.pooled_prompt_embeds)
+            : std::nullopt;
+    auto prompt_embeds_scale = generation_params.prompt_embeds_scale;
+    auto pooled_prompt_embeds_scale =
+        generation_params.pooled_prompt_embeds_scale;
+    std::vector<torch::Tensor> output =
+        forward_impl(image.value(),
+                     prompt_embeds,
+                     pooled_prompt_embeds,
+                     generation_params.height,
+                     generation_params.width,
+                     prompt_embeds_scale,
+                     pooled_prompt_embeds_scale);
+    DiTForwardOutput out;
+    out.tensors = output;
+    return out;
+  }
+
+  std::vector<torch::Tensor> forward_impl(
+      torch::Tensor image,
+      std::optional<torch::Tensor> prompt_embeds_opt,
+      std::optional<torch::Tensor> pooled_prompt_embeds_opt,
+      int64_t height = 384,
+      int64_t width = 384,
+      float prompt_embeds_scale = 1.0f,
+      float pooled_prompt_embeds_scale = 1.0f) {
+    torch::NoGradGuard no_grad;
+    int64_t batch_size = image.dim() == 4 ? image.size(0) : 1;
+    torch::Tensor image_latents =
+        encode_image(image, /*num_images_per_prompt=*/1);
+    torch::Tensor image_embeds =
+        image_embedder_->forward(image_latents).to(options_);
+
+    // prompt_embeds: [batch_size, seq_len, hidden_dim]
+    torch::Tensor prompt_embeds = prompt_embeds_opt.value_or(torch::zeros(
+        {batch_size, /*seq_len=*/512, /*hidden_dim=*/4096}, options_));
+    // pooled_prompt_embeds: [batch_size, pooled_hidden_dim]
+    torch::Tensor pooled_prompt_embeds = pooled_prompt_embeds_opt.value_or(
+        torch::zeros({batch_size, /*pooled_hidden_dim=*/768}, options_));
+
+    prompt_embeds = torch::cat({prompt_embeds, image_embeds}, /*dim=*/1);
+    prompt_embeds *= torch::full({batch_size}, prompt_embeds_scale, options_)
+                         .view({-1, 1, 1});
+    pooled_prompt_embeds *=
+        torch::full({batch_size}, pooled_prompt_embeds_scale, options_)
+            .view({-1, 1});
+
+    prompt_embeds = torch::sum(prompt_embeds, /*dim=*/0, /*keepdim=*/true);
+    pooled_prompt_embeds =
+        torch::sum(pooled_prompt_embeds, /*dim=*/0, /*keepdim=*/true);
+
+    // TODO: Add tensor output interface.
+    return {prompt_embeds, pooled_prompt_embeds};
+  }
+
+ private:
+  SiglipVisionModel image_encoder_{nullptr};
+  std::unique_ptr<SiglipImageProcessor> feature_extractor_;
+  ReduxImageEncoder image_embedder_{nullptr};
+};
+TORCH_MODULE(FluxPriorReduxPipeline);
+
+REGISTER_DIT_MODEL(fluxredux, FluxPriorReduxPipeline);
+}  // namespace xllm

--- a/xllm/models/dit/siglip_vision_model.h
+++ b/xllm/models/dit/siglip_vision_model.h
@@ -1,0 +1,475 @@
+/* Copyright 2026 The xLLM Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://github.com/jd-opensource/xllm/blob/main/LICENSE
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#pragma once
+
+#include <torch/torch.h>
+
+#include "core/framework/model/model_input_params.h"
+#include "core/framework/model_context.h"
+#include "models/model_registry.h"
+#include "xllm/core/layers/common/add_matmul.h"
+
+namespace xllm {
+// siglip_vision_model compatible with huggingface weights
+// ref to:
+// https://github.com/huggingface/transformers/tree/main/src/transformers/models/siglip
+class SiglipVisionEmbeddingsImpl : public torch::nn::Module {
+ public:
+  explicit SiglipVisionEmbeddingsImpl(const ModelContext& context) {
+    auto model_args = context.get_model_args();
+    auto options = context.get_tensor_options();
+    embed_dim_ = model_args.mm_hidden_size();
+    image_size_ = model_args.mm_image_size();
+    patch_embedding_ = register_module(
+        "patch_embedding",
+        torch::nn::Conv2d(torch::nn::Conv2dOptions(model_args.mm_num_channels(),
+                                                   embed_dim_,
+                                                   model_args.mm_patch_size())
+                              .stride(model_args.mm_patch_size())
+                              .bias(true)));
+    patch_embedding_->weight.set_data(patch_embedding_->weight.to(options));
+    patch_embedding_->bias.set_data(patch_embedding_->bias.to(options));
+
+    auto num_patches =
+        (model_args.mm_image_size() / model_args.mm_patch_size()) *
+        (model_args.mm_image_size() / model_args.mm_patch_size());
+    auto num_positions = num_patches;
+    position_embedding_ =
+        register_parameter("position_embedding",
+                           torch::randn({num_positions, embed_dim_}, options));
+    position_ids_ = register_buffer(
+        "position_ids",
+        torch::arange(0, num_positions, torch::kLong).unsqueeze(0));
+  }
+
+  torch::Tensor forward(const torch::Tensor& pixel_values) {
+    auto patch_embeds =
+        patch_embedding_->forward(pixel_values).flatten(2).transpose(1, 2);
+    torch::Tensor embeddings =
+        patch_embeds + position_embedding_.index({position_ids_});
+    return embeddings;
+  }
+
+  void load_state_dict(const StateDict& state_dict) {
+    const auto pos = state_dict.get_tensor("position_embedding.weight");
+    if (pos.defined()) {
+      CHECK_EQ(pos.sizes(), position_embedding_.sizes())
+          << "position_embedding weight size mismatch for " << name();
+      position_embedding_.data().copy_(pos);
+      is_position_embedding_loaded_ = true;
+    }
+
+    const auto weight = state_dict.get_tensor("patch_embedding.weight");
+    if (weight.defined()) {
+      CHECK_EQ(patch_embedding_->weight.sizes(), weight.sizes())
+          << "patch_embedding weight size mismatch for " << name();
+      patch_embedding_->weight.data().copy_(weight);
+      is_patch_embedding_weight_loaded_ = true;
+    }
+
+    const auto bias = state_dict.get_tensor("patch_embedding.bias");
+    if (bias.defined()) {
+      CHECK_EQ(patch_embedding_->bias.sizes(), bias.sizes())
+          << "patch_embedding bias size mismatch for " << name();
+      patch_embedding_->bias.data().copy_(bias);
+      is_patch_embedding_bias_loaded_ = true;
+    }
+  }
+
+  void verify_loaded_weights(const std::string& prefix) const {
+    CHECK(is_position_embedding_loaded_)
+        << "weight is not loaded for " << prefix + "position_embedding.weight";
+    CHECK(is_patch_embedding_weight_loaded_)
+        << "weight is not loaded for " << prefix + "patch_embedding.weight";
+    CHECK(is_patch_embedding_bias_loaded_)
+        << "bias is not loaded for " << prefix + "patch_embedding.bias";
+  }
+
+ private:
+  int64_t embed_dim_;
+  int64_t image_size_;
+  bool is_position_embedding_loaded_ = false;
+  bool is_patch_embedding_weight_loaded_ = false;
+  bool is_patch_embedding_bias_loaded_ = false;
+  torch::Tensor position_ids_;
+  torch::nn::Conv2d patch_embedding_ = nullptr;
+  torch::Tensor position_embedding_;
+};
+TORCH_MODULE(SiglipVisionEmbeddings);
+
+class SiglipAttentionImpl : public torch::nn::Module {
+ public:
+  SiglipAttentionImpl(const ModelContext& context) {
+    auto model_args = context.get_model_args();
+    auto options = context.get_tensor_options();
+    CHECK(model_args.mm_hidden_size() % model_args.mm_num_attention_heads() ==
+          0);
+    embed_dim_ = model_args.mm_hidden_size();
+    num_heads_ = model_args.mm_num_attention_heads();
+    head_dim_ = embed_dim_ / num_heads_;
+
+    q_proj_ = register_module("q_proj",
+                              layer::AddMatmul(model_args.mm_hidden_size(),
+                                               model_args.mm_hidden_size(),
+                                               true,
+                                               options));
+    k_proj_ = register_module("k_proj",
+                              layer::AddMatmul(model_args.mm_hidden_size(),
+                                               model_args.mm_hidden_size(),
+                                               true,
+                                               options));
+    v_proj_ = register_module("v_proj",
+                              layer::AddMatmul(model_args.mm_hidden_size(),
+                                               model_args.mm_hidden_size(),
+                                               true,
+                                               options));
+    o_proj_ = register_module("o_proj",
+                              layer::AddMatmul(model_args.mm_hidden_size(),
+                                               model_args.mm_hidden_size(),
+                                               true,
+                                               options));
+
+    scale_ = 1.0f / std::sqrt(static_cast<float>(head_dim_));
+  }
+
+  torch::Tensor forward(const torch::Tensor& hidden_states) {
+    auto bsz = hidden_states.size(0);
+    auto tgt_len = hidden_states.size(1);
+
+    auto query_states = q_proj_(hidden_states);
+    auto key_states = k_proj_(hidden_states);
+    auto value_states = v_proj_(hidden_states);
+
+    query_states = shape(query_states, tgt_len, bsz);
+    key_states = shape(key_states, -1, bsz);
+    value_states = shape(value_states, -1, bsz);
+
+    torch::Tensor attn_output = torch::scaled_dot_product_attention(
+        query_states, key_states, value_states, torch::nullopt, 0.0, false);
+
+    attn_output = attn_output.transpose(1, 2).contiguous();
+    attn_output =
+        attn_output.view(torch::IntArrayRef({bsz, tgt_len, embed_dim_}));
+
+    return o_proj_(attn_output);
+  }
+
+  void load_state_dict(const StateDict& state_dict) {
+    q_proj_->load_state_dict(state_dict.get_dict_with_prefix("q_proj."));
+    k_proj_->load_state_dict(state_dict.get_dict_with_prefix("k_proj."));
+    v_proj_->load_state_dict(state_dict.get_dict_with_prefix("v_proj."));
+    o_proj_->load_state_dict(state_dict.get_dict_with_prefix("out_proj."));
+  }
+
+  void verify_loaded_weights(const std::string& prefix) const {
+    q_proj_->verify_loaded_weights(prefix + "q_proj.");
+    k_proj_->verify_loaded_weights(prefix + "k_proj.");
+    v_proj_->verify_loaded_weights(prefix + "v_proj.");
+    o_proj_->verify_loaded_weights(prefix + "out_proj.");
+  }
+
+ private:
+  torch::Tensor shape(torch::Tensor tensor, int64_t seq_len, int64_t bsz) {
+    return tensor.view({bsz, seq_len, num_heads_, head_dim_})
+        .transpose(1, 2)
+        .contiguous();
+  }
+
+ private:
+  int64_t embed_dim_;
+  int64_t num_heads_;
+  int64_t head_dim_;
+  float scale_;
+
+  layer::AddMatmul o_proj_ = nullptr;
+  layer::AddMatmul q_proj_ = nullptr;
+  layer::AddMatmul k_proj_ = nullptr;
+  layer::AddMatmul v_proj_ = nullptr;
+};
+TORCH_MODULE(SiglipAttention);
+
+class SiglipMLPImpl : public torch::nn::Module {
+ public:
+  explicit SiglipMLPImpl(const ModelContext& context) {
+    auto model_args = context.get_model_args();
+    auto options = context.get_tensor_options();
+
+    act_ = register_module(
+        "act",
+        torch::nn::Functional(std::function<at::Tensor(const at::Tensor&)>(
+            [](const at::Tensor& x) { return torch::gelu(x, "tanh"); })));
+    fc1_ = register_module("fc1",
+                           layer::AddMatmul(model_args.mm_hidden_size(),
+                                            model_args.mm_intermediate_size(),
+                                            true,
+                                            options));
+    fc2_ = register_module("fc2",
+                           layer::AddMatmul(model_args.mm_intermediate_size(),
+                                            model_args.mm_hidden_size(),
+                                            true,
+                                            options));
+  }
+
+  torch::Tensor forward(const torch::Tensor& hidden_states) {
+    return fc2_(act_(fc1_(hidden_states)));
+  }
+
+  void load_state_dict(const StateDict& state_dict) {
+    fc1_->load_state_dict(state_dict.get_dict_with_prefix("fc1."));
+    fc2_->load_state_dict(state_dict.get_dict_with_prefix("fc2."));
+  }
+
+  void verify_loaded_weights(const std::string& prefix) const {
+    fc1_->verify_loaded_weights(prefix + "fc1.");
+    fc2_->verify_loaded_weights(prefix + "fc2.");
+  }
+
+ private:
+  torch::nn::Functional act_ = nullptr;
+  layer::AddMatmul fc1_ = nullptr;
+  layer::AddMatmul fc2_ = nullptr;
+};
+TORCH_MODULE(SiglipMLP);
+
+class SiglipEncoderLayerImpl : public torch::nn::Module {
+ public:
+  explicit SiglipEncoderLayerImpl(const ModelContext& context) {
+    auto model_args = context.get_model_args();
+    auto options = context.get_tensor_options();
+    self_attn_ = register_module("self_attn", SiglipAttention(context));
+    layer_norm1_ = register_module(
+        "layer_norm1",
+        torch::nn::LayerNorm(
+            torch::nn::LayerNormOptions({model_args.mm_hidden_size()})
+                .elementwise_affine(true)
+                .eps(model_args.mm_layer_norm_eps())));
+    layer_norm2_ = register_module(
+        "layer_norm2",
+        torch::nn::LayerNorm(
+            torch::nn::LayerNormOptions({model_args.mm_hidden_size()})
+                .elementwise_affine(true)
+                .eps(model_args.mm_layer_norm_eps())));
+    layer_norm1_->weight.set_data(layer_norm1_->weight.to(options));
+    layer_norm1_->bias.set_data(layer_norm1_->bias.to(options));
+    layer_norm2_->weight.set_data(layer_norm2_->weight.to(options));
+    layer_norm2_->bias.set_data(layer_norm2_->bias.to(options));
+    mlp_ = register_module("mlp", SiglipMLP(context));
+  }
+
+  torch::Tensor forward(const torch::Tensor& hidden_states) {
+    auto residual = hidden_states;
+    auto ln1_out = layer_norm1_->forward(hidden_states);
+    auto h = self_attn_->forward(ln1_out) + residual;
+    residual = h;
+    h = layer_norm2_->forward(h);
+    h = mlp_->forward(h);
+    h += residual;
+    return h;
+  }
+
+  void load_state_dict(const StateDict& state_dict) {
+    self_attn_->load_state_dict(state_dict.get_dict_with_prefix("self_attn."));
+    weight::load_weight(state_dict,
+                        "layer_norm1.weight",
+                        layer_norm1_->weight,
+                        layer_norm1_weight_loaded_);
+    weight::load_weight(state_dict,
+                        "layer_norm1.bias",
+                        layer_norm1_->bias,
+                        layer_norm1_bias_loaded_);
+    weight::load_weight(state_dict,
+                        "layer_norm2.weight",
+                        layer_norm2_->weight,
+                        layer_norm2_weight_loaded_);
+    weight::load_weight(state_dict,
+                        "layer_norm2.bias",
+                        layer_norm2_->bias,
+                        layer_norm2_bias_loaded_);
+    mlp_->load_state_dict(state_dict.get_dict_with_prefix("mlp."));
+  }
+
+  void verify_loaded_weights(const std::string& prefix) const {
+    self_attn_->verify_loaded_weights(prefix + "self_attn.");
+    mlp_->verify_loaded_weights(prefix + "mlp.");
+    CHECK(layer_norm1_weight_loaded_)
+        << "weight is not loaded for " << prefix + "layer_norm1.weight";
+    CHECK(layer_norm1_bias_loaded_)
+        << "weight is not loaded for " << prefix + "layer_norm1.bias";
+    CHECK(layer_norm2_weight_loaded_)
+        << "weight is not loaded for " << prefix + "layer_norm2.weight";
+    CHECK(layer_norm2_bias_loaded_)
+        << "weight is not loaded for " << prefix + "layer_norm2.bias";
+  }
+
+ private:
+  bool layer_norm1_weight_loaded_ = false;
+  bool layer_norm1_bias_loaded_ = false;
+  bool layer_norm2_weight_loaded_ = false;
+  bool layer_norm2_bias_loaded_ = false;
+
+  torch::nn::LayerNorm layer_norm1_ = nullptr;
+  torch::nn::LayerNorm layer_norm2_ = nullptr;
+  SiglipAttention self_attn_ = nullptr;
+  SiglipMLP mlp_ = nullptr;
+};
+TORCH_MODULE(SiglipEncoderLayer);
+
+class SiglipEncoderImpl : public torch::nn::Module {
+ public:
+  explicit SiglipEncoderImpl(const ModelContext& context) {
+    auto model_args = context.get_model_args();
+    auto options = context.get_tensor_options();
+    layers_.reserve(model_args.mm_num_hidden_layers());
+    for (int32_t i = 0; i < model_args.mm_num_hidden_layers(); i++) {
+      auto block = SiglipEncoderLayer(context);
+      layers_.push_back(block);
+    }
+  }
+
+  torch::Tensor forward(const torch::Tensor& embeddings) {
+    auto hidden_states = embeddings;
+    for (size_t i = 0; i < layers_.size(); ++i) {
+      auto& layer = layers_[i];
+      hidden_states = layer->forward(hidden_states);
+    }
+    return hidden_states;
+  }
+
+  void load_state_dict(const StateDict& state_dict) {
+    for (size_t i = 0; i < layers_.size(); ++i) {
+      layers_[i]->load_state_dict(
+          state_dict.get_dict_with_prefix("layers." + std::to_string(i) + "."));
+    }
+  }
+
+  void verify_loaded_weights(const std::string& prefix) const {
+    for (size_t i = 0; i < layers_.size(); ++i) {
+      layers_[i]->verify_loaded_weights(prefix + "layers." + std::to_string(i) +
+                                        ".");
+    }
+  }
+
+ private:
+  std::vector<SiglipEncoderLayer> layers_;
+};
+TORCH_MODULE(SiglipEncoder);
+
+class SiglipVisionTransformerImpl : public torch::nn::Module {
+ public:
+  explicit SiglipVisionTransformerImpl(const ModelContext& context) {
+    auto model_args = context.get_model_args();
+    auto options = context.get_tensor_options();
+    embeddings_ =
+        register_module("embeddings", SiglipVisionEmbeddings(context));
+    post_layer_norm_ = register_module(
+        "post_layer_norm",
+        torch::nn::LayerNorm(
+            torch::nn::LayerNormOptions({model_args.mm_hidden_size()})
+                .elementwise_affine(true)
+                .eps(model_args.mm_layer_norm_eps())));
+    post_layer_norm_->weight.set_data(post_layer_norm_->weight.to(options));
+    post_layer_norm_->bias.set_data(post_layer_norm_->bias.to(options));
+    encoder_ = register_module("encoder", SiglipEncoder(context));
+  }
+
+  torch::Tensor forward(const torch::Tensor& pixel_values) {
+    auto hidden_states = embeddings_->forward(pixel_values);
+    auto encoder_output = encoder_->forward(hidden_states);
+    auto last_hidden_state = post_layer_norm_->forward(encoder_output);
+    return last_hidden_state;
+  }
+
+  void load_state_dict(const StateDict& state_dict) {
+    embeddings_->load_state_dict(
+        state_dict.get_dict_with_prefix("embeddings."));
+    encoder_->load_state_dict(state_dict.get_dict_with_prefix("encoder."));
+    weight::load_weight(state_dict,
+                        "post_layernorm.weight",
+                        post_layer_norm_->weight,
+                        post_layer_norm_weight_loaded_);
+
+    weight::load_weight(state_dict,
+                        "post_layernorm.bias",
+                        post_layer_norm_->bias,
+                        post_layer_norm_bias_loaded_);
+  }
+
+  void verify_loaded_weights(const std::string& prefix) const {
+    embeddings_->verify_loaded_weights(prefix + "embeddings.");
+    encoder_->verify_loaded_weights(prefix + "encoder.");
+    CHECK(post_layer_norm_weight_loaded_)
+        << "weight is not loaded for " << prefix + "post_layernorm.weight";
+    CHECK(post_layer_norm_bias_loaded_)
+        << "weight is not loaded for " << prefix + "post_layernorm.bias";
+  }
+
+ private:
+  bool post_layer_norm_weight_loaded_ = false;
+  bool post_layer_norm_bias_loaded_ = false;
+  SiglipVisionEmbeddings embeddings_ = nullptr;
+  SiglipEncoder encoder_ = nullptr;
+  torch::nn::LayerNorm post_layer_norm_ = nullptr;
+};
+TORCH_MODULE(SiglipVisionTransformer);
+
+class SiglipVisionModelImpl : public torch::nn::Module {
+ public:
+  explicit SiglipVisionModelImpl(const ModelContext& context) {
+    auto model_args = context.get_model_args();
+    auto options = context.get_tensor_options();
+    transformer_ =
+        register_module("transformer", SiglipVisionTransformer(context));
+  }
+
+  torch::Tensor forward(const torch::Tensor& input_ids) {
+    auto last_hidden_states = transformer_->forward(input_ids);
+    return last_hidden_states;
+  }
+
+  void load_state_dict(const StateDict& state_dict) {
+    transformer_->load_state_dict(
+        state_dict.get_dict_with_prefix("vision_model."));
+  }
+
+  void load_model(std::unique_ptr<DiTFolderLoader> loader) {
+    for (const auto& state_dict : loader->get_state_dicts()) {
+      transformer_->load_state_dict(
+          state_dict->get_dict_with_prefix("vision_model."));
+    }
+
+    transformer_->verify_loaded_weights("vision_model.");
+  }
+
+ private:
+  SiglipVisionTransformer transformer_ = nullptr;
+};
+TORCH_MODULE(SiglipVisionModel);
+
+REGISTER_MODEL_ARGS(SiglipVisionModel, [&] {
+  LOAD_ARG_OR(dtype, "torch_dtype", "bfloat16");
+  LOAD_ARG_OR(mm_hidden_size, "hidden_size", 1152);
+  LOAD_ARG_OR(mm_image_size, "image_size", 384);
+  LOAD_ARG_OR(mm_intermediate_size, "intermediate_size", 4304);
+  LOAD_ARG_OR(mm_num_hidden_layers, "num_hidden_layers", 27);
+  LOAD_ARG_OR(mm_num_attention_heads, "num_attention_heads", 16);
+  LOAD_ARG_OR(mm_num_channels, "num_channels", 3);
+  LOAD_ARG_OR(mm_patch_size, "patch_size", 14);
+  LOAD_ARG_OR(mm_hidden_act, "hidden_act", "gelu_pytorch_tanh");
+  LOAD_ARG_OR(mm_layer_norm_eps, "layer_norm_eps", 1e-6);
+  LOAD_ARG_OR(mm_head_dim, "head_dim", 64);
+});
+
+}  // namespace xllm

--- a/xllm/models/models.h
+++ b/xllm/models/models.h
@@ -23,6 +23,7 @@ limitations under the License.
 #include "dit/pipeline_flux.h"                // IWYU pragma: keep
 #include "dit/pipeline_flux_control.h"        // IWYU pragma: keep
 #include "dit/pipeline_flux_fill.h"           // IWYU pragma: keep
+#include "dit/pipeline_flux_prior_redux.h"    // IWYU pragma: keep
 #include "llm/npu/deepseek_mtp.h"             // IWYU pragma: keep
 #include "llm/npu/deepseek_v2.h"              // IWYU pragma: keep
 #include "llm/npu/deepseek_v3.h"              // IWYU pragma: keep

--- a/xllm/processors/CMakeLists.txt
+++ b/xllm/processors/CMakeLists.txt
@@ -26,6 +26,7 @@ cc_library(
     glm4v_image_processor.h
     pywarpper_image_processor.h
     input_processor.h
+    siglip_image_processor.h
   SRCS
     image_processor.cpp
     clip_image_processor.cpp
@@ -33,6 +34,7 @@ cc_library(
     qwen2_vl_image_processor.cpp
     glm4v_image_processor.cpp
     pywarpper_image_processor.cpp
+    siglip_image_processor.cpp
   DEPS
     ${BASE_DEPS}
 )

--- a/xllm/processors/siglip_image_processor.cpp
+++ b/xllm/processors/siglip_image_processor.cpp
@@ -1,0 +1,67 @@
+/* Copyright 2026 The xLLM Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://github.com/jd-opensource/xllm/blob/main/LICENSE
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include "siglip_image_processor.h"
+
+namespace xllm {
+
+SiglipImageProcessor::SiglipImageProcessor(const ModelArgs& args) {
+  do_resize_ = args.mm_image_do_resize();
+  do_center_crop_ = args.mm_image_do_center_crop();
+  do_rescale_ = args.mm_image_do_rescale();
+  do_normalize_ = args.mm_image_do_normalize();
+  crop_size_ = std::make_pair(args.mm_image_crop_height_size(),
+                              args.mm_image_crop_width_size());
+  resample_ = args.mm_image_resample();
+  rescale_factor_ = args.mm_image_rescale_factor();
+  image_mean_ = args.mm_image_normalize_mean();
+  image_std_ = args.mm_image_normalize_std();
+  size_ = {args.mm_image_size_height(), args.mm_image_size_width()};
+}
+
+bool SiglipImageProcessor::process(const MMInput& mm_inputs, MMData& mm_datas) {
+  return false;
+}
+
+torch::Tensor SiglipImageProcessor::preprocess(const torch::Tensor& images) {
+  int64_t batch_size = images.size(0);
+  std::vector<torch::Tensor> processed_images;
+
+  for (int64_t i = 0; i < batch_size; ++i) {
+    torch::Tensor image = images[i];
+
+    if (do_resize_) {
+      image = resize(image, size_, resample_);
+    }
+
+    if (do_center_crop_) {
+      image = centerCrop(image, crop_size_);
+    }
+
+    if (do_rescale_) {
+      image = rescale(image, rescale_factor_);
+    }
+
+    if (do_normalize_) {
+      image = normalize(image, image_mean_, image_std_);
+    }
+
+    processed_images.push_back(image);
+  }
+
+  return torch::stack(processed_images);
+}
+
+}  // namespace xllm

--- a/xllm/processors/siglip_image_processor.h
+++ b/xllm/processors/siglip_image_processor.h
@@ -1,0 +1,49 @@
+/* Copyright 2026 The xLLM Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://github.com/jd-opensource/xllm/blob/main/LICENSE
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#pragma once
+
+#include <torch/torch.h>
+
+#include <vector>
+
+#include "core/util/tensor_helper.h"
+#include "image_processor.h"
+
+namespace xllm {
+
+class SiglipImageProcessor : public ImageProcessor {
+ public:
+  SiglipImageProcessor(const ModelArgs& args);
+  ~SiglipImageProcessor() override = default;
+  SiglipImageProcessor() = default;
+
+  bool process(const MMInput& mm_inputs, MMData& mm_datas) override;
+  torch::Tensor preprocess(const torch::Tensor& images);
+
+ private:
+  bool do_resize_;
+  bool do_center_crop_;
+  bool do_rescale_;
+  bool do_normalize_;
+  int64_t resample_;
+  double rescale_factor_;
+  std::pair<int64_t, int64_t> crop_size_;
+  std::vector<double> image_mean_;
+  std::vector<double> image_std_;
+  std::vector<int64_t> size_;
+};
+
+}  // namespace xllm

--- a/xllm/proto/image_generation.proto
+++ b/xllm/proto/image_generation.proto
@@ -85,6 +85,12 @@ message Parameters {
 
   // Output type, either "base64" or "url"
   // optional string output_type = 12;
+
+  // Scaling factor for prompt embeddings
+  optional float prompt_embeds_scale = 13;
+
+  // Scaling factor for pooled prompt embeddings
+  optional float pooled_prompt_embeds_scale = 14;
 }
 
 // Request structure for image generation tasks using FLUX models


### PR DESCRIPTION
This PR enables black-forest-labs/FLUX.1-Redux-dev to run on NPU devices.
The outputs prompt_embeds and pooled_prompt_embeds are not included yet and will be added in a later update.