### PR TITLE
feat: add qwen3/LlmRec support in rec framework [6/8].

### DIFF
--- a/xllm/core/common/rec_model_utils.h
+++ b/xllm/core/common/rec_model_utils.h
@@ -26,6 +26,25 @@ enum class RecModelKind : int8_t {
   kLlmRec = 2,
 };
 
+// Pipeline strategy types (extensible for future strategies)
+enum class RecPipelineType : uint8_t {
+  kLlmRecDefault = 0,     // LlmRec without mm_data (pure qwen)
+  kLlmRecWithMmData = 1,  // LlmRec with mm_data (qwen + embedding)
+  kOneRecDefault = 2,     // OneRec
+};
+
+// Pipeline strategy selector: choose strategy based on RecModelKind
+inline RecPipelineType get_rec_pipeline_type(RecModelKind kind) {
+  switch (kind) {
+    case RecModelKind::kLlmRec:
+      return RecPipelineType::kLlmRecDefault;
+    case RecModelKind::kOneRec:
+      return RecPipelineType::kOneRecDefault;
+    default:
+      return RecPipelineType::kLlmRecDefault;
+  }
+}
+
 inline constexpr bool is_onerec_model_type(std::string_view model_type) {
   return model_type == "onerec";
 }

--- a/xllm/core/distributed_runtime/dist_manager.cpp
+++ b/xllm/core/distributed_runtime/dist_manager.cpp
@@ -130,6 +130,8 @@ void DistManager::setup_multi_node_workers(
   } else if (model_backend == "vlm") {
     worker_type = (options.task_type() == "generate") ? WorkerType::VLM
                                                       : WorkerType::EVLM;
+  } else if (model_backend == "rec") {
+    worker_type = WorkerType::REC;
   } else {
     LOG(ERROR) << "Unsupported " << model_backend << " in multi-node.";
   }

--- a/xllm/core/distributed_runtime/rec_engine.cpp
+++ b/xllm/core/distributed_runtime/rec_engine.cpp
@@ -18,19 +18,32 @@ limitations under the License.
 #include <glog/logging.h>
 
 #include <algorithm>
+#include <chrono>
+#include <functional>
+#include <map>
 #include <memory>
 
+#include "common/global_flags.h"
 #include "common/metrics.h"
+#include "common/rec_model_utils.h"
 #include "framework/model/model_args.h"
 #include "framework/model_loader.h"
 #include "framework/parallel_state/parallel_state.h"
+#include "framework/request/rec_type.h"
+#include "util/env_var.h"
 #include "util/pretty_print.h"
 #include "util/timer.h"
 #include "util/utils.h"
 
 namespace xllm {
 
-RecEngine::RecEngine(const runtime::Options& options) : options_(options) {
+// ============================================================
+// RecEngine Implementation
+// ============================================================
+
+RecEngine::RecEngine(const runtime::Options& options,
+                     std::shared_ptr<DistManager> dist_manager)
+    : options_(options), dist_manager_(dist_manager) {
   const auto& devices = options_.devices();
   CHECK_GT(devices.size(), 0) << "At least one device is required";
 
@@ -39,33 +52,6 @@ RecEngine::RecEngine(const runtime::Options& options) : options_(options) {
   for (const auto device : devices) {
     CHECK_EQ(device.type(), device_type)
         << "All devices should be the same type";
-  }
-
-  // initialize process groups if there are multiple devices
-  if (devices.size() > 1) {
-    // create a process group for each device if there are multiple gpus
-    process_groups_ = parallel_state::create_npu_process_groups(devices);
-  }
-
-  WorkerType worker_type = WorkerType::REC;
-  const int32_t world_size = static_cast<int32_t>(devices.size());
-  for (size_t i = 0; i < devices.size(); ++i) {
-    const int32_t rank = static_cast<int32_t>(i);
-    ProcessGroup* pg = world_size > 1 ? process_groups_[i].get() : nullptr;
-    ParallelArgs parallel_args(rank, world_size, pg);
-    workers_.emplace_back(std::make_unique<Worker>(
-        parallel_args, devices[i], options_, worker_type));
-  }
-
-  if (workers_.size() > 1) {
-    // test process group
-    std::vector<folly::SemiFuture<folly::Unit>> futures;
-    futures.reserve(workers_.size());
-    for (auto& worker : workers_) {
-      futures.emplace_back(worker->process_group_test_async());
-    }
-    // wait up to 4 seconds for all futures to complete
-    folly::collectAll(futures).within(std::chrono::seconds(4)).get();
   }
 }
 
@@ -90,7 +76,6 @@ bool RecEngine::init_model() {
   auto model_loader = ModelLoader::create(model_path);
   LOG(INFO) << "Initializing model from: " << model_path;
 
-  // RecEngine does not use tokenizer
   tokenizer_ = model_loader->tokenizer();
   CHECK(tokenizer_ != nullptr);
 
@@ -98,82 +83,62 @@ bool RecEngine::init_model() {
   quant_args_ = model_loader->quant_args();
   tokenizer_args_ = model_loader->tokenizer_args();
 
-  // compute the number of local kv heads and head dim
-  const int world_size = static_cast<int>(workers_.size());
+  // Determine rec model kind and create pipeline via factory
+  rec_model_kind_ = get_rec_model_kind(args_.model_type());
+  auto pipeline_type = get_rec_pipeline_type(rec_model_kind_);
+  pipeline_ = create_pipeline(pipeline_type, *this);
+
+  // LlmRec-specific initialization
+  if (rec_model_kind_ == RecModelKind::kLlmRec) {
+#if defined(USE_NPU)
+    FLAGS_enable_atb_comm_multiprocess =
+        options_.enable_offline_inference() || (options_.nnodes() > 1);
+#endif
+
+    auto master_node_addr = options_.master_node_addr().value_or("");
+    CHECK(!master_node_addr.empty())
+        << "REC(kLlmRec) need to set master node addr, "
+           "Please set --master_node_addr.";
+  }
+
+  // Pipeline-specific setup
+  pipeline_->setup_workers();
+  pipeline_->process_group_test();
+
+  if (!threadpool_) {
+    threadpool_ = std::make_unique<ThreadPool>(16);
+  }
+
+  // Compute KV cache config (shared logic)
+  const int world_size = static_cast<int>(pipeline_->num_workers());
   const int64_t n_heads = args_.n_heads();
   const int64_t n_kv_heads = args_.n_kv_heads().value_or(n_heads);
   n_local_kv_heads_ = std::max<int64_t>(1, n_kv_heads / world_size);
   head_dim_ = args_.head_dim();
   dtype_ = xllm::util::parse_dtype(args_.dtype(), options_.devices()[0]);
 
-  // key + value for all layers
   LOG(INFO) << "Block info, block_size: " << options_.block_size()
             << ", n_local_kv_heads: " << n_local_kv_heads_
             << ", head_dim: " << head_dim_ << ", n_layers: " << args_.n_layers()
             << ", dtype: " << dtype_;
-
-  // RecEngine does not use tokenizer, skip vocab_size check
-
   LOG(INFO) << "Initializing model with " << args_;
   LOG(INFO) << "Initializing model with quant args: " << quant_args_;
   LOG(INFO) << "Initializing model with tokenizer args: " << tokenizer_args_;
 
-  // init model for each worker in parallel
-  // multiple workers, call async init
-  std::vector<folly::SemiFuture<bool>> futures;
-  futures.reserve(workers_.size());
-  for (auto& worker : workers_) {
-    futures.push_back(worker->init_model_async(model_path, FLAGS_random_seed));
-  }
-  // wait for all futures to complete
-  auto results = folly::collectAll(futures).get();
-  for (const auto& result : results) {
-    if (!result.value()) {
-      return false;
-    }
-  }
-
-  return true;
+  // Pipeline-specific model initialization
+  return pipeline_->init_model_workers(model_path);
 }
 
 Engine::KVCacheCapacity RecEngine::estimate_kv_cache_capacity() {
   const int64_t max_cache_size = options_.max_cache_size();
   const double max_memory_utilization = options_.max_memory_utilization();
 
-  const auto& device = workers_[0]->device();
-  // call worker to profile memory usage
-  std::vector<folly::SemiFuture<std::tuple<int64_t, int64_t>>> futures;
-  futures.reserve(workers_.size());
-  for (auto& worker : workers_) {
-    futures.push_back(worker->estimate_kv_cache_capacity_async());
-  }
+  int64_t cache_size_in_bytes = pipeline_->estimate_min_available_memory();
 
-  // pick smallest available memory from all devices
-  int64_t cache_size_in_bytes = std::numeric_limits<int64_t>::max();
-  // wait for all futures to complete
-  auto results = folly::collectAll(futures).get();
-  for (size_t i = 0; i < results.size(); ++i) {
-    const auto device = workers_[i]->device();
-    if (!results[i].hasValue()) {
-      LOG(ERROR) << "Failed to profile memory usage for device: " << device;
-      continue;
-    }
-    auto [available_memory, total_memory] = results[i].value();
-    LOG(INFO) << device
-              << ": available memory: " << readable_size(available_memory)
-              << ", total memory: " << readable_size(total_memory)
-              << ", Using max_memory_utilization: " << max_memory_utilization
-              << ", max_cache_size: " << readable_size(max_cache_size);
-    // apply memory cap from config if it is set
-    if (max_memory_utilization < 1.0) {
-      const int64_t buffer_memory =
-          total_memory * (1.0 - max_memory_utilization);
-      available_memory -= buffer_memory;
-    }
-    if (max_cache_size > 0) {
-      available_memory = std::min(available_memory, max_cache_size);
-    }
-    cache_size_in_bytes = std::min(cache_size_in_bytes, available_memory);
+  // apply memory cap from config
+  if (max_memory_utilization < 1.0 || max_cache_size > 0) {
+    // Re-estimate with caps applied (pipeline returns raw available memory)
+    // The caps are applied in estimate_min_available_memory
   }
 
   KVCacheCapacity kv_cache_cap;
@@ -182,16 +147,15 @@ Engine::KVCacheCapacity RecEngine::estimate_kv_cache_capacity() {
       << "Available kv cache size must be greater than 0";
 
   // compute kv cache slot size
-  const auto dtype_size = torch::scalarTypeToTypeMeta(dtype_).itemsize();
-  // key + value for all layers
-  const int64_t slot_size =
-      2 * n_local_kv_heads_ * head_dim_ * args_.n_layers() * dtype_size;
+  const int64_t dtype_size = torch::scalarTypeToTypeMeta(dtype_).itemsize();
+  const int64_t slot_size = 2 * dtype_size * head_dim_ * n_local_kv_heads_;
   kv_cache_cap.slot_size = slot_size;
+  kv_cache_cap.n_layers = args_.n_layers();
 
-  // compute kv blocks num
   const int32_t block_size = options_.block_size();
   const int64_t block_size_in_bytes = block_size * slot_size;
-  kv_cache_cap.n_blocks = cache_size_in_bytes / block_size_in_bytes;
+  kv_cache_cap.n_blocks = kv_cache_cap.cache_size_in_bytes /
+                          (args_.n_layers() * block_size_in_bytes);
   CHECK_GT(kv_cache_cap.n_blocks, 0) << "no n_blocks for kv cache";
 
   return kv_cache_cap;
@@ -212,6 +176,11 @@ bool RecEngine::allocate_kv_cache(const Engine::KVCacheCapacity& kv_cache_cap) {
       kv_cache_cap.n_blocks, block_size, n_local_kv_heads_, head_dim_});
   kv_cache_shape.emplace_back(std::vector<int64_t>{
       kv_cache_cap.n_blocks, block_size, n_local_kv_heads_, head_dim_});
+#if defined(USE_MLU)
+  for (auto& shape : kv_cache_shape) {
+    std::swap(shape[1], shape[2]);
+  }
+#endif
 
   LOG(INFO) << "Initializing k cache with shape: [" << kv_cache_shape[0] << "]";
   LOG(INFO) << "Initializing v cache with shape: [" << kv_cache_shape[1] << "]";
@@ -219,20 +188,68 @@ bool RecEngine::allocate_kv_cache(const Engine::KVCacheCapacity& kv_cache_cap) {
   // initialize block manager
   BlockManagerPool::Options options;
   options.num_blocks(kv_cache_cap.n_blocks)
-      .host_num_blocks(kv_cache_cap.n_blocks)
+      .host_num_blocks(0)
       .block_size(block_size)
       .enable_prefix_cache(options_.enable_prefix_cache())
       .enable_disagg_pd(options_.enable_disagg_pd())
       .enable_cache_upload(options_.enable_cache_upload());
-  kv_cache_manager_ = std::make_unique<BlockManagerPool>(options);
+  kv_cache_manager_ = std::make_unique<BlockManagerPool>(options, dp_size_);
 
-  // init kv cache for each worker in parallel
-  std::vector<folly::SemiFuture<bool>> futures;
-  futures.reserve(workers_.size());
-  for (auto& worker : workers_) {
-    futures.push_back(worker->allocate_kv_cache_async(kv_cache_shape));
+  return pipeline_->allocate_kv_cache(kv_cache_shape);
+}
+
+ForwardOutput RecEngine::step(std::vector<Batch>& batches) {
+  return pipeline_->step(batches);
+}
+
+void RecEngine::update_last_step_result(std::vector<Batch>& batch) {
+  UNUSED_PARAMETER(batch);
+}
+
+std::vector<int64_t> RecEngine::get_active_activation_memory() const {
+  return pipeline_->get_active_activation_memory();
+}
+
+// ============================================================
+// LlmRecEnginePipeline Implementation
+// ============================================================
+
+RecEngine::LlmRecEnginePipeline::LlmRecEnginePipeline(RecEngine& engine)
+    : RecEnginePipeline(engine) {}
+
+void RecEngine::LlmRecEnginePipeline::setup_workers() {
+  if (!engine_.dist_manager_) {
+    engine_.dist_manager_ = std::make_shared<DistManager>(engine_.options_);
   }
-  // wait for all futures to complete
+  engine_.worker_clients_ = engine_.dist_manager_->get_worker_clients();
+  engine_.dp_size_ = engine_.options_.dp_size();
+  engine_.worker_clients_num_ = engine_.worker_clients_.size();
+  engine_.dp_local_tp_size_ = engine_.worker_clients_num_ / engine_.dp_size_;
+}
+
+void RecEngine::LlmRecEnginePipeline::process_group_test() {
+#if !defined(USE_NPU)
+  if (engine_.worker_clients_num_ > 1) {
+    std::vector<folly::SemiFuture<folly::Unit>> futures;
+    futures.reserve(engine_.worker_clients_num_);
+    for (auto& worker : engine_.worker_clients_) {
+      futures.emplace_back(worker->process_group_test_async());
+    }
+    const int timeout_seconds = util::get_process_group_test_timeout_seconds();
+    folly::collectAll(futures)
+        .within(std::chrono::seconds(timeout_seconds))
+        .get();
+  }
+#endif
+}
+
+bool RecEngine::LlmRecEnginePipeline::init_model_workers(
+    const std::string& model_path) {
+  std::vector<folly::SemiFuture<bool>> futures;
+  futures.reserve(engine_.worker_clients_num_);
+  for (auto& worker : engine_.worker_clients_) {
+    futures.push_back(worker->init_model_async(model_path, FLAGS_random_seed));
+  }
   auto results = folly::collectAll(futures).get();
   for (const auto& result : results) {
     if (!result.value()) {
@@ -242,40 +259,362 @@ bool RecEngine::allocate_kv_cache(const Engine::KVCacheCapacity& kv_cache_cap) {
   return true;
 }
 
-// RecEngine executes model: prefill + decode steps
-// Similar to LLMEngine but simplified for rec model
-ForwardOutput RecEngine::step(std::vector<Batch>& batches) {
-  if (workers_.empty()) {
-    // empty worker, return
+int64_t RecEngine::LlmRecEnginePipeline::estimate_min_available_memory() {
+  const int64_t max_cache_size = engine_.options_.max_cache_size();
+  const double max_memory_utilization =
+      engine_.options_.max_memory_utilization();
+
+  std::vector<folly::SemiFuture<std::tuple<int64_t, int64_t>>> futures;
+  futures.reserve(engine_.worker_clients_.size());
+  for (auto& worker : engine_.worker_clients_) {
+    futures.push_back(worker->estimate_kv_cache_capacity_async());
+  }
+
+  int64_t cache_size_in_bytes = std::numeric_limits<int64_t>::max();
+  auto results = folly::collectAll(futures).get();
+  for (size_t i = 0; i < results.size(); ++i) {
+    if (!results[i].hasValue()) {
+      LOG(ERROR) << "Failed to profile memory usage for worker: " << i;
+      continue;
+    }
+    auto [available_memory, total_memory] = results[i].value();
+    LOG(INFO) << "worker #" << i
+              << ": available memory: " << readable_size(available_memory)
+              << ", total memory: " << readable_size(total_memory)
+              << ". Using max_memory_utilization: " << max_memory_utilization
+              << ", max_cache_size: " << readable_size(max_cache_size);
+    if (max_memory_utilization < 1.0) {
+      const int64_t buffer_memory =
+          total_memory * (1.0 - max_memory_utilization);
+      available_memory -= buffer_memory;
+    }
+    if (max_cache_size > 0) {
+      available_memory = std::min(available_memory, max_cache_size);
+    }
+    cache_size_in_bytes = std::min(cache_size_in_bytes, available_memory);
+  }
+  return cache_size_in_bytes;
+}
+
+bool RecEngine::LlmRecEnginePipeline::allocate_kv_cache(
+    const std::vector<std::vector<int64_t>>& kv_cache_shape) {
+  std::vector<folly::SemiFuture<bool>> futures;
+  futures.reserve(engine_.worker_clients_.size());
+  for (auto& worker : engine_.worker_clients_) {
+    futures.push_back(worker->allocate_kv_cache_async(kv_cache_shape));
+  }
+  auto results = folly::collectAll(futures).get();
+  for (const auto& result : results) {
+    if (!result.value()) {
+      return false;
+    }
+  }
+  return true;
+}
+
+size_t RecEngine::LlmRecEnginePipeline::num_workers() const {
+  if (engine_.dp_size_ > 1) {
+    return engine_.dp_local_tp_size_;
+  }
+  return engine_.worker_clients_.size();
+}
+
+std::vector<RawForwardInput> RecEngine::LlmRecEnginePipeline::prepare_inputs(
+    std::vector<Batch>& batch) {
+  std::vector<RawForwardInput> batched_inputs;
+  batched_inputs.reserve(engine_.dp_size_);
+
+  std::vector<int32_t> dp_global_token_nums(engine_.dp_size_);
+  std::vector<int32_t> dp_is_decode(engine_.dp_size_, 0);
+  bool global_empty_kv_cache = true;
+  BatchForwardType batch_forward_type;
+
+  for (int32_t dp_rank = 0; dp_rank < engine_.dp_size_; ++dp_rank) {
+    // kLlmRec needs refresh_forward_type for correct dp_is_decode
+    batch[dp_rank].refresh_forward_type();
+
+    batched_inputs.emplace_back(std::move(batch[dp_rank].prepare_forward_input(
+        engine_.args_, engine_.threadpool_.get())));
+    dp_global_token_nums[dp_rank] =
+        batched_inputs[dp_rank].flatten_tokens_vec.size();
+    global_empty_kv_cache =
+        batched_inputs[dp_rank].empty_kv_cache && global_empty_kv_cache;
+    if (batch_forward_type.is_empty() &&
+        !batched_inputs[dp_rank].batch_forward_type.is_empty()) {
+      batch_forward_type = batched_inputs[dp_rank].batch_forward_type;
+    }
+    dp_is_decode[dp_rank] = batch_forward_type.is_decode() &&
+                            batched_inputs[dp_rank].q_max_seq_len == 1;
+  }
+
+  for (int32_t dp_rank = 0; dp_rank < engine_.dp_size_; ++dp_rank) {
+    batched_inputs[dp_rank].dp_global_token_nums = dp_global_token_nums;
+    batched_inputs[dp_rank].dp_is_decode = dp_is_decode;
+    batched_inputs[dp_rank].global_empty_kv_cache = global_empty_kv_cache;
+    if (batched_inputs[dp_rank].batch_forward_type.is_empty()) {
+      batched_inputs[dp_rank].batch_forward_type = batch_forward_type;
+    }
+  }
+
+  return batched_inputs;
+}
+
+ForwardOutput RecEngine::LlmRecEnginePipeline::step(
+    std::vector<Batch>& batches) {
+  if (engine_.worker_clients_.empty()) {
+    return {};
+  }
+
+  DCHECK(engine_.dp_size_ == static_cast<int32_t>(batches.size()))
+      << "Split DP batch failed with dp_size as " << engine_.dp_size_
+      << " and actual batch size as " << batches.size() << ".";
+
+  auto run_one_step = [this, &batches](int step_idx) -> bool {
+    Timer timer;
+    auto raw_forward_inputs = prepare_inputs(batches);
+    COUNTER_ADD(prepare_input_latency_microseconds,
+                timer.elapsed_microseconds());
+
+    const bool all_empty =
+        std::all_of(raw_forward_inputs.begin(),
+                    raw_forward_inputs.end(),
+                    [](const RawForwardInput& input) {
+                      return input.flatten_tokens_vec.empty();
+                    });
+    if (all_empty) {
+      return false;
+    }
+
+    std::vector<folly::SemiFuture<std::optional<RawForwardOutput>>> futures;
+    futures.reserve(engine_.worker_clients_num_);
+
+    timer.reset();
+    for (size_t worker_rank = 0; worker_rank < engine_.worker_clients_num_;
+         ++worker_rank) {
+      auto dp_rank = worker_rank / engine_.dp_local_tp_size_;
+      futures.emplace_back(engine_.worker_clients_[worker_rank]->step_async(
+          raw_forward_inputs[dp_rank]));
+    }
+    auto results = folly::collectAll(futures).get();
+
+    if (step_idx == 0) {
+      COUNTER_ADD(rec_first_token_latency_microseconds,
+                  timer.elapsed_microseconds());
+    } else if (step_idx == 1) {
+      COUNTER_ADD(rec_second_token_latency_microseconds,
+                  timer.elapsed_microseconds());
+    } else if (step_idx == 2) {
+      COUNTER_ADD(rec_third_token_latency_microseconds,
+                  timer.elapsed_microseconds());
+    }
+
+    timer.reset();
+    size_t dp_rank = 0;
+    for (size_t worker_rank = 0; worker_rank < engine_.worker_clients_num_;
+         worker_rank += engine_.dp_local_tp_size_) {
+      auto result = results[worker_rank].value();
+      if (!result.has_value()) {
+        LOG(FATAL) << "Failed to execute model, result has no value";
+      }
+      if (result.value().src_seq_idxes.empty()) {
+        batches[dp_rank].process_sample_output(result.value(), false);
+      } else {
+        batches[dp_rank].process_beam_search_output(result.value(), false);
+        // Transfer src_blocks_ to blocks_ for beam search sequences
+        // RecEngine doesn't have Scheduler/BlockManagerPool to trigger this
+        for (size_t i = 0; i < batches[dp_rank].size(); ++i) {
+          auto* seq = batches[dp_rank][i];
+          if (seq->check_beam_search() &&
+              !seq->kv_state().src_blocks().empty()) {
+            seq->kv_state().process_beam_search(std::nullopt);
+          }
+        }
+      }
+      // Refresh sequences_ from sequence_groups_ after beam search processing.
+      // This is needed because SequencesGroup::process_beam_search() replaces
+      // its internal sequences_, invalidating pointers in Batch::sequences_.
+      batches[dp_rank].refresh_sequences_from_groups();
+      ++dp_rank;
+    }
+    COUNTER_ADD(rec_sampling_latency_microseconds,
+                timer.elapsed_microseconds());
+    return true;
+  };
+
+  for (size_t step_idx = 0; step_idx < kRecTotalSteps; ++step_idx) {
+    if (!run_one_step(step_idx)) {
+      break;
+    }
+  }
+
+  for (auto& batch : batches) {
+    batch.finish();
+  }
+  return {};
+}
+
+std::vector<int64_t>
+RecEngine::LlmRecEnginePipeline::get_active_activation_memory() const {
+  std::vector<folly::SemiFuture<int64_t>> futures;
+  futures.reserve(engine_.worker_clients_.size());
+  for (auto& worker : engine_.worker_clients_) {
+    futures.push_back(worker->get_active_activation_memory_async());
+  }
+
+  auto results = folly::collectAll(futures).get();
+  std::vector<int64_t> active_activation_memories;
+  active_activation_memories.reserve(futures.size());
+  for (auto& result : results) {
+    active_activation_memories.push_back(result.value());
+  }
+  return active_activation_memories;
+}
+
+// ============================================================
+// OneRecEnginePipeline Implementation
+// ============================================================
+
+RecEngine::OneRecEnginePipeline::OneRecEnginePipeline(RecEngine& engine)
+    : RecEnginePipeline(engine) {}
+
+void RecEngine::OneRecEnginePipeline::setup_workers() {
+  // OneRec uses local workers, no DistManager setup needed
+}
+
+void RecEngine::OneRecEnginePipeline::process_group_test() {
+  if (engine_.workers_.size() > 1) {
+    std::vector<folly::SemiFuture<folly::Unit>> futures;
+    futures.reserve(engine_.workers_.size());
+    for (auto& worker : engine_.workers_) {
+      futures.emplace_back(worker->process_group_test_async());
+    }
+    const int timeout_seconds = util::get_process_group_test_timeout_seconds();
+    folly::collectAll(futures)
+        .within(std::chrono::seconds(timeout_seconds))
+        .get();
+  }
+}
+
+bool RecEngine::OneRecEnginePipeline::init_model_workers(
+    const std::string& model_path) {
+  const auto& devices = engine_.options_.devices();
+  if (devices.size() > 1) {
+    engine_.process_groups_ =
+        parallel_state::create_npu_process_groups(devices);
+  }
+
+  engine_.workers_.clear();
+  WorkerType worker_type = WorkerType::REC;
+  const int32_t world_size = static_cast<int32_t>(devices.size());
+  for (size_t i = 0; i < devices.size(); ++i) {
+    const int32_t rank = static_cast<int32_t>(i);
+    ProcessGroup* pg =
+        world_size > 1 ? engine_.process_groups_[i].get() : nullptr;
+    ParallelArgs parallel_args(rank, world_size, pg);
+    engine_.workers_.emplace_back(std::make_unique<Worker>(
+        parallel_args, devices[i], engine_.options_, worker_type));
+  }
+
+  std::vector<folly::SemiFuture<bool>> futures;
+  futures.reserve(engine_.workers_.size());
+  for (auto& worker : engine_.workers_) {
+    futures.push_back(worker->init_model_async(model_path, FLAGS_random_seed));
+  }
+  auto results = folly::collectAll(futures).get();
+  for (const auto& result : results) {
+    if (!result.value()) {
+      return false;
+    }
+  }
+  return true;
+}
+
+int64_t RecEngine::OneRecEnginePipeline::estimate_min_available_memory() {
+  const int64_t max_cache_size = engine_.options_.max_cache_size();
+  const double max_memory_utilization =
+      engine_.options_.max_memory_utilization();
+
+  std::vector<folly::SemiFuture<std::tuple<int64_t, int64_t>>> futures;
+  futures.reserve(engine_.workers_.size());
+  for (auto& worker : engine_.workers_) {
+    futures.push_back(worker->estimate_kv_cache_capacity_async());
+  }
+
+  int64_t cache_size_in_bytes = std::numeric_limits<int64_t>::max();
+  auto results = folly::collectAll(futures).get();
+  for (size_t i = 0; i < results.size(); ++i) {
+    if (!results[i].hasValue()) {
+      LOG(ERROR) << "Failed to profile memory usage for worker: " << i;
+      continue;
+    }
+    auto [available_memory, total_memory] = results[i].value();
+    LOG(INFO) << "worker #" << i
+              << ": available memory: " << readable_size(available_memory)
+              << ", total memory: " << readable_size(total_memory)
+              << ". Using max_memory_utilization: " << max_memory_utilization
+              << ", max_cache_size: " << readable_size(max_cache_size);
+    if (max_memory_utilization < 1.0) {
+      const int64_t buffer_memory =
+          total_memory * (1.0 - max_memory_utilization);
+      available_memory -= buffer_memory;
+    }
+    if (max_cache_size > 0) {
+      available_memory = std::min(available_memory, max_cache_size);
+    }
+    cache_size_in_bytes = std::min(cache_size_in_bytes, available_memory);
+  }
+  return cache_size_in_bytes;
+}
+
+bool RecEngine::OneRecEnginePipeline::allocate_kv_cache(
+    const std::vector<std::vector<int64_t>>& kv_cache_shape) {
+  std::vector<folly::SemiFuture<bool>> futures;
+  futures.reserve(engine_.workers_.size());
+  for (auto& worker : engine_.workers_) {
+    futures.push_back(worker->allocate_kv_cache_async(kv_cache_shape));
+  }
+  auto results = folly::collectAll(futures).get();
+  for (const auto& result : results) {
+    if (!result.value()) {
+      return false;
+    }
+  }
+  return true;
+}
+
+size_t RecEngine::OneRecEnginePipeline::num_workers() const {
+  return engine_.workers_.size();
+}
+
+ForwardOutput RecEngine::OneRecEnginePipeline::step(
+    std::vector<Batch>& batches) {
+  if (engine_.workers_.empty()) {
     return {};
   }
 
   Timer timer;
-  auto forward_inputs = workers_[0]->prepare_inputs(batches[0]);
+  // OneRec does not need refresh_forward_type
+  auto forward_inputs = engine_.workers_[0]->prepare_inputs(batches[0]);
   COUNTER_ADD(prepare_input_latency_microseconds, timer.elapsed_microseconds());
 
   if (!forward_inputs.token_ids.defined()) {
-    // empty input, just return
     return {};
   }
 
   timer.reset();
-  // Prefill step: Run the first model execution
   const auto& prefill_output = get_model_output(forward_inputs);
   COUNTER_ADD(rec_first_token_latency_microseconds,
               timer.elapsed_microseconds());
 
   timer.reset();
-  // Use process_sample_output from Batch class (same as LLMEngine)
   batches[0].process_sample_output(prefill_output.sample_output, false);
   COUNTER_ADD(rec_sampling_latency_microseconds, timer.elapsed_microseconds());
 
-  // Decode steps: Run the model 2 more times for decoding
   ForwardOutput decode_output;
-
-  for (int i = 0; i < 2; ++i) {
+  for (size_t i = 0; i < kRecDecodeSteps; ++i) {
     timer.reset();
-    forward_inputs = workers_[0]->prepare_inputs(batches[0]);
+    // OneRec does not need refresh_forward_type
+    forward_inputs = engine_.workers_[0]->prepare_inputs(batches[0]);
     COUNTER_ADD(prepare_input_latency_microseconds,
                 timer.elapsed_microseconds());
 
@@ -290,53 +629,62 @@ ForwardOutput RecEngine::step(std::vector<Batch>& batches) {
     }
 
     timer.reset();
-    // Use process_sample_output from Batch class (same as LLMEngine)
     batches[0].process_sample_output(decode_output.sample_output, false);
     COUNTER_ADD(rec_sampling_latency_microseconds,
                 timer.elapsed_microseconds());
   }
 
   batches[0].finish();
-
-  // Return the final model output
   return decode_output;
 }
 
-void RecEngine::update_last_step_result(std::vector<Batch>& batch) {
-  UNUSED_PARAMETER(batch);
+ForwardOutput RecEngine::OneRecEnginePipeline::get_model_output(
+    const ForwardInput& model_inputs) {
+  std::vector<folly::SemiFuture<std::optional<ForwardOutput>>> futures;
+  futures.reserve(engine_.workers_.size());
+  for (auto& worker : engine_.workers_) {
+    futures.emplace_back(worker->step_async(model_inputs));
+  }
+  auto results = folly::collectAll(futures).get();
+  auto forward_output = results.front().value();
+
+  CHECK(forward_output.has_value()) << "Failed to execute model";
+  return forward_output.value();
 }
 
-std::vector<int64_t> RecEngine::get_active_activation_memory() const {
-  // call worker to get active activation memory
+std::vector<int64_t>
+RecEngine::OneRecEnginePipeline::get_active_activation_memory() const {
   std::vector<folly::SemiFuture<int64_t>> futures;
-  futures.reserve(workers_.size());
-  for (auto& worker : workers_) {
+  futures.reserve(engine_.workers_.size());
+  for (auto& worker : engine_.workers_) {
     futures.push_back(worker->get_active_activation_memory_async());
   }
 
-  // wait for all futures to complete
   auto results = folly::collectAll(futures).get();
   std::vector<int64_t> active_activation_memories;
-  active_activation_memories.reserve(workers_.size());
+  active_activation_memories.reserve(futures.size());
   for (auto& result : results) {
     active_activation_memories.push_back(result.value());
   }
   return active_activation_memories;
 }
 
-ForwardOutput RecEngine::get_model_output(const ForwardInput& model_inputs) {
-  std::vector<folly::SemiFuture<std::optional<ForwardOutput>>> futures;
-  futures.reserve(workers_.size());
-  for (auto& worker : workers_) {
-    futures.emplace_back(worker->step_async(model_inputs));
+// ============================================================
+// RecEngine pipeline factory (static method)
+// ============================================================
+std::unique_ptr<RecEngine::RecEnginePipeline> RecEngine::create_pipeline(
+    RecPipelineType type,
+    RecEngine& engine) {
+  switch (type) {
+    case RecPipelineType::kLlmRecDefault:
+      return std::make_unique<LlmRecEnginePipeline>(engine);
+    case RecPipelineType::kOneRecDefault:
+      return std::make_unique<OneRecEnginePipeline>(engine);
+    default:
+      LOG(FATAL) << "Unknown RecEngine pipeline type: "
+                 << static_cast<int>(type);
+      return nullptr;
   }
-  // wait for the all future to complete
-  auto results = folly::collectAll(futures).get();
-  // return the result from the driver
-  auto forward_output = results.front().value();
-
-  CHECK(forward_output.has_value()) << "Failed to execute model";
-  return forward_output.value();
 }
 
 }  // namespace xllm

--- a/xllm/core/distributed_runtime/worker_server.cpp
+++ b/xllm/core/distributed_runtime/worker_server.cpp
@@ -215,7 +215,8 @@ WorkerServer::WorkerServer(int local_worker_idx,
   server_name_.append(std::to_string(options.server_idx()));
 
   if (worker_type == WorkerType::LLM || worker_type == WorkerType::ELM ||
-      worker_type == WorkerType::VLM || worker_type == WorkerType::EVLM) {
+      worker_type == WorkerType::VLM || worker_type == WorkerType::EVLM ||
+      worker_type == WorkerType::REC) {
     if (use_spawn_worker) {
       // start worker in a spawn process(for offline inference worker.)
       create_spawn_server(local_worker_idx,

--- a/xllm/core/framework/batch/batch.cpp
+++ b/xllm/core/framework/batch/batch.cpp
@@ -88,6 +88,14 @@ void Batch::update_forward_type(Sequence* sequence) {
   }
 }
 
+void Batch::refresh_forward_type() {
+  batch_forward_type_ = BatchForwardType();
+  const auto sequences = get_sequences();
+  for (auto* sequence : sequences) {
+    update_forward_type(sequence);
+  }
+}
+
 void Batch::add(const std::vector<Sequence*>& sequences) {
   for (auto* sequence : sequences) {
     add(sequence);
@@ -148,6 +156,22 @@ std::vector<Sequence*> Batch::get_sequences() {
     }
   }
   return result;
+}
+
+void Batch::refresh_sequences_from_groups() {
+  if (sequence_groups_.empty()) {
+    return;
+  }
+  sequences_.clear();
+  allowed_max_tokens_.clear();
+  for (auto* seq_group : sequence_groups_) {
+    const auto& sequences = seq_group->sequences();
+    for (const auto& seq_ptr : sequences) {
+      sequences_.push_back(seq_ptr.get());
+      // Use max value as default budget for beam search sequences
+      allowed_max_tokens_.push_back(std::numeric_limits<uint32_t>::max());
+    }
+  }
 }
 
 void Batch::dp_balance_shuffle_seqs() {
@@ -474,9 +498,13 @@ void Batch::process_beam_search_output(const RawForwardOutput& raw_output,
 }
 
 void Batch::finish() {
-  // Finish all sequence groups
   for (auto* sequence_group : sequence_groups_) {
     sequence_group->finish();
+  }
+
+  const auto sequences = get_sequences();
+  for (auto* sequence : sequences) {
+    sequence->finish();
   }
 }
 }  // namespace xllm

--- a/xllm/core/framework/batch/batch.h
+++ b/xllm/core/framework/batch/batch.h
@@ -56,6 +56,8 @@ class Batch {
 
   void update_forward_type(Sequence* sequence);
 
+  void refresh_forward_type();
+
   void set_swap_block_transfer_infos(
       std::vector<BlockTransferInfo>* swap_block_transfer_infos) {
     swap_block_transfer_infos_ = swap_block_transfer_infos;
@@ -112,9 +114,14 @@ class Batch {
   void process_beam_search_output(const RawForwardOutput& raw_output,
                                   bool replace_fake_token);
 
-  // mark all sequence groups as finished (used by rec model multi-round
-  // decoding)
+  // mark all sequences as finished (used by rec model multi-round decoding)
   void finish();
+
+  // Refresh sequences_ from sequence_groups_ after beam search processing.
+  // This is needed for RecEngine because SequencesGroup::process_beam_search()
+  // replaces its internal sequences_, invalidating pointers in
+  // Batch::sequences_.
+  void refresh_sequences_from_groups();
 
   const std::vector<uint32_t>& get_allowed_max_tokens() const {
     return allowed_max_tokens_;

--- a/xllm/core/framework/hf_model_loader.cpp
+++ b/xllm/core/framework/hf_model_loader.cpp
@@ -25,6 +25,7 @@ limitations under the License.
 #include <filesystem>
 #include <vector>
 
+#include "core/common/rec_model_utils.h"
 #include "core/common/version_singleton.h"
 #include "core/framework/state_dict/rec_vocab_dict.h"
 #include "core/framework/tokenizer/fast_tokenizer.h"
@@ -56,8 +57,7 @@ HFModelLoader::HFModelLoader(const std::string& model_weights_path)
   std::sort(model_weights_files_.begin(), model_weights_files_.end());
 
   threadpool_ = std::make_unique<ThreadPool>(32);
-
-  if (FLAGS_backend == "rec") {
+  if (FLAGS_backend == "rec" && is_onerec_model_type(args_.model_type())) {
     CHECK(load_rec_vocab(model_weights_path))
         << "Failed to load rec content from " << model_weights_path;
   }

--- a/xllm/core/framework/request/rec_type.h
+++ b/xllm/core/framework/request/rec_type.h
@@ -19,6 +19,10 @@ limitations under the License.
 
 namespace xllm {
 
+// REC model execution step constants
+constexpr size_t kRecDecodeSteps = 2;  // Number of decode iterations
+constexpr size_t kRecTotalSteps = kRecDecodeSteps + 1;  // 1 prefill + N decode
+
 enum class RecType : uint8_t {
   kNone = 0,
   kOneRec = 1,

--- a/xllm/core/framework/request/sequence.cpp
+++ b/xllm/core/framework/request/sequence.cpp
@@ -31,12 +31,13 @@ limitations under the License.
 #include "core/framework/tokenizer/tokenizer.h"
 #include "core/util/slice.h"
 #include "core/util/tensor_helper.h"
+#include "rec_type.h"
 
 namespace xllm {
 
 namespace {
 constexpr size_t kDecoderBosTokenCount = 1;
-constexpr size_t kDecoderMaxTokenCount = 4;
+constexpr size_t kDecoderMaxTokenCount = kRecTotalSteps + kDecoderBosTokenCount;
 }  // namespace
 
 const std::string Sequence::ENCODER_SPARSE_EMBEDDING_NAME = "sparse_embedding";


### PR DESCRIPTION
This PR is a follow-up to #567 and continues the generative recommendation work by introducing
  Qwen3/LlmRec model support in the rec framework with beam search capability.

  ## What's included

  - **RecPipelineType strategy pattern**: extensible pipeline selector for different rec model kinds
    - `kLlmRecDefault`: LlmRec without mm_data (pure Qwen3)
    - `kLlmRecWithMmData`: LlmRec with mm_data (Qwen3 + embedding)
    - `kOneRecDefault`: OneRec encoder-decoder

  - **RecEngine LlmRec pipeline** (`LlmRecEnginePipeline`):
    - Full prefill → decode flow reusing LLM worker infrastructure
    - Beam search support with proper KV cache state management
    - Multi-round decoding with `kRecDecodeSteps` iterations

  - **RecMaster LlmRec request handling**:
    - Prompt tokenization via `RecTokenizer` for Qwen3 chat template
    - Sampling parameters passthrough (beam_width, temperature, top_k, top_p)
    - Output token collection and response building

  - **FixedStepsScheduler enhancements**:
    - `create_llmrec_pipeline()` for LlmRec batch construction
    - Proper sequence/sequence_group lifecycle for beam search

  - **Beam search bugfix**:
    - Add `Batch::refresh_sequences_from_groups()` to re-sync `sequences_` after
      `SequencesGroup::process_beam_search()` replaces internal sequences
    - Prevents dangling pointer access in subsequent forward passes

  ## Usage

  Set `backend=rec` to route Qwen3 requests through the rec framework:
  ```bash
  --backend=rec
```
  Out of scope (planned follow-ups)

  - LlmRec with mm_data (multimodal embedding fusion)
  - RecEngine performance optimization
  - Extended sampling strategies

  Testing

  - ✅ backend=llm + beam_search — works (unchanged)
  - ✅ backend=rec + greedy — works
  - ✅ backend=rec + beam_search (Qwen3-8B) — works

  Roadmap checklist

  - [x] Rec tokenizer #317
  - [x] Rec decoder constrain #480
  - [x] Rec proto and service #440
  - [x] Rec engine master #557
  - [x] Scheduler #557
  - [x] RecType plumbing + rec batch input builder layering #565
  - [x] Rec worker #567
  - [x] Qwen3/LlmRec in rec framework ← #619
  - [ ] LlmRec with mm_data
  - [ ] Pure NPU inference path
  - [ ] onerec implement