### PR TITLE
bugfix: fix KV cache memory leak when prefix cache is enabled.

### DIFF
--- a/xllm/core/framework/block/block_manager_pool.cpp
+++ b/xllm/core/framework/block/block_manager_pool.cpp
@@ -90,10 +90,13 @@ void BlockManagerPool::deallocate(std::vector<Sequence*>& sequences) {
 
 void BlockManagerPool::deallocate(Sequence* sequence) {
   DCHECK(sequence != nullptr);
-  // add blocks to the prefix cache
   int32_t dp_rank = get_dp_rank(sequence);
-  cache(sequence);
+  // deallocate must be called before cache() to correctly update
+  // num_used_blocks_ cache() increases ref_count, which would cause
+  // deallocate() to skip the decrement if called after
   block_managers_[dp_rank]->deallocate(sequence->kv_state().kv_blocks());
+  // add blocks to the prefix cache
+  cache(sequence);
   // release the blocks after prefix cache insertion
   sequence->reset();
 }


### PR DESCRIPTION
## Summary

- Fix KV cache memory leak that causes server to reject all requests when prefix cache is enabled
- Swap the order of `deallocate()` and `cache()` calls in `BlockManagerPool::deallocate()`

Fixes #828

## Problem

When `enable_prefix_cache=true`, `num_used_blocks_` is never decremented on request completion because:

1. `cache()` is called first, which inserts blocks into prefix cache and increments ref_count to 3
2. `deallocate()` checks `ref_count <= 2`, which is now FALSE
3. `num_used_blocks_` decrement is skipped

This causes `kv_cache_utilization` to exceed 100% and the scheduler to reject all new requests.

## Solution

Call `deallocate()` before `cache()` so the ref_count check sees the correct value (2) before the prefix cache adds its reference.

This is safe because `deallocate()` only updates the accounting counter - it doesn't free block memory. Block lifetime is managed by ref_count.

## Test plan

- [ ] Verify `kv_cache_utilization_perc` stays within 0-1 range after processing requests
- [ ] Verify `num_used_blocks` correctly decreases when requests complete
- [ ] Run existing test suite