### PR TITLE
refactor: improve code structure and naming conventions.

### DIFF
--- a/xllm/api_service/chat_service_impl.cpp
+++ b/xllm/api_service/chat_service_impl.cpp
@@ -869,7 +869,7 @@ void MMChatServiceImpl::process_async_impl(std::shared_ptr<MMChatCall> call) {
       rpc_request, call->get_x_request_id(), call->get_x_request_time());
 
   std::vector<Message> messages;
-  if (!build_messages<MMChatCall>(
+  if (!mm_service_utils::build_messages<MMChatCall>(
           req_messages, messages, call, master_->get_image_limit())) {
     return;
   }

--- a/xllm/api_service/embedding_service_impl.cpp
+++ b/xllm/api_service/embedding_service_impl.cpp
@@ -157,7 +157,7 @@ void MMEmbeddingServiceImpl::process_async_impl(
   auto& req_messages = rpc_request.messages();
 
   std::vector<Message> messages;
-  if (!build_messages<MMEmbeddingCall>(
+  if (!mm_service_utils::build_messages<MMEmbeddingCall>(
           req_messages, messages, call, master_->get_image_limit())) {
     return;
   }

--- a/xllm/api_service/mm_service_utils.h
+++ b/xllm/api_service/mm_service_utils.h
@@ -20,6 +20,7 @@ limitations under the License.
 #include "multimodal.pb.h"
 
 namespace xllm {
+namespace mm_service_utils {
 
 template <typename Call>
 bool build_messages(const google::protobuf::RepeatedPtrField<
@@ -81,4 +82,5 @@ bool build_messages(const google::protobuf::RepeatedPtrField<
   return true;
 };
 
+}  // namespace mm_service_utils
 }  // namespace xllm

--- a/xllm/core/framework/request/mm_batch_data.cpp
+++ b/xllm/core/framework/request/mm_batch_data.cpp
@@ -25,8 +25,8 @@ MMBatchData::MMBatchData(const std::vector<MMData>& datas) {
   this->batch(datas);
 }
 
-MMBatchData::MMBatchData(uint32_t ty, const MMDict& items)
-    : ty_(ty), data_(std::move(items)) {}
+MMBatchData::MMBatchData(uint32_t type, const MMDict& items)
+    : type_(type), data_(std::move(items)) {}
 
 bool MMBatchData::has(const MMKey& key) const {
   if (!valid()) return false;
@@ -95,18 +95,19 @@ void MMBatchData::batch(const std::vector<MMData>& mm_datas) {
     }
   }
 
-  ty_ = visitor.ty_;
+  type_ = visitor.type_;
   data_ = std::move(dict);
 }
 
 void MMBatchData::debug_print() const {
-  LOG(INFO) << "mm batch data debug print, ty:" << ty_;
+  LOG(INFO) << "mm batch data debug print, type:" << type_;
   LOG(INFO) << "=============== mm batch vec data ================";
   LOG(INFO) << "mm batch data vec count:" << mm_datas_.size();
   for (const auto& mm_data : mm_datas_) {
     mm_data.debug_print();
   }
   LOG(INFO) << "=============== mm batch data dict data ================";
+
   for (const auto& pair : data_) {
     if (std::holds_alternative<torch::Tensor>(pair.second)) {
       torch::Tensor item = std::get<torch::Tensor>(pair.second);

--- a/xllm/core/framework/request/mm_batch_data.h
+++ b/xllm/core/framework/request/mm_batch_data.h
@@ -33,12 +33,12 @@ class MMBatchData {
  public:
   MMBatchData() = default;
   MMBatchData(const std::vector<MMData>& datas);
-  MMBatchData(uint32_t ty, const MMDict& items);
+  MMBatchData(uint32_t type, const MMDict& items);
 
-  bool has(uint32_t type) const { return type & ty_ != 0; }
-  bool valid() const { return ty_ != MMType::NONE; }
+  bool has(uint32_t type) const { return type & type_ != 0; }
+  bool valid() const { return type_ != MMType::NONE; }
 
-  uint32_t type() const { return ty_; }
+  uint32_t type() const { return type_; }
   const MMDict& data() const { return data_; }
 
   bool has(const MMKey& key) const;
@@ -83,7 +83,7 @@ class MMBatchData {
   void debug_print() const;
 
  private:
-  uint32_t ty_ = MMType::NONE;
+  uint32_t type_ = MMType::NONE;
   MMDict data_;
   std::vector<MMData> mm_datas_;
 };

--- a/xllm/core/framework/request/mm_data.cpp
+++ b/xllm/core/framework/request/mm_data.cpp
@@ -19,11 +19,11 @@ limitations under the License.
 
 namespace xllm {
 
-MMData::MMData(uint32_t ty, const MMItemVec& items)
-    : ty_(ty), items_(std::move(items)) {}
+MMData::MMData(uint32_t type, const MMItemVec& items)
+    : type_(type), items_(std::move(items)) {}
 
-MMData::MMData(uint32_t ty, const MMDict& items)
-    : ty_(ty), items_(std::move(items)) {}
+MMData::MMData(uint32_t type, const MMDict& items)
+    : type_(type), items_(std::move(items)) {}
 
 bool MMData::has(const MMKey& key) const {
   if (!valid()) return false;
@@ -61,7 +61,7 @@ bool MMData::add(MMType type, const MMDataItem& item) {
 
   auto& vec = items<MMItemVec>();
 
-  ty_ |= type;
+  type_ |= type;
   vec.emplace_back(item);
 
   return true;
@@ -72,7 +72,7 @@ MMDataItem& MMData::add(MMType type) {
 
   auto& vec = items<MMItemVec>();
 
-  ty_ |= type;
+  type_ |= type;
   vec.emplace_back(type);
 
   return vec.back();
@@ -166,7 +166,7 @@ bool MMData::foreach (IItemVisitor& v) {
 }
 
 void MMData::debug_print() const {
-  LOG(INFO) << "mm data debug print, ty:" << ty_;
+  LOG(INFO) << "mm data debug print, type:" << type_;
 
   if (hold<MMItemVec>()) {
     const auto& vec = items<MMItemVec>();

--- a/xllm/core/framework/request/mm_data.h
+++ b/xllm/core/framework/request/mm_data.h
@@ -60,16 +60,16 @@ class MMData {
 
  public:
   MMData() = default;
-  MMData(uint32_t ty, const MMItemVec& items);
-  MMData(uint32_t ty, const MMDict& items);
+  MMData(uint32_t type, const MMItemVec& items);
+  MMData(uint32_t type, const MMDict& items);
 
-  bool has(uint32_t type) const { return type & ty_ != 0; }
-  bool has(MMType type) const { return type & ty_ != 0; }
+  bool has(uint32_t type) const { return type & type_ != 0; }
+  bool has(MMType type) const { return type & type_ != 0; }
 
   bool has(const MMKey& key) const;
-  bool valid() const { return ty_ != MMType::NONE; }
+  bool valid() const { return type_ != MMType::NONE; }
 
-  uint32_t type() const { return ty_; }
+  uint32_t type() const { return type_; }
   size_t size() const;
 
   bool add(MMType type, const MMDataItem& item);
@@ -87,7 +87,7 @@ class MMData {
     const auto& itor = dict.find(key);
     if (itor != dict.end()) return false;
 
-    ty_ |= type;
+    type_ |= type;
     dict.insert({key, value});
     return true;
   }
@@ -136,7 +136,7 @@ class MMData {
 
   template <typename T>
   void set(uint32_t type, const T& item) {
-    ty_ = type;
+    type_ = type;
     items_ = item;
   }
 
@@ -160,14 +160,14 @@ class MMData {
   }
 
   template <typename T>
-  void get_metadata(MMType ty, std::vector<T>& metadatas) const {
+  void get_metadata(MMType type, std::vector<T>& metadatas) const {
     if (!valid()) return;
 
     if (!hold<MMItemVec>()) return;
 
     const auto& item_vec = items<MMItemVec>();
     for (const auto& item : item_vec) {
-      if (item.type() != ty) continue;
+      if (item.type() != type) continue;
 
       if (auto res = item.template get_metadata<T>()) {
         metadatas.push_back(res.value());
@@ -182,7 +182,7 @@ class MMData {
   void debug_print() const;
 
  private:
-  uint32_t ty_ = MMType::NONE;
+  uint32_t type_ = MMType::NONE;
   MMItems items_;
 };
 

--- a/xllm/core/framework/request/mm_data_item.cpp
+++ b/xllm/core/framework/request/mm_data_item.cpp
@@ -18,15 +18,15 @@ limitations under the License.
 
 namespace xllm {
 
-MMDataItem::MMDataItem(MMType ty) : ty_(ty) {}
+MMDataItem::MMDataItem(MMType type) : type_(type) {}
 
-MMDataItem::MMDataItem(MMType ty, const MMDict& data)
-    : ty_(ty), data_(std::move(data)) {}
+MMDataItem::MMDataItem(MMType type, const MMDict& data)
+    : type_(type), data_(std::move(data)) {}
 
-MMDataItem::MMDataItem(MMType ty,
+MMDataItem::MMDataItem(MMType type,
                        const MMDict& data,
                        const MMMetadata& metadata)
-    : ty_(ty), data_(std::move(data)), metadata_(std::move(metadata)) {}
+    : type_(type), data_(std::move(data)), metadata_(std::move(metadata)) {}
 
 bool MMDataItem::has(const MMKey& key) const {
   if (!valid()) return false;
@@ -50,7 +50,7 @@ void MMDataItem::get(const MMKey& key, std::vector<torch::Tensor>& vec) const {
 }
 
 void MMDataItem::debug_print() const {
-  LOG(INFO) << "mm data item debug print, ty:" << ty_;
+  LOG(INFO) << "mm data item debug print, type:" << type_;
 
   for (const auto& pair : data_) {
     if (std::holds_alternative<torch::Tensor>(pair.second)) {

--- a/xllm/core/framework/request/mm_data_item.h
+++ b/xllm/core/framework/request/mm_data_item.h
@@ -43,18 +43,18 @@ class MMDataItem {
   };
 
  public:
-  MMDataItem(MMType ty);
-  MMDataItem(MMType ty, const MMDict& data);
-  MMDataItem(MMType ty, const MMDict& data, const MMMetadata& metadata);
+  MMDataItem(MMType type);
+  MMDataItem(MMType type, const MMDict& data);
+  MMDataItem(MMType type, const MMDict& data, const MMMetadata& metadata);
 
-  bool valid() const { return ty_ != MMType::NONE; }
-  bool is_type(MMType type) const { return ty_ == type; }
+  bool valid() const { return type_ != MMType::NONE; }
+  bool is_type(MMType type) const { return type_ == type; }
 
   const MMDict& data() const { return data_; }
   MMDict& mutable_data() { return data_; }
   void set_data(const MMDict& data) { data_ = std::move(data); }
 
-  MMType type() const { return ty_; }
+  MMType type() const { return type_; }
   bool has(const MMKey& key) const;
 
   void get(const MMKey& key, std::vector<torch::Tensor>& vec) const;
@@ -97,7 +97,7 @@ class MMDataItem {
   void debug_print() const;
 
  private:
-  MMType ty_ = MMType::NONE;
+  MMType type_ = MMType::NONE;
   MMDict data_;
   MMMetadata metadata_;
   MMItemState state_;

--- a/xllm/core/framework/request/mm_data_visitor.cpp
+++ b/xllm/core/framework/request/mm_data_visitor.cpp
@@ -64,7 +64,7 @@ bool CollectItemTensorVisitor::visit(const MMKey& key, MMValue& value) {
 }
 
 bool CollectMMDataTensorVisitor::visit(MMData& data) {
-  ty_ |= data.type();
+  type_ |= data.type();
   data.foreach (item_visitor_);
   return true;
 }

--- a/xllm/core/framework/request/mm_data_visitor.h
+++ b/xllm/core/framework/request/mm_data_visitor.h
@@ -56,7 +56,7 @@ class CollectMMDataTensorVisitor : public MMData::IVisitor {
   bool visit(MMData& data) override;
 
  public:
-  uint32_t ty_ = MMType::NONE;
+  uint32_t type_ = MMType::NONE;
   std::unordered_map<MMKey, std::vector<torch::Tensor>> datas_;
 
   CollectItemTensorVisitor item_visitor_;

--- a/xllm/core/framework/request/mm_embedding_handler.cpp
+++ b/xllm/core/framework/request/mm_embedding_handler.cpp
@@ -98,8 +98,8 @@ MMEmbeddingHandler::MMEmbeddingHandler(MMType::Value mm_type)
 bool MMEmbeddingHandler::load(const MMContent& content,
                               MMInputItem& input,
                               MMPayload& payload) {
-  input.type_ = mm_type_;
-  if (!parse_embedding_output(content.embedding, payload, input.embedding_)) {
+  input.type = mm_type_;
+  if (!parse_embedding_output(content.embedding, payload, input.embedding)) {
     return false;
   }
 

--- a/xllm/core/framework/request/mm_handler.cpp
+++ b/xllm/core/framework/request/mm_handler.cpp
@@ -92,13 +92,13 @@ bool ImageHandler::load(const MMContent& content,
   if (url.compare(0, dataurl_prefix_.size(), dataurl_prefix_) ==
       0) {  // data url
 
-    input.type_ = MMType::IMAGE;
-    return this->load_from_dataurl(url, input.raw_data_, payload);
+    input.type = MMType::IMAGE;
+    return this->load_from_dataurl(url, input.raw_data, payload);
   } else if (url.compare(0, httpurl_prefix_.size(), httpurl_prefix_) ==
              0) {  // http url
 
-    input.type_ = MMType::IMAGE;
-    return this->load_from_http(url, input.raw_data_);
+    input.type = MMType::IMAGE;
+    return this->load_from_http(url, input.raw_data);
   } else {
     LOG(ERROR) << " image url is invalid, url is " << url;
     return false;
@@ -107,7 +107,7 @@ bool ImageHandler::load(const MMContent& content,
 
 bool ImageHandler::decode(MMInputItem& input) {
   OpenCVImageDecoder decoder;
-  return decoder.decode(input.raw_data_, input.decode_data_);
+  return decoder.decode(input.raw_data, input.decode_data);
 }
 
 bool VideoHandler::load(const MMContent& content,
@@ -121,13 +121,13 @@ bool VideoHandler::load(const MMContent& content,
   if (url.compare(0, dataurl_prefix_.size(), dataurl_prefix_) ==
       0) {  // data url
 
-    input.type_ = MMType::VIDEO;
-    return this->load_from_dataurl(url, input.raw_data_, payload);
+    input.type = MMType::VIDEO;
+    return this->load_from_dataurl(url, input.raw_data, payload);
   } else if (url.compare(0, httpurl_prefix_.size(), httpurl_prefix_) ==
              0) {  // http url
 
-    input.type_ = MMType::VIDEO;
-    return this->load_from_http(url, input.raw_data_);
+    input.type = MMType::VIDEO;
+    return this->load_from_http(url, input.raw_data);
   } else {
     LOG(ERROR) << " video url is invalid, url is " << url;
     return false;
@@ -136,7 +136,7 @@ bool VideoHandler::load(const MMContent& content,
 
 bool VideoHandler::decode(MMInputItem& input) {
   OpenCVVideoDecoder decoder;
-  return decoder.decode(input.raw_data_, input.decode_data_, input.video_meta_);
+  return decoder.decode(input.raw_data, input.decode_data, input.video_meta);
 }
 
 MMHandlerSet::MMHandlerSet() {

--- a/xllm/core/framework/request/mm_input.cpp
+++ b/xllm/core/framework/request/mm_input.cpp
@@ -36,7 +36,7 @@ bool MMInputTransfer::trans(const std::vector<Message>& messages,
     const auto& message = messages[idx];
     const auto& mmc = std::get<MMContentVec>(message.content);
 
-    if (!this->trans(mmc, ins, inputs.payload_)) {
+    if (!this->trans(mmc, ins, inputs.payload)) {
       return false;
     }
 

--- a/xllm/core/framework/request/mm_input.h
+++ b/xllm/core/framework/request/mm_input.h
@@ -27,49 +27,46 @@ namespace xllm {
 
 struct MMInputItem {
   void clear() {
-    type_ = MMType::NONE;
-    raw_data_.clear();
+    type = MMType::NONE;
+    raw_data.clear();
   }
 
-  MMType type_ = MMType::NONE;
-
-  std::string raw_data_;  // binary
-
-  torch::Tensor decode_data_;  // image: rgb, [c,h,w], uint8
-
-  VideoMetadata video_meta_;
-
-  EmbeddingOutput embedding_;
+  MMType type = MMType::NONE;
+  std::string raw_data;       // binary
+  torch::Tensor decode_data;  // image: rgb, [c,h,w], uint8
+  VideoMetadata video_meta;
+  EmbeddingOutput embedding;
 };
 
 struct MMPayload {
   MMPayload() = default;
   explicit MMPayload(const std::string& data, size_t offset = 0)
-      : data_(std::move(data)), offset_(offset) {}
+      : data(std::move(data)), offset(offset) {}
 
   bool get(std::string& value, size_t len) {
-    if (len == data_.size()) {
-      value = std::move(data_);
+    if (len == data.size()) {
+      value = std::move(data);
       return true;
     }
 
-    if (data_.size() - offset_ < len) {
+    if (data.size() - offset < len) {
       return false;
     }
 
-    value = data_.substr(offset_, len);
-    offset_ += len;
+    value = data.substr(offset, len);
+    offset += len;
 
     return true;
   }
 
-  std::string data_;
-  size_t offset_;
+  std::string data;
+  size_t offset;
 };
 
-struct MMInput {
+class MMInput {
+ public:
   MMInput() = default;
-  explicit MMInput(const std::string& payload) : payload_(payload) {}
+  explicit MMInput(const std::string& payload) : payload(std::move(payload)) {}
 
   bool empty() const { return items_.empty(); }
   void clear() { items_.clear(); }
@@ -87,16 +84,16 @@ struct MMInput {
 
   std::vector<MMInputItem>::const_iterator end() const { return items_.end(); }
 
-  void insert(const std::vector<MMInputItem>& items) {
-    items_.insert(items_.end(), items.begin(), items.end());
+  void insert(const std::vector<MMInputItem>& inputs) {
+    items_.insert(items_.end(), inputs.begin(), inputs.end());
   }
 
   std::vector<torch::Tensor> get_decode_data(MMType type) const {
     std::vector<torch::Tensor> vec;
 
     for (const auto& item : items_) {
-      if (item.type_ == type) {
-        vec.emplace_back(item.decode_data_);
+      if (item.type == type) {
+        vec.emplace_back(item.decode_data);
       }
     }
     return std::move(vec);
@@ -106,14 +103,16 @@ struct MMInput {
     std::vector<VideoMetadata> metas;
     metas.reserve(items_.size());
     for (auto& item : items_) {
-      if (item.type_ == MMType::VIDEO) {
-        metas.push_back(item.video_meta_);
+      if (item.type == MMType::VIDEO) {
+        metas.push_back(item.video_meta);
       }
     }
     return metas;
   }
 
-  MMPayload payload_;
+  MMPayload payload;
+
+ private:
   std::vector<MMInputItem> items_;
 };
 

--- a/xllm/core/framework/request/mm_type.cpp
+++ b/xllm/core/framework/request/mm_type.cpp
@@ -18,7 +18,7 @@ limitations under the License.
 namespace xllm {
 
 std::optional<std::string> MMType::to_string() {
-  switch (value) {
+  switch (value_) {
     case Value::NONE:
       return std::nullopt;
     case Value::IMAGE:
@@ -30,7 +30,7 @@ std::optional<std::string> MMType::to_string() {
     case Value::EMBEDDING:
       return "embedding";
     default:
-      LOG(WARNING) << "Unknown mm type: " << static_cast<int>(value);
+      LOG(WARNING) << "Unknown mm type: " << static_cast<int>(value_);
   }
   return std::nullopt;
 }

--- a/xllm/core/framework/request/mm_type.h
+++ b/xllm/core/framework/request/mm_type.h
@@ -34,20 +34,20 @@ class MMType {
   };
 
   MMType() = default;
-  MMType(Value v) : value(v) {}
-  operator Value() const { return value; }
+  MMType(Value v) : value_(v) {}
+  operator Value() const { return value_; }
   explicit operator bool() const = delete;
 
-  bool operator==(MMType rhs) const { return value == rhs.value; }
-  bool operator!=(MMType rhs) const { return value != rhs.value; }
+  bool operator==(MMType rhs) const { return value_ == rhs.value_; }
+  bool operator!=(MMType rhs) const { return value_ != rhs.value_; }
 
-  bool operator==(Value v) const { return value == v; }
-  bool operator!=(Value v) const { return value != v; }
+  bool operator==(Value v) const { return value_ == v; }
+  bool operator!=(Value v) const { return value_ != v; }
 
   std::optional<std::string> to_string();
 
  private:
-  Value value = Value::NONE;
+  Value value_ = Value::NONE;
 };
 
 struct ImageMetadata {

--- a/xllm/processors/pywarpper_image_processor.cpp
+++ b/xllm/processors/pywarpper_image_processor.cpp
@@ -47,8 +47,8 @@ class __attribute__((visibility("hidden"))) PyWrapperImpl {
 
     try {
       py::list py_lst;
-      for (const auto& item : inputs.items_) {
-        py_lst.append(py::bytes(item.raw_data_));
+      for (const auto& item : inputs.items()) {
+        py_lst.append(py::bytes(item.raw_data));
       }
 
       py::dict res = preprocess_(py_lst, FLAGS_model);

--- a/xllm/processors/qwen2_vl_image_processor.cpp
+++ b/xllm/processors/qwen2_vl_image_processor.cpp
@@ -163,17 +163,17 @@ bool Qwen2VLImageProcessor::process(const MMInput& inputs, MMData& datas) {
     std::vector<torch::Tensor> videos;
     std::vector<VideoMetadata> video_meta_list;
 
-    if (input_item.type_ == MMType::IMAGE) {
-      if (input_item.decode_data_.defined()) {
-        images.push_back(input_item.decode_data_);
-      } else if (input_item.embedding_.embedding.defined()) {
-        images_embedding.push_back(input_item.embedding_);
+    if (input_item.type == MMType::IMAGE) {
+      if (input_item.decode_data.defined()) {
+        images.push_back(input_item.decode_data);
+      } else if (input_item.embedding.embedding.defined()) {
+        images_embedding.push_back(input_item.embedding);
       }
-    } else if (input_item.type_ == MMType::VIDEO) {
-      if (input_item.decode_data_.defined()) {
-        videos.push_back(input_item.decode_data_);
+    } else if (input_item.type == MMType::VIDEO) {
+      if (input_item.decode_data.defined()) {
+        videos.push_back(input_item.decode_data);
       }
-      video_meta_list.push_back(input_item.video_meta_);
+      video_meta_list.push_back(input_item.video_meta);
     }
 
     if (images_embedding.empty() && images.empty() &&


### PR DESCRIPTION
- Standardize public struct member naming (remove trailing underscores)
- Encapsulate MMInput by converting to class with private items_
- Move build_messages() to mm_service_utils namespace
- Extract helper methods in Sequence for better readability
- Remove redundant rec_type_ member and is_rec_request() method
- Fix missing return in Engine::pull_kv_blocks()