### PR TITLE
feat: add VMMTorchAllocator to resue multi shape graph buffer.

### DIFF
--- a/docs/en/features/graph_mode.md
+++ b/docs/en/features/graph_mode.md
@@ -1,0 +1,51 @@
+# Graph Mode
+
+## Overview
+
+xLLM supports Graph Mode: computation graphs are pre-captured and replayed in subsequent runs to reduce CPU overhead and improve inference performance. Graph Mode has corresponding implementations on different hardware platforms.
+
+## Feature Description
+
+To optimize Host-side scheduling, graph mode submits a large task from the CPU once and then executes small kernels in a streaming manner on the device, significantly reducing startup time and device bubbles.
+
+In the xLLM engine, Graph Mode provides the following:
+
+### Dynamic Shape Parameterization
+  - Key dynamic dimensions other than num_tokens are treated as whole-graph input parameters, including batch_size, kv_seq_lens, q_seq_lens, block_table_size, and the like, for flexibility. During memory allocation and kernel configuration, these parameters are used to compute required values—for example, block_table_size via $block\_table\_size = batch\_size \times (max\_seq\_len / block\_size)$. At graph launch, the actual values of these parameters are passed so kernels use the correct strides to access data.
+
+### Piecewise Graph
+  - When some operators do not support graph capture and thus break the full graph, each segment (piece) after the break is captured as a separate graph. This maximizes graph-mode benefits even when the full graph cannot be captured, and is commonly used for prefill and chunked prefill.
+
+### Multi-Shape Reusable Memory Pool
+  - To avoid waste from separate memory buffers (input, output, and intermediate tensors) per shape, we use an expandable memory pool. Multiple shapes share the pool base address, with different shapes using different offsets from that base.
+  - For a detailed multi-shape memory reuse design (background, implementation, and results), see: [Graph Mode Multi-Shape Memory Reuse Technical Documentation](graph_mode_multi_shape_memory_reuse.md)
+
+## Usage
+
+These features are implemented inside the xLLM engine and are transparent to users. Enable Graph Mode with the gflags parameter `enable_graph` (default: false). Set it to true in the xLLM service startup script, for example:
+
+```shell
+--enable_graph=true
+```
+
+## Performance Impact
+
+- With Graph Mode enabled, decode-phase throughput **improves by about 8%–10%** on models such as Qwen3-0.6B and Qwen3-1.7B.
+
+## Model Support
+
+The following table lists each model’s support on ACLGraph, CudaGraph, and MLUGraph.
+
+| Model | ACLGraph | CudaGraph | MLUGraph |
+|------|----------|-----------|----------|
+| Qwen3/Qwen3-MoE | ✅ | ✅ | ✅ |
+| DeepseekV3.2 | ✅ | | |
+| GLM4.5/4.6/4.7 | ✅ | | |
+| Qwen2.5-VL | | | ✅ |
+
+!!! warning "Adding Graph Mode support for new models"
+    Ensure that the kernels used in the computation implement dynamic dimension parameterization; otherwise the graph may break and kernels may need to be re-implemented.
+
+## Related Documentation
+
+- [Graph Mode Multi-Shape Memory Reuse Technical Documentation](graph_mode_multi_shape_memory_reuse.md)

--- a/docs/en/features/graph_mode_multi_shape_memory_reuse.md
+++ b/docs/en/features/graph_mode_multi_shape_memory_reuse.md
@@ -1,0 +1,503 @@
+# xLLM Graph Mode Multi-Shape Memory Reuse Technical Documentation
+
+## Overview
+
+This document describes the multi-shape memory reuse solution for Graph Mode (including CUDAGraph, ACLGraph, MLUGraph) in xLLM. The solution has two implemented mechanisms: (1) **Graph capture memory reuse**: different shapes of Graphs share physical memory, reducing memory usage from `sum(shape)` to `max(shape)`, implemented via CUDA Virtual Memory Management (VMM) API's multi-virtual address space mapping; (2) **Multi-shape input tensor reuse**: persistent parameters (PersistentParam) pre-allocate buffers with max shape, and replay uses slices to adapt to different actual shapes, so input-side memory also stays at `max(shape)`.
+
+**Scope**:
+- **CUDAGraph**: Graph Mode for CUDA platform (currently main implementation)
+- **ACLGraph**: Graph Mode for NPU platform (architecture supported, pending adaptation)
+- **MLUGraph**: Graph Mode for MLU platform (architecture supported, pending adaptation)
+
+## 1. Problem Background
+
+### 1.1 Problem Description
+
+When using Graph Mode (CUDAGraph/ACLGraph/MLUGraph) for inference with different shapes, GPU/NPU/MLU memory usage was found to grow linearly with the number of captures, reaching `sum(shape)` instead of the expected `max(shape)`.
+
+### 1.2 Root Cause
+
+- PyTorch's `CUDACachingAllocator` (CUDA platform) or other platform allocators allocate independent memory blocks for each Graph capture
+- Graph Mode requires memory addresses to remain stable between capture and replay
+- Different shapes of Graphs require different memory layouts, causing each shape to need independent memory
+- Since Graphs may be replayed at any time, these memories cannot be freed, leading to memory accumulation
+- Final memory usage = `sum(shape)` instead of the expected `max(shape)`
+
+### 1.3 Constraints
+
+- Graphs of different shapes **do not replay simultaneously**, allowing sharing of underlying physical memory
+- Need to support dynamically appearing new shapes, performing graph capture on demand
+- **Not allowed** to re-capture already captured shapes (all shapes must be cached)
+
+### 1.4 Technical Challenges in Problem Solving
+
+The following technical challenges were encountered when implementing the memory reuse solution:
+
+**Challenge 1: Virtual Address Reuse Conflict**
+
+The initial solution attempted to reuse the same virtual address space through `reset_allocation_pointer()`:
+- Reset allocation pointer to start position before each capture
+- Expected different shapes of Graphs to reuse the same virtual address
+
+**Problems Encountered**:
+- PyTorch's `CUDACachingAllocator` uses an `allocated_blocks` map to track memory blocks by address
+- When reusing virtual addresses, newly allocated addresses overwrite old entries in `allocated_blocks`
+- When tensors in old Graphs are destructed, `free()` is called, but the address is no longer in `allocated_blocks`
+- Triggers `invalid device pointer` error, causing program crash
+
+**Solution**:
+- Adopt multi-shape memory reuse solution: each capture uses a new virtual address (underlying implementation)
+- All shapes of Graphs share the same physical memory
+- Both avoids address conflicts and achieves physical memory reuse
+
+## 2. Similar Problems and Solutions in Other Products
+
+### 2.1 vLLM's Solution
+
+**vLLM's Approach**:
+
+1. **Shared Memory Pool**:
+   - Use `torch.cuda.graph_pool_handle()` to obtain a shared memory pool
+   - All Graphs of different shapes share the same memory pool
+   - Code location: `vllm/v1/worker/gpu/cudagraph_utils.py`
+   ```python
+   self.pool = torch.cuda.graph_pool_handle()
+   ```
+
+2. **Capture Order Optimization**:
+   - **Capture large shapes first, then small shapes**
+   - Small shapes can reuse free blocks in the memory pool allocated by large shapes
+   - Implementation: Sort in descending order in `capture_graphs()` function
+   ```python
+   # Capture larger graphs first.
+   sizes_to_capture = sorted(set(cudagraph_sizes.values()), reverse=True)
+   ```
+
+3. **Memory Management**:
+   - Relies on PyTorch's `CUDACachingAllocator` memory pool management
+   - Maximizes memory reuse through capture order
+   - Explicit comment in `capture_model()`:
+     ```python
+     # Capture the large shapes first so that the smaller shapes
+     # can reuse the memory pool allocated for the large shapes.
+     ```
+
+**Limitations**:
+- Memory accumulation may still occur: each Graph holds its own memory blocks, which cannot be freed even when inactive
+- Memory reuse depends on memory pool's free block management, not thorough enough
+- When there are many different shapes, memory usage still grows linearly
+
+### 2.2 SGLang's Solution
+
+**SGLang's Approach**:
+
+1. **Global Memory Pool**:
+   - Use `torch.cuda.graph_pool_handle()` or global graph memory pool
+   - Set global memory pool in `piecewise_cuda_graph_runner.py`:
+   ```python
+   if get_global_graph_memory_pool() is None:
+       set_global_graph_memory_pool(self.device_module.graph_pool_handle())
+   set_graph_pool_id(get_global_graph_memory_pool())
+   ```
+
+2. **Capture Order Optimization**:
+   - Also adopts **capture large shapes first, then small shapes** strategy
+   - Explicit comment in `cuda_graph_runner.py`:
+     ```python
+     # Capture the large shapes first so that the smaller shapes
+     # can reuse the memory pool allocated for the large shapes.
+     ```
+
+3. **Special Handling for Multimodal Scenarios**:
+   - SGLang has dedicated CUDA Graph implementation for multimodal encoders like ViT (Vision Transformer)
+   - Document mentions: "If there are many distinct S values, we need to increase VRAM usage which is graph-private memory pools for many graphs."
+   - (Note: VRAM stands for Video RAM, referring to GPU memory)
+   - Document source: `sglang/docs/advanced_features/cuda_graph_for_multi_modal_encoder.md` line 26
+   - This indicates SGLang recognizes that memory usage grows when there are many different shapes (because each graph has an independent memory pool)
+
+4. **Piecewise CUDA Graph Support**:
+   - SGLang supports piecewise CUDA Graph, can capture layer by layer
+   - Uses weak references to reduce memory usage
+
+**Limitations**:
+- Similar to vLLM, relies on PyTorch memory pool management
+- Document mentions: when there are many different shapes, VRAM usage needs to be increased (due to graph-private memory pools)
+- Memory reuse depends on memory pool's free block management, when there are many different shapes, memory usage may approach `sum(shape)`
+
+### 2.3 Solution Comparison Summary
+
+| Feature | vLLM Solution | SGLang Solution | xLLM Solution |
+|------|-----------|-------------|-----------|
+| **Memory Reuse Mechanism** | Shared memory pool + capture order optimization | Global memory pool + capture order optimization + Piecewise Graph | Multi-shape memory reuse (multi-virtual address spaces map to same physical memory) |
+| **Physical Memory Usage** | May reach `sum(shape)` | May approach `sum(shape)` (document mentions graph-private pools) | `max(shape)` ✅ |
+| **Address Conflicts** | None (shared memory pool) | None (global memory pool) | None (different virtual addresses) |
+| **Implementation Complexity** | Low (uses PyTorch existing mechanisms) | Low-Medium (supports Piecewise) | Medium (requires custom VMM allocator + supports Piecewise) |
+| **Memory Efficiency** | Depends on memory pool management | Depends on memory pool management | Optimal ✅ |
+| **Special Scenario Support** | Standard CUDA Graph | Piecewise Graph + Multimodal | Piecewise Graph (implemented)<br>CUDAGraph (implemented)<br>ACLGraph/MLUGraph (architecture supported) |
+| **Memory Growth Issue** | Grows to `sum(shape)` when many different shapes | Document mentions increased memory usage when many different shapes (graph-private pools) | Grows to `max(shape)` then stops ✅ |
+
+## 3. Intermediate Activations Multi-Shape Reuse Solution
+
+### 3.1 Core Concept
+
+**Multi-Shape Memory Reuse**:
+
+- **Functional Goal**: Different shapes of Graphs share physical memory, memory usage = `max(shape)` instead of `sum(shape)`
+- **Implementation Mechanism**: Each Graph capture uses a new virtual address space, all virtual address spaces map to the same physical memory
+- **Address Isolation**: PyTorch's `allocated_blocks` (CUDA platform) or other platforms' block management mechanisms use different virtual addresses to avoid conflicts
+- **Memory Efficiency**: Physical memory usage = `max(shape)`
+
+**Platform Support**:
+- **CUDA Platform**: Implemented using CUDA VMM API (current implementation)
+- **NPU/MLU Platform**: Architecture supports, needs adaptation to corresponding platform VMM APIs
+
+**Graph Mode Support**:
+- **Standard CUDA Graph**: Supports full Graph capture for decode phase
+- **Piecewise CUDA Graph**: Supports layer-by-layer capture for prefill phase (piecewise capture)
+- Both modes use the same multi-shape memory reuse mechanism
+
+### 3.2 Architecture Diagram
+
+```mermaid
+graph LR
+    subgraph PhyMem [Physical Memory]
+        P1[Page 1]
+        P2[Page 2]
+        P3[Page 3]
+    end
+    
+    subgraph VA1 [Virtual Space 1 - Capture 1]
+        V1A[0xa02000000]
+        V1B[0xa02200000]
+        V1C[0xa02400000]
+    end
+    
+    subgraph VA2 [Virtual Space 2 - Capture 2]
+        V2A[0xb02000000]
+        V2B[0xb02200000]
+        V2C[0xb02400000]
+    end
+    
+    V1A --> P1
+    V1B --> P2
+    V1C --> P3
+    V2A --> P1
+    V2B --> P2
+    V2C --> P3
+```
+
+### 3.3 Key Technologies
+
+**CUDA Virtual Memory Management (VMM) API**:
+
+- `cuMemAddressReserve`: Reserve virtual address space
+- `cuMemCreate`: Create physical memory handle
+- `cuMemMap`: Map physical memory to virtual address space
+- `cuMemUnmap`: Unmap
+- `cuMemRelease`: Release virtual address space or physical memory handle
+- `cuMemSetAccess`: Set memory access permissions
+
+**Key Feature**: The same physical memory handle can be mapped to multiple virtual address spaces.
+
+### 3.4 Implementation Architecture
+
+#### 3.4.1 Component Structure
+
+```
+┌─────────────────────────────────────────────────────┐
+│         CudaGraphExecutorImpl                      │
+│  - reset_vmm_allocator_offset()                           │
+│  - get_vmm_mempool_ptr()                          │
+│  - MemPoolContext activation                      │
+└────────────────┬────────────────────────────────────┘
+                 │
+                 ▼
+┌─────────────────────────────────────────────────────┐
+│         VMMTorchAllocator                           │
+│  - raw_alloc() / raw_alloc_with_stream()           │
+│  - raw_delete()                                     │
+│  - Implements CUDAAllocator interface              │
+└────────────────┬────────────────────────────────────┘
+                 │
+                 ▼
+┌─────────────────────────────────────────────────────┐
+│         SharedVMMAllocator                          │
+│  - switch_to_new_virtual_space()                   │
+│  - allocate()                                      │
+│  - extend_mapping()                                │
+│  - Manages VirtualSpace[] and PhyMemHandle[]      │
+└────────────────┬────────────────────────────────────┘
+                 │
+                 ▼
+┌─────────────────────────────────────────────────────┐
+│         vmm_api (Platform abstraction)              │
+│  - create_vir_ptr()                                │
+│  - create_phy_mem_handle()                         │
+│  - map() / unmap()                                 │
+│  - release_vir_ptr() / release_phy_mem_handle()    │
+└─────────────────────────────────────────────────────┘
+```
+
+#### 3.4.2 Core Class Design
+
+**SharedVMMAllocator**:
+
+- **Responsibility**: Manage physical memory and multiple virtual address spaces
+- **Key Data Structures**:
+  ```cpp
+  struct VirtualSpace {
+    VirPtr base_ptr;       // Virtual address base
+    size_t reserved_size;  // Reserved virtual address space size
+    size_t mapped_size;    // Mapped physical memory size
+  };
+  std::vector<VirtualSpace> virtual_spaces_;  // All virtual address spaces
+  std::vector<PhyMemHandle> handles_;        // Physical memory handles (shared)
+  ```
+- **Key Methods**:
+  - `switch_to_new_virtual_space()`: Create new virtual address space and map existing physical memory
+  - `allocate()`: Allocate memory from current virtual space
+  - `extend_mapping()`: Create new physical memory and map to all virtual spaces
+
+**VMMTorchAllocator**:
+
+- **Responsibility**: Adapt `SharedVMMAllocator` to PyTorch's `CUDAAllocator` interface
+- **Key Methods**:
+  - `raw_alloc()` / `raw_alloc_with_stream()`: Call `SharedVMMAllocator::allocate()`
+  - `raw_delete()`: Call `SharedVMMAllocator::deallocate()` (no-op)
+
+**Integration Point** (in `CudaGraphExecutorImpl`):
+
+```cpp
+// 1. Switch to new virtual address space before capture
+reset_vmm_allocator_offset(device_.index());
+
+// 2. Activate VMM MemPool (CUDA platform uses PyTorch MemPool)
+c10::cuda::MemPoolContext mempool_ctx(get_vmm_mempool_ptr());
+
+// 3. Execute capture (all allocations will use VMM allocator)
+graph->capture(...);
+```
+
+### 3.5 Implementation Details
+
+#### 3.5.1 File Structure
+
+```
+xllm/xllm/core/platform/
+├── shared_vmm_allocator.h          # SharedVMMAllocator header (platform-agnostic)
+├── shared_vmm_allocator.cpp         # SharedVMMAllocator implementation (platform-agnostic)
+├── vmm_torch_allocator.h            # VMMTorchAllocator header (CUDA platform)
+├── vmm_api.h                        # VMM API abstraction layer (multi-platform)
+└── vmm_api.cpp                      # VMM API implementation (currently CUDA, extensible)
+
+xllm/xllm/core/runtime/
+├── cuda_graph_executor_impl.h       # CUDAGraph integration point declaration
+└── cuda_graph_executor_impl.cpp     # CUDAGraph integration point implementation
+```
+
+#### 3.5.2 Key Implementation Flow
+
+**Capture Flow**:
+
+```
+1. reset_vmm_allocator_offset(device_id)
+   └─> SharedVMMAllocator::switch_to_new_virtual_space()
+       ├─> vmm::create_vir_ptr()  // Create new virtual space
+       ├─> Iterate handles_, map to new virtual space
+       └─> virtual_spaces_.push_back(new_space)
+
+2. MemPoolContext mempool_ctx(get_vmm_mempool_ptr())
+   └─> Activate VMM MemPool, subsequent allocations use VMMTorchAllocator
+
+3. graph->capture(...)
+   └─> All memory allocations through VMMTorchAllocator::raw_alloc()
+       └─> SharedVMMAllocator::allocate()
+           └─> Allocate from current virtual space
+```
+
+**Memory Extension Flow**:
+
+```
+SharedVMMAllocator::extend_mapping(new_size)
+├─> while (mapped_size_ < new_size)
+│   ├─> vmm::create_phy_mem_handle()  // Create new physical memory
+│   └─> for (auto& space : virtual_spaces_)
+│       └─> vmm::map(space.base_ptr + offset, handle)
+│           └─> Map to all virtual spaces
+└─> mapped_size_ += granularity
+```
+
+### 3.6 Key Technical Points
+
+#### 3.6.1 VMM API Usage (CUDA Platform Implementation)
+
+**Virtual Address Space Creation**:
+```cpp
+VirPtr base_ptr;
+vmm::create_vir_ptr(base_ptr, reserved_size);
+// CUDA platform underlying call: cuMemAddressReserve
+```
+
+**Physical Memory Creation**:
+```cpp
+PhyMemHandle handle;
+vmm::create_phy_mem_handle(handle, device_id);
+// CUDA platform underlying calls: cuMemGetAllocationGranularity + cuMemCreate
+```
+
+**Map Physical Memory to Virtual Space**:
+```cpp
+vmm::map(vir_ptr, phy_mem_handle, device_id);
+// CUDA platform underlying calls: cuMemMap + cuMemSetAccess
+```
+
+#### 3.6.2 PyTorch Integration (CUDA Platform)
+
+**MemPool Mechanism**:
+- `c10::cuda::MemPool` binds `CUDAAllocator*` at construction
+- `c10::cuda::MemPoolContext` activates MemPool within scope
+- `beginAllocateToPool()` / `endAllocateToPool()` route allocations to MemPool's allocator
+
+**Key Interface Implementation**:
+- `CUDAAllocator::raw_alloc()`: Core allocation interface
+- `CUDAAllocator::raw_delete()`: Deallocation interface (no-op in VMM)
+
+## 4. Multi-Shape Input Tensor Reuse (Implemented)
+
+Besides the "Graph capture memory" reuse via VMM multi-VA physical reuse in Section 3, xLLM also reuses **input tensors** across multiple shapes, avoiding per-shape input memory. This mechanism is implemented for CUDAGraph, ACLGraph, and MLUGraph.
+
+**Idea**:
+- Pre-allocate **one set** of persistent buffers for the Graph with **max shape** (tokens, positions, q_seq_lens, kv_seq_lens, block_tables, hidden_states, etc.).
+- On replay, regardless of the current request’s actual shape, **only this set of buffers** is used: copy the current input into the leading segment of the buffers, then pass **slices** matching the current actual shape to forward.
+- Thus input-side memory is **max(shape)** only; different shapes reuse the same buffers.
+
+**Implementation points**:
+
+1. **Persistent parameter class** (e.g. `CudaGraphPersistentParam` / ACL/MLU `GraphPersistentParam`):
+   - Allocates at construction with **max** dimensions: `max_tokens_per_batch`, `max_seqs_per_batch`, `max_block_table_len`, etc.
+   - All input/output tensors (tokens, positions, new_cache_slots, block_tables, q_seq_lens, kv_seq_lens, hidden_states, etc.) use these fixed-size buffers.
+
+2. **Write before replay**:
+   - Call `update()` / `update_input_buffer()` to copy the current request’s tokens, positions, ModelInputParams, etc. into the **leading actual segment** of the buffers (zero-fill padding if needed).
+   - Copy uses forms like `persistent_*.slice(0, 0, actual_*).copy_(input, true)` so only the used range is written.
+
+3. **Pass slice views on replay**:
+   - Forward does not allocate new inputs; getters return slices for the **current actual shape**, e.g.:
+     - `persistent_tokens(actual_tokens)` → `persistent_tokens_.slice(0, 0, actual_tokens)`
+     - Similarly for `persistent_positions(actual_tokens)`, `persistent_block_tables(actual_batch_size)`, etc.
+   - The same buffers are thus reused across replays of different shapes; memory is **max(shape)**.
+
+**Effect**:
+- Input tensor memory for multiple shapes is reduced from per-shape copies to **max(shape)**.
+- Together with Section 3 capture memory VMM reuse, overall memory behavior is: **capture** physical memory ≈ **max(shape)**, **input** side also **max(shape)**; both are part of the current implementation.
+
+**Code references**:
+- CUDA: `xllm/core/runtime/cuda_graph_executor_impl.cpp` (`CudaGraphPersistentParam` constructor and `update()`, and getters like `persistent_tokens()`).
+- ACL: `acl_graph_executor_impl.cpp`, `GraphPersistentParam::update()` and persistent tensor slices.
+- MLU: `mlu_graph_executor_impl.cpp`, `GraphPersistentParam::update_input_buffer()` and slices.
+
+## 5. Final Results
+
+### 5.1 Memory Efficiency
+
+| Metric | Previous Solution | New Solution |
+|------|---------|--------|
+| Physical Memory | `sum(shape)` | `max(shape)` ✅ |
+| Virtual Address Space | `max(shape)` | `sum(shape)` |
+| Stability | Address conflict crash | Stable ✅ |
+
+### 5.2 Performance Impact
+
+- **Capture Phase**: `switch_to_new_virtual_space()` needs to map all physical memory, overhead is O(number of physical pages)
+- **Replay Phase**: No additional overhead, same as standard Graph Mode replay (CUDAGraph/ACLGraph/MLUGraph)
+- **Memory Allocation**: O(1), allocate from current offset
+
+### 5.3 Virtual Address Space Overhead
+
+- 64-bit systems typically have 48-bit effective virtual address space (256TB)
+- Each virtual space is approximately 1.125x device memory (e.g., 80GB GPU = 90GB VA)
+- Theoretically can support thousands of different shape captures
+
+### 5.4 Test Verification
+
+✅ **Memory Reuse**: Different shape captures share physical memory  
+✅ **Address Uniqueness**: Each capture uses different virtual addresses  
+✅ **Stability**: Long-term stress testing shows no `invalid device pointer` errors  
+✅ **Memory Usage**: Memory usage reduced from `sum(shape)` to `max(shape)`
+
+### 5.5 Actual Results
+
+- **Memory Usage**: Reduced from `sum(shape)` to `max(shape)`, significantly reducing memory usage
+- **Stability**: Solved `invalid device pointer` errors caused by virtual address reuse
+- **Scalability**: Supports dynamically appearing new shapes, performing graph capture on demand
+- **Platform Support**: CUDA platform implemented, NPU/MLU platforms architecture supported pending adaptation
+
+## 6. Notes and Limitations
+
+### 6.1 Notes
+
+1. **Virtual Address Space Cleanup**:
+   - Current implementation retains all virtual spaces until destruction
+   - Future optimization: Release old virtual spaces when Graphs are no longer used
+
+2. **Multi-GPU Support**:
+   - Each device has an independent `SharedVMMAllocator` instance
+   - `device_id` parameter ensures correct mapping
+
+3. **Memory Alignment**:
+   - All allocations aligned to `granularity`, may have slight waste
+   - Alignment overhead typically < 1%
+
+### 6.2 Limitations
+
+1. **Platform Support Status**:
+   - **CUDA Platform**: Implemented (using CUDA VMM API)
+   - **NPU Platform (ACLGraph)**: Architecture supported, pending adaptation to NPU VMM API
+   - **MLU Platform (MLUGraph)**: Architecture supported, pending adaptation to MLU VMM API
+   - Current `VMMTorchAllocator` only adapts to CUDA platform's PyTorch interface
+
+2. **Virtual Address Space Growth**:
+   - Theoretically unlimited, but practically limited by system constraints
+   - 64-bit systems typically sufficient
+
+3. **No Dynamic Deallocation**:
+   - Physical memory not freed during allocator lifetime
+   - Virtual spaces cleaned up uniformly at destruction
+
+## 7. Future Optimization Directions
+
+1. **Virtual Space Cleanup**:
+   - Track Graph lifecycle (CUDAGraph/ACLGraph/MLUGraph)
+   - Release corresponding virtual spaces when Graphs are no longer used
+
+2. **Memory Fragmentation Management**:
+   - Support physical memory remapping
+   - Reduce virtual address space fragmentation
+
+3. **Multi-Platform Support**:
+   - **NPU Platform (ACLGraph)**: Adapt NPU VMM API, integrate in `AclGraphExecutorImpl`
+   - **MLU Platform (MLUGraph)**: Adapt MLU VMM API, integrate in `MluGraphExecutorImpl`
+   - Unify VMM API abstraction, support virtual memory management for different hardware platforms
+   - Implement corresponding Allocator adapters for each platform (similar to `VMMTorchAllocator`)
+
+## 8. References
+
+### 8.1 CUDA Platform
+
+- [CUDA Virtual Memory Management](https://docs.nvidia.com/cuda/cuda-driver-api/group__CUDA__VM.html)
+- [PyTorch CUDACachingAllocator](https://github.com/pytorch/pytorch/blob/main/c10/cuda/CUDACachingAllocator.h)
+- [CUDA Graph Capture](https://docs.nvidia.com/cuda/cuda-c-programming-guide/index.html#cuda-graphs)
+- [vLLM CUDA Graph Implementation](https://github.com/vllm-project/vllm/blob/main/vllm/v1/worker/gpu/cudagraph_utils.py)
+- [SGLang CUDA Graph Implementation](https://github.com/sgl-project/sglang/blob/main/python/sglang/srt/model_executor/cuda_graph_runner.py)
+
+### 8.2 xLLM Graph Mode
+
+- [xLLM CUDAGraph Implementation](../../xllm/core/runtime/cuda_graph_executor_impl.h)
+- [xLLM ACLGraph Implementation](../../xllm/core/runtime/acl_graph_executor_impl.h)
+- [xLLM MLUGraph Implementation](../../xllm/core/runtime/mlu_graph_executor_impl.h)
+
+---
+
+**Document Version**: v1.0  
+**Last Updated**: 2025-01-29  
+**Author**: xLLM Team

--- a/docs/zh/features/graph_mode.md
+++ b/docs/zh/features/graph_mode.md
@@ -1,0 +1,52 @@
+# Graph Mode
+
+## 概述
+
+xLLM 支持 Graph Mode，通过预捕获计算图并在后续执行中重放，减少 CPU 开销并提高推理性能。Graph Mode 在不同硬件平台上均有对应实现。
+
+## 功能介绍
+
+为了优化 Host 侧调度性能，图模式通过在 CPU 一次提交大任务后，设备内部流式执行小 kernel，显著降低启动时间和设备气泡。
+
+在 xLLM 引擎中，Graph Mode 实现了以下特性：
+
+### 动态维度参数化
+  - 将除 num_tokens 以外的关键动态维度作为整图输入参数，包括 batch_size、kv_seq_lens、q_seq_lens、block_table_size 等，从而提高灵活性。在进行图的内存分配和内核配置时，利用这些动态参数计算实际所需值，例如通过公式 $block\_table\_size = batch\_size \times (max\_seq\_len / block\_size)$ 计算 block_table_size。在图启动阶段，将上述实际参数传入，以确保 kernel 能够使用正确的 stride 访问数据。
+
+### Piecewise Graph
+  - 当部分算子不支持 graph 导致整图无法捕获（break graph）时，对 break 之后的各段（piece）分别捕获 graph。这样在无法整图捕获的情况下，仍能尽可能获得 graph mode 的收益，常用于 prefill、chunked_prefill 等场景。
+
+### 多 shape 复用的显存池
+  - 为了避免多 shape 使用单独显存 buffer（输入、输出和中间 Tensor）导致浪费，我们采用了可扩张的显存池。多 shape 复用基地址，不同 shape 对池基地址的偏移量（Offset）不同。
+  - 更详细的多 shape 复用内存方案（含问题背景、实现与效果）见：[Graph Mode 多 Shape 复用内存技术文档](graph_mode_multi_shape_memory_reuse.md)
+
+## 使用方式
+
+上述功能已在 xLLM 引擎内部实现，对用户透明。通过 gflags 参数 `enable_graph` 开启，默认为 false。在 xLLM 服务启动脚本中设置为 true 即可，示例如下：
+
+```shell
+--enable_graph=true
+```
+
+## 性能效果
+
+- 开启 Graph Mode 后，在 Qwen3-0.6B 和 Qwen3-1.7B 等模型上，decode 阶段吞吐 **提升约 8%–10%**。
+
+## 模型支持
+
+下表列出目前各模型在 ACLGraph、CudaGraph、MLUGraph 上的支持情况。
+
+| 模型 | ACLGraph | CudaGraph | MLUGraph |
+|------|----------|-----------|----------|
+| Qwen3/Qwen3-MoE | ✅ | ✅ | ✅ |
+| DeepseekV3.2 | ✅ | | |
+| GLM4.5/4.6/4.7 | ✅ | | |
+| Qwen2.5-VL | | | ✅ |
+
+
+!!! warning "为新模型添加 Graph Mode 支持"
+    需检查计算过程中用到的 kernel 是否实现了动态维度参数化；若未实现，会造成 break graph，可能需要重新实现 kernel。
+
+## 相关文档
+
+- [Graph Mode 多 Shape 复用内存技术文档](graph_mode_multi_shape_memory_reuse.md)

--- a/docs/zh/features/graph_mode_multi_shape_memory_reuse.md
+++ b/docs/zh/features/graph_mode_multi_shape_memory_reuse.md
@@ -1,0 +1,503 @@
+# xLLM Graph Mode 多 Shape 复用内存技术文档
+
+## 概述
+
+本文档描述了 xLLM 中 Graph Mode（包括 CUDAGraph、ACLGraph、MLUGraph）的多 shape 复用内存方案。该方案包含两部分已实现机制：（1）**Graph 捕获期显存复用**：不同 shape 的 Graph 共享物理内存，将显存占用从 `sum(shape)` 降低到 `max(shape)`，底层通过 CUDA Virtual Memory Management (VMM) API 的多虚拟地址空间映射实现；（2）**多 shape 输入 tensor 复用**：通过持久化参数（PersistentParam）预分配最大 shape 的 buffer，replay 时用 slice 适配不同 actual shape，使输入侧显存也保持为 `max(shape)`。
+
+**适用范围**：
+- **CUDAGraph**：CUDA 平台的 Graph Mode（当前主要实现）
+- **ACLGraph**：NPU 平台的 Graph Mode（架构支持，待适配）
+- **MLUGraph**：MLU 平台的 Graph Mode（架构支持，待适配）
+
+## 1. 问题背景
+
+### 1.1 问题描述
+
+在使用 Graph Mode（CUDAGraph/ACLGraph/MLUGraph）进行不同 shape 的推理时，发现 GPU/NPU/MLU 显存占用随 capture 次数线性增长，内存使用量达到 `sum(shape)` 而不是期望的 `max(shape)`。
+
+### 1.2 根本原因
+
+- PyTorch 的 `CUDACachingAllocator`（CUDA 平台）或其他平台的 allocator 为每次 Graph capture 分配独立的内存块
+- Graph Mode 的特性要求内存地址在 capture 和 replay 之间保持稳定
+- 不同 shape 的 Graph 需要不同的内存布局，导致每个 shape 都需要独立的内存
+- 由于 Graph 可能随时被 replay，这些内存无法释放，导致内存累积
+- 最终内存使用量 = `sum(shape)` 而不是期望的 `max(shape)`
+
+### 1.3 约束条件
+
+- 不同 shape 的 Graph **不会同时 replay**，允许共享底层物理内存
+- 需要支持动态出现的新 shape，按需进行 graph capture
+- **不允许**对已捕获的 shape 进行重新捕获（所有 shape 必须缓存）
+
+### 1.4 问题解决过程中的技术难点
+
+在实现内存复用方案时，遇到了以下技术难点：
+
+**难点 1：虚拟地址复用冲突**
+
+初始方案尝试通过 `reset_allocation_pointer()` 复用相同的虚拟地址空间：
+- 每次 capture 前重置分配指针到起始位置
+- 期望不同 shape 的 Graph 复用相同的虚拟地址
+
+**遇到的问题**：
+- PyTorch 的 `CUDACachingAllocator` 使用 `allocated_blocks` map 按地址跟踪内存块
+- 复用虚拟地址时，新分配的地址会覆盖 `allocated_blocks` 中的旧条目
+- 旧 Graph 中的 tensor 析构时调用 `free()`，但地址已不在 `allocated_blocks` 中
+- 触发 `invalid device pointer` 错误，导致程序崩溃
+
+**解决方案**：
+- 采用多 shape 复用内存方案：每次 capture 使用新的虚拟地址（底层实现）
+- 所有 shape 的 Graph 共享相同的物理内存
+- 既避免了地址冲突，又实现了物理内存复用
+
+## 2. 其他产品的类似问题和解法
+
+### 2.1 vLLM 的方案
+
+**vLLM 采用的方法**：
+
+1. **共享内存池**：
+   - 使用 `torch.cuda.graph_pool_handle()` 获取一个共享的内存池
+   - 所有不同 shape 的 Graph 共享同一个内存池
+   - 代码位置：`vllm/v1/worker/gpu/cudagraph_utils.py`
+   ```python
+   self.pool = torch.cuda.graph_pool_handle()
+   ```
+
+2. **捕获顺序优化**：
+   - **先捕获大 shape，再捕获小 shape**
+   - 小 shape 可以复用大 shape 分配的内存池中的空闲块
+   - 实现方式：在 `capture_graphs()` 函数中按降序排序
+   ```python
+   # Capture larger graphs first.
+   sizes_to_capture = sorted(set(cudagraph_sizes.values()), reverse=True)
+   ```
+
+3. **内存管理**：
+   - 依赖 PyTorch 的 `CUDACachingAllocator` 的内存池管理
+   - 通过捕获顺序来最大化内存复用
+   - 在 `capture_model()` 中明确注释：
+     ```python
+     # Capture the large shapes first so that the smaller shapes
+     # can reuse the memory pool allocated for the large shapes.
+     ```
+
+**局限性**：
+- 仍然可能出现内存累积：每个 Graph 持有自己的内存块，即使不活跃也无法释放
+- 内存复用依赖于内存池的空闲块管理，不够彻底
+- 当不同 shape 数量较多时，内存占用仍然会线性增长
+
+### 2.2 SGLang 的方案
+
+**SGLang 采用的方法**：
+
+1. **全局内存池**：
+   - 使用 `torch.cuda.graph_pool_handle()` 或全局 graph memory pool
+   - 在 `piecewise_cuda_graph_runner.py` 中设置全局内存池：
+   ```python
+   if get_global_graph_memory_pool() is None:
+       set_global_graph_memory_pool(self.device_module.graph_pool_handle())
+   set_graph_pool_id(get_global_graph_memory_pool())
+   ```
+
+2. **捕获顺序优化**：
+   - 同样采用**先捕获大 shape，再捕获小 shape**的策略
+   - 在 `cuda_graph_runner.py` 中明确注释：
+     ```python
+     # Capture the large shapes first so that the smaller shapes
+     # can reuse the memory pool allocated for the large shapes.
+     ```
+
+3. **多模态场景的特殊处理**：
+   - 针对 ViT（Vision Transformer）等多模态编码器，SGLang 有专门的 CUDA Graph 实现
+   - 文档中提到："If there are many distinct S values, we need to increase VRAM usage which is graph-private memory pools for many graphs."
+   - （注：VRAM 即 Video RAM，指 GPU 显存）
+   - 文档出处：`sglang/docs/advanced_features/cuda_graph_for_multi_modal_encoder.md` 第 26 行
+   - 这表明 SGLang 认识到当不同 shape 数量较多时，显存占用会增长（因为每个 graph 有独立的 memory pool）
+
+4. **Piecewise CUDA Graph 支持**：
+   - SGLang 支持 piecewise CUDA Graph，可以按层捕获
+   - 使用弱引用（weak reference）来减少内存占用
+
+**局限性**：
+- 与 vLLM 类似，依赖 PyTorch 内存池管理
+- 文档提到：当不同 shape 数量较多时，需要增加显存（VRAM）使用（因为 graph-private memory pools）
+- 内存复用依赖于内存池的空闲块管理，当不同 shape 数量较多时，内存占用可能接近 `sum(shape)`
+
+### 2.3 方案对比总结
+
+| 特性 | vLLM 方案 | SGLang 方案 | xLLM 方案 |
+|------|-----------|-------------|-----------|
+| **内存复用机制** | 共享内存池 + 捕获顺序优化 | 全局内存池 + 捕获顺序优化 + Piecewise Graph | 多 shape 复用内存（多虚拟地址空间映射同一物理内存） |
+| **物理内存使用** | 可能达到 `sum(shape)` | 可能接近 `sum(shape)`（文档提到 graph-private pools） | `max(shape)` ✅ |
+| **地址冲突** | 无（共享内存池） | 无（全局内存池） | 无（不同虚拟地址） |
+| **实现复杂度** | 低（使用 PyTorch 现有机制） | 低-中（支持 Piecewise） | 中（需要自定义 VMM allocator + 支持 Piecewise） |
+| **内存效率** | 依赖内存池管理 | 依赖内存池管理 | 最优 ✅ |
+| **特殊场景支持** | 标准 CUDA Graph | Piecewise Graph + 多模态 | Piecewise Graph（已实现）<br>CUDAGraph（已实现）<br>ACLGraph/MLUGraph（架构支持） |
+| **内存增长问题** | 不同 shape 多时会增长到 `sum(shape)` | 文档提到不同 shape 多时会增加显存使用（graph-private pools） | 增长到 `max(shape)` 后停止 ✅ |
+
+## 3. xLLM 中间激活值多 Shape 复用解法
+
+### 3.1 核心思路
+
+**多 shape 复用内存**：
+
+- **功能目标**：不同 shape 的 Graph 共享物理内存，显存占用 = `max(shape)` 而不是 `sum(shape)`
+- **实现机制**：每次 Graph capture 使用新的虚拟地址空间，所有虚拟地址空间映射到相同的物理内存
+- **地址隔离**：PyTorch 的 `allocated_blocks`（CUDA 平台）或其他平台的块管理机制使用不同虚拟地址，避免冲突
+- **内存效率**：物理内存使用量 = `max(shape)`
+
+**平台支持**：
+- **CUDA 平台**：使用 CUDA VMM API 实现（当前实现）
+- **NPU/MLU 平台**：架构设计支持，需要适配对应平台的 VMM API
+
+**Graph 模式支持**：
+- **标准 CUDA Graph**：支持 decode 阶段的完整 Graph capture
+- **Piecewise CUDA Graph**：支持 prefill 阶段的按层捕获（piecewise capture）
+- 两种模式都使用相同的多 shape 复用内存机制
+
+### 3.2 架构图
+
+```mermaid
+graph LR
+    subgraph PhyMem [Physical Memory]
+        P1[Page 1]
+        P2[Page 2]
+        P3[Page 3]
+    end
+    
+    subgraph VA1 [Virtual Space 1 - Capture 1]
+        V1A[0xa02000000]
+        V1B[0xa02200000]
+        V1C[0xa02400000]
+    end
+    
+    subgraph VA2 [Virtual Space 2 - Capture 2]
+        V2A[0xb02000000]
+        V2B[0xb02200000]
+        V2C[0xb02400000]
+    end
+    
+    V1A --> P1
+    V1B --> P2
+    V1C --> P3
+    V2A --> P1
+    V2B --> P2
+    V2C --> P3
+```
+
+### 3.3 关键技术
+
+**CUDA Virtual Memory Management (VMM) API**：
+
+- `cuMemAddressReserve`: 保留虚拟地址空间
+- `cuMemCreate`: 创建物理内存句柄
+- `cuMemMap`: 将物理内存映射到虚拟地址空间
+- `cuMemUnmap`: 取消映射
+- `cuMemRelease`: 释放虚拟地址空间或物理内存句柄
+- `cuMemSetAccess`: 设置内存访问权限
+
+**关键特性**：同一个物理内存句柄可以映射到多个虚拟地址空间。
+
+### 3.4 实现架构
+
+#### 3.4.1 组件结构
+
+```
+┌─────────────────────────────────────────────────────┐
+│         CudaGraphExecutorImpl                      │
+│  - reset_vmm_allocator_offset()                           │
+│  - get_vmm_mempool_ptr()                          │
+│  - MemPoolContext activation                      │
+└────────────────┬────────────────────────────────────┘
+                 │
+                 ▼
+┌─────────────────────────────────────────────────────┐
+│         VMMTorchAllocator                           │
+│  - raw_alloc() / raw_alloc_with_stream()           │
+│  - raw_delete()                                     │
+│  - Implements CUDAAllocator interface              │
+└────────────────┬────────────────────────────────────┘
+                 │
+                 ▼
+┌─────────────────────────────────────────────────────┐
+│         SharedVMMAllocator                          │
+│  - switch_to_new_virtual_space()                   │
+│  - allocate()                                      │
+│  - extend_mapping()                                │
+│  - Manages VirtualSpace[] and PhyMemHandle[]      │
+└────────────────┬────────────────────────────────────┘
+                 │
+                 ▼
+┌─────────────────────────────────────────────────────┐
+│         vmm_api (Platform abstraction)              │
+│  - create_vir_ptr()                                │
+│  - create_phy_mem_handle()                         │
+│  - map() / unmap()                                 │
+│  - release_vir_ptr() / release_phy_mem_handle()    │
+└─────────────────────────────────────────────────────┘
+```
+
+#### 3.4.2 核心类设计
+
+**SharedVMMAllocator**：
+
+- **职责**：管理物理内存和多个虚拟地址空间
+- **关键数据结构**：
+  ```cpp
+  struct VirtualSpace {
+    VirPtr base_ptr;       // 虚拟地址基址
+    size_t reserved_size;  // 保留的虚拟地址空间大小
+    size_t mapped_size;    // 已映射的物理内存大小
+  };
+  std::vector<VirtualSpace> virtual_spaces_;  // 所有虚拟地址空间
+  std::vector<PhyMemHandle> handles_;        // 物理内存句柄（共享）
+  ```
+- **关键方法**：
+  - `switch_to_new_virtual_space()`: 创建新的虚拟地址空间并映射已有物理内存
+  - `allocate()`: 从当前虚拟空间分配内存
+  - `extend_mapping()`: 创建新物理内存并映射到所有虚拟空间
+
+**VMMTorchAllocator**：
+
+- **职责**：将 `SharedVMMAllocator` 适配到 PyTorch 的 `CUDAAllocator` 接口
+- **关键方法**：
+  - `raw_alloc()` / `raw_alloc_with_stream()`: 调用 `SharedVMMAllocator::allocate()`
+  - `raw_delete()`: 调用 `SharedVMMAllocator::deallocate()` (no-op)
+
+**集成点**（在 `CudaGraphExecutorImpl` 中）：
+
+```cpp
+// 1. 在 capture 前切换到新虚拟地址空间
+reset_vmm_allocator_offset(device_.index());
+
+// 2. 激活 VMM MemPool（CUDA 平台使用 PyTorch MemPool）
+c10::cuda::MemPoolContext mempool_ctx(get_vmm_mempool_ptr());
+
+// 3. 执行 capture（此时所有分配会使用 VMM allocator）
+graph->capture(...);
+```
+
+### 3.5 实现细节
+
+#### 3.5.1 文件结构
+
+```
+xllm/xllm/core/platform/
+├── shared_vmm_allocator.h          # SharedVMMAllocator 头文件（平台无关）
+├── shared_vmm_allocator.cpp         # SharedVMMAllocator 实现（平台无关）
+├── vmm_torch_allocator.h            # VMMTorchAllocator 头文件（CUDA 平台）
+├── vmm_api.h                        # VMM API 抽象层（多平台）
+└── vmm_api.cpp                      # VMM API 实现（当前为 CUDA，支持扩展）
+
+xllm/xllm/core/runtime/
+├── cuda_graph_executor_impl.h       # CUDAGraph 集成点声明
+└── cuda_graph_executor_impl.cpp     # CUDAGraph 集成点实现
+```
+
+#### 3.5.2 关键实现流程
+
+**Capture 流程**：
+
+```
+1. reset_vmm_allocator_offset(device_id)
+   └─> SharedVMMAllocator::switch_to_new_virtual_space()
+       ├─> vmm::create_vir_ptr()  // 创建新虚拟空间
+       ├─> 遍历 handles_，映射到新虚拟空间
+       └─> virtual_spaces_.push_back(new_space)
+
+2. MemPoolContext mempool_ctx(get_vmm_mempool_ptr())
+   └─> 激活 VMM MemPool，后续分配使用 VMMTorchAllocator
+
+3. graph->capture(...)
+   └─> 所有内存分配通过 VMMTorchAllocator::raw_alloc()
+       └─> SharedVMMAllocator::allocate()
+           └─> 从当前虚拟空间分配
+```
+
+**内存扩展流程**：
+
+```
+SharedVMMAllocator::extend_mapping(new_size)
+├─> while (mapped_size_ < new_size)
+│   ├─> vmm::create_phy_mem_handle()  // 创建新物理内存
+│   └─> for (auto& space : virtual_spaces_)
+│       └─> vmm::map(space.base_ptr + offset, handle)
+│           └─> 映射到所有虚拟空间
+└─> mapped_size_ += granularity
+```
+
+### 3.6 关键技术点
+
+#### 3.6.1 VMM API 使用（CUDA 平台实现）
+
+**虚拟地址空间创建**：
+```cpp
+VirPtr base_ptr;
+vmm::create_vir_ptr(base_ptr, reserved_size);
+// CUDA 平台底层调用 cuMemAddressReserve
+```
+
+**物理内存创建**：
+```cpp
+PhyMemHandle handle;
+vmm::create_phy_mem_handle(handle, device_id);
+// CUDA 平台底层调用 cuMemGetAllocationGranularity + cuMemCreate
+```
+
+**映射物理内存到虚拟空间**：
+```cpp
+vmm::map(vir_ptr, phy_mem_handle, device_id);
+// CUDA 平台底层调用 cuMemMap + cuMemSetAccess
+```
+
+#### 3.6.2 PyTorch 集成（CUDA 平台）
+
+**MemPool 机制**：
+- `c10::cuda::MemPool` 在构造时绑定 `CUDAAllocator*`
+- `c10::cuda::MemPoolContext` 在作用域内激活 MemPool
+- `beginAllocateToPool()` / `endAllocateToPool()` 将分配路由到 MemPool 的 allocator
+
+**关键接口实现**：
+- `CUDAAllocator::raw_alloc()`: 核心分配接口
+- `CUDAAllocator::raw_delete()`: 释放接口（VMM 中为 no-op）
+
+## 4. xLLM  输入 Tensor 多 Shape 的复用
+
+除第 3 节「Graph 捕获期显存」通过 VMM 多虚拟地址复用物理内存外，xLLM 还对**多 shape 下的输入 tensor** 做了复用，避免按 shape 各占一份输入显存。该机制已实现并用于 CUDAGraph、ACLGraph、MLUGraph。
+
+**思路**：  
+- 为 Graph 预分配**一组**与「最大 shape」一致的**持久化 buffer**（tokens、positions、q_seq_lens、kv_seq_lens、block_tables、hidden_states 等）。  
+- Replay 时不论当前请求的 actual shape 多大，都**只使用这组 buffer**：先把当次输入拷贝到 buffer 的对应前段，再通过 **slice** 得到与当前 actual shape 一致的视图传给 forward。  
+- 因此输入侧显存只占 **max(shape)** 一份，不同 shape 复用同一组 buffer。
+
+**实现要点**：
+
+1. **持久化参数类**（如 `CudaGraphPersistentParam` / ACL/MLU 的 `GraphPersistentParam`）：  
+   - 构造时按「最大」维度分配：`max_tokens_per_batch`、`max_seqs_per_batch`、`max_block_table_len` 等。  
+   - 所有输入/输出相关 tensor（tokens、positions、new_cache_slots、block_tables、q_seq_lens、kv_seq_lens、hidden_states 等）均使用这批固定大小的 buffer。
+
+2. **Replay 前写入**：  
+   - 调用 `update()` / `update_input_buffer()`，将当次请求的 tokens、positions、ModelInputParams 等拷贝到上述 buffer 的**前 actual 段**（必要时对 padding 区域填 0）。  
+   - 拷贝使用 `persistent_*.slice(0, 0, actual_*).copy_(input, true)` 等形式，只写实际用到的区间。
+
+3. **Replay 时传 slice 视图**：  
+   - forward 使用的输入不重新分配，而是通过 getter 得到「当前 actual shape」的 slice，例如：  
+     - `persistent_tokens(actual_tokens)` → `persistent_tokens_.slice(0, 0, actual_tokens)`  
+     - `persistent_positions(actual_tokens)`、`persistent_block_tables(actual_batch_size)` 等同理。  
+   - 这样同一份 buffer 在不同 shape 的 replay 之间复用，显存为 **max(shape)**。
+
+**效果**：  
+- 多 shape 下**输入 tensor 显存**从按 shape 多份占用降为 **max(shape)** 一份。  
+- 与第 3 节「捕获期显存」VMM 复用组合后，整体显存行为为：**捕获期**物理显存约 **max(shape)**，**输入侧**也为 **max(shape)**，均为当前已实现方案。
+
+**代码位置参考**：  
+- CUDA：`xllm/core/runtime/cuda_graph_executor_impl.cpp`（`CudaGraphPersistentParam` 构造与 `update()`，以及 `persistent_tokens()` 等 getter）。  
+- ACL：`acl_graph_executor_impl.cpp` 中 `GraphPersistentParam::update()` 与持久化 tensor 的 slice。  
+- MLU：`mlu_graph_executor_impl.cpp` 中 `GraphPersistentParam::update_input_buffer()` 与 slice。
+
+## 5. 最终的效果
+
+### 5.1 内存效率
+
+| 指标 | 之前方案 | 新方案 |
+|------|---------|--------|
+| 物理内存 | `sum(shape)` | `max(shape)` ✅ |
+| 虚拟地址空间 | `max(shape)` | `sum(shape)` |
+| 稳定性 | 地址冲突崩溃 | 稳定 ✅ |
+
+### 5.2 性能影响
+
+- **Capture 阶段**：`switch_to_new_virtual_space()` 需要映射所有物理内存，开销为 O(物理页数)
+- **Replay 阶段**：无额外开销，与标准 Graph Mode replay 相同（CUDAGraph/ACLGraph/MLUGraph）
+- **内存分配**：O(1)，从当前偏移量分配
+
+### 5.3 虚拟地址空间开销
+
+- 64 位系统通常有 48 位有效虚拟地址空间（256TB）
+- 每个虚拟空间约 1.125x device memory（例如 80GB GPU = 90GB VA）
+- 理论上可支持数千个不同 shape 的 capture
+
+### 5.4 测试验证
+
+✅ **内存复用**：不同 shape 的 capture 共享物理内存  
+✅ **地址唯一性**：每个 capture 使用不同的虚拟地址  
+✅ **稳定性**：长时间压测无 `invalid device pointer` 错误  
+✅ **内存占用**：显存占用从 `sum(shape)` 降低到 `max(shape)`
+
+### 5.5 实际效果
+
+- **显存占用**：从 `sum(shape)` 降低到 `max(shape)`，显著减少显存使用
+- **稳定性**：解决了虚拟地址复用导致的 `invalid device pointer` 错误
+- **扩展性**：支持动态出现的新 shape，按需进行 graph capture
+- **平台支持**：CUDA 平台已实现，NPU/MLU 平台架构支持待适配
+
+## 6. 注意事项与限制
+
+### 6.1 注意事项
+
+1. **虚拟地址空间清理**：
+   - 当前实现保留所有虚拟空间直到析构
+   - 未来可优化：在 Graph 不再使用时释放旧虚拟空间
+
+2. **多 GPU 支持**：
+   - 每个设备有独立的 `SharedVMMAllocator` 实例
+   - `device_id` 参数确保正确映射
+
+3. **内存对齐**：
+   - 所有分配按 `granularity` 对齐，可能有少量浪费
+   - 对齐开销通常 < 1%
+
+### 6.2 限制
+
+1. **平台支持状态**：
+   - **CUDA 平台**：已实现（使用 CUDA VMM API）
+   - **NPU 平台（ACLGraph）**：架构支持，待适配 NPU VMM API
+   - **MLU 平台（MLUGraph）**：架构支持，待适配 MLU VMM API
+   - 当前 `VMMTorchAllocator` 仅适配 CUDA 平台的 PyTorch 接口
+
+2. **虚拟地址空间增长**：
+   - 理论上无限制，但实际受系统限制
+   - 64 位系统通常足够使用
+
+3. **不支持动态释放**：
+   - 物理内存在 allocator 生命周期内不释放
+   - 虚拟空间在析构时统一清理
+
+## 7. 未来优化方向
+
+1. **虚拟空间清理**：
+   - 跟踪 Graph 生命周期（CUDAGraph/ACLGraph/MLUGraph）
+   - 在 Graph 不再使用时释放对应虚拟空间
+
+2. **内存碎片整理**：
+   - 支持物理内存的重新映射
+   - 减少虚拟地址空间碎片
+
+3. **多平台支持**：
+   - **NPU 平台（ACLGraph）**：适配 NPU VMM API，在 `AclGraphExecutorImpl` 中集成
+   - **MLU 平台（MLUGraph）**：适配 MLU VMM API，在 `MluGraphExecutorImpl` 中集成
+   - 统一 VMM API 抽象，支持不同硬件平台的虚拟内存管理
+   - 为各平台实现对应的 Allocator 适配器（类似 `VMMTorchAllocator`）
+
+## 8. 参考文档
+
+### 8.1 CUDA 平台
+
+- [CUDA Virtual Memory Management](https://docs.nvidia.com/cuda/cuda-driver-api/group__CUDA__VM.html)
+- [PyTorch CUDACachingAllocator](https://github.com/pytorch/pytorch/blob/main/c10/cuda/CUDACachingAllocator.h)
+- [CUDA Graph Capture](https://docs.nvidia.com/cuda/cuda-c-programming-guide/index.html#cuda-graphs)
+- [vLLM CUDA Graph Implementation](https://github.com/vllm-project/vllm/blob/main/vllm/v1/worker/gpu/cudagraph_utils.py)
+- [SGLang CUDA Graph Implementation](https://github.com/sgl-project/sglang/blob/main/python/sglang/srt/model_executor/cuda_graph_runner.py)
+
+### 8.2 xLLM Graph Mode
+
+- [xLLM CUDAGraph 实现](../../xllm/core/runtime/cuda_graph_executor_impl.h)
+- [xLLM ACLGraph 实现](../../xllm/core/runtime/acl_graph_executor_impl.h)
+- [xLLM MLUGraph 实现](../../xllm/core/runtime/mlu_graph_executor_impl.h)
+
+---
+
+**文档版本**：v1.0  
+**最后更新**：2025-01-29  
+**作者**：xLLM Team

--- a/xllm/core/common/CMakeLists.txt
+++ b/xllm/core/common/CMakeLists.txt
@@ -68,4 +68,3 @@ cc_test(
 )
 target_link_libraries(common PRIVATE OpenSSL::SSL OpenSSL::Crypto protobuf::libprotobuf)
 add_dependencies(common brpc-static)
-

--- a/xllm/core/common/global_flags.cpp
+++ b/xllm/core/common/global_flags.cpp
@@ -99,6 +99,11 @@ DEFINE_bool(enable_prefill_piecewise_graph,
             "When enabled, attention operations use eager mode while other "
             "operations are captured in CUDA graphs.");
 
+DEFINE_bool(enable_graph_vmm_pool,
+            true,
+            "Whether to enable VMM-backed CUDA graph memory pool for "
+            "multi-shape graph memory reuse.");
+
 DEFINE_int32(max_tokens_for_graph_mode,
              2048,
              "Maximum number of tokens for graph execution. "

--- a/xllm/core/common/global_flags.h
+++ b/xllm/core/common/global_flags.h
@@ -91,6 +91,8 @@ DECLARE_bool(enable_graph_mode_decode_no_padding);
 
 DECLARE_bool(enable_prefill_piecewise_graph);
 
+DECLARE_bool(enable_graph_vmm_pool);
+
 DECLARE_int32(max_tokens_for_graph_mode);
 
 DECLARE_bool(enable_chunked_prefill);

--- a/xllm/core/platform/CMakeLists.txt
+++ b/xllm/core/platform/CMakeLists.txt
@@ -13,6 +13,7 @@ cc_library(
     device.h
     vmm_api.h
     shared_vmm_allocator.h
+    vmm_torch_allocator.h
   SRCS
     stream.cpp
     device.cpp

--- a/xllm/core/platform/vmm_torch_allocator.h
+++ b/xllm/core/platform/vmm_torch_allocator.h
@@ -1,0 +1,276 @@
+/* Copyright 2026 The xLLM Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://github.com/jd-opensource/xllm/blob/main/LICENSE
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#pragma once
+
+// VMMTorchAllocator is only available for platforms using PyTorch's
+// CUDACachingAllocator interface (CUDA, ILU, ROCm).
+#if defined(USE_CUDA) || defined(USE_ILU)
+
+#include <c10/cuda/CUDACachingAllocator.h>
+#include <glog/logging.h>
+
+#include "shared_vmm_allocator.h"
+
+namespace xllm {
+
+/**
+ * @brief VMMTorchAllocator - A PyTorch-compatible allocator wrapper for
+ * SharedVMMAllocator.
+ *
+ * Only raw_alloc/raw_alloc_with_stream/raw_delete are expected to be called.
+ * Other methods are implemented to satisfy the interface but should not be
+ * called at runtime.
+ */
+class VMMTorchAllocator
+    : public c10::cuda::CUDACachingAllocator::CUDAAllocator {
+ public:
+  explicit VMMTorchAllocator(SharedVMMAllocator* vmm_allocator)
+      : vmm_allocator_(vmm_allocator) {}
+
+  ~VMMTorchAllocator() override = default;
+
+  VMMTorchAllocator(const VMMTorchAllocator&) = delete;
+  VMMTorchAllocator& operator=(const VMMTorchAllocator&) = delete;
+
+  // ============== Core allocation methods (expected to be called)
+  // ==============
+
+  void* raw_alloc(size_t nbytes) override {
+    void* ptr = vmm_allocator_->allocate(nbytes);
+    total_allocated_ += nbytes;
+    alloc_count_++;
+    VLOG(10) << "VMMTorchAllocator::raw_alloc(" << nbytes << " bytes) -> "
+             << ptr << ", total_allocated: " << total_allocated_
+             << ", alloc_count: " << alloc_count_
+             << ", current_offset: " << vmm_allocator_->current_offset()
+             << ", high_water_mark: " << vmm_allocator_->high_water_mark();
+    return ptr;
+  }
+
+  void* raw_alloc_with_stream(size_t nbytes, cudaStream_t /*stream*/) override {
+    void* ptr = vmm_allocator_->allocate(nbytes);
+    total_allocated_ += nbytes;
+    alloc_count_++;
+    VLOG(10) << "VMMTorchAllocator::raw_alloc_with_stream(" << nbytes
+             << " bytes) -> " << ptr
+             << ", total_allocated: " << total_allocated_
+             << ", alloc_count: " << alloc_count_
+             << ", current_offset: " << vmm_allocator_->current_offset()
+             << ", high_water_mark: " << vmm_allocator_->high_water_mark();
+    return ptr;
+  }
+
+  void raw_delete(void* ptr) override {
+    VLOG(10) << "VMMTorchAllocator::raw_delete(" << ptr << ")";
+    vmm_allocator_->deallocate(ptr);
+  }
+
+  // ============== c10::Allocator interface (should NOT be called)
+  // ==============
+
+  c10::DataPtr allocate(size_t n) override {
+    LOG(FATAL) << "VMMTorchAllocator::allocate() called unexpectedly!";
+    void* ptr = vmm_allocator_->allocate(n);
+    return {ptr, ptr, &raw_deleter, c10::Device(c10::kCUDA)};
+  }
+
+  void copy_data(void* dest,
+                 const void* src,
+                 std::size_t count) const override {
+    LOG(FATAL) << "VMMTorchAllocator::copy_data() called unexpectedly!";
+    cudaMemcpy(dest, src, count, cudaMemcpyDefault);
+  }
+
+  // ============== CUDAAllocator interface (should NOT be called)
+  // ==============
+
+  void init(int /*device_count*/) override {
+    LOG(FATAL) << "VMMTorchAllocator::init() called unexpectedly!";
+  }
+
+  bool initialized() override {
+    LOG(FATAL) << "VMMTorchAllocator::initialized() called unexpectedly!";
+    return vmm_allocator_->is_initialized();
+  }
+
+  std::string name() override { return "VMMTorchAllocator"; }
+
+  void emptyCache() override {
+    LOG(FATAL) << "VMMTorchAllocator::emptyCache() called unexpectedly!";
+  }
+
+  c10::CachingDeviceAllocator::DeviceStats getDeviceStats(
+      c10::DeviceIndex /*device*/) override {
+    LOG(FATAL) << "VMMTorchAllocator::getDeviceStats() called unexpectedly!";
+    return {};
+  }
+
+  void resetAccumulatedStats(c10::DeviceIndex /*device*/) override {
+    LOG(FATAL)
+        << "VMMTorchAllocator::resetAccumulatedStats() called unexpectedly!";
+  }
+
+  void resetPeakStats(c10::DeviceIndex /*device*/) override {
+    LOG(FATAL) << "VMMTorchAllocator::resetPeakStats() called unexpectedly!";
+  }
+
+  double getMemoryFraction(c10::DeviceIndex /*device*/) override {
+    LOG(FATAL) << "VMMTorchAllocator::getMemoryFraction() called unexpectedly!";
+    return 1.0;
+  }
+
+  void setMemoryFraction(double /*fraction*/,
+                         c10::DeviceIndex /*device*/) override {
+    LOG(FATAL) << "VMMTorchAllocator::setMemoryFraction() called unexpectedly!";
+  }
+
+  void enable(bool /*value*/) override {
+    LOG(FATAL) << "VMMTorchAllocator::enable() called unexpectedly!";
+  }
+
+  bool isEnabled() const override {
+    LOG(FATAL) << "VMMTorchAllocator::isEnabled() called unexpectedly!";
+    return true;
+  }
+
+  void cacheInfo(c10::DeviceIndex /*device*/, size_t* largestBlock) override {
+    LOG(FATAL) << "VMMTorchAllocator::cacheInfo() called unexpectedly!";
+    if (largestBlock) {
+      *largestBlock =
+          vmm_allocator_->reserved_size() - vmm_allocator_->current_offset();
+    }
+  }
+
+  void* getBaseAllocation(void* ptr, size_t* size) override {
+    LOG(FATAL) << "VMMTorchAllocator::getBaseAllocation() called unexpectedly!";
+    if (size) {
+      *size = vmm_allocator_->mapped_size();
+    }
+    return ptr;
+  }
+
+  void recordStream(const c10::DataPtr& /*ptr*/,
+                    c10::cuda::CUDAStream /*stream*/) override {
+    LOG(FATAL) << "VMMTorchAllocator::recordStream() called unexpectedly!";
+  }
+
+  c10::cuda::CUDACachingAllocator::SnapshotInfo snapshot() override {
+    LOG(FATAL) << "VMMTorchAllocator::snapshot() called unexpectedly!";
+    return {};
+  }
+
+  void beginAllocateToPool(
+      c10::DeviceIndex /*device*/,
+      c10::cuda::MempoolId_t /*mempool_id*/,
+      std::function<bool(cudaStream_t)> /*filter*/) override {
+    LOG(FATAL)
+        << "VMMTorchAllocator::beginAllocateToPool() called unexpectedly!";
+  }
+
+  void endAllocateToPool(c10::DeviceIndex /*device*/,
+                         c10::cuda::MempoolId_t /*mempool_id*/) override {
+    LOG(FATAL) << "VMMTorchAllocator::endAllocateToPool() called unexpectedly!";
+  }
+
+  void releasePool(c10::DeviceIndex /*device*/,
+                   c10::cuda::MempoolId_t /*mempool_id*/) override {
+    LOG(FATAL) << "VMMTorchAllocator::releasePool() called unexpectedly!";
+  }
+
+  c10::cuda::CUDACachingAllocator::ShareableHandle shareIpcHandle(
+      void* /*ptr*/) override {
+    LOG(ERROR) << "VMMTorchAllocator::shareIpcHandle() called - not supported!";
+    TORCH_CHECK(false, name(), " does not support IPC");
+    return {};
+  }
+
+  std::shared_ptr<void> getIpcDevPtr(std::string /*handle*/) override {
+    LOG(ERROR) << "VMMTorchAllocator::getIpcDevPtr() called - not supported!";
+    TORCH_CHECK(false, name(), " does not support IPC");
+    return nullptr;
+  }
+
+  void recordHistory(
+      bool /*enabled*/,
+      c10::cuda::CUDACachingAllocator::CreateContextFn /*context_recorder*/,
+      size_t /*alloc_trace_max_entries*/,
+      c10::cuda::CUDACachingAllocator::RecordContext /*when*/) override {
+    LOG(FATAL) << "VMMTorchAllocator::recordHistory() called unexpectedly!";
+  }
+
+  void attachOutOfMemoryObserver(
+      c10::cuda::CUDACachingAllocator::OutOfMemoryObserver /*observer*/)
+      override {
+    LOG(FATAL) << "VMMTorchAllocator::attachOutOfMemoryObserver() called "
+                  "unexpectedly!";
+  }
+
+  void attachAllocatorTraceTracker(
+      c10::cuda::CUDACachingAllocator::AllocatorTraceTracker /*tracker*/)
+      override {
+    LOG(FATAL) << "VMMTorchAllocator::attachAllocatorTraceTracker() called "
+                  "unexpectedly!";
+  }
+
+  void enablePeerAccess(c10::DeviceIndex /*dev*/,
+                        c10::DeviceIndex /*dev_to_access*/) override {
+    LOG(FATAL) << "VMMTorchAllocator::enablePeerAccess() called unexpectedly!";
+  }
+
+  cudaError_t memcpyAsync(void* dst,
+                          int /*dstDevice*/,
+                          const void* src,
+                          int /*srcDevice*/,
+                          size_t count,
+                          cudaStream_t stream,
+                          bool /*p2p_enabled*/) override {
+    LOG(FATAL) << "VMMTorchAllocator::memcpyAsync() called unexpectedly!";
+    return cudaMemcpyAsync(dst, src, count, cudaMemcpyDefault, stream);
+  }
+
+  std::shared_ptr<c10::cuda::CUDACachingAllocator::AllocatorState>
+  getCheckpointState(c10::DeviceIndex /*device*/,
+                     c10::cuda::MempoolId_t /*id*/) override {
+    LOG(ERROR)
+        << "VMMTorchAllocator::getCheckpointState() called - not supported!";
+    TORCH_CHECK(false, name(), " does not support checkpointing");
+    return nullptr;
+  }
+
+  c10::cuda::CUDACachingAllocator::CheckpointDelta setCheckpointPoolState(
+      c10::DeviceIndex /*device*/,
+      std::shared_ptr<c10::cuda::CUDACachingAllocator::AllocatorState> /*pps*/)
+      override {
+    LOG(ERROR) << "VMMTorchAllocator::setCheckpointPoolState() called - not "
+                  "supported!";
+    TORCH_CHECK(false, name(), " does not support checkpointing");
+    return {};
+  }
+
+ private:
+  static void raw_deleter(void* ptr) {
+    // No-op: VMM memory is not freed individually
+    (void)ptr;
+  }
+
+  SharedVMMAllocator* vmm_allocator_;
+  size_t total_allocated_ = 0;  // Total bytes allocated (for logging)
+  size_t alloc_count_ = 0;      // Number of allocations (for logging)
+};
+
+}  // namespace xllm
+
+#endif  // USE_CUDA || USE_ILU

--- a/xllm/core/runtime/CMakeLists.txt
+++ b/xllm/core/runtime/CMakeLists.txt
@@ -62,6 +62,7 @@ cc_library(
     torch
     $<$<BOOL:${USE_NPU}>:torch_npu>
     :common
+    :platform
     :model_context
     :request
     :state_dict


### PR DESCRIPTION
客户端压测脚本，模拟线上随机变化的序列长度，并发3，序列长度50-1000. 最终会capture 3000/32=100个左右graph：
```bash
python stress_test_varlen.py --dataset-path test_requests_500.json --host 127.0.0.1 --port 17983 --num-prompts 10000 --max-concurrency 3 --model /export/home/models/Qwen3-0.6B --beam-width 128 --enable-varlen --varlen-min 0.1 --varlen-max 2.0
```
当服务端不开启`--enable_graph_vmm_pool=false`, 内存占用56.75% H800的80GB显存。

<img width="1862" height="1004" alt="image" src="https://github.com/user-attachments/assets/d37e17bd-c4e6-4782-a865-18a4858fbf64" />

当服务端开启`--enable_graph_vmm_pool=true`, 内存占用14.4% H800的80GB显存。
<img width="1806" height="1005" alt="image" src="https://github.com/user-attachments/assets/4290b3df-4721-4b6a-9a57-9160d819c557" />

