### PR TITLE
feat: support array content in chat json.

### DIFF
--- a/xllm/core/framework/prefix_cache/CMakeLists.txt
+++ b/xllm/core/framework/prefix_cache/CMakeLists.txt
@@ -41,7 +41,7 @@ if(USE_NPU)
       GTest::gtest_main
   )
 
-  target_link_libraries(prefix_test PRIVATE brpc OpenSSL::SSL OpenSSL::Crypto Folly::folly c_sec :xllm_server)
+  target_link_libraries(prefix_test PRIVATE brpc OpenSSL::SSL OpenSSL::Crypto Folly::folly c_sec nnopbase :xllm_server)
   add_dependencies(prefix_test brpc-static)
 endif()
 


### PR DESCRIPTION
## Summary

Add support for OpenAI-compatible complex message content (array format) in the chat completions API, aligning xLLM behavior with GLM official MaaS API.

## Changes

### `xllm/api_service/api_service.cpp`
- Add `PreprocessChatJson()` function that normalizes array content to string before protobuf parsing
- Text items in array are joined with newlines (`\n`)
- Non-text content (e.g., `image_url`) is rejected with a clear error message directing users to the multimodal endpoint
- Added type validation: `text` field must be a string, otherwise returns a clear error

### `xllm/core/framework/prefix_cache/CMakeLists.txt`
- Add `nnopbase` link dependency to `prefix_test`
- **Why this is included**: `api_service.cpp` now uses `nlohmann::json` (provided by `nnopbase`), and `prefix_test` transitively links against `xllm_server`. Without this fix, the build fails with undefined symbol errors. This is a direct consequence of the feature change, not a pre-existing bug.

## Example

Before (already supported):
```json
{"role": "user", "content": "Hello"}
```

After (now also supported):
```json
{"role": "user", "content": [{"type": "text", "text": "Hello"}, {"type": "text", "text": "World"}]}
```

The array content is normalized to: `"Hello\nWorld"`

## Compatibility

Tested against GLM official MaaS API - behavior is now fully aligned.