### PR TITLE
bugfix: enforce tool_choice parameter to control tool calling behavior

### DIFF
--- a/xllm/core/framework/request/request_params.cpp
+++ b/xllm/core/framework/request/request_params.cpp
@@ -285,12 +285,13 @@ void InitFromChatRequest(RequestParams& params, const ChatRequest& request) {
 
   // Parse tools from proto request
   if (request.tools_size() > 0) {
-    params.tools = parse_tools_from_proto(request.tools());
-
-    if (request.has_tool_choice()) {
-      params.tool_choice = request.tool_choice();
+    if (request.has_tool_choice() && request.tool_choice() == "none") {
+      // Don't pass tools to model when tool_choice is none
+      params.tool_choice = "none";
     } else {
-      params.tool_choice = "auto";
+      params.tools = parse_tools_from_proto(request.tools());
+      params.tool_choice =
+          request.has_tool_choice() ? request.tool_choice() : "auto";
     }
   }
 


### PR DESCRIPTION
## Summary

Fix `tool_choice` parameter not being enforced. Previously it was stored but never used.

## Changes

- `tool_choice=none`: Don't pass tools to model, preventing tool calls
- `tool_choice=auto/required`: Pass through as-is

## Known Limitation

`tool_choice=specific` (object format) not implemented - requires constrained decoding.