### PR TITLE
feat: support schedule overlap for multimodal model.

### DIFF
--- a/xllm/core/distributed_runtime/master.cpp
+++ b/xllm/core/distributed_runtime/master.cpp
@@ -105,9 +105,6 @@ Master::Master(const Options& options, EngineType type) : options_(options) {
   }
 
   if (type == EngineType::VLM) {
-    options_.enable_schedule_overlap(false);
-    LOG(WARNING) << "Force to disable schedule overlap for VLM model, not "
-                    "supported yet.";
     runtime::Options eng_options;
     eng_options.model_path(options_.model_path())
         .devices(devices)

--- a/xllm/core/distributed_runtime/vlm_master.cpp
+++ b/xllm/core/distributed_runtime/vlm_master.cpp
@@ -70,8 +70,7 @@ VLMMaster::VLMMaster(const Options& options)
       .enable_service_routing(options_.enable_service_routing())
       .disable_ttft_profiling(options_.disable_ttft_profiling())
       .enable_forward_interruption(options_.enable_forward_interruption())
-      // TODO: support later for VLM.
-      .enable_schedule_overlap(false)
+      .enable_schedule_overlap(options_.enable_schedule_overlap())
       .server_idx(options_.server_idx());
   scheduler_ = create_continuous_scheduler(engine_.get(), scheduler_options);
 
@@ -381,7 +380,7 @@ std::shared_ptr<Request> VLMMaster::generate_request(std::string prompt,
                          stream,
                          sp.echo,
                          sp.skip_special_tokens,
-                         false, /*enable_schedule_overlap*/
+                         options_.enable_schedule_overlap(),
                          callback,
                          nullptr);
   auto request = std::make_shared<Request>(sp.request_id,

--- a/xllm/core/runtime/vlm_worker_impl.cpp
+++ b/xllm/core/runtime/vlm_worker_impl.cpp
@@ -69,7 +69,9 @@ std::optional<ForwardOutput> VLMWorkerImpl::step(const ForwardInput& input) {
 
   COUNTER_ADD(execution_latency_seconds_model, timer.elapsed_seconds());
 
-  if (!driver_) {
+  if (!enable_schedule_overlap() && !driver_ && !dp_driver_ &&
+      !options_.enable_speculative_decode()) {
+    auto ret = device_.synchronize_default_stream();
     return std::nullopt;
   }
 


### PR DESCRIPTION
### Qwen3-VL-8B-Instruct benchmark
#### server command

```
NNODES=1
WORLD_SIZE=1

$BIN_PATH \
    --model $MODEL_PATH \
    --host=0.0.0.0 \
    --port $PORT \
    --devices="npu:$DEVICE" \
    --backend="vlm" \
    --master_node_addr=$MASTER_NODE_ADDR \
    --nnodes=$WORLD_SIZE \
    --node_rank=$i \
    --max_memory_utilization=0.9 \
    --max_tokens_per_batch=80000 \
    --max_seqs_per_batch=32 \
    --block_size=128 \
    --communication_backend="lccl" \
    --enable_schedule_overlap=true \
    --enable_chunked_prefill=false \
    --enable_prefix_cache=false \
```

### client command
```
vllm bench serve \
        --backend openai-chat \
        --base-url $API_BASE \
        --model $MODEL_PATH \
        --served-model-name $MODEL_NAME \
        --endpoint /v1/chat/completions \
        --num-warmups 4 \
        --dataset-name hf \
        --dataset-path "lmarena-ai/VisionArena-Chat" \
        --hf-split "train" \
        --num-prompts 100 \
        --max-concurrency 8 \
        --request-rate 10 \
        --save-result \
        --result-dir $RESULT_DIR \
        --result-filename $(basename $RESULT_FILE)"
```

### benchmark results

- enable_schedule_overlap
 ```
============ Serving Benchmark Result ============
Successful requests:                     100       
Failed requests:                         0         
Maximum request concurrency:             8         
Request rate configured (RPS):           10.00     
Benchmark duration (s):                  300.49    
Total input tokens:                      5280      
Total generated tokens:                  105073    
Request throughput (req/s):              0.33      
Output token throughput (tok/s):         349.67    
Peak output token throughput (tok/s):    495.00    
Peak concurrent requests:                10.00     
Total token throughput (tok/s):          367.24    
---------------Time to First Token----------------
Mean TTFT (ms):                          128.05    
Median TTFT (ms):                        124.24    
P99 TTFT (ms):                           208.51    
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          20.04     
Median TPOT (ms):                        20.04     
P99 TPOT (ms):                           22.73     
---------------Inter-token Latency----------------
Mean ITL (ms):                           19.65     
Median ITL (ms):                         19.53     
P99 ITL (ms):                            21.03     
==================================================
```

- disable_schedule_overlap
```
============ Serving Benchmark Result ============
Successful requests:                     100       
Failed requests:                         0         
Maximum request concurrency:             8         
Request rate configured (RPS):           10.00     
Benchmark duration (s):                  314.65    
Total input tokens:                      5280      
Total generated tokens:                  105076    
Request throughput (req/s):              0.32      
Output token throughput (tok/s):         333.94    
Peak output token throughput (tok/s):    469.00    
Peak concurrent requests:                10.00     
Total token throughput (tok/s):          350.72    
---------------Time to First Token----------------
Mean TTFT (ms):                          117.27    
Median TTFT (ms):                        115.71    
P99 TTFT (ms):                           219.12    
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          21.04     
Median TPOT (ms):                        21.08     
P99 TPOT (ms):                           24.03     
---------------Inter-token Latency----------------
Mean ITL (ms):                           20.65     
Median ITL (ms):                         20.53     
P99 ITL (ms):                            21.97     
==================================================
```