### PR TITLE
bugfix: fix the llm instance destroy issue in GR scene.

### DIFF
--- a/xllm/cc_api/examples/start-llm-instance.sh
+++ b/xllm/cc_api/examples/start-llm-instance.sh
@@ -2,6 +2,9 @@
 
 clear
 
+\rm -rf core.*
+cd build && make && cd ..
+
 # export ASDOPS_LOG_LEVEL=DEBUG
 # export ASDOPS_LOG_TO_STDOUT=1
 export ASCEND_RT_VISIBLE_DEVICES=12

--- a/xllm/cc_api/internal.h
+++ b/xllm/cc_api/internal.h
@@ -233,7 +233,7 @@ XLLM_Response handle_inference_request(LLMCore* llm_core,
           if (result.hasValue()) {
             return std::move(result).value();
           } else {
-            result.throwIfFailed();
+            result.throwUnlessValue();
             return XLLM_Response{};
           }
         })

--- a/xllm/core/distributed_runtime/dist_manager.cpp
+++ b/xllm/core/distributed_runtime/dist_manager.cpp
@@ -48,6 +48,10 @@ DistManager::~DistManager() {
 
     ServerRegistry::get_instance().unregister_server(server_name_);
   }
+
+  for (size_t i = 0; i < servers_.size(); ++i) {
+    servers_[i]->stop();
+  }
 }
 
 namespace {
@@ -171,7 +175,8 @@ void DistManager::setup_multi_node_workers(
             dp_local_process_group_num, world_size, devices[0].index());
     XllmServer* collective_server =
         ServerRegistry::get_instance().register_server(server_name_);
-    if (!collective_server->start(collective_service, master_node_addr)) {
+    if (!collective_server->start(
+            collective_service, master_node_addr, server_name_)) {
       LOG(ERROR) << "failed to start collective server on address: "
                  << master_node_addr;
       return;

--- a/xllm/core/distributed_runtime/worker_server.h
+++ b/xllm/core/distributed_runtime/worker_server.h
@@ -62,6 +62,8 @@ class WorkerServer {
       std::unique_ptr<ForwardSharedMemoryManager> input_shm_manager,
       std::unique_ptr<ForwardSharedMemoryManager> output_shm_manager);
 
+  void stop();
+
  private:
   DISALLOW_COPY_AND_ASSIGN(WorkerServer);
 

--- a/xllm/core/framework/xtensor/xtensor_manager_pool.cpp
+++ b/xllm/core/framework/xtensor/xtensor_manager_pool.cpp
@@ -92,7 +92,8 @@ void XTensorManagerPool::setup_multi_node_xtensor_managers(
       XllmServer* collective_server =
           ServerRegistry::get_instance().register_server(
               collective_server_name_);
-      if (!collective_server->start(collective_service, master_node_addr)) {
+      if (!collective_server->start(
+              collective_service, master_node_addr, collective_server_name_)) {
         LOG(ERROR) << "failed to start collective server on address: "
                    << master_node_addr;
         return;

--- a/xllm/server/xllm_server.h
+++ b/xllm/server/xllm_server.h
@@ -33,7 +33,8 @@ class XllmServer final {
   bool start(std::unique_ptr<DisaggPDService> disagg_pd_service);
   bool start(std::unique_ptr<PDOOCService> pd_ooc_service);
   bool start(std::shared_ptr<CollectiveService> service,
-             const std::string& addr);
+             const std::string& addr,
+             const std::string& server_name);
   bool start(std::shared_ptr<WorkerService> service, const std::string& addr);
   bool start(std::shared_ptr<XTensorManagerService> service,
              const std::string& addr);

--- a/xllm/server/xllm_server_registry.cpp
+++ b/xllm/server/xllm_server_registry.cpp
@@ -19,6 +19,8 @@ namespace xllm {
 
 XllmServer* ServerRegistry::register_server(const std::string& name) {
   {
+    LOG(INFO) << "Register server " << name << ".";
+
     std::lock_guard<std::mutex> lock(mutex_);
     if (servers_.find(name) != servers_.end()) {
       LOG(ERROR) << "Register server failed, " << name
@@ -33,6 +35,8 @@ XllmServer* ServerRegistry::register_server(const std::string& name) {
 
 void ServerRegistry::unregister_server(const std::string& name) {
   {
+    LOG(INFO) << "Unregister server " << name << ".";
+
     std::lock_guard<std::mutex> lock(mutex_);
     auto iter = servers_.find(name);
     if (iter == servers_.end()) {


### PR DESCRIPTION
xLLM is used as an infer engine in the generative recommandation scene. It usually uses only one card and creates one LLM engine for each model with one special version. we found an issue about HCCL which may fork an children process and holds some sockets resource. This PR provides a work-around temporarily and will remove after Ascend fixes it. 