### PR TITLE
refactor: rename pure device to rec multi-round.

### DIFF
--- a/xllm/core/common/global_flags.cpp
+++ b/xllm/core/common/global_flags.cpp
@@ -535,4 +535,4 @@ DEFINE_int64(max_token_per_req,
              1024,
              "Max tokens per request (prompt + generated). "
              "Used as a global guardrail for per-request token budget. "
-             "This is only used in pure device pipeline.");
+             "This is only used in Rec multi-round pipeline.");

--- a/xllm/core/common/rec_model_utils.h
+++ b/xllm/core/common/rec_model_utils.h
@@ -33,26 +33,26 @@ enum class RecPipelineType : uint8_t {
   kLlmRecDefault = 0,             // LlmRec without mm_data (pure qwen)
   kLlmRecWithMmData = 1,          // LlmRec with mm_data (qwen + embedding)
   kOneRecDefault = 2,             // OneRec
-  kLlmRecPureDevicePipeline = 3,  // LlmRec pure device pipeline for multi-round
+  kLlmRecMultiRoundPipeline = 3,  // LlmRec multi-round pipeline (device loop)
 };
 
-// Check if pure device mode is enabled
-// Pure device mode: multi-round decode loop runs entirely on device (Worker
-// layer) instead of being controlled by Engine layer
-inline bool is_pure_device_mode() { return FLAGS_max_decode_rounds > 0; }
+// Check if Rec multi-round mode is enabled.
+// Rec multi-round mode: multi-round decode loop runs on device (worker layer),
+// while the engine issues a single step.
+inline bool is_rec_multi_round_mode() { return FLAGS_max_decode_rounds > 0; }
 
-// Get the number of decode rounds for pure device mode
-// Returns 0 if pure device mode is disabled
-inline int32_t get_pure_device_decode_rounds() {
-  return is_pure_device_mode() ? FLAGS_max_decode_rounds : 0;
+// Get the number of decode rounds for Rec multi-round mode.
+// Returns 0 if Rec multi-round mode is disabled.
+inline int32_t get_rec_multi_round_decode_rounds() {
+  return is_rec_multi_round_mode() ? FLAGS_max_decode_rounds : 0;
 }
 
 // Pipeline strategy selector: choose strategy based on RecModelKind
 inline RecPipelineType get_rec_pipeline_type(RecModelKind kind) {
   switch (kind) {
     case RecModelKind::kLlmRec:
-      if (is_pure_device_mode()) {
-        return RecPipelineType::kLlmRecPureDevicePipeline;
+      if (is_rec_multi_round_mode()) {
+        return RecPipelineType::kLlmRecMultiRoundPipeline;
       } else {
         return RecPipelineType::kLlmRecDefault;
       }

--- a/xllm/core/distributed_runtime/rec_engine.h
+++ b/xllm/core/distributed_runtime/rec_engine.h
@@ -126,12 +126,12 @@ class RecEngine : public Engine {
   };
 
   // ============================================================
-  // PureDeviceEnginePipeline: kLlmRecPureDevicePipeline via local Worker
-  // For multi-round pure device inference (multi-round logic in worker)
+  // RecMultiRoundEnginePipeline: kLlmRecMultiRoundPipeline via local Worker
+  // For multi-round Rec inference (multi-round logic in worker/device)
   // ============================================================
-  class PureDeviceEnginePipeline final : public RecEnginePipeline {
+  class RecMultiRoundEnginePipeline final : public RecEnginePipeline {
    public:
-    explicit PureDeviceEnginePipeline(RecEngine& engine);
+    explicit RecMultiRoundEnginePipeline(RecEngine& engine);
 
     void setup_workers() override;
     void process_group_test() override;

--- a/xllm/core/distributed_runtime/rec_master.cpp
+++ b/xllm/core/distributed_runtime/rec_master.cpp
@@ -375,7 +375,7 @@ std::unique_ptr<RecMaster::RecMasterPipeline> RecMaster::create_pipeline(
     RecMaster& master) {
   switch (type) {
     case RecPipelineType::kLlmRecDefault:
-    case RecPipelineType::kLlmRecPureDevicePipeline:
+    case RecPipelineType::kLlmRecMultiRoundPipeline:
       return std::make_unique<LlmRecMasterPipeline>(master);
     case RecPipelineType::kLlmRecWithMmData:
       return std::make_unique<LlmRecWithMmDataMasterPipeline>(master);

--- a/xllm/core/framework/batch/CMakeLists.txt
+++ b/xllm/core/framework/batch/CMakeLists.txt
@@ -12,7 +12,7 @@ cc_library(
     batch_input_builder.h
     rec_batch_input_builder.h
     onerec_batch_input_builder.h
-    rec_pure_device_batch_input_builder.h
+    rec_multi_round_batch_input_builder.h
     mposition.h
   SRCS
     dit_batch.cpp
@@ -21,7 +21,7 @@ cc_library(
     batch_input_builder.cpp
     rec_batch_input_builder.cpp
     onerec_batch_input_builder.cpp
-    rec_pure_device_batch_input_builder.cpp
+    rec_multi_round_batch_input_builder.cpp
     mposition.cpp
     beam_search.h
   DEPS
@@ -49,4 +49,3 @@ target_link_libraries(batch_test
                       $<$<BOOL:${USE_NPU}>:hccl>
                       $<$<BOOL:${USE_NPU}>:c_sec>
                       $<$<BOOL:${USE_NPU}>:nnopbase>)
-

--- a/xllm/core/framework/batch/batch.cpp
+++ b/xllm/core/framework/batch/batch.cpp
@@ -382,7 +382,7 @@ void Batch::process_beam_sequence_group(const ForwardOutput& output) {
   if (beam_width <= 1) {
     return;
   }
-  int32_t total_rounds = get_pure_device_decode_rounds();
+  int32_t total_rounds = get_rec_multi_round_decode_rounds();
   size_t num_groups = sequence_groups_.size();
   if (num_groups == 0) {
     // Fallback: treat sequences_ as single group

--- a/xllm/core/framework/batch/rec_batch_input_builder.cpp
+++ b/xllm/core/framework/batch/rec_batch_input_builder.cpp
@@ -22,7 +22,7 @@ limitations under the License.
 
 #include "core/common/rec_model_utils.h"
 #include "onerec_batch_input_builder.h"
-#include "rec_pure_device_batch_input_builder.h"
+#include "rec_multi_round_batch_input_builder.h"
 
 namespace xllm {
 
@@ -48,9 +48,9 @@ std::unique_ptr<RecBatchInputBuilder> RecBatchInputBuilder::create(
           args,
           thread_pool);
     case RecType::kLlmRec:
-      // Check if pure device mode is enabled
-      if (is_pure_device_mode()) {
-        return std::make_unique<RecPureDeviceBatchInputBuilder>(
+      // Check if Rec multi-round mode is enabled
+      if (is_rec_multi_round_mode()) {
+        return std::make_unique<RecMultiRoundBatchInputBuilder>(
             sequence_groups,
             allowed_max_tokens,
             input_embeddings_vec,
@@ -60,7 +60,7 @@ std::unique_ptr<RecBatchInputBuilder> RecBatchInputBuilder::create(
             args,
             thread_pool);
       }
-      // Fall through for non-pure-device LlmRec (not yet implemented)
+      // Fall through for non-multi-round LlmRec (not yet implemented)
       break;
     case RecType::kNone:
       break;

--- a/xllm/core/framework/batch/rec_multi_round_batch_input_builder.h
+++ b/xllm/core/framework/batch/rec_multi_round_batch_input_builder.h
@@ -34,9 +34,9 @@ namespace xllm {
 
 struct ModelArgs;
 
-class RecPureDeviceBatchInputBuilder : public RecBatchInputBuilder {
+class RecMultiRoundBatchInputBuilder : public RecBatchInputBuilder {
  public:
-  explicit RecPureDeviceBatchInputBuilder(
+  explicit RecMultiRoundBatchInputBuilder(
       const std::vector<SequencesGroup*>& sequence_groups,
       const std::vector<uint32_t>& allowed_max_tokens,
       const std::vector<torch::Tensor>& input_embeddings_vec,
@@ -47,7 +47,7 @@ class RecPureDeviceBatchInputBuilder : public RecBatchInputBuilder {
       const ModelArgs* args,
       ThreadPool* thread_pool = nullptr);
 
-  ~RecPureDeviceBatchInputBuilder() override = default;
+  ~RecMultiRoundBatchInputBuilder() override = default;
 
   // Override base class method
   ForwardInput build_rec_forward_input(
@@ -55,8 +55,8 @@ class RecPureDeviceBatchInputBuilder : public RecBatchInputBuilder {
       uint32_t min_decoding_batch_size) override;
 
  private:
-  // Build pure device forward input for the whole batch (internal
-  // implementation)
+  // Build Rec multi-round forward input for the whole batch (internal
+  // implementation).
   ForwardInput build_forward_input();
 
   // Local builder state (copy of the legacy BatchInputBuilder::BuilderState)
@@ -112,24 +112,24 @@ class RecPureDeviceBatchInputBuilder : public RecBatchInputBuilder {
   };
 
  protected:
-  // Core building methods - provide pure device specific logic
+  // Core building methods - provide Rec multi-round specific logic.
   void process_single_sequence(
       int32_t seq_index,
       BuilderState* state_ptr = nullptr,
       std::unordered_set<int32_t>* write_block_ids_ptr = nullptr);
 
  private:
-  // State management for RecPureDevice
-  struct RecPureDeviceBuilderState {
+  // State management for RecMultiRound
+  struct RecMultiRoundBuilderState {
     // Base state compatible with single-round builder
     BuilderState base_state;
 
-    // Pure device step tracking data
+    // Rec multi-round step tracking data
     std::vector<int32_t> step_tokens_vec;
     std::vector<int32_t> step_positions_vec;
     std::vector<torch::Tensor> step_mrope_positions_vec;
 
-    // Pure device decode state buffers
+    // Rec multi-round decode state buffers
     std::vector<int32_t> decode_selected_token_idxes;
     std::vector<const RequestSamplingParam*> decode_sampling_params;
     std::vector<std::vector<int64_t>> decode_unique_token_ids_vec;
@@ -138,22 +138,22 @@ class RecPureDeviceBatchInputBuilder : public RecBatchInputBuilder {
     std::vector<int32_t> decode_sample_idxes;
     std::vector<int32_t> decode_positions_vec;
 
-    // Pure device specific metadata
+    // Rec multi-round specific metadata
     uint32_t total_steps = 0;
   };
 
   // Enhanced state
-  RecPureDeviceBuilderState rec_pure_device_state_;
+  RecMultiRoundBuilderState rec_multi_round_state_;
 
  private:
-  // Override extract_tokens_and_positions to handle rec pure device decode
-  // logic
+  // Override extract_tokens_and_positions to handle Rec multi-round decode
+  // logic.
   void extract_tokens_and_positions(Sequence* sequence,
                                     uint32_t n_kv_cache_tokens,
                                     uint32_t seq_len,
-                                    RecPureDeviceBuilderState* state_ptr);
+                                    RecMultiRoundBuilderState* state_ptr);
 
-  // Pure device specific forward input conversion functions
+  // Rec multi-round specific forward input conversion functions
   ForwardInput state_to_forward_input();
 
   void setup_kv_cache_info(Sequence* sequence,

--- a/xllm/core/framework/request/sequences_group.cpp
+++ b/xllm/core/framework/request/sequences_group.cpp
@@ -95,7 +95,8 @@ void SequencesGroup::generate_outputs(std::vector<SequenceOutput>& outputs,
                                       const Tokenizer& tokenizer,
                                       ThreadPool* thread_pool) {
   // Check for multi-round beam search results
-  if (is_pure_device_mode() && check_beam_search() && sequences_.size() == 1) {
+  if (is_rec_multi_round_mode() && check_beam_search() &&
+      sequences_.size() == 1) {
     auto* base = sequences_[0].get();
     if (base->has_beam_result()) {
       generate_multi_round_output(outputs, tokenizer, *base);

--- a/xllm/core/kernels/cuda/prefill_reshape_and_cache.cpp
+++ b/xllm/core/kernels/cuda/prefill_reshape_and_cache.cpp
@@ -22,13 +22,12 @@ limitations under the License.
 
 namespace xllm::kernel::cuda {
 
-// Prefill reshape and cache kernel for Rec pure device mode.
+// Prefill reshape and cache kernel for Rec multi-round mode.
 // Copies projected K and V tensors from prefill phase into shared KV cache.
-// This function is specifically designed for Rec (recommendation) pure device
-// mode, where multi-round decode loops run entirely on device. In this mode,
-// sequences share the same prompt prefix, and the prefill KV cache needs to be
-// stored in a shared cache format for efficient multi-round decoding on device.
-// Inputs:
+// This function is specifically designed for Rec (recommendation) multi-round
+// mode, where multi-round decode loops run on device. In this mode, sequences
+// share the same prompt prefix, and the prefill KV cache needs to be stored in
+// a shared cache format for efficient multi-round decoding on device. Inputs:
 //   proj_k          : [shared_len, kv_heads, head_dim] - projected K tensor
 //                     from prefill phase
 //   proj_v          : [shared_len, kv_heads, head_dim] - projected V tensor

--- a/xllm/core/runtime/acl_graph_executor_test.cpp
+++ b/xllm/core/runtime/acl_graph_executor_test.cpp
@@ -106,7 +106,7 @@ class SimpleCausalLM : public CausalLM {
         "pos_embedding",
         torch::randn({max_pos, args.hidden_size()},
                      torch::dtype(torch::kFloat32).device(device)));
-    // Initialize block-related tensors for pure device computation
+    // Initialize block-related tensors for Rec multi-round computation
     block_size_ = torch::tensor(4L, torch::dtype(torch::kInt64).device(device));
     scalar_one_ = torch::tensor(1L, torch::dtype(torch::kInt64).device(device));
 
@@ -171,7 +171,7 @@ class SimpleCausalLM : public CausalLM {
     }
 
     if (params.block_tables.defined() && !kv_caches.empty()) {
-      // Use block_tables to do embedding lookup from kv_cache - pure device
+      // Use block_tables to do embedding lookup from kv_cache - Rec multi-round
       // computation Calculate max_seq_len from actual seq_len tensor
       auto max_seq_len = torch::max(params.kv_seq_lens);
 

--- a/xllm/core/runtime/forward_params.h
+++ b/xllm/core/runtime/forward_params.h
@@ -98,7 +98,7 @@ class WorkerType {
   Value value_;
 };
 
-// step-level decode metadata for pure-device multi-round.
+// Step-level decode metadata for Rec multi-round (device loop).
 struct StepDecodeMeta {
   int32_t beam_width = 1;
   int32_t current_round = 0;
@@ -254,7 +254,7 @@ struct RawForwardOutput {
   std::vector<int32_t> out_tokens;
   std::vector<float> out_logprobs;
 
-  // batch-level beam output for rec pure device mode
+  // batch-level beam output for Rec multi-round mode
   std::vector<int32_t> beam_sequence_group;  // flattened 2D
   // multimodal embedding output
   std::vector<torch::Tensor> mm_embeddings;

--- a/xllm/core/scheduler/fixed_steps_scheduler.cpp
+++ b/xllm/core/scheduler/fixed_steps_scheduler.cpp
@@ -231,8 +231,9 @@ std::vector<Batch> FixedStepsScheduler::prepare_batch() {
     const std::shared_ptr<Request>& sample_request =
         waiting_priority_queue_.top();
     auto rec_type = sample_request->state().rec_type;
-    bool is_pure_device = is_pure_device_mode();
-    scheduler_pipeline_ = create_scheduler_pipeline(rec_type, is_pure_device);
+    bool is_rec_multi_round = is_rec_multi_round_mode();
+    scheduler_pipeline_ =
+        create_scheduler_pipeline(rec_type, is_rec_multi_round);
   }
 
   // remaining budget for the current batch
@@ -378,7 +379,7 @@ std::vector<Batch> FixedStepsScheduler::OneRecSchedulerPipeline::create_batches(
 }
 
 std::vector<Batch>
-FixedStepsScheduler::PureDeviceSchedulerPipeline::create_batches(
+FixedStepsScheduler::RecMultiRoundSchedulerPipeline::create_batches(
     FixedStepsScheduler& scheduler,
     BatchFactory* batch_factory) {
   return batch_factory->create_batches(
@@ -390,9 +391,9 @@ FixedStepsScheduler::PureDeviceSchedulerPipeline::create_batches(
 
 std::unique_ptr<FixedStepsScheduler::SchedulerPipeline>
 FixedStepsScheduler::create_scheduler_pipeline(RecType rec_type,
-                                               bool is_pure_device) {
-  if (is_pure_device) {
-    return std::make_unique<PureDeviceSchedulerPipeline>();
+                                               bool is_rec_multi_round) {
+  if (is_rec_multi_round) {
+    return std::make_unique<RecMultiRoundSchedulerPipeline>();
   }
   if (rec_type == RecType::kLlmRec) {
     return std::make_unique<LlmRecSchedulerPipeline>();

--- a/xllm/core/scheduler/fixed_steps_scheduler.h
+++ b/xllm/core/scheduler/fixed_steps_scheduler.h
@@ -81,21 +81,21 @@ class FixedStepsScheduler final : public ContinuousScheduler {
     }
   };
 
-  class PureDeviceSchedulerPipeline final : public SchedulerPipeline {
+  class RecMultiRoundSchedulerPipeline final : public SchedulerPipeline {
    public:
     std::vector<Batch> create_batches(FixedStepsScheduler& scheduler,
                                       BatchFactory* batch_factory) override;
     bool requires_kv_cache() const override { return false; }
     bool allocate_kv_cache(KVCacheManager* /*kv_cache_manager*/,
                            Sequence* /*sequence*/) override {
-      return true;  // PureDevice mode does not need KV cache allocation
+      return true;  // RecMultiRound mode does not need KV cache allocation
     }
   };
 
   // Factory method to create scheduler pipeline
   static std::unique_ptr<SchedulerPipeline> create_scheduler_pipeline(
       RecType rec_type,
-      bool is_pure_device);
+      bool is_rec_multi_round);
 
   std::vector<Batch> schedule_request(const absl::Duration& timeout);
 


### PR DESCRIPTION
## Summary

  - Rename the Rec “pure device” pipeline to RecMultiRound across engine, scheduler, and batch builder.
  - Rename batch input builder files and update includes/CMake references.
  - Update comments/log messages to clarify the multi-round device-loop semantics.
  - Keep flag names unchanged; only adjust descriptions.