### PR TITLE
feat: pin xllm process to the right numa region.

### DIFF
--- a/xllm/core/distributed_runtime/dist_manager.cpp
+++ b/xllm/core/distributed_runtime/dist_manager.cpp
@@ -23,6 +23,9 @@ limitations under the License.
 #include "framework/parallel_state/parallel_args.h"
 #include "framework/parallel_state/parallel_state.h"
 #include "framework/parallel_state/process_group.h"
+#if defined(USE_CUDA)
+#include "platform/numa_utils.h"
+#endif
 #include "remote_worker.h"
 #include "runtime/forward_shared_memory_manager.h"
 #include "runtime/llm_worker_impl.h"
@@ -85,12 +88,70 @@ std::unique_ptr<CommChannel> create_channel(const std::string& worker_addrs,
   return channel;
 }
 
+#if defined(USE_CUDA)
+void setup_numa_affinity_and_isolation(
+    const runtime::Options& options,
+    std::vector<int32_t>& device_numa_nodes,
+    std::vector<bool>& force_spawn_for_numa_isolation) {
+  const auto& devices = options.devices();
+
+  device_numa_nodes.assign(devices.size(), -1);
+  force_spawn_for_numa_isolation.assign(devices.size(), false);
+
+  std::set<int32_t> unique_numa_nodes;
+  for (size_t i = 0; i < devices.size(); ++i) {
+    device_numa_nodes[i] = numa::get_device_numa_node(devices[i].index());
+    if (device_numa_nodes[i] >= 0) {
+      unique_numa_nodes.insert(device_numa_nodes[i]);
+    }
+
+    LOG(INFO) << "NUMA mapping: local rank " << i << ", device "
+              << devices[i].index() << " -> NUMA node " << device_numa_nodes[i];
+  }
+
+  int32_t engine_numa_node = -1;
+  for (auto numa_node : device_numa_nodes) {
+    if (numa_node >= 0) {
+      engine_numa_node = numa_node;
+      break;
+    }
+  }
+
+  if (engine_numa_node >= 0) {
+    if (numa::bind_process_to_numa_node(engine_numa_node) != 0) {
+      LOG(WARNING) << "Failed to pin engine process to NUMA node "
+                   << engine_numa_node
+                   << ", fallback to per-worker affinity only";
+    }
+
+    if (unique_numa_nodes.size() > 1) {
+      for (size_t i = 0; i < devices.size(); ++i) {
+        force_spawn_for_numa_isolation[i] =
+            (device_numa_nodes[i] >= 0 &&
+             device_numa_nodes[i] != engine_numa_node);
+      }
+      LOG(INFO) << "Detected multi-NUMA local devices. Workers outside NUMA "
+                << engine_numa_node
+                << " will be spawned as isolated processes to avoid engine "
+                   "process cross-NUMA spanning";
+    }
+  }
+}
+#endif
+
 }  // namespace
 
 void DistManager::setup_multi_node_workers(
     const runtime::Options& options,
     const std::string& master_node_addr) {
   const auto& devices = options.devices();
+
+#if defined(USE_CUDA)
+  std::vector<int32_t> device_numa_nodes;
+  std::vector<bool> force_spawn_for_numa_isolation;
+  setup_numa_affinity_and_isolation(
+      options, device_numa_nodes, force_spawn_for_numa_isolation);
+#endif
 
   // Process/Thread Worker Mode, we use it in multi-nodes serving.
 
@@ -167,7 +228,17 @@ void DistManager::setup_multi_node_workers(
 
     // we use spawn process worker to launch a xllm instance
     // when start a offline inference task with multi-gpu/npu/mpu/...
+#if defined(USE_CUDA)
+    bool use_spawn_worker = (options.enable_offline_inference() && i > 0) ||
+                            force_spawn_for_numa_isolation[i];
+    if (force_spawn_for_numa_isolation[i]) {
+      LOG(INFO) << "Force spawn worker for local rank " << i << " (device "
+                << devices[i].index() << ", NUMA " << device_numa_nodes[i]
+                << ") to keep each process within a single NUMA region";
+    }
+#else
     bool use_spawn_worker = options.enable_offline_inference() && i > 0;
+#endif
     ParallelArgs parallel_args(rank, world_size, dp_size, nullptr, ep_size);
 
     servers_.emplace_back(std::make_unique<WorkerServer>(i,

--- a/xllm/core/distributed_runtime/spawn_worker_server/spawn_worker_server.cpp
+++ b/xllm/core/distributed_runtime/spawn_worker_server/spawn_worker_server.cpp
@@ -26,6 +26,9 @@ limitations under the License.
 
 #include "core/distributed_runtime/worker_server.h"
 #include "core/platform/device.h"
+#if defined(USE_CUDA)
+#include "core/platform/numa_utils.h"
+#endif
 #include "core/runtime/options.h"
 
 namespace xllm {
@@ -67,6 +70,25 @@ SpawnWorkerServer::SpawnWorkerServer(const std::string& master_node_addr,
   device.set_device();
   device.init_device_context();
   FLAGS_enable_atb_comm_multiprocess = true;
+#endif
+
+#if defined(USE_CUDA)
+  // Bind worker process to the same NUMA node as the device
+  // This prevents the process from spanning across NUMA nodes, which would
+  // significantly degrade memory access and other performance aspects
+  int32_t numa_node = numa::get_device_numa_node(device_idx);
+  if (numa_node >= 0) {
+    LOG(INFO) << "Worker process (device " << device_idx
+              << ") binding to NUMA node " << numa_node;
+    int32_t ret = numa::bind_process_to_numa_node(numa_node);
+    if (ret != 0) {
+      LOG(WARNING) << "Failed to bind worker process to NUMA node " << numa_node
+                   << ", continuing without NUMA binding";
+    }
+  } else {
+    LOG(INFO) << "NUMA node detection not available or not needed for device "
+              << device_idx;
+  }
 #endif
 
   ParallelArgs parallel_args(global_rank, world_size, 1, nullptr, 1);

--- a/xllm/core/distributed_runtime/worker_server.cpp
+++ b/xllm/core/distributed_runtime/worker_server.cpp
@@ -31,6 +31,9 @@ limitations under the License.
 
 #include "common/global_flags.h"
 #include "common/metrics.h"
+#if defined(USE_CUDA)
+#include "core/platform/numa_utils.h"
+#endif
 #include "framework/kv_cache/kv_cache.h"
 #include "framework/model/model_input_params.h"
 #include "framework/parallel_state/collective_communicator.h"
@@ -72,6 +75,25 @@ void WorkerServer::create_server(
   Device device(d);
   device.set_device();
   LOG(INFO) << "Create worker server with device: " << device.index();
+
+#if defined(USE_CUDA)
+  // Bind worker thread to the same NUMA node as the device
+  // This prevents the thread from spanning across NUMA nodes, which would
+  // significantly degrade memory access and other performance aspects
+  int32_t numa_node = numa::get_device_numa_node(device.index());
+  if (numa_node >= 0) {
+    LOG(INFO) << "Worker thread (device " << device.index()
+              << ") binding to NUMA node " << numa_node;
+    int32_t ret = numa::bind_thread_to_numa_node(numa_node);
+    if (ret != 0) {
+      LOG(WARNING) << "Failed to bind worker thread to NUMA node " << numa_node
+                   << ", continuing without NUMA binding";
+    }
+  } else {
+    LOG(INFO) << "NUMA node detection not available or not needed for device "
+              << device.index();
+  }
+#endif
 
   auto worker_global_rank = global_rank;
   // TODO: FIXME Later

--- a/xllm/core/platform/CMakeLists.txt
+++ b/xllm/core/platform/CMakeLists.txt
@@ -15,11 +15,13 @@ cc_library(
     shared_vmm_allocator.h
     vmm_torch_allocator.h
     $<$<BOOL:${USE_CUDA}>:cuda/cuda_utils.h>
+    $<$<BOOL:${USE_CUDA}>:numa_utils.h>
   SRCS
     stream.cpp
     device.cpp
     vmm_api.cpp
     shared_vmm_allocator.cpp
+    $<$<BOOL:${USE_CUDA}>:numa_utils.cpp>
   DEPS
     torch
     $<$<BOOL:${USE_NPU}>:torch_npu>
@@ -29,6 +31,7 @@ cc_library(
     $<$<BOOL:${USE_MLU}>:cndrv>
     $<$<OR:$<BOOL:${USE_CUDA}>,$<BOOL:${USE_ILU}>>:cuda>
     $<$<OR:$<BOOL:${USE_CUDA}>,$<BOOL:${USE_ILU}>>:cudart>
+    $<$<OR:$<BOOL:${USE_CUDA}>,$<BOOL:${USE_ILU}>>:numa>
     $<$<BOOL:${USE_MUSA}>:musa>
     $<$<BOOL:${USE_MUSA}>:musart>
     $<$<BOOL:${USE_NPU}>:platform_npu>

--- a/xllm/core/platform/numa_utils.cpp
+++ b/xllm/core/platform/numa_utils.cpp
@@ -1,0 +1,283 @@
+/* Copyright 2026 The xLLM Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://github.com/jd-opensource/xllm/blob/main/LICENSE
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include "numa_utils.h"
+
+#include <cuda_runtime.h>
+#include <glog/logging.h>
+#include <numa.h>
+#include <pthread.h>
+#include <sched.h>
+#include <unistd.h>
+
+#include <cerrno>
+#include <cstring>
+#include <fstream>
+
+namespace xllm {
+namespace numa {
+namespace {
+
+bool read_numa_node(const std::string& numa_path, int32_t* numa_node) {
+  if (numa_node == nullptr) {
+    return false;
+  }
+  std::ifstream numa_file(numa_path);
+  if (!numa_file.is_open()) {
+    return false;
+  }
+  numa_file >> *numa_node;
+  numa_file.close();
+  return true;
+}
+
+bool build_cpu_set_for_numa_node(int32_t numa_node,
+                                 cpu_set_t* cpu_set,
+                                 int32_t* nr_cpus) {
+  if (cpu_set == nullptr || nr_cpus == nullptr) {
+    return false;
+  }
+
+  CPU_ZERO(cpu_set);
+  *nr_cpus = 0;
+
+  struct bitmask* node_cpu_mask = numa_allocate_cpumask();
+  if (node_cpu_mask == nullptr) {
+    LOG(ERROR) << "Failed to allocate CPU mask for NUMA node " << numa_node;
+    return false;
+  }
+
+  if (numa_node_to_cpus(numa_node, node_cpu_mask) < 0) {
+    LOG(ERROR) << "Failed to query CPUs for NUMA node " << numa_node;
+    numa_free_cpumask(node_cpu_mask);
+    return false;
+  }
+
+  cpu_set_t current_affinity;
+  CPU_ZERO(&current_affinity);
+  const bool has_affinity_constraint =
+      (sched_getaffinity(0, sizeof(cpu_set_t), &current_affinity) == 0);
+  if (!has_affinity_constraint) {
+    LOG(WARNING) << "Failed to get current process affinity: "
+                 << strerror(errno) << ". Falling back to NUMA node CPU list.";
+  }
+
+  const int32_t nr_possible_cpus = numa_num_possible_cpus();
+  for (int32_t cpu = 0; cpu < nr_possible_cpus; ++cpu) {
+    if (!numa_bitmask_isbitset(node_cpu_mask, cpu)) {
+      continue;
+    }
+    if (has_affinity_constraint && !CPU_ISSET(cpu, &current_affinity)) {
+      continue;
+    }
+    if (cpu >= CPU_SETSIZE) {
+      continue;
+    }
+
+    CPU_SET(cpu, cpu_set);
+    ++(*nr_cpus);
+  }
+
+  numa_free_cpumask(node_cpu_mask);
+  return (*nr_cpus > 0);
+}
+
+void apply_process_memory_policy(int32_t numa_node) {
+  struct bitmask* node_mask = numa_allocate_nodemask();
+  if (node_mask == nullptr) {
+    LOG(WARNING) << "Failed to allocate NUMA node mask for memory policy";
+    return;
+  }
+
+  numa_bitmask_clearall(node_mask);
+  numa_bitmask_setbit(node_mask, numa_node);
+
+  struct bitmask* old_mask = numa_get_membind();
+  if (old_mask != nullptr) {
+    long migrate_result = numa_migrate_pages(getpid(), old_mask, node_mask);
+    if (migrate_result < 0) {
+      LOG(WARNING) << "numa_migrate_pages failed: " << strerror(errno);
+    }
+    numa_free_nodemask(old_mask);
+  }
+
+  numa_set_membind(node_mask);
+  numa_set_strict(1);
+  numa_free_nodemask(node_mask);
+}
+
+}  // namespace
+
+bool is_numa_available() {
+  // C++11 guarantees thread-safe initialization for function-local statics.
+  // NUMA availability is probed only on the first call and stored in
+  // `available`; subsequent calls directly reuse the cached result.
+  static const bool available = []() {
+    bool is_avail = (numa_available() >= 0);
+    if (!is_avail) {
+      LOG(WARNING) << "NUMA is not available on this system";
+    }
+    return is_avail;
+  }();
+  return available;
+}
+
+int32_t get_num_numa_nodes() {
+  if (!is_numa_available()) {
+    return -1;
+  }
+  return numa_num_configured_nodes();
+}
+
+int32_t get_device_numa_node(int32_t device_index) {
+  if (!is_numa_available()) {
+    return -1;
+  }
+
+  // For CUDA devices, read NUMA node from PCI sysfs path.
+  char pci_bus_id[32] = {0};
+  if (cudaDeviceGetPCIBusId(pci_bus_id, sizeof(pci_bus_id), device_index) ==
+      cudaSuccess) {
+    std::string numa_path =
+        "/sys/bus/pci/devices/" + std::string(pci_bus_id) + "/numa_node";
+    LOG(INFO) << "numa_path: " << numa_path;
+    int32_t numa_node;
+    const bool is_numa_node_valid = read_numa_node(numa_path, &numa_node);
+    if (is_numa_node_valid) {
+      LOG(INFO) << "numa_node: " << numa_node;
+      return numa_node;
+    }
+  }
+
+  LOG(WARNING) << "Unable to determine NUMA node for CUDA device "
+               << device_index << ", skipping NUMA binding";
+  return -1;
+}
+
+int32_t bind_process_to_numa_node(int32_t numa_node) {
+  if (!is_numa_available()) {
+    LOG(WARNING) << "NUMA not available, skipping process binding";
+    return -1;
+  }
+
+  int32_t num_nodes = get_num_numa_nodes();
+  if (numa_node < 0 || numa_node >= num_nodes) {
+    LOG(ERROR) << "Invalid NUMA node " << numa_node << ", valid range is [0, "
+               << num_nodes - 1 << "]";
+    return -1;
+  }
+
+  cpu_set_t cpu_set;
+  int32_t nr_cpus = 0;
+  if (!build_cpu_set_for_numa_node(numa_node, &cpu_set, &nr_cpus)) {
+    LOG(ERROR) << "No CPUs available on NUMA node " << numa_node
+               << " after applying affinity constraints";
+    return -1;
+  }
+
+  pid_t pid = getpid();
+  if (sched_setaffinity(pid, sizeof(cpu_set_t), &cpu_set) != 0) {
+    LOG(ERROR) << "Failed to bind process to NUMA node " << numa_node << ": "
+               << strerror(errno);
+    return -1;
+  }
+
+  apply_process_memory_policy(numa_node);
+
+  LOG(INFO) << "Successfully bound process " << pid << " to NUMA node "
+            << numa_node << " with " << nr_cpus
+            << " CPUs and strict NUMA memory policy";
+
+  return 0;
+}
+
+int32_t bind_thread_to_numa_node(int32_t numa_node) {
+  if (!is_numa_available()) {
+    LOG(WARNING) << "NUMA not available, skipping thread binding";
+    return -1;
+  }
+
+  int32_t num_nodes = get_num_numa_nodes();
+  if (numa_node < 0 || numa_node >= num_nodes) {
+    LOG(ERROR) << "Invalid NUMA node " << numa_node << ", valid range is [0, "
+               << num_nodes - 1 << "]";
+    return -1;
+  }
+
+  cpu_set_t cpu_set;
+  int32_t nr_cpus = 0;
+  if (!build_cpu_set_for_numa_node(numa_node, &cpu_set, &nr_cpus)) {
+    LOG(ERROR) << "No CPUs available on NUMA node " << numa_node
+               << " after applying affinity constraints";
+    return -1;
+  }
+
+  pthread_t thread = pthread_self();
+  if (pthread_setaffinity_np(thread, sizeof(cpu_set_t), &cpu_set) != 0) {
+    LOG(ERROR) << "Failed to bind thread to NUMA node " << numa_node << ": "
+               << strerror(errno);
+    return -1;
+  }
+
+  LOG(INFO) << "Successfully bound thread to NUMA node " << numa_node
+            << " with " << nr_cpus << " CPUs";
+
+  return 0;
+}
+
+int32_t get_current_numa_node() {
+  if (!is_numa_available()) {
+    return -1;
+  }
+
+  int32_t cpu = sched_getcpu();
+  if (cpu < 0) {
+    LOG(WARNING) << "Failed to get current CPU";
+    return -1;
+  }
+
+  return numa_node_of_cpu(cpu);
+}
+
+std::vector<int32_t> get_numa_node_cpus(int32_t numa_node) {
+  std::vector<int32_t> cpus;
+
+  if (!is_numa_available()) {
+    return cpus;
+  }
+
+  int32_t num_nodes = get_num_numa_nodes();
+  if (numa_node < 0 || numa_node >= num_nodes) {
+    LOG(ERROR) << "Invalid NUMA node " << numa_node;
+    return cpus;
+  }
+
+  cpu_set_t cpu_set;
+  int32_t nr_cpus = 0;
+  if (!build_cpu_set_for_numa_node(numa_node, &cpu_set, &nr_cpus)) {
+    return cpus;
+  }
+
+  for (int32_t cpu = 0; cpu < CPU_SETSIZE; ++cpu) {
+    if (CPU_ISSET(cpu, &cpu_set)) {
+      cpus.push_back(cpu);
+    }
+  }
+
+  return cpus;
+}
+
+}  // namespace numa
+}  // namespace xllm

--- a/xllm/core/platform/numa_utils.h
+++ b/xllm/core/platform/numa_utils.h
@@ -1,0 +1,71 @@
+/* Copyright 2026 The xLLM Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://github.com/jd-opensource/xllm/blob/main/LICENSE
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#pragma once
+
+#include <cstdint>
+#include <vector>
+
+namespace xllm {
+namespace numa {
+
+/**
+ * @brief Check if NUMA is available on the current system
+ * @return true if NUMA is available, false otherwise
+ */
+bool is_numa_available();
+
+/**
+ * @brief Get the number of NUMA nodes on the system
+ * @return Number of NUMA nodes, or -1 if NUMA is not available
+ */
+int32_t get_num_numa_nodes();
+
+/**
+ * @brief Get the NUMA node ID for a given device index
+ * @param device_index The device index (e.g., GPU/NPU index)
+ * @return The NUMA node ID, or -1 if unable to determine
+ */
+int32_t get_device_numa_node(int32_t device_index);
+
+/**
+ * @brief Bind current process to a specific NUMA node
+ * @param numa_node The NUMA node ID to bind to
+ * @return 0 on success, non-zero on failure
+ */
+int32_t bind_process_to_numa_node(int32_t numa_node);
+
+/**
+ * @brief Bind current thread to a specific NUMA node
+ * @param numa_node The NUMA node ID to bind to
+ * @return 0 on success, non-zero on failure
+ */
+int32_t bind_thread_to_numa_node(int32_t numa_node);
+
+/**
+ * @brief Get the NUMA node ID of the current process
+ * @return The NUMA node ID, or -1 if unable to determine
+ */
+int32_t get_current_numa_node();
+
+/**
+ * @brief Get list of CPU cores for a given NUMA node
+ * @param numa_node The NUMA node ID
+ * @return Vector of CPU core IDs belonging to the NUMA node
+ */
+std::vector<int32_t> get_numa_node_cpus(int32_t numa_node);
+
+}  // namespace numa
+}  // namespace xllm


### PR DESCRIPTION
## Summary
close: #462

Pin each xLLM worker process/thread to the NUMA node that is local to its assigned GPU device, preventing cross-NUMA memory access which degrades performance.

## What It Does

  1. Detects the NUMA node for each GPU device at startup.
  2. Pins the engine process to the NUMA node of the first device.
  3. For workers on a different NUMA node than the engine process (multi-NUMA configurations), forces them to run as spawned subprocesses (instead of threads) so each process stays within a single NUMA region.
  4. In spawned worker processes, re-binds the process to its device's NUMA node immediately on startup.
  5. In thread-based workers, binds the worker thread's CPU affinity to the device's NUMA node.


## How It's Implemented

  New utility module (`xllm/core/platform/numa_utils.{h,cpp}`):
  - `get_device_numa_node(device_idx)` — reads NUMA node from sysfs (/sys/bus/pci/devices/.../numa_node for CUDA).
  - `bind_process_to_numa_node(numa_node)` — uses sched_setaffinity + numa_set_membind + numa_migrate_pages to bind the process's CPU and memory to the target node.
  - `bind_thread_to_numa_node(numa_node)` — uses pthread_setaffinity_np for thread-level binding.

  Integration points:
  - `dist_manager.cpp`: Queries NUMA nodes for all devices, pins the engine process, and sets force_spawn_for_numa_isolation[i] = true for any device  on a different NUMA node than the engine.
  - `worker_server.cpp`: Calls bind_thread_to_numa_node when creating a thread-based worker; also adds resolve_spawn_worker_binary_path() to auto-detect the spawn worker binary path via /proc/self/exe as a fallback.
  - `spawn_worker_server.cpp`: Calls bind_process_to_numa_node at the very start of each spawned worker process.