### PR TITLE
bugfix: reslove release error of MemoryMapping.

### DIFF
--- a/xllm/core/framework/state_dict/state_dict.cpp
+++ b/xllm/core/framework/state_dict/state_dict.cpp
@@ -114,7 +114,7 @@ void destroy_memory_mapping(MemoryMapping* mapping) {
     if (mapping->fd != -1) {
       close(mapping->fd);
     }
-    free(mapping);
+    delete mapping;
   }
 }
 }  // namespace


### PR DESCRIPTION
## Issue

Server crashes with segmentation fault when loading models at startup.

**Error stack**:
```
#0  0x0000ffff8050b190 in ?? () from /usr/lib64/libjemalloc.so.2
#1  0x0000000000b7e5e0 in destroy_memory_mapping(MemoryMapping*) ()
#2  0x0000000000b7e7f4 in xllm::StateDictFromSafeTensor::~StateDictFromSafeTensor() ()
```

## Root Cause

`destroy_memory_mapping()` uses `free()` to release memory allocated by `std::make_unique` (i.e., `new`), mixing C++ and C memory management, causing jemalloc to trigger segmentation fault.

## Fix

Change `free(mapping)` to `delete mapping`.

## Impact

- ✅ Server starts successfully
- ✅ Models load correctly (e.g., GLM-4.7-MTP)
- ✅ Multi-threaded safetensor loading works properly
