### PR TITLE
bugfix: fix streaming tool call missing function name for GLM-4.7

### DIFF
--- a/xllm/function_call/glm47_detector.cpp
+++ b/xllm/function_call/glm47_detector.cpp
@@ -519,8 +519,13 @@ StreamingParseResult Glm47Detector::parse_streaming_increment(
 
       // Send tool name first if not sent yet
       if (!current_tool_name_sent_) {
-        if (func_name.empty()) {
-          LOG(WARNING) << "func_name should not be empty";
+        // Only send function name when we're sure it's complete:
+        // - Either we have <arg_key> (arguments started)
+        // - Or we have </tool_call> (tool call ended with no args)
+        if (func_name.empty() ||
+            (func_args_raw.empty() && is_tool_end != eot_token_)) {
+          // Function name not yet complete, wait for more data
+          return StreamingParseResult("", {});
         }
         calls.push_back(ToolCallItem(current_tool_id_, func_name, ""));
         current_tool_name_sent_ = true;


### PR DESCRIPTION
## Summary

- Fix streaming tool call not returning function name when stream mode is enabled for GLM-4.7 model
- When the buffer contained `<tool_call>` but the function name hadn't arrived yet, the non-greedy regex would match an empty string,
causing the tool call to be sent with an empty name

## Root Cause
In `parse_streaming_increment()`, when `func_name` was empty, the code would:
1. Log a warning but still send the tool call with an empty name
2. Mark `current_tool_name_sent_ = true`, preventing the name from ever being sent later

## Fix
Return early and wait for more streaming data when `func_name` is empty, instead of sending an empty function name.

## Test plan
- [x] Build the project: `python setup.py build`
- [x] Start the server: `cd /workdir && ./run.sh`
- [x] Run the test with streaming enabled: `python test.py`
- [x] Verify the warning `func_name should not be empty` no longer appears in logs
- [x] Verify the streaming response includes the function name in the tool call
