### PR TITLE
bugfix: fix mrope calculation in the multimodal situation.

### DIFF
--- a/xllm/models/llm/npu/qwen3_moe.h
+++ b/xllm/models/llm/npu/qwen3_moe.h
@@ -189,14 +189,21 @@ class Qwen3MoeModelImpl : public torch::nn::Module {
       auto apply = [this](torch::Tensor x) {
         // auto sections = mrope_section_;
         auto freqs_t = x[0].clone();
+        // mrop_length == freqs_length == head_dim / 2
+        int64_t mrop_length = static_cast<int64_t>(freqs_t.size(-1) / 2);
+
         for (int dim_idx = 1; dim_idx <= 2; ++dim_idx) {
           int64_t offset = dim_idx;  // H -> offset=1, W -> offset=2
           int64_t section_len = mrope_section_[dim_idx];
           int64_t length = section_len * 3;
 
-          // indices: [offset, offset+3, offset+6, ..., < length]
+          // Since the last dim of freqs is repeated to 2*mrop_length
+          // idx_first_half: [offset, offset+3, offset+6, ... < mrop_length]
+          // idx_second_half: [mrop_length+offset, mrop_length+offset+3,
+          //     mrop_length+offset+6, ... < 2*mrop_length]
           auto idx_first_half = torch::arange(offset, length, 3, torch::kLong);
-          auto idx_second_half = torch::arange(offset, length, 3, torch::kLong);
+          auto idx_second_half = torch::arange(
+              offset + mrop_length, length + mrop_length, 3, torch::kLong);
           auto idx_tensor =
               torch::cat({idx_first_half, idx_second_half}, 0).to(x.device());
           // freqs_t[..., idx] = freqs[dim_idx][..., idx]

--- a/xllm/models/llm/qwen3.h
+++ b/xllm/models/llm/qwen3.h
@@ -64,12 +64,22 @@ class QWen3ModelImpl : public LlmModelImplBase<layer::Qwen3DecoderLayer> {
     auto sin_pos = target_cos_sin_chunks[1].contiguous();
     auto apply = [this](torch::Tensor x) {
       auto freqs_t = x[0].clone();
+      // mrop_length == freqs_length == head_dim / 2
+      int64_t mrop_length = static_cast<int64_t>(freqs_t.size(-1) / 2);
+
       for (int dim_idx = 1; dim_idx <= 2; ++dim_idx) {
         int64_t offset = dim_idx;
         int64_t section_len = mrope_section_[dim_idx];
         int64_t length = section_len * 3;
+
+        // Since the last dim of freqs is repeated to 2*mrop_length
+        // idx_first_half: [offset, offset+3, offset+6, ... < mrop_length]
+        // idx_second_half: [mrop_length+offset, mrop_length+offset+3,
+        //     mrop_length+offset+6, ... < 2*mrop_length]
         auto idx_first_half = torch::arange(offset, length, 3, torch::kLong);
-        auto idx_second_half = torch::arange(offset, length, 3, torch::kLong);
+        auto idx_second_half = torch::arange(
+            offset + mrop_length, length + mrop_length, 3, torch::kLong);
+
         auto idx_tensor =
             torch::cat({idx_first_half, idx_second_half}, 0).to(x.device());
         // freqs_t[..., idx] = freqs[dim_idx][..., idx]

--- a/xllm/models/llm/qwen3_moe.h
+++ b/xllm/models/llm/qwen3_moe.h
@@ -65,14 +65,21 @@ class Qwen3MoeModelImpl : public LlmModelImplBase<layer::Qwen3MoeDecoderLayer> {
     auto sin_pos = target_cos_sin_chunks[1].contiguous();
     auto apply = [this](torch::Tensor x) {
       auto freqs_t = x[0].clone();
+      // mrop_length == freqs_length == head_dim / 2
+      int64_t mrop_length = static_cast<int64_t>(freqs_t.size(-1) / 2);
+
       for (int dim_idx = 1; dim_idx <= 2; ++dim_idx) {
         int64_t offset = dim_idx;  // H -> offset=1, W -> offset=2
         int64_t section_len = mrope_section_[dim_idx];
         int64_t length = section_len * 3;
 
-        // indices: [offset, offset+3, offset+6, ..., < length]
+        // Since the last dim of freqs is repeated to 2*mrop_length
+        // idx_first_half: [offset, offset+3, offset+6, ... < mrop_length]
+        // idx_second_half: [mrop_length+offset, mrop_length+offset+3,
+        //     mrop_length+offset+6, ... < 2*mrop_length]
         auto idx_first_half = torch::arange(offset, length, 3, torch::kLong);
-        auto idx_second_half = torch::arange(offset, length, 3, torch::kLong);
+        auto idx_second_half = torch::arange(
+            offset + mrop_length, length + mrop_length, 3, torch::kLong);
         auto idx_tensor =
             torch::cat({idx_first_half, idx_second_half}, 0).to(x.device());
         // freqs_t[..., idx] = freqs[dim_idx][..., idx]


### PR DESCRIPTION
xllm apply the repeat operation first "cat([cos, cos]), cat([sin, sin])", need to select the mrope part from both sections