### PR TITLE
bugfix: fix eager mode fallback crash in NPU decoder layers. (#826)

### DIFF
--- a/xllm/core/layers/npu/npu_qwen3_decoder_layer_impl.cpp
+++ b/xllm/core/layers/npu/npu_qwen3_decoder_layer_impl.cpp
@@ -312,11 +312,19 @@ void NpuQwen3DecoderLayerImpl::build_node_variant_pack(
         input_params.q_seq_lens_vec.data();
   }
 
-  if (FLAGS_enable_graph && !is_prefill &&
-      input_params.graph_buffer.tiling_data.defined()) {
-    node.variantPack.inTensors.at(input_idx++) =
-        atb_speed::Utils::AtTensor2Tensor(
-            input_params.graph_buffer.tiling_data);
+  // Only add tiling_data when the operation was built with
+  // enableAclGraphPagedAttention=true (which expects this input tensor)
+  if (decode_param_.enableAclGraphPagedAttention && !is_prefill) {
+    if (input_params.graph_buffer.tiling_data.defined()) {
+      node.variantPack.inTensors.at(input_idx++) =
+          atb_speed::Utils::AtTensor2Tensor(
+              input_params.graph_buffer.tiling_data);
+    } else {
+      // Eager mode fallback: provide placeholder when tiling_data is not
+      // available.
+      node.variantPack.inTensors.at(input_idx++) =
+          atb_speed::Utils::AtTensor2Tensor(at_placeholder_);
+    }
   }
 
   for (size_t i = 0; i < WEIGHT_COUNT_PER_LAYER; ++i) {

--- a/xllm/core/layers/npu/npu_qwen3_moe_decoder_layer_impl.cpp
+++ b/xllm/core/layers/npu/npu_qwen3_moe_decoder_layer_impl.cpp
@@ -396,11 +396,19 @@ void NpuQwen3MoeDecoderLayerImpl::build_node_variant_pack(
         const_cast<int32_t*>(input_params.q_seq_lens_vec.data());
   }
 
-  if (FLAGS_enable_graph && !is_prefill &&
-      input_params.graph_buffer.tiling_data.defined()) {
-    node.variantPack.inTensors.at(input_idx++) =
-        atb_speed::Utils::AtTensor2Tensor(
-            input_params.graph_buffer.tiling_data);
+  // Only add tiling_data when the operation was built with
+  // enableAclGraphPagedAttention=true (which expects this input tensor)
+  if (decode_param_.enableAclGraphPagedAttention && !is_prefill) {
+    if (input_params.graph_buffer.tiling_data.defined()) {
+      node.variantPack.inTensors.at(input_idx++) =
+          atb_speed::Utils::AtTensor2Tensor(
+              input_params.graph_buffer.tiling_data);
+    } else {
+      // Eager mode fallback: provide placeholder when tiling_data is not
+      // available.
+      node.variantPack.inTensors.at(input_idx++) =
+          atb_speed::Utils::AtTensor2Tensor(tensor_placeholder_);
+    }
   }
 
   for (size_t i = 0; i < WEIGHT_COUNT_PER_LAYER; ++i) {


### PR DESCRIPTION
## Summary

- Fix eager mode fallback crash when `kv_max_seq_len` exceeds `max_seq_len_for_graph_mode`
- Provide `tensor_placeholder_` when `tiling_data` is not available in eager mode

## Root Cause

When the system falls back to eager mode, decoder nodes built with `enableAclGraphPagedAttention=true` expect a `tiling_data` input tensor. However, eager mode doesn't provide this tensor, causing ATB `Setup()` to fail with error code 8.

## Test plan

- [ ] Verify server starts normally with `--enable_graph=true`
- [ ] Test with requests where `kv_max_seq_len > max_seq_len_for_graph_mode` to trigger eager mode fallback
- [ ] Confirm no crash occurs during eager mode execution

Fixes #826