### PR TITLE
feat: support in-batch prefix caching.

### DIFF
--- a/xllm/core/framework/block/block_manager_impl.cpp
+++ b/xllm/core/framework/block/block_manager_impl.cpp
@@ -68,8 +68,22 @@ std::vector<Block> BlockManagerImpl::allocate(size_t num_blocks) {
 void BlockManagerImpl::deallocate(const Slice<Block>& blocks) {
   if (options_.enable_prefix_cache()) {
     for (const auto& block : blocks) {
-      // the block is not shared by other sequence
-      if (block.is_valid() && block.ref_count() <= 2) {
+      if (!block.is_valid()) {
+        continue;
+      }
+      const uint32_t ref_count = block.ref_count();
+      // A block should reduce used-count when this release removes the last
+      // sequence-owned reference:
+      // - ref_count==1: only held by current sequence.
+      // - ref_count==2 && in prefix cache: held by current sequence + cache.
+      // For in-batch shared blocks without cache entry, ref_count can also be 2
+      // ("provider sequence + consumer sequence"). In that case another
+      // sequence still owns the block, so num_used_blocks_ must not be
+      // decremented yet.
+      const bool should_decrease_used =
+          (ref_count == 1) || (ref_count == 2 && prefix_cache_ != nullptr &&
+                               prefix_cache_->contains_block_id(block.id()));
+      if (should_decrease_used) {
         if (num_used_blocks_ == 0) {
           LOG(ERROR) << "num_used_blocks_==0 cannot fetch_sub for id:"
                      << block.id()

--- a/xllm/core/framework/prefix_cache/CMakeLists.txt
+++ b/xllm/core/framework/prefix_cache/CMakeLists.txt
@@ -7,10 +7,12 @@ cc_library(
     prefix_cache
   HDRS
     prefix_cache.h
+    in_batch_prefix_cache.h
     prefix_cache_with_upload.h
     prefix_cache_factory.h
   SRCS 
     prefix_cache.cpp
+    in_batch_prefix_cache.cpp
     prefix_cache_with_upload.cpp
     prefix_cache_factory.cpp
   DEPS
@@ -30,6 +32,7 @@ cc_test(
     prefix_test
   SRCS
     prefix_cache_test.cpp
+    in_batch_prefix_cache_test.cpp
   DEPS
     :flags
     :kv_cache

--- a/xllm/core/framework/prefix_cache/in_batch_prefix_cache.cpp
+++ b/xllm/core/framework/prefix_cache/in_batch_prefix_cache.cpp
@@ -1,0 +1,254 @@
+/* Copyright 2026 The xLLM Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://github.com/jd-opensource/xllm/blob/main/LICENSE
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include "framework/prefix_cache/in_batch_prefix_cache.h"
+
+#include <glog/logging.h>
+
+#include <algorithm>
+#include <cstring>
+#include <vector>
+
+#include "framework/prefix_cache/prefix_cache.h"
+
+namespace xllm {
+
+namespace {
+
+bool is_same_hash(const uint8_t* lhs, const XXH3Key& rhs) {
+  return std::memcmp(lhs, rhs.data, XXH3_128BITS_HASH_VALUE_LEN) == 0;
+}
+
+size_t compute_step_local_block_hashes(Sequence* sequence,
+                                       size_t block_size,
+                                       size_t start_block_index,
+                                       std::vector<XXH3Key>* block_hashes) {
+  if (sequence == nullptr || block_hashes == nullptr || block_size == 0) {
+    return 0;
+  }
+
+  const size_t full_blocks = sequence->num_tokens() / block_size;
+  if (full_blocks <= start_block_index) {
+    block_hashes->clear();
+    return 0;
+  }
+
+  block_hashes->clear();
+  block_hashes->reserve(full_blocks - start_block_index);
+
+  XXH3Key rolling_hash;
+  const auto kv_blocks = sequence->kv_state().kv_blocks();
+  if (start_block_index > 0) {
+    if (kv_blocks.size() < start_block_index) {
+      return 0;
+    }
+    rolling_hash.set(
+        kv_blocks[start_block_index - 1].get_immutable_hash_value());
+  }
+
+  const auto tokens = sequence->tokens();
+  for (size_t block_index = start_block_index; block_index < full_blocks;
+       ++block_index) {
+    XXH3Key current_hash;
+    const auto token_block =
+        tokens.slice(block_index * block_size, (block_index + 1) * block_size);
+    if (block_index == 0) {
+      xxh3_128bits_hash(nullptr, token_block, current_hash.data);
+    } else {
+      xxh3_128bits_hash(rolling_hash.data, token_block, current_hash.data);
+    }
+    block_hashes->push_back(current_hash);
+    rolling_hash = current_hash;
+  }
+
+  return full_blocks;
+}
+
+}  // namespace
+
+size_t InBatchPrefixCacheContext::LookupKeyHash::operator()(
+    const LookupKey& key) const {
+  size_t hash_value = std::hash<size_t>()(key.block_index);
+  hash_value ^= FixedStringKeyHash{}(key.hash) + 0x9e3779b97f4a7c15ULL +
+                (hash_value << 6) + (hash_value >> 2);
+  return hash_value;
+}
+
+bool InBatchPrefixCacheContext::LookupKeyEqual::operator()(
+    const LookupKey& lhs,
+    const LookupKey& rhs) const {
+  return lhs.block_index == rhs.block_index &&
+         FixedStringKeyEqual{}(lhs.hash, rhs.hash);
+}
+
+void InBatchPrefixCacheContext::try_match(Sequence* sequence,
+                                          size_t block_size) {
+  if (sequence == nullptr || providers_.empty() || block_size == 0 ||
+      !sequence->is_prefill_stage() || sequence->num_tokens() < block_size) {
+    return;
+  }
+
+  const size_t existing_full_blocks =
+      sequence->kv_state().kv_cache_tokens_num() / block_size;
+  const size_t full_blocks = sequence->num_tokens() / block_size;
+  if (full_blocks <= existing_full_blocks) {
+    return;
+  }
+
+  std::vector<XXH3Key> consumer_hashes;
+  if (compute_step_local_block_hashes(
+          sequence, block_size, existing_full_blocks, &consumer_hashes) == 0 ||
+      consumer_hashes.empty()) {
+    return;
+  }
+
+  LookupKey lookup_key;
+  lookup_key.block_index = existing_full_blocks;
+  lookup_key.hash = consumer_hashes.front();
+
+  const auto provider_iter = provider_index_.find(lookup_key);
+  if (provider_iter == provider_index_.end()) {
+    return;
+  }
+
+  const int32_t preferred_dp_rank = sequence->dp_rank();
+  size_t best_blocks = existing_full_blocks;
+  const Provider* best_provider = nullptr;
+
+  for (size_t provider_index : provider_iter->second) {
+    CHECK_LT(provider_index, providers_.size());
+    const auto& provider = providers_[provider_index];
+    if (provider.sequence == nullptr || provider.sequence == sequence ||
+        provider.available_full_blocks <= existing_full_blocks) {
+      continue;
+    }
+    if (preferred_dp_rank >= 0 && preferred_dp_rank != provider.dp_rank) {
+      continue;
+    }
+
+    const auto provider_blocks = provider.sequence->kv_state().kv_blocks();
+    if (provider_blocks.size() < provider.available_full_blocks) {
+      continue;
+    }
+
+    size_t matched_blocks = existing_full_blocks;
+    while (matched_blocks < full_blocks &&
+           matched_blocks < provider.available_full_blocks) {
+      const size_t consumer_hash_index = matched_blocks - existing_full_blocks;
+      if (!is_same_hash(
+              provider_blocks[matched_blocks].get_immutable_hash_value(),
+              consumer_hashes[consumer_hash_index])) {
+        break;
+      }
+      ++matched_blocks;
+    }
+
+    if (matched_blocks > best_blocks) {
+      best_blocks = matched_blocks;
+      best_provider = &provider;
+    }
+  }
+
+  if (best_provider == nullptr || best_blocks == 0) {
+    return;
+  }
+
+  const int32_t consumer_seq_id = sequence->seq_id();
+  const int32_t provider_seq_id = best_provider->sequence->seq_id();
+  const int32_t provider_dp_rank = best_provider->dp_rank;
+  const size_t shared_blocks_before =
+      sequence->kv_state().shared_kv_blocks_num();
+
+  if (preferred_dp_rank < 0) {
+    sequence->set_dp_rank(best_provider->dp_rank);
+  }
+
+  const auto provider_blocks = best_provider->sequence->kv_state().kv_blocks();
+  if (provider_blocks.size() < best_blocks) {
+    return;
+  }
+
+  std::vector<Block> shared_blocks;
+  shared_blocks.reserve(best_blocks);
+  for (size_t i = 0; i < best_blocks; ++i) {
+    shared_blocks.emplace_back(provider_blocks[i]);
+  }
+  sequence->add_shared_kv_blocks(std::move(shared_blocks));
+
+  LOG(INFO) << "[in_batch_prefix_cache][matched]"
+            << " consumer_seq_id=" << consumer_seq_id
+            << " provider_seq_id=" << provider_seq_id
+            << " matched_blocks=" << best_blocks
+            << " shared_blocks_before=" << shared_blocks_before
+            << " shared_blocks_after="
+            << sequence->kv_state().shared_kv_blocks_num()
+            << " consumer_dp_rank_before=" << preferred_dp_rank
+            << " consumer_dp_rank_after=" << sequence->dp_rank()
+            << " provider_dp_rank=" << provider_dp_rank
+            << " block_size=" << block_size;
+}
+
+void InBatchPrefixCacheContext::register_provider(
+    Sequence* sequence,
+    size_t block_size,
+    size_t max_handle_num_tokens) {
+  if (sequence == nullptr || block_size == 0 || !sequence->is_prefill_stage()) {
+    return;
+  }
+
+  size_t available_full_blocks = max_handle_num_tokens / block_size;
+  if (available_full_blocks == 0) {
+    return;
+  }
+  available_full_blocks =
+      std::min(available_full_blocks, sequence->kv_state().num_kv_blocks());
+
+  auto* mutable_blocks = sequence->kv_state().mutable_kv_blocks();
+  if (mutable_blocks == nullptr || mutable_blocks->empty()) {
+    return;
+  }
+  const size_t existed_shared_blocks_num = std::min(
+      sequence->kv_state().shared_kv_blocks_num(), available_full_blocks);
+  const uint32_t hashed_full_blocks = PrefixCache::compute_hash_keys(
+      sequence->tokens(), *mutable_blocks, existed_shared_blocks_num);
+  available_full_blocks =
+      std::min<size_t>(available_full_blocks, hashed_full_blocks);
+  if (available_full_blocks == 0 || sequence->dp_rank() < 0) {
+    return;
+  }
+
+  const size_t provider_index = providers_.size();
+  providers_.push_back({sequence, sequence->dp_rank(), available_full_blocks});
+
+  const auto blocks = sequence->kv_state().kv_blocks();
+  for (size_t block_index = 0; block_index < available_full_blocks;
+       ++block_index) {
+    LookupKey lookup_key;
+    lookup_key.block_index = block_index;
+    lookup_key.hash.set(blocks[block_index].get_immutable_hash_value());
+    provider_index_[lookup_key].push_back(provider_index);
+  }
+
+  LOG(INFO) << "[in_batch_prefix_cache][register_provider]"
+            << " seq_id=" << sequence->seq_id()
+            << " dp_rank=" << sequence->dp_rank()
+            << " max_handle_num_tokens=" << max_handle_num_tokens
+            << " hashed_full_blocks=" << hashed_full_blocks
+            << " available_full_blocks=" << available_full_blocks
+            << " existed_shared_blocks_num=" << existed_shared_blocks_num
+            << " block_size=" << block_size;
+}
+
+}  // namespace xllm

--- a/xllm/core/framework/prefix_cache/in_batch_prefix_cache.h
+++ b/xllm/core/framework/prefix_cache/in_batch_prefix_cache.h
@@ -1,0 +1,63 @@
+/* Copyright 2026 The xLLM Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://github.com/jd-opensource/xllm/blob/main/LICENSE
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+#include <unordered_map>
+#include <vector>
+
+#include "framework/request/sequence.h"
+#include "util/hash_util.h"
+
+namespace xllm {
+
+class InBatchPrefixCacheContext final {
+ public:
+  void try_match(Sequence* sequence, size_t block_size);
+  void register_provider(Sequence* sequence,
+                         size_t block_size,
+                         size_t max_handle_num_tokens);
+
+ private:
+  struct Provider {
+    Sequence* sequence = nullptr;
+    int32_t dp_rank = -1;
+    size_t available_full_blocks = 0;
+  };
+
+  struct LookupKey {
+    size_t block_index = 0;
+    XXH3Key hash;
+  };
+
+  struct LookupKeyHash {
+    size_t operator()(const LookupKey& key) const;
+  };
+
+  struct LookupKeyEqual {
+    bool operator()(const LookupKey& lhs, const LookupKey& rhs) const;
+  };
+
+  std::vector<Provider> providers_;
+  std::unordered_map<LookupKey,
+                     std::vector<size_t>,
+                     LookupKeyHash,
+                     LookupKeyEqual>
+      provider_index_;
+};
+
+}  // namespace xllm

--- a/xllm/core/framework/prefix_cache/in_batch_prefix_cache_test.cpp
+++ b/xllm/core/framework/prefix_cache/in_batch_prefix_cache_test.cpp
@@ -1,0 +1,199 @@
+/* Copyright 2026 The xLLM Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://github.com/jd-opensource/xllm/blob/main/LICENSE
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include "framework/prefix_cache/in_batch_prefix_cache.h"
+
+#include <gtest/gtest.h>
+
+#include <cstdint>
+#include <memory>
+#include <string>
+#include <vector>
+
+#include "framework/block/block_manager_impl.h"
+#include "framework/prefix_cache/prefix_cache.h"
+#include "framework/request/request.h"
+
+namespace xllm {
+
+namespace {
+
+constexpr int32_t kBlockSize = 16;
+
+std::vector<int32_t> make_block_prompt(
+    const std::initializer_list<int32_t>& block_tokens) {
+  std::vector<int32_t> prompt;
+  prompt.reserve(block_tokens.size() * kBlockSize);
+  for (int32_t token_id : block_tokens) {
+    prompt.insert(prompt.end(), kBlockSize, token_id);
+  }
+  return prompt;
+}
+
+std::shared_ptr<Request> make_request(const std::vector<int32_t>& prompt,
+                                      const std::string& request_id) {
+  RequestSamplingParam sampling_param;
+  SchedulerParam scheduler_param;
+
+  StoppingChecker stopping_checker;
+  stopping_checker.set_max_generated_tokens(8);
+  stopping_checker.set_max_context_len(
+      static_cast<int32_t>(prompt.size()) + 64);
+  stopping_checker.set_ignore_eos(true);
+
+  RequestState request_state("x",
+                             prompt,
+                             sampling_param,
+                             scheduler_param,
+                             stopping_checker,
+                             prompt.size() + 128,
+                             1,
+                             1,
+                             false,
+                             false,
+                             false,
+                             false,
+                             false,
+                             nullptr,
+                             nullptr);
+  return std::make_shared<Request>(
+      request_id, request_id, request_id, std::move(request_state), request_id);
+}
+
+Sequence* get_sequence(const std::shared_ptr<Request>& request) {
+  return request->sequences().front().get();
+}
+
+void allocate_prompt_blocks(Sequence* sequence, BlockManagerImpl* manager) {
+  ASSERT_NE(sequence, nullptr);
+  ASSERT_NE(manager, nullptr);
+  ASSERT_EQ(sequence->num_tokens() % kBlockSize, 0UL);
+  sequence->add_kv_blocks(manager->allocate(sequence->num_tokens() / kBlockSize));
+}
+
+void seed_consumer_prefix(Sequence* sequence,
+                          size_t cached_full_blocks,
+                          BlockManagerImpl* manager) {
+  ASSERT_NE(sequence, nullptr);
+  ASSERT_NE(manager, nullptr);
+  ASSERT_EQ(sequence->num_tokens() % kBlockSize, 0UL);
+  ASSERT_GT(cached_full_blocks, 0UL);
+  sequence->add_kv_blocks(manager->allocate(cached_full_blocks));
+  auto* blocks = sequence->kv_state().mutable_kv_blocks();
+  ASSERT_NE(blocks, nullptr);
+  ASSERT_EQ(PrefixCache::compute_hash_keys(sequence->tokens(), *blocks),
+            cached_full_blocks);
+  sequence->kv_state().set_kv_cache_tokens_num(cached_full_blocks * kBlockSize);
+}
+
+}  // namespace
+
+TEST(InBatchPrefixCacheContextTest, ChoosesLongestContinuousMatch) {
+  BlockManager::Options options;
+  options.num_blocks(64).block_size(kBlockSize);
+  BlockManagerImpl block_manager(options);
+  InBatchPrefixCacheContext context;
+
+  auto short_provider_request =
+      make_request(make_block_prompt({11, 22}), "short_provider");
+  auto long_provider_request =
+      make_request(make_block_prompt({11, 22, 33}), "long_provider");
+  auto consumer_request =
+      make_request(make_block_prompt({11, 22, 33, 44}), "consumer");
+
+  Sequence* short_provider = get_sequence(short_provider_request);
+  Sequence* long_provider = get_sequence(long_provider_request);
+  Sequence* consumer = get_sequence(consumer_request);
+
+  allocate_prompt_blocks(short_provider, &block_manager);
+  allocate_prompt_blocks(long_provider, &block_manager);
+  seed_consumer_prefix(consumer, /*cached_full_blocks=*/1, &block_manager);
+
+  short_provider->set_dp_rank(0);
+  long_provider->set_dp_rank(0);
+
+  context.register_provider(
+      short_provider, kBlockSize, short_provider->num_tokens());
+  context.register_provider(long_provider, kBlockSize, long_provider->num_tokens());
+  context.try_match(consumer, kBlockSize);
+
+  ASSERT_EQ(consumer->dp_rank(), 0);
+  ASSERT_EQ(consumer->kv_state().shared_kv_blocks_num(), 3UL);
+  ASSERT_EQ(consumer->kv_state().kv_cache_tokens_num(), 3 * kBlockSize);
+  ASSERT_EQ(consumer->kv_state().num_kv_blocks(), 3UL);
+
+  for (size_t i = 0; i < 3; ++i) {
+    EXPECT_EQ(consumer->kv_state().kv_blocks()[i].id(),
+              long_provider->kv_state().kv_blocks()[i].id());
+  }
+}
+
+TEST(InBatchPrefixCacheContextTest, NoHitLeavesConsumerStateUntouched) {
+  BlockManager::Options options;
+  options.num_blocks(64).block_size(kBlockSize);
+  BlockManagerImpl block_manager(options);
+  InBatchPrefixCacheContext context;
+
+  auto provider_request =
+      make_request(make_block_prompt({11, 99}), "provider");
+  auto consumer_request =
+      make_request(make_block_prompt({11, 22, 33}), "consumer");
+
+  Sequence* provider = get_sequence(provider_request);
+  Sequence* consumer = get_sequence(consumer_request);
+
+  allocate_prompt_blocks(provider, &block_manager);
+  seed_consumer_prefix(consumer, /*cached_full_blocks=*/1, &block_manager);
+  provider->set_dp_rank(0);
+
+  const auto original_block_id = consumer->kv_state().kv_blocks()[0].id();
+  context.register_provider(provider, kBlockSize, provider->num_tokens());
+  context.try_match(consumer, kBlockSize);
+
+  EXPECT_EQ(consumer->dp_rank(), -1);
+  ASSERT_EQ(consumer->kv_state().num_kv_blocks(), 1UL);
+  EXPECT_EQ(consumer->kv_state().shared_kv_blocks_num(), 0UL);
+  EXPECT_EQ(consumer->kv_state().kv_cache_tokens_num(), 1 * kBlockSize);
+  EXPECT_EQ(consumer->kv_state().kv_blocks()[0].id(), original_block_id);
+}
+
+TEST(InBatchPrefixCacheContextTest, DoesNotMatchAcrossDpRanks) {
+  BlockManager::Options options;
+  options.num_blocks(64).block_size(kBlockSize);
+  BlockManagerImpl block_manager(options);
+  InBatchPrefixCacheContext context;
+
+  auto provider_request =
+      make_request(make_block_prompt({11, 22, 33}), "provider");
+  auto consumer_request =
+      make_request(make_block_prompt({11, 22, 33, 44}), "consumer");
+
+  Sequence* provider = get_sequence(provider_request);
+  Sequence* consumer = get_sequence(consumer_request);
+
+  allocate_prompt_blocks(provider, &block_manager);
+  provider->set_dp_rank(0);
+  consumer->set_dp_rank(1);
+
+  context.register_provider(provider, kBlockSize, provider->num_tokens());
+  context.try_match(consumer, kBlockSize);
+
+  EXPECT_EQ(consumer->dp_rank(), 1);
+  EXPECT_EQ(consumer->kv_state().shared_kv_blocks_num(), 0UL);
+  EXPECT_EQ(consumer->kv_state().kv_cache_tokens_num(), 0UL);
+  EXPECT_EQ(consumer->kv_state().num_kv_blocks(), 0UL);
+}
+
+}  // namespace xllm

--- a/xllm/core/framework/prefix_cache/prefix_cache.cpp
+++ b/xllm/core/framework/prefix_cache/prefix_cache.cpp
@@ -193,6 +193,7 @@ size_t PrefixCache::insert(const Slice<int32_t>& token_ids,
       node_list.push_front(new_node);
 
       cached_blocks_.emplace(std::make_pair(token_hash_key, new_node));
+      cached_block_id_refs_[new_node->block.id()]++;
 
       num_blocks_++;
 
@@ -238,6 +239,7 @@ size_t PrefixCache::insert(Slice<Block>& blocks,
       node_list.push_front(new_node);
 
       cached_blocks_.emplace(std::make_pair(token_hash_key, new_node));
+      cached_block_id_refs_[new_node->block.id()]++;
 
       num_blocks_++;
 
@@ -277,8 +279,19 @@ size_t PrefixCache::evict(size_t n_blocks, std::vector<XXH3Key>* evict_keys) {
     iter_node = lru_lst_.remove_node(del_node);
 
     XXH3Key token_hash_key(del_node->block.get_immutable_hash_value());
+    const int32_t block_id = del_node->block.id();
 
     cached_blocks_.erase(token_hash_key);
+
+    auto block_iter = cached_block_id_refs_.find(block_id);
+    CHECK(block_iter != cached_block_id_refs_.end())
+        << "State inconsistency: block " << block_id
+        << " is in cached_blocks_ but not in cached_block_id_refs_.";
+    if (block_iter->second <= 1) {
+      cached_block_id_refs_.erase(block_iter);
+    } else {
+      block_iter->second--;
+    }
 
     delete del_node;
     ++evict_count;

--- a/xllm/core/framework/prefix_cache/prefix_cache.h
+++ b/xllm/core/framework/prefix_cache/prefix_cache.h
@@ -102,6 +102,19 @@ class PrefixCache {
                                     std::vector<Block>& blocks,
                                     const size_t cached_blocks = 0);
 
+  // A physical block can be held either by:
+  // 1) one or more sequences only, or
+  // 2) sequences + prefix cache nodes.
+  // BlockManagerImpl::deallocate() needs to distinguish these cases because
+  // "ref_count == 2" is ambiguous after in-batch prefix reuse is introduced:
+  // it may mean "sequence + cache" or "provider sequence + consumer sequence".
+  // This helper answers only the cache part: whether the block is currently
+  // referenced by any prefix-cache node.
+  bool contains_block_id(int32_t block_id) const {
+    auto iter = cached_block_id_refs_.find(block_id);
+    return iter != cached_block_id_refs_.end() && iter->second > 0;
+  }
+
  protected:
   size_t insert(const Slice<int32_t>& token_ids,
                 std::vector<Block>& blocks,
@@ -207,6 +220,12 @@ class PrefixCache {
 
   std::unordered_map<XXH3Key, Node*, FixedStringKeyHash, FixedStringKeyEqual>
       cached_blocks_;
+  // Reference count of physical block ids held by prefix-cache nodes.
+  // This is not the sequence/block ref_count; it only tracks cache ownership
+  // so release logic can tell apart:
+  // - sequence + prefix cache
+  // - provider sequence + consumer sequence (in-batch shared, not cached)
+  std::unordered_map<int32_t, size_t> cached_block_id_refs_;
 
   std::atomic<uint64_t> total_blocks_{0}, matched_blocks_{0};
 };

--- a/xllm/core/scheduler/CMakeLists.txt
+++ b/xllm/core/scheduler/CMakeLists.txt
@@ -37,6 +37,7 @@ cc_library(
     fixed_steps_scheduler.cpp
   DEPS
     :batch
+    :prefix_cache
     :request
     :runtime
     :profile
@@ -55,6 +56,7 @@ cc_test(
     chunked_prefill_scheduler_test.cpp
     continuous_scheduler_test.cpp
     fixed_steps_scheduler_test.cpp
+    mix_scheduler_test.cpp
   DEPS
     :scheduler
     :xllm_server

--- a/xllm/core/scheduler/chunked_prefill_scheduler.cpp
+++ b/xllm/core/scheduler/chunked_prefill_scheduler.cpp
@@ -17,6 +17,7 @@ limitations under the License.
 #include "scheduler/chunked_prefill_scheduler.h"
 
 #include <limits>
+#include <utility>
 
 #include "common/metrics.h"
 #include "framework/batch/batch_factory.h"
@@ -60,8 +61,10 @@ void ChunkedPrefillScheduler::handle_running_queue_requests(
     const size_t num_sequences = request->sequences().size();
     std::vector<Sequence*> candidate_sequences;
     std::vector<size_t> candidate_token_budgets;
+    std::vector<std::pair<Sequence*, size_t>> pending_in_batch_providers;
     candidate_sequences.reserve(num_sequences);
     candidate_token_budgets.reserve(num_sequences);
+    pending_in_batch_providers.reserve(num_sequences);
 
     bool has_enough_budget = true;
     bool has_enough_blocks = true;
@@ -151,11 +154,22 @@ void ChunkedPrefillScheduler::handle_running_queue_requests(
       allocated_estimate_latency += seq_estimate_latency;
       candidate_sequences.emplace_back(sequence.get());
       candidate_token_budgets.emplace_back(current_step_handle_tokens);
+      if (sequence->is_prefill_stage()) {
+        const size_t max_handle_num_tokens =
+            sequence->kv_state().kv_cache_tokens_num() +
+            current_step_handle_tokens;
+        pending_in_batch_providers.emplace_back(sequence.get(),
+                                                max_handle_num_tokens);
+      }
     }
     CHECK(allocated_tokens <= remaining_token_budget);
     CHECK(allocated_seqs <= remaining_seq_budget);
 
     if (has_enough_budget && has_enough_blocks) {
+      for (const auto& pending_provider : pending_in_batch_providers) {
+        register_in_batch_prefix_provider(pending_provider.first,
+                                          pending_provider.second);
+      }
       // remove the request from the priority queue
       running_queue->pop_top();
       // add the request to the batch
@@ -174,6 +188,12 @@ void ChunkedPrefillScheduler::handle_running_queue_requests(
 
     // budget exhausted, do partially schedule the request
     if (!has_enough_budget) {
+      if (!candidate_sequences.empty() && !request->check_beam_search()) {
+        for (const auto& pending_provider : pending_in_batch_providers) {
+          register_in_batch_prefix_provider(pending_provider.first,
+                                            pending_provider.second);
+        }
+      }
       handle_abnormal_request(running_queue,
                               candidate_sequences,
                               candidate_token_budgets,
@@ -227,6 +247,12 @@ void ChunkedPrefillScheduler::handle_running_queue_requests(
     }
 
     // no requests left to preempt
+    if (!candidate_sequences.empty() && !request->check_beam_search()) {
+      for (const auto& pending_provider : pending_in_batch_providers) {
+        register_in_batch_prefix_provider(pending_provider.first,
+                                          pending_provider.second);
+      }
+    }
     handle_abnormal_request(running_queue,
                             candidate_sequences,
                             candidate_token_budgets,
@@ -281,6 +307,8 @@ void ChunkedPrefillScheduler::handle_prefill_requests(
     size_t allocated_seqs = 0;
     size_t allocated_estimate_latency = 0;
     bool can_schedule = true;
+    std::vector<std::pair<Sequence*, size_t>> pending_in_batch_providers;
+    pending_in_batch_providers.reserve(request->sequences().size());
     std::vector<Sequence*> prefill_sequences;
     std::vector<size_t> prefill_sequences_budget;
     prefill_sequences.reserve(request->sequences().size());
@@ -375,6 +403,11 @@ void ChunkedPrefillScheduler::handle_prefill_requests(
       allocated_tokens += current_step_handle_tokens;
       allocated_seqs += 1;
       allocated_estimate_latency += seq_estimate_latency;
+      const size_t max_handle_num_tokens =
+          prefill_sequence->kv_state().kv_cache_tokens_num() +
+          current_step_handle_tokens;
+      pending_in_batch_providers.emplace_back(prefill_sequence.get(),
+                                              max_handle_num_tokens);
     }
 
     if (!can_schedule) {
@@ -383,6 +416,11 @@ void ChunkedPrefillScheduler::handle_prefill_requests(
         kv_cache_manager_->deallocate(seq);
       }
       break;
+    }
+
+    for (const auto& pending_provider : pending_in_batch_providers) {
+      register_in_batch_prefix_provider(pending_provider.first,
+                                        pending_provider.second);
     }
 
     prefill_stage_sequences.insert(prefill_stage_sequences.end(),
@@ -591,6 +629,7 @@ std::vector<Batch> ChunkedPrefillScheduler::prepare_batch() {
   size_t num_preempted_requests = 0;
   bool budget_exhausted = false;
   bool blocks_exhausted = false;
+  begin_in_batch_prefix_cache();
   // keep the requests in prefill stage
   std::vector<Sequence*> prefill_stage_sequences;
 
@@ -678,6 +717,8 @@ std::vector<Batch> ChunkedPrefillScheduler::prepare_batch() {
                             blocks_exhausted);
   }
 
+  end_in_batch_prefix_cache();
+
   if (!finished_requests.empty()) {
     response_processor_->process_completed_requests(finished_requests);
   }
@@ -723,6 +764,7 @@ bool ChunkedPrefillScheduler::allocate_blocks_for(
   CHECK_GT(token_budget, min_speculative_tokens_required_);
 
   allocate_shared_blocks_for(sequence);
+  try_match_in_batch_prefix(sequence);
 
   // number of tokens in the kv cache, which are already processed
   const size_t kv_cache_tokens_num = sequence->kv_cache_tokens_num();

--- a/xllm/core/scheduler/chunked_prefill_scheduler_test.cpp
+++ b/xllm/core/scheduler/chunked_prefill_scheduler_test.cpp
@@ -21,6 +21,7 @@ limitations under the License.
 #include <cmath>
 #include <optional>
 
+#include "common/global_flags.h"
 #include "distributed_runtime/engine.h"
 #include "util/utils.h"
 
@@ -50,11 +51,13 @@ class FakeTokenizer : public Tokenizer {
 
 class FakeEngine : public Engine {
  public:
-  FakeEngine(int32_t num_blocks, int32_t block_size) {
+  FakeEngine(int32_t num_blocks,
+             int32_t block_size,
+             bool enable_prefix_cache = false) {
     BlockManagerPool::Options opt;
     opt.num_blocks_ = num_blocks;
     opt.block_size_ = block_size;
-    opt.enable_prefix_cache_ = false;  // we dont consider prefix cache here
+    opt.enable_prefix_cache_ = enable_prefix_cache;
     fake_tokenizer_ = std::make_unique<FakeTokenizer>();
     fake_block_manager_ = std::make_unique<BlockManagerPool>(opt, 1);
   }
@@ -74,6 +77,19 @@ class FakeEngine : public Engine {
  private:
   std::unique_ptr<Tokenizer> fake_tokenizer_;
   std::unique_ptr<BlockManagerPool> fake_block_manager_;
+};
+
+class ScopedBoolFlagValue {
+ public:
+  ScopedBoolFlagValue(bool& flag, bool value) : flag_(flag), old_(flag) {
+    flag_ = value;
+  }
+
+  ~ScopedBoolFlagValue() { flag_ = old_; }
+
+ private:
+  bool& flag_;
+  bool old_;
 };
 
 ContinuousScheduler::Options create_scheduler_options(
@@ -179,6 +195,69 @@ void update_requests(std::vector<std::shared_ptr<Request>> requests) {
 }
 
 }  // namespace
+
+TEST(ChunkedPrefillSchedulerTest, ReusePrefixBlocksWithinBatch) {
+  ScopedBoolFlagValue enable_prefix_cache(FLAGS_enable_prefix_cache, true);
+
+  const int32_t block_size = 16;
+  const int32_t prompt_len = 128;
+  auto engine = std::make_unique<FakeEngine>(64, block_size, true);
+  auto opt = create_scheduler_options(1024, 16, 0, 1024, 1);
+  auto scheduler =
+      std::make_unique<ChunkedPrefillScheduler>(engine.get(), opt);
+
+  auto requests = generate_request({prompt_len, prompt_len},
+                                   {8, 8},
+                                   std::nullopt,
+                                   std::nullopt,
+                                   30000);
+  for (auto& request : requests) {
+    scheduler->add_request(request);
+  }
+
+  auto batches = scheduler->prepare_batch_test();
+  ASSERT_EQ(batches.size(), 1);
+  ASSERT_EQ(batches[0].size(), 2);
+  const auto& budgets = batches[0].get_allowed_max_tokens();
+  ASSERT_EQ(budgets.size(), 2);
+
+  auto* seq0 = batches[0][0];
+  auto* seq1 = batches[0][1];
+  Sequence* producer = nullptr;
+  Sequence* consumer = nullptr;
+  uint32_t producer_budget = 0;
+  uint32_t consumer_budget = 0;
+  if (seq0->kv_state().kv_cache_tokens_num() >
+      seq1->kv_state().kv_cache_tokens_num()) {
+    consumer = seq0;
+    producer = seq1;
+    consumer_budget = budgets[0];
+    producer_budget = budgets[1];
+  } else {
+    consumer = seq1;
+    producer = seq0;
+    consumer_budget = budgets[1];
+    producer_budget = budgets[0];
+  }
+
+  ASSERT_NE(producer, nullptr);
+  ASSERT_NE(consumer, nullptr);
+
+  const size_t expected_shared_blocks = prompt_len / block_size - 1;
+  EXPECT_EQ(consumer->kv_state().shared_kv_blocks_num(),
+            expected_shared_blocks);
+  EXPECT_EQ(consumer->kv_state().kv_cache_tokens_num(),
+            expected_shared_blocks * block_size);
+  EXPECT_EQ(consumer_budget, static_cast<uint32_t>(block_size));
+  EXPECT_EQ(producer_budget, static_cast<uint32_t>(prompt_len));
+
+  ASSERT_GE(producer->kv_state().num_kv_blocks(), expected_shared_blocks);
+  ASSERT_GE(consumer->kv_state().num_kv_blocks(), expected_shared_blocks);
+  for (size_t i = 0; i < expected_shared_blocks; ++i) {
+    EXPECT_EQ(producer->kv_state().kv_blocks()[i].id(),
+              consumer->kv_state().kv_blocks()[i].id());
+  }
+}
 
 // TEST-1:
 // Three independent prefill requests, according to the configs,

--- a/xllm/core/scheduler/continuous_scheduler.cpp
+++ b/xllm/core/scheduler/continuous_scheduler.cpp
@@ -26,6 +26,7 @@ limitations under the License.
 #include <iomanip>
 #include <memory>
 #include <sstream>
+#include <utility>
 
 #include "common/global_flags.h"
 #include "common/metrics.h"
@@ -35,6 +36,7 @@ limitations under the License.
 #include "framework/request/request.h"
 #include "framework/request/sequence.h"
 #include "scheduler/decode_priority_queue.h"
+#include "framework/prefix_cache/in_batch_prefix_cache.h"
 #include "util/utils.h"
 
 namespace xllm {
@@ -133,6 +135,45 @@ ContinuousScheduler::ContinuousScheduler(Engine* engine, const Options& options)
 }
 
 ContinuousScheduler::~ContinuousScheduler() { running_requests_.clear(); }
+
+bool ContinuousScheduler::enable_in_batch_prefix_cache() const {
+  return enable_prefix_cache_ && in_batch_prefix_cache_context_ != nullptr;
+}
+
+void ContinuousScheduler::begin_in_batch_prefix_cache() {
+  in_batch_prefix_cache_context_holder_.reset();
+  in_batch_prefix_cache_context_ = nullptr;
+  if (!enable_prefix_cache_) {
+    return;
+  }
+
+  in_batch_prefix_cache_context_holder_ =
+      std::make_unique<InBatchPrefixCacheContext>();
+  in_batch_prefix_cache_context_ = in_batch_prefix_cache_context_holder_.get();
+}
+
+void ContinuousScheduler::end_in_batch_prefix_cache() {
+  in_batch_prefix_cache_context_ = nullptr;
+  in_batch_prefix_cache_context_holder_.reset();
+}
+
+void ContinuousScheduler::try_match_in_batch_prefix(Sequence* sequence) {
+  if (!enable_in_batch_prefix_cache()) {
+    return;
+  }
+  in_batch_prefix_cache_context_->try_match(sequence,
+                                            kv_cache_manager_->block_size());
+}
+
+void ContinuousScheduler::register_in_batch_prefix_provider(
+    Sequence* sequence,
+    size_t max_handle_num_tokens) {
+  if (!enable_in_batch_prefix_cache()) {
+    return;
+  }
+  in_batch_prefix_cache_context_->register_provider(
+      sequence, kv_cache_manager_->block_size(), max_handle_num_tokens);
+}
 
 bool ContinuousScheduler::add_request(std::shared_ptr<Request>& request) {
   CHECK(request != nullptr);
@@ -268,6 +309,8 @@ void ContinuousScheduler::handle_prefill_requests(
     size_t allocated_seqs = 0;
     double allocated_estimate_latency = 0;
     bool can_schedule = true;
+    std::vector<std::pair<Sequence*, size_t>> pending_in_batch_providers;
+    pending_in_batch_providers.reserve(request->sequences().size());
     std::vector<Sequence*> prefill_sequences;
     std::vector<size_t> prefill_sequences_budget;
     prefill_sequences.reserve(request->sequences().size());
@@ -277,15 +320,38 @@ void ContinuousScheduler::handle_prefill_requests(
         continue;
       }
 
-      // FIXME: use actual num_tokens to handle
-      // Currently overestimating the number of tokens actually processed when
-      // enable prefix cache
-      size_t num_tokens = prefill_sequence->num_need_compute_tokens();
+      if (prefill_sequence->kv_state().num_kv_blocks() == 0) {
+        kv_cache_manager_->allocate_shared(prefill_sequence.get());
+      }
+      try_match_in_batch_prefix(prefill_sequence.get());
+
+      const size_t num_tokens = prefill_sequence->num_need_compute_tokens();
       if (remaining_token_budget < allocated_tokens + num_tokens ||
           remaining_seq_budget < allocated_seqs + 1) {
+        if (prefill_sequence->kv_state().num_kv_blocks() > 0) {
+          kv_cache_manager_->deallocate(prefill_sequence.get());
+        }
         can_schedule = false;
         budget_exhausted = true;
         break;
+      }
+
+      // OPTIMIZE for multi-slo requests
+      // for prefill requests, check latency after prefix cache match
+      double seq_estimate_latency = 0;
+      if (options_.enable_latency_aware_schedule()) {
+        seq_estimate_latency =
+            profile_manager_->predict_step_time(prefill_sequence.get(), false);
+        if (estimate_latency + allocated_estimate_latency +
+                seq_estimate_latency >
+            latency_budget) {
+          if (prefill_sequence->kv_state().num_kv_blocks() > 0) {
+            kv_cache_manager_->deallocate(prefill_sequence.get());
+          }
+          can_schedule = false;
+          budget_exhausted = true;
+          break;
+        }
       }
 
       // preempt offline decode
@@ -300,7 +366,7 @@ void ContinuousScheduler::handle_prefill_requests(
           bool enough_to_evict =
               check_if_enough_to_evict(running_queue_offline_.get(),
                                        prefill_sequence.get(),
-                                       num_tokens,
+                                       prefill_sequence->num_tokens(),
                                        num_request_to_evict);
           if (enough_to_evict) {
             for (size_t i = 0; i < num_request_to_evict; ++i) {
@@ -332,28 +398,13 @@ void ContinuousScheduler::handle_prefill_requests(
         }
       }
 
-      // OPTIMIZE for multi-slo requests
-      // for prefill requests, check latency after prefix cache match
-      double seq_estimate_latency = 0;
-      if (options_.enable_latency_aware_schedule()) {
-        seq_estimate_latency =
-            profile_manager_->predict_step_time(prefill_sequence.get(), false);
-        if (estimate_latency + allocated_estimate_latency +
-                seq_estimate_latency >
-            latency_budget) {
-          // release shared prefix blocks
-          kv_cache_manager_->deallocate(prefill_sequence.get());
-          can_schedule = false;
-          budget_exhausted = true;
-          break;
-        }
-      }
-
       prefill_sequences_budget.emplace_back(num_tokens);
       prefill_sequences.emplace_back(prefill_sequence.get());
       allocated_tokens += num_tokens;
       allocated_seqs += 1;
       allocated_estimate_latency += seq_estimate_latency;
+      pending_in_batch_providers.emplace_back(prefill_sequence.get(),
+                                              prefill_sequence->num_tokens());
     }
 
     if (!can_schedule) {
@@ -362,6 +413,11 @@ void ContinuousScheduler::handle_prefill_requests(
         kv_cache_manager_->deallocate(seq);
       }
       break;
+    }
+
+    for (const auto& pending_provider : pending_in_batch_providers) {
+      register_in_batch_prefix_provider(pending_provider.first,
+                                        pending_provider.second);
     }
 
     remaining_token_budget -= allocated_tokens;
@@ -899,6 +955,7 @@ std::vector<Batch> ContinuousScheduler::prepare_batch() {
   size_t num_online_decode_preempt_online_requests = 0;
   size_t num_online_prefill_preempt_offline_requests = 0;
   size_t num_online_decode_preempt_offline_requests = 0;
+  begin_in_batch_prefix_cache();
   // TO IMPROVE?: handle online decode request before prefill offline request
   handle_prefill_requests(latency_budget,
                           estimate_latency,
@@ -937,6 +994,8 @@ std::vector<Batch> ContinuousScheduler::prepare_batch() {
                            num_online_decode_preempt_offline_requests,
                            running_queue_offline_);
   }
+
+  end_in_batch_prefix_cache();
 
   num_preempted_requests = num_offline_decode_preempt_offline_requests +
                            num_online_decode_preempt_online_requests +

--- a/xllm/core/scheduler/continuous_scheduler.h
+++ b/xllm/core/scheduler/continuous_scheduler.h
@@ -40,6 +40,7 @@ limitations under the License.
 namespace xllm {
 class Engine;
 class DecodePriorityQueue;
+class InBatchPrefixCacheContext;
 
 class ContinuousScheduler : public Scheduler {
  public:
@@ -289,6 +290,13 @@ class ContinuousScheduler : public Scheduler {
                                 size_t max_handle_num_tokens,
                                 size_t& num_request_to_evict);
 
+  bool enable_in_batch_prefix_cache() const;
+  void begin_in_batch_prefix_cache();
+  void end_in_batch_prefix_cache();
+  void try_match_in_batch_prefix(Sequence* sequence);
+  void register_in_batch_prefix_provider(Sequence* sequence,
+                                         size_t max_handle_num_tokens);
+
   // build a batch of requests from the priority queue
   virtual std::vector<Batch> prepare_batch();
 
@@ -308,6 +316,8 @@ class ContinuousScheduler : public Scheduler {
   std::vector<std::shared_ptr<Request>> last_running_requests_;
   std::vector<Sequence*> last_running_sequences_;
   bool is_first_step_ = true;
+  std::unique_ptr<InBatchPrefixCacheContext> in_batch_prefix_cache_context_holder_;
+  InBatchPrefixCacheContext* in_batch_prefix_cache_context_ = nullptr;
 
  private:
   std::vector<Batch> schedule_request(const absl::Duration& timeout);

--- a/xllm/core/scheduler/continuous_scheduler_test.cpp
+++ b/xllm/core/scheduler/continuous_scheduler_test.cpp
@@ -40,11 +40,13 @@ class FakeTokenizer : public Tokenizer {
 
 class FakeEngine : public Engine {
  public:
-  FakeEngine(int32_t num_blocks, int32_t block_size) {
+  FakeEngine(int32_t num_blocks,
+             int32_t block_size,
+             bool enable_prefix_cache = false) {
     BlockManagerPool::Options opt;
     opt.num_blocks_ = num_blocks;
     opt.block_size_ = block_size;
-    opt.enable_prefix_cache_ = false;  // we dont consider prefix cache here
+    opt.enable_prefix_cache_ = enable_prefix_cache;
     fake_tokenizer_ = std::make_unique<FakeTokenizer>();
     fake_block_manager_ = std::make_unique<BlockManagerPool>(opt, 1);
   }
@@ -212,6 +214,70 @@ void set_chunk_kv(const std::shared_ptr<Request>& request, size_t kv_tokens) {
 }
 
 }  // namespace
+
+TEST(ContinuousSchedulerTest, ReusePrefixBlocksWithinBatch) {
+  ScopedBoolFlagValue enable_prefix_cache(FLAGS_enable_prefix_cache, true);
+
+  const int32_t block_size = 16;
+  const int32_t prompt_len = 128;
+  auto engine = std::make_unique<FakeEngine>(64, block_size, true);
+  auto opt = create_scheduler_options(1024, 16, 0, 1024, 1);
+  auto scheduler = std::make_unique<ContinuousScheduler>(engine.get(), opt);
+
+  auto requests = generate_request({prompt_len, prompt_len},
+                                   {8, 8},
+                                   std::nullopt,
+                                   std::nullopt,
+                                   std::nullopt,
+                                   std::nullopt,
+                                   30000);
+  for (auto& request : requests) {
+    scheduler->add_request(request);
+  }
+
+  auto batches = scheduler->prepare_batch_test();
+  ASSERT_EQ(batches.size(), 1);
+  ASSERT_EQ(batches[0].size(), 2);
+  const auto& budgets = batches[0].get_allowed_max_tokens();
+  ASSERT_EQ(budgets.size(), 2);
+
+  auto* seq0 = batches[0][0];
+  auto* seq1 = batches[0][1];
+  Sequence* producer = nullptr;
+  Sequence* consumer = nullptr;
+  uint32_t producer_budget = 0;
+  uint32_t consumer_budget = 0;
+  if (seq0->kv_state().kv_cache_tokens_num() >
+      seq1->kv_state().kv_cache_tokens_num()) {
+    consumer = seq0;
+    producer = seq1;
+    consumer_budget = budgets[0];
+    producer_budget = budgets[1];
+  } else {
+    consumer = seq1;
+    producer = seq0;
+    consumer_budget = budgets[1];
+    producer_budget = budgets[0];
+  }
+
+  ASSERT_NE(producer, nullptr);
+  ASSERT_NE(consumer, nullptr);
+
+  const size_t expected_shared_blocks = prompt_len / block_size - 1;
+  EXPECT_EQ(consumer->kv_state().shared_kv_blocks_num(),
+            expected_shared_blocks);
+  EXPECT_EQ(consumer->kv_state().kv_cache_tokens_num(),
+            expected_shared_blocks * block_size);
+  EXPECT_EQ(consumer_budget, static_cast<uint32_t>(block_size));
+  EXPECT_EQ(producer_budget, static_cast<uint32_t>(prompt_len));
+
+  ASSERT_GE(producer->kv_state().num_kv_blocks(), expected_shared_blocks);
+  ASSERT_GE(consumer->kv_state().num_kv_blocks(), expected_shared_blocks);
+  for (size_t i = 0; i < expected_shared_blocks; ++i) {
+    EXPECT_EQ(producer->kv_state().kv_blocks()[i].id(),
+              consumer->kv_state().kv_blocks()[i].id());
+  }
+}
 
 TEST(ContinuousSchedulerFactoryTest,
      ChunkedPrefillWithoutSPUsesChunkedScheduler) {

--- a/xllm/core/scheduler/mix_scheduler.cpp
+++ b/xllm/core/scheduler/mix_scheduler.cpp
@@ -15,9 +15,14 @@ limitations under the License.
 
 #include "scheduler/mix_scheduler.h"
 
+#include <glog/logging.h>
+
 #include <algorithm>
 #include <limits>
+#include <utility>
+#include <vector>
 
+#include "common/global_flags.h"
 #include "common/metrics.h"
 #include "framework/batch/batch_factory.h"
 #include "util/timer.h"
@@ -274,8 +279,10 @@ void MixScheduler::handle_running_queue_requests(
 
     std::vector<Sequence*> candidate_sequences;
     std::vector<size_t> candidate_token_budgets;
+    std::vector<std::pair<Sequence*, size_t>> pending_in_batch_providers;
     candidate_sequences.reserve(num_sequences);
     candidate_token_budgets.reserve(num_sequences);
+    pending_in_batch_providers.reserve(num_sequences);
 
     auto constant_overhead = profile_manager_->get_constant_overhead();
 
@@ -291,9 +298,11 @@ void MixScheduler::handle_running_queue_requests(
         continue;
       }
 
+      const size_t block_size = kv_cache_manager_->block_size();
+      try_match_in_batch_prefix(sequence.get());
+
       // support kv cache swapping between host and device and try to overlap
       // the computation and copy overhead.
-      auto block_size = kv_cache_manager_->block_size();
       size_t host_blocks_num =
           sequence->host_kv_state().kv_cache_tokens_num() / block_size;
       size_t device_blocks_num =
@@ -380,10 +389,16 @@ void MixScheduler::handle_running_queue_requests(
       allocated_tokens += current_step_handle_tokens;
       allocated_seqs += 1;
       allocated_copy_blocks += cur_step_copy_blocks;
+      pending_in_batch_providers.emplace_back(
+          sequence.get(), kv_cache_tokens_num + current_step_handle_tokens);
       candidate_sequences.emplace_back(sequence.get());
       candidate_token_budgets.emplace_back(current_step_handle_tokens);
     }
     if (!blocks_exhausted && !budget_exhausted) {
+      for (const auto& pending_provider : pending_in_batch_providers) {
+        register_in_batch_prefix_provider(pending_provider.first,
+                                          pending_provider.second);
+      }
       // remove the request from the priority queue
       running_queue.pop_front();
       // add the request to the batch
@@ -556,6 +571,7 @@ std::vector<Batch> MixScheduler::prepare_batch() {
   bool blocks_exhausted = false;
   // keep the requests in prefill stage
   std::vector<Sequence*> prefill_stage_sequences;
+  begin_in_batch_prefix_cache();
 
   handle_running_queue_requests(latency_budget,
                                 estimate_latency,
@@ -566,6 +582,7 @@ std::vector<Batch> MixScheduler::prepare_batch() {
                                 running_queue_,
                                 budget_exhausted,
                                 blocks_exhausted);
+  end_in_batch_prefix_cache();
 
   if (!finished_requests.empty()) {
     response_processor_->process_completed_requests(finished_requests);

--- a/xllm/core/scheduler/mix_scheduler_test.cpp
+++ b/xllm/core/scheduler/mix_scheduler_test.cpp
@@ -1,0 +1,256 @@
+/* Copyright 2026 The xLLM Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://github.com/jd-opensource/xllm/blob/main/LICENSE
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include "mix_scheduler.h"
+
+#include <gtest/gtest.h>
+
+#include <limits>
+#include <memory>
+#include <optional>
+#include <vector>
+
+#include "common/global_flags.h"
+#include "distributed_runtime/engine.h"
+
+namespace xllm {
+
+namespace {
+
+class FakeTokenizer : public Tokenizer {
+ public:
+  bool encode(const std::string_view& text,
+              std::vector<int32_t>* ids,
+              bool add_special_tokens = true) const {
+    NOT_IMPLEMENTED();
+  }
+  std::string decode(const Slice<int32_t>& ids,
+                     bool skip_special_tokens) const {
+    NOT_IMPLEMENTED();
+  }
+  std::optional<int32_t> token_to_id(const std::string_view& token) const {
+    NOT_IMPLEMENTED();
+  }
+  std::string id_to_token(int32_t id) const { NOT_IMPLEMENTED(); }
+  size_t vocab_size() const { NOT_IMPLEMENTED(); }
+  std::unique_ptr<Tokenizer> clone() const {
+    return std::make_unique<FakeTokenizer>();
+  }
+};
+
+class FakeEngine : public Engine {
+ public:
+  FakeEngine(int32_t num_blocks, int32_t block_size) {
+    BlockManagerPool::Options opt;
+    opt.num_blocks_ = num_blocks;
+    opt.block_size_ = block_size;
+    opt.enable_prefix_cache_ = true;
+    fake_tokenizer_ = std::make_unique<FakeTokenizer>();
+    fake_block_manager_ = std::make_unique<BlockManagerPool>(opt, 1);
+  }
+  ForwardOutput step(std::vector<Batch>& batch) { NOT_IMPLEMENTED(); }
+  void update_last_step_result(std::vector<Batch>& batch) { NOT_IMPLEMENTED(); }
+  const Tokenizer* tokenizer() const { return fake_tokenizer_.get(); }
+  BlockManagerPool* block_manager_pool() const {
+    return fake_block_manager_.get();
+  }
+  const ModelArgs& model_args() const { NOT_IMPLEMENTED(); }
+  const TokenizerArgs& tokenizer_args() const { NOT_IMPLEMENTED(); }
+  std::vector<int64_t> get_active_activation_memory() const {
+    NOT_IMPLEMENTED();
+  }
+  bool init() override { return true; }
+
+ private:
+  std::unique_ptr<Tokenizer> fake_tokenizer_;
+  std::unique_ptr<BlockManagerPool> fake_block_manager_;
+};
+
+ContinuousScheduler::Options create_scheduler_options(
+    int32_t max_tokens_per_batch,
+    int32_t max_seqs_per_batch,
+    int32_t num_speculative_tokens,
+    int32_t max_tokens_per_chunk_for_prefill,
+    int32_t dp_size) {
+  ContinuousScheduler::Options opt;
+  opt.num_speculative_tokens_ = num_speculative_tokens;
+  opt.max_tokens_per_chunk_for_prefill_ = max_tokens_per_chunk_for_prefill;
+  opt.max_tokens_per_batch_ = max_tokens_per_batch;
+  opt.max_seqs_per_batch_ = max_seqs_per_batch;
+  opt.dp_size_ = dp_size;
+  opt.priority_strategy_ = "fcfs";
+  opt.enable_profile_kv_blocks_ = true;
+  opt.enable_latency_aware_schedule_ = false;
+  opt.max_global_ttft_ms_ = std::numeric_limits<int32_t>::max();
+  opt.max_global_tpot_ms_ = std::numeric_limits<int32_t>::max();
+  return opt;
+}
+
+std::shared_ptr<Request> generate_request(const std::vector<int32_t>& prompt,
+                                          int32_t max_tokens) {
+  RequestSamplingParam sampling_param;
+  SchedulerParam scheduler_param;
+
+  StoppingChecker stopping_checker;
+  stopping_checker.set_max_generated_tokens(max_tokens);
+  stopping_checker.set_max_context_len(static_cast<int32_t>(prompt.size()) +
+                                       max_tokens + 128);
+  stopping_checker.set_ignore_eos(true);
+
+  RequestState req_state("x",
+                         prompt,
+                         sampling_param,
+                         scheduler_param,
+                         stopping_checker,
+                         static_cast<int32_t>(prompt.size()) + max_tokens + 256,
+                         1,
+                         1,
+                         false,
+                         false,
+                         false,
+                         false,
+                         false,
+                         nullptr,
+                         nullptr);
+  return std::make_shared<Request>("1", "1", "1", std::move(req_state), "1");
+}
+
+}  // namespace
+
+TEST(MixSchedulerTest, ReusePrefixBlocksWithinBatch) {
+  FLAGS_enable_prefix_cache = true;
+
+  const int32_t block_size = 16;
+  const int32_t prompt_len = 128;
+
+  auto engine = std::make_unique<FakeEngine>(64, block_size);
+  auto options = create_scheduler_options(1024, 16, 0, 1024, 1);
+  auto scheduler = std::make_unique<MixScheduler>(engine.get(), options);
+
+  const std::vector<int32_t> prompt(prompt_len, 42);
+  auto req0 = generate_request(prompt, 8);
+  auto req1 = generate_request(prompt, 8);
+  scheduler->add_request(req0);
+  scheduler->add_request(req1);
+
+  auto batches = scheduler->prepare_batch_test();
+  ASSERT_EQ(batches.size(), 1);
+  ASSERT_EQ(batches[0].size(), 2);
+
+  auto* seq0 = batches[0][0];
+  auto* seq1 = batches[0][1];
+  const auto& budgets = batches[0].get_allowed_max_tokens();
+  ASSERT_EQ(budgets.size(), 2);
+
+  Sequence* producer = nullptr;
+  Sequence* consumer = nullptr;
+  uint32_t producer_budget = 0;
+  uint32_t consumer_budget = 0;
+
+  if (seq0->kv_state().kv_cache_tokens_num() >
+      seq1->kv_state().kv_cache_tokens_num()) {
+    consumer = seq0;
+    producer = seq1;
+    consumer_budget = budgets[0];
+    producer_budget = budgets[1];
+  } else {
+    consumer = seq1;
+    producer = seq0;
+    consumer_budget = budgets[1];
+    producer_budget = budgets[0];
+  }
+
+  ASSERT_NE(producer, nullptr);
+  ASSERT_NE(consumer, nullptr);
+  ASSERT_GT(consumer->kv_state().kv_cache_tokens_num(), 0);
+
+  const size_t expected_shared_blocks = prompt_len / block_size - 1;
+  EXPECT_EQ(consumer->kv_state().shared_kv_blocks_num(),
+            expected_shared_blocks);
+  EXPECT_EQ(consumer->kv_state().kv_cache_tokens_num(),
+            expected_shared_blocks * block_size);
+  EXPECT_EQ(consumer_budget, static_cast<uint32_t>(block_size));
+  EXPECT_EQ(producer_budget, static_cast<uint32_t>(prompt_len));
+
+  ASSERT_GE(producer->kv_state().num_kv_blocks(), expected_shared_blocks);
+  ASSERT_GE(consumer->kv_state().num_kv_blocks(), expected_shared_blocks);
+  for (size_t i = 0; i < expected_shared_blocks; ++i) {
+    EXPECT_EQ(producer->kv_state().kv_blocks()[i].id(),
+              consumer->kv_state().kv_blocks()[i].id());
+  }
+}
+
+TEST(MixSchedulerTest, IdenticalRequestsStayDeterministicWithoutSampling) {
+  FLAGS_enable_prefix_cache = true;
+
+  const int32_t block_size = 16;
+  const int32_t prompt_len = 128;
+
+  auto engine = std::make_unique<FakeEngine>(64, block_size);
+  auto options = create_scheduler_options(1024, 16, 0, 1024, 1);
+  auto scheduler = std::make_unique<MixScheduler>(engine.get(), options);
+
+  const std::vector<int32_t> prompt(prompt_len, 7);
+  auto req0 = generate_request(prompt, 8);
+  auto req1 = generate_request(prompt, 8);
+  scheduler->add_request(req0);
+  scheduler->add_request(req1);
+
+  auto batches = scheduler->prepare_batch_test();
+  ASSERT_EQ(batches.size(), 1);
+  ASSERT_EQ(batches[0].size(), 2);
+  const auto& budgets = batches[0].get_allowed_max_tokens();
+  ASSERT_EQ(budgets.size(), 2);
+
+  auto* seq0 = batches[0][0];
+  auto* seq1 = batches[0][1];
+
+  // Same request content should keep exactly the same token stream.
+  ASSERT_EQ(seq0->tokens(), seq1->tokens());
+  ASSERT_EQ(seq0->num_prompt_tokens(), seq1->num_prompt_tokens());
+
+  const auto* sp0 = seq0->sampling_param();
+  const auto* sp1 = seq1->sampling_param();
+  ASSERT_NE(sp0, nullptr);
+  ASSERT_NE(sp1, nullptr);
+  EXPECT_FALSE(sp0->do_sample);
+  EXPECT_FALSE(sp1->do_sample);
+  EXPECT_FLOAT_EQ(sp0->temperature, 0.0f);
+  EXPECT_FLOAT_EQ(sp1->temperature, 0.0f);
+  EXPECT_FLOAT_EQ(sp0->top_p, 1.0f);
+  EXPECT_FLOAT_EQ(sp1->top_p, 1.0f);
+  EXPECT_EQ(sp0->top_k, -1);
+  EXPECT_EQ(sp1->top_k, -1);
+  EXPECT_EQ(sp0->beam_width, 0);
+  EXPECT_EQ(sp1->beam_width, 0);
+
+  // Although one sequence may reuse in-batch prefix blocks, both sequences
+  // should target the same logical prompt length for this prefill step.
+  const size_t logical_prefill_target_0 =
+      seq0->kv_state().kv_cache_tokens_num() + budgets[0];
+  const size_t logical_prefill_target_1 =
+      seq1->kv_state().kv_cache_tokens_num() + budgets[1];
+  EXPECT_EQ(logical_prefill_target_0, seq0->num_prompt_tokens());
+  EXPECT_EQ(logical_prefill_target_1, seq1->num_prompt_tokens());
+  EXPECT_EQ(logical_prefill_target_0, logical_prefill_target_1);
+
+  // Ensure batch-local prefix sharing is actually triggered in this scenario.
+  const bool has_in_batch_shared_prefix =
+      seq0->kv_state().shared_kv_blocks_num() > 0 ||
+      seq1->kv_state().shared_kv_blocks_num() > 0;
+  EXPECT_TRUE(has_in_batch_shared_prefix);
+}
+
+}  // namespace xllm

--- a/xllm/core/scheduler/prefill_only_scheduler.cpp
+++ b/xllm/core/scheduler/prefill_only_scheduler.cpp
@@ -17,6 +17,7 @@ limitations under the License.
 #include "scheduler/prefill_only_scheduler.h"
 
 #include <limits>
+#include <utility>
 
 #include "common/metrics.h"
 #include "framework/batch/batch_factory.h"
@@ -100,6 +101,8 @@ void PrefillOnlyScheduler::handle_prefill_requests(
     size_t allocated_seqs = 0;
     size_t allocated_estimate_latency = 0;
     bool can_schedule = true;
+    std::vector<std::pair<Sequence*, size_t>> pending_in_batch_providers;
+    pending_in_batch_providers.reserve(request->sequences().size());
     std::vector<Sequence*> prefill_sequences;
     std::vector<size_t> prefill_sequences_budget;
     prefill_sequences.reserve(request->sequences().size());
@@ -109,6 +112,11 @@ void PrefillOnlyScheduler::handle_prefill_requests(
         continue;
       }
 
+      if (prefill_sequence->kv_state().num_kv_blocks() == 0) {
+        kv_cache_manager_->allocate_shared(prefill_sequence.get());
+      }
+      try_match_in_batch_prefix(prefill_sequence.get());
+
       // FIXME: use actual num_tokens to handle
       // Currently overestimating the number of tokens actually processed when
       // enable prefix cache
@@ -117,6 +125,9 @@ void PrefillOnlyScheduler::handle_prefill_requests(
                                    remaining_token_budget);
       if (remaining_token_budget < allocated_tokens + num_tokens ||
           remaining_seq_budget < allocated_seqs + 1) {
+        if (prefill_sequence->kv_state().num_kv_blocks() > 0) {
+          kv_cache_manager_->deallocate(prefill_sequence.get());
+        }
         can_schedule = false;
         budget_exhausted = true;
         break;
@@ -177,8 +188,10 @@ void PrefillOnlyScheduler::handle_prefill_requests(
         if (estimate_latency + allocated_estimate_latency +
                 seq_estimate_latency >
             latency_budget) {
-          // release shared prefix blocks
-          kv_cache_manager_->deallocate(prefill_sequence.get());
+          if (prefill_sequence->kv_state().num_kv_blocks() > 0) {
+            // release shared prefix blocks
+            kv_cache_manager_->deallocate(prefill_sequence.get());
+          }
           can_schedule = false;
           budget_exhausted = true;
           break;
@@ -190,6 +203,8 @@ void PrefillOnlyScheduler::handle_prefill_requests(
       allocated_tokens += num_tokens;
       allocated_seqs += 1;
       allocated_estimate_latency += seq_estimate_latency;
+      pending_in_batch_providers.emplace_back(prefill_sequence.get(),
+                                              prefill_sequence->num_tokens());
     }
 
     if (!can_schedule) {
@@ -198,6 +213,11 @@ void PrefillOnlyScheduler::handle_prefill_requests(
         kv_cache_manager_->deallocate(seq);
       }
       break;
+    }
+
+    for (const auto& pending_provider : pending_in_batch_providers) {
+      register_in_batch_prefix_provider(pending_provider.first,
+                                        pending_provider.second);
     }
 
     remaining_token_budget -= allocated_tokens;
@@ -288,6 +308,8 @@ void PrefillOnlyScheduler::handle_last_step_prefill_requests(
     size_t allocated_seqs = 0;
     size_t allocated_estimate_latency = 0;
     bool can_schedule = true;
+    std::vector<std::pair<Sequence*, size_t>> pending_in_batch_providers;
+    pending_in_batch_providers.reserve(request->sequences().size());
     std::vector<Sequence*> prefill_sequences;
     std::vector<size_t> prefill_sequences_budget;
     prefill_sequences.reserve(request->sequences().size());
@@ -297,6 +319,11 @@ void PrefillOnlyScheduler::handle_last_step_prefill_requests(
         continue;
       }
 
+      if (prefill_sequence->kv_state().num_kv_blocks() == 0) {
+        kv_cache_manager_->allocate_shared(prefill_sequence.get());
+      }
+      try_match_in_batch_prefix(prefill_sequence.get());
+
       // FIXME: use actual num_tokens to handle
       // Currently overestimating the number of tokens actually processed when
       // enable prefix cache
@@ -305,6 +332,9 @@ void PrefillOnlyScheduler::handle_last_step_prefill_requests(
                                    remaining_token_budget);
       if (remaining_token_budget < allocated_tokens + num_tokens ||
           remaining_seq_budget < allocated_seqs + 1) {
+        if (prefill_sequence->kv_state().num_kv_blocks() > 0) {
+          kv_cache_manager_->deallocate(prefill_sequence.get());
+        }
         can_schedule = false;
         budget_exhausted = true;
         break;
@@ -363,8 +393,10 @@ void PrefillOnlyScheduler::handle_last_step_prefill_requests(
         if (estimate_latency + allocated_estimate_latency +
                 seq_estimate_latency >
             latency_budget) {
-          // release shared prefix blocks
-          kv_cache_manager_->deallocate(prefill_sequence.get());
+          if (prefill_sequence->kv_state().num_kv_blocks() > 0) {
+            // release shared prefix blocks
+            kv_cache_manager_->deallocate(prefill_sequence.get());
+          }
           can_schedule = false;
           budget_exhausted = true;
           break;
@@ -376,6 +408,8 @@ void PrefillOnlyScheduler::handle_last_step_prefill_requests(
       allocated_tokens += num_tokens;
       allocated_seqs += 1;
       allocated_estimate_latency += seq_estimate_latency;
+      pending_in_batch_providers.emplace_back(prefill_sequence.get(),
+                                              prefill_sequence->num_tokens());
     }
 
     if (!can_schedule) {
@@ -384,6 +418,11 @@ void PrefillOnlyScheduler::handle_last_step_prefill_requests(
         kv_cache_manager_->deallocate(seq);
       }
       break;
+    }
+
+    for (const auto& pending_provider : pending_in_batch_providers) {
+      register_in_batch_prefix_provider(pending_provider.first,
+                                        pending_provider.second);
     }
 
     remaining_token_budget -= allocated_tokens;
@@ -568,6 +607,7 @@ std::vector<Batch> PrefillOnlyScheduler::prepare_batch() {
   size_t num_online_decode_preempt_online_requests = 0;
   size_t num_online_prefill_preempt_offline_requests = 0;
   size_t num_online_decode_preempt_offline_requests = 0;
+  begin_in_batch_prefix_cache();
 
   // 1. handle last step prefill requests
   // try to finish prefill requests as soon as fast as possible
@@ -621,6 +661,7 @@ std::vector<Batch> PrefillOnlyScheduler::prepare_batch() {
                            num_online_decode_preempt_offline_requests,
                            running_queue_offline_);
   }
+  end_in_batch_prefix_cache();
 
   num_preempted_requests = num_offline_decode_preempt_offline_requests +
                            num_online_decode_preempt_online_requests +


### PR DESCRIPTION
details:

- Blocks with identical prefixes within the same batch can be reused ahead of time, since KV cache is computed for the entire batch before attention calculation. 

rewards:

- This reduces TTFT by ~50% for 4k-length prompts on Qwen3-32B.