### PR TITLE
bugfix: fix REC multi-round CUDA graph accuracy crash.

### DIFF
--- a/xllm/core/runtime/executor_impl_factory.cpp
+++ b/xllm/core/runtime/executor_impl_factory.cpp
@@ -45,6 +45,9 @@ std::unique_ptr<ExecutorImpl> ExecutorImplFactory::create_executor_impl(
     const torch::Device& device,
     const runtime::Options& options) {
   std::string backend = options.backend();
+  if (backend == "rec") {
+    backend = "llm";
+  }
   if (FLAGS_enable_graph) {
     backend = Device::type_str();
     LOG(INFO) << "Creating Graph Executor for " << backend << " device";


### PR DESCRIPTION
This PR fixes an accuracy mismatch in REC multi-round decode when enable_graph=true.

  Root cause:

  - decoder_reshape_and_cache assumed block_table is contiguous and read block_id with a stride-1 access pattern.
  - In CUDA graph replay, block_table may come from a sliced persistent tensor with non-unit stride.
  - This caused incorrect block_id reads, wrong KV cache writes, and decode divergence.

  Fix:

  - Update decoder_reshape_and_cache to read block_table using its actual stride (stride(0)), not a contiguous assumption.
  - Keep the kernel path compatible with both contiguous and non-contiguous block_table layouts.