### PR TITLE
bugfix: fix UTF-8 encoding error in GLM-4.7 streaming function calls.

### DIFF
--- a/xllm/function_call/glm47_detector.h
+++ b/xllm/function_call/glm47_detector.h
@@ -79,16 +79,9 @@ class Glm47Detector : public BaseFormatDetector {
   bool is_first_param_;
   bool value_started_;
   std::string cached_value_type_;
+  std::string utf8_buffer_;  // Buffer for incomplete UTF-8 sequences
   std::string last_arguments_;
   size_t streamed_raw_length_;
-
-  // UTF-8 buffer for handling incomplete multi-byte sequences in streaming
-  std::string utf8_buffer_;
-
-  // Split incomplete UTF-8 sequence from the end of input
-  // Returns: (complete_text, incomplete_bytes)
-  std::pair<std::string, std::string> split_incomplete_utf8(
-      const std::string& input) const;
 
   std::string trim_whitespace(std::string_view str) const;
 
@@ -119,6 +112,11 @@ class Glm47Detector : public BaseFormatDetector {
                                             const std::vector<JsonTool>& tools);
 
   void reset_streaming_state();
+
+  // Helper to split string into complete UTF-8 part and incomplete tail
+  // Returns: {complete_utf8_string, incomplete_tail}
+  std::pair<std::string, std::string> split_incomplete_utf8(
+      const std::string& str) const;
 };
 
 }  // namespace function_call


### PR DESCRIPTION
## Summary

- Fix UTF-8 encoding error (`json.exception.type_error.316: invalid UTF-8 byte at index 1: 0xE5`) when processing streaming function call responses with multi-byte UTF-8 characters (Chinese, Japanese, Korean, emoji)
- Add UTF-8 boundary detection and buffering to handle incomplete UTF-8 sequences split across streaming chunks
- Add comprehensive unit tests for UTF-8 streaming scenarios

## Root Cause

When streaming function call arguments, multi-byte UTF-8 characters can be split across chunk boundaries. The code was calling `nlohmann::json(content).dump()` on incomplete UTF-8 sequences, which caused the JSON library to throw a validation error.

For example, the Chinese character "北" (0xE5 0x8C 0x97) might arrive as:
- Chunk 1: `0xE5 0x8C` (incomplete)
- Chunk 2: `0x97` (completing the character)

## Solution

1. Added `split_incomplete_utf8()` helper function to detect incomplete UTF-8 sequences at chunk boundaries
2. Added `utf8_buffer_` member to buffer incomplete bytes until the next chunk
3. Modified `process_xml_to_json_streaming()` to:
   - Prepend buffered UTF-8 bytes from previous chunk
   - Split content into complete UTF-8 and incomplete tail
   - Only pass complete UTF-8 strings to the JSON library
   - Buffer incomplete tail for next chunk

## Test plan

- [x] All existing unit tests pass (19 tests)
- [x] New UTF-8 streaming tests pass (9 tests covering Chinese, Japanese, Korean, emoji, mixed content, one-byte-at-a-time scenarios)
- [x] End-to-end streaming tests pass with UTF-8 content