### PR TITLE
feat: support graph mode for LLM part of VLM model on NPU device.

### DIFF
--- a/xllm/core/layers/npu/npu_glm4_decoder_layer_impl.cpp
+++ b/xllm/core/layers/npu/npu_glm4_decoder_layer_impl.cpp
@@ -53,7 +53,7 @@ void NpuGlm4DecoderLayerImpl::param_from_args(
                               FLAGS_communication_backend};
   param.linearHasBias = {true, false, false, false};
   param.useQKNorm = false;
-
+  param.enableAclGraphPagedAttention = FLAGS_enable_graph && !isPrefill;
   param.numHiddenLayers = args.n_layers();
   param.usePostSelfAttnLayerNorm = true;
   param.usePostMlpLayerNorm = true;
@@ -220,12 +220,20 @@ void NpuGlm4DecoderLayerImpl::build_node_variant_pack(
       atb_speed::Utils::AtTensor2Tensor(input_params.block_tables);
   node.variantPack.inTensors.at(WEIGHT_COUNT_PER_LAYER + 10) =
       atb_speed::Utils::AtTensor2Tensor(input_params.new_cache_slots);
+  size_t input_idx = WEIGHT_COUNT_PER_LAYER + 11;
   if (is_prefill &&
       (FLAGS_enable_chunked_prefill || FLAGS_enable_prefix_cache)) {
-    node.variantPack.inTensors.at(WEIGHT_COUNT_PER_LAYER + 11) =
+    node.variantPack.inTensors.at(input_idx++) =
         atb_speed::Utils::AtTensor2Tensor(input_params.q_seq_lens);
-    node.variantPack.inTensors.at(WEIGHT_COUNT_PER_LAYER + 11).hostData =
+    node.variantPack.inTensors.at(input_idx - 1).hostData =
         input_params.q_seq_lens_vec.data();
+  }
+
+  if (FLAGS_enable_graph && !is_prefill &&
+      input_params.graph_buffer.tiling_data.defined()) {
+    node.variantPack.inTensors.at(input_idx++) =
+        atb_speed::Utils::AtTensor2Tensor(
+            input_params.graph_buffer.tiling_data);
   }
 
   for (size_t i = 0; i < WEIGHT_COUNT_PER_LAYER; ++i) {

--- a/xllm/core/runtime/acl_graph_executor_impl.cpp
+++ b/xllm/core/runtime/acl_graph_executor_impl.cpp
@@ -90,14 +90,13 @@ GraphPersistentParam::GraphPersistentParam(const ModelArgs& args,
   // Create persistent tensors with max_tokens_per_batch as first dimension
   persistent_tokens_ = torch::zeros({max_tokens_per_batch},
                                     torch::dtype(torch::kInt).device(device));
-  // mRoPE positions have shape [3, num_tokens], regular positions have shape
-  // [num_tokens]
-  if (use_mrope_) {
-    persistent_positions_ = torch::zeros(
-        {3, max_tokens_per_batch}, torch::dtype(torch::kInt).device(device));
-  } else {
+  if (args.rope_scaling_mrope_section().empty()) {
     persistent_positions_ = torch::zeros(
         {max_tokens_per_batch}, torch::dtype(torch::kInt).device(device));
+  } else {
+    persistent_positions_ = torch::zeros(
+        {3, max_tokens_per_batch}, torch::dtype(torch::kInt).device(device));
+    use_mrope_ = true;
   }
   persistent_new_cache_slots_ = torch::zeros(
       {max_tokens_per_batch}, torch::dtype(torch::kInt).device(device));
@@ -320,6 +319,7 @@ std::optional<ModelInputParams> GraphPersistentParam::update(
                                /*start=*/0,
                                /*end=*/actual_batch_size);
     }
+
     return params_for_capture;
   }
   return std::nullopt;

--- a/xllm/core/runtime/acl_graph_executor_impl.h
+++ b/xllm/core/runtime/acl_graph_executor_impl.h
@@ -88,13 +88,11 @@ class GraphPersistentParam {
   }
   torch::Tensor persistent_positions(uint32_t actual_tokens = 0) const {
     if (actual_tokens > 0) {
-      if (use_mrope_) {
-        // mRoPE positions have shape [3, num_tokens]
-        return persistent_positions_.slice(
-            /*dim=*/1, /*start=*/0, /*end=*/actual_tokens);
-      }
-      return persistent_positions_.slice(
-          /*dim=*/0, /*start=*/0, /*end=*/actual_tokens);
+      int32_t slice_dim = use_mrope_ ? 1 : 0;
+      return persistent_positions_
+          .slice(
+              /*dim=*/slice_dim, /*start=*/0, /*end=*/actual_tokens)
+          .contiguous();
     }
     return persistent_positions_;
   }

--- a/xllm/core/runtime/executor.cpp
+++ b/xllm/core/runtime/executor.cpp
@@ -15,7 +15,9 @@ limitations under the License.
 
 #include "executor.h"
 
+#include "common/global_flags.h"
 #include "executor_impl_factory.h"
+#include "platform/device.h"
 
 namespace xllm {
 

--- a/xllm/core/runtime/mlu_graph_executor_impl.cpp
+++ b/xllm/core/runtime/mlu_graph_executor_impl.cpp
@@ -242,15 +242,6 @@ ModelOutput MluGraphExecutorImpl::run(const torch::Tensor& tokens,
     CHECK_EQ(dp_is_decode.size(), params.dp_global_token_nums.size());
   }
 
-  // Process multimodal data for VLM models
-  if (options_.backend() == "vlm") {
-    auto* vlm_model = dynamic_cast<CausalVLM*>(model_);
-    if (vlm_model) {
-      xllm::VlmExecutorImpl::process_mm_data(
-          const_cast<ModelInputParams&>(params), vlm_model, device_, tokens);
-    }
-  }
-
   if (!graph_mode) {
     COUNTER_INC(num_model_execution_total_eager);
     return model_->forward(tokens, positions, kv_caches, params);

--- a/xllm/core/runtime/vlm_executor_impl.h
+++ b/xllm/core/runtime/vlm_executor_impl.h
@@ -50,20 +50,13 @@ class VlmExecutorImpl : public ExecutorImpl {
 
   virtual MMDict encode(const ModelInputParams& params);
 
-  // Static helper function to process multimodal data
-  // This can be called by other executor implementations (e.g.,
-  // MluGraphExecutorImpl)
-  static void process_mm_data(ModelInputParams& params,
-                              CausalVLM* model,
-                              const torch::Device& device,
-                              const torch::Tensor& tokens);
-
  private:
   // not own
   CausalVLM* model_;
   ModelArgs args_;
   torch::Device device_;
   runtime::Options options_;
+  std::unique_ptr<ExecutorImpl> llm_executor_;
 };
 // Q: backend device ?
 REGISTER_EXECUTOR("vlm", VlmExecutorImpl);

--- a/xllm/models/llm/npu/qwen3.h
+++ b/xllm/models/llm/npu/qwen3.h
@@ -148,7 +148,6 @@ class QWen3ModelImpl : public LlmModelImplBase<QWen3DecoderLayer> {
     auto target_cos_sin_chunks = target_cos_sin.chunk(/*chunks=*/2, /*dim=*/-1);
     auto cos_pos = target_cos_sin_chunks[0].contiguous();
     auto sin_pos = target_cos_sin_chunks[1].contiguous();
-
     if (positions.dim() == 2) {  // mrope
       auto apply = [this](torch::Tensor x) {
         auto freqs_t = x[0].clone();
@@ -164,12 +163,13 @@ class QWen3ModelImpl : public LlmModelImplBase<QWen3DecoderLayer> {
           // idx_first_half: [offset, offset+3, offset+6, ... < mrop_length]
           // idx_second_half: [mrop_length+offset, mrop_length+offset+3,
           //     mrop_length+offset+6, ... < 2*mrop_length]
-          auto idx_first_half = torch::arange(offset, length, 3, torch::kLong);
+          torch::TensorOptions options =
+              torch::TensorOptions().dtype(torch::kLong).device(x.device());
+          auto idx_first_half = torch::arange(offset, length, 3, options);
           auto idx_second_half = torch::arange(
-              offset + mrop_length, length + mrop_length, 3, torch::kLong);
+              offset + mrop_length, length + mrop_length, 3, options);
 
-          auto idx_tensor =
-              torch::cat({idx_first_half, idx_second_half}, 0).to(x.device());
+          auto idx_tensor = torch::cat({idx_first_half, idx_second_half}, 0);
           // freqs_t[..., idx] = freqs[dim_idx][..., idx]
           auto src = x[dim_idx].index_select(-1, idx_tensor);
           freqs_t.index_copy_(-1, idx_tensor, src);

--- a/xllm/models/llm/npu/qwen3_moe.h
+++ b/xllm/models/llm/npu/qwen3_moe.h
@@ -255,11 +255,12 @@ class Qwen3MoeModelImpl : public torch::nn::Module {
           // idx_first_half: [offset, offset+3, offset+6, ... < mrop_length]
           // idx_second_half: [mrop_length+offset, mrop_length+offset+3,
           //     mrop_length+offset+6, ... < 2*mrop_length]
-          auto idx_first_half = torch::arange(offset, length, 3, torch::kLong);
+          torch::TensorOptions options =
+              torch::TensorOptions().dtype(torch::kLong).device(x.device());
+          auto idx_first_half = torch::arange(offset, length, 3, options);
           auto idx_second_half = torch::arange(
-              offset + mrop_length, length + mrop_length, 3, torch::kLong);
-          auto idx_tensor =
-              torch::cat({idx_first_half, idx_second_half}, 0).to(x.device());
+              offset + mrop_length, length + mrop_length, 3, options);
+          auto idx_tensor = torch::cat({idx_first_half, idx_second_half}, 0);
           // freqs_t[..., idx] = freqs[dim_idx][..., idx]
           auto src = x[dim_idx].index_select(-1, idx_tensor);
           freqs_t.index_copy_(-1, idx_tensor, src);


### PR DESCRIPTION
- Qwen3-VL-Dense/Moe
- GLM-4.6V-Air
- GLM-4.6V-Flash

### Qwen3-VL-30B-A3B-Instruct benchmark
#### server command

```
NNODES=2
WORLD_SIZE=2

$BIN_PATH \
    --model $MODEL_PATH \
    --host=0.0.0.0 \
    --port $PORT \
    --devices="npu:$DEVICE" \
    --backend="vlm" \
    --master_node_addr=$MASTER_NODE_ADDR \
    --nnodes=$WORLD_SIZE \
    --node_rank=$i \
    --max_memory_utilization=0.8 \
    --max_tokens_per_batch=8192 \
    --max_seqs_per_batch=256 \
    --block_size=128 \
    --communication_backend="lccl" \
    --enable_schedule_overlap=false \
    --enable_chunked_prefill=false \
    --enable_prefix_cache=false \
```

### client command
```
evalscope perf \
  --model "$MODEL_NAME" \
  --url "$API_URL" \
  --api openai \
  --dataset random_vl \
  --number 10 \
  --parallel 1 \
  --min-prompt-length 1024 \
  --max-prompt-length 1024 \
  --image-width 1024 \
  --image-height 1024 \
  --image-format RGB \
  --image-num 1 \
  --min-tokens 256 \
  --max-tokens 256 \
  --tokenizer-path "$TOKENIZER_PATH" \
  --seed 42 \
  --outputs-dir "./results_512" \
  --extra-args '{"ignore_eos": true}'
```

### benchmark results

- enable_graph
 ```
+-----------------------------------+-----------+
| Key                               |     Value |
+===================================+===========+
| Time taken for tests (s)          |   31.2075 |
+-----------------------------------+-----------+
| Number of concurrency             |    1      |
+-----------------------------------+-----------+
| Request rate (req/s)              |   -1      |
+-----------------------------------+-----------+
| Total requests                    |   10      |
+-----------------------------------+-----------+
| Succeed requests                  |   10      |
+-----------------------------------+-----------+
| Failed requests                   |    0      |
+-----------------------------------+-----------+
| Output token throughput (tok/s)   |   82.0315 |
+-----------------------------------+-----------+
| Total token throughput (tok/s)    |  738.925  |
+-----------------------------------+-----------+
| Request throughput (req/s)        |    0.3204 |
+-----------------------------------+-----------+
| Average latency (s)               |    3.1205 |
+-----------------------------------+-----------+
| Average time to first token (s)   |    0.2011 |
+-----------------------------------+-----------+
| Average time per output token (s) |    0.0114 |
+-----------------------------------+-----------+
| Average inter-token latency (s)   |    0.0115 |
+-----------------------------------+-----------+
| Average input tokens per request  | 2050      |
+-----------------------------------+-----------+
| Average output tokens per request |  256      |
+-----------------------------------+-----------+
```

- disable_graph
```
+-----------------------------------+-----------+
| Key                               |     Value |
+===================================+===========+
| Time taken for tests (s)          |   44.3695 |
+-----------------------------------+-----------+
| Number of concurrency             |    1      |
+-----------------------------------+-----------+
| Request rate (req/s)              |   -1      |
+-----------------------------------+-----------+
| Total requests                    |   10      |
+-----------------------------------+-----------+
| Succeed requests                  |   10      |
+-----------------------------------+-----------+
| Failed requests                   |    0      |
+-----------------------------------+-----------+
| Output token throughput (tok/s)   |   57.6973 |
+-----------------------------------+-----------+
| Total token throughput (tok/s)    |  519.727  |
+-----------------------------------+-----------+
| Request throughput (req/s)        |    0.2254 |
+-----------------------------------+-----------+
| Average latency (s)               |    4.4367 |
+-----------------------------------+-----------+
| Average time to first token (s)   |    0.1989 |
+-----------------------------------+-----------+
| Average time per output token (s) |    0.0166 |
+-----------------------------------+-----------+
| Average inter-token latency (s)   |    0.017  |
+-----------------------------------+-----------+
| Average input tokens per request  | 2050      |
+-----------------------------------+-----------+
| Average output tokens per request |  256      |
+-----------------------------------+-----------+
```