### PR TITLE
feat: add scheduler and engine for pure device pipeline[1/3].

### DIFF
--- a/xllm/core/common/global_flags.cpp
+++ b/xllm/core/common/global_flags.cpp
@@ -500,3 +500,18 @@ DEFINE_string(
     "ATB",
     "NPU kernel backend. Supported options: ATB, TORCH. Default is ATB.");
 #endif
+
+// --- multi-step decode config ---
+
+DEFINE_int32(max_decode_rounds,
+             0,
+             "Maximum number of decode rounds for multi-step decoding. "
+             "0 means disabled.");
+
+DEFINE_int32(beam_width, 1, "Beam width for beam search.");
+
+DEFINE_int64(max_token_per_req,
+             1024,
+             "Max tokens per request (prompt + generated). "
+             "Used as a global guardrail for per-request token budget. "
+             "This is only used in pure device pipeline.");

--- a/xllm/core/common/global_flags.h
+++ b/xllm/core/common/global_flags.h
@@ -241,6 +241,14 @@ DECLARE_double(dit_cache_residual_diff_threshold);
 
 DECLARE_bool(enable_constrained_decoding);
 
+// --- multi-step decode config ---
+
+DECLARE_int32(max_decode_rounds);
+
+DECLARE_int32(beam_width);
+
+DECLARE_int64(max_token_per_req);
+
 #if defined(USE_NPU)
 DECLARE_string(npu_kernel_backend);
 #endif

--- a/xllm/core/common/help_formatter.h
+++ b/xllm/core/common/help_formatter.h
@@ -62,6 +62,10 @@ const OptionCategory kDisaggregatedPrefillDecodeOptions = {
      "npu_phy_id",
      "transfer_listen_port"}};
 
+const OptionCategory kMultiStepDecodeOptions = {
+    "MULTI-STEP DECODE OPTIONS",
+    {"max_decode_rounds", "beam_width", "max_token_per_req"}};
+
 const OptionCategory kMtpOptions = {
     "MTP OPTIONS",
     {"draft_model", "draft_devices", "num_speculative_tokens"}};
@@ -83,6 +87,7 @@ const std::vector<OptionCategory> kOptionCategories = {
     kCommonOptions,
     kMoeModelOptions,
     kDisaggregatedPrefillDecodeOptions,
+    kMultiStepDecodeOptions,
     kMtpOptions,
     kXllmServiceOptions,
     kOtherOptions};

--- a/xllm/core/common/rec_model_utils.h
+++ b/xllm/core/common/rec_model_utils.h
@@ -18,6 +18,8 @@ limitations under the License.
 #include <cstdint>
 #include <string_view>
 
+#include "core/common/global_flags.h"
+
 namespace xllm {
 
 enum class RecModelKind : int8_t {
@@ -28,16 +30,32 @@ enum class RecModelKind : int8_t {
 
 // Pipeline strategy types (extensible for future strategies)
 enum class RecPipelineType : uint8_t {
-  kLlmRecDefault = 0,     // LlmRec without mm_data (pure qwen)
-  kLlmRecWithMmData = 1,  // LlmRec with mm_data (qwen + embedding)
-  kOneRecDefault = 2,     // OneRec
+  kLlmRecDefault = 0,             // LlmRec without mm_data (pure qwen)
+  kLlmRecWithMmData = 1,          // LlmRec with mm_data (qwen + embedding)
+  kOneRecDefault = 2,             // OneRec
+  kLlmRecPureDevicePipeline = 3,  // LlmRec pure device pipeline for multi-round
 };
+
+// Check if pure device mode is enabled
+// Pure device mode: multi-round decode loop runs entirely on device (Worker
+// layer) instead of being controlled by Engine layer
+inline bool is_pure_device_mode() { return FLAGS_max_decode_rounds > 0; }
+
+// Get the number of decode rounds for pure device mode
+// Returns 0 if pure device mode is disabled
+inline int32_t get_pure_device_decode_rounds() {
+  return is_pure_device_mode() ? FLAGS_max_decode_rounds : 0;
+}
 
 // Pipeline strategy selector: choose strategy based on RecModelKind
 inline RecPipelineType get_rec_pipeline_type(RecModelKind kind) {
   switch (kind) {
     case RecModelKind::kLlmRec:
-      return RecPipelineType::kLlmRecDefault;
+      if (is_pure_device_mode()) {
+        return RecPipelineType::kLlmRecPureDevicePipeline;
+      } else {
+        return RecPipelineType::kLlmRecDefault;
+      }
     case RecModelKind::kOneRec:
       return RecPipelineType::kOneRecDefault;
     default:

--- a/xllm/core/distributed_runtime/rec_engine.h
+++ b/xllm/core/distributed_runtime/rec_engine.h
@@ -125,6 +125,28 @@ class RecEngine : public Engine {
     ForwardOutput get_model_output(const ForwardInput& model_inputs);
   };
 
+  // ============================================================
+  // PureDeviceEnginePipeline: kLlmRecPureDevicePipeline via local Worker
+  // For multi-round pure device inference (multi-round logic in worker)
+  // ============================================================
+  class PureDeviceEnginePipeline final : public RecEnginePipeline {
+   public:
+    explicit PureDeviceEnginePipeline(RecEngine& engine);
+
+    void setup_workers() override;
+    void process_group_test() override;
+    bool init_model_workers(const std::string& model_path) override;
+    int64_t estimate_min_available_memory() override;
+    bool allocate_kv_cache(
+        const std::vector<std::vector<int64_t>>& kv_cache_shape) override;
+    ForwardOutput step(std::vector<Batch>& batches) override;
+    std::vector<int64_t> get_active_activation_memory() const override;
+    size_t num_workers() const override;
+
+   private:
+    ForwardOutput get_model_output(const ForwardInput& model_inputs);
+  };
+
   // Factory method to create pipeline (can access private classes)
   static std::unique_ptr<RecEnginePipeline> create_pipeline(
       RecPipelineType type,

--- a/xllm/core/distributed_runtime/rec_master.cpp
+++ b/xllm/core/distributed_runtime/rec_master.cpp
@@ -375,6 +375,7 @@ std::unique_ptr<RecMaster::RecMasterPipeline> RecMaster::create_pipeline(
     RecMaster& master) {
   switch (type) {
     case RecPipelineType::kLlmRecDefault:
+    case RecPipelineType::kLlmRecPureDevicePipeline:
       return std::make_unique<LlmRecMasterPipeline>(master);
     case RecPipelineType::kLlmRecWithMmData:
       return std::make_unique<LlmRecWithMmDataMasterPipeline>(master);

--- a/xllm/core/framework/batch/batch.cpp
+++ b/xllm/core/framework/batch/batch.cpp
@@ -24,6 +24,7 @@ limitations under the License.
 #include "batch_input_builder.h"
 #include "common/global_flags.h"
 #include "common/metrics.h"
+#include "core/common/rec_model_utils.h"
 #include "framework/batch/mposition.h"
 #include "framework/model/model_args.h"
 #include "framework/model/model_input_params.h"
@@ -352,6 +353,69 @@ void Batch::process_sample_output(const RawForwardOutput& raw_output,
   if (!FLAGS_enable_schedule_overlap || replace_fake_token) {
     process_beam_search();
   }
+}
+
+void Batch::process_beam_sequence_group(const ForwardOutput& output) {
+  // TODO. uncomment this in next pr.
+  /*
+  if (!output.beam_sequence_group.defined() ||
+      output.beam_sequence_group.numel() == 0) {
+    return;
+  }
+
+  // Get sequences from either sequences_ or sequence_groups_
+  auto sequences = get_sequences();
+  if (sequences.empty()) {
+    return;
+  }
+
+  const int32_t beam_width = sequences[0]->sampling_param()->beam_width;
+  if (beam_width <= 1) {
+    return;
+  }
+  int32_t total_rounds = get_pure_device_decode_rounds();
+  size_t num_groups = sequence_groups_.size();
+  if (num_groups == 0) {
+    // Fallback: treat sequences_ as single group
+    num_groups = sequences.size();
+  }
+
+  // Tensor should already be on CPU (transferred in get_model_output)
+  auto seq_group_accessor = output.beam_sequence_group.accessor<int32_t, 3>();
+
+  // out_logprobs from beam_search_output, shape: [batch * beam_width]
+  // Tensor should already be on CPU (transferred in get_model_output)
+  bool has_logprobs = output.beam_search_output.out_logprobs.defined() &&
+                      output.beam_search_output.out_logprobs.numel() > 0;
+
+  for (size_t g = 0; g < num_groups; ++g) {
+    std::vector<std::vector<int32_t>> group_flat2d;
+    group_flat2d.reserve(static_cast<size_t>(beam_width));
+    std::vector<float> last_logprobs;
+    last_logprobs.reserve(static_cast<size_t>(beam_width));
+
+    for (int b = 0; b < beam_width; ++b) {
+      std::vector<int32_t> row_tokens;
+      row_tokens.reserve(static_cast<size_t>(total_rounds));
+      for (int c = 0; c < total_rounds; ++c) {
+        // Access [g][b][c]
+        row_tokens.push_back(seq_group_accessor[g][b][c]);
+      }
+      group_flat2d.emplace_back(std::move(row_tokens));
+      if (has_logprobs) {
+        // logprobs is flattened [batch * beam_width]
+        int logprob_idx = static_cast<int>(g) * beam_width + b;
+        last_logprobs.push_back(
+            output.beam_search_output.out_logprobs[logprob_idx].item<float>());
+      }
+    }
+    // Access sequence from sequence_groups_ if available
+    Sequence* seq = sequence_groups_.empty()
+                        ? sequences[g]
+                        : sequence_groups_[g]->sequences()[0].get();
+    seq->set_beam_result(beam_width, total_rounds, group_flat2d, last_logprobs);
+  }
+  */
 }
 
 void Batch::process_sample_output(const SampleOutput& sample_output,

--- a/xllm/core/framework/batch/batch.h
+++ b/xllm/core/framework/batch/batch.h
@@ -114,6 +114,8 @@ class Batch {
   void process_beam_search_output(const RawForwardOutput& raw_output,
                                   bool replace_fake_token);
 
+  void process_beam_sequence_group(const RawForwardOutput& raw_output);
+  void process_beam_sequence_group(const ForwardOutput& output);
   // mark all sequences as finished (used by rec model multi-round decoding)
   void finish();
 

--- a/xllm/core/framework/parallel_state/parallel_state.h
+++ b/xllm/core/framework/parallel_state/parallel_state.h
@@ -20,6 +20,11 @@ limitations under the License.
 
 namespace xllm {
 
+// Forward declaration
+namespace runtime {
+struct Options;
+}
+
 namespace parallel_state {
 
 std::optional<ParallelArgs> get_dp_attn_parallel_args(
@@ -49,6 +54,13 @@ torch::Tensor scatter(torch::Tensor input,
 // devices: list of devices to create process groups on.
 std::vector<std::unique_ptr<ProcessGroup>> create_npu_process_groups(
     const std::vector<torch::Device>& devices);
+
+// Create process groups for local (single-node) scenarios
+// Supports GPU (CUDA/MLU) and NPU, including single-device case
+// Parse port from options.master_node_addr() to support multiple instances
+std::vector<std::unique_ptr<ProcessGroup>> create_local_process_groups(
+    const std::vector<torch::Device>& devices,
+    const runtime::Options& options);
 
 }  // namespace parallel_state
 }  // namespace xllm

--- a/xllm/core/framework/request/sequence.h
+++ b/xllm/core/framework/request/sequence.h
@@ -277,6 +277,29 @@ class Sequence final {
 
   bool check_need_unique_tokens() { return need_unique_tokens_; }
 
+  // Multi-round beam search result caching
+  void set_beam_result(int32_t bw,
+                       int32_t total_rounds,
+                       const std::vector<std::vector<int32_t>>& flat,
+                       const std::vector<float>& last_logprobs) {
+    beam_width_cached_ = bw;
+    total_rounds_cached_ = total_rounds;
+    beam_seq_group_flat_ = flat;
+    beam_last_logprobs_ = last_logprobs;
+  }
+  bool has_beam_result() const {
+    return beam_width_cached_ > 0 && total_rounds_cached_ > 0 &&
+           !beam_seq_group_flat_.empty();
+  }
+  const std::vector<std::vector<int32_t>>& beam_seq_group_flat() const {
+    return beam_seq_group_flat_;
+  }
+  const std::vector<float>& beam_last_logprobs() const {
+    return beam_last_logprobs_;
+  }
+  int32_t beam_width_cached() const { return beam_width_cached_; }
+  int32_t total_rounds_cached() const { return total_rounds_cached_; }
+
   LogprobState* logprob_state() { return logprob_state_.get(); }
 
   // set sequence id
@@ -449,6 +472,12 @@ class Sequence final {
 
   // whether the last token is handled
   std::atomic<bool> last_token_handled_{false};
+
+  // Multi-round beam search result caching
+  int32_t beam_width_cached_ = 0;
+  int32_t total_rounds_cached_ = 0;
+  std::vector<std::vector<int32_t>> beam_seq_group_flat_;
+  std::vector<float> beam_last_logprobs_;
 };
 
 }  // namespace xllm

--- a/xllm/core/framework/request/sequences_group.cpp
+++ b/xllm/core/framework/request/sequences_group.cpp
@@ -17,8 +17,11 @@ limitations under the License.
 
 #include <unordered_set>
 
+#include "common/global_flags.h"
+#include "core/common/rec_model_utils.h"
 #include "framework/batch/beam_search.h"
 #include "util/blocking_counter.h"
+#include "util/slice.h"
 
 namespace xllm {
 
@@ -91,6 +94,15 @@ bool SequencesGroup::expand_sequences(bool share_prefix) {
 void SequencesGroup::generate_outputs(std::vector<SequenceOutput>& outputs,
                                       const Tokenizer& tokenizer,
                                       ThreadPool* thread_pool) {
+  // Check for multi-round beam search results
+  if (is_pure_device_mode() && check_beam_search() && sequences_.size() == 1) {
+    auto* base = sequences_[0].get();
+    if (base->has_beam_result()) {
+      generate_multi_round_output(outputs, tokenizer, *base);
+      return;
+    }
+  }
+
   if (sequence_params_.streaming) {
     for (auto& seq : sequences_) {
       outputs.push_back(std::move(seq->generate_output()));
@@ -295,6 +307,46 @@ void SequencesGroup::process_beam_search() {
 void SequencesGroup::finish() {
   for (auto& sequence : sequences_) {
     sequence->finish();
+  }
+}
+
+void SequencesGroup::generate_multi_round_output(
+    std::vector<SequenceOutput>& outputs,
+    const Tokenizer& tokenizer,
+    const Sequence& base) {
+  size_t bw = static_cast<size_t>(base.beam_width_cached());
+  const auto& last_lps = base.beam_last_logprobs();
+
+  // Rank by logprob
+  std::vector<std::pair<float, size_t>> rank;
+  rank.reserve(bw);
+  for (size_t b = 0; b < bw; ++b) {
+    float lp = (b < last_lps.size()) ? last_lps[b] : 0.0f;
+    rank.emplace_back(lp, b);
+  }
+  std::sort(rank.begin(), rank.end(), [](const auto& l, const auto& r) {
+    return l.first > r.first;
+  });
+
+  const auto& flat2d = base.beam_seq_group_flat();
+  size_t rounds = static_cast<size_t>(base.total_rounds_cached());
+  outputs.reserve(bw);
+
+  for (size_t i = 0; i < bw; ++i) {
+    size_t b = rank[i].second;
+    std::vector<int32_t> gen_ids(flat2d[b].begin(), flat2d[b].end());
+
+    SequenceOutput out;
+    out.index = i;
+    out.text = tokenizer.decode(Slice<int32_t>{gen_ids.data(), gen_ids.size()},
+                                sequence_params_.skip_special_tokens);
+    out.token_ids = std::move(gen_ids);
+
+    auto fr = base.finish_reason().to_string();
+    if (fr.has_value()) {
+      out.finish_reason = fr.value();
+    }
+    outputs.push_back(std::move(out));
   }
 }
 

--- a/xllm/core/framework/request/sequences_group.h
+++ b/xllm/core/framework/request/sequences_group.h
@@ -72,6 +72,11 @@ class SequencesGroup {
                                  const Tokenizer& tokenizer,
                                  ThreadPool* thread_pool = nullptr);
 
+  // Generate output for multi-round beam search
+  void generate_multi_round_output(std::vector<SequenceOutput>& outputs,
+                                   const Tokenizer& tokenizer,
+                                   const Sequence& base);
+
  private:
   const std::string& prompt_;                  // ref from request
   const std::vector<int32_t>& prompt_tokens_;  // ref from request

--- a/xllm/core/scheduler/fixed_steps_scheduler.h
+++ b/xllm/core/scheduler/fixed_steps_scheduler.h
@@ -81,6 +81,22 @@ class FixedStepsScheduler final : public ContinuousScheduler {
     }
   };
 
+  class PureDeviceSchedulerPipeline final : public SchedulerPipeline {
+   public:
+    std::vector<Batch> create_batches(FixedStepsScheduler& scheduler,
+                                      BatchFactory* batch_factory) override;
+    bool requires_kv_cache() const override { return false; }
+    bool allocate_kv_cache(KVCacheManager* /*kv_cache_manager*/,
+                           Sequence* /*sequence*/) override {
+      return true;  // PureDevice mode does not need KV cache allocation
+    }
+  };
+
+  // Factory method to create scheduler pipeline
+  static std::unique_ptr<SchedulerPipeline> create_scheduler_pipeline(
+      RecType rec_type,
+      bool is_pure_device);
+
   std::vector<Batch> schedule_request(const absl::Duration& timeout);
 
   // build a batch of requests from the priority queue


### PR DESCRIPTION
# feat: Add PureDevice Pipeline for Multi-Round Decode [1/3]

This PR introduces the foundational infrastructure for the **PureDevice Pipeline**, a new execution mode where multi-round decode loops run entirely on the device (Worker layer) instead of being controlled by the Engine layer. This is the first of three PRs to implement the complete feature.

## Background

The PureDevice mode is designed for scenarios requiring multi-round inference on device, such as beam search with multiple decode rounds. Unlike the traditional `LlmRecEnginePipeline` which uses distributed RPC calls, `PureDeviceEnginePipeline` directly holds and invokes local Workers, reducing communication overhead.

## What's Added

### 1. Global Configuration Flags
- `FLAGS_max_decode_rounds`: Maximum decode rounds (enables PureDevice mode when > 0)
- `FLAGS_beam_width`: Beam search width
- `FLAGS_max_token_per_req`: Maximum tokens per request

### 2. PureDevice Mode Detection
- `is_pure_device_mode()`: Check if PureDevice mode is enabled
- `get_pure_device_decode_rounds()`: Get the number of decode rounds
- New pipeline type: `RecPipelineType::kLlmRecPureDevicePipeline`

### 3. Scheduler Layer
- **`PureDeviceSchedulerPipeline`**: New scheduler pipeline with `requires_kv_cache() = false`
- Factory method `create_scheduler_pipeline()` for cleaner pipeline selection

### 4. Engine Layer
- **`PureDeviceEnginePipeline`**: New engine pipeline that:
  - Uses local `workers_` instead of distributed `worker_clients_`
  - Creates process groups via `create_local_process_groups()`
  - Calls `process_beam_sequence_group()` for output processing

### 5. Process Group Creation
- **`create_local_process_groups()`**: Creates process groups for local (single-node) scenarios
  - Supports NPU (HcclComm) and GPU (CUDA/MLU/ILU)
  - Parses port from `master_node_addr` to support multiple instances
  - Creates ProcessGroup even for single-device case (avoids nullptr issues)

### 6. Beam Result Caching in Sequence
- `set_beam_result()`: Cache multi-round beam search results
- `has_beam_result()`, `beam_seq_group_flat()`, `beam_last_logprobs()`: Query interfaces

### 7. Output Generation
- **`Batch::process_beam_sequence_group()`**: Process multi-round beam search results
- **`SequencesGroup::generate_multi_round_output()`**: Generate outputs ranked by logprob

## Architecture Overview

### Pipeline Selection

| Condition | Pipeline |
|-----------|----------|
| `max_decode_rounds > 0` | PureDevice Pipeline |
| `max_decode_rounds = 0` | LlmRec Pipeline |

### Data Flow

```
                    Request
                       │
                       ▼
        ┌──────────────────────────────┐
        │ PureDeviceSchedulerPipeline  │
        │  • requires_kv_cache = false │
        └──────────────────────────────┘
                       │
                       ▼
        ┌──────────────────────────────┐
        │ PureDeviceEnginePipeline     │
        │  • Local workers_ (no RPC)   │
        │  • create_local_process_     │
        │    groups() for TP comm      │
        └──────────────────────────────┘
                       │
                       ▼
        ┌──────────────────────────────┐
        │ Output Processing            │
        │                              │
        │  Batch                       │
        │    └─► process_beam_         │
        │        sequence_group()      │
        │            │                 │
        │            ▼                 │
        │  Sequence                    │
        │    └─► set_beam_result()     │
        │            │                 │
        │            ▼                 │
        │  SequencesGroup              │
        │    └─► generate_multi_       │
        │        round_output()        │
        └──────────────────────────────┘
                       │
                       ▼
                Final Output
            (ranked by logprob)
```

## Files Changed

| File | Changes |
|------|---------|
| `xllm/core/common/global_flags.h/cpp` | Add multi-step decode config flags |
| `xllm/core/common/rec_model_utils.h` | Add `is_pure_device_mode()`, new pipeline type |
| `xllm/core/scheduler/fixed_steps_scheduler.h/cpp` | Add `PureDeviceSchedulerPipeline` |
| `xllm/core/distributed_runtime/rec_engine.h/cpp` | Add `PureDeviceEnginePipeline` |
| `xllm/core/framework/parallel_state/parallel_state.h/cpp` | Add `create_local_process_groups()` |
| `xllm/core/framework/batch/batch.h/cpp` | Add `process_beam_sequence_group()` |
| `xllm/core/framework/request/sequence.h` | Add beam result caching |
| `xllm/core/framework/request/sequences_group.h/cpp` | Add multi-round output generation |

## Next Steps (PR [2/3] and [3/3])

- **PR [2/3]**: Batch builder and kernels
  - [ ] `MultiStepBatchInputBuilder` implementation
  - [ ] XAttention integration for multi-round decode
  - [ ] Beam search kernel support
  - [ ] Cache select kernel for KV cache reordering

- **PR [3/3]**: Worker layer and integration
  - [ ] `LlmRecPureDevicePipeline` implementation (multi-round loop logic)
  - [ ] Enable commented code in `process_beam_sequence_group()` and D2H transfer
  - [ ] End-to-end testing

## Testing

- [x] Build passes
- [ ] Runtime testing pending Worker layer implementation in next PR
