### PR TITLE
feat: add rec sampler in rec pipeline.

### DIFF
--- a/xllm/core/common/global_flags.cpp
+++ b/xllm/core/common/global_flags.cpp
@@ -446,7 +446,10 @@ DEFINE_bool(enable_beam_search_kernel,
             false,
             "Whether to enable beam search kernel.");
 
-DEFINE_bool(enable_fast_sampler, false, "Whether to enable fast sampler path.");
+DEFINE_bool(
+    enable_rec_fast_sampler,
+    true,
+    "Whether to enable RecSampler fast sampling path for Rec pipelines.");
 
 DEFINE_bool(enable_topk_sorted,
             true,

--- a/xllm/core/common/global_flags.h
+++ b/xllm/core/common/global_flags.h
@@ -220,7 +220,7 @@ DECLARE_int64(buffer_size_per_seq);
 // --- beam search config ---
 DECLARE_bool(enable_beam_search_kernel);
 
-DECLARE_bool(enable_fast_sampler);
+DECLARE_bool(enable_rec_fast_sampler);
 
 DECLARE_bool(enable_topk_sorted);
 

--- a/xllm/core/common/help_formatter.h
+++ b/xllm/core/common/help_formatter.h
@@ -77,9 +77,10 @@ const OptionCategory kMtpOptions = {
 const OptionCategory kXllmServiceOptions = {"XLLM-SERVICE OPTIONS",
                                             {"etcd_addr", "rank_tablefile"}};
 
-const OptionCategory kBeamSearchOptions = {
-    "BEAM SEARCH OPTIONS",
-    {"enable_beam_search_kernel", "enable_fast_sampler", "enable_topk_sorted"}};
+const OptionCategory kBeamSearchOptions = {"BEAM SEARCH OPTIONS",
+                                           {"enable_beam_search_kernel",
+                                            "enable_rec_fast_sampler",
+                                            "enable_topk_sorted"}};
 
 const OptionCategory kOtherOptions = {
     "OTHER OPTIONS",

--- a/xllm/core/framework/sampling/CMakeLists.txt
+++ b/xllm/core/framework/sampling/CMakeLists.txt
@@ -9,6 +9,7 @@ cc_library(
     logits_utils.h
     rejection_sampler.h
     sampler.h
+    rec_sampler.h
     beam_searcher.h
     rec_constrained_decoding.h
   SRCS
@@ -16,6 +17,7 @@ cc_library(
     logits_utils.cpp
     rejection_sampler.cpp
     sampler.cpp
+    rec_sampler.cpp
     beam_searcher.cpp
     rec_constrained_decoding.cpp
   DEPS

--- a/xllm/core/framework/sampling/rec_sampler.cpp
+++ b/xllm/core/framework/sampling/rec_sampler.cpp
@@ -1,0 +1,178 @@
+/* Copyright 2026 The xLLM Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://github.com/jd-opensource/xllm/blob/main/LICENSE
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include "rec_sampler.h"
+
+#include <glog/logging.h>
+#include <torch/torch.h>
+
+#include <cstdlib>
+
+#include "common/global_flags.h"
+#include "logits_utils.h"
+#include "sampler.h"
+#if defined(USE_CUDA)
+#include "kernels/cuda/cuda_ops_api.h"
+#endif
+
+namespace xllm {
+namespace {
+
+static inline bool use_air_log_softmax_env() {
+  static const bool enabled = []() {
+    const char* v = std::getenv("XLLM_USE_AIR_LOG_SOFTMAX");
+    if (!v) {
+      return false;
+    }
+    char c = v[0];
+    return c == '1' || c == 't' || c == 'T' || c == 'y' || c == 'Y';
+  }();
+  return enabled;
+}
+
+// Check if fast path sampling can be used for multi-round pipeline.
+static inline bool can_use_fast_path(const SamplingParameters& params) {
+  return params.use_beam_search && params.logprobs &&
+         FLAGS_enable_rec_fast_sampler && params.max_top_logprobs > 0 &&
+         !params.top_p.defined() && !FLAGS_enable_qwen3_reranker &&
+         FLAGS_max_decode_rounds > 0;
+}
+
+static inline torch::Tensor log_softmax_last_dim(
+    const torch::Tensor& input,
+    const torch::Tensor& temperatures) {
+  const bool has_temps = temperatures.defined();
+#if defined(USE_CUDA)
+  if (input.is_cuda() && use_air_log_softmax_env()) {
+    return kernel::cuda::air_log_softmax_last_dim(input, temperatures);
+  }
+#endif
+
+  if (!has_temps) {
+    return torch::log_softmax(input, /*dim=*/-1, /*dtype=*/torch::kFloat32);
+  }
+
+  auto logits = input.to(torch::kFloat32);
+  auto temps = temperatures.to(torch::kFloat32).to(input.device()).unsqueeze(1);
+  temps = torch::where(temps == 0, torch::ones_like(temps), temps);
+  logits.div_(temps);
+  return torch::log_softmax(logits, /*dim=*/-1);
+}
+
+}  // namespace
+
+RecSampler::RecSampler(RecPipelineType pipeline_type)
+    : sampler_(std::make_unique<Sampler>()),
+      strategy_(create_sampling_strategy(pipeline_type, *sampler_)) {
+  LOG(INFO) << "RecSampler initialized with Sampler delegate.";
+}
+
+SampleOutput RecSampler::forward(torch::Tensor& logits,
+                                 const SamplingParameters& params) const {
+  return strategy_->forward(logits, params);
+}
+
+// --- SamplingStrategy factory ---
+
+std::unique_ptr<RecSampler::SamplingStrategy>
+RecSampler::create_sampling_strategy(RecPipelineType type,
+                                     const Sampler& sampler) {
+  switch (type) {
+    case RecPipelineType::kLlmRecMultiRoundPipeline:
+      return std::make_unique<MultiRoundFastPathSamplingStrategy>(sampler);
+    case RecPipelineType::kLlmRecDefault:
+    case RecPipelineType::kLlmRecWithMmData:
+    case RecPipelineType::kOneRecDefault:
+      return std::make_unique<DefaultSamplingStrategy>(sampler);
+    default:
+      LOG(FATAL) << "Unknown RecPipelineType: " << static_cast<int>(type);
+      __builtin_unreachable();
+  }
+}
+
+// --- DefaultSamplingStrategy ---
+
+RecSampler::DefaultSamplingStrategy::DefaultSamplingStrategy(
+    const Sampler& sampler)
+    : sampler_(sampler) {}
+
+SampleOutput RecSampler::DefaultSamplingStrategy::forward(
+    torch::Tensor& logits,
+    const SamplingParameters& params) const {
+  return sampler_.forward(logits, params);
+}
+
+// --- MultiRoundFastPathSamplingStrategy ---
+
+RecSampler::MultiRoundFastPathSamplingStrategy::
+    MultiRoundFastPathSamplingStrategy(const Sampler& sampler)
+    : sampler_(sampler) {}
+
+SampleOutput RecSampler::MultiRoundFastPathSamplingStrategy::forward(
+    torch::Tensor& logits,
+    const SamplingParameters& params) const {
+  const bool use_fast_path = can_use_fast_path(params);
+
+  if (!use_fast_path) {
+    return sampler_.forward(logits, params);
+  }
+
+  LOG_FIRST_N(INFO, 1) << "RecSampler fast path activated.";
+
+  SampleOutput output;
+
+  if (params.frequency_penalties.defined()) {
+    apply_frequency_presence_penalties(logits,
+                                       params.unique_token_ids,
+                                       params.unique_token_counts,
+                                       params.frequency_penalties,
+                                       params.presence_penalties);
+  }
+
+  if (params.repetition_penalties.defined()) {
+    apply_repetition_penalties(
+        logits, params.unique_token_ids, params.repetition_penalties);
+  }
+
+  torch::Tensor sample_logits = logits;
+  if (params.selected_token_idxes.numel() != params.sample_idxes.numel()) {
+    sample_logits = logits.index_select(/*dim=*/0, params.sample_idxes);
+  }
+
+  CHECK_EQ(sample_logits.size(0), params.do_sample.size(0));
+
+  auto [topk_values, topk_indices] =
+      sample_logits.topk(params.max_top_logprobs,
+                         /*dim=*/-1,
+                         /*largest=*/true,
+                         /*sorted=*/FLAGS_enable_topk_sorted);
+  output.top_tokens = (topk_indices.scalar_type() == torch::kLong)
+                          ? topk_indices
+                          : topk_indices.to(torch::kLong);
+
+  torch::Tensor temperatures;
+  if (params.temperatures.defined()) {
+    temperatures = params.temperatures;
+    if (params.selected_token_idxes.numel() != params.sample_idxes.numel()) {
+      temperatures = temperatures.index_select(/*dim=*/0, params.sample_idxes);
+    }
+    temperatures = temperatures.to(torch::kFloat32);
+  }
+
+  output.top_logprobs = log_softmax_last_dim(topk_values, temperatures);
+  return output;
+}
+
+}  // namespace xllm

--- a/xllm/core/framework/sampling/rec_sampler.h
+++ b/xllm/core/framework/sampling/rec_sampler.h
@@ -1,0 +1,73 @@
+/* Copyright 2026 The xLLM Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://github.com/jd-opensource/xllm/blob/main/LICENSE
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#pragma once
+#include <torch/torch.h>
+
+#include <memory>
+
+#include "common/rec_model_utils.h"
+#include "sampling_params.h"
+
+namespace xllm {
+
+class Sampler;
+
+class RecSampler {
+ public:
+  explicit RecSampler(RecPipelineType pipeline_type);
+  ~RecSampler() = default;
+
+  // logits: [batch_size, vocab_size]
+  SampleOutput forward(torch::Tensor& logits,
+                       const SamplingParameters& params) const;
+
+ private:
+  class SamplingStrategy {
+   public:
+    virtual ~SamplingStrategy() = default;
+    virtual SampleOutput forward(torch::Tensor& logits,
+                                 const SamplingParameters& params) const = 0;
+  };
+
+  class DefaultSamplingStrategy final : public SamplingStrategy {
+   public:
+    explicit DefaultSamplingStrategy(const Sampler& sampler);
+    SampleOutput forward(torch::Tensor& logits,
+                         const SamplingParameters& params) const override;
+
+   private:
+    const Sampler& sampler_;
+  };
+
+  class MultiRoundFastPathSamplingStrategy final : public SamplingStrategy {
+   public:
+    explicit MultiRoundFastPathSamplingStrategy(const Sampler& sampler);
+    SampleOutput forward(torch::Tensor& logits,
+                         const SamplingParameters& params) const override;
+
+   private:
+    const Sampler& sampler_;
+  };
+
+  static std::unique_ptr<SamplingStrategy> create_sampling_strategy(
+      RecPipelineType type,
+      const Sampler& sampler);
+
+  std::unique_ptr<Sampler> sampler_;
+  std::unique_ptr<SamplingStrategy> strategy_;
+};
+
+}  // namespace xllm

--- a/xllm/core/kernels/cuda/air_log_softmax_last_dim.cu
+++ b/xllm/core/kernels/cuda/air_log_softmax_last_dim.cu
@@ -1,0 +1,177 @@
+/* Copyright 2026 The xLLM Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://github.com/jd-opensource/xllm/blob/main/LICENSE
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ==============================================================================*/
+
+#include <ATen/cuda/CUDAContext.h>
+#include <c10/cuda/CUDAException.h>
+#include <c10/cuda/CUDAGuard.h>
+#include <cuda_runtime.h>
+#include <glog/logging.h>
+
+#include <algorithm>
+#include <cstdint>
+#include <cub/block/block_reduce.cuh>
+#include <limits>
+
+#include "cuda_ops_api.h"
+#include "utils.h"
+
+namespace xllm::kernel::cuda {
+
+namespace {
+
+template <typename scalar_t, int kThreads>
+__global__ void log_softmax_last_dim_kernel(const scalar_t* __restrict__ input,
+                                            const float* __restrict__ temps,
+                                            bool has_temps,
+                                            float* __restrict__ output,
+                                            int32_t k,
+                                            int64_t stride) {
+  const int32_t row = static_cast<int32_t>(blockIdx.x);
+  const int64_t base = static_cast<int64_t>(row) * stride;
+
+  using BlockReduce = cub::BlockReduce<float, kThreads>;
+  __shared__ typename BlockReduce::TempStorage reduce_storage;
+  // NOTE: cub::BlockReduce::Reduce/Sum only returns valid result to thread 0.
+  // Use shared variables to broadcast reduction results to all threads.
+  __shared__ float s_row_max;
+  __shared__ float s_log_denom;
+  extern __shared__ float s_data[];
+
+  float inv_temp = 1.0f;
+  if (has_temps) {
+    float t = temps[row];
+    if (t == 0.0f) {
+      t = 1.0f;
+    }
+    inv_temp = 1.0f / t;
+  }
+
+  // Load data into shared memory with temperature scaling.
+  for (int32_t col = threadIdx.x; col < k; col += blockDim.x) {
+    s_data[col] = static_cast<float>(input[base + col]) * inv_temp;
+  }
+  __syncthreads();
+
+  float thread_max = -std::numeric_limits<float>::infinity();
+  for (int32_t col = threadIdx.x; col < k; col += blockDim.x) {
+    thread_max = s_data[col] > thread_max ? s_data[col] : thread_max;
+  }
+  float row_max_local =
+      BlockReduce(reduce_storage).Reduce(thread_max, cub::Max());
+  if (threadIdx.x == 0) {
+    s_row_max = row_max_local;
+  }
+  __syncthreads();
+
+  float thread_sum = 0.0f;
+  for (int32_t col = threadIdx.x; col < k; col += blockDim.x) {
+    thread_sum += expf(s_data[col] - s_row_max);
+  }
+  float row_sum_local = BlockReduce(reduce_storage).Sum(thread_sum);
+  if (threadIdx.x == 0) {
+    s_log_denom = logf(row_sum_local) + s_row_max;
+  }
+  __syncthreads();
+
+  for (int32_t col = threadIdx.x; col < k; col += blockDim.x) {
+    output[base + col] = s_data[col] - s_log_denom;
+  }
+}
+
+}  // namespace
+
+torch::Tensor air_log_softmax_last_dim(const torch::Tensor& input,
+                                       const torch::Tensor& temperatures) {
+  CHECK(input.is_cuda()) << "air_log_softmax_last_dim: input must be CUDA";
+  CHECK(input.dim() == 2)
+      << "air_log_softmax_last_dim: input must be 2D [B, K]";
+
+  const int64_t batch64 = input.size(0);
+  const int64_t k64 = input.size(1);
+  CHECK(batch64 >= 0 && batch64 <= INT32_MAX)
+      << "air_log_softmax_last_dim: batch too large";
+  CHECK(k64 > 0 && k64 <= INT32_MAX) << "air_log_softmax_last_dim: k too large";
+
+  const int32_t batch = static_cast<int32_t>(batch64);
+  const int32_t k = static_cast<int32_t>(k64);
+
+  if (batch == 0) {
+    return torch::empty(
+        {batch64, k64},
+        torch::TensorOptions().dtype(torch::kFloat32).device(input.device()));
+  }
+
+  bool has_temps = temperatures.defined();
+  torch::Tensor temps = temperatures;
+  if (has_temps) {
+    CHECK(temps.is_cuda())
+        << "air_log_softmax_last_dim: temperatures must be CUDA";
+    CHECK(temps.dim() == 1)
+        << "air_log_softmax_last_dim: temperatures must be 1D [B]";
+    CHECK(temps.size(0) == batch64)
+        << "air_log_softmax_last_dim: temperatures size mismatch";
+    CHECK(temps.scalar_type() == torch::kFloat32)
+        << "air_log_softmax_last_dim: temperatures must be float32";
+    temps = temps.contiguous();
+  }
+
+  c10::cuda::CUDAGuard device_guard(input.device());
+  auto in = input.contiguous();
+  auto out = torch::empty(
+      {batch64, k64},
+      torch::TensorOptions().dtype(torch::kFloat32).device(input.device()));
+
+  const int64_t stride = k64;
+  const cudaStream_t stream = at::cuda::getCurrentCUDAStream();
+
+  constexpr int kThreads = 256;
+  dim3 grid(batch);
+  dim3 block(std::min<int32_t>(kThreads, 1024));
+  const size_t shared_mem_bytes = k * sizeof(float);
+
+  // Guard against user-controlled k exceeding device shared memory limit.
+  // The kernel uses both static shared memory (BlockReduce::TempStorage for
+  // cub reductions) and dynamic shared memory (extern __shared__ s_data[] for
+  // input data). These occupy separate regions within the same per-block shared
+  // memory pool, so the guard must account for both.
+  using BlockReduce = cub::BlockReduce<float, kThreads>;
+  constexpr size_t kStaticSmem =
+      sizeof(typename BlockReduce::TempStorage) + 2 * sizeof(float);
+  const size_t total_shared_bytes = shared_mem_bytes + kStaticSmem;
+
+  // Use ATen's per-device cached properties to avoid repeated driver queries
+  // and correctly handle multi-GPU environments.
+  const int max_smem =
+      at::cuda::getCurrentDeviceProperties()->sharedMemPerBlock;
+  CHECK(total_shared_bytes <= static_cast<size_t>(max_smem))
+      << "air_log_softmax_last_dim: k (" << k << ") requires "
+      << total_shared_bytes << " bytes shared memory "
+      << "(dynamic=" << shared_mem_bytes << " + static=" << kStaticSmem
+      << "), exceeding device limit (" << max_smem << " bytes)";
+
+  DISPATCH_FLOATING_TYPES(in.scalar_type(), "air_log_softmax_last_dim", [&] {
+    const scalar_t* in_ptr = in.data_ptr<scalar_t>();
+    const float* t_ptr = has_temps ? temps.data_ptr<float>() : nullptr;
+    float* out_ptr = out.data_ptr<float>();
+    log_softmax_last_dim_kernel<scalar_t, kThreads>
+        <<<grid, block, shared_mem_bytes, stream>>>(
+            in_ptr, t_ptr, has_temps, out_ptr, k, stride);
+  });
+
+  C10_CUDA_KERNEL_LAUNCH_CHECK();
+  return out;
+}
+
+}  // namespace xllm::kernel::cuda

--- a/xllm/core/kernels/cuda/cuda_ops_api.h
+++ b/xllm/core/kernels/cuda/cuda_ops_api.h
@@ -110,4 +110,7 @@ std::pair<torch::Tensor, torch::Tensor> compute_topk_general(
     uint32_t k,
     torch::Device device);
 
+torch::Tensor air_log_softmax_last_dim(const torch::Tensor& input,
+                                       const torch::Tensor& temperatures);
+
 }  // namespace xllm::kernel::cuda

--- a/xllm/core/runtime/rec_worker_impl.h
+++ b/xllm/core/runtime/rec_worker_impl.h
@@ -29,6 +29,8 @@ limitations under the License.
 
 namespace xllm {
 
+class RecSampler;
+
 class RecWorkerImpl : public LLMWorkerImpl {
  public:
   RecWorkerImpl(const ParallelArgs& parallel_args,
@@ -231,6 +233,7 @@ class RecWorkerImpl : public LLMWorkerImpl {
     torch::Tensor cached_current_round_tensor_;
 
     RecWorkerImpl& worker_;
+    std::unique_ptr<RecSampler> rec_sampler_;
 
     // for async scheduler
     ThreadPool threadpool_;


### PR DESCRIPTION
  # feat: Add RecSampler with Strategy Pattern for Pipeline-Aware Sampling

  This PR introduces **RecSampler**, a pipeline-aware sampling component that uses the Strategy pattern to dispatch different sampling paths based on `RecPipelineType`. It also adds an optimized CUDA kernel for log-softmax computation used in the fast sampling path.

  ## Background

  The existing `LlmRecMultiRoundPipeline` directly called the generic `Sampler` for all sampling operations. As different Rec pipelines (LlmRec, OneRec, MultiRound) have distinct sampling requirements, a unified entry point with pipeline-specific dispatch was needed.
  RecSampler fills this role using composition-delegation, keeping the generic `Sampler` as a fallback while enabling optimized fast paths for specific pipelines.

  ## What's Added

  ### 1. CUDA Kernel: `air_log_softmax_last_dim`
  - Optimized log-softmax kernel for the last dimension with optional temperature scaling.
  - Enabled via environment variable `XLLM_USE_AIR_LOG_SOFTMAX`.
  - Falls back to `torch::log_softmax` when disabled or on CPU.

  ### 2. RecSampler with Strategy Pattern
  - **`RecSampler`**: Pipeline-aware sampling entry point, constructed with `RecPipelineType`.
  - **`SamplingStrategy`** interface with two implementations:
    - **`MultiRoundFastPathSamplingStrategy`**: Optimized path for `kLlmRecMultiRoundPipeline` — skips unnecessary sampling logic, directly computes topk + log_softmax.
    - **`DefaultSamplingStrategy`**: Delegates to the standard `Sampler` for all other pipelines.
  - Factory method `create_sampling_strategy()` for clean dispatch.

  ### 3. Pipeline Integration
  - `LlmRecMultiRoundPipeline` now owns a `RecSampler` instance (constructed with `kLlmRecMultiRoundPipeline`).
  - Replaces direct `worker_.sampler_->forward()` call with `rec_sampler_->forward()`.

  ### 4. Flag Rename
  - `FLAGS_enable_fast_sampler` → `FLAGS_enable_rec_fast_sampler` for clearer semantics (Rec-specific, not generic).
  - Default value: `true`.
  - Remains in `BEAM SEARCH OPTIONS` help category.

  ## Architecture Overview

  ### Strategy Dispatch

```
RecSampler(pipeline_type)
|
+-- create_sampling_strategy(type)
|   |
|   +-- kLlmRecMultiRoundPipeline --> MultiRoundFastPathSamplingStrategy
|   +-- kLlmRecDefault            --> DefaultSamplingStrategy
|   +-- kLlmRecWithMmData         --> DefaultSamplingStrategy
|   +-- kOneRecDefault             --> DefaultSamplingStrategy
|
+-- forward(logits, params)
    |
    +-- strategy_->forward(logits, params)
```


  ### Fast Path Activation Conditions

  The `MultiRoundFastPathSamplingStrategy` activates its optimized path when ALL conditions are met:
  - `params.use_beam_search == true`
  - `params.logprobs == true`
  - `FLAGS_enable_rec_fast_sampler == true`
  - `params.max_top_logprobs > 0`
  - `!params.top_p.defined()`
  - `!FLAGS_enable_qwen3_reranker`
  - `FLAGS_max_decode_rounds > 0`

Otherwise, it falls back to the standard `Sampler`.

  ## Files Changed

  | File | Changes |
  |------|---------|
  | `xllm/core/kernels/cuda/air_log_softmax_last_dim.cu` | New: CUDA kernel implementation |
  | `xllm/core/kernels/cuda/air_log_softmax_last_dim.h` | New: Kernel header |
  | `xllm/core/framework/sampling/rec_sampler.cpp` | New: RecSampler + Strategy implementations |
  | `xllm/core/framework/sampling/rec_sampler.h` | New: RecSampler + Strategy class declarations |
  | `xllm/core/framework/sampling/CMakeLists.txt` | Add rec_sampler to build |
  | `xllm/core/common/global_flags.cpp` | Rename flag to `enable_rec_fast_sampler`, default `true` |
  | `xllm/core/common/global_flags.h` | Rename flag declaration |
  | `xllm/core/common/help_formatter.h` | Update help category string |
  | `xllm/core/runtime/rec_worker_impl.cpp` | Integrate RecSampler into MultiRoundPipeline |
  | `xllm/core/runtime/rec_worker_impl.h` | Add RecSampler forward declaration and member |
  | `third_party/torch_npu_ops` | Submodule update |
  | `third_party/xllm_ops` | Submodule update |

  ## Design Decisions

  1. **Strategy pattern over if-else**: Extensible for future pipeline types (e.g., OneRec) without modifying existing code (Open-Closed Principle).
  2. **Composition-delegation**: RecSampler owns a `Sampler` instance rather than inheriting from it, avoiding tight coupling.
  3. **Flag rename**: `enable_rec_fast_sampler` makes it explicit this is Rec-pipeline-specific, not a generic sampler optimization.

  ## Testing

  - [x] Build passes
  - [x] Runtime testing with `--enable_rec_fast_sampler=true --max_decode_rounds=3 --beam_width=128`