### PR TITLE
docs: fix typo in path

### DIFF
--- a/docs/en/getting_started/quick_start.md
+++ b/docs/en/getting_started/quick_start.md
@@ -83,7 +83,7 @@ sudo docker run -it \
 
 ## Build xllm
 
-If you download a release image, i.e., an image with a version number in the tag, you can skip this step because the release image comes with a pre-compiled xllm binary, located at `/usr/loacl/bin/xllm`.
+If you download a release image, i.e., an image with a version number in the tag, you can skip this step because the release image comes with a pre-compiled xllm binary, located at `/usr/local/bin/xllm`.
 
 Download xllm and dependencies:
 ```bash

--- a/docs/zh/getting_started/quick_start.md
+++ b/docs/zh/getting_started/quick_start.md
@@ -83,7 +83,7 @@ sudo docker run -it \
 
 ## 编译xllm
 
-如果下载的是release镜像，即tag中带有版本号的镜像，可以跳过此步，因为release镜像自带编译好的xllm二进制文件，路径为`/usr/loacl/bin/xllm`。
+如果下载的是release镜像，即tag中带有版本号的镜像，可以跳过此步，因为release镜像自带编译好的xllm二进制文件，路径为`/usr/local/bin/xllm`。
 
 下载xllm及依赖
 ```bash


### PR DESCRIPTION
Fix typo: `loacl` to `local`