### PR TITLE
feat: initialize flashinfer planinfo at layer-0 forward stage.

### DIFF
--- a/xllm/core/kernels/cuda/batch_decode.cpp
+++ b/xllm/core/kernels/cuda/batch_decode.cpp
@@ -17,32 +17,13 @@ limitations under the License.
 
 #include "cuda_ops_api.h"
 #include "function_factory.h"
-#include "util/utils.h"
-
-namespace {
-// torch tensor is only on cpu
-std::unordered_map<std::string, torch::Tensor> cache_buffer_map;
-
-torch::Tensor get_cache_buffer(const int32_t seq_len,
-                               const torch::Device& device) {
-  int32_t seq_len_pow2 = xllm::util::ceil_pow2(seq_len);
-
-  std::string key = std::string("range_") + std::to_string(seq_len_pow2);
-  auto it = cache_buffer_map.find(key);
-  if (it != cache_buffer_map.end()) {
-    return it->second.slice(0, 0, seq_len);
-  }
-
-  auto options = torch::TensorOptions().dtype(torch::kInt32).device(device);
-  torch::Tensor buffer = torch::arange(seq_len_pow2, options);
-  cache_buffer_map.insert(std::make_pair(key, buffer));
-  return buffer.slice(0, 0, seq_len);
-}
-}  // namespace
+#include "utils.h"
 
 namespace xllm::kernel::cuda {
 
-void batch_decode(torch::Tensor float_workspace_buffer,
+void batch_decode(const std::string& uri,
+                  torch::Tensor plan_info,
+                  torch::Tensor float_workspace_buffer,
                   torch::Tensor int_workspace_buffer,
                   torch::Tensor page_locked_int_workspace_buffer,
                   torch::Tensor query,
@@ -59,42 +40,10 @@ void batch_decode(torch::Tensor float_workspace_buffer,
                   bool use_tensor_core,
                   torch::Tensor kv_seq_lens) {
   if (use_tensor_core) {
-    std::string uri = get_batch_prefill_uri(/*backend=*/"fa2",
-                                            query.scalar_type(),
-                                            k_cache.scalar_type(),
-                                            output.scalar_type(),
-                                            paged_kv_indptr.scalar_type(),
-                                            query.size(-1),
-                                            v_cache.size(-1),
-                                            /*pos_encoding_mode=*/0,
-                                            /*use_sliding_window=*/false,
-                                            /*use_logits_soft_cap=*/false,
-                                            /*use_fp16_qk_reduction=*/false);
-
     const int64_t batch_size = paged_kv_last_page_len.size(0);
     torch::Tensor qo_indptr_host =
         get_cache_buffer(batch_size + 1, torch::kCPU);
     torch::Tensor qo_indptr = qo_indptr_host.to(torch::kCUDA);
-    torch::Tensor paged_kv_indptr_host = paged_kv_indptr.to(torch::kCPU);
-    torch::Tensor kv_len_arr_host = kv_seq_lens.to(torch::kCPU);
-
-    auto plan_info =
-        FunctionFactory::get_instance().fa2_prefill_plan_func(uri).call(
-            float_workspace_buffer,
-            int_workspace_buffer,
-            page_locked_int_workspace_buffer,
-            qo_indptr_host,
-            paged_kv_indptr_host,
-            kv_len_arr_host,
-            batch_size,  // total_num_rows
-            batch_size,
-            query.size(1),    // num_qo_heads
-            k_cache.size(2),  // num_kv_heads
-            k_cache.size(1),  // block_size
-            enable_cuda_graph,
-            query.size(-1),    // head_dim_qk
-            v_cache.size(-1),  // head_dim_vo
-            /*causal=*/false);
 
     FunctionFactory::get_instance().fa2_prefill_paged_run_func(uri).call(
         float_workspace_buffer,
@@ -125,41 +74,6 @@ void batch_decode(torch::Tensor float_workspace_buffer,
         /*rope_rcp_theta=*/1.0 / 10000.0,
         /*token_pos_in_items_len=*/0);
   } else {
-    std::string uri = get_batch_decode_uri(query.scalar_type(),
-                                           k_cache.scalar_type(),
-                                           output.scalar_type(),
-                                           paged_kv_indptr.scalar_type(),
-                                           query.size(-1),
-                                           v_cache.size(-1),
-                                           /*pos_encoding_mode=*/0,
-                                           /*use_sliding_window=*/false,
-                                           /*use_logits_soft_cap=*/false);
-
-    torch::Tensor paged_kv_indptr_host = paged_kv_indptr.to(torch::kCPU);
-    const int64_t batch_size = paged_kv_last_page_len.size(0);
-
-    torch::Tensor empty_q_data =
-        torch::empty({0}, torch::TensorOptions().dtype(query.scalar_type()));
-    torch::Tensor empty_kv_data =
-        torch::empty({0}, torch::TensorOptions().dtype(k_cache.scalar_type()));
-
-    auto plan_info = FunctionFactory::get_instance().decode_plan_func(uri).call(
-        float_workspace_buffer,
-        int_workspace_buffer,
-        page_locked_int_workspace_buffer,
-        paged_kv_indptr_host,
-        batch_size,
-        query.size(1),    // num_qo_heads
-        k_cache.size(2),  // num_kv_heads
-        k_cache.size(1),  // block_size
-        enable_cuda_graph,
-        window_left,
-        /*logits_soft_cap=*/0.0,
-        query.size(-1),    // head_dim_qk
-        v_cache.size(-1),  // head_dim_vo
-        empty_q_data,
-        empty_kv_data);
-
     FunctionFactory::get_instance().decode_run_func(uri).call(
         float_workspace_buffer,
         int_workspace_buffer,

--- a/xllm/core/kernels/cuda/batch_prefill.cpp
+++ b/xllm/core/kernels/cuda/batch_prefill.cpp
@@ -18,7 +18,9 @@ limitations under the License.
 
 namespace xllm::kernel::cuda {
 
-void batch_prefill(torch::Tensor float_workspace_buffer,
+void batch_prefill(const std::string& uri,
+                   torch::Tensor plan_info,
+                   torch::Tensor float_workspace_buffer,
                    torch::Tensor int_workspace_buffer,
                    torch::Tensor page_locked_int_workspace_buffer,
                    torch::Tensor query,
@@ -36,44 +38,7 @@ void batch_prefill(torch::Tensor float_workspace_buffer,
                                   /*use_fp16_qk_reduction=*/false,
                                   /*use_custom_mask=*/false);
 
-  std::string uri = get_batch_prefill_uri(backend,
-                                          query.scalar_type(),
-                                          key.scalar_type(),
-                                          output.scalar_type(),
-                                          q_cu_seq_lens.scalar_type(),
-                                          query.size(-1),
-                                          value.size(-1),
-                                          /*pos_encoding_mode=*/0,
-                                          /*use_sliding_window=*/false,
-                                          /*use_logits_soft_cap=*/false,
-                                          /*use_fp16_qk_reduction=*/false);
-
-  torch::Tensor qo_indptr_host = q_cu_seq_lens.to(torch::kCPU);
-  torch::Tensor kv_cu_seq_lens_host = kv_cu_seq_lens.to(torch::kCPU);
-  torch::Tensor kv_len_arr_host =
-      kv_cu_seq_lens_host.slice(0, 1) - kv_cu_seq_lens_host.slice(0, 0, -1);
-  const int64_t total_num_rows = qo_indptr_host[-1].item<int64_t>();
-  const int64_t batch_size = qo_indptr_host.size(0) - 1;
-
   if (backend == "fa2") {
-    auto plan_info =
-        FunctionFactory::get_instance().fa2_prefill_plan_func(uri).call(
-            float_workspace_buffer,
-            int_workspace_buffer,
-            page_locked_int_workspace_buffer,
-            qo_indptr_host,
-            kv_cu_seq_lens_host,
-            kv_len_arr_host,
-            total_num_rows,
-            batch_size,
-            query.size(1),  // num_qo_heads
-            key.size(1),    // num_kv_heads
-            /*page_size=*/1,
-            enable_cuda_graph,
-            query.size(-1),  // head_dim_qk
-            value.size(-1),  // head_dim_vo
-            /*causal=*/true);
-
     FunctionFactory::get_instance().fa2_prefill_ragged_run_func(uri).call(
         float_workspace_buffer,
         int_workspace_buffer,
@@ -101,24 +66,6 @@ void batch_prefill(torch::Tensor float_workspace_buffer,
         /*rope_rcp_theta=*/1.0 / 10000.0,
         /*token_pos_in_items_len=*/0);
   } else if (backend == "fa3") {
-    auto plan_info =
-        FunctionFactory::get_instance().fa3_prefill_plan_func(uri).call(
-            float_workspace_buffer,
-            int_workspace_buffer,
-            page_locked_int_workspace_buffer,
-            qo_indptr_host,
-            kv_cu_seq_lens_host,
-            kv_len_arr_host,
-            total_num_rows,
-            batch_size,
-            query.size(1),  // num_qo_heads
-            key.size(1),    // num_kv_heads
-            /*page_size=*/1,
-            enable_cuda_graph,
-            query.size(-1),  // head_dim_qk
-            value.size(-1),  // head_dim_vo
-            /*causal=*/true);
-
     FunctionFactory::get_instance().fa3_prefill_ragged_run_func(uri).call(
         float_workspace_buffer,
         int_workspace_buffer,

--- a/xllm/core/kernels/cuda/cuda_ops_api.h
+++ b/xllm/core/kernels/cuda/cuda_ops_api.h
@@ -45,7 +45,9 @@ void reshape_paged_cache(
     torch::Tensor key_cache,  // [n_blocks, block_size, n_heads, head_dim]
     torch::Tensor value_cache);
 
-void batch_prefill(torch::Tensor float_workspace_buffer,
+void batch_prefill(const std::string& uri,
+                   torch::Tensor plan_info,
+                   torch::Tensor float_workspace_buffer,
                    torch::Tensor int_workspace_buffer,
                    torch::Tensor page_locked_int_workspace_buffer,
                    torch::Tensor query,
@@ -59,7 +61,9 @@ void batch_prefill(torch::Tensor float_workspace_buffer,
                    std::optional<torch::Tensor>& output_lse,
                    bool enable_cuda_graph);
 
-void batch_decode(torch::Tensor float_workspace_buffer,
+void batch_decode(const std::string& uri,
+                  torch::Tensor plan_info,
+                  torch::Tensor float_workspace_buffer,
                   torch::Tensor int_workspace_buffer,
                   torch::Tensor page_locked_int_workspace_buffer,
                   torch::Tensor query,

--- a/xllm/core/kernels/cuda/utils.h
+++ b/xllm/core/kernels/cuda/utils.h
@@ -15,11 +15,18 @@ limitations under the License.
 
 #pragma once
 
+#include <ATen/DynamicLibrary.h>
 #include <torch/torch.h>
 
 #include <string>
 
+#include "core/util/utils.h"
+
 namespace xllm::kernel::cuda {
+
+// torch tensor is only on cpu
+torch::Tensor get_cache_buffer(const int32_t seq_len,
+                               const torch::Device& device);
 
 // NOLINTBEGIN(cppcoreguidelines-macro-usage)
 #define DISPATCH_CASE_FLOATING_TYPES(...)              \

--- a/xllm/core/kernels/ops_api.cpp
+++ b/xllm/core/kernels/ops_api.cpp
@@ -153,7 +153,9 @@ void batch_prefill(AttentionParams& params) {
                      params.scale,
                      params.output);
 #elif defined(USE_CUDA)
-  cuda::batch_prefill(params.float_workspace_buffer,
+  cuda::batch_prefill(params.uri,
+                      params.plan_info,
+                      params.float_workspace_buffer,
                       params.int_workspace_buffer,
                       params.page_locked_int_workspace_buffer,
                       params.query,
@@ -223,7 +225,9 @@ void batch_decode(AttentionParams& params) {
                     params.seq_lens,
                     params.output);
 #elif defined(USE_CUDA)
-  cuda::batch_decode(params.float_workspace_buffer,
+  cuda::batch_decode(params.uri,
+                     params.plan_info,
+                     params.float_workspace_buffer,
                      params.int_workspace_buffer,
                      params.page_locked_int_workspace_buffer,
                      params.query,

--- a/xllm/core/kernels/param.h
+++ b/xllm/core/kernels/param.h
@@ -206,6 +206,8 @@ struct AttentionParams {
   torch::Tensor float_workspace_buffer;
   torch::Tensor int_workspace_buffer;
   torch::Tensor page_locked_int_workspace_buffer;
+  std::string uri;
+  torch::Tensor plan_info;
 
   bool enable_cuda_graph = false;
   // Whether to use tensor core for decode attention computation. Default: true.

--- a/xllm/core/layers/common/attention_metadata.cpp
+++ b/xllm/core/layers/common/attention_metadata.cpp
@@ -42,6 +42,7 @@ AttentionMetadata AttentionMetadata::build(
   attn_metadata.paged_kv_indptr = params.paged_kv_indptr;
   attn_metadata.paged_kv_indices = params.paged_kv_indices;
   attn_metadata.paged_kv_last_page_len = params.paged_kv_last_page_len;
+  attn_metadata.plan_info = std::make_shared<PlanInfo>();
 
   // for npu
   if (attn_mask.has_value()) {

--- a/xllm/core/layers/common/attention_metadata.h
+++ b/xllm/core/layers/common/attention_metadata.h
@@ -22,6 +22,12 @@ limitations under the License.
 namespace xllm {
 namespace layer {
 
+struct PlanInfo {
+  int32_t layer_id = -1;
+  torch::Tensor plan_info;
+  std::string uri;
+};
+
 struct AttentionMetadata {
  public:
   static AttentionMetadata build(
@@ -54,6 +60,7 @@ struct AttentionMetadata {
   torch::Tensor paged_kv_indptr;
   torch::Tensor paged_kv_indices;
   torch::Tensor paged_kv_last_page_len;
+  std::shared_ptr<PlanInfo> plan_info;
 
   // for npu
   torch::Tensor attn_mask;

--- a/xllm/core/layers/cuda/CMakeLists.txt
+++ b/xllm/core/layers/cuda/CMakeLists.txt
@@ -6,9 +6,11 @@ cc_library(
   HDRS
     attention.h
     flashinfer_workspace.h
+    flashinfer_planinfo.h
   SRCS
     attention.cpp
     flashinfer_workspace.cpp
+    flashinfer_planinfo.cpp
   DEPS
     :common_layers
 )

--- a/xllm/core/layers/cuda/flashinfer_planinfo.cpp
+++ b/xllm/core/layers/cuda/flashinfer_planinfo.cpp
@@ -1,0 +1,183 @@
+/* Copyright 2025 The xLLM Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://github.com/jd-opensource/xllm/blob/main/LICENSE
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include "flashinfer_planinfo.h"
+
+#include "core/util/utils.h"
+#include "flashinfer_workspace.h"
+#include "kernels/cuda/function_factory.h"
+#include "kernels/cuda/utils.h"
+
+namespace xllm {
+namespace layer {
+namespace flashinfer {
+
+void update_plan_info(std::shared_ptr<PlanInfo> plan_info,
+                      const std::string& backend,
+                      const AttentionMetadata& attn_meta,
+                      c10::ScalarType query_dtype,
+                      c10::ScalarType key_dtype,
+                      c10::ScalarType output_dtype,
+                      int32_t head_dim_qk,
+                      int32_t head_dim_vo,
+                      int32_t num_qo_heads,
+                      int32_t num_kv_heads,
+                      int32_t block_size,
+                      int32_t window_size_left,
+                      bool enable_cuda_graph,
+                      bool causal,
+                      bool use_tensor_core) {
+  CHECK(plan_info->layer_id != -1) << "Need to set layer_id to PlanInfo.";
+  if (plan_info->layer_id != 0) return;
+
+  // 1. prefill plan info
+  if (causal) {
+    plan_info->uri = kernel::cuda::get_batch_prefill_uri(
+        backend,
+        query_dtype,
+        key_dtype,
+        output_dtype,
+        attn_meta.q_cu_seq_lens.scalar_type(),
+        head_dim_qk,
+        head_dim_vo,
+        /*pos_encoding_mode=*/0,
+        /*use_sliding_window=*/false,
+        /*use_logits_soft_cap=*/false,
+        /*use_fp16_qk_reduction=*/false);
+
+    torch::Tensor qo_indptr_host = attn_meta.q_cu_seq_lens.to(torch::kCPU);
+    torch::Tensor kv_cu_seq_lens_host =
+        attn_meta.kv_cu_seq_lens.to(torch::kCPU);
+    torch::Tensor kv_len_arr_host =
+        kv_cu_seq_lens_host.slice(0, 1) - kv_cu_seq_lens_host.slice(0, 0, -1);
+    const int64_t total_num_rows = qo_indptr_host[-1].item<int64_t>();
+    const int64_t batch_size = qo_indptr_host.size(0) - 1;
+    auto call_plan_func = [&](auto&& func) {
+      return func.call(
+          FlashinferWorkspace::get_instance().get_float_workspace_buffer(),
+          FlashinferWorkspace::get_instance().get_int_workspace_buffer(),
+          FlashinferWorkspace::get_instance()
+              .get_page_locked_int_workspace_buffer(),
+          qo_indptr_host,
+          kv_cu_seq_lens_host,
+          kv_len_arr_host,
+          total_num_rows,
+          batch_size,
+          num_qo_heads,
+          num_kv_heads,
+          /*page_size=*/1,
+          enable_cuda_graph,
+          head_dim_qk,
+          head_dim_vo,
+          causal);
+    };
+    if (backend == "fa2") {
+      plan_info->plan_info = call_plan_func(
+          kernel::cuda::FunctionFactory::get_instance().fa2_prefill_plan_func(
+              plan_info->uri));
+    } else {
+      plan_info->plan_info = call_plan_func(
+          kernel::cuda::FunctionFactory::get_instance().fa3_prefill_plan_func(
+              plan_info->uri));
+    }
+  } else {
+    // 2. decode plan info
+    if (use_tensor_core) {
+      plan_info->uri = kernel::cuda::get_batch_prefill_uri(
+          /*backend=*/"fa2",
+          query_dtype,
+          key_dtype,
+          output_dtype,
+          attn_meta.paged_kv_indptr.scalar_type(),
+          head_dim_qk,
+          head_dim_vo,
+          /*pos_encoding_mode=*/0,
+          /*use_sliding_window=*/false,
+          /*use_logits_soft_cap=*/false,
+          /*use_fp16_qk_reduction=*/false);
+      const int64_t batch_size = attn_meta.paged_kv_last_page_len.size(0);
+      torch::Tensor qo_indptr_host =
+          kernel::cuda::get_cache_buffer(batch_size + 1, torch::kCPU);
+      torch::Tensor qo_indptr = qo_indptr_host.to(torch::kCUDA);
+      torch::Tensor paged_kv_indptr_host =
+          attn_meta.paged_kv_indptr.to(torch::kCPU);
+      torch::Tensor kv_len_arr_host = attn_meta.kv_seq_lens.to(torch::kCPU);
+      plan_info->plan_info =
+          kernel::cuda::FunctionFactory::get_instance()
+              .fa2_prefill_plan_func(plan_info->uri)
+              .call(FlashinferWorkspace::get_instance()
+                        .get_float_workspace_buffer(),
+                    FlashinferWorkspace::get_instance()
+                        .get_int_workspace_buffer(),
+                    FlashinferWorkspace::get_instance()
+                        .get_page_locked_int_workspace_buffer(),
+                    qo_indptr_host,
+                    paged_kv_indptr_host,
+                    kv_len_arr_host,
+                    batch_size,  // total_num_rows
+                    batch_size,
+                    num_qo_heads,  // num_qo_heads
+                    num_kv_heads,  // num_kv_heads
+                    block_size,    // block_size
+                    enable_cuda_graph,
+                    head_dim_qk,  // head_dim_qk
+                    head_dim_vo,  // head_dim_vo
+                    /*causal=*/false);
+    } else {
+      plan_info->uri = kernel::cuda::get_batch_decode_uri(
+          query_dtype,
+          key_dtype,
+          output_dtype,
+          attn_meta.paged_kv_indptr.scalar_type(),
+          head_dim_qk,
+          head_dim_vo,
+          /*pos_encoding_mode=*/0,
+          /*use_sliding_window=*/false,
+          /*use_logits_soft_cap=*/false);
+      torch::Tensor paged_kv_indptr_host =
+          attn_meta.paged_kv_indptr.to(torch::kCPU);
+      const int64_t batch_size = attn_meta.paged_kv_last_page_len.size(0);
+      torch::Tensor empty_q_data =
+          torch::empty({0}, torch::TensorOptions().dtype(query_dtype));
+      torch::Tensor empty_kv_data =
+          torch::empty({0}, torch::TensorOptions().dtype(key_dtype));
+      plan_info->plan_info =
+          kernel::cuda::FunctionFactory::get_instance()
+              .decode_plan_func(plan_info->uri)
+              .call(FlashinferWorkspace::get_instance()
+                        .get_float_workspace_buffer(),
+                    FlashinferWorkspace::get_instance()
+                        .get_int_workspace_buffer(),
+                    FlashinferWorkspace::get_instance()
+                        .get_page_locked_int_workspace_buffer(),
+                    paged_kv_indptr_host,
+                    batch_size,
+                    num_qo_heads,
+                    num_kv_heads,
+                    block_size,
+                    enable_cuda_graph,
+                    window_size_left,
+                    /*logits_soft_cap=*/0.0,
+                    head_dim_qk,
+                    head_dim_vo,
+                    empty_q_data,
+                    empty_kv_data);
+    }
+  }
+}
+
+}  // namespace flashinfer
+}  // namespace layer
+}  // namespace xllm

--- a/xllm/core/layers/cuda/flashinfer_planinfo.h
+++ b/xllm/core/layers/cuda/flashinfer_planinfo.h
@@ -1,0 +1,42 @@
+/* Copyright 2025 The xLLM Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://github.com/jd-opensource/xllm/blob/main/LICENSE
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#pragma once
+
+#include "layers/common/attention_metadata.h"
+
+namespace xllm {
+namespace layer {
+namespace flashinfer {
+
+void update_plan_info(std::shared_ptr<PlanInfo> plan_info,
+                      const std::string& backend,
+                      const AttentionMetadata& attn_meta,
+                      c10::ScalarType query_dtype,
+                      c10::ScalarType key_dtype,
+                      c10::ScalarType output_dtype,
+                      int32_t head_dim_qk,
+                      int32_t head_dim_vo,
+                      int32_t num_qo_heads,
+                      int32_t num_kv_heads,
+                      int32_t block_size,
+                      int32_t window_size_left,
+                      bool enable_cuda_graph,
+                      bool causal,
+                      bool use_tensor_core);
+
+}  // namespace flashinfer
+}  // namespace layer
+}  // namespace xllm

--- a/xllm/models/llm/deepseek_mtp.h
+++ b/xllm/models/llm/deepseek_mtp.h
@@ -179,6 +179,7 @@ class DeepseekMTPModelImpl : public torch::nn::Module {
 
     std::optional<torch::Tensor> residual;
     for (size_t i = 0; i < mtp_layers_.size(); i++) {
+      attn_metadata.plan_info->layer_id = i;
       auto& layer = mtp_layers_[i];
       hidden_states = layer(hidden_states,
                             residual,

--- a/xllm/models/llm/deepseek_v2.h
+++ b/xllm/models/llm/deepseek_v2.h
@@ -119,6 +119,7 @@ class DeepseekV2ModelImpl : public torch::nn::Module {
     torch::Tensor hidden_states = embed_tokens_(tokens);
     std::optional<torch::Tensor> residual;
     for (size_t i = 0; i < layers_.size(); i++) {
+      attn_metadata.plan_info->layer_id = i;
       auto& layer = layers_[i];
       hidden_states = layer(hidden_states,
                             residual,

--- a/xllm/models/llm/llm_model_base.h
+++ b/xllm/models/llm/llm_model_base.h
@@ -118,6 +118,7 @@ class LlmModelImplBase : public torch::nn::Module {
 
     std::optional<torch::Tensor> residual;
     for (size_t i = 0; i < layers_.size(); i++) {
+      attn_metadata.plan_info->layer_id = i;
       auto& layer = layers_[i];
       h = layer(h,
                 residual,

--- a/xllm/models/llm/qwen3.h
+++ b/xllm/models/llm/qwen3.h
@@ -128,6 +128,7 @@ class QWen3ModelImpl : public LlmModelImplBase<QWen3DecoderLayer> {
 
     std::optional<torch::Tensor> residual;
     for (size_t i = 0; i < layers_.size(); i++) {
+      attn_metadata.plan_info->layer_id = i;
       auto& layer = layers_[i];
       h = layer(h,
                 residual,

--- a/xllm/models/llm/qwen3_moe.h
+++ b/xllm/models/llm/qwen3_moe.h
@@ -190,6 +190,7 @@ class Qwen3MoeModelImpl : public torch::nn::Module {
 
     std::optional<torch::Tensor> residual;
     for (size_t i = 0; i < layers_.size(); i++) {
+      attn_metadata.plan_info->layer_id = i;
       auto& layer = layers_[i];
       h = layer(h,
                 residual,


### PR DESCRIPTION
01/05 07:08:24 - AISBench - INFO - Evaluation tasks completed.
01/05 07:08:24 - AISBench - INFO - Summarizing evaluation results...
dataset    version    metric    mode      vllm-api-general-chat
---------  ---------  --------  ------  -----------------------
gsm8k      7cd45e     accuracy  gen                       95.91
01/05 07:08:24 - AISBench - INFO - write summary to /export/home/root/xllm_github/benchmark/outputs/default/20260105_065752/summary/summary_20260105_065752.txt
01/05 07:08:24 - AISBench - INFO - write csv to /export/home/root/xllm_github/benchmark/outputs/default/20260105_065752/summary/summary_20260105_065752.csv


The markdown format results is as below:

| dataset | version | metric | mode | vllm-api-general-chat |
|----- | ----- | ----- | ----- | -----|
| gsm8k | 7cd45e | accuracy | gen | 95.91 |