### PR TITLE
feat: add chat support for backend=rec for rec framwork in stretch goals[1/N].

### DIFF
--- a/xllm/api_service/api_service.cpp
+++ b/xllm/api_service/api_service.cpp
@@ -85,8 +85,11 @@ APIService::APIService(Master* master,
         std::make_unique<ImageGenerationServiceImpl>(
             dynamic_cast<DiTMaster*>(master), model_names);
   } else if (FLAGS_backend == "rec") {
-    rec_completion_service_impl_ = std::make_unique<RecCompletionServiceImpl>(
-        dynamic_cast<RecMaster*>(master), model_names);
+    auto rec_master = dynamic_cast<RecMaster*>(master);
+    rec_completion_service_impl_ =
+        std::make_unique<RecCompletionServiceImpl>(rec_master, model_names);
+    chat_service_impl_ =
+        std::make_unique<ChatServiceImpl>(rec_master, model_names);
   }
   models_service_impl_ =
       ServiceImplFactory<ModelsServiceImpl>::create_service_impl(
@@ -241,6 +244,10 @@ void APIService::ChatCompletionsHttp(
     CHECK(mm_chat_service_impl_) << " mm chat service is invalid.";
     ChatCompletionsImpl<MMChatCall, MMChatServiceImpl>(
         mm_chat_service_impl_, done_guard, ctrl, request, response);
+  } else if (FLAGS_backend == "rec") {
+    CHECK(chat_service_impl_) << " chat service is invalid.";
+    ChatCompletionsImpl<ChatCall, ChatServiceImpl>(
+        chat_service_impl_, done_guard, ctrl, request, response);
   }
 }
 

--- a/xllm/api_service/chat_service_impl.h
+++ b/xllm/api_service/chat_service_impl.h
@@ -23,20 +23,29 @@ limitations under the License.
 
 namespace xllm {
 
+class RecMaster;
+
 using ChatCall = StreamCall<proto::ChatRequest, proto::ChatResponse>;
 
 // a class to handle completion requests
 class ChatServiceImpl final : public APIServiceImpl<ChatCall> {
  public:
+  // Constructor for LLM backend
   ChatServiceImpl(LLMMaster* master, const std::vector<std::string>& models);
+
+  // Constructor for Rec backend (LlmRec only, e.g., Qwen3)
+  ChatServiceImpl(RecMaster* master, const std::vector<std::string>& models);
 
   // brpc call_data needs to use shared_ptr
   void process_async_impl(std::shared_ptr<ChatCall> call);
 
  private:
+  void process_rec_chat_request(std::shared_ptr<ChatCall> call);
+
   DISALLOW_COPY_AND_ASSIGN(ChatServiceImpl);
 
   LLMMaster* master_ = nullptr;
+  RecMaster* rec_master_ = nullptr;
   const std::string tool_call_parser_format_;
   const std::string reasoning_parser_format_;
   bool is_force_reasoning_ = false;

--- a/xllm/core/distributed_runtime/engine.h
+++ b/xllm/core/distributed_runtime/engine.h
@@ -78,7 +78,8 @@ class Engine {
                               const std::vector<uint64_t>& src_blocks,
                               const int32_t dst_dp_rank,
                               const std::vector<uint64_t>& dst_blocks) {
-    LOG(FATAL) << " pull_kv_blocks is notimplemented!";
+    LOG(FATAL) << " pull_kv_blocks is not implemented!";
+    return false;
   };
 
   virtual std::vector<folly::SemiFuture<uint32_t>> transfer_kv_blocks(

--- a/xllm/core/distributed_runtime/rec_engine.h
+++ b/xllm/core/distributed_runtime/rec_engine.h
@@ -99,6 +99,9 @@ class RecEngine : public Engine {
 
    private:
     std::vector<RawForwardInput> prepare_inputs(std::vector<Batch>& batch);
+
+    // Get max tokens from batch for dynamic step control
+    size_t get_max_steps_from_batch(std::vector<Batch>& batches) const;
   };
 
   // ============================================================

--- a/xllm/core/distributed_runtime/rec_master.h
+++ b/xllm/core/distributed_runtime/rec_master.h
@@ -17,6 +17,7 @@ limitations under the License.
 
 #include <atomic>
 #include <functional>
+#include <optional>
 #include <thread>
 
 #include "framework/chat_template/jinja_chat_template.h"
@@ -52,8 +53,17 @@ class RecMaster : public Master {
       RequestParams sp,
       OutputCallback callback);
 
+  // chat
+  // Only supported for LlmRec models.
+  void handle_request(std::vector<Message> messages,
+                      std::optional<std::vector<int>> prompt_tokens,
+                      RequestParams sp,
+                      OutputCallback callback);
+
   // start the handling loop
   void run() override;
+
+  RecType rec_type() const { return rec_type_; }
 
  private:
   using RequestBuilder =

--- a/xllm/core/framework/batch/batch.h
+++ b/xllm/core/framework/batch/batch.h
@@ -132,6 +132,10 @@ class Batch {
     return cal_seq_exchange_index(kv_cache_tokens_num);
   }
 
+  // Get all sequences from either sequences_ or sequence_groups_
+  // Used by RecEngine to access sequences for stopping checker evaluation
+  std::vector<Sequence*> get_sequences();
+
  private:
   bool update_sequence_state(Sequence* seq, bool replace_fake_token);
 
@@ -146,8 +150,6 @@ class Batch {
       std::vector<uint32_t>& kv_cache_tokens_num);
 
   void dp_balance_shuffle_seqs();
-
-  std::vector<Sequence*> get_sequences();
 
   std::vector<Sequence*> sequences_;
   std::vector<SequencesGroup*> sequence_groups_;


### PR DESCRIPTION
This PR is a follow-up to #619 and continues the generative recommendation work by adding
OpenAI-compatible chat completions API support for the rec framework.

## What's included

- **ChatServiceImpl RecMaster support**:
  - New constructor accepting `RecMaster*` for rec backend routing
  - `process_rec_chat_request()` handling `/v1/chat/completions` for LlmRec models
  - Automatic backend routing: RecMaster requests bypass LLMMaster path

- **RecMaster chat interface** (`handle_request(messages, ...)`):
  - Chat template application via `JinjaChatTemplate` for Qwen3
  - Message-to-prompt conversion with tool_calls support
  - Streaming and non-streaming response modes

- **Dynamic max_tokens support**:
  - `get_max_steps_from_batch()` reads `max_tokens` from `StoppingChecker`
  - Replaces fixed `kRecDecodeSteps` when stopping checker is present
  - Falls back to `kRecDecodeSteps` for OneRec compatibility

- **Batch API enhancement**:
  - `Batch::get_sequences()` moved to public for RecEngine access
  - Handles both `sequences_` (LlmRec) and `sequence_groups_` (OneRec) scenarios

## Usage

With `backend=rec`, LlmRec models now support the standard chat completions API:

```bash
curl http://localhost:8080/v1/chat/completions \
  -H "Content-Type: application/json" \
  -d '{
    "model": "Qwen3-8B",
    "messages": [{"role": "user", "content": "Hello!"}],
    "max_tokens": 100,
    "stream": true
  }'
```

## Restrictions

- Chat completions API is **only supported for kLlmRec** models
- OneRec models return `INVALID_ARGUMENT` error for chat requests

## Testing

- [x] `backend=rec` + `/v1/chat/completions` (Qwen3-8B) — works
- [x] `backend=rec` + streaming mode — works
- [x] `backend=rec` + non-streaming mode — works
- [x] `backend=llm` + `/v1/chat/completions` — unchanged

## Roadmap checklist

- [x] Rec tokenizer #317
- [x] Rec decoder constrain #480
- [x] Rec proto and service #440
- [x] Rec engine master #557
- [x] Scheduler #557
- [x] RecType plumbing + rec batch input builder layering #565
- [x] Rec worker #567
- [x] Qwen3/LlmRec in rec framework #619
- [ ] LlmRec with mm_data
- [ ] Pure NPU inference path
- [ ] OneRec implementation

## Stretch goals

- [x] **Spin-off #1**: OpenAI-compatible chat completions for rec ← this PR
- [ ] Spin-off #2: add pipeline param in xllm.cpp
- [ ] Spin-off #3: add gpu framwork for rec