### PR TITLE
bugfix: set enable_schedule_overlap for warmup requests in ProfileManager.

### DIFF
--- a/xllm/core/scheduler/profile/profile_manager.cpp
+++ b/xllm/core/scheduler/profile/profile_manager.cpp
@@ -589,6 +589,7 @@ std::shared_ptr<Request> ProfileManager::generate_single_request(
   });
 
   RequestState req_state(token_ids);
+  req_state.enable_schedule_overlap = options_.enable_schedule_overlap();
   auto request = std::make_shared<Request>(
       /*request_id=*/"",
       /*x_request_id=*/"",


### PR DESCRIPTION
## Summary
- 修复启用 `enable_schedule_overlap` 和 `enable_graph` 时服务启动崩溃的问题

Fixes #786

## 问题原因
`ProfileManager::generate_single_request()` 创建预热请求时未设置 `enable_schedule_overlap`，导致 `update_last_step_token()` 中的 CHECK 失败。

## 修复方案
在创建 `RequestState` 后设置 `enable_schedule_overlap` 为引擎配置的值。

## Test plan
- [x] 使用 `--enable_schedule_overlap=true --enable_graph=true` 启动服务
- [x] 确认服务正常启动，预热完成无崩溃