### PR TITLE
bugfix: resolve test compile failed.

### DIFF
--- a/xllm/core/common/CMakeLists.txt
+++ b/xllm/core/common/CMakeLists.txt
@@ -64,7 +64,4 @@ cc_test(
     gflags::gflags
     glog::glog
 )
-target_link_libraries(common PRIVATE OpenSSL::SSL OpenSSL::Crypto protobuf::libprotobuf)
-add_dependencies(common brpc-static)
-
-
+target_link_libraries(common PRIVATE brpc-static OpenSSL::SSL OpenSSL::Crypto protobuf::libprotobuf)

--- a/xllm/core/framework/batch/CMakeLists.txt
+++ b/xllm/core/framework/batch/CMakeLists.txt
@@ -43,8 +43,11 @@ cc_test(
 target_link_libraries(batch_test
                       PUBLIC
                       Python::Python
+                      brpc-static
+                      OpenSSL::SSL
+                      OpenSSL::Crypto
+                      leveldb::leveldb
                       $<$<BOOL:${USE_NPU}>:ascendcl>
                       $<$<BOOL:${USE_NPU}>:hccl>
                       $<$<BOOL:${USE_NPU}>:c_sec>
                       $<$<BOOL:${USE_NPU}>:nnopbase>)
-

--- a/xllm/core/framework/eplb/CMakeLists.txt
+++ b/xllm/core/framework/eplb/CMakeLists.txt
@@ -45,4 +45,4 @@ cc_test(
     fmt::fmt
     GTest::gtest_main
 )
-
+target_link_libraries(eplb_policy_test PRIVATE brpc-static OpenSSL::SSL OpenSSL::Crypto leveldb::leveldb)

--- a/xllm/core/framework/sampling/CMakeLists.txt
+++ b/xllm/core/framework/sampling/CMakeLists.txt
@@ -40,7 +40,7 @@ cc_test(
     :sampler
     glog::glog
 )
-target_link_libraries(sampler_test PRIVATE brpc OpenSSL::SSL OpenSSL::Crypto leveldb::leveldb ZLIB::ZLIB protobuf::libprotobuf)
+target_link_libraries(sampler_test PRIVATE brpc-static OpenSSL::SSL OpenSSL::Crypto leveldb::leveldb ZLIB::ZLIB protobuf::libprotobuf)
 target_link_libraries(sampler_test
                       PUBLIC
                       Python::Python
@@ -48,4 +48,3 @@ target_link_libraries(sampler_test
                       $<$<BOOL:${USE_NPU}>:hccl>
                       $<$<BOOL:${USE_NPU}>:c_sec>
                       $<$<BOOL:${USE_NPU}>:nnopbase>)
-add_dependencies(sampler_test brpc-static)

--- a/xllm/core/layers/common/tests/CMakeLists.txt
+++ b/xllm/core/layers/common/tests/CMakeLists.txt
@@ -23,6 +23,7 @@ cc_test(
     torch
     GTest::gtest_main
 )
+target_link_libraries(layer_test PRIVATE leveldb::leveldb ZLIB::ZLIB protobuf::libprotobuf brpc-static OpenSSL::SSL OpenSSL::Crypto)
 
 # Add test for DeepEP
 # This test must exist individually, because it contains forked processes
@@ -43,3 +44,4 @@ cc_test(
     torch
     glog::glog
   )
+target_link_libraries(deep_ep_test PRIVATE leveldb::leveldb ZLIB::ZLIB protobuf::libprotobuf brpc-static OpenSSL::SSL OpenSSL::Crypto)

--- a/xllm/core/scheduler/CMakeLists.txt
+++ b/xllm/core/scheduler/CMakeLists.txt
@@ -56,3 +56,4 @@ cc_test(
     GTest::gtest_main
     $<$<BOOL:${USE_NPU}>:nnopbase>
 )
+target_link_libraries(chunked_prefill_scheduler_test PRIVATE brpc-static OpenSSL::SSL OpenSSL::Crypto leveldb::leveldb)

--- a/xllm/function_call/CMakeLists.txt
+++ b/xllm/function_call/CMakeLists.txt
@@ -46,6 +46,7 @@ function(add_detector_test TEST_NAME)
       GTest::gtest_main
       nlohmann_json::nlohmann_json
   )
+  target_link_libraries(${TEST_NAME} PRIVATE leveldb::leveldb ZLIB::ZLIB protobuf::libprotobuf brpc-static OpenSSL::SSL OpenSSL::Crypto)
 endfunction()
 
 add_detector_test(qwen25_detector_test)
@@ -53,4 +54,3 @@ add_detector_test(kimik2_detector_test)
 add_detector_test(deepseekv3_detector_test)
 add_detector_test(glm45_detector_test)
 add_detector_test(glm47_detector_test)
-


### PR DESCRIPTION
fix some compile errors for test, as follows:
```shell
FAILED: [code=1] /root/code/xllm/build/lib.linux-x86_64-cpython-312/xllm/eplb_policy_test 
: && /usr/bin/c++ -fPIC -Wno-format-truncation -DC10_USE_GLOG -g -Og  third_party/Mooncake/mooncake-transfer-engine/src/transport/tcp_transport/CMakeFiles/tcp_transport.dir/tcp_transport.cpp.o xllm/core/framework/eplb/CMakeFiles/eplb_policy_test.dir/eplb_policy_test.cpp.o -o /root/code/xllm/build/lib.linux-x86_64-cpython-312/xllm/eplb_policy_test -L/home/vipuser/miniconda3/envs/xllm/lib/python3.12/site-packages/torch   -L/home/vipuser/miniconda3/envs/xllm/lib/python3.12/site-packages/torch/lib   -L/usr/local/cuda/lib64   -L/home/vipuser/miniconda3/envs/xllm/lib/python3.12/site-packages/nvidia/cudnn/lib64   -L/home/vipuser/miniconda3/envs/xllm/lib/python3.12/site-packages/nvidia/cudnn/lib   -L/root/code/xllm/build/cmake.linux-x86_64-cpython-312/third_party/brpc/output/lib   -L/lib/intel64   -L/lib/intel64_win   -L/lib/win-x64 -Wl,-rpath,/home/vipuser/miniconda3/envs/xllm/lib/python3.12/site-packages/torch:/home/vipuser/miniconda3/envs/xllm/lib/python3.12/site-packages/torch/lib:/usr/local/cuda/lib64:/home/vipuser/miniconda3/envs/xllm/lib/python3.12/site-packages/nvidia/cudnn/lib64:/home/vipuser/miniconda3/envs/xllm/lib/python3.12/site-packages/nvidia/cudnn/lib:/root/code/xllm/build/cmake.linux-x86_64-cpython-312/third_party/brpc/output/lib:/lib/intel64:/lib/intel64_win:/lib/win-x64:/home/vipuser/miniconda3/envs/xllm/lib:/usr/local/cuda-12.4/targets/x86_64-linux/lib  xllm/core/framework/eplb/libeplb.a  vcpkg_installed/x64-linux/debug/lib/libfmtd.a  vcpkg_installed/x64-linux/debug/lib/manual-link/libgtest_main.a  xllm/core/framework/request/librequest.a  xllm/core/common/libcommon.a  xllm/core/framework/kv_cache/libkv_cache.a  xllm/core/framework/prefix_cache/libprefix_cache.a  xllm/core/framework/block/libblock.a  xllm/core/framework/tokenizer/libtokenizer.a  xllm/core/framework/chat_template/libchat_template.a  xllm/core/util/libutil.a  xllm/core/framework/xtensor/libxtensor.a  xllm/core/framework/request/librequest.a  xllm/core/common/libcommon.a  xllm/core/framework/kv_cache/libkv_cache.a  xllm/core/framework/prefix_cache/libprefix_cache.a  xllm/core/framework/block/libblock.a  xllm/core/framework/tokenizer/libtokenizer.a  xllm/core/framework/chat_template/libchat_template.a  xllm/core/util/libutil.a  xllm/core/framework/xtensor/libxtensor.a  vcpkg_installed/x64-linux/debug/lib/libopencv_highgui4d.a  vcpkg_installed/x64-linux/debug/lib/libopencv_ml4d.a  vcpkg_installed/x64-linux/debug/lib/libopencv_objdetect4d.a  vcpkg_installed/x64-linux/debug/lib/libquirc.a  vcpkg_installed/x64-linux/debug/lib/libopencv_photo4d.a  vcpkg_installed/x64-linux/debug/lib/libopencv_stitching4d.a  vcpkg_installed/x64-linux/debug/lib/libopencv_video4d.a  vcpkg_installed/x64-linux/debug/lib/libopencv_calib3d4d.a  vcpkg_installed/x64-linux/debug/lib/libopencv_features2d4d.a  vcpkg_installed/x64-linux/debug/lib/libopencv_flann4d.a  vcpkg_installed/x64-linux/debug/lib/libopencv_videoio4d.a  vcpkg_installed/x64-linux/debug/lib/libopencv_imgcodecs4d.a  vcpkg_installed/x64-linux/debug/lib/libjpeg.a  vcpkg_installed/x64-linux/debug/lib/libwebpdecoder.a  vcpkg_installed/x64-linux/debug/lib/libwebp.a  vcpkg_installed/x64-linux/debug/lib/libwebpdemux.a  vcpkg_installed/x64-linux/debug/lib/libwebpmux.a  vcpkg_installed/x64-linux/debug/lib/libsharpyuv.a  vcpkg_installed/x64-linux/debug/lib/libpng16d.a  vcpkg_installed/x64-linux/debug/lib/libtiffd.a  vcpkg_installed/x64-linux/debug/lib/liblzma.a  vcpkg_installed/x64-linux/debug/lib/libjpeg.a  vcpkg_installed/x64-linux/debug/lib/libwebpdecoder.a  vcpkg_installed/x64-linux/debug/lib/libwebp.a  vcpkg_installed/x64-linux/debug/lib/libwebpdemux.a  vcpkg_installed/x64-linux/debug/lib/libwebpmux.a  vcpkg_installed/x64-linux/debug/lib/libsharpyuv.a  vcpkg_installed/x64-linux/debug/lib/libpng16d.a  vcpkg_installed/x64-linux/debug/lib/libtiffd.a  vcpkg_installed/x64-linux/debug/lib/liblzma.a  vcpkg_installed/x64-linux/debug/lib/libOpenEXR-3_1_d.a  vcpkg_installed/x64-linux/debug/lib/libImath-3_1_d.a  vcpkg_installed/x64-linux/debug/lib/libIlmThread-3_1_d.a  vcpkg_installed/x64-linux/debug/lib/libIex-3_1_d.a  vcpkg_installed/x64-linux/debug/lib/libopencv_imgproc4d.a  vcpkg_installed/x64-linux/debug/lib/libopencv_core4d.a  vcpkg_installed/x64-linux/debug/lib/libavdevice.a  vcpkg_installed/x64-linux/debug/lib/libavfilter.a  vcpkg_installed/x64-linux/debug/lib/libavformat.a  vcpkg_installed/x64-linux/debug/lib/libavcodec.a  vcpkg_installed/x64-linux/debug/lib/libswresample.a  vcpkg_installed/x64-linux/debug/lib/libswscale.a  vcpkg_installed/x64-linux/debug/lib/libavutil.a  -lm  -latomic  third_party/cpprestsdk/Release/Binaries/libcpprest.a  -L/root/code/xllm/build/cmake.linux-x86_64-cpython-312/vcpkg_installed/x64-linux/lib/pkgconfig/../../lib  -lssl  -lcrypto  -ldl  -pthread  vcpkg_installed/x64-linux/lib/libboost_random.a  vcpkg_installed/x64-linux/lib/libboost_system.a  vcpkg_installed/x64-linux/lib/libboost_thread.a  vcpkg_installed/x64-linux/lib/libboost_filesystem.a  vcpkg_installed/x64-linux/lib/libboost_chrono.a  vcpkg_installed/x64-linux/lib/libboost_atomic.a  vcpkg_installed/x64-linux/lib/libboost_date_time.a  vcpkg_installed/x64-linux/lib/libboost_regex.a  third_party/etcd_cpp_apiv3/src/libetcd-cpp-api.a  third_party/cpprestsdk/Release/Binaries/libcpprest.a  vcpkg_installed/x64-linux/lib/libssl.a  vcpkg_installed/x64-linux/lib/libcrypto.a  vcpkg_installed/x64-linux/debug/lib/libgrpc++.a  vcpkg_installed/x64-linux/debug/lib/libgrpc.a  vcpkg_installed/x64-linux/debug/lib/libgpr.a  vcpkg_installed/x64-linux/debug/lib/libabsl_random_distributions.a  vcpkg_installed/x64-linux/debug/lib/libabsl_random_seed_sequences.a  vcpkg_installed/x64-linux/debug/lib/libabsl_random_internal_pool_urbg.a  vcpkg_installed/x64-linux/debug/lib/libabsl_random_internal_randen.a  vcpkg_installed/x64-linux/debug/lib/libabsl_random_internal_randen_hwaes.a  vcpkg_installed/x64-linux/debug/lib/libabsl_random_internal_randen_hwaes_impl.a  vcpkg_installed/x64-linux/debug/lib/libabsl_random_internal_randen_slow.a  vcpkg_installed/x64-linux/debug/lib/libabsl_random_internal_platform.a  vcpkg_installed/x64-linux/debug/lib/libabsl_random_internal_seed_material.a  vcpkg_installed/x64-linux/debug/lib/libabsl_random_seed_gen_exception.a  vcpkg_installed/x64-linux/debug/lib/libupb_json.a  vcpkg_installed/x64-linux/debug/lib/libupb_textformat.a  vcpkg_installed/x64-linux/debug/lib/libupb_reflection.a  vcpkg_installed/x64-linux/debug/lib/libupb_collections.a  vcpkg_installed/x64-linux/debug/lib/libupb_mini_table.a  vcpkg_installed/x64-linux/debug/lib/libupb.a  vcpkg_installed/x64-linux/debug/lib/libupb_fastdecode.a  vcpkg_installed/x64-linux/debug/lib/libupb_utf8_range.a  vcpkg_installed/x64-linux/debug/lib/libupb_extension_registry.a  vcpkg_installed/x64-linux/debug/lib/libdescriptor_upb_proto.a  vcpkg_installed/x64-linux/debug/lib/libcares.a  vcpkg_installed/x64-linux/debug/lib/libaddress_sorting.a  -lm  vcpkg_installed/x64-linux/debug/lib/libabsl_statusor.a  vcpkg_installed/x64-linux/debug/lib/libabsl_status.a  vcpkg_installed/x64-linux/debug/lib/libabsl_strerror.a  vcpkg_installed/x64-linux/debug/lib/libleveldb.a  third_party/Mooncake/mooncake-store/src/libmooncake_store.a  third_party/Mooncake/mooncake-transfer-engine/src/libtransfer_engine.a  vcpkg_installed/x64-linux/debug/lib/libcurl-d.a  vcpkg_installed/x64-linux/debug/lib/libz.a  third_party/Mooncake/mooncake-transfer-engine/src/common/base/libbase.a  -libverbs  -lpthread  vcpkg_installed/x64-linux/lib/libjsoncpp.a  -lnuma  -lrt  -libverbs  third_party/Mooncake/mooncake-store/src/cachelib_memory_allocator/libcachelib_memory_allocator.a  vcpkg_installed/x64-linux/debug/lib/libfolly.a  vcpkg_installed/x64-linux/debug/lib/libfmtd.a  vcpkg_installed/x64-linux/lib/libboost_context.a  vcpkg_installed/x64-linux/lib/libboost_filesystem.a  vcpkg_installed/x64-linux/lib/libboost_program_options.a  vcpkg_installed/x64-linux/lib/libboost_regex.a  vcpkg_installed/x64-linux/lib/libboost_system.a  vcpkg_installed/x64-linux/lib/libboost_thread.a  vcpkg_installed/x64-linux/lib/libboost_chrono.a  vcpkg_installed/x64-linux/lib/libboost_atomic.a  vcpkg_installed/x64-linux/debug/lib/libdouble-conversion.a  vcpkg_installed/x64-linux/debug/lib/libevent_extrad.a  vcpkg_installed/x64-linux/debug/lib/libevent_pthreadsd.a  vcpkg_installed/x64-linux/debug/lib/libevent_cored.a  vcpkg_installed/x64-linux/debug/lib/libssl.a  vcpkg_installed/x64-linux/debug/lib/libcrypto.a  third_party/sentencepiece/libsentencepiece.a  third_party/sentencepiece/libproto_sentencepiece.a  third_party/sentencepiece/libproto_sentencepiece_model.a  xllm/core/framework/tokenizer/tokenizers/x86_64-unknown-linux-gnu/debug/librust_tokenizers.a  vcpkg_installed/x64-linux/debug/lib/libre2.a  vcpkg_installed/x64-linux/debug/lib/libabsl_flags.a  vcpkg_installed/x64-linux/debug/lib/libabsl_flags_internal.a  vcpkg_installed/x64-linux/debug/lib/libabsl_flags_marshalling.a  vcpkg_installed/x64-linux/debug/lib/libabsl_flags_reflection.a  vcpkg_installed/x64-linux/debug/lib/libabsl_flags_config.a  vcpkg_installed/x64-linux/debug/lib/libabsl_flags_program_name.a  vcpkg_installed/x64-linux/debug/lib/libabsl_flags_private_handle_accessor.a  vcpkg_installed/x64-linux/debug/lib/libabsl_flags_commandlineflag.a  vcpkg_installed/x64-linux/debug/lib/libabsl_flags_commandlineflag_internal.a  vcpkg_installed/x64-linux/lib/libboost_serialization.a  vcpkg_installed/x64-linux/lib/libssl.a  vcpkg_installed/x64-linux/lib/libcrypto.a  -ldl  third_party/smhasher/src/libSMHasherSupport.a  -lbrpc  /home/vipuser/miniconda3/envs/xllm/lib/libpython3.12.so  xllm/core/distributed_runtime/libcollective_service.a  xllm/proto/libxllm_proto.a  vcpkg_installed/x64-linux/debug/lib/libabsl_cord.a  vcpkg_installed/x64-linux/debug/lib/libabsl_cordz_info.a  vcpkg_installed/x64-linux/debug/lib/libabsl_cord_internal.a  vcpkg_installed/x64-linux/debug/lib/libabsl_cordz_functions.a  vcpkg_installed/x64-linux/debug/lib/libabsl_cordz_handle.a  vcpkg_installed/x64-linux/debug/lib/libabsl_crc_cord_state.a  vcpkg_installed/x64-linux/debug/lib/libabsl_crc32c.a  vcpkg_installed/x64-linux/debug/lib/libabsl_str_format_internal.a  vcpkg_installed/x64-linux/debug/lib/libabsl_crc_internal.a  vcpkg_installed/x64-linux/debug/lib/libabsl_crc_cpu_detect.a  vcpkg_installed/x64-linux/debug/lib/libabsl_raw_hash_set.a  vcpkg_installed/x64-linux/debug/lib/libabsl_hash.a  vcpkg_installed/x64-linux/debug/lib/libabsl_bad_optional_access.a  vcpkg_installed/x64-linux/debug/lib/libabsl_bad_variant_access.a  vcpkg_installed/x64-linux/debug/lib/libabsl_city.a  vcpkg_installed/x64-linux/debug/lib/libabsl_low_level_hash.a  vcpkg_installed/x64-linux/debug/lib/libabsl_hashtablez_sampler.a  vcpkg_installed/x64-linux/debug/lib/libabsl_exponential_biased.a  vcpkg_installed/x64-linux/debug/lib/libabsl_synchronization.a  vcpkg_installed/x64-linux/debug/lib/libabsl_graphcycles_internal.a  vcpkg_installed/x64-linux/debug/lib/libabsl_kernel_timeout_internal.a  vcpkg_installed/x64-linux/debug/lib/libabsl_time.a  vcpkg_installed/x64-linux/debug/lib/libabsl_civil_time.a  vcpkg_installed/x64-linux/debug/lib/libabsl_time_zone.a  vcpkg_installed/x64-linux/debug/lib/libabsl_stacktrace.a  vcpkg_installed/x64-linux/debug/lib/libabsl_symbolize.a  vcpkg_installed/x64-linux/debug/lib/libabsl_strings.a  vcpkg_installed/x64-linux/debug/lib/libabsl_string_view.a  vcpkg_installed/x64-linux/debug/lib/libabsl_strings_internal.a  vcpkg_installed/x64-linux/debug/lib/libabsl_int128.a  vcpkg_installed/x64-linux/debug/lib/libabsl_throw_delegate.a  vcpkg_installed/x64-linux/debug/lib/libabsl_malloc_internal.a  vcpkg_installed/x64-linux/debug/lib/libabsl_debugging_internal.a  vcpkg_installed/x64-linux/debug/lib/libabsl_demangle_internal.a  vcpkg_installed/x64-linux/debug/lib/libabsl_base.a  vcpkg_installed/x64-linux/debug/lib/libabsl_raw_logging_internal.a  vcpkg_installed/x64-linux/debug/lib/libabsl_log_severity.a  vcpkg_installed/x64-linux/debug/lib/libabsl_spinlock_wait.a  -lrt  vcpkg_installed/x64-linux/debug/lib/libglog.a  vcpkg_installed/x64-linux/debug/lib/libgflags_debug.a  xllm/core/platform/libplatform.a  /home/vipuser/miniconda3/envs/xllm/lib/python3.12/site-packages/torch/lib/libtorch.so  -Wl,--no-as-needed,"/home/vipuser/miniconda3/envs/xllm/lib/python3.12/site-packages/torch/lib/libtorch_cpu.so" -Wl,--as-needed  vcpkg_installed/x64-linux/debug/lib/libprotobufd.a  vcpkg_installed/x64-linux/debug/lib/libz.a  -Wl,--no-as-needed,"/home/vipuser/miniconda3/envs/xllm/lib/python3.12/site-packages/torch/lib/libtorch_cuda.so" -Wl,--as-needed  /home/vipuser/miniconda3/envs/xllm/lib/python3.12/site-packages/torch/lib/libc10_cuda.so  /home/vipuser/miniconda3/envs/xllm/lib/python3.12/site-packages/torch/lib/libc10.so  /usr/local/cuda-12.4/targets/x86_64-linux/lib/libcudart.so  -lcuda  -lcudart  vcpkg_installed/x64-linux/debug/lib/libgtest.a && :
/usr/bin/ld: /root/code/xllm/build/cmake.linux-x86_64-cpython-312/third_party/brpc/output/lib/libbrpc.a(iobuf.cpp.o): in function `butil::IOBuf::cut_into_SSL_channel(ssl_st*, int*)':
/root/code/xllm/third_party/brpc/src/butil/iobuf.cpp:1031: undefined reference to `ERR_clear_error'
/usr/bin/ld: /root/code/xllm/third_party/brpc/src/butil/iobuf.cpp:1032: undefined reference to `SSL_write'
/usr/bin/ld: /root/code/xllm/third_party/brpc/src/butil/iobuf.cpp:1036: undefined reference to `SSL_get_error'
/usr/bin/ld: /root/code/xllm/build/cmake.linux-x86_64-cpython-312/third_party/brpc/output/lib/libbrpc.a(iobuf.cpp.o): in function `butil::IOBuf::cut_multiple_into_SSL_channel(ssl_st*, butil::IOBuf* const*, unsigned long, int*)':
/root/code/xllm/third_party/brpc/src/butil/iobuf.cpp:1074: undefined reference to `SSL_get_wbio'
/usr/bin/ld: /root/code/xllm/third_party/brpc/src/butil/iobuf.cpp:1075: undefined reference to `BIO_ctrl'
/usr/bin/ld: /root/code/xllm/third_party/brpc/src/butil/iobuf.cpp:1057: undefined reference to `BIO_fd_non_fatal_error'
/usr/bin/ld: /root/code/xllm/third_party/brpc/src/butil/iobuf.cpp:1076: undefined reference to `BIO_ctrl'
/usr/bin/ld: /root/code/xllm/third_party/brpc/src/butil/iobuf.cpp:1077: undefined reference to `BIO_fd_non_fatal_error'
/usr/bin/ld: /root/code/xllm/build/cmake.linux-x86_64-cpython-312/third_party/brpc/output/lib/libbrpc.a(iobuf.cpp.o): in function `butil::IOPortal::append_from_SSL_channel(ssl_st*, int*, unsigned long)':
/root/code/xllm/third_party/brpc/src/butil/iobuf.cpp:1753: undefined reference to `ERR_clear_error'
/usr/bin/ld: /root/code/xllm/third_party/brpc/src/butil/iobuf.cpp:1754: undefined reference to `SSL_read'
/usr/bin/ld: /root/code/xllm/third_party/brpc/src/butil/iobuf.cpp:1755: undefined reference to `SSL_get_error'
/usr/bin/ld: /root/code/xllm/third_party/brpc/src/butil/iobuf.cpp:1770: undefined reference to `BIO_fd_non_fatal_error'
collect2: error: ld returned 1 exit status
```