### PR TITLE
bugfix: fix MiMo-VL weights loading crash on NPU device.

### DIFF
--- a/xllm/core/layers/npu/loader/qwen2dot5_vision_encoder_loader.cpp
+++ b/xllm/core/layers/npu/loader/qwen2dot5_vision_encoder_loader.cpp
@@ -105,7 +105,6 @@ void Qwen2dot5VisionEncoderLoader::load_state_dict(
       set_weight(state_dict, name, index);
     }
   }
-  get_weights_col_packed_qkv();
 }
 
 // tp spilt weight


### PR DESCRIPTION
bugfix: fix MiMo-VL weights loading crash on NPU device.