### PR TITLE
bugfix: fix mrope position tensor shape mismatch in NPU graph mode.

### DIFF
--- a/xllm/core/runtime/acl_graph_executor_impl.cpp
+++ b/xllm/core/runtime/acl_graph_executor_impl.cpp
@@ -22,6 +22,7 @@ limitations under the License.
 #include <torch_npu/csrc/libs/init_npu.h>
 #include <torch_npu/torch_npu.h>
 
+#include <boost/algorithm/string.hpp>
 #include <numeric>
 
 #include "core/common/global_flags.h"
@@ -63,6 +64,9 @@ GraphPersistentParam::GraphPersistentParam(const ModelArgs& args,
   // Future logic can be extended here for more complex model-specific behavior
   need_update_attention_plan_ = (args.model_type() != "deepseek_v32");
 
+  // Check if mRoPE is used (for VLM models like qwen2-vl)
+  use_mrope_ = boost::iequals(args.rope_scaling_rope_type(), "mrope");
+
   // Use max_tokens_per_batch for first dimension size
   // num_decode_tokens
   const int64_t max_tokens_per_batch = FLAGS_max_tokens_per_batch;
@@ -77,8 +81,13 @@ GraphPersistentParam::GraphPersistentParam(const ModelArgs& args,
   // Create persistent tensors with max_tokens_per_batch as first dimension
   persistent_tokens_ = torch::zeros({max_tokens_per_batch},
                                     torch::dtype(torch::kInt).device(device));
-  persistent_positions_ = torch::zeros(
-      {max_tokens_per_batch}, torch::dtype(torch::kInt).device(device));
+  // mRoPE positions have shape [3, num_tokens], regular positions have shape
+  // [num_tokens]
+  const auto positions_shape =
+      use_mrope_ ? std::vector<int64_t>{3, max_tokens_per_batch}
+                 : std::vector<int64_t>{max_tokens_per_batch};
+  persistent_positions_ =
+      torch::zeros(positions_shape, torch::dtype(torch::kInt).device(device));
   persistent_new_cache_slots_ = torch::zeros(
       {max_tokens_per_batch}, torch::dtype(torch::kInt).device(device));
 
@@ -179,7 +188,10 @@ std::optional<ModelInputParams> GraphPersistentParam::update(
   // Copy data from input parameters to persistent graph tensors
   persistent_tokens_.slice(/*dim=*/0, /*start=*/0, /*end=*/actual_num_tokens)
       .copy_(tokens, /*non_blocking=*/true);
-  persistent_positions_.slice(/*dim=*/0, /*start=*/0, /*end=*/actual_num_tokens)
+  // mRoPE positions have shape [3, num_tokens], slice on dim 1
+  const int slice_dim = use_mrope_ ? 1 : 0;
+  persistent_positions_
+      .slice(/*dim=*/slice_dim, /*start=*/0, /*end=*/actual_num_tokens)
       .copy_(positions, /*non_blocking=*/true);
   q_seq_lens_.slice(/*dim=*/0, /*start=*/0, /*end=*/actual_batch_size)
       .copy_(params.q_seq_lens, /*non_blocking=*/true);

--- a/xllm/core/runtime/acl_graph_executor_impl.h
+++ b/xllm/core/runtime/acl_graph_executor_impl.h
@@ -78,8 +78,10 @@ class GraphPersistentParam {
   }
   torch::Tensor persistent_positions(uint32_t actual_tokens = 0) const {
     if (actual_tokens > 0) {
+      // mRoPE positions have shape [3, num_tokens], slice on dim 1
+      const int slice_dim = use_mrope_ ? 1 : 0;
       return persistent_positions_.slice(
-          /*dim=*/0, /*start=*/0, /*end=*/actual_tokens);
+          /*dim=*/slice_dim, /*start=*/0, /*end=*/actual_tokens);
     }
     return persistent_positions_;
   }
@@ -195,6 +197,9 @@ class GraphPersistentParam {
 
   // for mtp model
   torch::Tensor persistent_embedding_;
+
+  // for mrope (multimodal rotary position embedding)
+  bool use_mrope_ = false;
 
   // ModelOutput fields
   torch::Tensor aux_hidden_states_;


### PR DESCRIPTION
## Summary

- Fix VLM models (qwen2.5-vl, glm4v) crash during decode phase on NPU with Graph Mode
- Add `use_mrope_` flag to detect mRoPE models
- Initialize `persistent_positions_` with correct shape `[3, max_tokens]` for mRoPE
- Fix slicing dimension (dim=1 for mRoPE, dim=0 for regular positions)

Fixes #884

## Test plan

- [x] Verified qwen2.5-7b-vl inference completes without crash on NPU
- [x] Regression test: verify regular LLM models still work correctly