### PR TITLE
refactor: unify rec multi round decode mode with one-stage flag.

### DIFF
--- a/xllm/core/common/global_flags.cpp
+++ b/xllm/core/common/global_flags.cpp
@@ -613,6 +613,7 @@ DEFINE_int32(health_check_interval_ms,
              3000,
              "Worker health check interval in milliseconds.");
 
-DEFINE_bool(enable_xattention_two_stage_decode,
+DEFINE_bool(enable_xattention_one_stage,
             false,
-            "Whether to enable xattention two stage decode.");
+            "Whether to force xattention one-stage decode for rec "
+            "multi-round mode.");

--- a/xllm/core/common/global_flags.h
+++ b/xllm/core/common/global_flags.h
@@ -282,7 +282,7 @@ DECLARE_int32(max_decode_rounds);
 
 DECLARE_int32(beam_width);
 
-DECLARE_bool(enable_xattention_two_stage_decode);
+DECLARE_bool(enable_xattention_one_stage);
 
 DECLARE_bool(use_audio_in_video);
 

--- a/xllm/core/layers/common/attention_metadata_builder.cpp
+++ b/xllm/core/layers/common/attention_metadata_builder.cpp
@@ -129,17 +129,7 @@ AttentionMetadata AttentionMetadataBuilder::build(
       attn_metadata.step_tensor = llmrec_params.current_round_tensor;
     }
 
-    const bool has_two_stage_cache_tensors =
-        llmrec_params.two_stage_shared_lse.defined() ||
-        llmrec_params.two_stage_shared_o.defined() ||
-        llmrec_params.two_stage_unshared_lse.defined() ||
-        llmrec_params.two_stage_unshared_o.defined() ||
-        llmrec_params.two_stage_q_cu_seq_lens_shared.defined() ||
-        llmrec_params.two_stage_paged_kv_indptr_expanded.defined() ||
-        llmrec_params.two_stage_paged_kv_indices_expanded.defined() ||
-        llmrec_params.two_stage_paged_kv_last_page_len_expanded.defined();
-
-    if (has_two_stage_cache_tensors) {
+    if (!FLAGS_enable_xattention_one_stage) {
 #if defined(USE_CUDA) || defined(USE_MUSA)
       attn_metadata.xattention_two_stage_decode_cache.emplace(
           XAttentionTwoStageDecodeCache{});

--- a/xllm/core/layers/cuda/xattention.cpp
+++ b/xllm/core/layers/cuda/xattention.cpp
@@ -125,11 +125,6 @@ void XAttentionImpl::run_two_stage_decode(
   CHECK_EQ(total_beam % batch_size, 0)
       << "total_beam must be divisible by batch_size";
 
-  CHECK(attn_metadata.xattention_two_stage_decode_cache.has_value())
-      << "xattention_two_stage_decode_cache must be prepared before "
-         "run_two_stage_decode (expected from "
-         "RecWorkerImpl::prepare_input_for_current_round).";
-
   const auto& cache = attn_metadata.xattention_two_stage_decode_cache.value();
   CHECK(cache.shared_lse.defined() && cache.shared_o.defined() &&
         cache.unshared_lse.defined() && cache.unshared_o.defined())
@@ -413,10 +408,10 @@ void XAttentionImpl::decoder_forward(const AttentionMetadata& attn_metadata,
                                                 attn_metadata.unshared_k_cache,
                                                 attn_metadata.unshared_v_cache,
                                                 attn_metadata.step_tensor);
-  if (FLAGS_enable_xattention_two_stage_decode) {
-    run_two_stage_decode(attn_metadata, query, output);
-  } else {
+  if (FLAGS_enable_xattention_one_stage) {
     run_single_stage_decode(attn_metadata, key, query, output);
+  } else {
+    run_two_stage_decode(attn_metadata, query, output);
   }
 }
 

--- a/xllm/core/layers/cuda/xattention_test.cpp
+++ b/xllm/core/layers/cuda/xattention_test.cpp
@@ -32,24 +32,6 @@ limitations under the License.
 namespace xllm::layer::test {
 namespace {
 
-class ScopedDecodeFlags {
- public:
-  ScopedDecodeFlags()
-      : old_enable_xattention_two_stage_decode_(
-            FLAGS_enable_xattention_two_stage_decode),
-        old_max_tokens_per_batch_(FLAGS_max_tokens_per_batch) {}
-
-  ~ScopedDecodeFlags() {
-    FLAGS_enable_xattention_two_stage_decode =
-        old_enable_xattention_two_stage_decode_;
-    FLAGS_max_tokens_per_batch = old_max_tokens_per_batch_;
-  }
-
- private:
-  bool old_enable_xattention_two_stage_decode_;
-  int32_t old_max_tokens_per_batch_;
-};
-
 struct DecodeTestInput {
   AttentionMetadata attn_metadata;
   torch::Tensor query;
@@ -215,7 +197,7 @@ class XAttentionDecodeCompareTest : public ::testing::Test {
   }
 
   torch::Tensor run_decode_once(DecodeTestInput& input, bool enable_two_stage) {
-    FLAGS_enable_xattention_two_stage_decode = enable_two_stage;
+    FLAGS_enable_xattention_one_stage = !enable_two_stage;
     FLAGS_max_tokens_per_batch = kSharedSeqLen;
 
     XAttentionImpl attention(
@@ -242,8 +224,6 @@ class XAttentionDecodeCompareTest : public ::testing::Test {
   void compare_single_and_two_stage(torch::ScalarType dtype,
                                     double atol,
                                     double rtol) {
-    ScopedDecodeFlags guard;
-
     constexpr int64_t kSeed = 20260303;
     torch::manual_seed(kSeed);
     torch::cuda::manual_seed_all(kSeed);

--- a/xllm/core/runtime/cuda_graph_executor_impl.cpp
+++ b/xllm/core/runtime/cuda_graph_executor_impl.cpp
@@ -381,9 +381,10 @@ std::optional<ModelInputParams> CudaGraphPersistentParam::update(
         .copy_(embedding, /*non_blocking=*/true);
   }
 
-  const bool enable_two_stage_decode =
-      FLAGS_enable_xattention_two_stage_decode &&
+  const bool is_decode_with_llmrec =
       params.batch_forward_type.is_decode() && params.has_llmrec_params();
+  const bool use_two_stage_decode =
+      !FLAGS_enable_xattention_one_stage && is_decode_with_llmrec;
   const int32_t head_dim = args_.head_dim();
   const int64_t n_heads = args_.n_heads();
   const int64_t n_kv_heads = args_.n_kv_heads().value_or(n_heads);
@@ -408,7 +409,7 @@ std::optional<ModelInputParams> CudaGraphPersistentParam::update(
 
   bool use_tensor_core =
       xllm::kernel::cuda::should_use_tensor_core(dtype, n_heads, n_kv_heads);
-  if (enable_two_stage_decode) {
+  if (use_two_stage_decode) {
     if (params.q_seq_lens.defined() && params.q_seq_lens.numel() > 0) {
       const int64_t q_numel = params.q_seq_lens.numel();
       q_seq_lens_.slice(/*dim=*/0, /*start=*/0, /*end=*/q_numel)
@@ -434,10 +435,6 @@ std::optional<ModelInputParams> CudaGraphPersistentParam::update(
 
     // Update plan_info if attn_metadata exists and enable_cuda_graph is true.
     const auto& llmrec_params = *params.llmrec_params();
-    CHECK(attn_metadata->xattention_two_stage_decode_cache.has_value())
-        << "two-stage cache must be prepared in rec worker before "
-           "cuda graph update";
-
     auto cache = attn_metadata->xattention_two_stage_decode_cache.value();
     CHECK(cache.q_cu_seq_lens_shared.defined())
         << "q_cu_seq_lens_shared must be initialized in rec worker";

--- a/xllm/core/runtime/rec_worker_impl.cpp
+++ b/xllm/core/runtime/rec_worker_impl.cpp
@@ -554,29 +554,31 @@ void RecWorkerImpl::LlmRecMultiRoundPipeline::allocate_kv_caches_related() {
           .unsqueeze(1);
   cached_current_round_tensor_ = torch::zeros({1}, int_options);
 
-  if (FLAGS_enable_xattention_two_stage_decode) {
-    const int64_t num_heads = runtime_.context->get_model_args().n_heads();
-    const int64_t max_total_beam =
-        static_cast<int64_t>(max_seqs_per_batch_) * beam_width_;
-    auto fp32_options =
-        torch::TensorOptions().dtype(torch::kFloat32).device(device);
-    cached_two_stage_shared_lse_ =
-        torch::zeros({max_total_beam, num_heads, 1}, fp32_options);
-    cached_two_stage_shared_o_ =
-        torch::zeros({max_total_beam, num_heads, head_dim}, kv_cache_options);
-    cached_two_stage_unshared_lse_ =
-        torch::zeros({max_total_beam, num_heads, 1}, fp32_options);
-    cached_two_stage_unshared_o_ =
-        torch::zeros({max_total_beam, num_heads, head_dim}, kv_cache_options);
-    cached_two_stage_q_cu_seq_lens_shared_ =
-        torch::zeros({max_seqs_per_batch_ + 1}, int_options);
-    cached_two_stage_paged_kv_indptr_expanded_ =
-        torch::zeros({max_total_beam + 1}, int_options);
-    cached_two_stage_paged_kv_indices_expanded_ =
-        torch::zeros({max_total_beam}, int_options);
-    cached_two_stage_paged_kv_last_page_len_expanded_ =
-        torch::zeros({max_total_beam}, int_options);
+  if (FLAGS_enable_xattention_one_stage) {
+    return;
   }
+
+  const int64_t num_heads = runtime_.context->get_model_args().n_heads();
+  const int64_t max_total_beam =
+      static_cast<int64_t>(max_seqs_per_batch_) * beam_width_;
+  auto fp32_options =
+      torch::TensorOptions().dtype(torch::kFloat32).device(device);
+  cached_two_stage_shared_lse_ =
+      torch::zeros({max_total_beam, num_heads, 1}, fp32_options);
+  cached_two_stage_shared_o_ =
+      torch::zeros({max_total_beam, num_heads, head_dim}, kv_cache_options);
+  cached_two_stage_unshared_lse_ =
+      torch::zeros({max_total_beam, num_heads, 1}, fp32_options);
+  cached_two_stage_unshared_o_ =
+      torch::zeros({max_total_beam, num_heads, head_dim}, kv_cache_options);
+  cached_two_stage_q_cu_seq_lens_shared_ =
+      torch::zeros({max_seqs_per_batch_ + 1}, int_options);
+  cached_two_stage_paged_kv_indptr_expanded_ =
+      torch::zeros({max_total_beam + 1}, int_options);
+  cached_two_stage_paged_kv_indices_expanded_ =
+      torch::zeros({max_total_beam}, int_options);
+  cached_two_stage_paged_kv_last_page_len_expanded_ =
+      torch::zeros({max_total_beam}, int_options);
 }
 
 void RecWorkerImpl::LlmRecMultiRoundPipeline::
@@ -865,7 +867,7 @@ void RecWorkerImpl::LlmRecMultiRoundPipeline::prepare_two_stage_round_input(
 // TODO: implement prepare_two_stage_round_input for NPU
 #elif defined(USE_CUDA)
   auto& llm_rec_params = input.input_params.mutable_llmrec_params();
-  CHECK(FLAGS_enable_xattention_two_stage_decode)
+  CHECK_EQ(FLAGS_enable_xattention_one_stage, false)
       << "prepare_two_stage_round_input should only be called when "
          "two-stage decode is enabled";
 
@@ -966,16 +968,16 @@ void RecWorkerImpl::LlmRecMultiRoundPipeline::prepare_input_for_current_round(
 #if defined(USE_NPU)
 // TODO: implement prepare_input_for_current_round for NPU
 #elif defined(USE_CUDA)
-  if (FLAGS_enable_xattention_two_stage_decode) {
+  if (FLAGS_enable_xattention_one_stage) {
+    input.input_params.paged_kv_indices = results.paged_kv_indices;
+    input.input_params.paged_kv_indptr = results.paged_kv_indptr;
+    input.input_params.paged_kv_last_page_len = results.paged_kv_last_page_len;
+    input.input_params.num_sequences =
+        input.input_params.paged_kv_last_page_len.numel();
+  } else {
     prepare_two_stage_round_input(input, round, top_tokens, beam_tensors);
     return;
   }
-
-  input.input_params.paged_kv_indices = results.paged_kv_indices;
-  input.input_params.paged_kv_indptr = results.paged_kv_indptr;
-  input.input_params.paged_kv_last_page_len = results.paged_kv_last_page_len;
-  input.input_params.num_sequences =
-      input.input_params.paged_kv_last_page_len.numel();
 #endif
   // previous_step corresponds to the decode step that produced tokens for
   // this round.
@@ -1020,100 +1022,104 @@ RecWorkerImpl::LlmRecMultiRoundPipeline::compute_next_round_input_async(
 #if defined(USE_NPU)
 // TODO: implement compute_next_round_input_async for NPU
 #elif defined(USE_CUDA)
-  if (FLAGS_enable_xattention_two_stage_decode) {
+  if (FLAGS_enable_xattention_one_stage) {
+    // Capture necessary data for async computation
+    auto full_kv_offsets = full_kv_cache_offsets_->full_kv_offsets;
+    auto full_kv_mask = full_kv_cache_offsets_->full_kv_mask;
+    auto full_kv_indices = full_kv_cache_offsets_->full_kv_indices;
+    auto unshared_full_kv_offsets = full_kv_cache_offsets_->unshared_offsets;
+    auto real_max_decode_step_ids = full_kv_cache_offsets_->max_decode_step_ids;
+    uint32_t unshared_kv_begin_offset = max_tokens_per_batch_;
+
+    // Launch async computation in thread pool (can overlap with GPU execution)
+    threadpool_.schedule([=, this, promise = std::move(promise)]() mutable {
+      auto device = runtime_.worker.device();
+      auto int32_device_options =
+          torch::TensorOptions().dtype(torch::kInt32).device(device);
+      // Protect CUDA graph capture from conflicting GPU work submitted on
+      // prepare_stream_ while capture is in progress. Use shared lock to allow
+      // multiple prepare operations to run concurrently, but prevent conflicts
+      // with capture operations. This mirrors the NPU DeviceCaptureLock usage
+      // in WorkerImpl::prepare_work_before_execute.
+      std::optional<std::shared_lock<std::shared_mutex>> lock_guard;
+      if (runtime_.worker.options_.enable_graph()) {
+        auto& replay_lock =
+            ::xllm::cuda::DeviceCaptureLock::get_instance().get_read_lock(
+                runtime_.worker.device_.index());
+        lock_guard.emplace(replay_lock);
+      }
+
+      c10::StreamGuard streamGuard =
+          runtime_.worker.prepare_stream_->set_stream_guard();
+      auto shared_kv_offsets = full_kv_offsets.slice(2, 0, max_token_per_req_)
+                                   .slice(0, 0, batch_size);
+
+      auto shared_kv_lens_each_batch = torch::diff(kv_seq_lens);
+
+      auto shared_kv_lens_each_batch_broadcast =
+          shared_kv_lens_each_batch.unsqueeze(1).unsqueeze(1);
+
+      auto shared_mask =
+          full_kv_mask.slice(2, 0, max_token_per_req_).slice(0, 0, batch_size);
+
+      shared_mask.copy_(shared_kv_offsets <
+                        shared_kv_lens_each_batch_broadcast);
+
+      auto kv_lens_batch_offsets = kv_seq_lens.slice(0, 0, -1);
+
+      auto kv_lens_batch_offsets_broadcast =
+          kv_lens_batch_offsets.unsqueeze(1).unsqueeze(1);
+
+      auto shared_kv_indices = full_kv_indices.slice(2, 0, max_token_per_req_)
+                                   .slice(0, 0, batch_size);
+
+      shared_kv_indices.copy_(kv_lens_batch_offsets_broadcast +
+                              shared_kv_offsets);
+
+      auto unshared_kv_offsets =
+          unshared_full_kv_offsets.slice(0, 0, batch_size);
+      int32_t unshared_kv_len = beam_width * max_decode_step;
+      auto unshared_kv_indices =
+          full_kv_indices
+              .slice(
+                  2, max_token_per_req_, max_token_per_req_ + unshared_kv_len)
+              .slice(0, 0, batch_size);
+      unshared_kv_indices.copy_(unshared_kv_offsets + unshared_kv_begin_offset);
+
+      auto unshared_mask =
+          full_kv_mask
+              .slice(
+                  2, max_token_per_req_, max_token_per_req_ + unshared_kv_len)
+              .slice(0, 0, batch_size);
+      auto real_max_decode_step_ids_slice =
+          real_max_decode_step_ids.slice(0, 0, batch_size);
+      unshared_mask.copy_(real_max_decode_step_ids_slice <= current_step);
+
+      unshared_kv_len = current_step + 1;
+
+      auto batch_beam_shared_kv_lens =
+          (shared_kv_lens_each_batch.unsqueeze(1).expand({-1, beam_width}) +
+           unshared_kv_len)
+              .flatten();
+      auto cumsum_result = torch::cumsum(batch_beam_shared_kv_lens, 0);
+      auto paged_kv_indptr =
+          torch::cat({torch::zeros({1}, int32_device_options),
+                      cumsum_result.to(int32_device_options)},
+                     0);
+      auto paged_kv_indices = full_kv_indices.masked_select(full_kv_mask);
+      auto paged_kv_last_page_len =
+          torch::ones({batch_size * beam_width}, int32_device_options);
+      runtime_.worker.prepare_stream_->synchronize();
+
+      NextRoundInputResults results;
+      results.paged_kv_indices = paged_kv_indices;
+      results.paged_kv_indptr = paged_kv_indptr;
+      results.paged_kv_last_page_len = paged_kv_last_page_len;
+      promise.setValue(results);
+    });
+  } else {
     promise.setValue(NextRoundInputResults{});
-    return future;
   }
-
-  // Capture necessary data for async computation
-  auto full_kv_offsets = full_kv_cache_offsets_->full_kv_offsets;
-  auto full_kv_mask = full_kv_cache_offsets_->full_kv_mask;
-  auto full_kv_indices = full_kv_cache_offsets_->full_kv_indices;
-  auto unshared_full_kv_offsets = full_kv_cache_offsets_->unshared_offsets;
-  auto real_max_decode_step_ids = full_kv_cache_offsets_->max_decode_step_ids;
-  uint32_t unshared_kv_begin_offset = max_tokens_per_batch_;
-
-  // Launch async computation in thread pool (can overlap with GPU execution)
-  threadpool_.schedule([=, this, promise = std::move(promise)]() mutable {
-    auto device = runtime_.worker.device();
-    auto int32_device_options =
-        torch::TensorOptions().dtype(torch::kInt32).device(device);
-    // Protect CUDA graph capture from conflicting GPU work submitted on
-    // prepare_stream_ while capture is in progress. Use shared lock to allow
-    // multiple prepare operations to run concurrently, but prevent conflicts
-    // with capture operations. This mirrors the NPU DeviceCaptureLock usage in
-    // WorkerImpl::prepare_work_before_execute.
-    std::optional<std::shared_lock<std::shared_mutex>> lock_guard;
-    if (runtime_.worker.options_.enable_graph()) {
-      auto& replay_lock =
-          ::xllm::cuda::DeviceCaptureLock::get_instance().get_read_lock(
-              runtime_.worker.device_.index());
-      lock_guard.emplace(replay_lock);
-    }
-
-    c10::StreamGuard streamGuard =
-        runtime_.worker.prepare_stream_->set_stream_guard();
-    auto shared_kv_offsets =
-        full_kv_offsets.slice(2, 0, max_token_per_req_).slice(0, 0, batch_size);
-
-    auto shared_kv_lens_each_batch = torch::diff(kv_seq_lens);
-
-    auto shared_kv_lens_each_batch_broadcast =
-        shared_kv_lens_each_batch.unsqueeze(1).unsqueeze(1);
-
-    auto shared_mask =
-        full_kv_mask.slice(2, 0, max_token_per_req_).slice(0, 0, batch_size);
-
-    shared_mask.copy_(shared_kv_offsets < shared_kv_lens_each_batch_broadcast);
-
-    auto kv_lens_batch_offsets = kv_seq_lens.slice(0, 0, -1);
-
-    auto kv_lens_batch_offsets_broadcast =
-        kv_lens_batch_offsets.unsqueeze(1).unsqueeze(1);
-
-    auto shared_kv_indices =
-        full_kv_indices.slice(2, 0, max_token_per_req_).slice(0, 0, batch_size);
-
-    shared_kv_indices.copy_(kv_lens_batch_offsets_broadcast +
-                            shared_kv_offsets);
-
-    auto unshared_kv_offsets = unshared_full_kv_offsets.slice(0, 0, batch_size);
-    int32_t unshared_kv_len = beam_width * max_decode_step;
-    auto unshared_kv_indices =
-        full_kv_indices
-            .slice(2, max_token_per_req_, max_token_per_req_ + unshared_kv_len)
-            .slice(0, 0, batch_size);
-    unshared_kv_indices.copy_(unshared_kv_offsets + unshared_kv_begin_offset);
-
-    auto unshared_mask =
-        full_kv_mask
-            .slice(2, max_token_per_req_, max_token_per_req_ + unshared_kv_len)
-            .slice(0, 0, batch_size);
-    auto real_max_decode_step_ids_slice =
-        real_max_decode_step_ids.slice(0, 0, batch_size);
-    unshared_mask.copy_(real_max_decode_step_ids_slice <= current_step);
-
-    unshared_kv_len = current_step + 1;
-
-    auto batch_beam_shared_kv_lens =
-        (shared_kv_lens_each_batch.unsqueeze(1).expand({-1, beam_width}) +
-         unshared_kv_len)
-            .flatten();
-    auto cumsum_result = torch::cumsum(batch_beam_shared_kv_lens, 0);
-    auto paged_kv_indptr = torch::cat({torch::zeros({1}, int32_device_options),
-                                       cumsum_result.to(int32_device_options)},
-                                      0);
-    auto paged_kv_indices = full_kv_indices.masked_select(full_kv_mask);
-    auto paged_kv_last_page_len =
-        torch::ones({batch_size * beam_width}, int32_device_options);
-    runtime_.worker.prepare_stream_->synchronize();
-
-    NextRoundInputResults results;
-    results.paged_kv_indices = paged_kv_indices;
-    results.paged_kv_indptr = paged_kv_indptr;
-    results.paged_kv_last_page_len = paged_kv_last_page_len;
-    promise.setValue(results);
-  });
 #endif
   return future;
 }
@@ -1208,16 +1214,21 @@ RecWorkerImpl::LlmRecMultiRoundPipeline::FullKvCacheOffsets::FullKvCacheOffsets(
 // RecWorkerImpl Implementation
 // ============================================================
 
+void RecWorkerImpl::initialize_xattention_workspace() {
+#if defined(USE_CUDA)
+  if (FLAGS_enable_xattention_one_stage) {
+    return;
+  }
+  ::xllm::layer::xattention::XAttentionWorkspace::get_instance().initialize(
+      device_);
+#endif
+}
+
 RecWorkerImpl::RecWorkerImpl(const ParallelArgs& parallel_args,
                              const torch::Device& device,
                              const runtime::Options& options)
     : LLMWorkerImpl(parallel_args, device, options) {
-#if defined(USE_CUDA)
-  if (FLAGS_enable_xattention_two_stage_decode) {
-    ::xllm::layer::xattention::XAttentionWorkspace::get_instance().initialize(
-        device_);
-  }
-#endif
+  initialize_xattention_workspace();
 
   if (!is_driver()) {
     return;
@@ -1229,10 +1240,7 @@ RecWorkerImpl::RecWorkerImpl(const ParallelArgs& parallel_args,
 #if defined(USE_CUDA)
         ::xllm::layer::flashinfer::FlashinferWorkspace::get_instance()
             .initialize(device_);
-        if (FLAGS_enable_xattention_two_stage_decode) {
-          ::xllm::layer::xattention::XAttentionWorkspace::get_instance()
-              .initialize(device_);
-        }
+        initialize_xattention_workspace();
 #endif
       });
 

--- a/xllm/core/runtime/rec_worker_impl.h
+++ b/xllm/core/runtime/rec_worker_impl.h
@@ -280,6 +280,8 @@ class RecWorkerImpl : public LLMWorkerImpl {
 
   void prepare_multi_modal_data(ForwardInput& processed_inputs);
 
+  void initialize_xattention_workspace();
+
   std::vector<std::unique_ptr<RecWorkPipeline>> work_pipelines_;
 
   RecModelKind rec_model_kind_ = RecModelKind::kNone;


### PR DESCRIPTION
## What This PR Changes
  1. Uses a single gflag to select decode mode:
     - `FLAGS_enable_xattention_one_stage == true` -> one-stage
     - `FLAGS_enable_xattention_one_stage == false` -> two-stage
  2. Removes legacy/extra mode-selection paths:
     - `enable_xattention_two_stage_decode`
     - `enable_xattention_one_stage_decode`
     - `is_xattention_two_stage_decode_enabled()`
  3. Removes cache-state-based mode gating:
     - No branch selection based on `xattention_two_stage_decode_cache.has_value()`
     - No branch selection based on aggregated `two_stage_* .defined()` checks