### PR TITLE
feat: add rec kernel and builder for pure device pipeline[2/3].

### DIFF
--- a/xllm/core/framework/batch/CMakeLists.txt
+++ b/xllm/core/framework/batch/CMakeLists.txt
@@ -3,7 +3,7 @@ include(cc_library)
 include(cc_test)
 
 cc_library(
-  NAME 
+  NAME
     batch
   HDRS
     dit_batch.h
@@ -12,14 +12,16 @@ cc_library(
     batch_input_builder.h
     rec_batch_input_builder.h
     onerec_batch_input_builder.h
+    rec_pure_device_batch_input_builder.h
     mposition.h
-  SRCS 
+  SRCS
     dit_batch.cpp
     batch.cpp
     batch_factory.cpp
     batch_input_builder.cpp
     rec_batch_input_builder.cpp
     onerec_batch_input_builder.cpp
+    rec_pure_device_batch_input_builder.cpp
     mposition.cpp
     beam_search.h
   DEPS

--- a/xllm/core/framework/batch/batch.cpp
+++ b/xllm/core/framework/batch/batch.cpp
@@ -357,8 +357,6 @@ void Batch::process_sample_output(const RawForwardOutput& raw_output,
 }
 
 void Batch::process_beam_sequence_group(const ForwardOutput& output) {
-  // TODO. uncomment this in next pr.
-  /*
   if (!output.beam_sequence_group.defined() ||
       output.beam_sequence_group.numel() == 0) {
     return;
@@ -416,7 +414,6 @@ void Batch::process_beam_sequence_group(const ForwardOutput& output) {
                         : sequence_groups_[g]->sequences()[0].get();
     seq->set_beam_result(beam_width, total_rounds, group_flat2d, last_logprobs);
   }
-  */
 }
 
 void Batch::process_sample_output(const SampleOutput& sample_output,

--- a/xllm/core/framework/batch/rec_batch_input_builder.cpp
+++ b/xllm/core/framework/batch/rec_batch_input_builder.cpp
@@ -20,7 +20,9 @@ limitations under the License.
 #include <cstdint>
 #include <memory>
 
+#include "core/common/rec_model_utils.h"
 #include "onerec_batch_input_builder.h"
+#include "rec_pure_device_batch_input_builder.h"
 
 namespace xllm {
 
@@ -45,8 +47,22 @@ std::unique_ptr<RecBatchInputBuilder> RecBatchInputBuilder::create(
           batch_id,
           args,
           thread_pool);
-    case RecType::kNone:
     case RecType::kLlmRec:
+      // Check if pure device mode is enabled
+      if (is_pure_device_mode()) {
+        return std::make_unique<RecPureDeviceBatchInputBuilder>(
+            sequence_groups,
+            allowed_max_tokens,
+            input_embeddings_vec,
+            mm_data_vec,
+            swap_block_transfer_infos,
+            batch_id,
+            args,
+            thread_pool);
+      }
+      // Fall through for non-pure-device LlmRec (not yet implemented)
+      break;
+    case RecType::kNone:
       break;
   }
 

--- a/xllm/core/framework/batch/rec_pure_device_batch_input_builder.cpp
+++ b/xllm/core/framework/batch/rec_pure_device_batch_input_builder.cpp
@@ -1,0 +1,442 @@
+/* Copyright 2026 The xLLM Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://github.com/jd-opensource/xllm/blob/main/LICENSE
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include "rec_pure_device_batch_input_builder.h"
+
+#include <c10/core/DeviceType.h>
+#include <torch/torch.h>
+
+#include <algorithm>
+#include <cstring>
+#include <thread>
+#include <unordered_map>
+#include <unordered_set>
+#include <vector>
+
+#include "common/global_flags.h"
+#include "common/metrics.h"
+#include "core/common/rec_model_utils.h"
+#include "framework/batch/mposition.h"
+#include "framework/model/model_args.h"
+#include "framework/model/model_input_params.h"
+#include "framework/request/sequence.h"
+#include "framework/request/sequences_group.h"
+#include "framework/sampling/sampling_params.h"
+#include "runtime/params_utils.h"
+#include "util/blocking_counter.h"
+#include "util/slice.h"
+#include "util/tensor_helper.h"
+#include "util/threadpool.h"
+#include "util/utils.h"
+
+namespace xllm {
+
+RecPureDeviceBatchInputBuilder::RecPureDeviceBatchInputBuilder(
+    const std::vector<SequencesGroup*>& sequence_groups,
+    const std::vector<uint32_t>& allowed_max_tokens,
+    const std::vector<torch::Tensor>& input_embeddings_vec,
+    const std::vector<MMData>& mm_data_vec,
+    std::vector<BlockTransferInfo>* swap_block_transfer_infos,
+    const uint64_t batch_id,
+    const ModelArgs* args,
+    ThreadPool* thread_pool)
+    : allowed_max_tokens_(allowed_max_tokens),
+      input_embeddings_vec_(input_embeddings_vec),
+      mm_data_vec_(mm_data_vec),
+      args_(args),
+      batch_forward_type_(BatchForwardType::DECODE),
+      swap_block_transfer_infos_(swap_block_transfer_infos),
+      thread_pool_(thread_pool),
+      batch_id_(batch_id) {
+  // Extract sequences from sequence_groups
+  sequences_.clear();
+  for (auto* seq_group : sequence_groups) {
+    const auto& group_sequences = seq_group->sequences();
+    for (const auto& seq_ptr : group_sequences) {
+      sequences_.push_back(seq_ptr.get());
+    }
+  }
+
+  num_sequences_ = static_cast<int32_t>(sequences_.size());
+
+  if (args_ != nullptr) {
+    use_mrope_ = (args_->rope_scaling_rope_type() == "mrope");
+  }
+
+  // Initialize RecPureDevice specific state
+  rec_pure_device_state_.total_steps = get_pure_device_decode_rounds();
+  rec_pure_device_state_.base_state.batch_forward_type = batch_forward_type_;
+}
+
+void RecPureDeviceBatchInputBuilder::process_single_sequence(
+    int32_t seq_index,
+    BuilderState* state_ptr,
+    std::unordered_set<int32_t>* write_block_ids_ptr) {
+  RecPureDeviceBuilderState& state = rec_pure_device_state_;
+  BuilderState& base_state = state.base_state;
+
+  auto* sequence = sequences_[seq_index];
+  const auto token_ids = sequence->tokens();
+  const uint32_t n_tokens = token_ids.size();
+  const uint32_t n_kv_cache_tokens = sequence->kv_state().kv_cache_tokens_num();
+
+  // Validate and calculate sequence lengths
+  CHECK(allowed_max_tokens_[seq_index] > 0);
+  uint32_t q_seq_len =
+      std::min(n_tokens - n_kv_cache_tokens, allowed_max_tokens_[seq_index]);
+  uint32_t seq_len = q_seq_len + n_kv_cache_tokens;
+
+  // add decode data;
+  uint32_t decode_q_seq_len = 1;
+  uint32_t decode_seq_len = n_kv_cache_tokens + 1;
+
+  CHECK_GT(q_seq_len, 0) << "at least one token should be processed. "
+                         << "n_tokens: " << n_tokens
+                         << ", n_kv_cache_tokens: " << n_kv_cache_tokens
+                         << ", current_max_tokens_capacity: "
+                         << sequence->kv_state().current_max_tokens_capacity()
+                         << ", allowed_max_tokens: "
+                         << allowed_max_tokens_[seq_index];
+
+  // Update state
+  int32_t offset = is_mtp_decode_ ? -1 : 0;
+  base_state.max_seq_len = std::max(base_state.max_seq_len, seq_len);
+  base_state.q_max_seq_len = std::max(base_state.q_max_seq_len, q_seq_len);
+#if defined(USE_NPU)
+  base_state.seq_lens.push_back(seq_len);
+  base_state.q_seq_lens.push_back(q_seq_len);
+#elif defined(USE_MLU) || defined(USE_CUDA) || defined(USE_ILU)
+  base_state.seq_lens.push_back(base_state.seq_lens.back() + seq_len);
+  base_state.q_seq_lens.push_back(base_state.q_seq_lens.back() + q_seq_len);
+#endif
+
+  // Call our enhanced method to process tokens and positions
+  // This handles both regular decode and step-level decode cases
+  extract_tokens_and_positions(sequence, n_kv_cache_tokens, seq_len, &state);
+
+  // not Setup KV cache for prefill
+
+  setup_kv_cache_info(sequence,
+                      n_kv_cache_tokens,
+                      decode_seq_len,
+                      decode_q_seq_len,
+                      &base_state,
+                      write_block_ids_ptr);
+
+  // Track prefill sequences
+  if (sequence->stage() == SequenceStage::PREFILL) {
+    base_state.prefill_seq_len++;
+  }
+}
+
+ForwardInput RecPureDeviceBatchInputBuilder::build_rec_forward_input(
+    uint32_t /*num_decoding_tokens*/,
+    uint32_t /*min_decoding_batch_size*/) {
+  // Pure device mode doesn't use num_decoding_tokens and
+  // min_decoding_batch_size parameters, so we ignore them and call the internal
+  // build_forward_input method
+  return build_forward_input();
+}
+
+ForwardInput RecPureDeviceBatchInputBuilder::build_forward_input() {
+  // Reset rec pure device state for this build
+  rec_pure_device_state_.total_steps = get_pure_device_decode_rounds();
+
+  is_mtp_decode_ = false;
+  // Single-threaded processing for now; can be extended to use thread_pool_
+  for (int32_t i = 0; i < static_cast<int32_t>(sequences_.size()); ++i) {
+    process_single_sequence(i, &rec_pure_device_state_.base_state, nullptr);
+  }
+  return state_to_forward_input();
+}
+
+void RecPureDeviceBatchInputBuilder::extract_tokens_and_positions(
+    Sequence* sequence,
+    uint32_t n_kv_cache_tokens,
+    uint32_t seq_len,
+    RecPureDeviceBuilderState* state_ptr) {
+  // First build the "base" view that matches the single-round builder
+  BuilderState& base_state = state_ptr->base_state;
+
+  const auto& token_ids = sequence->tokens();
+  const uint32_t n_tokens = token_ids.size();
+
+  // Prepare adjusted token counts for sampling
+  std::unordered_map<int32_t, int32_t> adjusted_token_to_count_map;
+  for (uint32_t j = n_kv_cache_tokens; j < seq_len; ++j) {
+    // skip prompt tokens except the last one
+    if (j + 1 < n_tokens) continue;
+    ++adjusted_token_to_count_map[token_ids[j]];
+  }
+
+  // Handle MRope positions
+  if (use_mrope_) {
+    const auto& args = *args_;
+    MPositionHelper helper(*sequence, args);
+    base_state.mrope_positions_vec.push_back(helper.get_positions());
+  }
+
+  // Process each token
+  for (uint32_t j = n_kv_cache_tokens; j < seq_len; ++j) {
+    base_state.flatten_tokens_vec.push_back(token_ids[j]);
+
+    if (!use_mrope_) {
+      base_state.flatten_positions_vec.push_back(static_cast<int32_t>(j));
+    }
+
+    // Handle sampling for last tokens
+    if (j + 1 < n_tokens) continue;
+
+    // Inlined sampling/unique-token logic on base_state.
+    BuilderState& state = base_state;
+
+    const auto token_id = sequence->tokens()[j];
+    // Adjust token count
+    --adjusted_token_to_count_map[token_id];
+
+    // Select token for sampling
+    state.selected_token_idxes.push_back(
+        static_cast<int32_t>(state.flatten_tokens_vec.size() - 1));
+    state.sampling_params.push_back(sequence->sampling_param());
+
+    // Process unique tokens
+    const auto& seq_token_counts = sequence->token_to_count_map();
+    auto& ids = state.unique_token_ids_vec.emplace_back();
+    auto& counts = state.unique_token_counts_vec.emplace_back();
+
+    ids.reserve(seq_token_counts.size());
+    counts.reserve(seq_token_counts.size());
+
+    for (const auto& [tok_id, count] : seq_token_counts) {
+      const auto it = adjusted_token_to_count_map.find(tok_id);
+      const auto adjust_count =
+          (it != adjusted_token_to_count_map.end()) ? it->second : 0;
+
+      if (count > adjust_count) {
+        ids.push_back(tok_id);
+        counts.push_back(count - adjust_count);
+      }
+    }
+
+    state.unique_token_lens_vec.push_back(static_cast<int32_t>(ids.size()));
+
+    // Mark sample token if it's the last token
+    if (j == seq_len - 1) {
+      state.sample_idxes.push_back(
+          static_cast<int32_t>(state.selected_token_idxes.size() - 1));
+    }
+  }
+
+  // Add extra token id
+  if (n_tokens == seq_len) {
+    // last chunk of prefill and decode
+    // add -1 as extra token id
+    base_state.extra_token_ids.push_back(-1);
+    base_state.embedding_ids.push_back(sequence->get_embedding_id());
+  } else {
+    base_state.extra_token_ids.push_back(token_ids[seq_len]);
+  }
+
+  // begin process decode data
+  seq_len = n_kv_cache_tokens + 1;
+  uint32_t prompt_len = sequence->num_prompt_tokens();
+  state_ptr->decode_positions_vec.push_back(static_cast<int32_t>(prompt_len));
+
+  int32_t bw = std::max(1, FLAGS_beam_width);
+  const int32_t sel_start =
+      static_cast<int32_t>(state_ptr->decode_selected_token_idxes.size());
+  state_ptr->decode_selected_token_idxes.reserve(sel_start + bw);
+  state_ptr->decode_sample_idxes.reserve(state_ptr->decode_sample_idxes.size() +
+                                         bw);
+  state_ptr->decode_unique_token_ids_vec.resize(
+      state_ptr->decode_unique_token_ids_vec.size() + bw);
+  state_ptr->decode_unique_token_counts_vec.resize(
+      state_ptr->decode_unique_token_counts_vec.size() + bw);
+  state_ptr->decode_unique_token_lens_vec.insert(
+      state_ptr->decode_unique_token_lens_vec.end(), bw, 0);
+  state_ptr->decode_sampling_params.reserve(
+      state_ptr->decode_sampling_params.size() + bw);
+  for (int32_t i = 0; i < bw; ++i) {
+    const int32_t idx = sel_start + i;
+    state_ptr->decode_selected_token_idxes.push_back(idx);
+    state_ptr->decode_sample_idxes.push_back(idx);
+    state_ptr->decode_sampling_params.push_back(sequence->sampling_param());
+  }
+}
+
+void RecPureDeviceBatchInputBuilder::setup_kv_cache_info(
+    Sequence* sequence,
+    uint32_t n_kv_cache_tokens,
+    uint32_t seq_len,
+    uint32_t q_seq_len,
+    BuilderState* state_ptr,
+    std::unordered_set<int32_t>* write_block_ids_ptr) {
+#if defined(USE_NPU)
+  (void)write_block_ids_ptr;
+  BuilderState& state = *state_ptr;
+  const auto blocks = sequence->kv_state().kv_blocks();
+  std::vector<int32_t> block_ids;
+  block_ids.reserve(blocks.size());
+  for (const auto& block : blocks) {
+    block_ids.push_back(block.id());
+  }
+  state.block_tables_vec.emplace_back(std::move(block_ids));
+#elif defined(USE_MLU) || defined(USE_CUDA) || defined(USE_ILU)
+  RecPureDeviceBuilderState& state = rec_pure_device_state_;
+  BuilderState& base_state = state.base_state;
+
+  // fill paged_kv_last_page_len for batch_size calculation.
+  base_state.paged_kv_last_page_len.push_back(seq_len);
+  base_state.block_tables_vec.emplace_back(std::vector<int32_t>{});
+#endif
+}
+
+ForwardInput RecPureDeviceBatchInputBuilder::state_to_forward_input() {
+  BuilderState& state = rec_pure_device_state_.base_state;
+  if (state.flatten_tokens_vec.empty()) {
+    return {};
+  }
+
+  ForwardInput forward_input;
+
+  // Create tensors (same as BatchInputBuilder)
+  forward_input.token_ids =
+      torch::tensor(state.flatten_tokens_vec, torch::kInt);
+
+  if (!use_mrope_) {
+    forward_input.positions =
+        torch::tensor(state.flatten_positions_vec, torch::kInt);
+  } else {
+    forward_input.positions = torch::cat(state.mrope_positions_vec, 1);
+  }
+
+  auto& input_params = forward_input.input_params;
+  input_params.batch_forward_type = state.batch_forward_type;
+  input_params.num_sequences = state.block_tables_vec.size();
+  input_params.kv_max_seq_len = state.max_seq_len;
+  input_params.q_max_seq_len = state.q_max_seq_len;
+  input_params.kv_seq_lens = torch::tensor(state.seq_lens, torch::kInt);
+  input_params.q_seq_lens = torch::tensor(state.q_seq_lens, torch::kInt);
+  input_params.kv_seq_lens_vec = std::move(state.seq_lens);
+  input_params.q_seq_lens_vec = std::move(state.q_seq_lens);
+  input_params.new_cache_slots =
+      torch::tensor(state.new_token_slot_ids, torch::kInt);
+
+  // for flashinfer
+  input_params.paged_kv_indptr =
+      torch::tensor(state.paged_kv_indptr, torch::kInt);
+  input_params.paged_kv_indices =
+      torch::tensor(state.paged_kv_indices, torch::kInt);
+  input_params.paged_kv_last_page_len =
+      torch::tensor(state.paged_kv_last_page_len, torch::kInt);
+
+  // Setup multimodal data
+  input_params.mm_data.batch(mm_data_vec_);
+
+  // Setup block tables
+  util::pad_2d_vector(state.block_tables_vec, /*pad_value=*/0);
+  input_params.block_tables =
+      create_2d_tensor(state.block_tables_vec, torch::kInt);
+
+  if (input_embeddings_vec_.size() != 0) {
+    input_params.input_embedding = torch::cat(input_embeddings_vec_);
+  }
+
+  if (swap_block_transfer_infos_ != nullptr &&
+      swap_block_transfer_infos_->size() > 0) {
+    input_params.swap_blocks.insert(input_params.swap_blocks.end(),
+                                    swap_block_transfer_infos_->begin(),
+                                    swap_block_transfer_infos_->end());
+  }
+
+  CHECK_EQ(state.sampling_params.size(), state.selected_token_idxes.size());
+  // Setup sampling parameters
+  if (!state.selected_token_idxes.empty()) {
+    util::pad_2d_vector<int64_t>(state.unique_token_ids_vec, /*pad_value=*/0);
+    util::pad_2d_vector(state.unique_token_counts_vec, /*pad_value=*/0);
+
+    forward_input.sampling_params.init(state.sampling_params,
+                                       state.selected_token_idxes,
+                                       state.sample_idxes,
+                                       state.unique_token_ids_vec,
+                                       state.unique_token_counts_vec,
+                                       state.unique_token_lens_vec);
+  }
+
+  // Rec pure device specific metadata
+  auto& rec_pure_device_state = rec_pure_device_state_;
+  rec_pure_device_state.total_steps = get_pure_device_decode_rounds();
+  const int32_t beam_width = FLAGS_beam_width;
+  const int32_t total_round = rec_pure_device_state.total_steps;
+  const int32_t current_round = 0;
+  std::vector<int64_t> full_kv_shape;
+  std::vector<int32_t> decode_positions_vec;
+
+  // Setup decoder sampling parameters for rec pure device decode
+  if (!rec_pure_device_state.decode_selected_token_idxes.empty()) {
+    CHECK_EQ(rec_pure_device_state.decode_sampling_params.size(),
+             rec_pure_device_state.decode_selected_token_idxes.size());
+    util::pad_2d_vector<int64_t>(
+        rec_pure_device_state.decode_unique_token_ids_vec,
+        /*pad_value=*/0);
+    util::pad_2d_vector(rec_pure_device_state.decode_unique_token_counts_vec,
+                        /*pad_value=*/0);
+
+    forward_input.decoder_sampling_params.init(
+        rec_pure_device_state.decode_sampling_params,
+        rec_pure_device_state.decode_selected_token_idxes,
+        rec_pure_device_state.decode_sample_idxes,
+        rec_pure_device_state.decode_unique_token_ids_vec,
+        rec_pure_device_state.decode_unique_token_counts_vec,
+        rec_pure_device_state.decode_unique_token_lens_vec);
+  }
+
+  // Set full_kv_shape if we have rec pure device decode data
+  if (is_pure_device_mode() && !sequences_.empty()) {
+    int64_t batch_size = static_cast<int64_t>(sequences_.size());
+    int64_t n_kv_heads =
+        args_ ? args_->n_kv_heads().value_or(args_->n_heads()) : 0;
+    int64_t head_dim = args_ ? args_->head_dim() : 0;
+
+    int32_t decode_rounds = get_pure_device_decode_rounds();
+    full_kv_shape = {
+        batch_size * FLAGS_max_token_per_req +
+            batch_size * FLAGS_beam_width * std::max(0, decode_rounds - 1),
+        n_kv_heads,
+        head_dim};
+  }
+
+  // Decode positions
+  if (!rec_pure_device_state.decode_positions_vec.empty()) {
+    decode_positions_vec = rec_pure_device_state.decode_positions_vec;
+  }
+
+  if (is_pure_device_mode()) {
+    StepDecodeMeta step_meta;
+    step_meta.beam_width = beam_width;
+    step_meta.current_round = current_round;
+    step_meta.total_round = total_round;
+    step_meta.full_kv_shape = std::move(full_kv_shape);
+    step_meta.decode_positions_vec = std::move(decode_positions_vec);
+    forward_input.step_decode = std::move(step_meta);
+  }
+
+  // Batch ID
+  input_params.batch_id = batch_id_;
+
+  return forward_input;
+}
+
+}  // namespace xllm

--- a/xllm/core/framework/batch/rec_pure_device_batch_input_builder.h
+++ b/xllm/core/framework/batch/rec_pure_device_batch_input_builder.h
@@ -1,0 +1,191 @@
+/* Copyright 2026 The xLLM Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://github.com/jd-opensource/xllm/blob/main/LICENSE
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#pragma once
+
+#include <torch/torch.h>
+
+#include <cstdint>
+#include <limits>
+#include <unordered_set>
+#include <vector>
+
+#include "batch_input_builder.h"
+#include "framework/request/mm_data.h"
+#include "framework/request/sequence.h"
+#include "framework/request/sequences_group.h"
+#include "rec_batch_input_builder.h"
+#include "runtime/forward_params.h"
+#include "util/threadpool.h"
+
+namespace xllm {
+
+struct ModelArgs;
+
+class RecPureDeviceBatchInputBuilder : public RecBatchInputBuilder {
+ public:
+  explicit RecPureDeviceBatchInputBuilder(
+      const std::vector<SequencesGroup*>& sequence_groups,
+      const std::vector<uint32_t>& allowed_max_tokens,
+      const std::vector<torch::Tensor>& input_embeddings_vec,
+      const std::vector<MMData>& mm_data_vec,
+      // for beam-search
+      std::vector<BlockTransferInfo>* swap_block_transfer_infos,
+      const uint64_t batch_id,
+      const ModelArgs* args,
+      ThreadPool* thread_pool = nullptr);
+
+  ~RecPureDeviceBatchInputBuilder() override = default;
+
+  // Override base class method
+  ForwardInput build_rec_forward_input(
+      uint32_t num_decoding_tokens,
+      uint32_t min_decoding_batch_size) override;
+
+ private:
+  // Build pure device forward input for the whole batch (internal
+  // implementation)
+  ForwardInput build_forward_input();
+
+  // Local builder state (copy of the legacy BatchInputBuilder::BuilderState)
+  struct BuilderState {
+    // Token and position data
+    std::vector<int32_t> flatten_tokens_vec;
+    std::vector<int32_t> flatten_positions_vec;
+    std::vector<torch::Tensor> mrope_positions_vec;
+
+    // Sampling data
+    std::vector<const RequestSamplingParam*> sampling_params;
+    std::vector<int32_t> selected_token_idxes;
+    std::vector<int32_t> sample_idxes;
+
+    // Unique token tracking
+    std::vector<std::vector<int64_t>> unique_token_ids_vec;
+    std::vector<std::vector<int32_t>> unique_token_counts_vec;
+    std::vector<int32_t> unique_token_lens_vec;
+
+    // Sequence metadata
+    BatchForwardType batch_forward_type;
+    uint32_t max_seq_len = 0;
+    uint32_t q_max_seq_len = 0;
+#if defined(USE_NPU)
+    std::vector<int32_t> seq_lens;
+    std::vector<int32_t> q_seq_lens;
+#elif defined(USE_MLU) || defined(USE_CUDA) || defined(USE_ILU)
+    std::vector<int32_t> seq_lens = {0};    // cu_seq_lens
+    std::vector<int32_t> q_seq_lens = {0};  // q_cu_seq_len
+#endif
+
+    // Cache and block data
+    std::vector<int32_t> new_token_slot_ids;
+    std::vector<std::vector<int32_t>> block_tables_vec;
+
+    // beam search kernel input
+    std::vector<float> acc_logprob_vec;
+
+    // Additional data
+    std::vector<int32_t> embedding_ids;
+    std::vector<int32_t> extra_token_ids;
+    uint32_t prefill_seq_len = 0;
+    std::vector<TransferKVInfo> transfer_kv_infos;
+
+    // for continuous kvcache
+    std::vector<int64_t> new_cache_slot_offsets;  //[n_tokens]
+    std::vector<int64_t> kv_cache_start_offsets;  //[n_seq]
+
+    // for flashinfer
+    std::vector<int32_t> paged_kv_indptr = {0};
+    std::vector<int32_t> paged_kv_indices;
+    std::vector<int32_t> paged_kv_last_page_len;
+  };
+
+ protected:
+  // Core building methods - provide pure device specific logic
+  void process_single_sequence(
+      int32_t seq_index,
+      BuilderState* state_ptr = nullptr,
+      std::unordered_set<int32_t>* write_block_ids_ptr = nullptr);
+
+ private:
+  // State management for RecPureDevice
+  struct RecPureDeviceBuilderState {
+    // Base state compatible with single-round builder
+    BuilderState base_state;
+
+    // Pure device step tracking data
+    std::vector<int32_t> step_tokens_vec;
+    std::vector<int32_t> step_positions_vec;
+    std::vector<torch::Tensor> step_mrope_positions_vec;
+
+    // Pure device decode state buffers
+    std::vector<int32_t> decode_selected_token_idxes;
+    std::vector<const RequestSamplingParam*> decode_sampling_params;
+    std::vector<std::vector<int64_t>> decode_unique_token_ids_vec;
+    std::vector<std::vector<int32_t>> decode_unique_token_counts_vec;
+    std::vector<int32_t> decode_unique_token_lens_vec;
+    std::vector<int32_t> decode_sample_idxes;
+    std::vector<int32_t> decode_positions_vec;
+
+    // Pure device specific metadata
+    uint32_t total_steps = 0;
+  };
+
+  // Enhanced state
+  RecPureDeviceBuilderState rec_pure_device_state_;
+
+ private:
+  // Override extract_tokens_and_positions to handle rec pure device decode
+  // logic
+  void extract_tokens_and_positions(Sequence* sequence,
+                                    uint32_t n_kv_cache_tokens,
+                                    uint32_t seq_len,
+                                    RecPureDeviceBuilderState* state_ptr);
+
+  // Pure device specific forward input conversion functions
+  ForwardInput state_to_forward_input();
+
+  void setup_kv_cache_info(Sequence* sequence,
+                           uint32_t n_kv_cache_tokens,
+                           uint32_t seq_len,
+                           uint32_t q_seq_len,
+                           BuilderState* state_ptr,
+                           std::unordered_set<int32_t>* write_block_ids_ptr);
+
+  // Input data (same semantics as in BatchInputBuilder)
+  // Extracted from sequence_groups_ in constructor
+  std::vector<Sequence*> sequences_;
+  const std::vector<uint32_t>& allowed_max_tokens_;
+  const std::vector<torch::Tensor>& input_embeddings_vec_;
+  const std::vector<MMData>& mm_data_vec_;
+  const ModelArgs* args_;
+  BatchForwardType batch_forward_type_;
+
+  // Configuration/state
+  int32_t num_sequences_ = 0;
+  bool use_mrope_ = false;
+
+  // swap blocks between device/host/global memory (optional)
+  std::unordered_set<int32_t> write_block_ids_;
+  std::vector<BlockTransferInfo>* swap_block_transfer_infos_ = nullptr;
+
+  // thread pool for potential future multithreaded processing, not owned
+  ThreadPool* thread_pool_ = nullptr;
+  uint64_t batch_id_ = 0;
+
+  // whether prepare draft input for MTP(EAGLE) at Decode phase.
+  bool is_mtp_decode_ = false;
+};
+
+}  // namespace xllm

--- a/xllm/core/kernels/cuda/CMakeLists.txt
+++ b/xllm/core/kernels/cuda/CMakeLists.txt
@@ -1,4 +1,5 @@
 include(cc_library)
+include(cc_test)
 
 file(GLOB_RECURSE CUDA_HEADER_FILES
   "${CMAKE_CURRENT_LIST_DIR}/*.h"
@@ -23,3 +24,30 @@ cc_library(
     :util
     :platform
 )
+
+cc_test(
+  NAME
+    decoder_reshape_and_cache_test
+  SRCS
+    decoder_reshape_and_cache_test.cpp
+  DEPS
+    :cuda_kernels
+    torch
+    GTest::gtest_main
+    glog::glog
+)
+target_link_libraries( decoder_reshape_and_cache_test PRIVATE brpc)
+
+
+cc_test(
+  NAME
+    cache_select_test
+  SRCS
+    cache_select_test.cpp
+  DEPS
+    :cuda_kernels
+    torch
+    GTest::gtest_main
+    glog::glog
+)
+target_link_libraries(cache_select_test PRIVATE brpc)

--- a/xllm/core/kernels/cuda/beam_search.cpp
+++ b/xllm/core/kernels/cuda/beam_search.cpp
@@ -1,0 +1,129 @@
+/* Copyright 2026 The xLLM Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://github.com/jd-opensource/xllm/blob/main/LICENSE
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include <ATen/cuda/CUDAContext.h>
+#include <cuda_runtime.h>
+#include <torch/script.h>
+#include <torch/torch.h>
+
+#include "cuda.h"
+
+namespace xllm::kernel::cuda {
+
+void beam_search(torch::Tensor acc_logprob,
+                 torch::Tensor in_sequence_group,
+                 torch::Tensor top_tokens,
+                 torch::Tensor top_logprobs,
+                 torch::Tensor out_acc_logprob,
+                 torch::Tensor out_token_ids,
+                 torch::Tensor out_token_index,
+                 torch::Tensor out_beam_count_prefix_sums,
+                 torch::Tensor out_sequence_group,
+                 uint32_t batch_size,
+                 uint32_t current_step) {
+  torch::Device device = acc_logprob.device();
+
+  uint32_t beam_size = in_sequence_group.size(1);
+
+  uint32_t top_k = top_tokens.size(1);
+  uint32_t total_rounds = in_sequence_group.size(2);
+
+  CHECK_EQ(beam_size, top_k) << "beam_size must be equal with top_k.";
+
+  if (current_step == 0) {
+    auto tokens_view =
+        top_tokens.view({batch_size, top_k}).slice(1, 0, beam_size);
+    auto init_probs_view =
+        top_logprobs.view({batch_size, top_k}).slice(1, 0, beam_size);
+
+    out_token_ids.view({batch_size, beam_size}).copy_(tokens_view);
+    out_acc_logprob.view({batch_size, beam_size}).copy_(init_probs_view);
+
+    auto indices =
+        torch::arange(
+            beam_size,
+            torch::TensorOptions().dtype(torch::kInt32).device(device))
+            .unsqueeze(0)
+            .expand({batch_size, -1})
+            .reshape({-1, 1});
+    out_token_index.copy_(indices);
+
+    auto sequence_view =
+        out_sequence_group.view({batch_size, beam_size, total_rounds});
+    sequence_view.slice(2, 0, 1).squeeze(2).copy_(tokens_view);
+
+  } else {
+    auto combined_probs =
+        (acc_logprob + top_logprobs).view({batch_size, beam_size * top_k});
+
+    auto topk_result = torch::topk(combined_probs, beam_size, -1);
+    auto new_probs = std::get<0>(topk_result);    // [batch_size, beam_size]
+    auto new_indices = std::get<1>(topk_result);  // [batch_size, beam_size]
+
+    auto ordered_indices = new_indices.argsort(static_cast<int64_t>(1), false);
+    // Reorder new_probs (and corresponding new_indices) by ordered_indices to
+    // keep alignment.
+    if (current_step < total_rounds - 1) {
+      new_probs = new_probs.gather(1, ordered_indices);
+      new_indices = new_indices.gather(1, ordered_indices);
+    }
+
+    auto parent_beam = (new_indices / top_k).to(torch::kLong);
+    auto token_in_beam = (new_indices % top_k).to(torch::kLong);
+
+    auto top_tokens_reshaped = top_tokens.view({batch_size, beam_size, top_k});
+
+    auto batch_idx =
+        torch::arange(batch_size,
+                      torch::TensorOptions().dtype(torch::kLong).device(device))
+            .unsqueeze(1)
+            .expand_as(parent_beam);
+
+    using torch::indexing::TensorIndex;
+    auto new_tokens = top_tokens_reshaped.index({TensorIndex(batch_idx),
+                                                 TensorIndex(parent_beam),
+                                                 TensorIndex(token_in_beam)});
+
+    out_acc_logprob.view({batch_size, beam_size}).copy_(new_probs);
+    out_token_index.view({batch_size, beam_size})
+        .copy_(new_indices.to(torch::kInt32));
+    out_token_ids.view({batch_size, beam_size}).copy_(new_tokens);
+
+    auto batch_range =
+        torch::arange(
+            batch_size,
+            torch::TensorOptions().dtype(torch::kInt32).device(device))
+            .unsqueeze(1)
+            .expand({-1, beam_size});
+    auto beam_range =
+        torch::arange(
+            beam_size,
+            torch::TensorOptions().dtype(torch::kInt32).device(device))
+            .unsqueeze(0)
+            .expand({batch_size, -1});
+
+    using torch::indexing::Slice;
+    using torch::indexing::TensorIndex;
+    out_sequence_group.slice(2, 0, current_step) =
+        in_sequence_group.index({TensorIndex(batch_range),
+                                 TensorIndex(parent_beam.to(torch::kInt32)),
+                                 Slice(0, current_step)});
+
+    out_sequence_group.slice(2, current_step, current_step + 1) =
+        new_tokens.unsqueeze(2);
+  }
+}
+
+}  // namespace xllm::kernel::cuda

--- a/xllm/core/kernels/cuda/cache_select.cu
+++ b/xllm/core/kernels/cuda/cache_select.cu
@@ -1,0 +1,308 @@
+/* Copyright 2026 The xLLM Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://github.com/jd-opensource/xllm/blob/main/LICENSE
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include <ATen/cuda/CUDAContext.h>
+#include <c10/cuda/CUDAException.h>
+#include <c10/cuda/CUDAGuard.h>
+#include <cuda_runtime.h>
+#include <torch/extension.h>
+
+#include <cstdint>
+#include <vector>
+
+#include "cuda_ops_api.h"
+
+namespace {
+
+// In-place cache selection kernel for Xattention.
+// Reorders KV cache entries based on beam search results. After beam search,
+// the beam indices may have changed, and this kernel copies KV cache data from
+// old beam positions to new beam positions to maintain consistency.
+// Inputs:
+//   k_ptrs_i64      : [Layer] - pointers to K cache tensors for each layer
+//   v_ptrs_i64      : [Layer] - pointers to V cache tensors for each layer
+//   beam_index      : [B*Beam] - mapping from new beam index to old beam index
+//   block_table     : [B] - request ID per batch item
+//   B               : batch size
+//   Beam            : beam width
+//   Kv              : number of KV heads
+//   MaxStep         : maximum decode steps
+//   D               : head dimension
+//   MaxReq          : maximum number of requests
+//   Layer           : number of transformer layers
+//   decode_step     : current decode step (0-indexed)
+// Cache layout: [MaxReq, Beam, MaxStep, Kv, D]
+// The kernel performs two passes to avoid overwriting data:
+//   pass-1: copy from old_beam > new_beam (increasing new_beam)
+//   pass-2: copy from old_beam < new_beam (decreasing new_beam)
+template <typename scalar_t>
+__global__ void cache_select_inplace_ptrs_kernel(
+    const int64_t* __restrict__ k_ptrs_i64,   // [Layer]
+    const int64_t* __restrict__ v_ptrs_i64,   // [Layer]
+    const int32_t* __restrict__ beam_index,   // [B*Beam]
+    const int32_t* __restrict__ block_table,  // [B]
+    int32_t B,
+    int32_t Beam,
+    int32_t Kv,
+    int32_t MaxStep,
+    int32_t D,
+    int32_t MaxReq,
+    int32_t Layer,
+    int32_t decode_step) {
+  const int32_t b = static_cast<int32_t>(blockIdx.x);
+  const int32_t kv = static_cast<int32_t>(blockIdx.y);
+  const int32_t layer = static_cast<int32_t>(blockIdx.z);
+
+  if (b >= B || kv >= Kv || layer >= Layer) {
+    return;
+  }
+
+  const int32_t step_end =
+      decode_step < (MaxStep - 1) ? decode_step : (MaxStep - 1);
+
+  const int32_t req = block_table[b];
+  if (req < 0 || req >= MaxReq) {
+    return;
+  }
+
+  scalar_t* __restrict__ k_cache =
+      reinterpret_cast<scalar_t*>(static_cast<uintptr_t>(k_ptrs_i64[layer]));
+  scalar_t* __restrict__ v_cache =
+      reinterpret_cast<scalar_t*>(static_cast<uintptr_t>(v_ptrs_i64[layer]));
+
+  // base(req, beam, s, kv, d) = ((((req*Beam + beam)*MaxStep + s)*Kv + kv) * D
+  // + d)
+  const int64_t req_base = static_cast<int64_t>(req) * Beam;
+  const int64_t step_kv_stride = static_cast<int64_t>(Kv) * D;
+  const int64_t kv_d_base = static_cast<int64_t>(kv) * D;
+
+  // grid_step is typically small; loop over s in-kernel to reduce launch
+  // blocks.
+  for (int32_t s = 0; s <= step_end; ++s) {
+    // pass-1: new_beam increasing, copy if old_beam > new_beam
+    for (int32_t new_beam = 0; new_beam < Beam; ++new_beam) {
+      const int32_t old_beam = beam_index[b * Beam + new_beam] / Beam;
+      if (old_beam >= 0 && old_beam < Beam && old_beam > new_beam) {
+        const int64_t dst_base =
+            ((req_base + new_beam) * MaxStep + s) * step_kv_stride + kv_d_base;
+        const int64_t src_base =
+            ((req_base + old_beam) * MaxStep + s) * step_kv_stride + kv_d_base;
+        for (int32_t d = static_cast<int32_t>(threadIdx.x); d < D;
+             d += static_cast<int32_t>(blockDim.x)) {
+          k_cache[dst_base + d] = k_cache[src_base + d];
+          v_cache[dst_base + d] = v_cache[src_base + d];
+        }
+      }
+    }
+
+    // pass-2: new_beam decreasing, copy if old_beam < new_beam
+    for (int32_t new_beam = Beam - 1; new_beam >= 0; --new_beam) {
+      const int32_t old_beam = beam_index[b * Beam + new_beam] / Beam;
+      if (old_beam >= 0 && old_beam < Beam && old_beam < new_beam) {
+        const int64_t dst_base =
+            ((req_base + new_beam) * MaxStep + s) * step_kv_stride + kv_d_base;
+        const int64_t src_base =
+            ((req_base + old_beam) * MaxStep + s) * step_kv_stride + kv_d_base;
+        for (int32_t d = static_cast<int32_t>(threadIdx.x); d < D;
+             d += static_cast<int32_t>(blockDim.x)) {
+          k_cache[dst_base + d] = k_cache[src_base + d];
+          v_cache[dst_base + d] = v_cache[src_base + d];
+        }
+      }
+    }
+  }
+}
+
+void cache_select_cuda_launch_ptrs(
+    torch::Tensor k0,
+    torch::Tensor v0,
+    torch::Tensor k_ptrs_i64,       // [Layer] int64 (CUDA)
+    torch::Tensor v_ptrs_i64,       // [Layer] int64 (CUDA)
+    torch::Tensor beam_index_i32,   // [B*Beam, 1] int32
+    torch::Tensor block_table_i32,  // [B] int32
+    int64_t decode_step,
+    int64_t layer_num) {
+  CHECK(k_ptrs_i64.is_cuda() && v_ptrs_i64.is_cuda())
+      << "k_ptrs_i64/v_ptrs_i64 must be CUDA";
+  CHECK_EQ(k_ptrs_i64.scalar_type(), torch::kInt64)
+      << "k_ptrs_i64/v_ptrs_i64 must be int64";
+  CHECK_EQ(v_ptrs_i64.scalar_type(), torch::kInt64)
+      << "k_ptrs_i64/v_ptrs_i64 must be int64";
+  CHECK(k_ptrs_i64.is_contiguous() && v_ptrs_i64.is_contiguous())
+      << "k_ptrs_i64/v_ptrs_i64 must be contiguous";
+
+  const int64_t B64 = block_table_i32.size(0);
+  const int64_t Beam64 = k0.size(1);
+  const int64_t MaxStep64 = k0.size(2);
+  const int64_t Kv64 = k0.size(3);
+  const int64_t D64 = k0.size(4);
+  const int64_t MaxReq64 = k0.size(0);
+  const int64_t Layer64 = layer_num;
+
+  const int32_t B = static_cast<int32_t>(B64);
+  const int32_t Beam = static_cast<int32_t>(Beam64);
+  const int32_t Kv = static_cast<int32_t>(Kv64);
+  const int32_t MaxStep = static_cast<int32_t>(MaxStep64);
+  const int32_t D = static_cast<int32_t>(D64);
+  const int32_t MaxReq = static_cast<int32_t>(MaxReq64);
+  const int32_t Layer = static_cast<int32_t>(Layer64);
+  const int32_t decode_step_i32 = static_cast<int32_t>(decode_step);
+
+  // Warp-aligned threads, capped to keep occupancy reasonable.
+  int threads_per_block = ((D + 31) / 32) * 32;
+  if (threads_per_block < 32) {
+    threads_per_block = 32;
+  }
+  if (threads_per_block > 256) {
+    threads_per_block = 256;
+  }
+  dim3 block_dim(static_cast<unsigned int>(threads_per_block), 1, 1);
+
+  CHECK_LE(Kv64, static_cast<int64_t>(UINT32_MAX)) << "Kv too large for grid.y";
+  CHECK_LE(Layer64, 65535) << "layer_num too large for grid.z";
+  dim3 grid_dim(static_cast<unsigned int>(B),
+                static_cast<unsigned int>(Kv),
+                static_cast<unsigned int>(Layer));
+
+  cudaStream_t stream = at::cuda::getCurrentCUDAStream();
+
+  AT_DISPATCH_FLOATING_TYPES_AND2(torch::ScalarType::Half,
+                                  torch::ScalarType::BFloat16,
+                                  k0.scalar_type(),
+                                  "cache_select_inplace_ptrs_kernel",
+                                  [&] {
+                                    cache_select_inplace_ptrs_kernel<scalar_t>
+                                        <<<grid_dim, block_dim, 0, stream>>>(
+                                            k_ptrs_i64.data_ptr<int64_t>(),
+                                            v_ptrs_i64.data_ptr<int64_t>(),
+                                            beam_index_i32.data_ptr<int32_t>(),
+                                            block_table_i32.data_ptr<int32_t>(),
+                                            B,
+                                            Beam,
+                                            Kv,
+                                            MaxStep,
+                                            D,
+                                            MaxReq,
+                                            Layer,
+                                            decode_step_i32);
+                                  });
+
+  C10_CUDA_KERNEL_LAUNCH_CHECK();
+}
+
+}  // namespace
+
+namespace xllm::kernel::cuda {
+void cache_select(const torch::Tensor& beam_index,  // [B*Beam, 1]
+                  std::vector<torch::Tensor>& unshared_k_cache,
+                  std::vector<torch::Tensor>& unshared_v_cache,
+                  const torch::Tensor& block_table,  // [B, 1]
+                  int64_t decode_step,
+                  int64_t beam_size,
+                  int64_t layer_num) {
+  CHECK_GE(layer_num, 0) << "layer_num must be >= 0";
+  if (layer_num == 0) {
+    return;
+  }
+  CHECK_EQ(static_cast<int64_t>(unshared_k_cache.size()), layer_num)
+      << "unshared_k_cache length mismatch";
+  CHECK_EQ(static_cast<int64_t>(unshared_v_cache.size()), layer_num)
+      << "unshared_v_cache length mismatch";
+
+  CHECK(beam_index.is_cuda()) << "beam_index must be CUDA";
+  CHECK(block_table.is_cuda()) << "block_table must be CUDA";
+  CHECK_EQ(block_table.dim(), 2) << "block_table must be [B, 1]";
+  CHECK_EQ(block_table.size(1), 1) << "block_table must be [B, 1]";
+  CHECK_EQ(beam_index.dim(), 2) << "beam_index must be [B*Beam, 1]";
+  CHECK_EQ(beam_index.size(1), 1) << "beam_index must be [B*Beam, 1]";
+  CHECK_GE(decode_step, 0) << "decode_step must be >= 0";
+  CHECK_GT(beam_size, 0) << "beam_size must be > 0";
+
+  const int64_t B = block_table.size(0);
+  CHECK_EQ(beam_index.size(0), B * beam_size)
+      << "beam_index size mismatch with B*beam_size";
+
+  // Prepare indices (int32, contiguous).
+  auto beam_index_i32 = beam_index.to(torch::kInt32).contiguous();
+  auto block_table_i32 =
+      block_table.select(1, 0).to(torch::kInt32).contiguous();  // [B]
+
+  // Validate shapes/dtypes against layer 0.
+  const auto& k0 = unshared_k_cache[0];
+  const auto& v0 = unshared_v_cache[0];
+  CHECK(k0.is_cuda() && v0.is_cuda()) << "cache must be CUDA";
+  CHECK(k0.is_contiguous() && v0.is_contiguous()) << "cache must be contiguous";
+  CHECK_EQ(k0.dim(), 5) << "cache must be 5D [MaxReq, Beam, MaxStep, Kv, D]";
+  CHECK_EQ(v0.sizes(), k0.sizes()) << "k/v cache shapes must match";
+  CHECK_EQ(k0.size(1), beam_size) << "beam_size mismatch with cache";
+  CHECK_LT(decode_step, k0.size(2)) << "decode_step must be < max_decode_step";
+
+  // Pack layer pointers into CUDA int64 tensors so we can launch once.
+  // Note: pointer values are produced on host (data_ptr()), then copied to GPU.
+  c10::cuda::CUDAGuard device_guard(k0.device());
+  auto ptr_cuda_opts =
+      torch::TensorOptions().dtype(torch::kInt64).device(k0.device());
+  auto k_ptrs_i64 = torch::empty({layer_num}, ptr_cuda_opts);
+  auto v_ptrs_i64 = torch::empty({layer_num}, ptr_cuda_opts);
+  std::vector<int64_t> k_ptrs_host(static_cast<size_t>(layer_num));
+  std::vector<int64_t> v_ptrs_host(static_cast<size_t>(layer_num));
+
+  for (int64_t layer = 0; layer < layer_num; ++layer) {
+    auto k = unshared_k_cache[static_cast<size_t>(layer)];
+    auto v = unshared_v_cache[static_cast<size_t>(layer)];
+    CHECK(k.is_cuda() && v.is_cuda()) << "cache must be CUDA";
+    CHECK(k.is_contiguous() && v.is_contiguous()) << "cache must be contiguous";
+    CHECK_EQ(k.sizes(), k0.sizes()) << "all layers must have same cache shape";
+    CHECK_EQ(v.sizes(), k0.sizes()) << "all layers must have same cache shape";
+    CHECK_EQ(k.scalar_type(), k0.scalar_type())
+        << "all layers must have same dtype";
+    CHECK_EQ(v.scalar_type(), k0.scalar_type())
+        << "all layers must have same dtype";
+    CHECK_EQ(k.get_device(), k0.get_device())
+        << "all layers must be on the same CUDA device";
+    CHECK_EQ(v.get_device(), k0.get_device())
+        << "all layers must be on the same CUDA device";
+
+    k_ptrs_host[static_cast<size_t>(layer)] =
+        static_cast<int64_t>(reinterpret_cast<uintptr_t>(k.data_ptr()));
+    v_ptrs_host[static_cast<size_t>(layer)] =
+        static_cast<int64_t>(reinterpret_cast<uintptr_t>(v.data_ptr()));
+  }
+
+  cudaStream_t stream = at::cuda::getCurrentCUDAStream();
+  C10_CUDA_CHECK(
+      cudaMemcpyAsync(k_ptrs_i64.data_ptr<int64_t>(),
+                      k_ptrs_host.data(),
+                      static_cast<size_t>(layer_num) * sizeof(int64_t),
+                      cudaMemcpyHostToDevice,
+                      stream));
+  C10_CUDA_CHECK(
+      cudaMemcpyAsync(v_ptrs_i64.data_ptr<int64_t>(),
+                      v_ptrs_host.data(),
+                      static_cast<size_t>(layer_num) * sizeof(int64_t),
+                      cudaMemcpyHostToDevice,
+                      stream));
+
+  cache_select_cuda_launch_ptrs(k0,
+                                v0,
+                                k_ptrs_i64,
+                                v_ptrs_i64,
+                                beam_index_i32,
+                                block_table_i32,
+                                decode_step,
+                                layer_num);
+}
+
+}  // namespace xllm::kernel::cuda

--- a/xllm/core/kernels/cuda/cache_select_test.cpp
+++ b/xllm/core/kernels/cuda/cache_select_test.cpp
@@ -1,0 +1,311 @@
+/* Copyright 2026 The xLLM Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://github.com/jd-opensource/xllm/blob/main/LICENSE
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include <glog/logging.h>
+#include <gtest/gtest.h>
+#include <torch/torch.h>
+
+#include <limits>
+#include <vector>
+
+#include "core/kernels/cuda/cuda_ops_api.h"
+
+class CacheSelctTest : public ::testing::Test {
+ protected:
+  void SetUp() override {
+    if (!torch::cuda::is_available()) {
+      GTEST_SKIP() << "CUDA not available, skipping test.";
+    }
+    device_ = torch::Device(torch::kCUDA);
+    dtype_ = torch::kFloat16;
+  }
+
+  torch::Device device_ = torch::kCPU;
+  torch::ScalarType dtype_ = torch::kFloat16;
+};
+
+void cache_select(
+    const torch::Tensor& beam_index,  // [batch * beam, 1] - out_token_index
+    std::vector<torch::Tensor>&
+        unshared_k_cache,  // per layer: [max_num_request, beam_size,
+                           // max_decode_step, kv_heads, head_dim]
+    std::vector<torch::Tensor>&
+        unshared_v_cache,  // per layer: [max_num_request, beam_size,
+                           // max_decode_step, kv_heads, head_dim]
+    const torch::Tensor& block_table,  // [batch_size, 1]
+    int64_t decode_step,               // current round (step 0, 1, ...)
+    int64_t beam_size,                 // beam width
+    int64_t layer_num) {               // number of layers
+
+  int64_t batch_size = block_table.size(0);
+  int64_t total_beams = beam_index.size(0);
+  int64_t kv_heads = unshared_k_cache[0].size(3);
+  int64_t head_dim = unshared_k_cache[0].size(4);
+  CHECK_EQ(total_beams, batch_size * beam_size) << "beam_index size mismatch";
+
+  if (layer_num > 0) {
+    int64_t max_num_request = unshared_k_cache[0].size(0);
+    int64_t max_decode_step = unshared_k_cache[0].size(2);
+    auto beam_index_reshaped =
+        beam_index.reshape({batch_size, beam_size})
+            .to(torch::kLong);  // [batch_size, beam_size]
+    auto parent_beam = (beam_index_reshaped / beam_size)
+                           .to(torch::kLong);  // [batch_size, beam_size]
+
+    auto _block_table = block_table.select(1, 0);
+
+    auto cache_opts = unshared_k_cache[0].options();
+    auto ori_k_cache = torch::zeros(
+        {layer_num, batch_size, beam_size, max_decode_step, kv_heads, head_dim},
+        cache_opts);
+    auto ori_v_cache = torch::zeros(
+        {layer_num, batch_size, beam_size, max_decode_step, kv_heads, head_dim},
+        cache_opts);
+
+    for (int64_t layer = 0; layer < layer_num; ++layer) {
+      auto k_cache = unshared_k_cache[layer];
+      auto v_cache = unshared_v_cache[layer];
+      ori_k_cache[layer].copy_(k_cache.index_select(0, _block_table));
+      ori_v_cache[layer].copy_(v_cache.index_select(0, _block_table));
+    }
+
+    for (int64_t layer = 0; layer < layer_num; ++layer) {
+      auto k_cache = unshared_k_cache[layer];
+      auto v_cache = unshared_v_cache[layer];
+
+      for (int64_t b = 0; b < batch_size; ++b) {
+        int64_t request_id = block_table[b].item<int64_t>();
+
+        CHECK_GE(request_id, 0) << "Invalid request_id: " << request_id;
+        CHECK_LT(request_id, max_num_request)
+            << "request_id (" << request_id << ") >= max_num_request ("
+            << max_num_request << ")";
+
+        auto parent_beam_batch = parent_beam[b];  // [beam_size]
+
+        for (int64_t new_beam = 0; new_beam < beam_size; ++new_beam) {
+          int64_t old_beam = parent_beam_batch[new_beam].item<int64_t>();
+
+          CHECK_GE(old_beam, 0) << "Invalid old_beam: " << old_beam;
+          CHECK_LT(old_beam, beam_size)
+              << "old_beam (" << old_beam << ") >= beam_size (" << beam_size
+              << ")";
+          if (new_beam == old_beam) {
+            continue;
+          }
+          for (int64_t step = 0; step <= decode_step; ++step) {
+            k_cache[request_id][new_beam][step].copy_(
+                ori_k_cache[layer][request_id][old_beam][step]);
+            v_cache[request_id][new_beam][step].copy_(
+                ori_v_cache[layer][request_id][old_beam][step]);
+          }
+        }
+      }
+    }
+  }
+}
+void cache_select_intelligent(
+    const torch::Tensor& beam_index,  // [batch * beam, 1] - out_token_index
+    std::vector<torch::Tensor>&
+        unshared_k_cache,  // per layer: [max_num_request, beam_size,
+                           // max_decode_step, kv_heads, head_dim]
+    std::vector<torch::Tensor>&
+        unshared_v_cache,  // per layer: [max_num_request, beam_size,
+                           // max_decode_step, kv_heads, head_dim]
+    const torch::Tensor& block_table,  // [batch_size, 1]
+    int64_t decode_step,               // current round (step 0, 1, ...)
+    int64_t beam_size,                 // beam width
+    int64_t layer_num) {
+  int64_t batch_size = block_table.size(0);
+  int64_t total_beams = beam_index.size(0);
+  CHECK_EQ(total_beams, batch_size * beam_size) << "beam_index size mismatch";
+
+  if (layer_num > 0) {
+    int64_t max_num_request = unshared_k_cache[0].size(0);
+    int64_t max_decode_step = unshared_k_cache[0].size(2);
+
+    CHECK_EQ(unshared_k_cache.size(), static_cast<size_t>(layer_num))
+        << "unshared_k_cache size mismatch";
+    CHECK_EQ(unshared_v_cache.size(), static_cast<size_t>(layer_num))
+        << "unshared_v_cache size mismatch";
+    CHECK_LT(decode_step, max_decode_step)
+        << "decode_step must be less than max_decode_step";
+    auto beam_index_reshaped =
+        beam_index.reshape({batch_size, beam_size})
+            .to(torch::kLong);  // [batch_size, beam_size]
+    auto parent_beam = (beam_index_reshaped / beam_size)
+                           .to(torch::kLong);  // [batch_size, beam_size]
+
+    auto block_table_cpu =
+        block_table.select(1, 0).to(torch::kCPU);  // [batch_size]
+    std::vector<int64_t> dirct_beam(batch_size * beam_size, -1);
+    for (int64_t b = 0; b < batch_size; ++b) {
+      for (int64_t new_beam = 0; new_beam < beam_size; ++new_beam) {
+        int64_t old_beam = parent_beam[b][new_beam].item<int64_t>();
+        dirct_beam[b * beam_size + new_beam] = old_beam > new_beam ? 1 : -1;
+      }
+    }
+    for (int64_t layer = 0; layer < layer_num; ++layer) {
+      auto& k_cache = unshared_k_cache[layer];
+      auto& v_cache = unshared_v_cache[layer];
+
+      for (int64_t b = 0; b < batch_size; ++b) {
+        int64_t request_id = block_table_cpu[b].item<int64_t>();
+
+        CHECK_GE(request_id, 0) << "Invalid request_id: " << request_id;
+        CHECK_LT(request_id, max_num_request)
+            << "request_id (" << request_id << ") >= max_num_request ("
+            << max_num_request << ")";
+
+        auto parent_beam_batch = parent_beam[b];  // [beam_size]
+
+        for (int64_t new_beam = 0; new_beam < beam_size; ++new_beam) {
+          int64_t old_beam = parent_beam_batch[new_beam].item<int64_t>();
+
+          CHECK_GE(old_beam, 0) << "Invalid old_beam: " << old_beam;
+          CHECK_LT(old_beam, beam_size)
+              << "old_beam (" << old_beam << ") >= beam_size (" << beam_size
+              << ")";
+
+          if (new_beam == old_beam) {
+            continue;
+          }
+          if (dirct_beam[b * beam_size + new_beam] == 1) {
+            for (int64_t step = 0; step <= decode_step; ++step) {
+              k_cache[request_id][new_beam][step].copy_(
+                  k_cache[request_id][old_beam][step]);
+              v_cache[request_id][new_beam][step].copy_(
+                  v_cache[request_id][old_beam][step]);
+            }
+          }
+        }
+        for (int64_t new_beam = beam_size - 1; new_beam > 0; --new_beam) {
+          int64_t old_beam = parent_beam_batch[new_beam].item<int64_t>();
+          CHECK_GE(old_beam, 0) << "Invalid old_beam: " << old_beam;
+          CHECK_LT(old_beam, beam_size)
+              << "old_beam (" << old_beam << ") >= beam_size (" << beam_size
+              << ")";
+
+          if (new_beam == old_beam) {
+            continue;
+          }
+          if (dirct_beam[b * beam_size + new_beam] == -1) {
+            for (int64_t step = 0; step <= decode_step; ++step) {
+              k_cache[request_id][new_beam][step].copy_(
+                  k_cache[request_id][old_beam][step]);
+              v_cache[request_id][new_beam][step].copy_(
+                  v_cache[request_id][old_beam][step]);
+            }
+          }
+        }
+      }
+    }
+  }
+}
+
+TEST_F(CacheSelctTest, CorrectnessTest) {
+  // Small shapes are enough to catch indexing bugs, while keeping the test
+  // fast.
+  const int64_t batch_size = 1;
+  const int64_t beam_size = 2;
+  const int64_t top_k = 2;
+  int32_t current_step = 1;
+  const int64_t kv_heads = 8;
+  const int64_t head_dim = 128;
+  const int64_t layer_num = 2;
+  const int64_t max_num_request = 1;
+  const int64_t max_decode_step = 3;
+  const auto float_opts = torch::TensorOptions().device(device_).dtype(dtype_);
+  const auto int_opts =
+      torch::TensorOptions().device(device_).dtype(torch::kInt32);
+
+  torch::Tensor beam_index = torch::randint(
+      0, beam_size * top_k, {batch_size * beam_size, 1}, int_opts);
+  auto beam_after_sort =
+      beam_index.gather(0, beam_index.argsort(static_cast<int64_t>(0), false));
+  std::vector<torch::Tensor> base_k_cache;
+  std::vector<torch::Tensor> base_v_cache;
+
+  for (int64_t layer = 0; layer < layer_num; ++layer) {
+    base_k_cache.push_back(torch::randn(
+        {max_num_request, beam_size, max_decode_step, kv_heads, head_dim},
+        float_opts));
+    base_v_cache.push_back(torch::randn(
+        {max_num_request, beam_size, max_decode_step, kv_heads, head_dim},
+        float_opts));
+  }
+
+  std::vector<torch::Tensor> k_cache_intelligent;
+  std::vector<torch::Tensor> v_cache_intelligent;
+  std::vector<torch::Tensor> k_cache_normal;
+  std::vector<torch::Tensor> v_cache_normal;
+  k_cache_intelligent.reserve(layer_num);
+  v_cache_intelligent.reserve(layer_num);
+  k_cache_normal.reserve(layer_num);
+  v_cache_normal.reserve(layer_num);
+  for (int64_t layer = 0; layer < layer_num; ++layer) {
+    k_cache_intelligent.push_back(base_k_cache[layer].clone());
+    v_cache_intelligent.push_back(base_v_cache[layer].clone());
+    k_cache_normal.push_back(base_k_cache[layer].clone());
+    v_cache_normal.push_back(base_v_cache[layer].clone());
+  }
+
+  //   use cache intelligent
+  torch::Tensor block_table =
+      torch::randint(0, max_num_request, {batch_size, 1}, int_opts);
+  cache_select_intelligent(beam_after_sort,
+                           k_cache_intelligent,
+                           v_cache_intelligent,
+                           block_table,
+                           current_step,
+                           beam_size,
+                           layer_num);
+  //   use cache normal
+  cache_select(beam_after_sort,
+               k_cache_normal,
+               v_cache_normal,
+               block_table,
+               current_step,
+               beam_size,
+               layer_num);
+
+  // CUDA kernel version (single launch over layer axis).
+  std::vector<torch::Tensor> k_cache_cuda;
+  std::vector<torch::Tensor> v_cache_cuda;
+  k_cache_cuda.reserve(layer_num);
+  v_cache_cuda.reserve(layer_num);
+  for (int64_t layer = 0; layer < layer_num; ++layer) {
+    k_cache_cuda.push_back(base_k_cache[layer].clone());
+    v_cache_cuda.push_back(base_v_cache[layer].clone());
+  }
+  xllm::kernel::cuda::cache_select(beam_after_sort,
+                                   k_cache_cuda,
+                                   v_cache_cuda,
+                                   block_table,
+                                   current_step,
+                                   beam_size,
+                                   layer_num);
+  for (int64_t layer = 0; layer < layer_num; ++layer) {
+    EXPECT_TRUE(torch::allclose(
+        k_cache_intelligent[layer], k_cache_normal[layer], 1e-5, 1e-5));
+    EXPECT_TRUE(torch::allclose(
+        v_cache_intelligent[layer], v_cache_normal[layer], 1e-5, 1e-5));
+
+    EXPECT_TRUE(torch::allclose(
+        k_cache_intelligent[layer], k_cache_cuda[layer], 1e-5, 1e-5));
+    EXPECT_TRUE(torch::allclose(
+        v_cache_intelligent[layer], v_cache_cuda[layer], 1e-5, 1e-5));
+  }
+}

--- a/xllm/core/kernels/cuda/cuda_ops_api.h
+++ b/xllm/core/kernels/cuda/cuda_ops_api.h
@@ -95,4 +95,43 @@ torch::Tensor matmul(torch::Tensor a,
                      torch::Tensor b,
                      std::optional<torch::Tensor> bias);
 
+void decoder_reshape_and_cache(torch::Tensor proj_k,
+                               torch::Tensor proj_v,
+                               torch::Tensor unshared_k_cache,
+                               torch::Tensor unshared_v_cache,
+                               torch::Tensor block_table,
+                               uint32_t step);
+
+void cache_select(const torch::Tensor& beam_index,
+                  std::vector<torch::Tensor>& unshared_k_cache,
+                  std::vector<torch::Tensor>& unshared_v_cache,
+                  const torch::Tensor& block_table,
+                  int64_t decode_step,
+                  int64_t beam_size,
+                  int64_t layer_num);
+
+void lse_combine(torch::Tensor output,
+                 torch::Tensor shared_o,
+                 torch::Tensor shared_lse,
+                 torch::Tensor unshared_o,
+                 torch::Tensor unshared_lse);
+void prefill_reshape_and_cache(
+    torch::Tensor proj_k,  // [shared_len, kv_heads, head_dim]
+    torch::Tensor proj_v,  // [shared_len, kv_heads, head_dim]
+    torch::Tensor
+        shared_k_cache,  // [num_shared_kv_seq_len, kv_heads, head_dim]
+    torch::Tensor shared_v_cache);
+
+void beam_search(torch::Tensor acc_logprob,
+                 torch::Tensor in_sequence_group,
+                 torch::Tensor top_tokens,
+                 torch::Tensor top_logprobs,
+                 torch::Tensor out_acc_logprob,
+                 torch::Tensor out_token_ids,
+                 torch::Tensor out_token_index,
+                 torch::Tensor out_beam_count_prefix_sums,
+                 torch::Tensor out_sequence_group,
+                 uint32_t batch_size,
+                 uint32_t current_step);
+
 }  // namespace xllm::kernel::cuda

--- a/xllm/core/kernels/cuda/decoder_reshape_and_cache.cu
+++ b/xllm/core/kernels/cuda/decoder_reshape_and_cache.cu
@@ -1,0 +1,166 @@
+/* Copyright 2026 The xLLM Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://github.com/jd-opensource/xllm/blob/main/LICENSE
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+#include <c10/cuda/CUDAGuard.h>
+#include <cuda_runtime.h>
+#include <torch/cuda.h>
+
+#include "cuda_ops_api.h"
+#include "utils.h"
+
+namespace {
+
+// Fused decoder reshape and cache kernel.
+// Copies proj_k and proj_v into unshared_k_cache / unshared_v_cache at the
+// positions specified by block_table and step.
+// Inputs:
+//   proj_k           : [batch_size, beam_size, kv_heads, head_dim]
+//   proj_v           : [batch_size, beam_size, kv_heads, head_dim]
+//   unshared_k_cache : [max_num_request, beam_size, max_decode_step, kv_heads,
+//   head_dim] unshared_v_cache : [max_num_request, beam_size, max_decode_step,
+//   kv_heads, head_dim] block_table      : [batch_size] - block_id per batch
+//   step             : current decode step
+template <typename scalar_t>
+__global__ void decoder_reshape_and_cache_kernel(
+    const scalar_t* __restrict__ proj_k,  // [batch_size, beam_size, kv_heads,
+                                          // head_dim]
+    const scalar_t* __restrict__ proj_v,  // [batch_size, beam_size, kv_heads,
+                                          // head_dim]
+    scalar_t* __restrict__ unshared_k_cache,  // [max_num_request, beam_size,
+                                              // max_decode_step, kv_heads,
+                                              // head_dim]
+    scalar_t* __restrict__ unshared_v_cache,  // [max_num_request, beam_size,
+                                              // max_decode_step, kv_heads,
+                                              // head_dim]
+    const int64_t* __restrict__ block_table,  // [batch_size]
+    const int64_t batch_size,
+    const int64_t beam_size,
+    const int64_t kv_heads,
+    const int64_t head_dim,
+    const int64_t max_decode_step,
+    const int64_t max_num_request,
+    const uint32_t step) {
+  const int64_t total_elements = batch_size * beam_size * kv_heads;
+  const int64_t idx = static_cast<int64_t>(blockIdx.y);
+
+  if (idx >= total_elements) {
+    return;
+  }
+
+  // Decode flattened index -> (batch, beam, kv_head)
+  const int64_t batch_idx = idx / (beam_size * kv_heads);
+  const int64_t remaining = idx % (beam_size * kv_heads);
+  const int64_t beam_idx = remaining / kv_heads;
+  const int64_t kv_head_idx = remaining % kv_heads;
+
+  const int64_t block_id = block_table[batch_idx];
+
+  // Guard invalid block id
+  if (block_id < 0 || block_id >= max_num_request) {
+    return;
+  }
+
+  // Compute base indices.
+  // proj_k[batch_idx, beam_idx, kv_head_idx, :]
+  const int64_t src_base =
+      ((batch_idx * beam_size + beam_idx) * kv_heads + kv_head_idx) * head_dim;
+
+  // unshared_*_cache[block_id, beam_idx, step, kv_head_idx, :]
+  const int64_t dst_base =
+      (((block_id * beam_size + beam_idx) * max_decode_step + step) * kv_heads +
+       kv_head_idx) *
+      head_dim;
+
+  // Copy the full head_dim with threads parallelizing along D.
+  for (int64_t d = threadIdx.x; d < head_dim; d += blockDim.x) {
+    unshared_k_cache[dst_base + d] = proj_k[src_base + d];
+    unshared_v_cache[dst_base + d] = proj_v[src_base + d];
+  }
+}
+
+}  // namespace
+
+namespace xllm::kernel::cuda {
+
+void decoder_reshape_and_cache(torch::Tensor proj_k,
+                               torch::Tensor proj_v,
+                               torch::Tensor unshared_k_cache,
+                               torch::Tensor unshared_v_cache,
+                               torch::Tensor block_table,
+                               uint32_t step) {
+  CHECK_EQ(proj_k.dim(), 4) << "proj_k must be 4-dimensional";
+  CHECK_EQ(proj_v.dim(), 4) << "proj_v must be 4-dimensional";
+  CHECK_EQ(unshared_k_cache.dim(), 5)
+      << "unshared_k_cache must be 5-dimensional";
+  CHECK_EQ(unshared_v_cache.dim(), 5)
+      << "unshared_v_cache must be 5-dimensional";
+  CHECK_EQ(block_table.dim(), 2) << "block_table must be 2-dimensional";
+  CHECK_EQ(block_table.size(1), 1) << "block_table second dim must be 1";
+
+  const int64_t batch_size = proj_k.size(0);
+  const int64_t beam_size = proj_k.size(1);
+  const int64_t kv_heads = proj_k.size(2);
+  const int64_t head_dim = proj_k.size(3);
+  const int64_t max_num_request = unshared_k_cache.size(0);
+  const int64_t max_decode_step = unshared_k_cache.size(2);
+
+  CHECK_EQ(proj_v.sizes(), proj_k.sizes())
+      << "proj_v and proj_k must have same shape";
+  CHECK_EQ(block_table.size(0), batch_size)
+      << "block_table size must match batch_size";
+  CHECK_GE(step, 0) << "step must be in valid range";
+  CHECK_LT(step, max_decode_step) << "step must be in valid range";
+  CHECK_EQ(unshared_k_cache.size(1), beam_size)
+      << "unshared_k_cache beam_size mismatch";
+  CHECK_EQ(unshared_k_cache.size(3), kv_heads)
+      << "unshared_k_cache kv_heads mismatch";
+  CHECK_EQ(unshared_k_cache.size(4), head_dim)
+      << "unshared_k_cache head_dim mismatch";
+  CHECK_EQ(unshared_v_cache.sizes(), unshared_k_cache.sizes())
+      << "unshared_v_cache and unshared_k_cache must have same shape";
+
+  const at::cuda::OptionalCUDAGuard device_guard(device_of(proj_k));
+  const cudaStream_t stream = at::cuda::getCurrentCUDAStream();
+
+  torch::Tensor block_table_flat = block_table.select(1, 0).to(torch::kInt64);
+
+  // Launch kernel: one block per (batch, beam, kv_head), threads along
+  // head_dim.
+  const int64_t total_elements = batch_size * beam_size * kv_heads;
+  const int threads_per_block = 128;
+  dim3 block_dim(threads_per_block, 1, 1);
+  dim3 grid_dim(1, static_cast<unsigned int>(total_elements), 1);
+
+  DISPATCH_FLOATING_TYPES(
+      proj_k.scalar_type(), "decoder_reshape_and_cache_kernel", [&] {
+        decoder_reshape_and_cache_kernel<scalar_t>
+            <<<grid_dim, block_dim, 0, stream>>>(
+                proj_k.data_ptr<scalar_t>(),
+                proj_v.data_ptr<scalar_t>(),
+                unshared_k_cache.data_ptr<scalar_t>(),
+                unshared_v_cache.data_ptr<scalar_t>(),
+                block_table_flat.data_ptr<int64_t>(),
+                batch_size,
+                beam_size,
+                kv_heads,
+                head_dim,
+                max_decode_step,
+                max_num_request,
+                step);
+      });
+
+  C10_CUDA_KERNEL_LAUNCH_CHECK();
+}
+
+}  // namespace xllm::kernel::cuda

--- a/xllm/core/kernels/cuda/decoder_reshape_and_cache_test.cpp
+++ b/xllm/core/kernels/cuda/decoder_reshape_and_cache_test.cpp
@@ -1,0 +1,175 @@
+/* Copyright 2026 The xLLM Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://github.com/jd-opensource/xllm/blob/main/LICENSE
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include <gtest/gtest.h>
+#include <torch/torch.h>
+
+#include "core/kernels/cuda/cuda_ops_api.h"
+
+namespace xllm::kernel::cuda {
+namespace test {
+
+// This test validates `xllm::kernel::cuda::decoder_reshape_and_cache` by
+// comparing its output against two CPU/PyTorch reference implementations:
+//
+// - `torch_reference`: copies one full [beam_size, kv_heads, head_dim] slab at
+//   once using `select(...).copy_` (easy to read and matches the math).
+// - `torch_reference_bench_style`: copies one [head_dim] vector at a time for
+//   each (b, beam, kv_head), mirroring the style used in the Python benchmark.
+//
+// Having two independent references helps catch subtle indexing/layout bugs in
+// the CUDA kernel (e.g. mixing up beam/step strides).
+class DecoderReshapeAndCacheTest : public ::testing::Test {
+ protected:
+  void SetUp() override {
+    if (!torch::cuda::is_available()) {
+      GTEST_SKIP() << "CUDA not available, skipping test.";
+    }
+    device_ = torch::Device(torch::kCUDA);
+    dtype_ = torch::kFloat16;
+  }
+
+  torch::Device device_ = torch::kCPU;
+  torch::ScalarType dtype_ = torch::kFloat16;
+};
+
+// Reference implementation using PyTorch indexing ops.
+// It writes:
+//   unshared_*_cache[request_id, :, step, :, :] = proj_*(b, :, :, :)
+//
+// Expected shapes:
+// - proj_k/proj_v:         [batch_size, beam_size, kv_heads, head_dim]
+// - unshared_k/unshared_v: [max_num_request, beam_size, max_decode_step,
+// kv_heads, head_dim]
+// - block_table:           [batch_size, 1] mapping batch -> request_id
+// (block_id)
+
+void torch_reference(
+    torch::Tensor proj_k,  // [batch_size, beam_size, kv_heads, head_dim]
+    torch::Tensor proj_v,  // [batch_size, beam_size, kv_heads, head_dim]
+    torch::Tensor unshared_k_cache,  // [max_num_request, beam_size,
+                                     // max_decode_step, kv_heads, head_dim]
+    torch::Tensor unshared_v_cache,  // [max_num_request, beam_size,
+                                     // max_decode_step, kv_heads, head_dim]
+    torch::Tensor block_table,       // [batch_size, 1]
+    uint32_t step) {
+  // Read shapes.
+  int64_t batch_size = proj_k.size(0);
+  int64_t beam_size = proj_k.size(1);
+  int64_t kv_heads = proj_k.size(2);
+  int64_t head_dim = proj_k.size(3);
+  int64_t max_num_request = unshared_k_cache.size(0);
+  int64_t max_decode_step = unshared_k_cache.size(2);
+  // Basic shape checks.
+  CHECK_EQ(proj_v.sizes(), proj_k.sizes())
+      << "proj_v and proj_k must have same shape";
+  CHECK_EQ(block_table.size(0), batch_size)
+      << "block_table size must match batch_size";
+  CHECK_EQ(block_table.size(1), 1) << "block_table second dim must be 1";
+  CHECK_LT(step, max_decode_step) << "step must be less than max_decode_step";
+  CHECK_EQ(unshared_k_cache.size(1), beam_size)
+      << "unshared_k_cache beam_size mismatch";
+  CHECK_EQ(unshared_k_cache.size(3), kv_heads)
+      << "unshared_k_cache kv_heads mismatch";
+  CHECK_EQ(unshared_k_cache.size(4), head_dim)
+      << "unshared_k_cache head_dim mismatch";
+  CHECK_EQ(unshared_v_cache.sizes(), unshared_k_cache.sizes())
+      << "unshared_v_cache and unshared_k_cache must have same shape";
+
+  // Move block_table to CPU so `.item<>()` does not repeatedly sync.
+  auto block_table_cpu =
+      block_table.select(1, 0).to(torch::kCPU);  // [batch_size]
+
+  // For each batch element, write into its assigned request_id slot.
+  for (int64_t b = 0; b < batch_size; ++b) {
+    int64_t request_id = block_table_cpu[b].item<int64_t>();
+
+    // Validate request_id.
+    CHECK_GE(request_id, 0) << "Invalid request_id: " << request_id;
+    CHECK_LT(request_id, max_num_request)
+        << "request_id (" << request_id << ") >= max_num_request ("
+        << max_num_request << ")";
+
+    // Extract one batch slice: [beam_size, kv_heads, head_dim]
+    auto proj_k_batch = proj_k[b];  // [beam_size, kv_heads, head_dim]
+    auto proj_v_batch = proj_v[b];  // [beam_size, kv_heads, head_dim]
+
+    // Write into cache at decode step `step`.
+    // NOTE: dimension order is [request_id, beam, step, kv_head, head_dim].
+    unshared_k_cache[request_id].select(1, step).copy_(proj_k_batch);
+    unshared_v_cache[request_id].select(1, step).copy_(proj_v_batch);
+  }
+}
+
+TEST_F(DecoderReshapeAndCacheTest, CorrectnessTest) {
+  // Small shapes are enough to catch indexing bugs, while keeping the test
+  // fast.
+  const int64_t batch_size = 1;
+  const int64_t beam_size = 2;
+  const int64_t kv_heads = 8;
+  const int64_t head_dim = 128;
+  const int64_t max_num_request = 33437;
+  const int64_t max_decode_step = 3;
+  const uint32_t step = 1;
+
+  auto options = torch::TensorOptions().device(device_).dtype(dtype_);
+
+  // 1) Prepare inputs.
+  // proj_k/proj_v: [batch_size, beam_size, kv_heads, head_dim]
+  torch::Tensor proj_k =
+      torch::randn({batch_size, beam_size, kv_heads, head_dim}, options);
+  torch::Tensor proj_v =
+      torch::randn({batch_size, beam_size, kv_heads, head_dim}, options);
+
+  // 2) Prepare block table mapping batch index -> request_id (block_id).
+  // Here we map the only batch element to request_id=0.
+  torch::Tensor block_table =
+      torch::tensor({0}, torch::kInt64).view({batch_size, 1}).to(device_);
+
+  // 3) Prepare caches.
+  // Layout: [max_num_request, beam_size, max_decode_step, kv_heads, head_dim]
+  torch::Tensor unshared_k_cache = torch::zeros(
+      {max_num_request, beam_size, max_decode_step, kv_heads, head_dim},
+      options);
+  torch::Tensor unshared_v_cache = torch::zeros(
+      {max_num_request, beam_size, max_decode_step, kv_heads, head_dim},
+      options);
+
+  // Reference buffers (two independent references).
+  torch::Tensor ref_k_cache = unshared_k_cache.clone();
+  torch::Tensor ref_v_cache = unshared_v_cache.clone();
+
+  // 4) Run CUDA kernel under test.
+  decoder_reshape_and_cache(
+      proj_k, proj_v, unshared_k_cache, unshared_v_cache, block_table, step);
+
+  // 5) Run references.
+  torch_reference(proj_k, proj_v, ref_k_cache, ref_v_cache, block_table, step);
+
+  // 6) Compare results.
+  EXPECT_TRUE(torch::allclose(unshared_k_cache, ref_k_cache, 1e-5, 1e-5));
+  EXPECT_TRUE(torch::allclose(unshared_v_cache, ref_v_cache, 1e-5, 1e-5));
+
+  // Sanity-check that the expected slice was copied for each batch element.
+  for (int64_t b = 0; b < batch_size; ++b) {
+    int64_t rid = block_table[b][0].item<int64_t>();
+    torch::Tensor copied_k = unshared_k_cache[rid].select(1, step);
+    torch::Tensor source_k = proj_k[b];
+    EXPECT_TRUE(torch::allclose(copied_k, source_k, 1e-5, 1e-5));
+  }
+}
+
+}  // namespace test
+}  // namespace xllm::kernel::cuda

--- a/xllm/core/kernels/cuda/lse_combine.cu
+++ b/xllm/core/kernels/cuda/lse_combine.cu
@@ -1,0 +1,168 @@
+/* Copyright 2026 The xLLM Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://github.com/jd-opensource/xllm/blob/main/LICENSE
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+#include <c10/cuda/CUDAGuard.h>
+#include <cuda_runtime.h>
+#include <torch/cuda.h>
+
+#include <cmath>
+
+#include "cuda_ops_api.h"
+#include "utils.h"
+
+namespace {
+
+// Fused log-sum-exp combine kernel.
+//
+// Layout and strategy (aligned with the TileLang version):
+//   - Each block is responsible for one (batch_idx, head_idx) pair, i.e. one
+//     row in the flattened [B * H, D] layout.
+//   - Threads within a block parallelize along the head_dim (D) dimension to
+//     ensure coalesced global memory access.
+//
+// Tensors:
+//   shared_o    : [B, H, D] - shared attention output
+//   shared_lse  : [B, H, 1] - shared log-sum-exp (FP32)
+//   unshared_o  : [B, H, D] - unshared attention output
+//   unshared_lse: [B, H, 1] - unshared log-sum-exp (FP32)
+//   output      : [B, H, D] - combined output
+template <typename scalar_t, typename out_scalar_t>
+__global__ void lse_combine_kernel(
+    out_scalar_t* __restrict__ output,        // [B, H, D]
+    const scalar_t* __restrict__ shared_o,    // [B, H, D]
+    const float* __restrict__ shared_lse,     // [B, H, 1], always FP32
+    const scalar_t* __restrict__ unshared_o,  // [B, H, D]
+    const float* __restrict__ unshared_lse,   // [B, H, 1], always FP32
+    const int64_t B,                          // batch_size * beam_size
+    const int64_t H,                          // num_heads
+    const int64_t D) {                        // head_dim
+  const int64_t total_elements = B * H;
+  const int64_t idx = static_cast<int64_t>(blockIdx.y);
+
+  if (idx >= total_elements) {
+    return;
+  }
+
+  // Load LSE scalars for this (batch, head) pair.
+  const float shared_lse_val = shared_lse[idx];
+  const float unshared_lse_val = unshared_lse[idx];
+
+  // 1. Compute element-wise max LSE.
+  const float lse_max = fmaxf(shared_lse_val, unshared_lse_val);
+
+  // 2. Compute base-2 exponentials relative to max.
+  const float exp_shared = exp2f(shared_lse_val - lse_max);
+  const float exp_unshared = exp2f(unshared_lse_val - lse_max);
+
+  // 3. Compute merged LSE.
+  const float lse_new = lse_max + log2f(exp_shared + exp_unshared);
+
+  // 4. Compute normalized weights.
+  const float w_shared = exp2f(shared_lse_val - lse_new);
+  const float w_unshared = exp2f(unshared_lse_val - lse_new);
+
+  // 5. Weighted combine along the head_dim.
+  const int64_t base_idx = idx * D;
+  // Threads in the block parallelize along D with stride blockDim.x for
+  // coalesced global memory access.
+  for (int64_t d = threadIdx.x; d < D; d += blockDim.x) {
+    const float shared_val = static_cast<float>(shared_o[base_idx + d]);
+    const float unshared_val = static_cast<float>(unshared_o[base_idx + d]);
+    const float combined = w_shared * shared_val + w_unshared * unshared_val;
+    output[base_idx + d] = static_cast<out_scalar_t>(combined);
+  }
+}
+
+}  // namespace
+
+namespace xllm::kernel::cuda {
+
+// Host wrapper for the fused LSE combine kernel.
+//
+// All inputs are expected to be on the same CUDA device:
+//   shared_o    : [B, H, D], floating type (including Half/BFloat16)
+//   shared_lse  : [B, H, 1], float32
+//   unshared_o  : [B, H, D], same type/shape as shared_o
+//   unshared_lse: [B, H, 1], float32
+//   output      : [B, H, D], will be resized/allocated as needed.
+void lse_combine(torch::Tensor output,
+                 torch::Tensor shared_o,
+                 torch::Tensor shared_lse,
+                 torch::Tensor unshared_o,
+                 torch::Tensor unshared_lse) {
+  CHECK_EQ(shared_o.dim(), 3) << "shared_o must be 3D [B, H, D]";
+  CHECK_EQ(unshared_o.dim(), 3) << "unshared_o must be 3D [B, H, D]";
+  CHECK_EQ(shared_lse.dim(), 3) << "shared_lse must be 3D [B, H, 1]";
+  CHECK_EQ(unshared_lse.dim(), 3) << "unshared_lse must be 3D [B, H, 1]";
+
+  const int64_t B = shared_o.size(0);
+  const int64_t H = shared_o.size(1);
+  const int64_t D = shared_o.size(2);
+
+  CHECK_EQ(shared_o.sizes(), unshared_o.sizes())
+      << "shared_o and unshared_o must have same shape";
+  CHECK_EQ(shared_lse.scalar_type(), torch::kFloat32)
+      << "shared_lse must be float32";
+  CHECK_EQ(unshared_lse.scalar_type(), torch::kFloat32)
+      << "unshared_lse must be float32";
+  CHECK_EQ(shared_lse.size(0), B)
+      << "shared_lse shape mismatch, expected [B, H, 1]";
+  CHECK_EQ(shared_lse.size(1), H)
+      << "shared_lse shape mismatch, expected [B, H, 1]";
+  CHECK_EQ(shared_lse.size(2), 1)
+      << "shared_lse shape mismatch, expected [B, H, 1]";
+  CHECK_EQ(unshared_lse.size(0), B)
+      << "unshared_lse shape mismatch, expected [B, H, 1]";
+  CHECK_EQ(unshared_lse.size(1), H)
+      << "unshared_lse shape mismatch, expected [B, H, 1]";
+  CHECK_EQ(unshared_lse.size(2), 1)
+      << "unshared_lse shape mismatch, expected [B, H, 1]";
+
+  // Ensure output has the correct shape and dtype.
+  if (!output.defined() || output.sizes() != shared_o.sizes()) {
+    output = torch::empty_like(shared_o);
+  }
+
+  const at::cuda::OptionalCUDAGuard device_guard(device_of(shared_o));
+  const cudaStream_t stream = at::cuda::getCurrentCUDAStream();
+
+  // Launch kernel: one block per (batch, head) pair, threads along D.
+  const int64_t total_elements = B * H;
+  const int threads_per_block = 128;
+  dim3 block_dim(threads_per_block, 1, 1);
+  dim3 grid_dim(1, static_cast<unsigned int>(total_elements), 1);
+
+  DISPATCH_FLOATING_TYPES(
+      shared_o.scalar_type(), "lse_combine_kernel_input", [&] {
+        using in_t = scalar_t;
+        DISPATCH_FLOATING_TYPES(
+            output.scalar_type(), "lse_combine_kernel_output", [&] {
+              using out_t = scalar_t;
+              lse_combine_kernel<in_t, out_t>
+                  <<<grid_dim, block_dim, 0, stream>>>(
+                      output.data_ptr<out_t>(),
+                      shared_o.data_ptr<in_t>(),
+                      shared_lse.data_ptr<float>(),
+                      unshared_o.data_ptr<in_t>(),
+                      unshared_lse.data_ptr<float>(),
+                      B,
+                      H,
+                      D);
+            });
+      });
+
+  C10_CUDA_KERNEL_LAUNCH_CHECK();
+}
+
+}  // namespace xllm::kernel::cuda

--- a/xllm/core/kernels/cuda/prefill_reshape_and_cache.cpp
+++ b/xllm/core/kernels/cuda/prefill_reshape_and_cache.cpp
@@ -1,0 +1,53 @@
+/* Copyright 2026 The xLLM Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://github.com/jd-opensource/xllm/blob/main/LICENSE
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include <ATen/cuda/CUDAContext.h>
+#include <cuda_runtime.h>
+#include <torch/script.h>
+#include <torch/torch.h>
+
+#include "cuda.h"
+
+namespace xllm::kernel::cuda {
+
+// Prefill reshape and cache kernel for Rec pure device mode.
+// Copies projected K and V tensors from prefill phase into shared KV cache.
+// This function is specifically designed for Rec (recommendation) pure device
+// mode, where multi-round decode loops run entirely on device. In this mode,
+// sequences share the same prompt prefix, and the prefill KV cache needs to be
+// stored in a shared cache format for efficient multi-round decoding on device.
+// Inputs:
+//   proj_k          : [shared_len, kv_heads, head_dim] - projected K tensor
+//                     from prefill phase
+//   proj_v          : [shared_len, kv_heads, head_dim] - projected V tensor
+//                     from prefill phase
+//   shared_k_cache  : [num_shared_kv_seq_len, kv_heads, head_dim] - shared K
+//                     cache buffer for storing prefill KV cache
+//   shared_v_cache  : [num_shared_kv_seq_len, kv_heads, head_dim] - shared V
+//                     cache buffer for storing prefill KV cache
+void prefill_reshape_and_cache(
+    torch::Tensor proj_k,  // [shared_len, kv_heads, head_dim]
+    torch::Tensor proj_v,  // [shared_len, kv_heads, head_dim]
+    torch::Tensor
+        shared_k_cache,  // [num_shared_kv_seq_len, kv_heads, head_dim]
+    torch::Tensor shared_v_cache) {
+  int64_t shared_len = proj_k.size(0);
+  shared_k_cache = shared_k_cache.slice(0, 0, shared_len);
+  shared_v_cache = shared_v_cache.slice(0, 0, shared_len);
+  shared_k_cache.copy_(proj_k);
+  shared_v_cache.copy_(proj_v);
+}
+
+}  // namespace xllm::kernel::cuda

--- a/xllm/core/util/CMakeLists.txt
+++ b/xllm/core/util/CMakeLists.txt
@@ -46,6 +46,9 @@ cc_library(
   DEPS
     torch
     brpc
+    OpenSSL::SSL
+    OpenSSL::Crypto
+    leveldb::leveldb
     nlohmann_json::nlohmann_json
     glog::glog
     torch


### PR DESCRIPTION
# feat: Add Rec Kernel and Builder for PureDevice Pipeline [2/3]

This PR implements the **batch builder and CUDA kernels** for the PureDevice Pipeline, enabling multi-round decode operations on device. This is the second of three PRs to implement the complete feature.

## Background

Building on PR [1/3] which established the foundational infrastructure, this PR adds the core components needed for multi-round decode execution:
- **MultiStepBatchInputBuilder**: Constructs batch inputs for multi-step decode operations
- **Beam Search Function**: Performs beam search selection on device (using PyTorch operations)
- **Cache Select Kernel**: Reorders KV cache after beam search
- **Decoder Reshape and Cache**: Handles decoder-stage KV cache operations
- **LSE Combine Kernel**: Prepared for future shared/unshared attention computation separation (not core to current PR)

## What's Added

### 1. MultiStepBatchInputBuilder
- **Purpose**: Standalone batch input builder for multi-round/step-level decode
- **Key Features**:
  - Does NOT inherit from legacy `BatchInputBuilder` to avoid impacting existing behavior
  - Supports multi-step token and position extraction
  - Manages beam search state tracking
  - Processes unique token tracking for sampling
- **Files**:
  - `multi_step_batch_input_builder.h/cpp`: Core builder implementation
  - `BuilderState`: Internal state management for batch construction
  - `MultiStepBuilderState`: Enhanced state for multi-step operations

### 2. Beam Search Function
- **Purpose**: Device-side beam search selection for multi-round decode
- **Implementation**: C++ function using PyTorch tensor operations
- **Key Features**:
  - Combines accumulated logprobs with top-k logprobs
  - Selects top-k beams per batch using PyTorch's `topk` operation
  - Maintains beam sequence groups across rounds
  - Handles initial step (step 0) and subsequent steps differently
- **Files**:
  - `beam_search.cpp`: Beam search implementation using PyTorch operations
  - `cuda_ops_api.h`: API declarations

### 3. Cache Select Kernel
- **Purpose**: In-place KV cache reordering after beam search
- **Key Features**:
  - 2-pass in-place algorithm to avoid temporary buffers
  - Supports multi-layer KV cache reordering
  - Handles beam index mapping and block table lookup
  - Optimized for coalesced memory access
- **Files**:
  - `cache_select.cu`: CUDA kernel implementation
  - `cache_select_test.cpp`: Comprehensive test suite

### 4. LSE Combine Kernel (Future Preparation)
- **Purpose**: Prepared for future shared/unshared attention computation separation
- **Note**: This kernel is implemented but not core to the current PR's functionality. It will be used when attention computation is split into shared and unshared parts for optimization.
- **Key Features**:
  - Combines shared and unshared attention outputs using log-sum-exp
  - Handles FP32 log-sum-exp values
  - Block-level parallelism (one block per batch-head pair)
  - Thread-level parallelism along head dimension
- **Files**:
  - `lse_combine.cu`: CUDA kernel implementation
  - `lse_combine_test.cpp`: Comprehensive test suite

### 5. Decoder Reshape and Cache
- **Purpose**: Reshape and cache operations for decoder stage
- **Key Features**:
  - Handles KV cache reshaping for decoder operations
  - Supports continuous KV cache layout
  - Manages cache slot offsets and start offsets
- **Files**:
  - `decoder_reshape_and_cache.cu`: CUDA kernel implementation
  - `decoder_reshape_and_cache_test.cpp`: Test suite

### 6. Prefill Reshape and Cache
- **Purpose**: Reshape and cache operations for prefill stage
- **Files**:
  - `prefill_reshape_and_cache.cpp`: Implementation

### 7. Batch Integration
- **`Batch::process_beam_sequence_group()`**: Processes multi-round beam search results
  - Extracts beam sequences from output tensors
  - Caches results in `Sequence` objects via `set_beam_result()`
  - Handles logprobs extraction and ranking
- **`Batch::build_forward_input()`**: Integration with `MultiStepBatchInputBuilder`
  - Detects PureDevice mode and uses `MultiStepBatchInputBuilder`

### 8. Model Input Parameters
- **`ModelInputParams`**: Extended with multi-step decode parameters
  - Beam search configuration
  - Multi-step decode state tracking
  - Forward parameter extensions

### 9. Forward Parameters
- **`ForwardParams`**: Extended with beam search output structures
  - `BeamSearchOutput`: Contains beam search results and logprobs
  - Integration with `ForwardOutput` for result passing

## Architecture Overview

### Data Flow

```
                    Multi-Round Decode Request
                              │
                              ▼
        ┌─────────────────────────────────────────┐
        │ MultiStepBatchInputBuilder              │
        │  • Extract tokens & positions           │
        │  • Build ForwardInput                   │
        └─────────────────────────────────────────┘
                              │
                              ▼
        ┌─────────────────────────────────────────┐
        │ Forward Pass (Model)                    │
        │  • XAttention with beam support         │
        └─────────────────────────────────────────┘
                              │
                              ▼
        ┌─────────────────────────────────────────┐
        │ Beam Search Function                    │
        │  • Combine logprobs (PyTorch ops)       │
        │  • Select top-k beams                   │
        │  • Update sequence groups               │
        └─────────────────────────────────────────┘
                              │
                              ▼
        ┌─────────────────────────────────────────┐
        │ Cache Select Kernel                     │
        │  • Reorder KV cache by beam index       │
        │  • In-place 2-pass algorithm            │
        └─────────────────────────────────────────┘
                              │
                              ▼
        ┌─────────────────────────────────────────┐
        │ Batch::process_beam_sequence_group()    │
        │  • Extract results                      │
        │  • Cache in Sequence objects            │
        └─────────────────────────────────────────┘
                              │
                              ▼
                    Next Round / Final Output
```



## Next Steps (PR [3/3])

- **PR [3/3]**: Worker layer and integration
  - [ ] `LlmRecPureDevicePipeline` implementation (multi-round loop logic)
  - [ ] implement layer and worker
  - [ ] Performance benchmarking

## Dependencies

- PR [1/3]: Foundation infrastructure (pipeline types, scheduler, engine)
- PyTorch CUDA extensions
- CUDA runtime (for kernel implementations)

