### PR TITLE
bugfix: fix kLlmRec KV cache allocation insufficient in rec FixedStepsSchduler.

### DIFF
--- a/xllm/core/scheduler/fixed_steps_scheduler.h
+++ b/xllm/core/scheduler/fixed_steps_scheduler.h
@@ -28,7 +28,6 @@ limitations under the License.
 #include "common/types.h"
 #include "framework/batch/batch.h"
 #include "framework/batch/batch_factory.h"
-#include "framework/block/block_manager_pool.h"
 #include "framework/request/request.h"
 #include "framework/request/sequence.h"
 #include "runtime/xservice_client.h"


### PR DESCRIPTION
  This PR is a follow-up bugfix to the chat completions API support added in the previous PR #643 . It fixes a KV cache allocation issue that caused assertion failures during LlmRec inference.

  ## Problem

  When running LlmRec models with the chat completions API, the following assertion failure occurred:

  batch_input_builder.cpp:283] Check failed: sequence->kv_state().current_max_tokens_capacity() >= seq_len

  The root cause was that `FixedStepsScheduler::LlmRecSchedulerPipeline::allocate_kv_cache()` was not properly allocating KV cache capacity for the full sequence length (prefill tokens + max generated tokens).

  ## What's fixed

  - **KV cache allocation in LlmRecSchedulerPipeline**:
    - Now correctly calculates required capacity: `num_tokens + max_generated_tokens`
    - Uses `KVCacheManager::allocate()` instead of `BlockManagerPool` for proper capacity tracking
    - Ensures `current_max_tokens_capacity() >= seq_len` check passes

  ## Files changed

  - `xllm/core/scheduler/fixed_steps_scheduler.cpp`
  - `xllm/core/scheduler/fixed_steps_scheduler.h`

  ## Testing

  - [x] `backend=rec` + `/v1/chat/completions` (Qwen3-8B) — no longer crashes
  - [x] KV cache capacity assertion passes

