### PR TITLE
bugfix: gracefully fallback to eager mode when seq_len exceeds graph mode limit.

### DIFF
--- a/xllm/core/runtime/acl_graph_executor_impl.cpp
+++ b/xllm/core/runtime/acl_graph_executor_impl.cpp
@@ -918,7 +918,11 @@ torch::Tensor AclGraphExecutorImpl::run(const torch::Tensor& tokens,
 
   // Early return if conditions are not suitable for graph operations
   if (!capture_supported) {
-    LOG(FATAL) << "Not suitable for graph operations.";
+    LOG_FIRST_N(WARNING, 1)
+        << "Falling back to eager mode because kv_max_seq_len ("
+        << params_single.kv_max_seq_len << ") > max_seq_len (" << max_seq_len
+        << "). This message is logged only once. "
+        << "Monitor counter 'num_model_execution_total_eager' for frequency.";
     COUNTER_INC(num_model_execution_total_eager);
     return model_->forward(tokens, positions, kv_caches, params);
   }


### PR DESCRIPTION
## Summary

- Fix server crash when `kv_max_seq_len` exceeds `max_seq_len_for_graph_mode`
- Replace `LOG(FATAL)` with `VLOG` to allow graceful fallback to eager mode

Fixes #798

## Root Cause

When `kv_max_seq_len > max_seq_len_for_graph_mode`, the code uses `LOG(FATAL)` which terminates the process. The intended eager mode fallback code after `LOG(FATAL)` never executes.

## Changes

```diff
-    LOG(FATAL) << "Not suitable for graph operations.";
+    VLOG(kGraphExecutorLogVerboseLevel)
+        << "Not suitable for graph operations, falling back to eager mode. "
+        << "kv_max_seq_len: " << params_single.kv_max_seq_len
+        << ", max_seq_len: " << max_seq_len;
```

## Test Plan

- [x] Set `--max_seq_len_for_graph_mode=32768` and send ~34k token request
- [x] Verify server falls back to eager mode instead of crashing