### PR TITLE
feat: optimize the loading weights under tp condition.

### DIFF
--- a/xllm/core/runtime/worker_impl.cpp
+++ b/xllm/core/runtime/worker_impl.cpp
@@ -645,8 +645,7 @@ bool WorkerImpl::init_model(const std::string& model_weights_path,
 
   std::unique_ptr<ScopedAtenLoadThreads> scoped_load_threads;
   if (tp_world_size > 1) {
-    const int32_t prev_threads =
-        static_cast<int32_t>(torch::get_num_threads());
+    const int32_t prev_threads = static_cast<int32_t>(torch::get_num_threads());
     LOG(INFO) << "Temporarily setting ATen threads to 1 during weight loading"
               << ", tp_world_size=" << tp_world_size
               << ", prev_threads=" << prev_threads;


### PR DESCRIPTION
## Description
During the initialization of Tensor Parallel (TP) models, weights are loaded concurrently across all ranks. The assembly of MoE weights—specifically operations like stack and cat—is CPU-bound and managed by ATen’s internal thread pools. If each rank utilizes multiple threads, it triggers severe CPU oversubscription and memory bandwidth bottlenecks, where host-side contention outweighs I/O speed. To optimize this, we temporarily restrict ATen to a single thread during the load_model() phase to minimize inter-rank competition and accelerate total loading time. The original thread settings are restored immediately after to ensure runtime compute performance is unaffected.

