### PR TITLE
docs: Remove `ASCEND_RT_VISIBLE_DEVICES` from multi-machine examples

### DIFF
--- a/docs/en/getting_started/multi_machine.md
+++ b/docs/en/getting_started/multi_machine.md
@@ -69,7 +69,6 @@ rm -rf core.*
 
 source /usr/local/Ascend/ascend-toolkit/set_env.sh 
 source /usr/local/Ascend/nnal/atb/set_env.sh
-export ASCEND_RT_VISIBLE_DEVICES=0
 export HCCL_IF_BASE_PORT=43432  # HCCL communication base port
 
 MODEL_PATH="/path/to/your/DeepSeek-R1"             # Model path

--- a/docs/zh/getting_started/multi_machine.md
+++ b/docs/zh/getting_started/multi_machine.md
@@ -66,7 +66,6 @@ rm -rf core.*
 
 source /usr/local/Ascend/ascend-toolkit/set_env.sh 
 source /usr/local/Ascend/nnal/atb/set_env.sh
-export ASCEND_RT_VISIBLE_DEVICES=0
 export HCCL_IF_BASE_PORT=43432  # HCCL 通信基础端口
 
 MODEL_PATH="/path/to/your/DeepSeek-R1"             # 模型路径


### PR DESCRIPTION
**Description of the problem**

In the sample script, `ASCEND_RT_VISIBLE_DEVICES` is setup to use 1 device, but the number of local nodes instantiated per instance is 16. This mismatch could lead to potential issues in configurations where the `ASCEND_RT_VISIBLE_DEVICES` env variable is taken into account.

**Proposed solution**

Remove `ASCEND_RT_VISIBLE_DEVICES`.