### PR TITLE
feat: support QwenImageEditPlus pipeline with embedding infer.

### DIFF
--- a/xllm/core/common/global_flags.cpp
+++ b/xllm/core/common/global_flags.cpp
@@ -603,7 +603,7 @@ DEFINE_int32(random_seed, -1, "Random seed for random number generator.");
 DEFINE_string(dit_cache_policy,
               "TaylorSeer",
               "The policy of dit cache(e.g. None, FBCache, TaylorSeer, "
-              "FBCacheTaylorSeer).");
+              "FBCacheTaylorSeer, ResidualCache).");
 
 DEFINE_int64(dit_cache_warmup_steps, 0, "The number of warmup steps.");
 
@@ -624,6 +624,48 @@ DEFINE_bool(enable_constrained_decoding,
             "Whether to enable constrained decoding, which is used to ensure "
             "that the output meets specific format or structural requirements "
             "through pre-defined rules.");
+
+DEFINE_int64(dit_cache_start_steps,
+             5,
+             "The number of steps to skip at the start");
+
+DEFINE_int64(dit_cache_end_steps, 5, "The number of steps to skip at the end.");
+
+DEFINE_int64(dit_cache_start_blocks,
+             5,
+             "The number of blocks to skip at the start.");
+
+DEFINE_int64(dit_cache_end_blocks,
+             5,
+             "The number of blocks to skip at the end.");
+
+// --- dit parallel config ---
+
+DEFINE_int64(dit_dp_size, 1, "Data parallelism size for DiT models.");
+
+DEFINE_int64(dit_tp_size, 1, "Tensor parallelism size for DiT models");
+
+DEFINE_int64(dit_sp_size, 1, "Sequence parallelism size for DiT models");
+
+DEFINE_int64(dit_cfg_size,
+             1,
+             "Classifier-free guidiance parallelism size for DiT models");
+
+DEFINE_int64(dit_sp_communication_overlap,
+             1,
+             "Communication & Computation overlap for sequence parallel");
+
+// --- dit debug ---
+
+DEFINE_bool(dit_debug_print,
+            false,
+            "whether print the debug info for dit models");
+
+// --- embedding type ---
+
+DEFINE_bool(enable_return_mm_full_embeddings,
+            false,
+            "return vit and sequence embeddings for vlm models");
 
 DEFINE_bool(
     use_audio_in_video,

--- a/xllm/core/common/global_flags.h
+++ b/xllm/core/common/global_flags.h
@@ -293,6 +293,26 @@ DECLARE_double(dit_cache_residual_diff_threshold);
 
 DECLARE_bool(enable_constrained_decoding);
 
+DECLARE_int64(dit_cache_start_steps);
+
+DECLARE_int64(dit_cache_end_steps);
+
+DECLARE_int64(dit_cache_start_blocks);
+
+DECLARE_int64(dit_cache_end_blocks);
+
+DECLARE_int64(dit_tp_size);
+
+DECLARE_int64(dit_sp_size);
+
+DECLARE_int64(dit_cfg_size);
+
+DECLARE_int64(dit_dp_size);
+
+DECLARE_bool(dit_debug_print);
+
+DECLARE_bool(enable_return_mm_full_embeddings);
+
 // --- multi-step decode config ---
 
 DECLARE_int32(max_decode_rounds);

--- a/xllm/core/common/macros.h
+++ b/xllm/core/common/macros.h
@@ -62,6 +62,34 @@ namespace xllm {
     }                                         \
   } while (0)
 
+#define TORCH_TENSOR_VEC_TO_PROTO_TENSOR_LIST(proto_field, torch_tensor_vec) \
+  do {                                                                       \
+    proto_field->mutable_tensors()->Reserve(torch_tensor_vec.size());        \
+    for (const auto& torch_tensor : torch_tensor_vec) {                      \
+      proto::Tensor* pb_tensor = proto_field->add_tensors();                 \
+      if (!util::torch_to_proto(torch_tensor, pb_tensor)) {                  \
+        LOG(ERROR)                                                           \
+            << "Failed to convert torch Tensor to PB Tensor (list item)";    \
+      }                                                                      \
+    }                                                                        \
+  } while (0)
+
+#define TORCH_TENSOR_TO_PROTO_TENSOR(proto_field, torch_tensor)       \
+  do {                                                                \
+    if (torch_tensor->defined()) {                                    \
+      if (!util::torch_to_proto(*torch_tensor, proto_field)) {        \
+        LOG(ERROR) << "Failed to convert torch Tensor to Pb Tensor "; \
+      }                                                               \
+    }                                                                 \
+  } while (0)
+
+#define PROTO_TENSOR_TO_TORCH_TENSOR(proto_field, torch_tensor)     \
+  do {                                                              \
+    if (!util::torch_to_proto(*torch_tensor, *proto_field)) {       \
+      LOG(ERROR) << "Failed to convert torch Tensor to Pb Tensor "; \
+    }                                                               \
+  } while (0)
+
 #define CALLBACK_WITH_ERROR_ARGS2(CODE, MSG) callback(Status{CODE, MSG})
 #define CALLBACK_WITH_ERROR_ARGS4(CODE, MSG, ID, TARGET_XSERVICE_ADDR) \
   callback({Status{CODE, MSG}, ID, TARGET_XSERVICE_ADDR})

--- a/xllm/core/common/options.h
+++ b/xllm/core/common/options.h
@@ -128,6 +128,14 @@ class Options {
 
   PROPERTY(int32_t, ep_size) = 1;
 
+  PROPERTY(int32_t, dit_dp_size) = 1;
+
+  PROPERTY(int32_t, dit_tp_size) = 1;
+
+  PROPERTY(int32_t, dit_sp_size) = 1;
+
+  PROPERTY(int32_t, dit_cfg_size) = 1;
+
   PROPERTY(std::optional<std::string>, instance_name);
 
   PROPERTY(bool, enable_disagg_pd) = false;

--- a/xllm/core/distributed_runtime/dist_manager.cpp
+++ b/xllm/core/distributed_runtime/dist_manager.cpp
@@ -181,13 +181,28 @@ void DistManager::setup_multi_node_workers(
   const int32_t ep_size = options.ep_size();
   /* TODO(CP): support smem  + CP */
   const int32_t dp_local_tp_size = world_size / dp_size;
+  const int32_t dit_dp_size = options.dit_dp_size();
+  const int32_t dit_tp_size = options.dit_tp_size();
+  const int32_t dit_sp_size = options.dit_sp_size();
+  const int32_t dit_cfg_size = options.dit_cfg_size();
 
-  LOG(INFO) << "Multi-node serving world_size = " << world_size
+  const auto& model_backend = options.backend();
+  if (model_backend == "dit") {
+    LOG(INFO) << "Multi-node serving world_size = " << world_size
+              << ", each_node_ranks = " << each_node_ranks
+              << ", current node rank = " << options.node_rank()
+              << ", nnodes = " << options.nnodes()
+              << ", dp_size = " << dit_dp_size << ", tp_size = " << dit_tp_size
+              << ", sp_size = " << dit_sp_size
+              << ", cfg_size = " << dit_cfg_size;
+  } else {
+    LOG(INFO) << "Multi-node serving world_size = " << world_size
             << ", each_node_ranks = " << each_node_ranks
             << ", current node rank = " << options.node_rank()
             << ", nnodes = " << options.nnodes() << ", dp_size = " << dp_size
             << ", cp_size = " << cp_size << ", ep_size = " << ep_size
             << ", tp_size = " << dp_local_tp_size;
+  }
 
   CHECK_EQ((world_size % dp_size), 0)
       << "Global world size must be divisible by dp size in multi-node "
@@ -196,7 +211,6 @@ void DistManager::setup_multi_node_workers(
   runtime::Options worker_server_options = options;
   worker_server_options.world_size(world_size);
   WorkerType worker_type("LLM");
-  const auto& model_backend = options.backend();
   if (model_backend == "llm") {
     if (options.task_type() == "generate") {
       worker_type = WorkerType::LLM;
@@ -219,6 +233,8 @@ void DistManager::setup_multi_node_workers(
     }
   } else if (model_backend == "rec") {
     worker_type = WorkerType::REC;
+  } else if (model_backend == "dit") {
+    worker_type = WorkerType::DIT;
   } else {
     LOG(FATAL) << "Unsupported " << model_backend << " in multi-node.";
   }

--- a/xllm/core/distributed_runtime/dit_engine.cpp
+++ b/xllm/core/distributed_runtime/dit_engine.cpp
@@ -19,7 +19,9 @@ limitations under the License.
 #include <glog/logging.h>
 #include <sys/sysinfo.h>
 
+#include "common/device_monitor.h"
 #include "core/common/metrics.h"
+#include "core/distributed_runtime/master.h"
 #include "core/platform/device.h"
 #include "framework/parallel_state/parallel_args.h"
 #include "framework/parallel_state/parallel_state.h"
@@ -28,8 +30,16 @@ limitations under the License.
 #include "util/timer.h"
 
 namespace xllm {
-DiTEngine::DiTEngine(const runtime::Options& options) : options_(options) {
+DiTEngine::DiTEngine(const runtime::Options& options,
+                     std::shared_ptr<DistManager> dist_manager)
+    : options_(options), dist_manager_(dist_manager) {
+  auto master_node_addr = options.master_node_addr().value_or("");
+  CHECK(!master_node_addr.empty())
+      << " DIT need to set master node addr, Please set --master_node_addr.";
+
   const auto& devices = options_.devices();
+  // initialize device monitor
+  DeviceMonitor::get_instance().initialize(devices);
   CHECK_GT(devices.size(), 0) << "At least one device is required";
 
   CHECK(!devices[0].is_cpu()) << "CPU device is not supported";
@@ -37,43 +47,26 @@ DiTEngine::DiTEngine(const runtime::Options& options) : options_(options) {
   for (size_t i = 0; i < devices.size(); ++i) {
     CHECK(devices[i].type() == device_type)
         << "All devices should be the same type";
-    Device device(devices[i]);
-    device.set_device();
+
+#if defined(USE_NPU)
+    FLAGS_enable_atb_comm_multiprocess =
+        options.enable_offline_inference() || (options.nnodes() > 1);
+#endif
   }
 
-  if (devices.size() > 1) {
-    // create a process group for each device if there are multiple gpus
-    process_groups_ = parallel_state::create_npu_process_groups(devices);
-  }
-  const int32_t world_size = static_cast<int32_t>(devices.size());
+  // setup all workers and create worker clients in nnode_rank=0 engine side.
+  setup_workers(options);
+  worker_clients_num_ = worker_clients_.size();
 
-  CHECK(!options_.enable_shm()) << "Dit can not support enable_shm currently.";
+  // init thread pool
+  threadpool_ = std::make_unique<ThreadPool>(16);
+}
 
-  // create workers
-  for (int32_t rank = 0; rank < world_size; ++rank) {
-    ProcessGroup* pg = world_size > 1 ? process_groups_[rank].get() : nullptr;
-    ParallelArgs parallel_args(rank, world_size, pg);
-    workers_.emplace_back(
-        std::make_unique<DiTWorker>(parallel_args, devices[rank], options_));
+void DiTEngine::setup_workers(const runtime::Options& options) {
+  if (!dist_manager_) {
+    dist_manager_ = std::make_shared<DistManager>(options);
   }
-
-  if (workers_.size() > 1) {
-    // test process group
-    std::vector<folly::SemiFuture<folly::Unit>> futures;
-    futures.reserve(workers_.size());
-    for (auto& worker : workers_) {
-      futures.emplace_back(worker->process_group_test_async());
-    }
-    // Wait for all futures to complete with a configurable timeout.
-    // The timeout can be adjusted via the
-    // XLLM_PROCESS_GROUP_ASYNC_TIMEOUT_SECONDS environment variable (default: 4
-    // seconds). This is particularly important in multi-node multi-device
-    // scenarios where network latency may require a longer timeout period.
-    const int timeout_seconds = util::get_process_group_test_timeout_seconds();
-    folly::collectAll(futures)
-        .within(std::chrono::seconds(timeout_seconds))
-        .get();
-  }
+  worker_clients_ = dist_manager_->get_worker_clients();
 }
 
 bool DiTEngine::init() {
@@ -86,13 +79,14 @@ bool DiTEngine::init() {
 
 bool DiTEngine::init_model() {
   const std::string& model_path = options_.model_path();
+
   // init model for each worker in parallel
   // multiple workers, call async init
   std::vector<folly::SemiFuture<bool>> futures;
-  LOG(INFO) << "Starting to init model on " << workers_.size() << " workers.";
-  futures.reserve(workers_.size());
-  for (auto& worker : workers_) {
-    futures.push_back(worker->init_model(model_path));
+  futures.reserve(worker_clients_num_);
+  for (auto& worker : worker_clients_) {
+    futures.push_back(worker->init_model_async(
+        model_path, FLAGS_random_seed, MasterStatus::WAKEUP));
   }
 
   // wait for all futures to complete
@@ -108,17 +102,25 @@ bool DiTEngine::init_model() {
   return true;
 }
 
+// TODO : change to ForwardOutput?
 DiTForwardOutput DiTEngine::step(std::vector<DiTBatch>& batches) {
-  CHECK(!workers_.empty());
+  if (worker_clients_.empty()) {
+    // empty worker, return
+    return {};
+  }
 
   Timer timer;
-  auto forward_inputs = workers_[0]->prepare_inputs(batches[0]);
+  auto dit_forward_input = batches[0].prepare_forward_input();
+  RawForwardInput raw_forward_input;
+  raw_forward_input.dit_forward_input = dit_forward_input;
   COUNTER_ADD(prepare_input_latency_seconds, timer.elapsed_seconds());
 
-  std::vector<folly::SemiFuture<std::optional<DiTForwardOutput>>> futures;
-  futures.reserve(workers_.size());
-  for (auto& worker : workers_) {
-    futures.emplace_back(worker->step(forward_inputs));
+  std::vector<folly::SemiFuture<std::optional<RawForwardOutput>>> futures;
+  futures.reserve(worker_clients_num_);
+
+  for (auto worker_rank = 0; worker_rank < worker_clients_num_; ++worker_rank) {
+    futures.emplace_back(
+        worker_clients_[worker_rank]->step_async(raw_forward_input));
   }
 
   // wait for the all future to complete
@@ -127,22 +129,22 @@ DiTForwardOutput DiTEngine::step(std::vector<DiTBatch>& batches) {
   // return the result from the driver
   auto forward_output = results.front().value();
   DCHECK(forward_output.has_value()) << "Failed to execute model";
-  batches[0].process_forward_output(forward_output.value());
-  return forward_output.value();
+  batches[0].process_forward_output(forward_output.value().dit_forward_output);
+  return forward_output.value().dit_forward_output;
 }
 
 std::vector<int64_t> DiTEngine::get_active_activation_memory() const {
   // call worker to get active activation memory
   std::vector<folly::SemiFuture<int64_t>> futures;
-  futures.reserve(workers_.size());
-  for (auto& worker : workers_) {
-    futures.push_back(worker->get_active_activation_memory());
+  futures.reserve(worker_clients_num_);
+  for (auto& worker : worker_clients_) {
+    futures.push_back(worker->get_active_activation_memory_async());
   }
 
   // wait for all futures to complete
   auto results = folly::collectAll(futures).get();
   std::vector<int64_t> active_activation_memories;
-  active_activation_memories.reserve(workers_.size());
+  active_activation_memories.reserve(worker_clients_num_);
   for (auto& result : results) {
     active_activation_memories.push_back(result.value());
   }

--- a/xllm/core/distributed_runtime/dit_engine.h
+++ b/xllm/core/distributed_runtime/dit_engine.h
@@ -21,16 +21,19 @@ limitations under the License.
 #include <memory>
 
 #include "common/macros.h"
+#include "dist_manager.h"
+#include "engine.h"
 #include "framework/batch/dit_batch.h"
 #include "framework/parallel_state/process_group.h"
 #include "framework/quant_args.h"
-#include "runtime/dit_worker.h"
+#include "runtime/dit_worker_impl.h"
 
 namespace xllm {
 
-class DiTEngine {
+class DiTEngine : public Engine {
  public:
-  DiTEngine(const runtime::Options& options);
+  DiTEngine(const runtime::Options& options,
+            std::shared_ptr<DistManager> dist_manager = nullptr);
 
   ~DiTEngine() = default;
 
@@ -43,16 +46,44 @@ class DiTEngine {
   // return the active activation memory
   std::vector<int64_t> get_active_activation_memory() const;
 
+  std::shared_ptr<DistManager> get_dist_manager() { return dist_manager_; }
+
+  // These two functions wouldn't be used in dit inference progress
+  ForwardOutput step(std::vector<Batch>& batch) override {
+    ForwardOutput output;
+    return output;
+  }
+
+  void update_last_step_result(std::vector<Batch>& batch) override { return; }
+
+ protected:
+  // worker client which is used for call worker
+  // The reason for adding a worker client is to unify the
+  // access code for both local and remote workers, thereby
+  // introducing an additional worker_client abstraction.
+  std::vector<std::shared_ptr<WorkerClient>> worker_clients_;
+
+  // For multi-node serving
+  // engine brpc server, all workers connect to engine_server_,
+  // engine_server_ will send a UniqueId for workers to
+  // create process group. And workers send worker brpc server
+  // address to engine, engine will create WorkerClient for each worker.
+  // Engine call workers to step via these WorkerClients.
+  std::shared_ptr<DistManager> dist_manager_ = nullptr;
+
+  std::unique_ptr<ThreadPool> threadpool_ = nullptr;
+
  private:
+  // setup workers internal
+  void setup_workers(const runtime::Options& options);
+  // init models
   bool init_model();
   // options
   runtime::Options options_;
-
+  // num of worker_clients
+  int64_t worker_clients_num_;
   // a list of process groups, with each process group handling a single device
   std::vector<std::unique_ptr<ProcessGroup>> process_groups_;
-
-  // a list of workers, with each worker handling a partial of model
-  std::vector<std::unique_ptr<DiTWorker>> workers_;
 };
 
 }  // namespace xllm

--- a/xllm/core/distributed_runtime/dit_master.cpp
+++ b/xllm/core/distributed_runtime/dit_master.cpp
@@ -37,20 +37,10 @@ limitations under the License.
 #include "util/timer.h"
 
 namespace xllm {
+volatile bool DiTAssistantMaster::running_ = false;
+
 DiTMaster::DiTMaster(const Options& options)
     : Master(options, EngineType::DIT) {
-  // construct engine
-  const auto devices =
-      DeviceNameUtils::parse_devices(options_.devices().value_or("auto"));
-  LOG(INFO) << "Creating engine with devices: "
-            << DeviceNameUtils::to_string(devices);
-
-  runtime::Options eng_options;
-  eng_options.model_path(options.model_path())
-      .model_id(options.model_id())
-      .devices(devices);
-
-  engine_ = std::make_unique<DiTEngine>(eng_options);
   CHECK(engine_->init());
 
   DiTScheduler::Options scheduler_options;
@@ -155,6 +145,38 @@ void DiTMaster::generate() {
   running_.store(true, std::memory_order_relaxed);
   scheduler_->generate();
   running_.store(false, std::memory_order_relaxed);
+}
+
+DiTAssistantMaster::DiTAssistantMaster(const Options& options)
+    : Master(options, EngineType::DIT) {
+  // setup process workers
+  auto master_node_addr = options_.master_node_addr().value_or("");
+  // TODO: support local unix domain socket later.
+  if (master_node_addr.empty()) {
+    LOG(FATAL)
+        << "MultiNodeEngine required master_node_addr, current value is empty.";
+    return;
+  }
+
+  running_ = true;
+}
+
+DiTAssistantMaster::~DiTAssistantMaster() {
+  // wait for the loop thread to finish
+  if (loop_thread_.joinable()) {
+    loop_thread_.join();
+  }
+}
+
+void DiTAssistantMaster::run() {
+  signal(SIGINT, DiTAssistantMaster::handle_signal);
+  signal(SIGTERM, DiTAssistantMaster::handle_signal);
+
+  loop_thread_ = std::thread([this]() {
+    while (running_) {
+      std::this_thread::sleep_for(std::chrono::seconds(5));
+    }
+  });
 }
 
 }  // namespace xllm

--- a/xllm/core/distributed_runtime/dit_master.h
+++ b/xllm/core/distributed_runtime/dit_master.h
@@ -53,8 +53,6 @@ class DiTMaster : public Master {
   void generate();
 
  private:
-  std::unique_ptr<DiTEngine> engine_;
-
   std::unique_ptr<DiTScheduler> scheduler_;
 
   // thread pool for handling requests
@@ -68,6 +66,19 @@ class DiTMaster : public Master {
 
   // flag to indicate if the handler is running
   std::atomic_bool running_{false};
+};
+
+class DiTAssistantMaster : public Master {
+ public:
+  DiTAssistantMaster(const Options& options);
+  ~DiTAssistantMaster();
+  void run() override;
+
+  static void handle_signal(int signum) { running_ = false; }
+
+ private:
+  std::thread loop_thread_;
+  static volatile bool running_;
 };
 
 }  // namespace xllm

--- a/xllm/core/distributed_runtime/master.cpp
+++ b/xllm/core/distributed_runtime/master.cpp
@@ -382,6 +382,35 @@ Master::Master(const Options& options, EngineType type)
         .rec_worker_max_concurrency(options_.rec_worker_max_concurrency());
 
     engine_ = std::make_unique<RecEngine>(eng_options);
+  } else if (type == EngineType::DIT) {
+    // construct dit engine
+    runtime::Options eng_options;
+    eng_options.model_path(options.model_path())
+        .model_id(options.model_id())
+        .devices(devices)
+        .backend(options.backend())
+        .enable_prefix_cache(options_.enable_prefix_cache())
+        .enable_chunked_prefill(options_.enable_chunked_prefill())
+        .enable_offline_inference(options_.enable_offline_inference())
+        .max_memory_utilization(options_.max_memory_utilization())
+        .master_node_addr(options.master_node_addr())
+        .nnodes(options.nnodes())
+        .task_type(options_.task_type())
+        .enable_shm(options_.enable_shm())
+        .input_shm_size(options_.input_shm_size() * 1024 * 1024)
+        .output_shm_size(options_.output_shm_size() * 1024 * 1024)
+        .is_local(options_.is_local())
+        .node_rank(options_.node_rank())
+        .enable_schedule_overlap(options_.enable_schedule_overlap())
+        .dp_size(options_.dp_size())
+        .ep_size(options_.ep_size())
+        .dit_dp_size(options_.dit_dp_size())
+        .dit_tp_size(options_.dit_tp_size())
+        .dit_sp_size(options_.dit_sp_size())
+        .dit_cfg_size(options_.dit_cfg_size());
+
+    auto dit_engine = std::make_unique<DiTEngine>(eng_options);
+    engine_ = std::move(dit_engine);
   } else {
     LOG(WARNING) << "Not supported llm engine type: "
                  << static_cast<size_t>(type);

--- a/xllm/core/distributed_runtime/worker_server.cpp
+++ b/xllm/core/distributed_runtime/worker_server.cpp
@@ -41,6 +41,7 @@ limitations under the License.
 #include "framework/kv_cache/kv_cache.h"
 #include "framework/model/model_input_params.h"
 #include "framework/parallel_state/collective_communicator.h"
+#include "framework/parallel_state/dit_collective_communicator.h"
 #include "framework/parallel_state/mapping_npu.h"
 #include "framework/state_dict/state_dict.h"
 #include "runtime/forward_params.h"
@@ -137,15 +138,32 @@ void WorkerServer::create_server(
     return;
   }
 
-  CollectiveCommunicator comm(
-      worker_global_rank, world_size, dp_size, ep_size, cp_size);
-  const ParallelArgs* parallel_args = comm.parallel_args();
-  comm.create_process_groups(master_node_addr, device);
+  const ParallelArgs* parallel_args = nullptr;
+  std::unique_ptr<CollectiveCommunicatorBase> comm;
+  if (worker_type == WorkerType::DIT) {
+    auto dit_comm =
+        std::make_unique<DiTCollectiveCommunicator>(worker_global_rank,
+                                                    world_size,
+                                                    options.dit_dp_size(),
+                                                    options.dit_tp_size(),
+                                                    options.dit_sp_size(),
+                                                    options.dit_cfg_size());
+    comm = std::move(dit_comm);
+  } else {
+    auto common_comm = std::make_unique<CollectiveCommunicator>(
+        worker_global_rank, world_size, dp_size, ep_size, cp_size);
+    comm = std::move(common_comm);
+  }
+
+  comm->create_process_groups(master_node_addr, device);
+  parallel_args = comm->parallel_args();
 
   std::unique_ptr<Worker> worker =
       std::make_unique<Worker>(*parallel_args, device, options, worker_type);
   worker_service->set_worker(std::move(worker));
-  if (options.enable_shm() && input_shm_manager && output_shm_manager) {
+  bool create_shm =
+      options.enable_shm() && input_shm_manager && output_shm_manager;
+  if (create_shm) {
     worker_service->create_polling_shm_thread(std::move(input_shm_manager),
                                               std::move(output_shm_manager));
   }
@@ -280,7 +298,8 @@ WorkerServer::WorkerServer(int local_worker_idx,
 
   if (worker_type == WorkerType::LLM || worker_type == WorkerType::ELM ||
       worker_type == WorkerType::VLM || worker_type == WorkerType::EVLM ||
-      worker_type == WorkerType::REC || worker_type == WorkerType::MMEVLM) {
+      worker_type == WorkerType::REC || worker_type == WorkerType::MMEVLM ||
+      worker_type == WorkerType::DIT) {
     if (use_spawn_worker) {
       // start worker in a spawn process(for offline inference worker.)
       create_spawn_server(local_worker_idx,

--- a/xllm/core/distributed_runtime/worker_service.cpp
+++ b/xllm/core/distributed_runtime/worker_service.cpp
@@ -73,6 +73,7 @@ void WorkerService::step(ForwardInput& fwd_input,
                          torch::Tensor& top_logprobs,
                          torch::Tensor& embeddings,
                          std::vector<torch::Tensor>& mm_embeddings,
+                         std::vector<torch::Tensor>& dit_images,
                          torch::Tensor& expert_load_data,
                          int32_t& prepared_layer_id,
                          torch::Tensor& src_seq_idxes,
@@ -80,7 +81,6 @@ void WorkerService::step(ForwardInput& fwd_input,
                          torch::Tensor& out_logprobs) {
   // execute model
   auto future = worker_->step_async(fwd_input);
-
   if (!options_.enable_schedule_overlap()) {
     auto forward_outputs = std::move(future).get();
     // convert ForwardOutput to proto::ForwardOutput which contain Tokens.
@@ -89,6 +89,8 @@ void WorkerService::step(ForwardInput& fwd_input,
       const auto& sample_output = forward_outputs.value().sample_output;
       const auto& beam_search_output =
           forward_outputs.value().beam_search_output;
+      const auto& dit_forward_output =
+          forward_outputs.value().dit_forward_output;
       expert_load_data =
           safe_to(forward_outputs.value().expert_load_data, torch::kCPU, true);
       prepared_layer_id = forward_outputs.value().prepared_layer_id;
@@ -105,6 +107,12 @@ void WorkerService::step(ForwardInput& fwd_input,
         mm_embeddings.reserve(sample_output.mm_embeddings.size());
         for (auto mm_embedding : sample_output.mm_embeddings) {
           mm_embeddings.emplace_back(safe_to(mm_embedding, torch::kCPU, true));
+        }
+
+        dit_images.clear();
+        dit_images.reserve(dit_forward_output.tensors.size());
+        for (auto dit_image : dit_forward_output.tensors) {
+          dit_images.emplace_back(safe_to(dit_image, torch::kCPU, true));
         }
 
         // [num_seq]
@@ -175,6 +183,7 @@ void WorkerService::create_polling_shm_thread(
           torch::Tensor top_logprobs;
           torch::Tensor embeddings;
           std::vector<torch::Tensor> mm_embeddings;
+          std::vector<torch::Tensor> dit_images;
           torch::Tensor expert_load_data;
           int32_t prepared_layer_id = -1;
 
@@ -190,6 +199,7 @@ void WorkerService::create_polling_shm_thread(
                top_logprobs,
                embeddings,
                mm_embeddings,
+               dit_images,
                expert_load_data,
                prepared_layer_id,
                src_seq_idxes,
@@ -202,6 +212,7 @@ void WorkerService::create_polling_shm_thread(
                                                top_logprobs,
                                                embeddings,
                                                mm_embeddings,
+                                               dit_images,
                                                expert_load_data,
                                                prepared_layer_id,
                                                src_seq_idxes,
@@ -635,6 +646,7 @@ void WorkerService::ExecuteModel(::google::protobuf::RpcController* controller,
         torch::Tensor top_logprobs;
         torch::Tensor embeddings;
         std::vector<torch::Tensor> mm_embeddings;
+        std::vector<torch::Tensor> dit_images;
         torch::Tensor expert_load_data;
         int32_t prepared_layer_id = -1;
         // beam search kernel output
@@ -649,6 +661,7 @@ void WorkerService::ExecuteModel(::google::protobuf::RpcController* controller,
              top_logprobs,
              embeddings,
              mm_embeddings,
+             dit_images,
              expert_load_data,
              prepared_layer_id,
              src_seq_idxes,
@@ -665,6 +678,7 @@ void WorkerService::ExecuteModel(::google::protobuf::RpcController* controller,
                                 src_seq_idxes,
                                 out_tokens,
                                 out_logprobs,
+                                dit_images,
                                 pb_forward_output);
         COUNTER_ADD(worker_service_latency_seconds, timer.elapsed_seconds());
       });
@@ -693,6 +707,14 @@ void WorkerService::GetLastStepResult(
           auto embeddings =
               safe_to(sample_output.embeddings, torch::kCPU, true);
           embeddings = safe_to(embeddings, torch::kFloat32, true);
+
+          std::vector<torch::Tensor> dit_images;
+          dit_images.reserve(
+              forward_outputs.value().dit_forward_output.tensors.size());
+          for (auto image :
+               forward_outputs.value().dit_forward_output.tensors) {
+            dit_images.emplace_back(image);
+          }
 
           // [num_seq]
           const auto& next_tokens =
@@ -730,6 +752,7 @@ void WorkerService::GetLastStepResult(
                                     src_seq_idxes,
                                     out_tokens,
                                     out_logprobs,
+                                    dit_images,
                                     pb_forward_output);
           }
         }

--- a/xllm/core/distributed_runtime/worker_service.h
+++ b/xllm/core/distributed_runtime/worker_service.h
@@ -148,6 +148,7 @@ class WorkerService : public proto::DistributeWorker {
             torch::Tensor& top_logprobs,
             torch::Tensor& embeddings,
             std::vector<torch::Tensor>& mm_embeddings,
+            std::vector<torch::Tensor>& dit_images,
             torch::Tensor& expert_load_data,
             int32_t& prepared_layer_id,
             torch::Tensor& src_seq_idxes,

--- a/xllm/core/framework/batch/batch.cpp
+++ b/xllm/core/framework/batch/batch.cpp
@@ -416,15 +416,20 @@ void Batch::process_sample_output(const RawForwardOutput& raw_output,
         continue;
       }
       std::vector<torch::Tensor> seq_mm_embeddings;
-      seq_mm_embeddings.reserve(n_images);
-      for (int i = mm_embedding_idx; i < mm_embedding_idx + n_images; ++i) {
+      // if we want to return the full embeding of images and prompts,
+      // the output is a single embedding tensor, else it would be a vector of
+      // image embeddings
+      int64_t output_tensor_size =
+        FLAGS_enable_return_mm_full_embeddings ? 1 : n_images;
+      seq_mm_embeddings.reserve(output_tensor_size);
+      for (int i = mm_embedding_idx; i < mm_embedding_idx + output_tensor_size; ++i) {
         CHECK_LT(i, raw_output.mm_embeddings.size());
         seq_mm_embeddings.push_back(raw_output.mm_embeddings[i]);
       }
       seq->update_mm_embeddings(seq_mm_embeddings);
       // we only support complete mm embedding in one iteration now
       CHECK(seq->finished());
-      mm_embedding_idx += n_images;
+      mm_embedding_idx += output_tensor_size;
     }
   }
 

--- a/xllm/core/framework/batch/dit_batch.cpp
+++ b/xllm/core/framework/batch/dit_batch.cpp
@@ -61,6 +61,7 @@ DiTForwardInput DiTBatch::prepare_forward_input() {
   std::vector<torch::Tensor> negative_pooled_prompt_embeds;
 
   std::vector<torch::Tensor> images;
+  std::vector<torch::Tensor> condition_images;
   std::vector<torch::Tensor> mask_images;
   std::vector<torch::Tensor> control_images;
   std::vector<torch::Tensor> latents;
@@ -106,6 +107,7 @@ DiTForwardInput DiTBatch::prepare_forward_input() {
 
     images.emplace_back(input_params.image);
     mask_images.emplace_back(input_params.mask_image);
+    condition_images.emplace_back(input_params.condition_image);
     control_images.emplace_back(input_params.control_image);
   }
 
@@ -127,6 +129,10 @@ DiTForwardInput DiTBatch::prepare_forward_input() {
 
   if (check_tensors_valid(images)) {
     input.images = torch::stack(images);
+  }
+
+  if (check_tensors_valid(condition_images)) {
+    input.condition_images = torch::stack(condition_images);
   }
 
   if (check_tensors_valid(mask_images)) {

--- a/xllm/core/framework/dit_cache/CMakeLists.txt
+++ b/xllm/core/framework/dit_cache/CMakeLists.txt
@@ -13,6 +13,7 @@ cc_library(
   fbcache.h
   fbcache_taylorseer.h
   taylorseer.h
+  residual_cache.h
  SRCS
   dit_cache_impl.cpp
   dit_cache.cpp
@@ -20,6 +21,7 @@ cc_library(
   fbcache.cpp
   fbcache_taylorseer.cpp
   taylorseer.cpp
+  residual_cache.cpp
  DEPS
   torch
   glog::glog

--- a/xllm/core/framework/dit_cache/dit_cache.cpp
+++ b/xllm/core/framework/dit_cache/dit_cache.cpp
@@ -19,26 +19,48 @@ namespace xllm {
 
 bool DiTCache::init(const DiTCacheConfig& cfg) {
   active_cache_ = create_dit_cache(cfg);
-  if (!active_cache_) {
+  active_cond_cache_ = create_dit_cache(cfg);
+  if (!active_cache_ || !active_cond_cache_) {
     return false;
   }
   active_cache_->init(cfg);
+  active_cond_cache_->init(cfg);
   return true;
 }
 
-bool DiTCache::on_before_block(const CacheBlockIn& blockin) {
+torch::Tensor DiTCache::get_tensor_or_empty(const TensorMap& m,
+                                            const std::string& k) {
+  auto it = m.find(k);
+  if (it != m.end()) return it->second;
+  return torch::Tensor();
+}
+
+bool DiTCache::on_before_block(const CacheBlockIn& blockin, bool use_cfg) {
+  if (use_cfg) {
+    return active_cond_cache_->on_before_block(blockin);
+  }
   return active_cache_->on_before_block(blockin);
 }
 
-CacheBlockOut DiTCache::on_after_block(const CacheBlockIn& blockin) {
+CacheBlockOut DiTCache::on_after_block(const CacheBlockIn& blockin,
+                                       bool use_cfg) {
+  if (use_cfg) {
+    return active_cond_cache_->on_after_block(blockin);
+  }
   return active_cache_->on_after_block(blockin);
 }
 
-bool DiTCache::on_before_step(const CacheStepIn& stepin) {
+bool DiTCache::on_before_step(const CacheStepIn& stepin, bool use_cfg) {
+  if (use_cfg) {
+    return active_cond_cache_->on_before_step(stepin);
+  }
   return active_cache_->on_before_step(stepin);
 }
 
-CacheStepOut DiTCache::on_after_step(const CacheStepIn& stepin) {
+CacheStepOut DiTCache::on_after_step(const CacheStepIn& stepin, bool use_cfg) {
+  if (use_cfg) {
+    return active_cond_cache_->on_after_step(stepin);
+  }
   return active_cache_->on_after_step(stepin);
 }
 

--- a/xllm/core/framework/dit_cache/dit_cache.h
+++ b/xllm/core/framework/dit_cache/dit_cache.h
@@ -35,14 +35,41 @@ class DiTCache {
 
   bool init(const DiTCacheConfig& cfg);
 
-  bool on_before_block(const CacheBlockIn& blockin);
-  CacheBlockOut on_after_block(const CacheBlockIn& blockin);
+  DiTCache(const DiTCacheConfig& cfg) {
+    active_cache_ = create_dit_cache(cfg);
+    active_cond_cache_ = create_dit_cache(cfg);
+    if (!active_cache_ || !active_cond_cache_) {
+      LOG(ERROR) << "failed to initialized dit cache, "
+                    "please check your config";
+    }
+    active_cache_->init(cfg);
+    active_cond_cache_->init(cfg);
+  }
 
-  bool on_before_step(const CacheStepIn& stepin);
-  CacheStepOut on_after_step(const CacheStepIn& stepin);
+  bool on_before_block(const CacheBlockIn& blockin, bool use_cfg = false);
+
+  CacheBlockOut on_after_block(const CacheBlockIn& blockin,
+                               bool use_cfg = false);
+
+  bool on_before_step(const CacheStepIn& stepin, bool use_cfg = false);
+
+  CacheStepOut on_after_step(const CacheStepIn& stepin, bool use_cfg = false);
+
+  virtual void set_infer_steps(const int64_t& infer_steps) {
+    active_cache_->set_infer_steps(infer_steps);
+    active_cond_cache_->set_infer_steps(infer_steps);
+  }
+
+  virtual void set_num_blocks(const int64_t& num_blocks) {
+    active_cache_->set_num_blocks(num_blocks);
+    active_cond_cache_->set_num_blocks(num_blocks);
+  }
 
  private:
+  torch::Tensor get_tensor_or_empty(const TensorMap& m, const std::string& k);
+
   std::unique_ptr<DitCacheImpl> active_cache_;
+  std::unique_ptr<DitCacheImpl> active_cond_cache_;
 };
 
 }  // namespace xllm

--- a/xllm/core/framework/dit_cache/dit_cache_config.h
+++ b/xllm/core/framework/dit_cache/dit_cache_config.h
@@ -22,6 +22,7 @@ enum class PolicyType {
   FBCache,
   TaylorSeer,
   FBCacheTaylorSeer,
+  ResidualCache
 };
 
 struct DiTBaseCacheOptions {
@@ -50,6 +51,23 @@ struct FBCacheTaylorSeerOptions : public DiTBaseCacheOptions {
   int n_derivatives = 3;
 };
 
+struct ResidualCacheOptions {
+  // The number of steps to skip at the start.
+  int64_t dit_cache_start_steps = 5;
+
+  // The number of steps to skip at the end.
+  int64_t dit_cache_end_steps = 5;
+
+  // The number of blocks to skip at the start.
+  int64_t dit_cache_start_blocks = 5;
+
+  // The number of blocks to skip at the end.
+  int64_t dit_cache_end_blocks = 5;
+
+  // the interval steps to skip for derivative calculation.
+  int64_t skip_interval_steps = 3;
+};
+
 struct DiTCacheConfig {
   DiTCacheConfig() = default;
 
@@ -64,6 +82,9 @@ struct DiTCacheConfig {
 
   // the configuration for combined FBCache with TaylorSeer policy.
   FBCacheTaylorSeerOptions fbcachetaylorseer;
+
+  // the configuration for ResidualCache policy.
+  ResidualCacheOptions residual_cache;
 };
 
 }  // namespace xllm

--- a/xllm/core/framework/dit_cache/dit_cache_impl.cpp
+++ b/xllm/core/framework/dit_cache/dit_cache_impl.cpp
@@ -18,6 +18,7 @@ limitations under the License.
 #include "dit_non_cache.h"
 #include "fbcache.h"
 #include "fbcache_taylorseer.h"
+#include "residual_cache.h"
 #include "taylorseer.h"
 
 namespace xllm {
@@ -55,6 +56,8 @@ std::unique_ptr<DitCacheImpl> create_dit_cache(const DiTCacheConfig& cfg) {
       return std::make_unique<TaylorSeer>();
     case PolicyType::FBCacheTaylorSeer:
       return std::make_unique<FBCacheTaylorSeer>();
+    case PolicyType::ResidualCache:
+      return std::make_unique<ResidualCache>();
     default:
       return std::make_unique<DiTNonCache>();
   }

--- a/xllm/core/framework/dit_cache/dit_cache_impl.h
+++ b/xllm/core/framework/dit_cache/dit_cache_impl.h
@@ -37,10 +37,20 @@ class DitCacheImpl {
   virtual bool on_before_step(const CacheStepIn& stepin) = 0;
   virtual CacheStepOut on_after_step(const CacheStepIn& stepin) = 0;
 
+  virtual void set_infer_steps(const int64_t& infer_steps) {
+    infer_steps_ = infer_steps;
+  }
+
+  virtual void set_num_blocks(const int64_t& num_blocks) {
+    num_blocks_ = num_blocks;
+  }
+
  protected:
   int64_t num_inference_steps_;
   int64_t warmup_steps_;
   int64_t current_step_;
+  int64_t infer_steps_;
+  int64_t num_blocks_;
   TensorMap buffers;
 
   static torch::Tensor get_tensor_or_empty(const TensorMap& m,

--- a/xllm/core/framework/dit_cache/residual_cache.cpp
+++ b/xllm/core/framework/dit_cache/residual_cache.cpp
@@ -1,0 +1,136 @@
+/* Copyright 2026 The xLLM Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://github.com/jd-opensource/xllm/blob/main/LICENSE
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include "residual_cache.h"
+
+namespace xllm {
+
+void ResidualCache::init(const DiTCacheConfig& cfg) {
+  CHECK_GT(cfg.residual_cache.skip_interval_steps, 0)
+      << "skip_interval_steps must be > 0";
+  CHECK_GT(cfg.residual_cache.dit_cache_start_steps, 0)
+      << "dit_cache_start_steps must be > 0";
+  CHECK_GT(cfg.residual_cache.dit_cache_end_steps, 0)
+      << "dit_cache_end_steps must be > 0";
+  CHECK_GT(cfg.residual_cache.dit_cache_start_blocks, 0)
+      << "dit_cache_start_blocks must be > 0";
+  CHECK_GT(cfg.residual_cache.dit_cache_end_blocks, 0)
+      << "dit_cache_end_blocks must be > 0";
+  skip_interval_steps_ = cfg.residual_cache.skip_interval_steps;
+  dit_cache_start_steps_ = cfg.residual_cache.dit_cache_start_steps;
+  dit_cache_end_steps_ = cfg.residual_cache.dit_cache_end_steps;
+  dit_cache_start_blocks_ = cfg.residual_cache.dit_cache_start_blocks;
+  dit_cache_end_blocks_ = cfg.residual_cache.dit_cache_end_blocks;
+  reset_cache();
+}
+
+void ResidualCache::reset_cache() {
+  use_cache_ = false;
+  update_cache_ = false;
+}
+
+void ResidualCache::mark_step_begin() { ++current_step_; }
+
+torch::Tensor ResidualCache::get_residual(const torch::Tensor& hidden_states,
+                                          const std::string& key) {
+  return hidden_states - buffers[key];
+}
+
+torch::Tensor ResidualCache::add_residual(const torch::Tensor& hidden_states,
+                                          const std::string& key) {
+  return hidden_states + buffers[key];
+}
+
+void ResidualCache::update(const torch::Tensor& residual,
+                           const std::string& key) {
+  buffers[key] = residual;
+}
+
+bool ResidualCache::cache_validation() {
+  bool step_valid =
+      infer_steps_ > dit_cache_start_steps_ + dit_cache_end_steps_ &&
+      infer_steps_ > dit_cache_start_steps_ &&
+      infer_steps_ > dit_cache_end_steps_;
+  bool block_valid =
+      num_blocks_ > dit_cache_start_blocks_ + dit_cache_end_blocks_ &&
+      num_blocks_ > dit_cache_start_blocks_ &&
+      num_blocks_ > dit_cache_end_blocks_;
+  return step_valid & block_valid;
+}
+
+bool ResidualCache::on_before_block(const CacheBlockIn& blockin) {
+  // when infer_steps is less than skipped_skips, won't use cache
+  if (!cache_validation() || !use_cache_ ||
+      blockin.block_id < dit_cache_start_blocks_ ||
+      blockin.block_id >= num_blocks_ - dit_cache_end_blocks_ - 1) {
+    return false;
+  }
+
+  return true;
+}
+
+CacheBlockOut ResidualCache::on_after_block(const CacheBlockIn& blockin) {
+  TensorMap out_map;
+  auto hidden_states = get_tensor_or_empty(blockin.tensors, "hidden_states");
+  auto encoder_hidden_states =
+      get_tensor_or_empty(blockin.tensors, "encoder_hidden_states");
+  if (cache_validation()) {
+    if (use_cache_) {
+      if (blockin.block_id == num_blocks_ - dit_cache_end_blocks_ - 1) {
+        out_map["hidden_states"] = add_residual(hidden_states, "hidden_states");
+        out_map["encoder_hidden_states"] =
+            add_residual(encoder_hidden_states, "encoder_hidden_states");
+        return CacheBlockOut(out_map);
+      }
+    } else if (update_cache_) {
+      if (blockin.block_id == dit_cache_start_blocks_ - 1) {
+        // cache
+        update(hidden_states.clone(), "hidden_states");
+        update(encoder_hidden_states.clone(), "encoder_hidden_states");
+      } else if (blockin.block_id == num_blocks_ - dit_cache_end_blocks_ - 1) {
+        // calculate residual and update cache
+        update(get_residual(hidden_states, "hidden_states"), "hidden_states");
+        update(get_residual(encoder_hidden_states, "encoder_hidden_states"),
+               "encoder_hidden_states");
+      }
+    }
+  }
+  out_map["hidden_states"] = hidden_states;
+  out_map["encoder_hidden_states"] = encoder_hidden_states;
+  return CacheBlockOut(out_map);
+}
+
+bool ResidualCache::on_before_step(const CacheStepIn& stepin) {
+  current_step_ = stepin.step_id;
+  // if outside the target steps, do nothing
+  if (!cache_validation() || current_step_ < dit_cache_start_steps_ - 1 ||
+      current_step_ >= infer_steps_ - dit_cache_end_steps_) {
+    reset_cache();
+    return false;
+  }
+  // if inside target steps, use_cache when inside the interval
+  // update cache when interval ends
+  use_cache_ =
+      ((current_step_ - (dit_cache_start_steps_ - 1)) % skip_interval_steps_ !=
+       0);
+  update_cache_ = !use_cache_;
+  return false;
+}
+
+CacheStepOut ResidualCache::on_after_step(const CacheStepIn& stepin) {
+  return CacheStepOut(stepin.tensors);
+}
+
+}  // namespace xllm

--- a/xllm/core/framework/dit_cache/residual_cache.h
+++ b/xllm/core/framework/dit_cache/residual_cache.h
@@ -1,0 +1,76 @@
+/* Copyright 2026 The xLLM Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://github.com/jd-opensource/xllm/blob/main/LICENSE
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#pragma once
+
+#include <torch/torch.h>
+
+#include <cmath>
+#include <vector>
+
+#include "dit_cache_impl.h"
+
+namespace xllm {
+
+using TensorMap = std::unordered_map<std::string, torch::Tensor>;
+
+class ResidualCache : public DitCacheImpl {
+ public:
+  ResidualCache() = default;
+  ~ResidualCache() = default;
+
+  ResidualCache(const ResidualCache&) = delete;
+  ResidualCache& operator=(const ResidualCache&) = delete;
+  ResidualCache(ResidualCache&&) = default;
+  ResidualCache& operator=(ResidualCache&&) = default;
+
+  void init(const DiTCacheConfig& cfg) override;
+  // check whether to use cache
+  bool cache_validation();
+
+  // Reset all cached derivatives and internal state
+  void reset_cache();
+
+  // Mark the beginning of a new inference step
+  void mark_step_begin();
+
+  // calculate residual
+  torch::Tensor get_residual(const torch::Tensor& hidden_states,
+                             const std::string& key);
+
+  // add residaul to hidden states
+  torch::Tensor add_residual(const torch::Tensor& hidden_states,
+                             const std::string& key);
+
+  // Update internal caches with the new residual
+  void update(const torch::Tensor& residual, const std::string& key);
+
+  bool on_before_block(const CacheBlockIn& blockin) override;
+  CacheBlockOut on_after_block(const CacheBlockIn& blockin) override;
+
+  bool on_before_step(const CacheStepIn& stepin) override;
+  CacheStepOut on_after_step(const CacheStepIn& stepin) override;
+
+ private:
+  bool use_cache_ = false;
+  bool update_cache_ = false;
+  int64_t skip_interval_steps_;
+  int64_t dit_cache_start_steps_;
+  int64_t dit_cache_end_steps_;
+  int64_t dit_cache_start_blocks_;
+  int64_t dit_cache_end_blocks_;
+};
+
+}  // namespace xllm

--- a/xllm/core/framework/dit_model_context.cpp
+++ b/xllm/core/framework/dit_model_context.cpp
@@ -33,11 +33,13 @@ DiTModelContext::DiTModelContext(
     const std::unordered_map<std::string, ModelArgs>& model_args,
     const std::unordered_map<std::string, QuantArgs>& quant_args,
     const torch::TensorOptions& tensor_options,
+    const DiTCacheConfig& dit_config,
     const std::string& model_type)
     : parallel_args_(input_parallel_args),
       model_args_(std::move(model_args)),
       quant_args_(std::move(quant_args)),
       tensor_options_(tensor_options),
+      dit_config_(dit_config),
       model_type_(model_type) {
 #if defined(USE_NPU)
   int32_t device_id = tensor_options.device().index();

--- a/xllm/core/framework/dit_model_context.h
+++ b/xllm/core/framework/dit_model_context.h
@@ -21,6 +21,7 @@ limitations under the License.
 
 #include <memory>
 
+#include "core/framework/dit_cache/dit_cache_config.h"
 #include "core/framework/model/model_args.h"
 #include "core/framework/model_context.h"
 #include "core/framework/quant_args.h"
@@ -36,6 +37,7 @@ class DiTModelContext {
                   const std::unordered_map<std::string, ModelArgs>& model_args,
                   const std::unordered_map<std::string, QuantArgs>& quant_args,
                   const torch::TensorOptions& tensor_options,
+                  const DiTCacheConfig& dit_config,
                   const std::string& model_type);
 
   const ModelArgs& get_model_args(const std::string& component) const;
@@ -54,6 +56,8 @@ class DiTModelContext {
 
   const std::string& model_type() const { return model_type_; }
 
+  const DiTCacheConfig& get_dit_config() const { return dit_config_; }
+
 #if defined(USE_NPU)
   const atb::Context* get_atb_context() const { return context_; }
 #endif
@@ -63,6 +67,7 @@ class DiTModelContext {
   std::unordered_map<std::string, QuantArgs> quant_args_;
   ParallelArgs parallel_args_;
   torch::TensorOptions tensor_options_;
+  DiTCacheConfig dit_config_;
   std::string model_type_;
 
 #if defined(USE_NPU)

--- a/xllm/core/framework/dit_model_loader.cpp
+++ b/xllm/core/framework/dit_model_loader.cpp
@@ -276,6 +276,13 @@ DiTModelLoader::DiTModelLoader(const std::string& model_root_path)
     LOG(FATAL) << "DiTModelLoader: model_index.json root is not an object!";
   }
 
+  if (root_json.contains("_class_name")) {
+    set_model_type(root_json["_class_name"]);
+  } else {
+    LOG(WARNING)
+        << "model_index.json doesn't contains the _class_name key, xllm may "
+        << "not obtain model type for dit model";
+  }
   // parse model_index.json & initialize model_loader
   for (const auto& [json_key, json_value] : root_json.items()) {
     if (!json_value.is_array() || json_value.size() != 2) {

--- a/xllm/core/framework/dit_model_loader.h
+++ b/xllm/core/framework/dit_model_loader.h
@@ -71,8 +71,14 @@ class DiTModelLoader {
 
   std::string get_torch_dtype() const;
 
+  void set_model_type(const std::string& model_type) {
+    model_type_ = model_type;
+  }
+  std::string get_model_type() { return model_type_; }
+
  private:
   std::string model_root_path_;
+  std::string model_type_;
 
   std::unordered_map<std::string, std::unique_ptr<DiTFolderLoader>>
       name_to_loader_;

--- a/xllm/core/framework/model/model_args.h
+++ b/xllm/core/framework/model/model_args.h
@@ -425,6 +425,23 @@ struct ModelArgs {
   PROPERTY(float, max_shift) = 0;
   PROPERTY(int64_t, base_image_seq_len) = 0;
   PROPERTY(int64_t, max_image_seq_len) = 0;
+  PROPERTY(float, shift_terminal) = 0;
+
+  // qwen_image_edit_2509 vae related args
+  PROPERTY(int64_t, base_dim) = 0;
+  PROPERTY(int64_t, z_dim) = 0;
+  PROPERTY(std::vector<int64_t>, dim_mult) = {};
+  PROPERTY(std::vector<double>, attn_scales) = {};
+  PROPERTY(std::vector<bool>, temperal_downsample) = {};
+  PROPERTY(int64_t, num_res_blocks) = 0;
+  PROPERTY(double, dropout) = 0;
+  PROPERTY(std::vector<double>, latents_mean) = {};
+  PROPERTY(std::vector<double>, latents_std) = {};
+
+  // qwen_image_edit_2511 dit related args
+  PROPERTY(bool, zero_cond_t) = false;
+  PROPERTY(bool, use_additional_t_cond) = false;
+  PROPERTY(bool, use_layer3d_rope) = false;
 };
 
 // Qwen hybrid models may describe full-attention layers explicitly via

--- a/xllm/core/framework/model/model_input_params.h
+++ b/xllm/core/framework/model/model_input_params.h
@@ -31,6 +31,7 @@ limitations under the License.
 #include "npu_cp_ep_padding.h"
 #include "npu_cp_prepare.h"
 #include "npu_dp_ep_padding.h"
+#include "runtime/dit_forward_params.h"
 #include "util/hash_util.h"
 #include "util/tensor_helper.h"
 
@@ -414,6 +415,8 @@ struct ModelInputParams {
 
     params.batch_id = batch_id;
 
+    params.dit_forward_input = dit_forward_input.to(device);
+
     // rec_params device conversion for both OneRec and LLM-Rec variants
     if (const auto* onerec = onerec_params()) {
       params.rec_params = onerec->to(device);
@@ -584,6 +587,9 @@ struct ModelInputParams {
   std::vector<int32_t> ring_cache_seqlen_host;
 
   RecModelInputParams rec_params;
+
+  // dit input data
+  DiTForwardInput dit_forward_input;
 
   const OneRecModelInputParams* onerec_params() const {
     return std::get_if<OneRecModelInputParams>(&rec_params);

--- a/xllm/core/framework/parallel_state/CMakeLists.txt
+++ b/xllm/core/framework/parallel_state/CMakeLists.txt
@@ -6,6 +6,8 @@ cc_library(
     parallel_state
   HDRS
     mapping_npu.h
+    dit_mapping_npu.h
+    rank_generator.h
     parallel_args.h
     parallel_state.h
     process_group.h
@@ -14,14 +16,18 @@ cc_library(
     $<$<BOOL:${USE_MUSA}>:musa_process_group.h>
     $<$<BOOL:${USE_CUDA}>:cuda_process_group.h>
     $<$<BOOL:${USE_ILU}>:ilu_process_group.h>
+    collective_communicator_base.h
     collective_communicator.h
+    dit_collective_communicator.h
   SRCS
     mapping_npu.cpp
+    dit_mapping_npu.cpp
     parallel_state.cpp
     parallel_state_async.cpp
     process_group.cpp
     $<$<BOOL:${USE_NPU}>:npu_process_group.cpp>
     collective_communicator.cpp
+    dit_collective_communicator.cpp
   DEPS
     :common
     torch

--- a/xllm/core/framework/parallel_state/collective_communicator.cpp
+++ b/xllm/core/framework/parallel_state/collective_communicator.cpp
@@ -41,7 +41,8 @@ CollectiveCommunicator::CollectiveCommunicator(int global_rank,
                                                int world_size,
                                                int dp_size,
                                                int ep_size,
-                                               int cp_size) {
+                                               int cp_size)
+    : CollectiveCommunicatorBase(global_rank, world_size) {
 #if defined(USE_NPU)
   // create hccl process group with hccl_root_info
   // std::vector<HcclRootInfo> unique_ids;

--- a/xllm/core/framework/parallel_state/collective_communicator.h
+++ b/xllm/core/framework/parallel_state/collective_communicator.h
@@ -15,15 +15,11 @@ limitations under the License.
 
 #pragma once
 
-#include <memory>
-#include <string>
-
-#include "parallel_args.h"
-#include "process_group.h"
+#include "collective_communicator_base.h"
 
 namespace xllm {
 
-class CollectiveCommunicator {
+class CollectiveCommunicator : public CollectiveCommunicatorBase {
  public:
   CollectiveCommunicator(int global_rank,
                          int world_size,
@@ -33,10 +29,10 @@ class CollectiveCommunicator {
   ~CollectiveCommunicator() = default;
 
   void create_process_groups(const std::string& master_addr,
-                             const torch::Device& device);
+                             const torch::Device& device) override;
 
   // init communicator and return parallel args.
-  const ParallelArgs* parallel_args();
+  const ParallelArgs* parallel_args() override;
 
  private:
   std::unique_ptr<ParallelArgs> parallel_args_;

--- a/xllm/core/framework/parallel_state/collective_communicator_base.h
+++ b/xllm/core/framework/parallel_state/collective_communicator_base.h
@@ -1,0 +1,48 @@
+/* Copyright 2026 The xLLM Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://github.com/jd-opensource/xllm/blob/main/LICENSE
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#pragma once
+
+#include <torch/torch.h>
+
+#include <memory>
+#include <string>
+
+#include "parallel_args.h"
+#include "process_group.h"
+
+namespace xllm {
+
+class CollectiveCommunicatorBase {
+ public:
+  CollectiveCommunicatorBase(int global_rank, int world_size)
+      : global_rank_(global_rank), world_size_(world_size) {}
+
+  virtual ~CollectiveCommunicatorBase() = default;
+
+  virtual void create_process_groups(const std::string& master_addr,
+                                     const torch::Device& device) = 0;
+
+  virtual const ParallelArgs* parallel_args() = 0;
+
+  int get_global_rank() const { return global_rank_; }
+  int get_world_size() const { return world_size_; }
+
+ protected:
+  int global_rank_;
+  int world_size_;
+};
+
+}  // namespace xllm

--- a/xllm/core/framework/parallel_state/dit_collective_communicator.cpp
+++ b/xllm/core/framework/parallel_state/dit_collective_communicator.cpp
@@ -1,0 +1,184 @@
+/* Copyright 2026 The xLLM Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://github.com/jd-opensource/xllm/blob/main/LICENSE
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include "dit_collective_communicator.h"
+
+#include "mapping_npu.h"
+
+#if defined(USE_NPU)
+#include "npu_process_group.h"
+#elif defined(USE_MLU)
+#include "mlu_process_group.h"
+#elif defined(USE_CUDA)
+#include "cuda_process_group.h"
+#elif defined(USE_ILU)
+#include "ilu_process_group.h"
+#elif defined(USE_MUSA)
+#include "musa_process_group.h"
+#endif
+#include "common/global_flags.h"
+#include "parallel_args.h"
+#include "platform/device.h"
+#include "process_group.h"
+#include "util/net.h"
+namespace xllm {
+
+DiTCollectiveCommunicator::DiTCollectiveCommunicator(int32_t global_rank,
+                                                     int32_t world_size,
+                                                     int32_t dit_dp_size,
+                                                     int32_t dit_tp_size,
+                                                     int32_t dit_sp_size,
+                                                     int32_t dit_cfg_size)
+    : CollectiveCommunicatorBase(global_rank, world_size) {
+#if defined(USE_NPU)
+  DiTMappingNPU::Options dit_mapping_options;
+  dit_mapping_options.dit_tp_size(dit_tp_size)
+      .dit_sp_size(dit_sp_size)
+      .dit_cfg_size(dit_cfg_size)
+      .dit_dp_size(dit_dp_size);
+  dit_mapping_npu_ = std::make_unique<DiTMappingNPU>(
+      world_size, global_rank, dit_mapping_options);
+  parallel_args_ = std::make_unique<ParallelArgs>(global_rank,
+                                                  world_size,
+                                                  dit_dp_size,
+                                                  dit_tp_size,
+                                                  dit_sp_size,
+                                                  dit_cfg_size,
+                                                  nullptr);
+#endif
+}
+
+void DiTCollectiveCommunicator::create_process_groups(
+    const std::string& master_addr,
+    const torch::Device& device) {
+  Device device_(device);
+  device_.set_device();
+  std::string host;
+  int32_t port;
+  net::parse_host_port_from_addr(master_addr, host, port);
+
+  int32_t global_rank = parallel_args_->rank();
+  int32_t world_size = parallel_args_->world_size();
+  int32_t dp_size = parallel_args_->dit_dp_size();
+  int32_t tp_size = parallel_args_->dit_tp_size();
+  int32_t sp_size = parallel_args_->dit_sp_size();
+  int32_t cfg_size = parallel_args_->dit_cfg_size();
+
+  process_group_ = create_process_group(global_rank,
+                                        world_size,
+                                        world_size,
+                                        ++port,
+                                        false,
+                                        host,
+                                        "world_group",
+                                        device);
+
+  parallel_args_->process_group_ = process_group_.get();
+
+  if (tp_size > 1) {
+    auto tp_parallel_info = dit_mapping_npu_->get_parallel_info("tp");
+    auto group_id = tp_parallel_info.current_group_id();
+    auto num_group = tp_parallel_info.num_group();
+    auto local_rank = tp_parallel_info.rank();
+    auto& rank_per_group = tp_parallel_info.rank_per_group()[group_id];
+    int port_offset = group_id + 1;
+#if defined(USE_NPU)
+    dit_tp_group_ = create_process_group(global_rank,
+                                         local_rank,
+                                         rank_per_group,
+                                         world_size,
+                                         tp_size,
+                                         port + port_offset,
+                                         host,
+                                         "tp_group",
+                                         device);
+    parallel_args_->dit_tp_group_ = dit_tp_group_.get();
+#endif
+    port += num_group;
+  }
+
+  if (sp_size > 1) {
+    auto sp_parallel_info = dit_mapping_npu_->get_parallel_info("sp");
+    auto group_id = sp_parallel_info.current_group_id();
+    auto num_group = sp_parallel_info.num_group();
+    auto local_rank = sp_parallel_info.rank();
+    auto& rank_per_group = sp_parallel_info.rank_per_group()[group_id];
+    int port_offset = group_id + 1;
+#if defined(USE_NPU)
+    dit_sp_group_ = create_process_group(global_rank,
+                                         local_rank,
+                                         rank_per_group,
+                                         world_size,
+                                         sp_size,
+                                         port + port_offset,
+                                         host,
+                                         "sp_group",
+                                         device);
+    parallel_args_->dit_sp_group_ = dit_sp_group_.get();
+#endif
+    port += num_group;
+  }
+
+  if (cfg_size > 1) {
+    auto cfg_parallel_info = dit_mapping_npu_->get_parallel_info("cfg");
+    auto group_id = cfg_parallel_info.current_group_id();
+    auto num_group = cfg_parallel_info.num_group();
+    auto local_rank = cfg_parallel_info.rank();
+    auto& rank_per_group = cfg_parallel_info.rank_per_group()[group_id];
+    int port_offset = group_id + 1;
+#if defined(USE_NPU)
+    dit_cfg_group_ = create_process_group(global_rank,
+                                          local_rank,
+                                          rank_per_group,
+                                          world_size,
+                                          cfg_size,
+                                          port + port_offset,
+                                          host,
+                                          "cfg_group",
+                                          device);
+    parallel_args_->dit_cfg_group_ = dit_cfg_group_.get();
+#endif
+    port += num_group;
+  }
+
+  if (dp_size > 1) {
+    auto dp_parallel_info = dit_mapping_npu_->get_parallel_info("dp");
+    auto group_id = dp_parallel_info.current_group_id();
+    auto num_group = dp_parallel_info.num_group();
+    auto local_rank = dp_parallel_info.rank();
+    auto& rank_per_group = dp_parallel_info.rank_per_group()[group_id];
+    int port_offset = group_id + 1;
+#if defined(USE_NPU)
+    dit_dp_group_ = create_process_group(global_rank,
+                                         local_rank,
+                                         rank_per_group,
+                                         world_size,
+                                         dp_size,
+                                         port + port_offset,
+                                         host,
+                                         "dp_group",
+                                         device);
+    parallel_args_->dit_dp_group_ = dit_dp_group_.get();
+#endif
+    port += num_group;
+  }
+}
+
+const ParallelArgs* DiTCollectiveCommunicator::parallel_args() {
+  // TODO: init communicator
+  return parallel_args_.get();
+}
+
+}  // namespace xllm

--- a/xllm/core/framework/parallel_state/dit_collective_communicator.h
+++ b/xllm/core/framework/parallel_state/dit_collective_communicator.h
@@ -1,0 +1,50 @@
+/* Copyright 2026 The xLLM Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://github.com/jd-opensource/xllm/blob/main/LICENSE
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#pragma once
+
+#include "collective_communicator_base.h"
+#include "dit_mapping_npu.h"
+
+namespace xllm {
+
+class DiTCollectiveCommunicator : public CollectiveCommunicatorBase {
+ public:
+  DiTCollectiveCommunicator(int32_t global_rank,
+                            int32_t world_size,
+                            int32_t dit_dp_size,
+                            int32_t dit_tp_size,
+                            int32_t dit_sp_size,
+                            int32_t dit_cfg_size);
+
+  ~DiTCollectiveCommunicator() = default;
+
+  void create_process_groups(const std::string& master_addr,
+                             const torch::Device& device) override;
+
+  // init communicator and return parallel args.
+  const ParallelArgs* parallel_args() override;
+
+ private:
+  std::unique_ptr<DiTMappingNPU> dit_mapping_npu_{nullptr};
+  std::unique_ptr<ParallelArgs> parallel_args_;
+  std::unique_ptr<ProcessGroup> process_group_;
+  std::unique_ptr<ProcessGroup> dit_tp_group_;
+  std::unique_ptr<ProcessGroup> dit_sp_group_;
+  std::unique_ptr<ProcessGroup> dit_dp_group_;
+  std::unique_ptr<ProcessGroup> dit_cfg_group_;
+};
+
+}  // namespace xllm

--- a/xllm/core/framework/parallel_state/dit_mapping_npu.cpp
+++ b/xllm/core/framework/parallel_state/dit_mapping_npu.cpp
@@ -1,0 +1,145 @@
+/* Copyright 2026 The xLLM Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://github.com/jd-opensource/xllm/blob/main/LICENSE
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include "dit_mapping_npu.h"
+
+#include <glog/logging.h>
+
+namespace xllm {
+
+DiTMappingNPU::DiTMappingNPU(const int32_t world_size,
+                             const int32_t rank,
+                             const Options& options)
+    : rank_(rank), options_(options), world_size_(world_size) {
+  tp_.backend("hccl");
+  sp_.backend("hccl");
+  cfg_.backend("hccl");
+  dp_.backend("hccl");
+  parse_parallel_info();
+  validate();
+  rank_generator_ =
+      std::make_unique<RankGenerator>(tp_.group_size(),
+                                      sp_.group_size(),
+                                      cfg_.group_size(),
+                                      dp_.group_size(),
+                                      /*group_order=*/"tp-sp-cfg-dp");
+  set_group_by_type(tp_, "tp");
+  set_group_by_type(sp_, "sp");
+  set_group_by_type(cfg_, "cfg");
+  set_group_by_type(dp_, "dp");
+}
+
+void DiTMappingNPU::parse_parallel_info() {
+  if (options_.dit_tp_size() != -1) {
+    tp_.group_size(options_.dit_tp_size());
+  }
+  if (options_.dit_sp_size() != -1) {
+    sp_.group_size(options_.dit_sp_size());
+  }
+  if (options_.dit_cfg_size() != -1) {
+    cfg_.group_size(options_.dit_cfg_size());
+  }
+  if (options_.dit_dp_size() != -1) {
+    dp_.group_size(options_.dit_dp_size());
+  }
+}
+
+void DiTMappingNPU::validate() {
+  CHECK(cfg_.group_size() * tp_.group_size() * sp_.group_size() *
+            dp_.group_size() ==
+        world_size_)
+      << "World size must equal to cfg_size * tp_size * sp_size. "
+         "cfg_size is " +
+             std::to_string(cfg_.group_size()) +
+             ". "
+             "tp_size is " +
+             std::to_string(tp_.group_size()) +
+             ". "
+             "sp_size is " +
+             std::to_string(sp_.group_size()) +
+             ". "
+             "dp_size is " +
+             std::to_string(dp_.group_size()) +
+             ". "
+             "world_size is " +
+             std::to_string(world_size_) +
+             ". "
+             "Please check `cfg`, `tp`, `sp`, `dp` and `world_size`.";
+
+  CHECK(cfg_.group_size() <= 2) << "cfg_size must less than 2 "
+                                   "cfg_size is " +
+                                       std::to_string(cfg_.group_size()) +
+                                       ". Please check `cfg` .";
+}
+
+void DiTMappingNPU::set_group_by_type(ParallelInfo& parallel_info,
+                                      const std::string& group_type) {
+  auto rank_per_group = rank_generator_->get_ranks(group_type);
+  parallel_info.rank_per_group(rank_per_group);
+  auto group_size = rank_per_group[0].size();
+  parallel_info.num_group(world_size_ / group_size);
+  auto [current_group_id, local_rank] =
+      get_current_group_id(rank_per_group, rank_);
+  CHECK(current_group_id >= 0 && local_rank >= 0)
+      << "Failed to get current group id : " << current_group_id
+      << " local_rank " << local_rank;
+  parallel_info.current_group_id(current_group_id);
+  parallel_info.rank(local_rank);
+}
+
+std::tuple<int32_t, int32_t> DiTMappingNPU::get_current_group_id(
+    const std::vector<std::vector<int32_t>>& rank_per_group,
+    int32_t target_rank_id) {
+  for (int32_t idx = 0; idx < rank_per_group.size(); ++idx) {
+    const auto& group = rank_per_group[idx];
+    auto it = std::find(group.begin(), group.end(), target_rank_id);
+    if (it != group.end()) {
+      return std::make_tuple(idx, std::distance(group.begin(), it));
+    }
+  }
+  return std::make_tuple(-1, -1);
+}
+
+const ParallelInfo& DiTMappingNPU::get_parallel_info(
+    const std::string& group_type) const {
+  if (group_type == "tp") {
+    return tp_;
+  } else if (group_type == "sp") {
+    return sp_;
+  } else if (group_type == "cfg") {
+    return cfg_;
+  } else if (group_type == "dp") {
+    return dp_;
+  } else {
+    LOG(ERROR) << "get unexpected group_type: " << group_type;
+  }
+}
+
+nlohmann::json DiTMappingNPU::to_json() {
+  nlohmann::json data;
+
+  data["SpSize"] = options_.dit_sp_size();
+  data["TpSize"] = options_.dit_tp_size();
+  data["CfgSize"] = options_.dit_cfg_size();
+  data["worldSize"] = world_size_;
+  data["rank"] = rank_;
+  data["sp"] = sp_.to_json();
+  data["tp"] = tp_.to_json();
+  data["cfg"] = cfg_.to_json();
+  data["dp"] = dp_.to_json();
+  return data;
+}
+
+}  // namespace xllm

--- a/xllm/core/framework/parallel_state/dit_mapping_npu.h
+++ b/xllm/core/framework/parallel_state/dit_mapping_npu.h
@@ -1,0 +1,72 @@
+/* Copyright 2026 The xLLM Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://github.com/jd-opensource/xllm/blob/main/LICENSE
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#pragma once
+
+#include <glog/logging.h>
+
+#include "core/common/macros.h"
+#include "core/util/json_reader.h"
+#include "mapping_npu.h"
+#include "rank_generator.h"
+namespace xllm {
+
+class DiTMappingNPU final {
+ public:
+  struct Options {
+    // cfg size
+    PROPERTY(int32_t, dit_cfg_size) = -1;
+    // tp size
+    PROPERTY(int32_t, dit_tp_size) = -1;
+    // sp size
+    PROPERTY(int32_t, dit_sp_size) = -1;
+    // dp size
+    PROPERTY(int32_t, dit_dp_size) = -1;
+  };
+
+  DiTMappingNPU(const int32_t world_size,
+                const int32_t rank,
+                const Options& options);
+
+  int32_t get_num_nodes();
+
+  void parse_parallel_info();
+
+  void validate();
+
+  void set_group_by_type(ParallelInfo& parallel_info,
+                         const std::string& group_type);
+
+  std::tuple<int32_t, int32_t> get_current_group_id(
+      const std::vector<std::vector<int>>& rank_per_group,
+      int target_rank_id);
+
+  const ParallelInfo& get_parallel_info(const std::string& group_type) const;
+
+  nlohmann::json to_json();
+
+ private:
+  Options options_;
+  int32_t num_nodes_;
+  int32_t world_size_ = 0;
+  int32_t rank_ = 0;
+  int32_t local_world_size_ = 0;
+  ParallelInfo sp_ = ParallelInfo();
+  ParallelInfo tp_ = ParallelInfo();
+  ParallelInfo cfg_ = ParallelInfo();
+  ParallelInfo dp_ = ParallelInfo();
+  std::unique_ptr<RankGenerator> rank_generator_{nullptr};
+};
+}  // namespace xllm

--- a/xllm/core/framework/parallel_state/npu_process_group.cpp
+++ b/xllm/core/framework/parallel_state/npu_process_group.cpp
@@ -12,7 +12,6 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
-
 #include "npu_process_group.h"
 
 #include <torch_npu/csrc/core/npu/NPUCachingAllocator.h>
@@ -98,10 +97,53 @@ ProcessGroupImpl::ProcessGroupImpl(int32_t global_rank,
     hccl_pg_options->global_ranks_in_group = uint32_ranks;
     rank = local_rank;
   }
-
   auto store = create_tcp_store(host, port, rank);
   pg_ = std::make_unique<c10d_npu::ProcessGroupHCCL>(
       store, rank, rank_size, hccl_pg_options);
+}
+
+ProcessGroupImpl::ProcessGroupImpl(int32_t global_rank,
+                                   int32_t local_rank,
+                                   const std::vector<int32_t>& group_ranks,
+                                   int32_t world_size,
+                                   int32_t rank_size,
+                                   int32_t port,
+                                   const std::string& host,
+                                   const std::string& group_name,
+                                   const torch::Device& device)
+    : ProcessGroup(global_rank, world_size, device),
+      comm_stream_(c10_npu::getNPUStreamFromPool(device.index())) {
+  c10::intrusive_ptr<c10d_npu::ProcessGroupHCCL::Options> hccl_pg_options =
+      c10d_npu::ProcessGroupHCCL::Options::create();
+  hccl_pg_options->group_id = group_name;
+  if (world_size != rank_size) {
+    std::vector<uint32_t> uint32_ranks;
+    for (auto rank : group_ranks) {
+      uint32_ranks.push_back(static_cast<uint32_t>(rank));
+    }
+    hccl_pg_options->global_ranks_in_group = uint32_ranks;
+  }
+
+  if (FLAGS_dit_debug_print) {
+    std::stringstream ranks_ss;
+    ranks_ss << "Group : [" << group_ranks[0];
+    for (size_t i = 1; i < group_ranks.size(); i++) {
+      ranks_ss << ", " << group_ranks[i];
+    }
+    ranks_ss << "]" << std::endl;
+
+    LOG(INFO) << "Creating HccLProcessGroup for " << group_name
+              << " group, with global rank " << global_rank << ", local rank"
+              << local_rank << ", with port " << host << ":" << port
+              << ", rank_size is " << rank_size << ", world_size is "
+              << world_size
+              << ", the following ranks should share the same port, "
+              << ranks_ss.str();
+  }
+
+  auto store = create_tcp_store(host, port, local_rank);
+  pg_ = std::make_unique<c10d_npu::ProcessGroupHCCL>(
+      store, local_rank, rank_size, hccl_pg_options);
 }
 
 // Destructor.
@@ -121,94 +163,5 @@ ProcessGroupImpl::ProcessGroupImpl(int rank,
     : ProcessGroup(rank, world_size, device),
       comm_(comm),
       comm_stream_(c10_npu::getNPUStreamFromPool(device.index())) {}
-
-void ProcessGroupImpl::allgather(const torch::Tensor& input,
-                                 std::vector<torch::Tensor>& outputs) {
-  CHECK_EQ(input.device(), device())
-      << "input should be on the same device as the process group";
-  CHECK_EQ(outputs.size(), world_size())
-      << "outputs should have the same size as world_size";
-  check_input(input);
-  torch::DeviceGuard device_guard(device());
-
-  if (pg_) {
-    std::vector<torch::Tensor> input_tensors = {input};
-    std::vector<std::vector<torch::Tensor>> output_tensors = {outputs};
-    pg_->allgather(output_tensors, input_tensors)->wait();
-    return;
-  }
-  CHECK(comm_ != nullptr) << "HCCL comm is not initialized.";
-
-  torch::Tensor flattened_output = flatten_for_scatter_gather(outputs);
-
-  const auto count = input.numel();
-  const auto data_type = to_hccl_data_type(input);
-
-  auto compute_stream = c10_npu::getCurrentNPUStream();
-
-  auto ready = std::make_shared<c10_npu::NPUEvent>();
-  ready->record(compute_stream);
-  ready->block(comm_stream_);
-
-  c10_npu::NPUCachingAllocator::recordStream(input.storage().data_ptr(),
-                                             comm_stream_);
-  c10_npu::NPUCachingAllocator::recordStream(
-      flattened_output.storage().data_ptr(), comm_stream_);
-
-  HCCLCHECK(HcclAllGather(
-      /*sendbuff=*/input.data_ptr(),
-      /*recvbuff=*/flattened_output.data_ptr(),
-      /*sendcount=*/count,
-      /*datatype=*/data_type,
-      /*comm=*/comm_,
-      /*stream=*/comm_stream_.stream()));
-
-  auto done = std::make_shared<c10_npu::NPUEvent>();
-  done->record(comm_stream_);
-  done->block(compute_stream);
-
-  for (int i = 0; i < static_cast<int>(outputs.size()); ++i) {
-    outputs[i].copy_(flattened_output[i], /*non_blocking=*/true);
-  }
-}
-
-void ProcessGroupImpl::allreduce(torch::Tensor& input) {
-  CHECK_EQ(input.device(), device())
-      << "input should be on the same device as the process group";
-  check_input(input);
-  torch::DeviceGuard device_guard(device());
-
-  if (pg_) {
-    std::vector<torch::Tensor> input_tensors = {input};
-    pg_->allreduce(input_tensors)->wait();
-    return;
-  }
-  CHECK(comm_ != nullptr) << "HCCL comm is not initialized.";
-
-  const auto count = input.numel();
-  const auto data_type = to_hccl_data_type(input);
-
-  auto compute_stream = c10_npu::getCurrentNPUStream();
-
-  auto ready = std::make_shared<c10_npu::NPUEvent>();
-  ready->record(compute_stream);
-  ready->block(comm_stream_);
-
-  c10_npu::NPUCachingAllocator::recordStream(input.storage().data_ptr(),
-                                             comm_stream_);
-
-  HCCLCHECK(HcclAllReduce(
-      /*sendbuff=*/input.data_ptr(),
-      /*recvbuff=*/input.data_ptr(),
-      /*count=*/count,
-      /*datatype=*/data_type,
-      /*op=*/HCCL_REDUCE_SUM,
-      /*comm=*/comm_,
-      /*stream=*/comm_stream_.stream()));
-
-  auto done = std::make_shared<c10_npu::NPUEvent>();
-  done->record(comm_stream_);
-  done->block(compute_stream);
-}
 
 }  // namespace xllm

--- a/xllm/core/framework/parallel_state/npu_process_group.h
+++ b/xllm/core/framework/parallel_state/npu_process_group.h
@@ -19,6 +19,7 @@ limitations under the License.
 #include <torch_npu/csrc/core/npu/NPUEvent.h>
 #include <torch_npu/csrc/core/npu/NPUStream.h>
 
+#include "core/common/global_flags.h"
 #include "hccl/hccl.h"
 #include "process_group.h"
 
@@ -41,13 +42,18 @@ class ProcessGroupImpl : public ProcessGroup {
                    const std::string& group_name,
                    const torch::Device& device);
 
+  ProcessGroupImpl(int32_t global_rank,
+                   int32_t local_rank,
+                   const std::vector<int32_t>& group_ranks,
+                   int32_t world_size,
+                   int32_t rank_size,
+                   int32_t port,
+                   const std::string& host,
+                   const std::string& group_name,
+                   const torch::Device& device);
+
   // Destructor.
   ~ProcessGroupImpl() override;
-
-  void allreduce(torch::Tensor& input) override;
-
-  void allgather(const torch::Tensor& input,
-                 std::vector<torch::Tensor>& outputs) override;
 
  private:
   HcclComm comm_ = nullptr;

--- a/xllm/core/framework/parallel_state/parallel_args.h
+++ b/xllm/core/framework/parallel_state/parallel_args.h
@@ -88,6 +88,21 @@ struct ParallelArgs {
         dp_local_process_group_(dp_local_process_group),
         dp_size_(dp_size) {}
 
+  ParallelArgs(int32_t rank,
+               int32_t world_size,
+               int32_t dit_dp_size,
+               int32_t dit_tp_size,
+               int32_t dit_sp_size,
+               int32_t dit_cfg_size,
+               ProcessGroup* process_group)
+      : rank_(rank),
+        world_size_(world_size),
+        dit_dp_size_(dit_dp_size),
+        dit_tp_size_(dit_tp_size),
+        dit_sp_size_(dit_sp_size),
+        dit_cfg_size_(dit_cfg_size),
+        process_group_(process_group) {}
+
   // rank of current process
   PROPERTY(int32_t, rank) = 0;
 
@@ -102,6 +117,18 @@ struct ParallelArgs {
 
   // cp size
   PROPERTY(int32_t, cp_size) = 1;
+  
+  // dit dp size
+  PROPERTY(int32_t, dit_dp_size) = 1;
+
+  // dit tp size
+  PROPERTY(int32_t, dit_tp_size) = 1;
+
+  // dit sp size
+  PROPERTY(int32_t, dit_sp_size) = 1;
+
+  // dit cfg size
+  PROPERTY(int32_t, dit_cfg_size) = 1;
 
   // atb hccl mapping json data
   PROPERTY(nlohmann::json, mapping_data);
@@ -130,6 +157,12 @@ struct ParallelArgs {
   ProcessGroup* sp_group_ = nullptr;
   ProcessGroup* moe_ep_group_ = nullptr;
   ProcessGroup* moe_tp_group_ = nullptr;
+
+  // ProcessGroups for DiT models
+  ProcessGroup* dit_tp_group_ = nullptr;
+  ProcessGroup* dit_sp_group_ = nullptr;
+  ProcessGroup* dit_cfg_group_ = nullptr;
+  ProcessGroup* dit_dp_group_ = nullptr;
 };
 
 }  // namespace xllm

--- a/xllm/core/framework/parallel_state/parallel_state.cpp
+++ b/xllm/core/framework/parallel_state/parallel_state.cpp
@@ -268,6 +268,156 @@ torch::Tensor scatter(torch::Tensor input,
   return tensor_list[rank];
 }
 
+std::function<torch::Tensor()> all_to_all_4D(const torch::Tensor& input,
+                                             int32_t scatter_idx,
+                                             int32_t gather_idx,
+                                             bool async_ops,
+                                             ProcessGroup* process_group) {
+  if (!process_group) {
+    return [input]() { return input; };
+  }
+  const int32_t group_size = process_group->world_size();
+
+  if (group_size == 1) {
+    return [input]() { return input; };
+  }
+
+  auto rank = process_group->rank();
+
+  TORCH_CHECK(input.dim() == 4,
+              "all_to_all_4D: input must be 4D, got dim=",
+              input.dim());
+  auto send_input = input;
+
+  if (scatter_idx == 2 && gather_idx == 1) {
+    // branch A : from "sequence shard" -> "head shard"
+    // input: (bs, seqlen / group_size (shard_seqlen), head_num, head_dim)
+    //   output (bs, seqlen, head_num / group_size, head_dim)
+    auto sizes = send_input.sizes().vec();
+    const int64_t bs = sizes[0];
+    const int64_t shard_seqlen = sizes[1];
+    const int64_t head_num = sizes[2];
+    const int64_t head_size = sizes[3];
+    const int64_t seqlen = shard_seqlen * group_size;
+    TORCH_CHECK(head_num % group_size == 0,
+                "all_to_all_4D(A): head_num must be divisible by group_size");
+    const int64_t shard_head_num = head_num / group_size;
+
+    // prepare expected shape for All2All (group_size, shard_seqlen, bs,
+    // shard_head_num, head_size)
+    auto input_t =
+        send_input
+            .reshape({bs, shard_seqlen, group_size, shard_head_num, head_size})
+            .transpose(
+                0,
+                2)  // (group_size, shard_seqlen, bs, shard_head_num, head_size)
+            .contiguous();
+    torch::Tensor output = torch::empty_like(input_t);
+    std::vector<int64_t> input_split_size = {};
+    std::vector<int64_t> output_split_size = {};
+
+    if (!async_ops) {
+      process_group->all_to_all_single(
+          output, input_t, output_split_size, input_split_size, async_ops);
+      output = output.reshape({seqlen, bs, shard_head_num, head_size})
+                   .transpose(0, 1)
+                   .contiguous()
+                   .reshape({bs, seqlen, shard_head_num, head_size});
+      return [output]() { return output; };
+    } else {
+      c10::intrusive_ptr<c10d::Work> all2all_work;
+      process_group->all_to_all_single(output,
+                                       input_t,
+                                       output_split_size,
+                                       input_split_size,
+                                       async_ops,
+                                       &all2all_work);
+      return [output,
+              all2all_work,
+              bs,
+              seqlen,
+              shard_head_num,
+              head_size]() mutable -> torch::Tensor {
+        all2all_work->wait();
+        auto comm_output =
+            output.reshape({seqlen, bs, shard_head_num, head_size})
+                .transpose(0, 1)
+                .contiguous()
+                .reshape({bs, seqlen, shard_head_num, head_size});
+        return comm_output;
+      };
+    }
+  } else if (scatter_idx == 1 && gather_idx == 2) {
+    // branch B : from "head shard" -> "sequence shard"
+    // input: (bs, seqlen, head_num / group_size, head_size)
+    // output (bs, seqlen / group_size, head_num, haed_size)
+    auto sizes = send_input.sizes().vec();
+    const int64_t bs = sizes[0];
+    const int64_t seqlen = sizes[1];
+    const int64_t shard_head_num = sizes[2];
+    const int64_t head_size = sizes[3];
+    TORCH_CHECK(seqlen % group_size == 0,
+                "all_to_all_4D(B): seqlen must be divisible by group_size");
+    const int64_t shard_seqlen = seqlen / group_size;
+    const int64_t head_num = shard_head_num * group_size;
+
+    // prepare expected shape for All2All (group_size, shard_head_num,
+    // shard_seqlen, bs, head_size)
+    auto input_t =
+        send_input
+            .reshape({bs, group_size, shard_seqlen, shard_head_num, head_size})
+            .transpose(
+                0,
+                3)  // (shard_head_num, group_size, shard_seqlen, bs, head_size)
+            .transpose(
+                0,
+                1)  // (group_size, shard_head_num, shard_seqlen, bs, head_size)
+            .contiguous();
+    torch::Tensor output = torch::empty_like(input_t);
+    std::vector<int64_t> input_split_size = {};
+    std::vector<int64_t> output_split_size = {};
+
+    if (!async_ops) {
+      process_group->all_to_all_single(output,
+                                       input_t,
+                                       output_split_size,
+                                       input_split_size,
+                                       /*async_op=*/false);
+      output = output.reshape({head_num, shard_seqlen, bs, head_size})
+                   .transpose(0, 2)
+                   .contiguous()
+                   .reshape({bs, shard_seqlen, head_num, head_size});
+      return [output]() { return output; };
+    } else {
+      c10::intrusive_ptr<c10d::Work> all2all_work;
+      process_group->all_to_all_single(output,
+                                       input_t,
+                                       output_split_size,
+                                       input_split_size,
+                                       /*async_op=*/true,
+                                       &all2all_work);
+      return [output,
+              all2all_work,
+              head_num,
+              shard_seqlen,
+              bs,
+              head_size]() mutable -> torch::Tensor {
+        all2all_work->wait();
+        auto comm_output =
+            output.reshape({head_num, shard_seqlen, bs, head_size})
+                .transpose(0, 2)
+                .contiguous()
+                .reshape({bs, shard_seqlen, head_num, head_size});
+        return comm_output;
+      };
+    }
+  } else {
+    TORCH_CHECK(false,
+                "all_to_all_4D: only (scatter_idx,gather_idx)=(2,1) or (1,2) "
+                "are supported");
+  }
+}
+
 std::vector<std::unique_ptr<ProcessGroup>> create_npu_process_groups(
     const std::vector<torch::Device>& devices) {
 #if defined(USE_NPU)

--- a/xllm/core/framework/parallel_state/parallel_state.h
+++ b/xllm/core/framework/parallel_state/parallel_state.h
@@ -72,6 +72,12 @@ torch::Tensor scatter(torch::Tensor input,
                       ProcessGroup* process_group,
                       int dim = -1);
 
+std::function<torch::Tensor()> all_to_all_4D(const torch::Tensor& input_,
+                                             int32_t scatter_idx,
+                                             int32_t gather_idx,
+                                             bool is_sync,
+                                             ProcessGroup* pg);
+
 // Create a process group where each process has a single device
 // devices: list of devices to create process groups on.
 std::vector<std::unique_ptr<ProcessGroup>> create_npu_process_groups(

--- a/xllm/core/framework/parallel_state/process_group.cpp
+++ b/xllm/core/framework/parallel_state/process_group.cpp
@@ -156,6 +156,35 @@ void ProcessGroup::reduce_scatter(const torch::Tensor& input,
       ->wait();
 }
 
+void ProcessGroup::all_to_all_single(
+    torch::Tensor output,
+    torch::Tensor input,
+    std::vector<int64_t> output_split_sizes,
+    std::vector<int64_t> input_split_sizes,
+    bool async_op,
+    c10::intrusive_ptr<c10d::Work>* async_work) {
+  CHECK(pg_ != nullptr) << "Process group is not initialized.";
+  CHECK(output.defined())
+      << "Output of all_to_all_single function is not defined";
+  CHECK(input.defined())
+      << "Input of all_to_all_single function is not defined";
+  if (input.is_complex()) {
+    input = torch::view_as_real(input);
+  }
+  if (output.is_complex()) {
+    output = torch::view_as_real(output);
+  }
+
+  auto opts = c10d::AllToAllOptions();
+  auto work = pg_->alltoall_base(
+      output, input, output_split_sizes, input_split_sizes, opts);
+  if (async_op) {
+    *async_work = work;
+  } else {
+    work->wait();
+  }
+}
+
 std::unique_ptr<ProcessGroup> create_process_group(
     int32_t rank,
     int32_t world_size,
@@ -169,4 +198,31 @@ std::unique_ptr<ProcessGroup> create_process_group(
       rank, world_size, rank_size, port, trans, host, group_name, device);
 }
 
+#if defined(USE_NPU)
+// TODO: This function is used by DiT models, since the DiT communication group
+// info have already been calculated by rank_generator, we only need to pass the
+// info to create the process groups. For any device that want to reuse the
+// function and dit process groups, please implement the corresponding
+// ProcessGroupImpl construct function.
+std::unique_ptr<ProcessGroup> create_process_group(
+    int32_t global_rank,
+    int32_t local_rank,
+    const std::vector<int32_t>& group_ranks,
+    int32_t world_size,
+    int32_t rank_size,
+    int32_t port,
+    const std::string& host,
+    const std::string& group_name,
+    const torch::Device& device) {
+  return std::make_unique<ProcessGroupImpl>(global_rank,
+                                            local_rank,
+                                            group_ranks,
+                                            world_size,
+                                            rank_size,
+                                            port,
+                                            host,
+                                            group_name,
+                                            device);
+}
+#endif
 }  // namespace xllm

--- a/xllm/core/framework/parallel_state/process_group.h
+++ b/xllm/core/framework/parallel_state/process_group.h
@@ -88,6 +88,14 @@ class ProcessGroup {
   virtual void reduce_scatter(const torch::Tensor& input,
                               torch::Tensor& output);
 
+  virtual void all_to_all_single(
+      torch::Tensor output,
+      torch::Tensor input,
+      std::vector<int64_t> output_split_sizes = {},
+      std::vector<int64_t> input_split_sizes = {},
+      bool async_op = false,
+      c10::intrusive_ptr<c10d::Work>* async_work = nullptr);
+
  private:
   // rank of current process.
   int32_t rank_ = 0;
@@ -117,6 +125,17 @@ std::unique_ptr<xllm::ProcessGroup> create_process_group(
     int32_t rank_size,
     int32_t port,
     bool trans,
+    const std::string& host,
+    const std::string& group_name,
+    const torch::Device& device);
+
+std::unique_ptr<xllm::ProcessGroup> create_process_group(
+    int32_t global_rank,
+    int32_t local_rank,
+    const std::vector<int32_t>& group_ranks,
+    int32_t world_size,
+    int32_t rank_size,
+    int32_t port,
     const std::string& host,
     const std::string& group_name,
     const torch::Device& device);

--- a/xllm/core/framework/parallel_state/rank_generator.h
+++ b/xllm/core/framework/parallel_state/rank_generator.h
@@ -1,0 +1,266 @@
+#include <glog/logging.h>
+
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+#include "core/common/global_flags.h"
+
+class RankGenerator {
+ public:
+  RankGenerator(int32_t tp,
+                int32_t sp,
+                int32_t cfg,
+                int32_t dp,
+                const std::string& group_order = "tp-sp-cfg-dp",
+                int32_t rank_offset = 0)
+      : tp_(tp), sp_(sp), cfg_(cfg), dp_(dp), rank_offset_(rank_offset) {
+    world_size_ = tp * sp * cfg * dp;
+
+    group_size_map_["tp"] = tp;
+    group_size_map_["sp"] = sp;
+    group_size_map_["cfg"] = cfg;
+    group_size_map_["dp"] = dp;
+
+    auto full_order = group_order;
+    for (const auto& group_size_pair : group_size_map_) {
+      const std::string& group_name = group_size_pair.first;
+      int32_t group_size = group_size_pair.second;
+
+      if (full_order.find(group_name) == std::string::npos) {
+        if (group_size != 1) {
+          LOG(FATAL) << "The size of (" << group_name << ") is (" << group_size
+                     << "), but you haven't specified it in order ("
+                     << full_order << ").";
+        } else {
+          full_order = full_order + "-" + group_name;
+        }
+      }
+    }
+
+    group_order_ = full_order;
+
+    auto split = [](const std::string& s,
+                    char delimiter) -> std::vector<std::string> {
+      std::vector<std::string> tokens;
+      std::string token;
+      std::istringstream tokenStream(s);
+      while (std::getline(tokenStream, token, delimiter)) {
+        tokens.push_back(token);
+      }
+      return tokens;
+    };
+
+    ordered_group_name_ = split(group_order_, '-');
+    for (const std::string& token : ordered_group_name_) {
+      auto it = group_size_map_.find(token);
+      if (it != group_size_map_.end()) {
+        ordered_group_size_.push_back(it->second);
+      }
+    }
+
+    LOG(INFO) << "RankGenerator initialized with tp=" << tp << ", sp=" << sp
+              << ", cfg=" << cfg << ", dp=" << dp << ", order=" << group_order_
+              << ", world_size=" << world_size_;
+
+    if (FLAGS_dit_debug_print) {
+      debug_print();
+    }
+  }
+
+  std::vector<std::vector<int32_t>> get_ranks(const std::string& group_query) {
+    std::vector<bool> mask = get_mask(group_query);
+    std::vector<std::vector<int32_t>> ranks =
+        generate_masked_orthogonal_rank_groups(
+            world_size_, ordered_group_size_, mask);
+    if (rank_offset_ > 0) {
+      for (auto& rank_group : ranks) {
+        for (size_t i = 0; i < rank_group.size(); i++) {
+          rank_group[i] += rank_offset_;
+        }
+      }
+    }
+
+    return ranks;
+  }
+
+  int32_t get_world_size() const { return world_size_; }
+  const std::string& get_order() const { return group_order_; }
+  int32_t get_tp() const { return tp_; }
+  int32_t get_sp() const { return sp_; }
+  int32_t get_cfg() const { return cfg_; }
+  int32_t get_dp() const { return dp_; }
+
+  void debug_print() {
+    print_ranks("cfg");
+    print_ranks("tp");
+    print_ranks("sp");
+    print_ranks("dp");
+  }
+
+  void print_ranks(const std::string& group_query) {
+    auto ranks = get_ranks(group_query);
+
+    std::stringstream ss;
+    ss << "Ranks for query '" << group_query << "':" << std::endl;
+    for (size_t i = 0; i < ranks.size(); i++) {
+      ss << "  Group " << i << ": [";
+      for (size_t j = 0; j < ranks[i].size(); j++) {
+        ss << ranks[i][j];
+        if (j < ranks[i].size() - 1) ss << ", ";
+      }
+      ss << "]" << std::endl;
+    }
+    LOG(INFO) << ss.str();
+  }
+
+ private:
+  std::vector<int32_t> prefix_product(const std::vector<int32_t>& group_size,
+                                      int32_t init = 1) {
+    std::vector<int32_t> prefix_product_sizes;
+    prefix_product_sizes.push_back(init);
+    for (int32_t size : group_size) {
+      init = init * size;
+      prefix_product_sizes.push_back(init);
+    }
+    return prefix_product_sizes;
+  }
+
+  int32_t inner_product(const std::vector<int32_t>& a,
+                        const std::vector<int32_t>& b) {
+    int32_t result = 0;
+    for (size_t i = 0; i < a.size(); i++) {
+      result += a[i] * b[i];
+    }
+    return result;
+  }
+
+  std::vector<int32_t> decompose(int32_t index,
+                                 const std::vector<int32_t>& shape,
+                                 const std::vector<int32_t>& stride = {}) {
+    std::vector<int32_t> idx;
+    std::vector<int32_t> actual_stride;
+
+    if (stride.empty()) {
+      actual_stride = prefix_product(shape);
+    } else {
+      actual_stride = stride;
+    }
+
+    for (size_t i = 0; i < shape.size(); i++) {
+      int32_t d = actual_stride[i];
+      int32_t s = shape[i];
+      idx.push_back((index / d) % s);
+    }
+
+    int32_t sum = 0;
+    for (size_t i = 0; i < idx.size(); i++) {
+      sum += idx[i] * actual_stride[i];
+    }
+
+    if (sum != index) {
+      std::stringstream ss;
+      ss << "idx " << index << " with shape [";
+      for (size_t i = 0; i < shape.size(); i++) {
+        ss << shape[i];
+        if (i < shape.size() - 1) ss << ", ";
+      }
+      ss << "] mismatch the return idx [";
+      for (size_t i = 0; i < idx.size(); i++) {
+        ss << idx[i];
+        if (i < idx.size() - 1) ss << ", ";
+      }
+      ss << "]";
+      LOG(INFO) << ss.str();
+    }
+
+    return idx;
+  }
+
+  std::vector<std::vector<int32_t>> generate_masked_orthogonal_rank_groups(
+      int32_t world_size,
+      const std::vector<int32_t>& parallel_size,
+      const std::vector<bool>& mask) {
+    std::vector<int32_t> queried_group_size;
+    std::vector<int32_t> unqueried_group_size;
+    for (size_t i = 0; i < parallel_size.size(); i++) {
+      if (mask[i]) {
+        queried_group_size.push_back(parallel_size[i]);
+      } else {
+        unqueried_group_size.push_back(parallel_size[i]);
+      }
+    }
+    std::vector<int32_t> global_group_stride = prefix_product(parallel_size);
+    std::vector<int32_t> queried_group_stride;
+    std::vector<int32_t> unqueried_group_stride;
+    for (size_t i = 0; i < parallel_size.size(); i++) {
+      if (mask[i]) {
+        queried_group_stride.push_back(global_group_stride[i]);
+      } else {
+        unqueried_group_stride.push_back(global_group_stride[i]);
+      }
+    }
+    std::vector<int32_t> queried_group_prefix =
+        prefix_product(queried_group_size);
+    // group size equals to the product of queryed group type sizes;
+    int32_t group_size = queried_group_prefix.back();
+    int32_t num_of_group = world_size / group_size;
+
+    std::vector<std::vector<int32_t>> ranks;
+    for (int32_t group_index = 0; group_index < num_of_group; group_index++) {
+      std::vector<int32_t> decomposed_group_idx =
+          decompose(group_index, unqueried_group_size);
+      std::vector<int32_t> rank;
+      for (int32_t rank_in_group = 0; rank_in_group < group_size;
+           rank_in_group++) {
+        std::vector<int32_t> decomposed_rank_idx =
+            decompose(rank_in_group, queried_group_size);
+        int32_t calculated_rank =
+            inner_product(decomposed_rank_idx, queried_group_stride) +
+            inner_product(decomposed_group_idx, unqueried_group_stride);
+        rank.push_back(calculated_rank);
+      }
+      ranks.push_back(rank);
+    }
+
+    return ranks;
+  }
+
+  std::vector<bool> get_mask(const std::string& group_query) {
+    std::vector<std::string> query_group_name = split(group_query, '-');
+    std::vector<bool> mask(ordered_group_name_.size(), false);
+
+    for (const std::string& group_name : query_group_name) {
+      auto it = std::find(
+          ordered_group_name_.begin(), ordered_group_name_.end(), group_name);
+      if (it != ordered_group_name_.end()) {
+        size_t index = std::distance(ordered_group_name_.begin(), it);
+        mask[index] = true;
+      }
+    }
+
+    return mask;
+  }
+
+  std::vector<std::string> split(const std::string& s, char delimiter) {
+    std::vector<std::string> tokens;
+    std::string token;
+    std::istringstream tokenStream(s);
+    while (std::getline(tokenStream, token, delimiter)) {
+      tokens.push_back(token);
+    }
+    return tokens;
+  }
+
+ private:
+  int32_t tp_;
+  int32_t sp_;
+  int32_t cfg_;
+  int32_t dp_;
+  int32_t rank_offset_;
+  int32_t world_size_;
+  std::string group_order_;
+  std::vector<int32_t> ordered_group_size_;
+  std::vector<std::string> ordered_group_name_;
+  std::unordered_map<std::string, int32_t> group_size_map_;
+};

--- a/xllm/core/framework/request/dit_request_params.cpp
+++ b/xllm/core/framework/request/dit_request_params.cpp
@@ -86,6 +86,7 @@ DiTRequestParams::DiTRequestParams(const proto::ImageGenerationRequest& request,
   if (input.has_latent()) {
     input_params.latent = util::proto_to_torch(input.latent());
   }
+
   if (input.has_masked_image_latent()) {
     input_params.masked_image_latent =
         util::proto_to_torch(input.masked_image_latent());
@@ -98,6 +99,16 @@ DiTRequestParams::DiTRequestParams(const proto::ImageGenerationRequest& request,
       LOG(ERROR) << "Base64 image decode failed";
     }
     if (!decoder.decode(raw_bytes, input_params.image)) {
+      LOG(ERROR) << "Image decode failed.";
+    }
+  }
+
+  if (input.has_condition_image()) {
+    std::string raw_bytes;
+    if (!butil::Base64Decode(input.condition_image(), &raw_bytes)) {
+      LOG(ERROR) << "Base64 image decode failed";
+    }
+    if (!decoder.decode(raw_bytes, input_params.condition_image)) {
       LOG(ERROR) << "Image decode failed.";
     }
   }

--- a/xllm/core/framework/request/dit_request_state.h
+++ b/xllm/core/framework/request/dit_request_state.h
@@ -98,6 +98,8 @@ struct DiTInputParams {
 
   torch::Tensor image;
 
+  torch::Tensor condition_image;
+
   torch::Tensor control_image;
 
   torch::Tensor mask_image;

--- a/xllm/core/framework/state_dict/state_dict.cpp
+++ b/xllm/core/framework/state_dict/state_dict.cpp
@@ -193,6 +193,11 @@ StateDict StateDict::get_dict_with_prefix(
   return tensors;
 }
 
+bool StateDict::has(const std::string& tensor_name) const {
+  const auto it = dict_.find(tensor_name);
+  return it != dict_.end();
+}
+
 StateDictFromSafeTensor::StateDictFromSafeTensor(
     std::unique_ptr<MemoryMapping> mem_map,
     std::unordered_map<std::string, torch::Tensor> dict)

--- a/xllm/core/framework/state_dict/state_dict.h
+++ b/xllm/core/framework/state_dict/state_dict.h
@@ -58,6 +58,8 @@ class StateDict {
 
   size_t size() const { return dict_.size(); }
 
+  bool has(const std::string& tensor_name) const;
+
   std::string_view prefix() const { return prefix_; }
 
   auto begin() const { return dict_.begin(); }

--- a/xllm/core/layers/common/add_matmul.cpp
+++ b/xllm/core/layers/common/add_matmul.cpp
@@ -98,5 +98,46 @@ void FusedAddMatmulImpl::load_state_dict(
   }
 }
 
+WeightTransposeAddMatmulImpl::WeightTransposeAddMatmulImpl(
+    int64_t in,
+    int64_t out,
+    bool with_bias,
+    const torch::TensorOptions& options)
+    : AddMatmulImpl(in, out, with_bias, options) {}
+
+torch::Tensor WeightTransposeAddMatmulImpl::forward(const torch::Tensor& x) {
+  // use addmm when bias is provided
+  if (with_bias_) {
+    auto sizes = x.sizes();
+    if (sizes.size() == 3) {
+      torch::Tensor t = x.reshape({sizes[0] * sizes[1], sizes[2]});
+      return torch::addmm(bias_, t, weight_)
+          .reshape({sizes[0], sizes[1], weight_.size(1)});
+    } else {
+      return torch::addmm(bias_, x, weight_);
+    }
+  } else {
+    return torch::matmul(x, weight_);
+  }
+}
+
+void WeightTransposeAddMatmulImpl::load_state_dict(
+    const StateDict& state_dict) {
+  // only transpoes weights when state_dict has the key
+  // or it would be transposed multiple times when having
+  // multiple state dicts
+  if (state_dict.has("weight")) {
+    xllm::weight::load_weight(state_dict, "weight", weight_, weight_is_loaded_);
+    // weight need to be transposed when using addmm
+    if (with_bias_) {
+      torch::Tensor transposed = weight_.data().transpose(0, 1).contiguous();
+      weight_.set_data(transposed);
+    }
+  }
+  if (with_bias_) {
+    weight::load_weight(state_dict, "bias", bias_, bias_is_loaded_);
+  }
+}
+
 }  // namespace layer
 }  // namespace xllm

--- a/xllm/core/layers/common/add_matmul.h
+++ b/xllm/core/layers/common/add_matmul.h
@@ -29,9 +29,9 @@ class AddMatmulImpl : public torch::nn::Module {
                 bool with_bias,
                 const torch::TensorOptions& options);
 
-  torch::Tensor forward(const torch::Tensor& x);
+  virtual torch::Tensor forward(const torch::Tensor& x);
 
-  void load_state_dict(const xllm::StateDict& state_dict);
+  virtual void load_state_dict(const xllm::StateDict& state_dict);
 
   void verify_loaded_weights(const std::string& prefix) const;
 
@@ -59,5 +59,18 @@ class FusedAddMatmulImpl : public AddMatmulImpl {
 };
 TORCH_MODULE(FusedAddMatmul);
 
+class WeightTransposeAddMatmulImpl : public AddMatmulImpl {
+ public:
+  WeightTransposeAddMatmulImpl(int64_t in,
+                               int64_t out,
+                               bool with_bias,
+                               const torch::TensorOptions& options);
+
+  torch::Tensor forward(const torch::Tensor& x) override;
+
+  void load_state_dict(const xllm::StateDict& state_dict) override;
+};
+
+TORCH_MODULE(WeightTransposeAddMatmul);
 }  // namespace layer
 }  // namespace xllm

--- a/xllm/core/runtime/CMakeLists.txt
+++ b/xllm/core/runtime/CMakeLists.txt
@@ -24,7 +24,7 @@ cc_library(
     worker_impl.h
     llm_worker_impl.h
     vlm_worker_impl.h
-    dit_worker.h
+    dit_worker_impl.h
     embed_worker_impl.h
     embed_vlm_worker_impl.h
     rec_worker_impl.h
@@ -50,7 +50,7 @@ cc_library(
     worker_impl.cpp
     llm_worker_impl.cpp
     vlm_worker_impl.cpp
-    dit_worker.cpp
+    dit_worker_impl.cpp
     embed_worker_impl.cpp
     embed_vlm_worker_impl.cpp
     rec_worker_impl.cpp

--- a/xllm/core/runtime/dit_forward_params.h
+++ b/xllm/core/runtime/dit_forward_params.h
@@ -27,8 +27,144 @@ namespace xllm {
 
 // dit related forward input params
 struct DiTForwardInput {
+  bool valid() const {
+    return prompts.size() > 0 || prompt_embeds.defined() ||
+           pooled_prompt_embeds.defined() || images.defined();
+  }
+
+  void save_with_prefix(std::string prefix) const {
+    torch::save(images, prefix + "images_cpp.pt");
+    torch::save(prompt_embeds, prefix + "prompt_embeds_cpp.pt");
+    torch::save(negative_prompt_embeds, prefix + "neg_prompt_embeds_cpp.pt");
+  }
+  void debug_print(std::ostream& os = std::cout) const {
+    os << "=== DiTForwardInput Debug Info ===" << std::endl;
+
+    // Print basic data types
+    os << "batch_size: " << batch_size << std::endl;
+
+    // Print prompts vectors
+    os << "prompts: [";
+    for (size_t i = 0; i < prompts.size(); ++i) {
+      os << "\"" << prompts[i] << "\"";
+      if (i < prompts.size() - 1) os << ", ";
+    }
+    os << "]" << std::endl;
+
+    os << "prompts_2: [";
+    for (size_t i = 0; i < prompts_2.size(); ++i) {
+      os << "\"" << prompts_2[i] << "\"";
+      if (i < prompts_2.size() - 1) os << ", ";
+    }
+    os << "]" << std::endl;
+
+    os << "negative_prompts: [";
+    for (size_t i = 0; i < negative_prompts.size(); ++i) {
+      os << "\"" << negative_prompts[i] << "\"";
+      if (i < negative_prompts.size() - 1) os << ", ";
+    }
+    os << "]" << std::endl;
+
+    os << "negative_prompts_2: [";
+    for (size_t i = 0; i < negative_prompts_2.size(); ++i) {
+      os << "\"" << negative_prompts_2[i] << "\"";
+      if (i < negative_prompts_2.size() - 1) os << ", ";
+    }
+    os << "]" << std::endl;
+
+    // Print tensor shapes
+    os << "\n--- Tensor Shapes ---" << std::endl;
+
+    os << "images: ";
+    if (images.defined()) {
+      os << images.sizes() << std::endl;
+    } else {
+      os << "undefined" << std::endl;
+    }
+
+    os << "condition_images: ";
+    if (condition_images.defined()) {
+      os << condition_images.sizes() << std::endl;
+    } else {
+      os << "undefined" << std::endl;
+    }
+
+    os << "mask_images: ";
+    if (mask_images.defined()) {
+      os << mask_images.sizes() << std::endl;
+    } else {
+      os << "undefined" << std::endl;
+    }
+
+    os << "control_image: ";
+    if (control_image.defined()) {
+      os << control_image.sizes() << std::endl;
+    } else {
+      os << "undefined" << std::endl;
+    }
+
+    os << "masked_image_latents: ";
+    if (masked_image_latents.defined()) {
+      os << masked_image_latents.sizes() << std::endl;
+    } else {
+      os << "undefined" << std::endl;
+    }
+
+    os << "prompt_embeds: ";
+    if (prompt_embeds.defined()) {
+      os << prompt_embeds.sizes() << std::endl;
+    } else {
+      os << "undefined" << std::endl;
+    }
+
+    os << "pooled_prompt_embeds: ";
+    if (pooled_prompt_embeds.defined()) {
+      os << pooled_prompt_embeds.sizes() << std::endl;
+    } else {
+      os << "undefined" << std::endl;
+    }
+
+    os << "negative_prompt_embeds: ";
+    if (negative_prompt_embeds.defined()) {
+      os << negative_prompt_embeds.sizes() << std::endl;
+    } else {
+      os << "undefined" << std::endl;
+    }
+
+    os << "negative_pooled_prompt_embeds: ";
+    if (negative_pooled_prompt_embeds.defined()) {
+      os << negative_pooled_prompt_embeds.sizes() << std::endl;
+    } else {
+      os << "undefined" << std::endl;
+    }
+
+    os << "latents: ";
+    if (latents.defined()) {
+      os << latents.sizes() << std::endl;
+    } else {
+      os << "undefined" << std::endl;
+    }
+
+    // Print generation_params
+    os << "\n--- Generation Parameters ---" << std::endl;
+    os << "width: " << generation_params.width << std::endl;
+    os << "height: " << generation_params.height << std::endl;
+    os << "num_inference_steps: " << generation_params.num_inference_steps
+       << std::endl;
+    os << "true_cfg_scale: " << generation_params.true_cfg_scale << std::endl;
+    os << "guidance_scale: " << generation_params.guidance_scale << std::endl;
+    os << "num_images_per_prompt: " << generation_params.num_images_per_prompt
+       << std::endl;
+    os << "seed: " << generation_params.seed << std::endl;
+    os << "max_sequence_length: " << generation_params.max_sequence_length
+       << std::endl;
+    os << "strength: " << generation_params.strength << std::endl;
+
+    os << "===============================" << std::endl;
+  }
+
   DiTForwardInput to(const torch::Device& device,
-                     torch::ScalarType dtype) const {
+                     torch::ScalarType dtype = torch::kBFloat16) const {
     DiTForwardInput input = *this;
 
     if (prompt_embeds.defined()) {
@@ -63,6 +199,14 @@ struct DiTForwardInput {
     if (mask_images.defined()) {
       input.mask_images = mask_images.to(device, dtype);
     }
+
+    if (condition_images.defined()) {
+      input.condition_images = condition_images.to(device, dtype);
+    }
+
+    if (control_image.defined()) {
+      input.control_image = control_image.to(device, dtype);
+    }
     return input;
   }
 
@@ -81,6 +225,8 @@ struct DiTForwardInput {
   std::vector<std::string> negative_prompts_2;
 
   torch::Tensor images;
+
+  torch::Tensor condition_images;
 
   torch::Tensor mask_images;
 
@@ -104,6 +250,9 @@ struct DiTForwardInput {
 
 // dit related forward output params
 struct DiTForwardOutput {
+  void save_with_prefix(std::string prefix) const {
+    torch::save(tensors[0], prefix + "dit_images_cpp.pt");
+  }
   // generated tensor
   std::vector<torch::Tensor> tensors;
 };

--- a/xllm/core/runtime/dit_worker_impl.cpp
+++ b/xllm/core/runtime/dit_worker_impl.cpp
@@ -13,7 +13,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
 
-#include "dit_worker.h"
+#include "dit_worker_impl.h"
 
 #include <c10/core/DeviceGuard.h>
 #include <folly/Unit.h>
@@ -61,81 +61,123 @@ DiTCacheConfig parse_dit_cache_from_flags() {
     cache_config.fbcachetaylorseer.warmup_steps = FLAGS_dit_cache_warmup_steps;
     cache_config.fbcachetaylorseer.residual_diff_threshold =
         FLAGS_dit_cache_residual_diff_threshold;
+  } else if (FLAGS_dit_cache_policy == "ResidualCache") {
+    cache_config.selected_policy = PolicyType::ResidualCache;
+    cache_config.residual_cache.dit_cache_start_steps =
+        FLAGS_dit_cache_start_steps;
+    cache_config.residual_cache.dit_cache_end_steps = FLAGS_dit_cache_end_steps;
+    cache_config.residual_cache.dit_cache_start_blocks =
+        FLAGS_dit_cache_start_blocks;
+    cache_config.residual_cache.dit_cache_end_blocks =
+        FLAGS_dit_cache_end_blocks;
+    cache_config.residual_cache.skip_interval_steps =
+        FLAGS_dit_cache_skip_interval_steps;
   } else if (FLAGS_dit_cache_policy == "None") {
-    cache_config.selected_policy = PolicyType::TaylorSeer;
+    cache_config.selected_policy = PolicyType::None;
   }
   return cache_config;
 }
 }  // namespace
 
-DiTWorker::DiTWorker(const ParallelArgs& parallel_args,
-                     const torch::Device& device,
-                     const runtime::Options& options)
-    : device_(device), options_(options), parallel_args_(parallel_args) {
+DiTWorkerImpl::DiTWorkerImpl(const ParallelArgs& parallel_args,
+                             const torch::Device& device,
+                             const runtime::Options& options)
+    : WorkerImpl(parallel_args, device, options) {
   device_.set_device();
 }
 
-bool DiTWorker::init_model(const std::string& model_weights_path) {
+bool DiTWorkerImpl::init_model(ModelContext& context) {
+  LOG(ERROR)
+      << "init model with model_context was not implemented for dit models";
+  return false;
+}
+
+bool DiTWorkerImpl::init_model(const std::string& model_weights_path,
+                               int32_t random_seed,
+                               MasterStatus master_status) {
   CHECK(dit_model_ == nullptr) << "Model is already initialized.";
+
+  // set same random seed for all worker
+  device_.set_seed(random_seed);
 
   auto loader = std::make_unique<DiTModelLoader>(model_weights_path);
   dtype_ = util::parse_dtype(loader->get_torch_dtype(), device_);
 
   auto tensor_options = torch::dtype(dtype_).device(device_);
-  context_ = DiTModelContext(parallel_args_,
-                             std::move(loader->get_model_args()),
-                             std::move(loader->get_quant_args()),
-                             tensor_options,
-                             options_.model_id());
+  DiTCacheConfig cache_config = parse_dit_cache_from_flags();
 
-  dit_model_ = create_dit_model(context_);
+  auto model_type = loader->get_model_type();
+
+  if (!ModelRegistry::has_dit_model_factory(model_type)) {
+    LOG(WARNING) << "could not find model_type: " << model_type
+                 << ", using model_id: " << options_.model_id() << " instead.";
+    model_type = options_.model_id();
+  }
+
+  dit_context_ = DiTModelContext(parallel_args_,
+                                 std::move(loader->get_model_args()),
+                                 std::move(loader->get_quant_args()),
+                                 tensor_options,
+                                 cache_config,
+                                 model_type);
+
+  dit_model_ = create_dit_model(dit_context_);
   CHECK(dit_model_ != nullptr) << "Failed to create model.";
   dit_model_->load_model(std::move(loader));
 
   dit_model_executor_ =
       std::make_unique<DiTExecutor>(dit_model_.get(), options_);
 
-  DiTCacheConfig cache_config = parse_dit_cache_from_flags();
   DiTCache::get_instance().init(cache_config);
 
   return true;
 }
 
-folly::SemiFuture<bool> DiTWorker::init_model_async(
-    const std::string& model_weights_path) {
+folly::SemiFuture<bool> DiTWorkerImpl::init_model_async(
+    const std::string& model_weights_path,
+    int32_t random_seed,
+    MasterStatus master_status) {
   auto promise = std::make_shared<folly::Promise<bool>>();
   auto future = promise->getSemiFuture();
-  threadpool_.schedule([this, model_weights_path, promise]() mutable {
-    bool status = this->init_model(model_weights_path);
+  threadpool_.schedule([this,
+                        model_weights_path,
+                        random_seed,
+                        master_status,
+                        promise]() mutable {
+    bool status =
+        this->init_model(model_weights_path, random_seed, master_status);
     promise->setValue(status);
   });
   return future;
 }
 
-std::optional<DiTForwardOutput> DiTWorker::step(const DiTForwardInput& inputs) {
+std::optional<ForwardOutput> DiTWorkerImpl::step(const ForwardInput& inputs) {
+  torch::DeviceGuard device_guard(device_);
   Timer timer;
-
-  auto output = dit_model_executor_->forward(inputs.to(device_, dtype_));
+  auto output = dit_model_executor_->forward(
+      inputs.input_params.dit_forward_input.to(device_, dtype_));
 
   auto ret = device_.synchronize_default_stream();
   COUNTER_ADD(execution_latency_seconds_model, timer.elapsed_seconds());
-
-  return output;
+  ForwardOutput forward_output;
+  forward_output.dit_forward_output = output;
+  return forward_output;
 }
 
-folly::SemiFuture<std::optional<DiTForwardOutput>> DiTWorker::step_async(
-    const DiTForwardInput& inputs) {
-  auto promise =
-      std::make_shared<folly::Promise<std::optional<DiTForwardOutput>>>();
-  auto future = promise->getSemiFuture();
-  threadpool_.schedule([this, inputs, promise]() mutable {
-    auto output = this->step(inputs);
-    promise->setValue(output);
+folly::SemiFuture<std::optional<ForwardOutput>> DiTWorkerImpl::step_async(
+    const ForwardInput& inputs) {
+  folly::Promise<std::optional<ForwardOutput>> promise;
+  auto future = promise.getSemiFuture();
+  threadpool_.schedule([this,
+                        input = std::move(inputs),
+                        promise = std::move(promise)]() mutable {
+    auto output = this->step(input);
+    promise.setValue(output);
   });
   return future;
 }
 
-void DiTWorker::process_group_test() {
+void DiTWorkerImpl::process_group_test() {
   // create random tensors
   const auto options = torch::dtype(torch::kHalf).device(device_);
   torch::Tensor tensor = torch::randn({10, 10}, options);
@@ -153,7 +195,7 @@ void DiTWorker::process_group_test() {
   // context_.get_parallel_args().process_group_);
 }
 
-folly::SemiFuture<folly::Unit> DiTWorker::process_group_test_async() {
+folly::SemiFuture<folly::Unit> DiTWorkerImpl::process_group_test_async() {
   folly::Promise<folly::Unit> promise;
   auto future = promise.getSemiFuture();
   threadpool_.schedule([this, promise = std::move(promise)]() mutable {
@@ -164,11 +206,11 @@ folly::SemiFuture<folly::Unit> DiTWorker::process_group_test_async() {
 }
 
 // prepare input for execution
-DiTForwardInput DiTWorker::prepare_inputs(DiTBatch& batch) {
+DiTForwardInput DiTWorkerImpl::prepare_inputs(DiTBatch& batch) {
   return dit_model_executor_->prepare_inputs(batch);
 }
 
-int64_t DiTWorker::get_active_activation_memory() {
+int64_t DiTWorkerImpl::get_active_activation_memory() {
   return DeviceMonitor::get_instance()
       .get_device_stats(device_.index())
       .active_activation_memory;

--- a/xllm/core/runtime/dit_worker_impl.h
+++ b/xllm/core/runtime/dit_worker_impl.h
@@ -27,24 +27,34 @@ limitations under the License.
 #include "options.h"
 #include "platform/device.h"
 #include "util/threadpool.h"
+#include "worker_impl.h"
 
 namespace xllm {
 
-class DiTWorker {
+class DiTWorkerImpl : public WorkerImpl {
  public:
-  DiTWorker(const ParallelArgs& parallel_args,
-            const torch::Device& device,
-            const runtime::Options& options);
+  DiTWorkerImpl(const ParallelArgs& parallel_args,
+                const torch::Device& device,
+                const runtime::Options& options);
 
-  ~DiTWorker() = default;
+  ~DiTWorkerImpl() = default;
 
   // initialize model, cache manager. blocking call
-  bool init_model(const std::string& model_weights_path);
+  bool init_model(const std::string& model_weights_path,
+                  int32_t random_seed,
+                  MasterStatus master_status) override;
 
   folly::SemiFuture<bool> init_model_async(
-      const std::string& model_weights_path);
+      const std::string& model_weights_path,
+      int32_t random_seed,
+      MasterStatus master_status) override;
 
-  std::optional<DiTForwardOutput> step(const DiTForwardInput& inputs);
+  bool init_model(ModelContext& context) override;
+
+  std::optional<ForwardOutput> step(const ForwardInput& inputs) override;
+
+  folly::SemiFuture<std::optional<ForwardOutput>> step_async(
+      const ForwardInput& inputs);
 
   folly::SemiFuture<std::optional<DiTForwardOutput>> step_async(
       const DiTForwardInput& inputs);
@@ -59,20 +69,12 @@ class DiTWorker {
   int64_t get_active_activation_memory();
 
  private:
-  runtime::Options options_;
-
   std::unique_ptr<DiTModel> dit_model_;
 
   std::unique_ptr<DiTExecutor> dit_model_executor_;
 
-  Device device_;
-
-  torch::ScalarType dtype_;
-
   // model context, includes model args, parallel args and date type etc.
-  mutable DiTModelContext context_;
-
-  ParallelArgs parallel_args_;
+  mutable DiTModelContext dit_context_;
 
   ThreadPool threadpool_;
 };

--- a/xllm/core/runtime/embed_vlm_worker_impl.cpp
+++ b/xllm/core/runtime/embed_vlm_worker_impl.cpp
@@ -70,7 +70,6 @@ std::optional<ForwardOutput> EmbedVLMWorkerImpl::step(
   auto model_output = model_executor_->forward(
       flatten_tokens, flatten_positions, kv_caches_, params);
   auto hidden_states = model_output.hidden_states;
-
   ret = device_.synchronize_default_stream();
   COUNTER_ADD(execution_latency_seconds_model, timer.elapsed_seconds());
 
@@ -81,13 +80,26 @@ std::optional<ForwardOutput> EmbedVLMWorkerImpl::step(
   // driver prepare model output
   ForwardOutput output;
   SampleOutput sample_output;
-
   if (sampling_params.selected_token_idxes.defined() &&
       input.sampling_params.is_embeddings) {
     EmbeddingVLM* em_model = dynamic_cast<EmbeddingVLM*>(model_.get());
     auto embeddings =
         em_model->pooler(hidden_states, sampling_params.selected_token_idxes);
     sample_output.embeddings = embeddings;
+    // split full embeddings and add them to mm_embeddings
+    // so that the user could receive embeddings of images and texts
+    if (FLAGS_enable_return_mm_full_embeddings) {
+      auto q_seq_len_vec = input.input_params.q_seq_lens_vec;
+      sample_output.mm_embeddings.reserve(q_seq_len_vec.size());
+      int32_t token_start_idx = 0;
+      for (auto seq_len : q_seq_len_vec) {
+        auto image_embed =
+            embeddings.slice(0, token_start_idx, token_start_idx + seq_len);
+        sample_output.mm_embeddings.emplace_back(image_embed);
+        token_start_idx += seq_len;
+      }
+    }
+
     output.sample_output = sample_output;
     output.embedding = embeddings;
   }

--- a/xllm/core/runtime/embed_vlm_worker_impl.h
+++ b/xllm/core/runtime/embed_vlm_worker_impl.h
@@ -18,6 +18,7 @@ limitations under the License.
 #include <folly/futures/Future.h>
 #include <torch/torch.h>
 
+#include "core/common/global_flags.h"
 #include "executor.h"
 #include "forward_params.h"
 #include "framework/model/causal_vlm.h"

--- a/xllm/core/runtime/forward_params.h
+++ b/xllm/core/runtime/forward_params.h
@@ -33,6 +33,7 @@ limitations under the License.
 #include "framework/sampling/beam_searcher.h"
 #include "framework/sampling/sampling_params.h"
 #include "platform/device.h"
+#include "runtime/dit_forward_params.h"
 
 namespace xllm {
 
@@ -203,6 +204,9 @@ struct ForwardOutput {
 
   BeamSearchOutput beam_search_output;
   torch::Tensor beam_sequence_group;
+
+  // dit output data
+  DiTForwardOutput dit_forward_output;
 };
 
 // Model input with raw data, which will be
@@ -259,6 +263,9 @@ struct RawForwardInput {
   std::vector<int32_t> paged_kv_last_page_len;  //[n_seq]
   // multimodal data
   MMBatchData mm_data;
+
+  // dit input data
+  DiTForwardInput dit_forward_input;
 
   RawForwardInput cp_partition(int32_t cp_rank, int32_t cp_size) const {
     RawForwardInput outputs = *this;
@@ -505,6 +512,8 @@ struct RawForwardOutput {
   std::vector<int32_t> beam_sequence_group;  // flattened 2D
   // multimodal embedding output
   std::vector<torch::Tensor> mm_embeddings;
+  // dit output data
+  DiTForwardOutput dit_forward_output;
 };
 
 struct BatchedForwardInputs {

--- a/xllm/core/runtime/forward_shared_memory_manager.cpp
+++ b/xllm/core/runtime/forward_shared_memory_manager.cpp
@@ -248,6 +248,53 @@ inline size_t get_mm_batch_data_size(const MMBatchData& mm_data) {
   return total;
 }
 
+// calculate dit input size
+inline size_t get_dit_generation_params_size(
+    const DiTGenerationParams& params) {
+  return type_size<int32_t> *
+             4  // width, height, num_inference_steps, max_sequence_length
+         + type_size<float> *
+               4  // true_cfg_scale, guidance_scale, strength, cfg_renorm_min
+         + type_size<uint32_t>  // num_images_per_prompt
+         + type_size<int64_t>   // seed
+         + type_size<bool>;     // enable_cfg_renorm
+}
+
+inline size_t get_dit_forward_input_size(const DiTForwardInput& input) {
+  size_t size = type_size<int>;  // batch_size
+
+  // Vector of strings
+  size += get_string_vector_size(input.prompts);
+  size += get_string_vector_size(input.prompts_2);
+  size += get_string_vector_size(input.negative_prompts);
+  size += get_string_vector_size(input.negative_prompts_2);
+
+  // Tensors
+  size += get_tensor_size(input.images);
+  size += get_tensor_size(input.condition_images);
+  size += get_tensor_size(input.mask_images);
+  size += get_tensor_size(input.control_image);
+  size += get_tensor_size(input.masked_image_latents);
+  size += get_tensor_size(input.prompt_embeds);
+  size += get_tensor_size(input.pooled_prompt_embeds);
+  size += get_tensor_size(input.negative_prompt_embeds);
+  size += get_tensor_size(input.negative_pooled_prompt_embeds);
+  size += get_tensor_size(input.latents);
+
+  // Generation params
+  size += get_dit_generation_params_size(input.generation_params);
+
+  return size;
+}
+
+inline size_t get_dit_forward_output_size(const DiTForwardOutput& output) {
+  size_t size = type_size<uint64_t>;  // vector size
+  for (const auto& tensor : output.tensors) {
+    size += get_tensor_size(tensor);
+  }
+  return size;
+}
+
 size_t calculate_raw_forward_input_size(const RawForwardInput& input) {
   size_t total = 0;
 
@@ -311,6 +358,9 @@ size_t calculate_raw_forward_input_size(const RawForwardInput& input) {
   }
   // eplb_info
   total += get_eplb_info_size(input.eplb_info);
+
+  // dit input
+  total += get_dit_forward_input_size(input.dit_forward_input);
 
   return total;
 }
@@ -603,6 +653,53 @@ inline void write_mm_batch_data(char*& buffer, const MMBatchData& mm_data) {
       is_mm_item ? write_mm_data_items : write_mm_data_dict;
   for (const auto& mm_data : vec) {
     write_mm_data(buffer, mm_data);
+  }
+}
+
+// write dit data
+inline void write_dit_generation_params(char*& buffer,
+                                        const DiTGenerationParams& params) {
+  write_data(buffer, params.width);
+  write_data(buffer, params.height);
+  write_data(buffer, params.num_inference_steps);
+  write_data(buffer, params.true_cfg_scale);
+  write_data(buffer, params.guidance_scale);
+  write_data(buffer, params.num_images_per_prompt);
+  write_data(buffer, params.seed);
+  write_data(buffer, params.max_sequence_length);
+  write_data(buffer, params.strength);
+  write_data(buffer, params.enable_cfg_renorm);
+  write_data(buffer, params.cfg_renorm_min);
+}
+
+inline void write_dit_forward_input(char*& buffer,
+                                    const DiTForwardInput& input) {
+  write_data(buffer, input.batch_size);
+
+  write_string_vector(buffer, input.prompts);
+  write_string_vector(buffer, input.prompts_2);
+  write_string_vector(buffer, input.negative_prompts);
+  write_string_vector(buffer, input.negative_prompts_2);
+
+  write_tensor(buffer, input.images);
+  write_tensor(buffer, input.condition_images);
+  write_tensor(buffer, input.mask_images);
+  write_tensor(buffer, input.control_image);
+  write_tensor(buffer, input.masked_image_latents);
+  write_tensor(buffer, input.prompt_embeds);
+  write_tensor(buffer, input.pooled_prompt_embeds);
+  write_tensor(buffer, input.negative_prompt_embeds);
+  write_tensor(buffer, input.negative_pooled_prompt_embeds);
+  write_tensor(buffer, input.latents);
+
+  write_dit_generation_params(buffer, input.generation_params);
+}
+
+inline void write_dit_forward_output(char*& buffer,
+                                     const DiTForwardOutput& output) {
+  write_data(buffer, static_cast<uint64_t>(output.tensors.size()));
+  for (const auto& tensor : output.tensors) {
+    write_tensor(buffer, tensor);
   }
 }
 
@@ -1033,6 +1130,55 @@ inline void read_mm_batch_data(const char*& buffer,
   batch_mm_data.batch(std::move(vec));
 }
 
+// read dit data
+inline void read_dit_generation_params(const char*& buffer,
+                                       DiTGenerationParams& params) {
+  read_data(buffer, params.width);
+  read_data(buffer, params.height);
+  read_data(buffer, params.num_inference_steps);
+  read_data(buffer, params.true_cfg_scale);
+  read_data(buffer, params.guidance_scale);
+  read_data(buffer, params.num_images_per_prompt);
+  read_data(buffer, params.seed);
+  read_data(buffer, params.max_sequence_length);
+  read_data(buffer, params.strength);
+  read_data(buffer, params.enable_cfg_renorm);
+  read_data(buffer, params.cfg_renorm_min);
+}
+
+inline void read_dit_forward_input(const char*& buffer,
+                                   DiTForwardInput& input) {
+  read_data(buffer, input.batch_size);
+
+  read_string_vector(buffer, input.prompts);
+  read_string_vector(buffer, input.prompts_2);
+  read_string_vector(buffer, input.negative_prompts);
+  read_string_vector(buffer, input.negative_prompts_2);
+
+  read_tensor(buffer, input.images);
+  read_tensor(buffer, input.condition_images);
+  read_tensor(buffer, input.mask_images);
+  read_tensor(buffer, input.control_image);
+  read_tensor(buffer, input.masked_image_latents);
+  read_tensor(buffer, input.prompt_embeds);
+  read_tensor(buffer, input.pooled_prompt_embeds);
+  read_tensor(buffer, input.negative_prompt_embeds);
+  read_tensor(buffer, input.negative_pooled_prompt_embeds);
+  read_tensor(buffer, input.latents);
+
+  read_dit_generation_params(buffer, input.generation_params);
+}
+
+inline void read_dit_forward_output(const char*& buffer,
+                                    DiTForwardOutput& output) {
+  uint64_t size;
+  read_data(buffer, size);
+  output.tensors.resize(size);
+  for (auto& tensor : output.tensors) {
+    read_tensor(buffer, tensor);
+  }
+}
+
 inline void deserialize_raw_forward_input(const char*& buffer,
                                           const uint64_t buffer_size,
                                           ForwardInput& forward_input,
@@ -1166,6 +1312,9 @@ inline void deserialize_raw_forward_input(const char*& buffer,
   read_tensor(buffer, input_params.new_cache_slots);
   read_tensor(buffer, input_params.block_tables);
 
+  // read dit input
+  read_dit_forward_input(buffer, input_params.dit_forward_input);
+
 #if defined(USE_NPU)
   if (device_buffer != nullptr && stream != nullptr) {
     stream->synchronize();
@@ -1181,7 +1330,6 @@ inline void serialize_raw_forward_input(const RawForwardInput& input,
   } else {
     write_2d_vector_to_tensor(buffer, input.m_positions_vec);
   }
-
   // ModelInputParams
   write_data(buffer, input.batch_forward_type.value());
   write_data(buffer, input.num_sequences);
@@ -1254,6 +1402,9 @@ inline void serialize_raw_forward_input(const RawForwardInput& input,
   // root cause is identified and the error is resolved.
   write_vector_to_tensor(buffer, input.new_token_slot_ids);
   write_2d_vector_to_tensor(buffer, input.block_tables_vec);
+
+  // write dit input
+  write_dit_forward_input(buffer, input.dit_forward_input);
 }
 
 size_t calculate_raw_token_size(const RawToken& token) {
@@ -1292,6 +1443,8 @@ size_t calculate_raw_forward_output_size(const RawForwardOutput& output) {
   size += get_vector_size(output.out_tokens);
   size += get_vector_size(output.out_logprobs);
   size += type_size<int32_t>;  // prepared_layer_id
+  // dit output data
+  size += get_dit_forward_output_size(output.dit_forward_output);
 
   return size;
 }
@@ -1357,6 +1510,8 @@ void deserialize_raw_forward_output(const char* buffer,
   read_data(buffer, output.prepared_layer_id);
 
   read_vector_tensor(buffer, output.mm_embeddings);
+  // read dit output
+  read_dit_forward_output(buffer, output.dit_forward_output);
 }
 
 void serialize_raw_forward_output(const RawForwardOutput& output,
@@ -1371,6 +1526,8 @@ void serialize_raw_forward_output(const RawForwardOutput& output,
   write_data(buffer, output.prepared_layer_id);
 
   write_vector_tensor(buffer, output.mm_embeddings);
+  // write dit output
+  write_dit_forward_output(buffer, output.dit_forward_output);
 }
 
 void convert_raw_forward_input_to_forward_input(RawForwardInput& raw_input,
@@ -1433,6 +1590,10 @@ void convert_raw_forward_input_to_forward_input(RawForwardInput& raw_input,
       std::move(raw_input.kv_cache_start_offsets), tensor_options);
 
   input_params.mm_data = std::move(raw_input.mm_data);
+
+  // dit input data
+  input_params.dit_forward_input = std::move(raw_input.dit_forward_input);
+
   if (!raw_input.selected_token_idxes.empty()) {
     util::pad_2d_vector<int64_t>(raw_input.unique_token_ids_vec, 0);
     util::pad_2d_vector(raw_input.unique_token_counts_vec, 0);
@@ -1459,6 +1620,7 @@ void convert_tensor_to_raw_output(
     const torch::Tensor& top_logprobs,
     const torch::Tensor& embeddings,
     const std::vector<torch::Tensor>& mm_embeddings,
+    const std::vector<torch::Tensor>& dit_images,
     const torch::Tensor& expert_load_data,
     int32_t prepared_layer_id,
     const torch::Tensor& src_seq_idxes,
@@ -1503,6 +1665,7 @@ void convert_tensor_to_raw_output(
 
   raw_output.outputs.reserve(num_seqs);
   raw_output.mm_embeddings = mm_embeddings;
+  raw_output.dit_forward_output.tensors = dit_images;
   for (int32_t output_idx = 0; output_idx < num_seqs; ++output_idx) {
     RawSampleOutput raw_sample_output;
 
@@ -1634,7 +1797,6 @@ bool ForwardSharedMemoryManager::raw_input_write(const RawForwardInput& input) {
   CHECK(total_size == real_size) << "total_size != real_size.";
   std::atomic_thread_fence(std::memory_order_release);
   control_ptr_->version = ++last_version_;
-
   return true;
 }
 
@@ -1666,6 +1828,7 @@ bool ForwardSharedMemoryManager::raw_output_write(
     const torch::Tensor& top_logprobs,
     const torch::Tensor& embeddings,
     const std::vector<torch::Tensor>& mm_embeddings,
+    const std::vector<torch::Tensor>& dit_images,
     const torch::Tensor& expert_load_data,
     int32_t prepared_layer_id,
     const torch::Tensor& src_seq_idxes,
@@ -1678,6 +1841,7 @@ bool ForwardSharedMemoryManager::raw_output_write(
                                top_logprobs,
                                embeddings,
                                mm_embeddings,
+                               dit_images,
                                expert_load_data,
                                prepared_layer_id,
                                src_seq_idxes,
@@ -1697,7 +1861,6 @@ bool ForwardSharedMemoryManager::raw_output_write(
   char* test = static_cast<char*>(base_address()) + sizeof(ControlMetadata);
   std::atomic_thread_fence(std::memory_order_release);
   control_ptr_->version = ++last_version_;
-
   return true;
 }
 

--- a/xllm/core/runtime/forward_shared_memory_manager.h
+++ b/xllm/core/runtime/forward_shared_memory_manager.h
@@ -17,6 +17,7 @@ limitations under the License.
 
 #include <memory>
 
+#include "dit_forward_params.h"
 #include "forward_params.h"
 #include "params_utils.h"
 #include "util/shared_memory_manager.h"
@@ -110,6 +111,7 @@ class ForwardSharedMemoryManager : public SharedMemoryManager {
                         const torch::Tensor& top_logprobs,
                         const torch::Tensor& embeddings,
                         const std::vector<torch::Tensor>& mm_embeddings,
+                        const std::vector<torch::Tensor>& dit_images,
                         const torch::Tensor& expert_load_data,
                         int32_t prepared_layer_id,
                         const torch::Tensor& src_seq_idxes,

--- a/xllm/core/runtime/options.h
+++ b/xllm/core/runtime/options.h
@@ -110,6 +110,22 @@ struct Options {
 
   // Context parallelism size
   PROPERTY(int32_t, cp_size) = 1;
+  
+  // dit data parallelism size
+  // Default set as 1
+  PROPERTY(int32_t, dit_dp_size) = 1;
+
+  // dit tensor parallelism size
+  // Default set as 1
+  PROPERTY(int32_t, dit_tp_size) = 1;
+
+  // dit sequence parallelism size
+  // Default set as 1
+  PROPERTY(int32_t, dit_sp_size) = 1;
+
+  // dit classifier-free guidance  parallelism size
+  // Default set as 1
+  PROPERTY(int32_t, dit_cfg_size) = 1;
 
   // enable enable_schedule_overlap to improve runtime execution efficiency.
   PROPERTY(bool, enable_schedule_overlap) = true;

--- a/xllm/core/runtime/params_utils.cpp
+++ b/xllm/core/runtime/params_utils.cpp
@@ -364,6 +364,11 @@ void proto_to_forward_input(const proto::ForwardInput* pb_forward_input,
     proto_to_mmdata(pb_forward_input->mm_data(), &input_params.mm_data);
   }
 
+  if (pb_forward_input->has_dit_forward_input()) {
+    proto_to_dit_forward_input(pb_forward_input->dit_forward_input(),
+                               input_params.dit_forward_input);
+  }
+
   COUNTER_ADD(proto_latency_seconds_proto2i, timer.elapsed_seconds());
 }
 
@@ -534,6 +539,11 @@ void forward_input_to_proto(const RawForwardInput& inputs,
     mmdata_to_proto(inputs.mm_data, pb_forward_input->mutable_mm_data());
   }
 
+  if (inputs.dit_forward_input.valid()) {
+    dit_forward_input_to_proto(inputs.dit_forward_input,
+                               pb_forward_input->mutable_dit_forward_input());
+  }
+
   COUNTER_ADD(proto_latency_seconds_i2proto, timer.elapsed_seconds());
 }
 
@@ -583,7 +593,8 @@ void proto_to_forward_output(const proto::ForwardOutput& pb_output,
     }
     raw_forward_output.outputs.emplace_back(s);
   }
-
+  proto_to_dit_forward_output(pb_output.dit_forward_output(),
+                              raw_forward_output.dit_forward_output);
   COUNTER_ADD(proto_latency_seconds_proto2o, timer.elapsed_seconds());
 }
 
@@ -597,6 +608,7 @@ void forward_output_to_proto(const torch::Tensor& next_tokens,
                              const torch::Tensor& src_seq_idxes,
                              const torch::Tensor& out_tokens,
                              const torch::Tensor& out_logprobs,
+                             const std::vector<torch::Tensor>& dit_images,
                              proto::ForwardOutput* pb_forward_output) {
   Timer timer;
   int32_t num_seqs = next_tokens.size(0);
@@ -747,7 +759,11 @@ void forward_output_to_proto(const torch::Tensor& next_tokens,
     ADD_VECTOR_TO_PROTO(pb_forward_output->mutable_out_logprobs(),
                         out_logprobs_slice);
   }
-
+  if (!dit_images.empty()) {
+    TORCH_TENSOR_VEC_TO_PROTO_TENSOR_LIST(
+        pb_forward_output->mutable_dit_forward_output()->mutable_tensors(),
+        dit_images);
+  }
   COUNTER_ADD(proto_latency_seconds_o2proto, timer.elapsed_seconds());
   return;
 }
@@ -825,6 +841,215 @@ bool block_transfer_info_to_proto(
     return false;
   }
   pb_block_transfer_info->set_batch_id(batch_id);
+  return true;
+}
+
+bool dit_forward_input_to_proto(const DiTForwardInput& dit_inputs,
+                                proto::DiTForwardInput* pb_dit_inputs) {
+  pb_dit_inputs->set_batch_size(dit_inputs.batch_size);
+
+  ADD_VECTOR_TO_PROTO(pb_dit_inputs->mutable_prompts(), dit_inputs.prompts);
+
+  ADD_VECTOR_TO_PROTO(pb_dit_inputs->mutable_prompts_2(), dit_inputs.prompts_2);
+
+  ADD_VECTOR_TO_PROTO(pb_dit_inputs->mutable_negative_prompts(),
+                      dit_inputs.negative_prompts);
+
+  ADD_VECTOR_TO_PROTO(pb_dit_inputs->mutable_negative_prompts_2(),
+                      dit_inputs.negative_prompts_2);
+
+  torch_tensor_to_proto_tensor(dit_inputs.images,
+                               pb_dit_inputs->mutable_images());
+
+  torch_tensor_to_proto_tensor(dit_inputs.condition_images,
+                               pb_dit_inputs->mutable_condition_images());
+
+  torch_tensor_to_proto_tensor(dit_inputs.mask_images,
+                               pb_dit_inputs->mutable_mask_images());
+
+  torch_tensor_to_proto_tensor(dit_inputs.control_image,
+                               pb_dit_inputs->mutable_control_image());
+
+  torch_tensor_to_proto_tensor(dit_inputs.masked_image_latents,
+                               pb_dit_inputs->mutable_masked_image_latents());
+
+  torch_tensor_to_proto_tensor(dit_inputs.prompt_embeds,
+                               pb_dit_inputs->mutable_prompt_embeds());
+
+  torch_tensor_to_proto_tensor(dit_inputs.pooled_prompt_embeds,
+                               pb_dit_inputs->mutable_pooled_prompt_embeds());
+
+  torch_tensor_to_proto_tensor(dit_inputs.negative_prompt_embeds,
+                               pb_dit_inputs->mutable_negative_prompt_embeds());
+
+  torch_tensor_to_proto_tensor(
+      dit_inputs.negative_pooled_prompt_embeds,
+      pb_dit_inputs->mutable_negative_pooled_prompt_embeds());
+
+  torch_tensor_to_proto_tensor(dit_inputs.latents,
+                               pb_dit_inputs->mutable_latents());
+
+  if (!generation_params_to_proto(dit_inputs.generation_params,
+                                  pb_dit_inputs->mutable_generation_params())) {
+    LOG(ERROR) << "Failed to convert generation_params";
+    return false;
+  }
+
+  return true;
+}
+
+bool generation_params_to_proto(
+    const DiTGenerationParams& dit_generation_params,
+    proto::DiTGenerationParams* pb_dit_generation_params) {
+  pb_dit_generation_params->set_width(dit_generation_params.width);
+  pb_dit_generation_params->set_height(dit_generation_params.height);
+  pb_dit_generation_params->set_num_inference_steps(
+      dit_generation_params.num_inference_steps);
+  pb_dit_generation_params->set_true_cfg_scale(
+      dit_generation_params.true_cfg_scale);
+  pb_dit_generation_params->set_guidance_scale(
+      dit_generation_params.guidance_scale);
+  pb_dit_generation_params->set_num_images_per_prompt(
+      dit_generation_params.num_images_per_prompt);
+  pb_dit_generation_params->set_seed(dit_generation_params.seed);
+  pb_dit_generation_params->set_max_sequence_length(
+      dit_generation_params.max_sequence_length);
+  pb_dit_generation_params->set_strength(dit_generation_params.strength);
+  pb_dit_generation_params->set_enable_cfg_renorm(
+      dit_generation_params.enable_cfg_renorm);
+  pb_dit_generation_params->set_cfg_renorm_min(
+      dit_generation_params.cfg_renorm_min);
+  return true;
+}
+
+bool proto_to_dit_forward_input(const proto::DiTForwardInput& pb_dit_inputs,
+                                DiTForwardInput& dit_inputs) {
+  dit_inputs.batch_size = pb_dit_inputs.batch_size();
+
+  std::vector<std::string> prompts = std::vector<std::string>(
+      pb_dit_inputs.prompts().begin(), pb_dit_inputs.prompts().end());
+  std::vector<std::string> prompts_2 = std::vector<std::string>(
+      pb_dit_inputs.prompts_2().begin(), pb_dit_inputs.prompts_2().end());
+  std::vector<std::string> negative_prompts =
+      std::vector<std::string>(pb_dit_inputs.negative_prompts().begin(),
+                               pb_dit_inputs.negative_prompts().end());
+  std::vector<std::string> negative_prompts_2 =
+      std::vector<std::string>(pb_dit_inputs.negative_prompts_2().begin(),
+                               pb_dit_inputs.negative_prompts_2().end());
+  dit_inputs.prompts = std::move(prompts);
+
+  dit_inputs.prompts_2 = std::move(prompts_2);
+
+  dit_inputs.negative_prompts = std::move(negative_prompts);
+
+  dit_inputs.negative_prompts_2 = std::move(negative_prompts_2);
+
+  if (pb_dit_inputs.has_images()) {
+    dit_inputs.images = util::proto_to_torch(pb_dit_inputs.images());
+  }
+
+  if (pb_dit_inputs.has_condition_images()) {
+    dit_inputs.condition_images =
+        util::proto_to_torch(pb_dit_inputs.condition_images());
+  }
+
+  if (pb_dit_inputs.has_mask_images()) {
+    dit_inputs.mask_images = util::proto_to_torch(pb_dit_inputs.mask_images());
+  }
+
+  if (pb_dit_inputs.has_control_image()) {
+    dit_inputs.control_image =
+        util::proto_to_torch(pb_dit_inputs.control_image());
+  }
+
+  if (pb_dit_inputs.has_masked_image_latents()) {
+    dit_inputs.masked_image_latents =
+        util::proto_to_torch(pb_dit_inputs.masked_image_latents());
+  }
+
+  if (pb_dit_inputs.has_prompt_embeds()) {
+    dit_inputs.prompt_embeds =
+        util::proto_to_torch(pb_dit_inputs.prompt_embeds());
+  }
+
+  if (pb_dit_inputs.has_pooled_prompt_embeds()) {
+    dit_inputs.pooled_prompt_embeds =
+        util::proto_to_torch(pb_dit_inputs.pooled_prompt_embeds());
+  }
+
+  if (pb_dit_inputs.has_negative_prompt_embeds()) {
+    dit_inputs.negative_prompt_embeds =
+        util::proto_to_torch(pb_dit_inputs.negative_prompt_embeds());
+  }
+
+  if (pb_dit_inputs.has_negative_pooled_prompt_embeds()) {
+    dit_inputs.negative_pooled_prompt_embeds =
+        util::proto_to_torch(pb_dit_inputs.negative_pooled_prompt_embeds());
+  }
+
+  if (pb_dit_inputs.has_latents()) {
+    dit_inputs.latents = util::proto_to_torch(pb_dit_inputs.latents());
+  }
+
+  if (!proto_to_generation_params(pb_dit_inputs.generation_params(),
+                                  dit_inputs.generation_params)) {
+    LOG(ERROR) << "Failed to convert generation_params";
+    return false;
+  }
+
+  return true;
+}
+
+bool proto_to_generation_params(
+    const proto::DiTGenerationParams& pb_dit_generation_params,
+    DiTGenerationParams& dit_generation_params) {
+  LOG(INFO) << "start brpc transfer";
+  dit_generation_params.width = pb_dit_generation_params.width();
+  dit_generation_params.height = pb_dit_generation_params.height();
+  dit_generation_params.num_inference_steps =
+      pb_dit_generation_params.num_inference_steps();
+  dit_generation_params.true_cfg_scale =
+      pb_dit_generation_params.true_cfg_scale();
+  dit_generation_params.guidance_scale =
+      pb_dit_generation_params.guidance_scale();
+  dit_generation_params.num_images_per_prompt =
+      pb_dit_generation_params.num_images_per_prompt();
+  dit_generation_params.seed = pb_dit_generation_params.seed();
+  dit_generation_params.max_sequence_length =
+      pb_dit_generation_params.max_sequence_length();
+  dit_generation_params.strength = pb_dit_generation_params.strength();
+  dit_generation_params.enable_cfg_renorm =
+      pb_dit_generation_params.enable_cfg_renorm();
+  dit_generation_params.cfg_renorm_min =
+      pb_dit_generation_params.cfg_renorm_min();
+  return true;
+}
+
+bool proto_to_dit_forward_output(const proto::DiTForwardOutput& pb_dit_outputs,
+                                 DiTForwardOutput& dit_outputs) {
+  const auto& pb_tensor_list = pb_dit_outputs.tensors();
+  std::vector<torch::Tensor> torch_tensor_vec;
+  torch_tensor_vec.reserve(pb_tensor_list.tensors_size());
+  for (const auto& pb_tensor : pb_tensor_list.tensors()) {
+    torch::Tensor torch_tensor = util::proto_to_torch(pb_tensor);
+    if (!torch_tensor.defined()) {
+      LOG(ERROR) << "Failed to convert PB Tensor to torch Tensor (list item)";
+      return false;
+    }
+    torch_tensor_vec.emplace_back(std::move(torch_tensor));
+  }
+  dit_outputs.tensors = std::move(torch_tensor_vec);
+  return true;
+}
+
+bool torch_tensor_to_proto_tensor(const torch::Tensor& torch_tensor,
+                                  proto::Tensor* proto_tensor) {
+  if (torch_tensor.defined()) {
+    if (!util::torch_to_proto(torch_tensor, proto_tensor)) {
+      LOG(ERROR) << "Failed to convert torch Tensor to Pb Tensor ";
+      return false;
+    }
+  }
   return true;
 }
 

--- a/xllm/core/runtime/params_utils.h
+++ b/xllm/core/runtime/params_utils.h
@@ -44,6 +44,7 @@ void forward_output_to_proto(const torch::Tensor& next_tokens,
                              const torch::Tensor& src_seq_idxes,
                              const torch::Tensor& out_tokens,
                              const torch::Tensor& out_logprobs,
+                             const std::vector<torch::Tensor>& dit_images,
                              proto::ForwardOutput* pb_forward_output);
 
 Token build_token(int64_t index,
@@ -65,4 +66,23 @@ bool block_transfer_info_to_proto(
     const std::vector<BlockTransferInfo>& block_transfer_info,
     proto::BlockTransferInfos* pb_block_transfer_info);
 
+bool dit_forward_input_to_proto(const DiTForwardInput& dit_inputs,
+                                proto::DiTForwardInput* pb_dit_inputs);
+
+bool generation_params_to_proto(
+    const DiTGenerationParams& dit_generation_params,
+    proto::DiTGenerationParams* pb_dit_generation_params);
+
+bool proto_to_dit_forward_input(const proto::DiTForwardInput& pb_dit_inputs,
+                                DiTForwardInput& dit_inputs);
+
+bool proto_to_generation_params(
+    const proto::DiTGenerationParams& pb_dit_generation_params,
+    DiTGenerationParams& dit_generation_params);
+
+bool proto_to_dit_forward_output(const proto::DiTForwardOutput& pb_dit_outputs,
+                                 DiTForwardOutput& dit_outputs);
+
+bool torch_tensor_to_proto_tensor(const torch::Tensor& torch_tensor,
+                                  proto::Tensor* proto_tensor);
 }  // namespace xllm

--- a/xllm/core/runtime/worker.cpp
+++ b/xllm/core/runtime/worker.cpp
@@ -30,6 +30,7 @@ limitations under the License.
 #include "framework/kv_cache/kv_cache.h"
 #include "framework/model/model_input_params.h"
 #include "framework/state_dict/state_dict.h"
+#include "runtime/dit_worker_impl.h"
 #include "runtime/eagle3_worker_impl.h"
 #include "runtime/embed_vlm_worker_impl.h"
 #include "runtime/embed_worker_impl.h"
@@ -69,6 +70,8 @@ Worker::Worker(const ParallelArgs& parallel_args,
     impl_ = new RecWorkerImpl(parallel_args, device, options);
   } else if (worker_type == WorkerType::MMEVLM) {
     impl_ = new MMEmbedVLMWorkerImpl(parallel_args, device, options);
+  } else if (worker_type == WorkerType::DIT) {
+    impl_ = new DiTWorkerImpl(parallel_args, device, options);
   } else {
     LOG(ERROR) << "Unknown worker type, please check logic";
   }

--- a/xllm/core/scheduler/dit_scheduler.cpp
+++ b/xllm/core/scheduler/dit_scheduler.cpp
@@ -48,9 +48,11 @@ void DiTAsyncResponseProcessor::process_failed_request(
     std::shared_ptr<DiTRequest> request,
     Status status) {}
 
-DiTDynamicBatchScheduler::DiTDynamicBatchScheduler(DiTEngine* engine,
+DiTDynamicBatchScheduler::DiTDynamicBatchScheduler(Engine* engine,
                                                    const Options& options)
-    : options_(options), engine_(engine), request_queue_(kRequestQueueSize) {
+    : options_(options),
+      engine_(dynamic_cast<DiTEngine*>(engine)),
+      request_queue_(kRequestQueueSize) {
   CHECK(engine_ != nullptr);
 
   response_handler_ = std::make_unique<DiTAsyncResponseProcessor>();

--- a/xllm/core/scheduler/dit_scheduler.h
+++ b/xllm/core/scheduler/dit_scheduler.h
@@ -26,13 +26,14 @@ limitations under the License.
 
 #include "common/macros.h"
 #include "common/types.h"
+#include "distributed_runtime/dit_engine.h"
+#include "distributed_runtime/engine.h"
 #include "framework/batch/dit_batch.h"
 #include "framework/request/dit_request.h"
 #include "scheduler.h"
 #include "util/threadpool.h"
 
 namespace xllm {
-class DiTEngine;
 
 class DiTAsyncResponseProcessor final {
  public:
@@ -65,7 +66,7 @@ class DiTScheduler : public SchedulerBase {
 
 class DiTDynamicBatchScheduler : public DiTScheduler {
  public:
-  DiTDynamicBatchScheduler(DiTEngine* engine, const Options& options);
+  DiTDynamicBatchScheduler(Engine* engine, const Options& options);
   virtual ~DiTDynamicBatchScheduler();
 
   bool add_request(std::shared_ptr<DiTRequest>& request) override;

--- a/xllm/core/scheduler/scheduler_factory.cpp
+++ b/xllm/core/scheduler/scheduler_factory.cpp
@@ -61,7 +61,7 @@ std::unique_ptr<ContinuousScheduler> create_continuous_scheduler(
 }
 
 std::unique_ptr<DiTScheduler> create_dit_scheduler(
-    DiTEngine* engine,
+    Engine* engine,
     DiTScheduler::Options options) {
   return std::make_unique<DiTDynamicBatchScheduler>(engine, options);
 }

--- a/xllm/core/scheduler/scheduler_factory.h
+++ b/xllm/core/scheduler/scheduler_factory.h
@@ -27,7 +27,7 @@ std::unique_ptr<ContinuousScheduler> create_continuous_scheduler(
     ContinuousScheduler::Options options);
 
 std::unique_ptr<DiTScheduler> create_dit_scheduler(
-    DiTEngine* engine,
+    Engine* engine,
     DiTScheduler::Options options);
 
 std::unique_ptr<FixedStepsScheduler> create_fixed_steps_scheduler(

--- a/xllm/core/util/shared_memory_manager.cpp
+++ b/xllm/core/util/shared_memory_manager.cpp
@@ -44,7 +44,6 @@ SharedMemoryManager::SharedMemoryManager(const std::string& name,
   // First try to create exclusively (O_CREAT | O_EXCL)
   fd_ = shm_open(name.c_str(), O_CREAT | O_RDWR | O_EXCL, 0666);
   is_creator = (fd_ != -1);
-
   // If creation failed, try opening existing
   if (!is_creator) {
     fd_ = shm_open(name.c_str(), O_RDWR, 0666);

--- a/xllm/core/util/utils.cpp
+++ b/xllm/core/util/utils.cpp
@@ -483,6 +483,9 @@ torch::Tensor proto_to_torch(const proto::Tensor& proto_tensor) {
     data_ptr = get_data_from_contents<uint8_t>(proto_contents, proto_datatype);
     data_count = proto_contents.bytes_contents().size() /
                  static_cast<size_t>(sizeof(torch::Half));
+  } else if (proto_datatype == "BYTES") {
+    data_ptr = get_data_from_contents<uint8_t>(proto_contents, proto_datatype);
+    data_count = proto_contents.bytes_contents().size();
   }
 
   if (data_ptr == nullptr) {

--- a/xllm/models/dit/flowmatch_euler_discrete_scheduler.h
+++ b/xllm/models/dit/flowmatch_euler_discrete_scheduler.h
@@ -42,7 +42,13 @@ class FlowMatchEulerDiscreteSchedulerImpl : public torch::nn::Module {
     max_shift_ = args_.max_shift(),
     base_image_seq_len_ = args_.base_image_seq_len();
     max_image_seq_len_ = args_.max_image_seq_len();
-    shift_terminal_ = std::nullopt;
+    // shift_terminal_ = static_cast<int64_t>(args_.shift_terminal()) == -1 ?
+    // std::nullopt : args_.shift_terminal();
+    if (static_cast<int64_t>(args_.shift_terminal()) == -1) {
+      shift_terminal_ = std::nullopt;
+    } else {
+      shift_terminal_ = args_.shift_terminal();
+    }
     time_shift_type_ = "exponential";
     std::vector<float> timesteps_vec(num_train_timesteps_);
     for (int i = 0; i < num_train_timesteps_; ++i) {
@@ -385,6 +391,7 @@ TORCH_MODULE(FlowMatchEulerDiscreteScheduler);
 REGISTER_MODEL_ARGS(FlowMatchEulerDiscreteScheduler, [&] {
   LOAD_ARG_OR(num_train_timesteps, "num_train_timesteps", 1000);
   LOAD_ARG_OR(shift, "shift", 1);
+  LOAD_ARG_OR(shift_terminal, "shift_terminal", -1);
   LOAD_ARG_OR(use_dynamic_shifting, "use_dynamic_shifting", true);
   LOAD_ARG_OR(base_shift, "base_shift", 0.5f);
   LOAD_ARG_OR(max_shift, "max_shift", 1.15f);

--- a/xllm/models/dit/npu/qwen_image_edit/autoencoder_kl_qwenimage.h
+++ b/xllm/models/dit/npu/qwen_image_edit/autoencoder_kl_qwenimage.h
@@ -1,0 +1,2082 @@
+/* Copyright 2026 The xLLM Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://github.com/jd-opensource/xllm/blob/main/LICENSE
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+#pragma once
+#include <torch/nn/modules/conv.h>
+#include <torch/nn/modules/dropout.h>
+#include <torch/nn/modules/linear.h>
+#include <torch/nn/modules/normalization.h>
+#include <torch/torch.h>
+#include <torch_npu/csrc/aten/CustomFunctions.h>
+#include <torch_npu/csrc/libs/init_npu.h>
+
+#include <iostream>
+#include <memory>
+#include <optional>
+#include <stdexcept>
+#include <string>
+#include <vector>
+
+#include "core/framework/dit_model_loader.h"
+#include "core/framework/model/model_input_params.h"
+#include "core/framework/state_dict/state_dict.h"
+#include "core/layers/common/add_matmul.h"
+#include "framework/model_context.h"
+#include "models/dit/utils/common_util.h"
+#include "models/model_registry.h"
+
+#ifdef TORCH_HIGHER_THAN_PTA6
+#include <torch_npu/csrc/framework/OpCommand.h>
+#else
+#include <torch_npu/csrc/aten/NPUNativeFunctions.h>
+#include <torch_npu/csrc/framework/utils/OpPreparation.h>
+#endif
+
+// VAE model compatible with huggingface weights
+// ref to:
+// https://github.com/huggingface/diffusers/blob/main/src/diffusers/models/autoencoders/autoencoder_kl_qwenimage.py
+
+namespace xllm::dit::npu {
+namespace qwenimage {
+
+class QwenImageBaseModule : public torch::nn::Module {
+ public:
+  virtual torch::Tensor forward(
+      const torch::Tensor& x,
+      std::shared_ptr<std::vector<torch::Tensor>> feat_cache = nullptr,
+      std::shared_ptr<std::vector<int64_t>> feat_idx = nullptr) = 0;
+  virtual ~QwenImageBaseModule() = default;
+};
+
+const int64_t CACHE_T = 2;
+
+class QwenImageCausalConv3dImpl : public torch::nn::Module {
+ public:
+  QwenImageCausalConv3dImpl(const ModelContext& context,
+                            int64_t in_channels,
+                            int64_t out_channels,
+                            torch::IntArrayRef kernel_size,
+                            torch::IntArrayRef stride = 1,
+                            torch::IntArrayRef padding = 0) {
+    conv_ = register_module(
+        "conv",
+        torch::nn::Conv3d(
+            torch::nn::Conv3dOptions(in_channels, out_channels, kernel_size)
+                .stride(stride)
+                .padding(0)
+                .bias(true)));
+
+    auto p = padding.size() == 1
+                 ? std::vector<int64_t>{padding[0], padding[0], padding[0]}
+                 : std::vector<int64_t>(padding.begin(), padding.end());
+
+    padding_ = {p[2], p[2], p[1], p[1], 2 * p[0], 0};
+  }
+
+  torch::Tensor forward(const torch::Tensor& x,
+                        const torch::Tensor& cache_x = torch::Tensor()) {
+    auto padding_vec = padding_;
+    auto result_x = x;
+
+    if (cache_x.defined() && padding_[4] > 0) {
+      auto device_x = result_x.device();
+      auto cache_device = cache_x.to(device_x);
+      result_x = torch::cat({cache_device, result_x}, 2);
+      padding_vec[4] -= cache_x.size(2);
+    }
+
+    result_x = torch::nn::functional::pad(
+        result_x, torch::nn::functional::PadFuncOptions(padding_vec));
+    return conv_(result_x);
+  }
+
+  void load_state_dict(const StateDict& state_dict) {
+    weight::load_weight(state_dict, "weight", conv_->weight, is_weight_loaded_);
+    weight::load_weight(state_dict, "bias", conv_->bias, is_bias_loaded_);
+  }
+
+  void verify_loaded_weights(const std::string& prefix) const {
+    CHECK(is_weight_loaded_)
+        << "weight is not loaded for " << prefix + "weight";
+    CHECK(is_bias_loaded_) << "weight is not loaded for " << prefix + "bias";
+  }
+
+ private:
+  bool is_weight_loaded_{false};
+  bool is_bias_loaded_{false};
+  torch::nn::Conv3d conv_ = nullptr;
+  std::vector<int64_t> padding_;
+};
+
+TORCH_MODULE(QwenImageCausalConv3d);
+
+class QwenImageRMS_normImpl : public torch::nn::Module {
+ public:
+  QwenImageRMS_normImpl(const ModelContext& context,
+                        int64_t dim,
+                        bool channel_first = true,
+                        bool images = true,
+                        bool is_bias = false,
+                        bool fused = false)
+      : channel_first_(channel_first), fused_(fused), is_bias_(is_bias) {
+    auto broadcastable_dims =
+        images ? std::vector<int64_t>{1, 1} : std::vector<int64_t>{1, 1, 1};
+    auto shape = std::vector<int64_t>{dim};
+    if (channel_first) {
+      shape.insert(
+          shape.end(), broadcastable_dims.begin(), broadcastable_dims.end());
+    }
+
+    scale_ = std::sqrt(dim);
+    weight_ = register_parameter("gamma", torch::ones(shape));
+
+    if (is_bias_) {
+      bias_ = register_parameter("bias", torch::zeros(shape));
+    }
+  }
+
+  torch::Tensor forward(const torch::Tensor& x) {
+    if (fused_) {
+      auto [output, rstd] =
+          at_npu::native::custom_ops::npu_rms_norm(x, weight_, 0);
+
+      if (is_bias_ && bias_.defined()) {
+        output = output + bias_.to(output.device());
+      }
+      return output;
+    } else {
+      auto output = torch::nn::functional::normalize(
+                        x,
+                        torch::nn::functional::NormalizeFuncOptions().dim(
+                            channel_first_ ? 1 : -1)) *
+                    scale_ * weight_;
+      if (is_bias_) {
+        output = output + bias_;
+      }
+      return output;
+    }
+  }
+
+  void load_state_dict(const StateDict& state_dict) {
+    weight::load_weight(state_dict, "gamma", weight_, is_weight_loaded_);
+    if (is_bias_) {
+      weight::load_weight(state_dict, "bias", bias_, is_bias_loaded_);
+    }
+  }
+
+  void verify_loaded_weights(const std::string& prefix) const {
+    CHECK(is_weight_loaded_)
+        << "weight is not loaded for " << prefix + "weight";
+    CHECK(!is_bias_ || is_bias_loaded_)
+        << "bias is not loaded for " << prefix + "bias";
+  }
+
+ private:
+  bool channel_first_;
+  double scale_;
+  bool is_bias_;
+  bool fused_;
+  bool is_weight_loaded_{false};
+  bool is_bias_loaded_{false};
+  torch::Tensor weight_;
+  torch::Tensor bias_;
+  torch::TensorOptions options_;
+};
+
+TORCH_MODULE(QwenImageRMS_norm);
+
+class QwenImageUpsampleImpl : public torch::nn::Module {
+ public:
+  QwenImageUpsampleImpl(
+      const ModelContext& context,
+      const torch::nn::functional::InterpolateFuncOptions options)
+      : options_(options) {}
+
+  torch::Tensor forward(const torch::Tensor& x) {
+    // auto result = upsample_(x.to(torch::kFloat));
+    auto result =
+        torch::nn::functional::interpolate(x.to(torch::kFloat), options_);
+    return result.to(x.dtype());
+  }
+
+ private:
+  torch::nn::functional::InterpolateFuncOptions options_;
+  torch::nn::Upsample upsample_ = nullptr;
+};
+
+TORCH_MODULE(QwenImageUpsample);
+
+class QwenImageResampleImpl : public QwenImageBaseModule {
+ public:
+  QwenImageResampleImpl(const ModelContext& context,
+                        int64_t dim,
+                        const std::string& mode)
+      : dim_(dim), mode_(mode) {
+    if (mode_ == "upsample2d") {
+      resample_ = register_module(
+          "resample",
+          torch::nn::Sequential(
+              QwenImageUpsample(context,
+                                torch::nn::functional::InterpolateFuncOptions()
+                                    .scale_factor(std::vector<double>{2.0, 2.0})
+                                    .mode(torch::kNearestExact)),
+              torch::nn::Conv2d(
+                  torch::nn::Conv2dOptions(/*in_channels=*/dim,
+                                           /*out_channels=*/dim / 2,
+                                           /*kernel_size=*/3)
+                      .padding(1))));
+    } else if (mode_ == "upsample3d") {
+      resample_ = register_module(
+          "resample",
+          torch::nn::Sequential(
+              QwenImageUpsample(context,
+                                torch::nn::functional::InterpolateFuncOptions()
+                                    .scale_factor(std::vector<double>{2.0, 2.0})
+                                    .mode(torch::kNearestExact)),
+              torch::nn::Conv2d(
+                  torch::nn::Conv2dOptions(/*in_channels=*/dim,
+                                           /*out_channels=*/dim / 2,
+                                           /*kernel_size=*/3)
+                      .padding(1))));
+
+      time_conv_ = register_module(
+          "time_conv",
+          QwenImageCausalConv3d(context,
+                                /*in_channels=*/dim,
+                                /*out_channels=*/dim * 2,
+                                /*kernel_size=*/torch::IntArrayRef{3, 1, 1},
+                                /*stride=*/torch::IntArrayRef{1, 1, 1},
+                                /*padding=*/torch::IntArrayRef{1, 0, 0}));
+
+    } else if (mode_ == "downsample2d") {
+      resample_ = register_module(
+          "resample",
+          torch::nn::Sequential(
+              torch::nn::ZeroPad2d(torch::nn::ZeroPad2dOptions({/*left=*/0,
+                                                                /*right=*/1,
+                                                                /*top=*/0,
+                                                                /*bottom=*/1})),
+              torch::nn::Conv2d(torch::nn::Conv2dOptions(/*in_channels=*/dim,
+                                                         /*out_channels=*/dim,
+                                                         /*kernel_size=*/3)
+                                    .stride(2))));
+    } else if (mode_ == "downsample3d") {
+      resample_ = register_module(
+          "resample",
+          torch::nn::Sequential(
+              torch::nn::ZeroPad2d(torch::nn::ZeroPad2dOptions({/*left=*/0,
+                                                                /*right=*/1,
+                                                                /*top=*/0,
+                                                                /*bottom=*/1})),
+              torch::nn::Conv2d(torch::nn::Conv2dOptions(/*in_channels=*/dim,
+                                                         /*out_channels=*/dim,
+                                                         /*kernel_size=*/3)
+                                    .stride(2))));
+      time_conv_ = register_module(
+          "time_conv",
+          QwenImageCausalConv3d(context,
+                                /*in_channels=*/dim,
+                                /*out_channels=*/dim,
+                                /*kernel_size=*/torch::IntArrayRef{3, 1, 1},
+                                /*stride=*/torch::IntArrayRef{2, 1, 1},
+                                /*padding=*/torch::IntArrayRef{0, 0, 0}));
+    } else {
+      resample_ = register_module("resample",
+                                  torch::nn::Sequential(torch::nn::Identity()));
+    }
+
+    rep_tensor_ = register_parameter("rep_tensor", torch::tensor({-999.0}));
+  }
+
+  torch::Tensor forward(
+      const torch::Tensor& x,
+      std::shared_ptr<std::vector<torch::Tensor>> feat_cache = nullptr,
+      std::shared_ptr<std::vector<int64_t>> feat_idx = nullptr) override {
+    if (feat_idx == nullptr) {
+      feat_idx =
+          std::make_shared<std::vector<int64_t>>(std::vector<int64_t>{0});
+    }
+    auto sizes = x.sizes();
+    auto b = sizes[0], c = sizes[1], t = sizes[2], h = sizes[3], w = sizes[4];
+    auto result_x = x;
+
+    if (mode_ == "upsample3d" && feat_cache && feat_idx) {
+      auto idx = (*feat_idx)[0];
+
+      if (idx < feat_cache->size() && feat_cache->at(idx).defined()) {
+        auto cache_x = result_x
+                           .index({torch::indexing::Slice(),
+                                   torch::indexing::Slice(),
+                                   torch::indexing::Slice(
+                                       -CACHE_T, torch::indexing::None)})
+                           .clone();
+
+        if (cache_x.size(2) < 2 && feat_cache->at(idx).defined() &&
+            !torch::equal(rep_tensor_, feat_cache->at(idx))) {
+          auto last_frame =
+              feat_cache->at(idx)
+                  .index({torch::indexing::Slice(),
+                          torch::indexing::Slice(),
+                          torch::indexing::Slice(-1, torch::indexing::None)})
+                  .unsqueeze(2)
+                  .to(cache_x.device());
+          cache_x = torch::cat({last_frame, cache_x}, 2);
+        }
+        if (cache_x.size(2) < 2 && feat_cache->at(idx).defined() &&
+            torch::equal(rep_tensor_, feat_cache->at(idx))) {
+          cache_x = torch::cat(
+              {torch::zeros_like(cache_x).to(cache_x.device()), cache_x}, 2);
+        }
+        if (torch::equal(rep_tensor_, feat_cache->at(idx))) {
+          result_x = time_conv_->forward(result_x);
+        } else {
+          result_x = time_conv_->forward(result_x, feat_cache->at(idx));
+        }
+        feat_cache->at(idx) = cache_x;
+        (*feat_idx)[0]++;
+
+        result_x = result_x.reshape({b, 2, c, t, h, w});
+        result_x = torch::stack({result_x.index({torch::indexing::Slice(), 0}),
+                                 result_x.index({torch::indexing::Slice(), 1})},
+                                3);
+        result_x = result_x.reshape({b, c, t * 2, h, w});
+      } else {
+        feat_cache->at(idx) = rep_tensor_;
+        (*feat_idx)[0]++;
+      }
+    }
+
+    t = result_x.size(2);
+    result_x = result_x.permute({0, 2, 1, 3, 4}).reshape({b * t, c, h, w});
+    result_x = resample_->forward(result_x);
+    result_x =
+        result_x
+            .view({b, t, result_x.size(1), result_x.size(2), result_x.size(3)})
+            .permute({0, 2, 1, 3, 4});
+
+    if (mode_ == "downsample3d" && feat_cache && feat_idx) {
+      auto idx = (*feat_idx)[0];
+
+      if (idx < feat_cache->size() && feat_cache->at(idx).defined()) {
+        auto cache_x =
+            result_x
+                .index({torch::indexing::Slice(),
+                        torch::indexing::Slice(),
+                        torch::indexing::Slice(-1, torch::indexing::None)})
+                .clone();
+
+        auto concat_x = torch::cat(
+            {feat_cache->at(idx).index(
+                 {torch::indexing::Slice(),
+                  torch::indexing::Slice(),
+                  torch::indexing::Slice(-1, torch::indexing::None)}),
+             result_x},
+            2);
+
+        result_x = time_conv_->forward(concat_x);
+        feat_cache->at(idx) = cache_x;
+        (*feat_idx)[0]++;
+      } else {
+        feat_cache->at(idx) = result_x.clone();
+        (*feat_idx)[0]++;
+      }
+    }
+
+    return result_x;
+  }
+
+  void load_state_dict(const StateDict& state_dict) {
+    auto params = resample_->named_parameters();
+    for (auto& param : params) {
+      std::string name = param.key();
+      if (name == "1.weight") {
+        weight::load_weight(
+            state_dict, "resample.1.weight", param.value(), is_weight_loaded_);
+      } else if (name == "1.bias") {
+        weight::load_weight(
+            state_dict, "resample.1.bias", param.value(), is_bias_loaded_);
+      }
+    }
+    if (time_conv_) {
+      time_conv_->load_state_dict(
+          state_dict.get_dict_with_prefix("time_conv."));
+    }
+  }
+
+  void verify_loaded_weights(const std::string& prefix) const {
+    CHECK(is_weight_loaded_)
+        << "weight is not loaded for " << prefix + "weight";
+    CHECK(is_bias_loaded_) << "bias is not loaded for " << prefix + "bias";
+    if (time_conv_) {
+      time_conv_->verify_loaded_weights("time_conv.");
+    }
+  }
+
+ private:
+  int64_t dim_;
+  std::string mode_;
+  bool is_weight_loaded_{false};
+  bool is_bias_loaded_{false};
+  torch::Tensor rep_tensor_;
+  torch::nn::Sequential resample_{nullptr};
+  QwenImageCausalConv3d time_conv_{nullptr};
+};
+
+TORCH_MODULE(QwenImageResample);
+
+class QwenImageResidualBlockImpl : public QwenImageBaseModule {
+ public:
+  QwenImageResidualBlockImpl(const ModelContext& context,
+                             int64_t in_dim,
+                             int64_t out_dim,
+                             double dropout = 0.0,
+                             const std::string& non_linearity = "silu")
+      : in_dim_(in_dim), out_dim_(out_dim) {
+    activation_ = register_module("silu", torch::nn::SiLU());
+
+    norm1_ = register_module("norm1",
+                             QwenImageRMS_norm(context,
+                                               in_dim,
+                                               /*channel_first=*/true,
+                                               /*images=*/false,
+                                               /*is_bias=*/false,
+                                               /*fused=*/false));
+    conv1_ = register_module(
+        "conv1",
+        QwenImageCausalConv3d(context,
+                              in_dim,
+                              out_dim,
+                              /*kernel_size=*/torch::IntArrayRef{3, 3, 3},
+                              /*stride=*/torch::IntArrayRef{1, 1, 1},
+                              /*padding=*/torch::IntArrayRef{1, 1, 1}));
+    norm2_ = register_module("norm2",
+                             QwenImageRMS_norm(context,
+                                               out_dim,
+                                               /*channel_first=*/true,
+                                               /*images=*/false,
+                                               /*is_bias=*/false,
+                                               /*fused=*/false));
+    dropout_layer_ = register_module("dropout", torch::nn::Dropout(dropout));
+    conv2_ = register_module(
+        "conv2",
+        QwenImageCausalConv3d(context,
+                              out_dim,
+                              out_dim,
+                              /*kernel_size=*/torch::IntArrayRef{3, 3, 3},
+                              /*stride=*/torch::IntArrayRef{1, 1, 1},
+                              /*padding=*/torch::IntArrayRef{1, 1, 1}));
+
+    if (in_dim != out_dim) {
+      conv_shortcut_ = register_module(
+          "conv_shortcut",
+          QwenImageCausalConv3d(context,
+                                in_dim,
+                                out_dim,
+                                /*kernel_size=*/torch::IntArrayRef{1, 1, 1},
+                                /*stride=*/torch::IntArrayRef{1, 1, 1},
+                                /*padding=*/torch::IntArrayRef{0, 0, 0}));
+    } else {
+      identity_ = register_module("conv_shortcut", torch::nn::Identity());
+    }
+  }
+
+  torch::Tensor forward(
+      const torch::Tensor& x,
+      std::shared_ptr<std::vector<torch::Tensor>> feat_cache = nullptr,
+      std::shared_ptr<std::vector<int64_t>> feat_idx = nullptr) override {
+    if (feat_idx == nullptr) {
+      feat_idx =
+          std::make_shared<std::vector<int64_t>>(std::vector<int64_t>{0});
+    }
+    torch::Tensor h = torch::empty({0});
+    if (conv_shortcut_) {
+      h = conv_shortcut_->forward(x);
+    } else {
+      h = identity_->forward(x);
+    }
+    auto result_x = x;
+
+    result_x = norm1_->forward(result_x);
+    result_x = activation_->forward(result_x);
+
+    if (feat_cache && feat_idx) {
+      auto idx = (*feat_idx)[0];
+      auto cache_x =
+          result_x
+              .index({torch::indexing::Slice(),
+                      torch::indexing::Slice(),
+                      torch::indexing::Slice(-CACHE_T, torch::indexing::None)})
+              .clone();
+      if (cache_x.size(2) < 2 && feat_cache->at(idx).defined()) {
+        auto last_frame =
+            feat_cache->at(idx)
+                .index({torch::indexing::Slice(),
+                        torch::indexing::Slice(),
+                        torch::indexing::Slice(-1, torch::indexing::None)})
+                .unsqueeze(2)
+                .to(cache_x.device());
+        cache_x = torch::cat({last_frame, cache_x}, 2);
+      }
+
+      result_x = conv1_->forward(result_x, feat_cache->at(idx));
+      feat_cache->at(idx) = cache_x;
+      (*feat_idx)[0]++;
+    } else {
+      result_x = conv1_->forward(result_x);
+    }
+    result_x = norm2_->forward(result_x);
+    result_x = activation_->forward(result_x);
+    result_x = dropout_layer_->forward(result_x);
+
+    if (feat_cache && feat_idx) {
+      auto idx = (*feat_idx)[0];
+      auto cache_x =
+          result_x
+              .index({torch::indexing::Slice(),
+                      torch::indexing::Slice(),
+                      torch::indexing::Slice(-CACHE_T, torch::indexing::None)})
+              .clone();
+
+      if (cache_x.size(2) < 2 && feat_cache->at(idx).defined()) {
+        auto last_frame =
+            feat_cache->at(idx)
+                .index({torch::indexing::Slice(),
+                        torch::indexing::Slice(),
+                        torch::indexing::Slice(-1, torch::indexing::None)})
+                .unsqueeze(2)
+                .to(cache_x.device());
+        cache_x = torch::cat({last_frame, cache_x}, 2);
+      }
+      result_x = conv2_->forward(result_x, feat_cache->at(idx));
+      feat_cache->at(idx) = cache_x;
+      (*feat_idx)[0]++;
+    } else {
+      result_x = conv2_->forward(result_x);
+    }
+
+    return result_x + h;
+  }
+
+  void load_state_dict(const StateDict& state_dict) {
+    norm1_->load_state_dict(state_dict.get_dict_with_prefix("norm1."));
+    norm2_->load_state_dict(state_dict.get_dict_with_prefix("norm2."));
+
+    conv1_->load_state_dict(state_dict.get_dict_with_prefix("conv1."));
+
+    conv2_->load_state_dict(state_dict.get_dict_with_prefix("conv2."));
+
+    if (conv_shortcut_) {
+      conv_shortcut_->load_state_dict(
+          state_dict.get_dict_with_prefix("conv_shortcut."));
+    }
+  }
+
+  void verify_loaded_weights(const std::string& prefix) const {
+    norm1_->verify_loaded_weights("norm1.");
+    norm2_->verify_loaded_weights("norm2.");
+    conv1_->verify_loaded_weights("conv1.");
+    conv2_->verify_loaded_weights("conv2.");
+    if (conv_shortcut_) {
+      conv_shortcut_->verify_loaded_weights("conv_shortcut.");
+    }
+  }
+
+ private:
+  int64_t in_dim_, out_dim_;
+  QwenImageRMS_norm norm1_{nullptr}, norm2_{nullptr};
+  QwenImageCausalConv3d conv1_{nullptr}, conv2_{nullptr};
+  QwenImageCausalConv3d conv_shortcut_{nullptr};
+  torch::nn::Dropout dropout_layer_{nullptr};
+  torch::nn::SiLU activation_{nullptr};
+  torch::nn::Identity identity_{nullptr};
+};
+
+TORCH_MODULE(QwenImageResidualBlock);
+
+class QwenImageAttentionBlockImpl : public QwenImageBaseModule {
+ public:
+  QwenImageAttentionBlockImpl(const ModelContext& context, int64_t dim)
+      : dim_(dim) {
+    norm_ = register_module("norm",
+                            QwenImageRMS_norm(context,
+                                              dim,
+                                              /*channel_first=*/true,
+                                              /*images=*/true,
+                                              /*is_bias=*/false,
+                                              /*fused=*/false));
+    to_qkv_ = register_module(
+        "to_qkv",
+        torch::nn::Conv2d(torch::nn::Conv2dOptions(/*in_channels=*/dim,
+                                                   /*out_channels=*/dim * 3,
+                                                   /*kernel_size=*/1)));
+    proj_ = register_module(
+        "proj",
+        torch::nn::Conv2d(torch::nn::Conv2dOptions(/*in_channels=*/dim,
+                                                   /*out_channels=*/dim,
+                                                   /*kernel_size=*/1)));
+  }
+
+  torch::Tensor forward(
+      const torch::Tensor& x,
+      std::shared_ptr<std::vector<torch::Tensor>> feat_cache = nullptr,
+      std::shared_ptr<std::vector<int64_t>> feat_idx = nullptr) override {
+    if (feat_idx == nullptr) {
+      feat_idx =
+          std::make_shared<std::vector<int64_t>>(std::vector<int64_t>{0});
+    }
+    auto identity = x;
+    auto sizes = x.sizes();
+    auto b = sizes[0], c = sizes[1], t = sizes[2], h = sizes[3], w = sizes[4];
+
+    auto reshaped_x = x.permute({0, 2, 1, 3, 4}).reshape({b * t, c, h, w});
+    reshaped_x = norm_->forward(reshaped_x);
+
+    auto qkv = to_qkv_->forward(reshaped_x);
+    qkv = qkv.reshape({b * t, 1, c * 3, h * w});
+    qkv = qkv.permute({0, 1, 3, 2}).contiguous();
+
+    auto chunks = qkv.chunk(3, -1);
+    auto q = chunks[0], k = chunks[1], v = chunks[2];
+
+    auto results = at_npu::native::custom_ops::npu_fusion_attention(
+        q,
+        k,
+        v,
+        /*head_num=*/1,
+        /*input_layout=*/"BNSD",
+        /*pse*/ torch::nullopt,
+        /*padding_mask=*/torch::nullopt,
+        /*atten_mask=*/torch::nullopt,
+        /*scale=*/pow(c, -0.5),
+        /*keep_prob=*/1.0,
+        /*pre_tockens=*/65535,
+        /*next_tockens=*/65535);
+    auto attn_output = std::get<0>(results);
+    attn_output =
+        attn_output.squeeze(1).permute({0, 2, 1}).reshape({b * t, c, h, w});
+
+    auto output = proj_->forward(attn_output);
+
+    output = output.view({b, t, c, h, w}).permute({0, 2, 1, 3, 4});
+
+    return output + identity;
+  }
+
+  void load_state_dict(const StateDict& state_dict) {
+    norm_->load_state_dict(state_dict.get_dict_with_prefix("norm."));
+
+    weight::load_weight(
+        state_dict, "to_qkv.weight", to_qkv_->weight, is_qkv_weight_loaded_);
+    weight::load_weight(
+        state_dict, "to_qkv.bias", to_qkv_->bias, is_qkv_bias_loaded_);
+    weight::load_weight(
+        state_dict, "proj.weight", proj_->weight, is_proj_weight_loaded_);
+    weight::load_weight(
+        state_dict, "proj.bias", proj_->bias, is_proj_bias_loaded_);
+  }
+
+  void verify_loaded_weights(const std::string& prefix) {
+    norm_->verify_loaded_weights("norm.");
+
+    CHECK(is_qkv_weight_loaded_)
+        << "weight is not loaded for " << prefix + "weight";
+    CHECK(is_qkv_bias_loaded_)
+        << "weight is not loaded for " << prefix + "bias";
+    CHECK(is_proj_weight_loaded_)
+        << "weight is not loaded for " << prefix + "weight";
+    CHECK(is_proj_bias_loaded_)
+        << "weight is not loaded for " << prefix + "bias";
+  }
+
+ private:
+  int64_t dim_;
+  QwenImageRMS_norm norm_{nullptr};
+  torch::nn::Conv2d to_qkv_{nullptr};
+  torch::nn::Conv2d proj_{nullptr};
+  bool is_qkv_weight_loaded_{false};
+  bool is_qkv_bias_loaded_{false};
+  bool is_proj_weight_loaded_{false};
+  bool is_proj_bias_loaded_{false};
+};
+
+TORCH_MODULE(QwenImageAttentionBlock);
+
+class QwenImageMidBlockImpl : public torch::nn::Module {
+ public:
+  QwenImageMidBlockImpl(const ModelContext& context,
+                        int64_t dim,
+                        double dropout = 0.0,
+                        const std::string& non_linearity = "silu",
+                        int64_t num_layers = 1)
+      : dim_(dim) {
+    resnets_ = register_module("resnets", torch::nn::ModuleList());
+    attentions_ = register_module("attentions", torch::nn::ModuleList());
+
+    auto resnet_0 =
+        QwenImageResidualBlock(context, dim, dim, dropout, non_linearity);
+    resnets_->push_back(resnet_0);
+
+    for (int64_t i = 0; i < num_layers; i++) {
+      auto attention = QwenImageAttentionBlock(context, dim);
+      attentions_->push_back(attention);
+
+      auto resnet =
+          QwenImageResidualBlock(context, dim, dim, dropout, non_linearity);
+      resnets_->push_back(resnet);
+    }
+  }
+
+  torch::Tensor forward(
+      const torch::Tensor& x,
+      std::shared_ptr<std::vector<torch::Tensor>> feat_cache = nullptr,
+      std::shared_ptr<std::vector<int64_t>> feat_idx = nullptr) {
+    if (feat_idx == nullptr) {
+      feat_idx =
+          std::make_shared<std::vector<int64_t>>(std::vector<int64_t>{0});
+    }
+    auto result_x = x;
+
+    result_x = resnets_[0]->as<QwenImageResidualBlock>()->forward(
+        result_x, feat_cache, feat_idx);
+
+    for (size_t i = 0; i < attentions_->size(); i++) {
+      result_x =
+          attentions_[i]->as<QwenImageAttentionBlock>()->forward(result_x);
+      result_x = resnets_[i + 1]->as<QwenImageResidualBlock>()->forward(
+          result_x, feat_cache, feat_idx);
+    }
+
+    return result_x;
+  }
+
+  void load_state_dict(const StateDict& state_dict) {
+    for (size_t i = 0; i < resnets_->size(); i++) {
+      auto prefix = "resnets." + std::to_string(i) + ".";
+      resnets_[i]->as<QwenImageResidualBlock>()->load_state_dict(
+          state_dict.get_dict_with_prefix(prefix));
+    }
+
+    for (size_t i = 0; i < attentions_->size(); i++) {
+      auto prefix = "attentions." + std::to_string(i) + ".";
+      attentions_[i]->as<QwenImageAttentionBlock>()->load_state_dict(
+          state_dict.get_dict_with_prefix(prefix));
+    }
+  }
+
+  void verify_loaded_weights(const std::string& prefix) {
+    for (size_t i = 0; i < resnets_->size(); i++) {
+      auto prefix = "resnets." + std::to_string(i) + ".";
+      resnets_[i]->as<QwenImageResidualBlock>()->verify_loaded_weights(prefix);
+    }
+
+    for (size_t i = 0; i < attentions_->size(); i++) {
+      auto prefix = "attentions." + std::to_string(i) + ".";
+      attentions_[i]->as<QwenImageAttentionBlock>()->verify_loaded_weights(
+          prefix);
+    }
+  }
+
+ private:
+  int64_t dim_;
+  torch::nn::ModuleList resnets_;
+  torch::nn::ModuleList attentions_;
+};
+
+TORCH_MODULE(QwenImageMidBlock);
+
+class QwenImageEncoder3dImpl : public torch::nn::Module {
+ public:
+  QwenImageEncoder3dImpl(const ModelContext& context,
+                         int64_t dim = 128,
+                         int64_t z_dim = 4,
+                         std::vector<int64_t> dim_mult = {1, 2, 4, 4},
+                         int64_t num_res_blocks = 2,
+                         std::vector<double> attn_scales = {},
+                         std::vector<bool> temperal_downsample = {true,
+                                                                  true,
+                                                                  false},
+                         double dropout = 0.0,
+                         int64_t input_channels = 3,
+                         const std::string& non_linearity = "silu")
+      : dim_(dim),
+        z_dim_(z_dim),
+        dim_mult_(dim_mult),
+        num_res_blocks_(num_res_blocks),
+        attn_scales_(attn_scales),
+        temperal_downsample_(temperal_downsample) {
+    nonlinearity_ = register_module("silu", torch::nn::SiLU());
+
+    std::vector<int64_t> dims = {dim * 1};
+    for (auto u : dim_mult_) {
+      dims.push_back(dim * u);
+    }
+
+    double scale = 1.0;
+
+    conv_in_ = register_module(
+        "conv_in",
+        QwenImageCausalConv3d(context,
+                              input_channels,
+                              /*out_channels=*/dims[0],
+                              /*kernel_size=*/torch::IntArrayRef{3, 3, 3},
+                              /*stride=*/torch::IntArrayRef{1, 1, 1},
+                              /*padding=*/torch::IntArrayRef{1, 1, 1}));
+
+    down_blocks_ = register_module("down_blocks", torch::nn::ModuleList());
+
+    size_t counter = 0;
+    for (size_t i = 0; i < dims.size() - 1; i++) {
+      int64_t in_dim = dims[i];
+      int64_t out_dim = dims[i + 1];
+
+      for (int64_t j = 0; j < num_res_blocks_; j++) {
+        auto res_block = QwenImageResidualBlock(
+            context, in_dim, out_dim, dropout, non_linearity);
+        down_blocks_->push_back(res_block);
+        resnet_blocks_idx_.push_back(counter);
+        counter += 1;
+
+        if (std::find(attn_scales_.begin(), attn_scales_.end(), scale) !=
+            attn_scales_.end()) {
+          auto attn_block = QwenImageAttentionBlock(context, out_dim);
+          down_blocks_->push_back(attn_block);
+          attention_blocks_idx_.push_back(counter);
+          counter += 1;
+        }
+        in_dim = out_dim;
+      }
+
+      if (i != dim_mult_.size() - 1) {
+        std::string mode =
+            temperal_downsample_[i] ? "downsample3d" : "downsample2d";
+        auto downsample = QwenImageResample(context, out_dim, mode);
+        down_blocks_->push_back(downsample);
+        resample_blocks_idx_.push_back(counter);
+        counter += 1;
+        scale /= 2.0;
+      }
+    }
+
+    mid_block_ = register_module(
+        "mid_block",
+        QwenImageMidBlock(
+            context, dims.back(), dropout, non_linearity, /*num_layers=*/1));
+
+    norm_out_ = register_module("norm_out",
+                                QwenImageRMS_norm(context,
+                                                  dims.back(),
+                                                  /*channel_first=*/true,
+                                                  /*images=*/false,
+                                                  /*is_bias=*/false,
+                                                  /*fused=*/false));
+    conv_out_ = register_module(
+        "conv_out",
+        QwenImageCausalConv3d(context,
+                              /*in_channels=*/dims.back(),
+                              /*out_channels=*/z_dim,
+                              /*kernel_size=*/torch::IntArrayRef{3, 3, 3},
+                              /*stride=*/torch::IntArrayRef{1, 1, 1},
+                              /*padding=*/torch::IntArrayRef{1, 1, 1}));
+  }
+
+  torch::Tensor forward(
+      const torch::Tensor& x,
+      std::shared_ptr<std::vector<torch::Tensor>> feat_cache = nullptr,
+      std::shared_ptr<std::vector<int64_t>> feat_idx = nullptr) {
+    if (feat_idx == nullptr) {
+      feat_idx =
+          std::make_shared<std::vector<int64_t>>(std::vector<int64_t>{0});
+    }
+    torch::Tensor result_x;
+
+    if (feat_cache && feat_idx) {
+      auto idx = (*feat_idx)[0];
+      auto cache_x =
+          x.index({torch::indexing::Slice(),
+                   torch::indexing::Slice(),
+                   torch::indexing::Slice(-CACHE_T, torch::indexing::None)})
+              .clone();
+
+      if (cache_x.size(2) < 2 && feat_cache->at(idx).defined()) {
+        auto last_frame =
+            feat_cache->at(idx)
+                .index({torch::indexing::Slice(),
+                        torch::indexing::Slice(),
+                        torch::indexing::Slice(-1, torch::indexing::None)})
+                .unsqueeze(2)
+                .to(cache_x.device());
+        cache_x = torch::cat({last_frame, cache_x}, 2);
+      }
+      result_x = conv_in_->forward(x, feat_cache->at(idx));
+      feat_cache->at(idx) = cache_x;
+      (*feat_idx)[0]++;
+    } else {
+      result_x = conv_in_->forward(x);
+    }
+
+    int64_t counter = 0;
+    for (auto& layer : *down_blocks_) {
+      if (feat_cache) {
+        counter = counter + 1;
+        result_x =
+            std::dynamic_pointer_cast<QwenImageBaseModule>(layer)->forward(
+                result_x, feat_cache, feat_idx);
+      } else {
+        result_x =
+            std::dynamic_pointer_cast<QwenImageBaseModule>(layer)->forward(
+                result_x,
+                nullptr,
+                std::make_shared<std::vector<int64_t>>(
+                    std::vector<int64_t>{0}));
+      }
+    }
+
+    result_x = mid_block_->forward(result_x, feat_cache, feat_idx);
+
+    result_x = norm_out_->forward(result_x);
+    result_x = nonlinearity_->forward(result_x);
+
+    if (feat_cache && feat_idx) {
+      auto idx = (*feat_idx)[0];
+      auto cache_x =
+          result_x
+              .index({torch::indexing::Slice(),
+                      torch::indexing::Slice(),
+                      torch::indexing::Slice(-CACHE_T, torch::indexing::None)})
+              .clone();
+
+      if (cache_x.size(2) < 2 && idx < feat_cache->size() &&
+          feat_cache->at(idx).defined()) {
+        auto last_frame =
+            feat_cache->at(idx)
+                .index({torch::indexing::Slice(),
+                        torch::indexing::Slice(),
+                        torch::indexing::Slice(-1, torch::indexing::None)})
+                .unsqueeze(2)
+                .to(cache_x.device());
+        cache_x = torch::cat({last_frame, cache_x}, 2);
+      }
+
+      result_x = conv_out_->forward(result_x, feat_cache->at(idx));
+      feat_cache->at(idx) = cache_x;
+      (*feat_idx)[0]++;
+    } else {
+      result_x = conv_out_->forward(result_x);
+    }
+
+    return result_x;
+  }
+
+  void load_state_dict(const StateDict& state_dict) {
+    conv_in_->load_state_dict(state_dict.get_dict_with_prefix("conv_in."));
+
+    for (size_t resnet_idx : resnet_blocks_idx_) {
+      down_blocks_[resnet_idx]->as<QwenImageResidualBlock>()->load_state_dict(
+          state_dict.get_dict_with_prefix("down_blocks." +
+                                          std::to_string(resnet_idx) + "."));
+    }
+
+    for (size_t attention_idx : attention_blocks_idx_) {
+      down_blocks_[attention_idx]
+          ->as<QwenImageAttentionBlock>()
+          ->load_state_dict(state_dict.get_dict_with_prefix(
+              "down_blocks." + std::to_string(attention_idx) + "."));
+    }
+
+    for (size_t resample_idx : resample_blocks_idx_) {
+      down_blocks_[resample_idx]->as<QwenImageResample>()->load_state_dict(
+          state_dict.get_dict_with_prefix("down_blocks." +
+                                          std::to_string(resample_idx) + "."));
+    }
+
+    mid_block_->load_state_dict(state_dict.get_dict_with_prefix("mid_block."));
+    norm_out_->load_state_dict(state_dict.get_dict_with_prefix("norm_out."));
+    conv_out_->load_state_dict(state_dict.get_dict_with_prefix("conv_out."));
+  }
+
+  void verify_loaded_weights(const std::string& prefix) {
+    conv_in_->verify_loaded_weights("conv_in.");
+    for (size_t resnet_idx : resnet_blocks_idx_) {
+      down_blocks_[resnet_idx]
+          ->as<QwenImageResidualBlock>()
+          ->verify_loaded_weights(std::to_string(resnet_idx) + ".");
+    }
+
+    for (size_t attention_idx : attention_blocks_idx_) {
+      down_blocks_[attention_idx]
+          ->as<QwenImageAttentionBlock>()
+          ->verify_loaded_weights(std::to_string(attention_idx) + ".");
+    }
+
+    for (size_t resample_idx : resample_blocks_idx_) {
+      down_blocks_[resample_idx]
+          ->as<QwenImageResample>()
+          ->verify_loaded_weights(std::to_string(resample_idx) + ".");
+    }
+    mid_block_->verify_loaded_weights("mid_block.");
+    norm_out_->verify_loaded_weights("norm_out.");
+    conv_out_->verify_loaded_weights("conv_out.");
+  }
+
+ private:
+  int64_t dim_, z_dim_;
+  std::vector<int64_t> dim_mult_;
+  std::vector<size_t> resnet_blocks_idx_;
+  std::vector<size_t> attention_blocks_idx_;
+  std::vector<size_t> resample_blocks_idx_;
+  int64_t num_res_blocks_;
+  std::vector<double> attn_scales_;
+  std::vector<bool> temperal_downsample_;
+
+  torch::nn::SiLU nonlinearity_{nullptr};
+  QwenImageCausalConv3d conv_in_{nullptr};
+  torch::nn::ModuleList down_blocks_{nullptr};
+  QwenImageMidBlock mid_block_{nullptr};
+  QwenImageRMS_norm norm_out_{nullptr};
+  QwenImageCausalConv3d conv_out_{nullptr};
+};
+
+TORCH_MODULE(QwenImageEncoder3d);
+
+class QwenImageUpBlockImpl : public torch::nn::Module {
+ public:
+  QwenImageUpBlockImpl(const ModelContext& context,
+                       int64_t in_dim,
+                       int64_t out_dim,
+                       int64_t num_res_blocks,
+                       double dropout = 0.0,
+                       const std::string& upsample_mode = "",
+                       const std::string& non_linearity = "silu")
+      : in_dim_(in_dim), out_dim_(out_dim) {
+    resnets_ = register_module("resnets", torch::nn::ModuleList());
+    int64_t current_dim = in_dim;
+
+    for (int64_t i = 0; i < num_res_blocks + 1; i++) {
+      auto resnet = QwenImageResidualBlock(
+          context, current_dim, out_dim, dropout, non_linearity);
+      resnets_->push_back(resnet);
+      current_dim = out_dim;
+    }
+
+    if (!upsample_mode.empty()) {
+      upsamplers_ = register_module("upsamplers", torch::nn::ModuleList());
+      auto upsample = QwenImageResample(context, out_dim, upsample_mode);
+      upsamplers_->push_back(upsample);
+    }
+  }
+
+  torch::Tensor forward(
+      const torch::Tensor& x,
+      std::shared_ptr<std::vector<torch::Tensor>> feat_cache = nullptr,
+      std::shared_ptr<std::vector<int64_t>> feat_idx = nullptr) {
+    if (feat_idx == nullptr) {
+      feat_idx =
+          std::make_shared<std::vector<int64_t>>(std::vector<int64_t>{0});
+    }
+
+    auto result_x = x;
+
+    for (auto& resnet : *resnets_) {
+      if (feat_cache && feat_idx) {
+        result_x =
+            std::dynamic_pointer_cast<QwenImageBaseModule>(resnet)->forward(
+                result_x, feat_cache, feat_idx);
+      } else {
+        result_x =
+            std::dynamic_pointer_cast<QwenImageBaseModule>(resnet)->forward(
+                result_x,
+                nullptr,
+                std::make_shared<std::vector<int64_t>>(
+                    std::vector<int64_t>{0}));
+      }
+    }
+
+    if (upsamplers_) {
+      if (feat_cache && feat_idx) {
+        result_x =
+            std::dynamic_pointer_cast<QwenImageBaseModule>(upsamplers_[0])
+                ->forward(result_x, feat_cache, feat_idx);
+      } else {
+        result_x =
+            std::dynamic_pointer_cast<QwenImageBaseModule>(upsamplers_[0])
+                ->forward(result_x,
+                          nullptr,
+                          std::make_shared<std::vector<int64_t>>(
+                              std::vector<int64_t>{0}));
+      }
+    }
+
+    return result_x;
+  }
+
+  void load_state_dict(const StateDict& state_dict) {
+    for (size_t i = 0; i < resnets_->size(); i++) {
+      auto prefix = "resnets." + std::to_string(i) + ".";
+      resnets_[i]->as<QwenImageResidualBlock>()->load_state_dict(
+          state_dict.get_dict_with_prefix(prefix));
+    }
+
+    if (upsamplers_) {
+      upsamplers_[0]->as<QwenImageResample>()->load_state_dict(
+          state_dict.get_dict_with_prefix("upsamplers.0."));
+    }
+  }
+
+  void verify_loaded_weights(const std::string& prefix) {
+    for (size_t i = 0; i < resnets_->size(); i++) {
+      auto prefix = "resnets." + std::to_string(i) + ".";
+      resnets_[i]->as<QwenImageResidualBlock>()->verify_loaded_weights(prefix);
+    }
+
+    if (upsamplers_) {
+      upsamplers_[0]->as<QwenImageResample>()->verify_loaded_weights(
+          "upsamplers.0.");
+    }
+  }
+
+ private:
+  int64_t in_dim_, out_dim_;
+  torch::nn::ModuleList resnets_{nullptr};
+  torch::nn::ModuleList upsamplers_{nullptr};
+};
+
+TORCH_MODULE(QwenImageUpBlock);
+
+class QwenImageDecoder3dImpl : public torch::nn::Module {
+ public:
+  QwenImageDecoder3dImpl(const ModelContext& context,
+                         int64_t dim = 128,
+                         int64_t z_dim = 4,
+                         std::vector<int64_t> dim_mult = {1, 2, 4, 4},
+                         int64_t num_res_blocks = 2,
+                         std::vector<double> attn_scales = {},
+                         std::vector<bool> temperal_upsample = {false,
+                                                                true,
+                                                                true},
+                         double dropout = 0.0,
+                         int64_t input_channels = 3,
+                         const std::string& non_linearity = "silu")
+      : dim_(dim),
+        z_dim_(z_dim),
+        dim_mult_(dim_mult),
+        num_res_blocks_(num_res_blocks),
+        attn_scales_(attn_scales),
+        temperal_upsample_(temperal_upsample) {
+    nonlinearity_ = register_module("silu", torch::nn::SiLU());
+
+    std::vector<int64_t> dims = {dim * dim_mult.back()};
+    for (int64_t i = dim_mult.size() - 1; i >= 0; i--) {
+      dims.push_back(dim * dim_mult.at(i));
+    }
+
+    double scale = 1.0 / std::pow(2, dim_mult.size() - 2);
+
+    conv_in_ =
+        register_module("conv_in",
+                        QwenImageCausalConv3d(context,
+                                              z_dim,
+                                              dims[0],
+                                              torch::IntArrayRef{3, 3, 3},
+                                              torch::IntArrayRef{1, 1, 1},
+                                              torch::IntArrayRef{1, 1, 1}));
+
+    mid_block_ = register_module(
+        "mid_block",
+        QwenImageMidBlock(
+            context, dims[0], dropout, non_linearity, /*num_layers=*/1));
+
+    up_blocks_ = register_module("up_blocks", torch::nn::ModuleList());
+    for (size_t i = 0; i < dims.size() - 1; i++) {
+      int64_t in_dim = dims[i];
+      int64_t out_dim = dims[i + 1];
+
+      if (i > 0) {
+        in_dim = in_dim / 2;
+      }
+
+      std::string upsample_mode;
+      if (i != dim_mult.size() - 1) {
+        upsample_mode = temperal_upsample[i] ? "upsample3d" : "upsample2d";
+      }
+
+      auto up_block = QwenImageUpBlock(context,
+                                       in_dim,
+                                       out_dim,
+                                       num_res_blocks,
+                                       dropout,
+                                       upsample_mode,
+                                       non_linearity);
+      up_blocks_->push_back(up_block);
+
+      if (!upsample_mode.empty()) {
+        scale *= 2.0;
+      }
+    }
+
+    norm_out_ = register_module(
+        "norm_out",
+        QwenImageRMS_norm(context, dims.back(), true, false, false, false));
+    conv_out_ = register_module(
+        "conv_out",
+        QwenImageCausalConv3d(context,
+                              /*in_channels=*/dims.back(),
+                              /*out_channels=*/input_channels,
+                              /*kernel_size=*/torch::IntArrayRef{3, 3, 3},
+                              /*stride=*/torch::IntArrayRef{1, 1, 1},
+                              /*padding=*/torch::IntArrayRef{1, 1, 1}));
+  }
+
+  torch::Tensor forward(
+      const torch::Tensor& x,
+      std::shared_ptr<std::vector<torch::Tensor>> feat_cache = nullptr,
+      std::shared_ptr<std::vector<int64_t>> feat_idx = nullptr) {
+    if (feat_idx == nullptr) {
+      feat_idx =
+          std::make_shared<std::vector<int64_t>>(std::vector<int64_t>{0});
+    }
+    auto result_x = x;
+
+    if (feat_cache) {
+      auto idx = (*feat_idx)[0];
+      auto cache_x =
+          result_x
+              .index({torch::indexing::Slice(),
+                      torch::indexing::Slice(),
+                      torch::indexing::Slice(-CACHE_T, torch::indexing::None)})
+              .clone();
+
+      if (cache_x.size(2) < 2 && feat_cache->at(idx).defined()) {
+        auto last_frame =
+            feat_cache->at(idx)
+                .index({torch::indexing::Slice(),
+                        torch::indexing::Slice(),
+                        torch::indexing::Slice(-1, torch::indexing::None)})
+                .unsqueeze(2)
+                .to(cache_x.device());
+        cache_x = torch::cat({last_frame, cache_x}, 2);
+      }
+
+      result_x = conv_in_->forward(result_x, feat_cache->at(idx));
+      feat_cache->at(idx) = cache_x;
+      (*feat_idx)[0]++;
+    } else {
+      result_x = conv_in_->forward(result_x);
+    }
+
+    result_x = mid_block_->forward(result_x, feat_cache, feat_idx);
+
+    for (auto& up_block : *up_blocks_) {
+      result_x = up_block->as<QwenImageUpBlock>()->forward(
+          result_x, feat_cache, feat_idx);
+    }
+
+    result_x = norm_out_->forward(result_x);
+    result_x = nonlinearity_->forward(result_x);
+
+    if (feat_cache) {
+      auto idx = (*feat_idx)[0];
+      auto cache_x =
+          result_x
+              .index({torch::indexing::Slice(),
+                      torch::indexing::Slice(),
+                      torch::indexing::Slice(-CACHE_T, torch::indexing::None)})
+              .clone();
+
+      if (cache_x.size(2) < 2 && idx < feat_cache->size() &&
+          feat_cache->at(idx).defined()) {
+        auto last_frame =
+            feat_cache->at(idx)
+                .index({torch::indexing::Slice(),
+                        torch::indexing::Slice(),
+                        torch::indexing::Slice(-1, torch::indexing::None)})
+                .unsqueeze(2)
+                .to(cache_x.device());
+        cache_x = torch::cat({last_frame, cache_x}, 2);
+      }
+
+      result_x = conv_out_->forward(result_x, feat_cache->at(idx));
+      feat_cache->at(idx) = cache_x;
+      (*feat_idx)[0]++;
+    } else {
+      result_x = conv_out_->forward(result_x);
+    }
+    return result_x;
+  }
+
+  void load_state_dict(const StateDict& state_dict) {
+    conv_in_->load_state_dict(state_dict.get_dict_with_prefix("conv_in."));
+    mid_block_->load_state_dict(state_dict.get_dict_with_prefix("mid_block."));
+
+    for (size_t i = 0; i < up_blocks_->size(); i++) {
+      auto prefix = "up_blocks." + std::to_string(i) + ".";
+      up_blocks_[i]->as<QwenImageUpBlock>()->load_state_dict(
+          state_dict.get_dict_with_prefix(prefix));
+    }
+
+    norm_out_->load_state_dict(state_dict.get_dict_with_prefix("norm_out."));
+    conv_out_->load_state_dict(state_dict.get_dict_with_prefix("conv_out."));
+  }
+
+  void verify_loaded_weights(const std::string& prefix) {
+    conv_in_->verify_loaded_weights("conv_in.");
+
+    mid_block_->verify_loaded_weights("mid_block.");
+    for (size_t i = 0; i < up_blocks_->size(); i++) {
+      auto prefix = "up_blocks." + std::to_string(i) + ".";
+      up_blocks_[i]->as<QwenImageUpBlock>()->verify_loaded_weights(prefix);
+    }
+
+    norm_out_->verify_loaded_weights("norm_out.");
+    conv_out_->verify_loaded_weights("conv_out.");
+  }
+
+  std::vector<std::shared_ptr<Module>> get_modules() const {
+    std::vector<std::shared_ptr<Module>> module = modules();
+    return module;
+  }
+
+ private:
+  int64_t dim_, z_dim_;
+  std::vector<int64_t> dim_mult_;
+  int64_t num_res_blocks_;
+  std::vector<double> attn_scales_;
+  std::vector<bool> temperal_upsample_;
+
+  torch::nn::SiLU nonlinearity_{nullptr};
+  QwenImageCausalConv3d conv_in_{nullptr};
+  QwenImageMidBlock mid_block_{nullptr};
+  torch::nn::ModuleList up_blocks_{nullptr};
+  QwenImageRMS_norm norm_out_{nullptr};
+  QwenImageCausalConv3d conv_out_{nullptr};
+};
+
+TORCH_MODULE(QwenImageDecoder3d);
+
+class DiagonalGaussianDistribution {
+ public:
+  DiagonalGaussianDistribution(torch::Tensor parameters,
+                               bool deterministic = false)
+      : parameters_(std::move(parameters)), deterministic_(deterministic) {
+    auto chunks = parameters_.chunk(2, 1);
+    mean_ = chunks[0];
+    logvar_ = chunks[1];
+
+    logvar_ = torch::clamp(logvar_, -30.0f, 20.0f);
+
+    std_ = torch::exp(0.5f * logvar_);
+    var_ = torch::exp(logvar_);
+
+    if (deterministic_) {
+      std_.fill_(0.0f);
+      var_.fill_(0.0f);
+    }
+  }
+
+  torch::Tensor sample(int64_t seed) const {
+    torch::TensorOptions options = mean_.options();
+    std::vector<int64_t> shape(mean_.sizes().begin(), mean_.sizes().end());
+    return mean_ + std_ * xllm::dit::randn_tensor(shape, seed, options);
+  }
+
+  torch::Tensor kl(const std::optional<DiagonalGaussianDistribution>& other =
+                       std::nullopt) const {
+    if (deterministic_) {
+      return torch::tensor(0.0f, mean_.options());
+    }
+
+    if (!other.has_value()) {
+      return 0.5f * torch::sum(torch::pow(mean_, 2) + var_ - 1.0f - logvar_,
+                               {1, 2, 3});
+    } else {
+      const auto& other_dist = other.value();
+      return 0.5f * torch::sum(torch::pow(mean_ - other_dist.mean_, 2) /
+                                       other_dist.var_ +
+                                   var_ / other_dist.var_ - 1.0f - logvar_ +
+                                   other_dist.logvar_,
+                               {1, 2, 3});
+    }
+  }
+
+  torch::Tensor nll(const torch::Tensor& sample,
+                    const std::vector<int64_t>& dims = {1, 2, 3}) const {
+    if (deterministic_) {
+      return torch::tensor(0.0f, mean_.options());
+    }
+    const float logtwopi = std::log(2.0f * M_PI);
+    return 0.5f *
+           torch::sum(logtwopi + logvar_ + torch::pow(sample - mean_, 2) / var_,
+                      dims);
+  }
+
+  torch::Tensor mode() const { return mean_; }
+
+  const torch::Tensor& mean() const { return mean_; }
+  const torch::Tensor& std() const { return std_; }
+  const torch::Tensor& var() const { return var_; }
+  const torch::Tensor& logvar() const { return logvar_; }
+
+ private:
+  torch::Tensor parameters_;
+  torch::Tensor mean_;
+  torch::Tensor logvar_;
+  torch::Tensor std_;
+  torch::Tensor var_;
+  bool deterministic_;
+};
+
+struct AutoencoderKLOutput {
+  DiagonalGaussianDistribution latent_dist;
+  AutoencoderKLOutput(DiagonalGaussianDistribution dist)
+      : latent_dist(std::move(dist)) {}
+};
+
+struct DecoderOutput {
+  torch::Tensor sample;
+  DecoderOutput(torch::Tensor sample) : sample(std::move(sample)) {}
+};
+
+class AutoencoderKLQwenImageImpl : public torch::nn::Module {
+ public:
+  AutoencoderKLQwenImageImpl(const ModelContext& context)
+      : args_(context.get_model_args()),
+        z_dim_(context.get_model_args().z_dim()),
+        temperal_downsample_(context.get_model_args().temperal_downsample()),
+        base_dim_(context.get_model_args().base_dim()),
+        dim_mult_(context.get_model_args().dim_mult()),
+        num_res_blocks_(context.get_model_args().num_res_blocks()),
+        attn_scales_(context.get_model_args().attn_scales()),
+        dropout_(context.get_model_args().dropout()) {
+    temperal_upsample_ = std::vector<bool>(temperal_downsample_.rbegin(),
+                                           temperal_downsample_.rend());
+
+    int64_t input_channels = context.get_model_args().in_channels();
+    encoder_ = register_module("encoder",
+                               QwenImageEncoder3d(context,
+                                                  base_dim_,
+                                                  z_dim_ * 2,
+                                                  dim_mult_,
+                                                  num_res_blocks_,
+                                                  attn_scales_,
+                                                  temperal_downsample_,
+                                                  dropout_,
+                                                  input_channels));
+
+    quant_conv_ =
+        register_module("quant_conv",
+                        QwenImageCausalConv3d(context,
+                                              z_dim_ * 2,
+                                              z_dim_ * 2,
+                                              torch::IntArrayRef{1, 1, 1},
+                                              torch::IntArrayRef{1, 1, 1},
+                                              torch::IntArrayRef{0, 0, 0}));
+
+    post_quant_conv_ =
+        register_module("post_quant_conv",
+                        QwenImageCausalConv3d(context,
+                                              z_dim_,
+                                              z_dim_,
+                                              torch::IntArrayRef{1, 1, 1},
+                                              torch::IntArrayRef{1, 1, 1},
+                                              torch::IntArrayRef{0, 0, 0}));
+
+    decoder_ = register_module("decoder",
+                               QwenImageDecoder3d(context,
+                                                  base_dim_,
+                                                  z_dim_,
+                                                  dim_mult_,
+                                                  num_res_blocks_,
+                                                  attn_scales_,
+                                                  temperal_upsample_,
+                                                  dropout_,
+                                                  input_channels));
+
+    spatial_compression_ratio_ =
+        static_cast<int64_t>(std::pow(2, temperal_downsample_.size()));
+
+    use_slicing_ = false;
+    use_tiling_ = false;
+    tile_sample_min_height_ = 256;
+    tile_sample_min_width_ = 256;
+    tile_sample_stride_height_ = 192;
+    tile_sample_stride_width_ = 192;
+
+    cached_conv_counts_ = {{"decoder", count_conv3d_modules(*decoder_)},
+                           {"encoder", count_conv3d_modules(*encoder_)}};
+  }
+
+  void enable_tiling(int64_t tile_sample_min_height = -1,
+                     int64_t tile_sample_min_width = -1,
+                     int64_t tile_sample_stride_height = -1,
+                     int64_t tile_sample_stride_width = -1) {
+    use_tiling_ = true;
+    if (tile_sample_min_height > 0)
+      tile_sample_min_height_ = tile_sample_min_height;
+    if (tile_sample_min_width > 0)
+      tile_sample_min_width_ = tile_sample_min_width;
+    if (tile_sample_stride_height > 0)
+      tile_sample_stride_height_ = tile_sample_stride_height;
+    if (tile_sample_stride_width > 0)
+      tile_sample_stride_width_ = tile_sample_stride_width;
+  }
+
+  void clear_cache() {
+    conv_num_ = count_conv3d_modules(*decoder_);
+    conv_idx_ = std::make_shared<std::vector<int64_t>>(std::vector<int64_t>{0});
+    feat_map_ = std::make_shared<std::vector<torch::Tensor>>(
+        std::vector<torch::Tensor>(conv_num_));
+
+    enc_conv_num_ = count_conv3d_modules(*encoder_);
+    enc_conv_idx_ =
+        std::make_shared<std::vector<int64_t>>(std::vector<int64_t>{0});
+    enc_feat_map_ = std::make_shared<std::vector<torch::Tensor>>(
+        std::vector<torch::Tensor>(enc_conv_num_));
+  }
+
+  torch::Tensor _encode(const torch::Tensor& x) {
+    auto sizes = x.sizes();
+    auto b = sizes[0], c = sizes[1], num_frame = sizes[2], height = sizes[3],
+         width = sizes[4];
+
+    if (use_tiling_ &&
+        (width > tile_sample_min_width_ || height > tile_sample_min_height_)) {
+      return tiled_encode(x);
+    }
+
+    clear_cache();
+    auto iter = 1 + (num_frame - 1) / 4;
+    torch::Tensor out;
+
+    for (int64_t i = 0; i < iter; i++) {
+      enc_conv_idx_->at(0) = 0;
+      torch::Tensor tile;
+
+      if (i == 0) {
+        tile = x.index({torch::indexing::Slice(),
+                        torch::indexing::Slice(),
+                        torch::indexing::Slice(0, 1),
+                        torch::indexing::Slice(),
+                        torch::indexing::Slice()});
+      } else {
+        tile = x.index({torch::indexing::Slice(),
+                        torch::indexing::Slice(),
+                        torch::indexing::Slice(1 + 4 * (i - 1), 1 + 4 * i),
+                        torch::indexing::Slice(),
+                        torch::indexing::Slice()});
+      }
+
+      auto encoded_tile = encoder_->forward(tile, enc_feat_map_, enc_conv_idx_);
+
+      if (i == 0) {
+        out = encoded_tile;
+      } else {
+        out = torch::cat({out, encoded_tile}, 2);
+      }
+    }
+
+    auto enc = quant_conv_->forward(out);
+    clear_cache();
+    return enc;
+  }
+
+  AutoencoderKLOutput encode(const torch::Tensor& x, bool return_dict = true) {
+    torch::Tensor h;
+
+    if (use_slicing_ && x.size(0) > 1) {
+      std::vector<torch::Tensor> encoded_slices;
+      auto slices = x.split(1);
+      for (auto& slice : slices) {
+        encoded_slices.push_back(_encode(slice));
+      }
+      h = torch::cat(encoded_slices);
+    } else {
+      h = _encode(x);
+    }
+
+    auto posterior = DiagonalGaussianDistribution(h);
+
+    if (!return_dict) {
+      return {posterior};
+    }
+
+    AutoencoderKLOutput output(posterior);
+    return output;
+  }
+
+  DecoderOutput _decode(const torch::Tensor& z, bool return_dict = true) {
+    auto sizes = z.sizes();
+    auto b = sizes[0], c = sizes[1], num_frame = sizes[2], height = sizes[3],
+         width = sizes[4];
+
+    auto tile_latent_min_height =
+        tile_sample_min_height_ / spatial_compression_ratio_;
+    auto tile_latent_min_width =
+        tile_sample_min_width_ / spatial_compression_ratio_;
+
+    if (use_tiling_ &&
+        (width > tile_latent_min_width || height > tile_latent_min_height)) {
+      return tiled_decode(z, return_dict);
+    }
+
+    clear_cache();
+    auto x = post_quant_conv_->forward(z);
+    torch::Tensor out;
+
+    for (int64_t i = 0; i < num_frame; i++) {
+      conv_idx_->at(0) = 0;
+      auto frame = x.index({torch::indexing::Slice(),
+                            torch::indexing::Slice(),
+                            torch::indexing::Slice(i, i + 1),
+                            torch::indexing::Slice(),
+                            torch::indexing::Slice()});
+
+      auto decoded_frame = decoder_->forward(frame, feat_map_, conv_idx_);
+
+      if (i == 0) {
+        out = decoded_frame;
+      } else {
+        out = torch::cat({out, decoded_frame}, 2);
+      }
+    }
+
+    out = torch::clamp(out, -1.0, 1.0);
+    clear_cache();
+
+    if (!return_dict) {
+      return {out};
+    }
+    DecoderOutput output(out);
+
+    return output;
+  }
+
+  DecoderOutput decode(const torch::Tensor& z, bool return_dict = true) {
+    torch::Tensor decoded;
+
+    if (use_slicing_ && z.size(0) > 1) {
+      std::vector<torch::Tensor> decoded_slices;
+      auto slices = z.split(1);
+      for (auto& slice : slices) {
+        auto output = _decode(slice, true);
+        decoded_slices.push_back(output.sample);
+      }
+      decoded = torch::cat(decoded_slices);
+    } else {
+      auto output = _decode(z, true);
+      decoded = output.sample;
+    }
+
+    if (!return_dict) {
+      return {decoded};
+    }
+    DecoderOutput output(decoded);
+
+    return output;
+  }
+
+  torch::Tensor blend_v(const torch::Tensor& a,
+                        const torch::Tensor& b,
+                        int64_t blend_extent) {
+    auto result_b = b.clone();
+    blend_extent = std::min({a.size(3), b.size(3), blend_extent});
+
+    for (int64_t y = 0; y < blend_extent; y++) {
+      auto weight_a = 1.0 - static_cast<double>(y) / blend_extent;
+      auto weight_b = static_cast<double>(y) / blend_extent;
+
+      auto a_slice = a.index(
+          {torch::indexing::Slice(),
+           torch::indexing::Slice(),
+           torch::indexing::Slice(),
+           torch::indexing::Slice(-blend_extent + y, -blend_extent + y + 1),
+           torch::indexing::Slice()});
+
+      auto b_slice = result_b.index({torch::indexing::Slice(),
+                                     torch::indexing::Slice(),
+                                     torch::indexing::Slice(),
+                                     torch::indexing::Slice(y, y + 1),
+                                     torch::indexing::Slice()});
+
+      auto blended = a_slice * weight_a + b_slice * weight_b;
+      result_b.index_put_({torch::indexing::Slice(),
+                           torch::indexing::Slice(),
+                           torch::indexing::Slice(),
+                           torch::indexing::Slice(y, y + 1),
+                           torch::indexing::Slice()},
+                          blended);
+    }
+
+    return result_b;
+  }
+
+  torch::Tensor blend_h(const torch::Tensor& a,
+                        const torch::Tensor& b,
+                        int64_t blend_extent) {
+    auto result_b = b.clone();
+    blend_extent = std::min({a.size(4), b.size(4), blend_extent});
+
+    for (int64_t x = 0; x < blend_extent; x++) {
+      auto weight_a = 1.0 - static_cast<double>(x) / blend_extent;
+      auto weight_b = static_cast<double>(x) / blend_extent;
+
+      auto a_slice = a.index(
+          {torch::indexing::Slice(),
+           torch::indexing::Slice(),
+           torch::indexing::Slice(),
+           torch::indexing::Slice(),
+           torch::indexing::Slice(-blend_extent + x, -blend_extent + x + 1)});
+
+      auto b_slice = result_b.index({torch::indexing::Slice(),
+                                     torch::indexing::Slice(),
+                                     torch::indexing::Slice(),
+                                     torch::indexing::Slice(),
+                                     torch::indexing::Slice(x, x + 1)});
+
+      auto blended = a_slice * weight_a + b_slice * weight_b;
+      result_b.index_put_({torch::indexing::Slice(),
+                           torch::indexing::Slice(),
+                           torch::indexing::Slice(),
+                           torch::indexing::Slice(),
+                           torch::indexing::Slice(x, x + 1)},
+                          blended);
+    }
+
+    return result_b;
+  }
+
+  torch::Tensor tiled_encode(const torch::Tensor& x) {
+    auto sizes = x.sizes();
+    auto b = sizes[0], c = sizes[1], num_frames = sizes[2], height = sizes[3],
+         width = sizes[4];
+
+    auto latent_height = height / spatial_compression_ratio_;
+    auto latent_width = width / spatial_compression_ratio_;
+
+    auto tile_latent_min_height =
+        tile_sample_min_height_ / spatial_compression_ratio_;
+    auto tile_latent_min_width =
+        tile_sample_min_width_ / spatial_compression_ratio_;
+    auto tile_latent_stride_height =
+        tile_sample_stride_height_ / spatial_compression_ratio_;
+    auto tile_latent_stride_width =
+        tile_sample_stride_width_ / spatial_compression_ratio_;
+
+    auto blend_height = tile_latent_min_height - tile_latent_stride_height;
+    auto blend_width = tile_latent_min_width - tile_latent_stride_width;
+
+    std::vector<std::vector<torch::Tensor>> rows;
+
+    for (int64_t i = 0; i < height; i += tile_sample_stride_height_) {
+      std::vector<torch::Tensor> row;
+
+      for (int64_t j = 0; j < width; j += tile_sample_stride_width_) {
+        clear_cache();
+        std::vector<torch::Tensor> time_frames;
+        auto frame_range = 1 + (num_frames - 1) / 4;
+
+        for (int64_t k = 0; k < frame_range; k++) {
+          enc_conv_idx_->at(0) = 0;
+          torch::Tensor tile;
+
+          if (k == 0) {
+            tile = x.index(
+                {torch::indexing::Slice(),
+                 torch::indexing::Slice(),
+                 torch::indexing::Slice(0, 1),
+                 torch::indexing::Slice(i, i + tile_sample_min_height_),
+                 torch::indexing::Slice(j, j + tile_sample_min_width_)});
+          } else {
+            tile = x.index(
+                {torch::indexing::Slice(),
+                 torch::indexing::Slice(),
+                 torch::indexing::Slice(1 + 4 * (k - 1), 1 + 4 * k),
+                 torch::indexing::Slice(i, i + tile_sample_min_height_),
+                 torch::indexing::Slice(j, j + tile_sample_min_width_)});
+          }
+
+          auto encoded_tile =
+              encoder_->forward(tile, enc_feat_map_, enc_conv_idx_);
+          auto quantized_tile = quant_conv_->forward(encoded_tile);
+          time_frames.push_back(quantized_tile);
+        }
+
+        row.push_back(torch::cat(time_frames, 2));
+      }
+      rows.push_back(row);
+    }
+    clear_cache();
+
+    std::vector<torch::Tensor> result_rows;
+
+    for (int64_t i = 0; i < static_cast<int64_t>(rows.size()); i++) {
+      std::vector<torch::Tensor> result_row;
+
+      for (int64_t j = 0; j < static_cast<int64_t>(rows[i].size()); j++) {
+        auto tile = rows[i][j];
+
+        if (i > 0) {
+          tile = blend_v(rows[i - 1][j], tile, blend_height);
+        }
+        if (j > 0) {
+          tile = blend_h(rows[i][j - 1], tile, blend_width);
+        }
+
+        result_row.push_back(
+            tile.index({torch::indexing::Slice(),
+                        torch::indexing::Slice(),
+                        torch::indexing::Slice(),
+                        torch::indexing::Slice(0, tile_latent_stride_height),
+                        torch::indexing::Slice(0, tile_latent_stride_width)}));
+      }
+
+      result_rows.push_back(torch::cat(result_row, -1));
+    }
+
+    auto enc = torch::cat(result_rows, 3)
+                   .index({torch::indexing::Slice(),
+                           torch::indexing::Slice(),
+                           torch::indexing::Slice(),
+                           torch::indexing::Slice(0, latent_height),
+                           torch::indexing::Slice(0, latent_width)});
+
+    return enc;
+  }
+
+  DecoderOutput tiled_decode(const torch::Tensor& z, bool return_dict = true) {
+    auto sizes = z.sizes();
+    auto b = sizes[0], c = sizes[1], num_frames = sizes[2], height = sizes[3],
+         width = sizes[4];
+
+    auto sample_height = height * spatial_compression_ratio_;
+    auto sample_width = width * spatial_compression_ratio_;
+
+    auto tile_latent_min_height =
+        tile_sample_min_height_ / spatial_compression_ratio_;
+    auto tile_latent_min_width =
+        tile_sample_min_width_ / spatial_compression_ratio_;
+    auto tile_latent_stride_height =
+        tile_sample_stride_height_ / spatial_compression_ratio_;
+    auto tile_latent_stride_width =
+        tile_sample_stride_width_ / spatial_compression_ratio_;
+
+    auto blend_height = tile_sample_min_height_ - tile_sample_stride_height_;
+    auto blend_width = tile_sample_min_width_ - tile_sample_stride_width_;
+
+    std::vector<std::vector<torch::Tensor>> rows;
+
+    for (int64_t i = 0; i < height; i += tile_latent_stride_height) {
+      std::vector<torch::Tensor> row;
+
+      for (int64_t j = 0; j < width; j += tile_latent_stride_width) {
+        clear_cache();
+        std::vector<torch::Tensor> time_frames;
+
+        for (int64_t k = 0; k < num_frames; k++) {
+          conv_idx_->at(0) = 0;
+          auto tile =
+              z.index({torch::indexing::Slice(),
+                       torch::indexing::Slice(),
+                       torch::indexing::Slice(k, k + 1),
+                       torch::indexing::Slice(i, i + tile_latent_min_height),
+                       torch::indexing::Slice(j, j + tile_latent_min_width)});
+
+          auto post_quant_tile = post_quant_conv_->forward(tile);
+          auto decoded_tile =
+              decoder_->forward(post_quant_tile, feat_map_, conv_idx_);
+          time_frames.push_back(decoded_tile);
+        }
+
+        row.push_back(torch::cat(time_frames, 2));
+      }
+      rows.push_back(row);
+    }
+    clear_cache();
+
+    std::vector<torch::Tensor> result_rows;
+
+    for (int64_t i = 0; i < static_cast<int64_t>(rows.size()); i++) {
+      std::vector<torch::Tensor> result_row;
+
+      for (int64_t j = 0; j < static_cast<int64_t>(rows[i].size()); j++) {
+        auto tile = rows[i][j];
+
+        if (i > 0) {
+          tile = blend_v(rows[i - 1][j], tile, blend_height);
+        }
+        if (j > 0) {
+          tile = blend_h(rows[i][j - 1], tile, blend_width);
+        }
+
+        result_row.push_back(
+            tile.index({torch::indexing::Slice(),
+                        torch::indexing::Slice(),
+                        torch::indexing::Slice(),
+                        torch::indexing::Slice(0, tile_sample_stride_height_),
+                        torch::indexing::Slice(0, tile_sample_stride_width_)}));
+      }
+
+      result_rows.push_back(torch::cat(result_row, -1));
+    }
+
+    auto dec = torch::cat(result_rows, 3)
+                   .index({torch::indexing::Slice(),
+                           torch::indexing::Slice(),
+                           torch::indexing::Slice(),
+                           torch::indexing::Slice(0, sample_height),
+                           torch::indexing::Slice(0, sample_width)});
+
+    if (!return_dict) {
+      return {dec};
+    }
+    DecoderOutput output(dec);
+    return output;
+  }
+
+  DecoderOutput forward(const torch::Tensor& sample,
+                        bool sample_posterior = false,
+                        bool return_dict = true,
+                        int64_t seed = 42) {
+    auto x = sample;
+
+    auto encode_output = encode(x, true);
+    auto posterior = encode_output.latent_dist;
+
+    torch::Tensor z;
+    if (sample_posterior) {
+      z = posterior.sample(seed);
+    } else {
+      z = posterior.mode();
+    }
+
+    auto dec = decode(z, return_dict);
+    return dec;
+  }
+
+  void load_model(std::unique_ptr<DiTFolderLoader> loader) {
+    for (const auto& state_dict : loader->get_state_dicts()) {
+      encoder_->load_state_dict(state_dict->get_dict_with_prefix("encoder."));
+      decoder_->load_state_dict(state_dict->get_dict_with_prefix("decoder."));
+      quant_conv_->load_state_dict(
+          state_dict->get_dict_with_prefix("quant_conv."));
+      post_quant_conv_->load_state_dict(
+          state_dict->get_dict_with_prefix("post_quant_conv."));
+    }
+    verify_loaded_weights("");
+  }
+
+  void verify_loaded_weights(const std::string& prefix) {
+    encoder_->verify_loaded_weights("encoder.");
+    decoder_->verify_loaded_weights("decoder.");
+    quant_conv_->verify_loaded_weights("quant_conv.");
+    post_quant_conv_->verify_loaded_weights("post_quant_conv.");
+  }
+
+ private:
+  template <typename ModuleType>
+  int64_t count_conv3d_modules(const ModuleType& module) {
+    int64_t count = 0;
+    for (const auto& m : module.named_modules()) {
+      if (auto conv =
+              dynamic_cast<QwenImageCausalConv3dImpl*>(m.value().get())) {
+        count++;
+      }
+    }
+    return count;
+  }
+
+  int64_t base_dim_;
+  int64_t z_dim_;
+  std::vector<int64_t> dim_mult_;
+  int64_t num_res_blocks_;
+  std::vector<double> attn_scales_;
+  std::vector<bool> temperal_downsample_;
+  std::vector<bool> temperal_upsample_;
+  double dropout_;
+
+  int64_t spatial_compression_ratio_;
+  bool use_slicing_, use_tiling_;
+  int64_t tile_sample_min_height_;
+  int64_t tile_sample_min_width_;
+  int64_t tile_sample_stride_height_;
+  int64_t tile_sample_stride_width_;
+
+  std::unordered_map<std::string, int64_t> cached_conv_counts_;
+
+  int64_t conv_num_;
+  int64_t enc_conv_num_;
+  std::shared_ptr<std::vector<int64_t>> conv_idx_;
+  std::shared_ptr<std::vector<int64_t>> enc_conv_idx_;
+  std::shared_ptr<std::vector<torch::Tensor>> feat_map_;
+  std::shared_ptr<std::vector<torch::Tensor>> enc_feat_map_;
+
+  QwenImageEncoder3d encoder_{nullptr};
+  QwenImageCausalConv3d quant_conv_{nullptr};
+  QwenImageCausalConv3d post_quant_conv_{nullptr};
+  QwenImageDecoder3d decoder_{nullptr};
+
+  ModelArgs args_;
+};
+
+TORCH_MODULE(AutoencoderKLQwenImage);
+
+REGISTER_MODEL_ARGS(AutoencoderKLQwenImage, [&] {
+  LOAD_ARG_OR(base_dim, "base_dim", 96);
+  LOAD_ARG_OR(z_dim, "z_dim", 16);
+  LOAD_ARG_OR(in_channels, "in_channels", 3);
+  LOAD_ARG_OR(dim_mult, "dim_mult", (std::vector<int64_t>{1, 2, 4, 4}));
+  LOAD_ARG_OR(attn_scales, "attn_scales", (std::vector<double>{}));
+  LOAD_ARG_OR(temperal_downsample,
+              "temperal_downsample",
+              (std::vector<bool>{false, true, true}));
+  LOAD_ARG_OR(num_res_blocks, "num_res_blocks", 2);
+  LOAD_ARG_OR(dropout, "dropout", 0);
+  LOAD_ARG_OR(latents_mean,
+              "latents_mean",
+              (std::vector<double>{-0.7571,
+                                   -0.7089,
+                                   -0.9113,
+                                   0.1075,
+                                   -0.1745,
+                                   0.9653,
+                                   -0.1517,
+                                   1.5508,
+                                   0.4134,
+                                   -0.0715,
+                                   0.5517,
+                                   -0.3632,
+                                   -0.1922,
+                                   -0.9497,
+                                   0.2503,
+                                   -0.2921}));
+  LOAD_ARG_OR(latents_std,
+              "latents_std",
+              (std::vector<double>{2.8184,
+                                   1.4541,
+                                   2.3275,
+                                   2.6558,
+                                   1.2196,
+                                   1.7708,
+                                   2.6052,
+                                   2.0743,
+                                   3.2687,
+                                   2.1526,
+                                   2.8652,
+                                   1.5579,
+                                   1.6382,
+                                   1.1253,
+                                   2.8251,
+                                   1.916}));
+});
+
+}  // namespace qwenimage
+}  // namespace xllm::dit::npu

--- a/xllm/models/dit/npu/qwen_image_edit/pipeline_qwenimage_base.h
+++ b/xllm/models/dit/npu/qwen_image_edit/pipeline_qwenimage_base.h
@@ -1,0 +1,55 @@
+/* Copyright 2026 The xLLM Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://github.com/jd-opensource/xllm/blob/main/LICENSE
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+#pragma once
+#include <acl/acl.h>
+#include <torch/torch.h>
+
+#include <algorithm>
+#include <memory>
+#include <string>
+
+#include "autoencoder_kl_qwenimage.h"
+#include "core/common/global_flags.h"
+#include "core/framework/dit_cache/dit_cache.h"
+#include "core/framework/dit_model_loader.h"
+#include "core/framework/model/model_input_params.h"
+#include "core/framework/model_context.h"
+#include "core/framework/request/dit_request_state.h"
+#include "core/framework/state_dict/state_dict.h"
+#include "core/framework/state_dict/utils.h"
+#include "framework/parallel_state/parallel_state.h"
+#include "models/dit/flowmatch_euler_discrete_scheduler.h"
+#include "models/dit/utils/common_util.h"
+#include "models/model_registry.h"
+#include "processors/qwen2_vl_image_processor.h"
+#include "transformer_qwen_image.h"
+namespace xllm::dit::npu {
+namespace qwenimage {
+
+class QwenImagePipelineBaseImpl : public torch::nn::Module {
+ protected:
+  torch::Device device_ = torch::kCPU;
+  torch::ScalarType dtype_;
+  torch::TensorOptions options_;
+  AutoencoderKLQwenImage vae_{nullptr};
+  xllm::dit::VAEImageProcessor vae_image_processor_{nullptr};
+  std::unique_ptr<Qwen2VLImageProcessor> qwen_image_processor_{nullptr};
+  QwenImageTransformer2DModel transformer_{nullptr};
+  std::unique_ptr<Tokenizer> qwen_tokenizer_;
+  std::unique_ptr<Tokenizer> tokenizer_;
+  xllm::FlowMatchEulerDiscreteScheduler scheduler_{nullptr};
+};
+}  // namespace qwenimage
+}  // namespace xllm::dit::npu

--- a/xllm/models/dit/npu/qwen_image_edit/pipeline_qwenimage_edit_plus.h
+++ b/xllm/models/dit/npu/qwen_image_edit/pipeline_qwenimage_edit_plus.h
@@ -1,0 +1,663 @@
+/* Copyright 2026 The xLLM Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://github.com/jd-opensource/xllm/blob/main/LICENSE
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+#pragma once
+#include "core/framework/state_dict/state_dict.h"
+#include "pipeline_qwenimage_base.h"
+
+#define CONDITION_IMAGE_SIZE 147456
+#define VAE_IMAGE_SIZE 1048576
+
+namespace xllm::dit::npu {
+namespace qwenimage {
+class QwenImageEditPlusPipelineImpl : public QwenImagePipelineBaseImpl {
+ public:
+  QwenImageEditPlusPipelineImpl(const DiTModelContext& context)
+      : parallel_args_(context.get_parallel_args()),
+        vae_model_args_(context.get_model_args("vae")) {
+    options_ = context.get_tensor_options();
+    dtype_ = options_.dtype().toScalarType();
+    device_ = options_.device();
+    LOG(INFO) << "model info " << dtype_ << " ; " << options_.device();
+
+    in_channels_ = context.get_model_args("transformer").in_channels();
+    num_layers_ = context.get_model_args("transformer").num_layers();
+
+    vae_scale_factor_ = static_cast<int64_t>(
+        std::pow(2, vae_model_args_.temperal_downsample().size()));
+    latent_channels_ = vae_model_args_.z_dim();
+    tokenizer_max_length_ = 1024;
+
+    prompt_template_encode_ =
+        "<|im_start|>system\nDescribe the key features of the input image "
+        "(color, shape, size, texture, objects, background), then explain how "
+        "the user's text instruction should alter or modify the image. "
+        "Generate a new image that meets the user's requirements while "
+        "maintaining consistency with the original input where "
+        "appropriate.<|im_end|>\n<|im_start|>user\n{}<|im_end|>\n<|im_start|>"
+        "assistant\n";
+    prompt_template_encode_start_idx_ = 64;
+    default_sample_size_ = 128;
+
+    vae_ = AutoencoderKLQwenImage(context.get_model_context("vae"));
+    transformer_ = QwenImageTransformer2DModel(
+        context.get_model_context("transformer"), parallel_args_);
+    scheduler_ =
+        FlowMatchEulerDiscreteScheduler(context.get_model_context("scheduler"));
+
+    vae_image_processor_ =
+        xllm::dit::VAEImageProcessor(context.get_model_context("vae"),
+                                     true,
+                                     true,
+                                     false,
+                                     false,
+                                     false,
+                                     latent_channels_);
+    register_module("vae", vae_);
+    register_module("scheduler", scheduler_);
+    register_module("transformer", transformer_);
+    register_module("vae_image_processor", vae_image_processor_);
+  }
+
+  std::vector<torch::Tensor> _extract_masked_hidden(
+      const torch::Tensor& hidden_states,
+      const torch::Tensor& mask) {
+    auto bool_mask = mask.to(torch::kBool);
+    auto valid_lengths = bool_mask.sum(1);
+
+    auto valid_lengths_cpu = valid_lengths.to(torch::kCPU).contiguous();
+
+    std::vector<int64_t> lengths_list;
+    lengths_list.reserve(valid_lengths_cpu.numel());
+
+    int64_t* lengths_ptr = valid_lengths_cpu.data_ptr<int64_t>();
+    for (int64_t i = 0; i < valid_lengths_cpu.numel(); ++i) {
+      lengths_list.push_back(lengths_ptr[i]);
+    }
+
+    auto selected = hidden_states.index({bool_mask});
+    auto split_result = torch::split(selected, lengths_list, 0);
+
+    return std::vector<torch::Tensor>(split_result.begin(), split_result.end());
+  }
+
+  std::pair<torch::Tensor, torch::Tensor> _get_qwen_prompt_embeds(
+      const std::vector<std::string>& prompt,
+      const std::vector<torch::Tensor>& image,
+      torch::TensorOptions& options) {
+    std::string img_prompt_template =
+        "Picture {}: <|vision_start|><|image_pad|><|vision_end|>";
+    std::string base_img_prompt = "";
+
+    torch::Tensor prompt_embeds;
+    torch::Tensor prompt_embeds_mask;
+    return std::make_pair(prompt_embeds, prompt_embeds_mask);
+  }
+
+  void _encode_prompt(const std::vector<torch::Tensor>& image,
+                      const std::vector<std::string>& prompt,
+                      torch::Tensor& prompt_embeds,
+                      torch::Tensor& prompt_embeds_mask,
+                      torch::TensorOptions& options,
+                      int64_t num_images_per_prompt = 1,
+                      int64_t max_sequence_length = 1024) {
+    int64_t batch_size = prompt_embeds.defined() ? prompt_embeds.size(0) : 1;
+    if (!prompt_embeds.defined()) {
+      std::tie(prompt_embeds, prompt_embeds_mask) =
+          _get_qwen_prompt_embeds(prompt, image, options);
+    }
+
+    CHECK(prompt_embeds.defined())
+        << "currently, the prompt input is not supported for qwen image, "
+        << "expected a valid prompt_embeds input, but got empty tensor ";
+
+    auto seq_len = prompt_embeds.size(1);
+    prompt_embeds = prompt_embeds.repeat({1, num_images_per_prompt, 1});
+    prompt_embeds =
+        prompt_embeds.view({batch_size * num_images_per_prompt, seq_len, -1});
+    if (prompt_embeds_mask.defined()) {
+      prompt_embeds_mask =
+          prompt_embeds_mask.repeat({1, num_images_per_prompt, 1});
+      prompt_embeds_mask = prompt_embeds_mask.view(
+          {batch_size * num_images_per_prompt, seq_len});
+    } else {
+      prompt_embeds_mask =
+          torch::ones({prompt_embeds.size(0), prompt_embeds.size(1)});
+    }
+  }
+
+  torch::Tensor _retrieve_latents(const AutoencoderKLOutput& encoder_output,
+                                  int64_t seed = 42,
+                                  const std::string& sample_mode = "sample") {
+    if (sample_mode == "sample") {
+      return encoder_output.latent_dist.sample(seed);
+    } else if (sample_mode == "argmax") {
+      return encoder_output.latent_dist.mode();
+    } else {
+      CHECK(false)
+          << "sample_mode is expected to be 'sample' or 'argmax', but get: "
+          << sample_mode;
+      return torch::Tensor();
+    }
+  }
+
+  torch::Tensor _pack_latents(torch::Tensor latents,
+                              int64_t batch_size,
+                              int64_t num_channels_latents,
+                              int64_t height,
+                              int64_t width) {
+    latents = latents.view(
+        {batch_size, num_channels_latents, height / 2, 2, width / 2, 2});
+    latents = latents.permute({0, 2, 4, 1, 3, 5});
+    latents = latents.reshape(
+        {batch_size, (height / 2) * (width / 2), num_channels_latents * 4});
+
+    return latents;
+  }
+
+  torch::Tensor _unpack_latents(torch::Tensor latents,
+                                int64_t height,
+                                int64_t width,
+                                int64_t vae_scale_factor) {
+    auto sizes = latents.sizes();
+    int64_t batch_size = sizes[0];
+    int64_t num_patches = sizes[1];
+    int64_t channels = sizes[2];
+
+    height = 2 * (height / (vae_scale_factor * 2));
+    width = 2 * (width / (vae_scale_factor * 2));
+
+    latents =
+        latents.view({batch_size, height / 2, width / 2, channels / 4, 2, 2});
+    latents = latents.permute({0, 3, 1, 4, 2, 5});
+    latents =
+        latents.reshape({batch_size, channels / (2 * 2), 1, height, width});
+
+    return latents;
+  }
+
+  torch::Tensor _encode_vae_image(torch::Tensor image,
+                                  int64_t seed,
+                                  torch::Device device) {
+    auto image_latents = _retrieve_latents(vae_->encode(image), seed, "argmax");
+    auto latents_mean =
+        torch::tensor(vae_model_args_.latents_mean(), torch::kDouble);
+    latents_mean = latents_mean.view({1, latent_channels_, 1, 1, 1})
+                       .to(device, image_latents.dtype());
+    auto latents_std =
+        torch::tensor(vae_model_args_.latents_std(), torch::kDouble);
+    latents_std = latents_std.view({1, latent_channels_, 1, 1, 1})
+                      .to(device, image_latents.dtype());
+    image_latents = (image_latents - latents_mean) / latents_std;
+    return image_latents;
+  }
+
+  std::pair<torch::Tensor, torch::Tensor> _prepare_latents(
+      const std::vector<torch::Tensor>& images,
+      int64_t batch_size,
+      int64_t num_channels_latents,
+      int64_t height,
+      int64_t width,
+      torch::TensorOptions& options,
+      int64_t seed,
+      torch::Tensor latents = torch::Tensor()) {
+    height = 2 * (height / (vae_scale_factor_ * 2));
+    width = 2 * (width / (vae_scale_factor_ * 2));
+
+    std::vector<int64_t> shape = {
+        batch_size, 1, num_channels_latents, height, width};
+
+    torch::Tensor image_latents;
+    if (!images.empty()) {
+      std::vector<torch::Tensor> all_image_latents;
+
+      for (const auto& image : images) {
+        auto current_image = image.to(options);
+        torch::Tensor current_image_latents;
+
+        if (current_image.size(1) != latent_channels_) {
+          current_image_latents =
+              _encode_vae_image(current_image, seed, device_);
+        } else {
+          current_image_latents = current_image;
+        }
+
+        current_image_latents = torch::cat({current_image_latents}, 0);
+        int64_t image_latent_height = current_image_latents.size(3);
+        int64_t image_latent_width = current_image_latents.size(4);
+
+        current_image_latents = _pack_latents(current_image_latents,
+                                              batch_size,
+                                              num_channels_latents,
+                                              image_latent_height,
+                                              image_latent_width);
+        all_image_latents.emplace_back(current_image_latents);
+      }
+
+      image_latents = torch::cat(all_image_latents, 1);
+    }
+
+    if (!latents.defined()) {
+      latents = xllm::dit::randn_tensor(shape, seed, options);
+      latents = _pack_latents(
+          latents, batch_size, num_channels_latents, height, width);
+    } else {
+      latents = latents.to(options);
+    }
+    return std::make_pair(latents, image_latents);
+  }
+
+  DiTForwardOutput forward(const DiTForwardInput& input) {
+    torch::NoGradGuard no_grad;
+    const auto& generation_params = input.generation_params;
+    auto height = generation_params.height;
+    auto width = generation_params.width;
+    auto true_cfg_scale = generation_params.true_cfg_scale;
+    auto num_inference_steps = generation_params.num_inference_steps;
+    DiTCache::get_instance().set_infer_steps(num_inference_steps);
+    DiTCache::get_instance().set_num_blocks(num_layers_);
+    auto max_sequence_length = generation_params.max_sequence_length;
+    auto seed = generation_params.seed >= 0 ? generation_params.seed : 42;
+
+    auto prompts = input.prompts;
+    auto prompts_2 = input.prompts_2;
+    auto negative_prompts = input.negative_prompts;
+    auto negative_prompts_2 = input.negative_prompts_2;
+    auto latents = input.latents;
+    if (latents.defined()) {
+      latents = latents.to(options_.device(), dtype_);
+    }
+
+    auto prompt_embeds = input.prompt_embeds;
+    if (prompt_embeds.defined()) {
+      prompt_embeds = prompt_embeds.to(options_.device(), dtype_);
+    }
+    auto pooled_prompt_embeds = input.pooled_prompt_embeds;
+    torch::Tensor prompt_embeds_mask;
+
+    auto negative_prompt_embeds = input.negative_prompt_embeds;
+    if (negative_prompt_embeds.defined()) {
+      negative_prompt_embeds =
+          negative_prompt_embeds.to(options_.device(), dtype_);
+    }
+    auto negative_pooled_prompt_embeds = input.negative_pooled_prompt_embeds;
+    torch::Tensor negative_prompt_embeds_mask;
+
+    std::vector<torch::Tensor> image_list;
+
+    torch::Tensor images;
+
+    if (FLAGS_dit_debug_print) {
+      input.debug_print();
+    }
+
+    if (input.images.defined()) {
+      images = input.images.to(options_.device(), dtype_);
+      if (input.images.dim() == 3) {
+        image_list.emplace_back(images);
+      } else if (input.images.dim() == 4) {
+        if (input.images.size(0) > 1) {
+          LOG(ERROR) << "currently dit models doesn't support batch inference"
+                     << "batch size: " << input.images.size(0);
+        }
+        image_list.emplace_back(images[0]);
+      } else {
+        LOG(ERROR)
+            << "image inputs are expected to be a 4 dim tensor, but got: "
+            << input.images.dim() << "s tensor";
+      }
+    } else {
+      LOG(ERROR) << "QwenImageEditPlus pipeline expected to have "
+                 << "image inputs";
+    }
+
+    torch::Tensor conditional_images;
+    if (input.condition_images.defined()) {
+      conditional_images = input.condition_images.to(options_.device(), dtype_);
+      if (input.condition_images.dim() == 3) {
+        image_list.emplace_back(conditional_images);
+      } else if (input.condition_images.dim() == 4) {
+        if (input.condition_images.size(0) > 1) {
+          LOG(ERROR) << "currently dit models doesn't support batch inference"
+                     << "batch size: " << input.condition_images.size(0);
+        }
+        image_list.emplace_back(conditional_images[0]);
+      } else {
+        LOG(ERROR)
+            << "image inputs are expected to be a 4 dim tensor, but got: "
+            << input.condition_images.dim() << "s tensor";
+      }
+    }
+    double height_size = images.size(2);
+    double width_size = images.size(3);
+    int64_t num_images_per_prompt = 1;
+
+    double aspect_ratio = width_size / height_size;
+    auto [calculated_width, calculated_height] =
+        xllm::dit::calculate_dimensions(1024 * 1024, aspect_ratio);
+
+    height = (height == 0) ? calculated_height : height;
+    width = (width == 0) ? calculated_width : width;
+
+    int64_t multiple_of = vae_scale_factor_ * 2;
+    width = (width / multiple_of) * multiple_of;
+    height = (height / multiple_of) * multiple_of;
+
+    current_timestep_ = torch::Tensor();
+
+    int64_t batch_size = prompts.size();
+    std::vector<torch::Tensor> condition_images;
+    std::vector<torch::Tensor> vae_images;
+    std::vector<std::pair<int64_t, int64_t>> condition_image_sizes;
+    std::vector<std::pair<int64_t, int64_t>> vae_image_sizes;
+
+    if (images.defined() && !(images.size(1) == latent_channels_)) {
+      for (size_t i = 0; i < image_list.size(); i++) {
+        aspect_ratio =
+            static_cast<double>(image_list[i].size(2)) / image_list[i].size(1);
+        auto [condition_width, condition_height] =
+            xllm::dit::calculate_dimensions(CONDITION_IMAGE_SIZE, aspect_ratio);
+        auto [vae_width, vae_height] =
+            xllm::dit::calculate_dimensions(VAE_IMAGE_SIZE, aspect_ratio);
+        condition_image_sizes.push_back({condition_width, condition_height});
+        vae_image_sizes.push_back({vae_width, vae_height});
+
+        auto img = image_list[i].unsqueeze(0);
+        auto condition_img = vae_image_processor_->resize(
+            img, condition_height, condition_width);
+        auto vae_img =
+            vae_image_processor_->preprocess(img, vae_height, vae_width)
+                .unsqueeze(2);
+
+        condition_images.push_back(condition_img);
+        vae_images.push_back(vae_img);
+      }
+    }
+
+    bool has_neg_prompt = negative_prompts.size() > 0;
+
+    bool do_true_cfg = (true_cfg_scale > 1.0) && has_neg_prompt;
+    // inplace update prompt_embeds and prompt_embeds_mask
+    _encode_prompt(condition_images,
+                   prompts,
+                   prompt_embeds,
+                   prompt_embeds_mask,
+                   options_,
+                   num_images_per_prompt,
+                   max_sequence_length);
+
+    if (do_true_cfg) {
+      // inplace update negative_prompt_embeds and negative_prompt_embeds_mask
+      _encode_prompt(condition_images,
+                     negative_prompts,
+                     negative_prompt_embeds,
+                     negative_prompt_embeds_mask,
+                     options_,
+                     num_images_per_prompt,
+                     max_sequence_length);
+    }
+
+    int64_t num_channels_latents = in_channels_ / 4;
+    torch::Tensor final_latents;
+    torch::Tensor image_latents;
+
+    std::tie(final_latents, image_latents) =
+        _prepare_latents(vae_images,
+                         batch_size * num_images_per_prompt,
+                         num_channels_latents,
+                         height,
+                         width,
+                         options_,
+                         seed,
+                         latents);
+
+    std::vector<std::vector<int64_t>> main_shape = {
+        {1, height / vae_scale_factor_ / 2, width / vae_scale_factor_ / 2}};
+
+    for (const auto& [vae_width, vae_height] : vae_image_sizes) {
+      main_shape.push_back({1,
+                            vae_height / vae_scale_factor_ / 2,
+                            vae_width / vae_scale_factor_ / 2});
+    }
+
+    std::vector<float> new_sigmas;
+    for (int64_t i = 0; i < num_inference_steps; ++i) {
+      new_sigmas.push_back(1.0f - static_cast<float>(i) /
+                                      (num_inference_steps - 1) *
+                                      (1.0f - 1.0f / num_inference_steps));
+    }
+
+    int64_t image_seq_len = final_latents.size(1);
+    float mu = xllm::dit::calculate_shift(image_seq_len,
+                                          scheduler_->base_image_seq_len(),
+                                          scheduler_->max_image_seq_len(),
+                                          scheduler_->base_shift(),
+                                          scheduler_->max_shift());
+    auto [timesteps, num_inference_steps_actual] =
+        xllm::dit::retrieve_timesteps(
+            scheduler_, num_inference_steps, device_, new_sigmas, mu);
+    int64_t num_warmup_steps =
+        std::max(static_cast<int64_t>(timesteps.numel()) -
+                     num_inference_steps_actual * scheduler_->order(),
+                 static_cast<int64_t>(0LL));
+
+    num_timesteps_ = timesteps.size(0);
+    torch::Tensor txt_seq_lens;
+    if (prompt_embeds_mask.defined()) {
+      txt_seq_lens = prompt_embeds_mask.sum(1);
+    }
+    torch::Tensor negative_txt_seq_lens;
+    if (do_true_cfg && negative_prompt_embeds_mask.defined()) {
+      negative_txt_seq_lens = negative_prompt_embeds_mask.sum(1);
+    }
+    /*
+    if (prompt_embeds.size(1) % FLAGS_dit_sp_size != 0) {
+      int64_t pad_len =
+          FLAGS_dit_sp_size - prompt_embeds.size(1) % FLAGS_dit_sp_size;
+      std::vector<int64_t> pad_with = {
+          0,
+          0,  // 第3维�~Hhe   ight�~I�        ~Mpad
+          0,
+          pad_len,  // 第 2维�~Hchannels�~I�~I~M�~P~Npad
+          0,
+          0};  // 第1维�~Hbatch�~I�~Mpad
+      std::vector<int64_t> pad_with_mask = {
+          // 第3维�~Hhe   ight�~I�        ~Mpad
+          0,
+          pad_len,  // 第 2维�~Hchannels�~I�~I~M�~P~Npad
+          0,
+          0};  // 第1维�~Hbatch�~I�~Mpad
+      prompt_embeds = torch::pad(prompt_embeds, pad_with, "constant", 0);
+      prompt_embeds_mask =
+          torch::pad(prompt_embeds_mask, pad_with_mask, "constant", 0);
+    }
+
+    if (negative_prompt_embeds.size(1) % FLAGS_dit_sp_size != 0) {
+      int64_t pad_len = FLAGS_dit_sp_size -
+                        negative_prompt_embeds.size(1) % FLAGS_dit_sp_size;
+      std::vector<int64_t> pad_with = {
+          0,
+          0,  // 第3维�~Hhe   ight�~I�        ~Mpad
+          0,
+          pad_len,  // 第 2维�~Hchannels�~I�~I~M�~P~Npad
+          0,
+          0};  // 第1维�~Hbatch�~I�~Mpad
+      std::vector<int64_t> pad_with_mask = {
+          // 第3维�~Hhe   ight�~I�        ~Mpad
+          0,
+          pad_len,  // 第 2维�~Hchannels�~I�~I~M�~P~Npad
+          0,
+          0};
+      negative_prompt_embeds =
+          torch::pad(negative_prompt_embeds, pad_with, "constant", 0);
+      negative_prompt_embeds_mask =
+          torch::pad(negative_prompt_embeds_mask, pad_with_mask, "constant", 0);
+    }
+    */
+    scheduler_->set_begin_index(0);
+    for (int64_t i = 0; i < timesteps.size(0); ++i) {
+      auto t = timesteps[i];
+      current_timestep_ = t;
+
+      auto latent_model_input = final_latents;
+      if (image_latents.defined()) {
+        latent_model_input = torch::cat({final_latents, image_latents}, 1);
+      }
+
+      auto timestep_expanded =
+          t.expand({final_latents.size(0)}).to(final_latents.dtype());
+
+      torch::Tensor noise_pred;
+      torch::Tensor neg_noise_pred;
+      torch::Tensor pos_neg_noise_preds;
+      if (FLAGS_dit_cfg_size == 2 && do_true_cfg) {
+        auto rank = parallel_args_.dit_cfg_group_->rank();
+        if (rank == 0) {
+          noise_pred = transformer_->forward(latent_model_input,
+                                             prompt_embeds,
+                                             prompt_embeds_mask,
+                                             timestep_expanded / 1000.0,
+                                             main_shape,
+                                             txt_seq_lens,
+                                             /*use_cfg=*/false,
+                                             /*step_index=*/i);
+          noise_pred = noise_pred.slice(1, 0, final_latents.size(1));
+          pos_neg_noise_preds =
+              xllm::parallel_state::gather(noise_pred,
+                                           parallel_args_.dit_cfg_group_,
+                                           /*dim=*/0);
+        } else {
+          neg_noise_pred = transformer_->forward(latent_model_input,
+                                                 negative_prompt_embeds,
+                                                 negative_prompt_embeds_mask,
+                                                 timestep_expanded / 1000.0,
+                                                 main_shape,
+                                                 negative_txt_seq_lens,
+                                                 /*use_cfg=*/true,
+                                                 /*step_index=*/i);
+
+          neg_noise_pred = neg_noise_pred.slice(1, 0, final_latents.size(1));
+          pos_neg_noise_preds =
+              xllm::parallel_state::gather(neg_noise_pred,
+                                           parallel_args_.dit_cfg_group_,
+                                           /*dim=*/0);
+        }
+        auto noise_preds = torch::chunk(pos_neg_noise_preds, 2, 0);
+        auto comb_pred =
+            noise_preds[1] + true_cfg_scale * (noise_preds[0] - noise_preds[1]);
+        auto cond_norm = torch::norm(noise_preds[0], 2, -1, true);
+        auto noise_norm = torch::norm(comb_pred, 2, -1, true);
+        noise_pred = comb_pred * (cond_norm / noise_norm);
+
+      } else {
+        noise_pred = transformer_->forward(latent_model_input,
+                                           prompt_embeds,
+                                           prompt_embeds_mask,
+                                           timestep_expanded / 1000.0,
+                                           main_shape,
+                                           txt_seq_lens,
+                                           /*use_cfg=*/false,
+                                           /*step_index=*/i);
+        noise_pred = noise_pred.slice(1, 0, final_latents.size(1));
+        if (do_true_cfg) {
+          neg_noise_pred = transformer_->forward(latent_model_input,
+                                                 negative_prompt_embeds,
+                                                 negative_prompt_embeds_mask,
+                                                 timestep_expanded / 1000.0,
+                                                 main_shape,
+                                                 negative_txt_seq_lens,
+                                                 /*use_cfg=*/true,
+                                                 /*step_index=*/i);
+
+          neg_noise_pred = neg_noise_pred.slice(1, 0, final_latents.size(1));
+
+          auto comb_pred =
+              neg_noise_pred + true_cfg_scale * (noise_pred - neg_noise_pred);
+          auto cond_norm = torch::norm(noise_pred, 2, -1, true);
+          auto noise_norm = torch::norm(comb_pred, 2, -1, true);
+          noise_pred = comb_pred * (cond_norm / noise_norm);
+        }
+      }
+
+      auto latents_dtype = final_latents.dtype();
+      final_latents = scheduler_->step(noise_pred, t, final_latents);
+      if (final_latents.dtype() != latents_dtype) {
+        final_latents = final_latents.to(latents_dtype);
+      }
+    }
+
+    current_timestep_ = torch::Tensor();
+
+    torch::Tensor output_image;
+
+    auto unpacked_latents =
+        _unpack_latents(final_latents, height, width, vae_scale_factor_)
+            .to(dtype_);
+    auto latents_mean =
+        torch::tensor(vae_model_args_.latents_mean(), torch::kDouble);
+    latents_mean = latents_mean.view({1, latent_channels_, 1, 1, 1})
+                       .to(device_, image_latents.dtype());
+    auto latents_std =
+        torch::tensor(vae_model_args_.latents_std(), torch::kDouble);
+    latents_std = 1.0 / latents_std.view({1, latent_channels_, 1, 1, 1})
+                            .to(device_, image_latents.dtype());
+
+    unpacked_latents = unpacked_latents / latents_std + latents_mean;
+    output_image = vae_->decode(unpacked_latents).sample.squeeze(2);
+    output_image = vae_image_processor_->postprocess(output_image, "pil");
+    auto output = std::vector<torch::Tensor>{{output_image}};
+    DiTForwardOutput out;
+    out.tensors = output;
+    return out;
+  }
+
+  void load_model(std::unique_ptr<DiTModelLoader> loader) {
+    LOG(INFO) << "QwenImageEditPlusPipeline loading model from"
+              << loader->model_root_path();
+    std::string model_path = loader->model_root_path();
+    auto transformer_loader = loader->take_component_loader("transformer");
+    auto vae_loader = loader->take_component_loader("vae");
+    auto clip_loader = loader->take_component_loader("text_encoder");
+    auto tokenizer_loader = loader->take_component_loader("tokenizer");
+    auto processor_loader = loader->take_component_loader("processor");
+    LOG(INFO) << " QwenImageEditplus model components loaded, start to load "
+                 "weights to sub models";
+
+    vae_->load_model(std::move(vae_loader));
+    vae_->to(options_.device(), dtype_);
+    transformer_->load_model(std::move(transformer_loader));
+    transformer_->to(options_.device(), dtype_);
+  }
+
+ private:
+  int64_t vae_scale_factor_;
+  int64_t latent_channels_;
+  int64_t tokenizer_max_length_;
+  int64_t prompt_template_encode_start_idx_;
+  int64_t default_sample_size_;
+  int64_t in_channels_;
+  int64_t num_timesteps_;
+  int64_t num_layers_;
+  const ParallelArgs parallel_args_;
+  torch::Tensor current_timestep_;
+  string prompt_template_encode_;
+  const ModelArgs& vae_model_args_;
+};
+
+REGISTER_MODEL_ARGS(Qwen2Tokenizer, [&] {});
+TORCH_MODULE(QwenImageEditPlusPipeline);
+
+REGISTER_DIT_MODEL(QwenImageEditPlusPipeline, QwenImageEditPlusPipeline);
+}  // namespace qwenimage
+}  // namespace xllm::dit::npu

--- a/xllm/models/dit/npu/qwen_image_edit/transformer_qwen_image.h
+++ b/xllm/models/dit/npu/qwen_image_edit/transformer_qwen_image.h
@@ -1,0 +1,2171 @@
+/* Copyright 2026 The xLLM Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://github.com/jd-opensource/xllm/blob/main/LICENSE
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+#pragma once
+#include <glog/logging.h>
+#include <torch/nn/functional/linear.h>
+#include <torch/torch.h>
+#include <torch_npu/csrc/aten/CustomFunctions.h>
+#include <torch_npu/csrc/libs/init_npu.h>
+
+#include <cmath>
+#include <iostream>
+#include <memory>
+#include <optional>
+#include <stdexcept>
+#include <string>
+#include <vector>
+
+#include "core/framework/dit_cache/dit_cache.h"
+#include "core/framework/dit_model_loader.h"
+#include "core/framework/model/model_input_params.h"
+#include "core/framework/state_dict/state_dict.h"
+#include "core/framework/state_dict/utils.h"
+#include "core/layers/common/add_matmul.h"
+#include "framework/model_context.h"
+#include "framework/parallel_state/parallel_state.h"
+#include "models/dit/utils/dit_parallel_linear.h"
+#include "models/dit/utils/sequence_parallel_pad_manager.h"
+#include "models/model_registry.h"
+
+#ifdef TORCH_HIGHER_THAN_PTA6
+#include <torch_npu/csrc/framework/OpCommand.h>
+#else
+#include <torch_npu/csrc/aten/NPUNativeFunctions.h>
+#include <torch_npu/csrc/framework/utils/OpPreparation.h>
+#endif
+
+#include <torch_npu/csrc/libs/init_npu.h>
+#include <torch_npu/torch_npu.h>
+
+#include <cstdlib>
+namespace xllm::dit::npu {
+namespace qwenimage {
+
+inline torch::Tensor gather_sequence(const torch::Tensor& input_,
+                                     int64_t dim,
+                                     ProcessGroup* pg) {
+  auto group_size = pg->world_size();
+  auto input = input_.contiguous();
+  if (group_size == 1) {
+    return input;
+  }
+
+  // all gather
+  auto tensor_list = parallel_state::gather(input, pg, dim);
+
+  // concat
+  auto output = torch::cat(tensor_list, dim);
+
+  return output;
+}
+
+inline torch::Tensor split_sequence(const torch::Tensor& input,
+                                    int64_t dim,
+                                    ProcessGroup* pg) {
+  auto group_size = pg->world_size();
+  auto rank = pg->rank();
+
+  if (group_size == 1) {
+    return input;
+  }
+
+  torch::Tensor input_ = input;
+
+  int64_t dim_size = input_.size(dim);
+
+  auto tensor_list = torch::split(input_, dim_size / group_size, dim);
+  auto output = tensor_list[rank].contiguous();
+  return output;
+}
+
+// TODO: This class should be extracted from dit class and integrated into a
+// common class.
+class RMSNormImpl : public torch::nn::Module {
+ public:
+  // Constructor: dim (normalization dimension), eps (stabilization term)
+  // elementwise_affine (enable affine transform), bias (enable bias term)
+  RMSNormImpl(int64_t dim, double eps, bool elementwise_affine, bool bias)
+      : eps_(eps), elementwise_affine_(elementwise_affine), is_bias_(bias) {
+    if (elementwise_affine_) {
+      weight_ = register_parameter("weight", torch::ones({dim}));
+      if (is_bias_) {
+        bias_ = register_parameter("bias", torch::zeros({dim}));
+      }
+    }
+  }
+
+  torch::Tensor forward(const torch::Tensor& hidden_states) {
+    auto [output, rstd] =
+        at_npu::native::custom_ops::npu_rms_norm(hidden_states, weight_, eps_);
+    if (is_bias_ && bias_.defined()) {
+      output = output + bias_;
+    }
+    return output;
+  }
+
+  void load_state_dict(const StateDict& state_dict) {
+    if (elementwise_affine_) {
+      weight::load_weight(state_dict, "weight", weight_, weight_is_loaded_);
+      if (is_bias_) {
+        weight::load_weight(state_dict, "bias", bias_, bias_is_loaded_);
+      }
+    }
+  }
+
+  void verify_loaded_weights(const std::string& prefix) const {
+    CHECK(weight_is_loaded_)
+        << "weight is not loaded for " << prefix + "weight";
+    CHECK(!is_bias_ || bias_is_loaded_)
+        << "bias is not loaded for " << prefix + "bias";
+  }
+
+ private:
+  double eps_;               // Small epsilon to avoid division by zero
+  bool elementwise_affine_;  // Whether to apply learnable affine parameters
+  torch::Tensor weight_;     // Learnable scale parameter
+  torch::Tensor bias_;       // Learnable bias parameter (optional)
+  bool is_bias_;
+  bool weight_is_loaded_{false};
+  bool bias_is_loaded_{false};
+};
+TORCH_MODULE(RMSNorm);
+
+// TODO: This class should be extracted from dit class and integrated into a
+// common class.
+class AdaLayerNormContinuousImpl : public torch::nn::Module {
+ public:
+  explicit AdaLayerNormContinuousImpl(const ModelContext& context,
+                                      int64_t embedding_dim,
+                                      int64_t conditioning_embedding_dim,
+                                      bool elementwise_affine = true,
+                                      double eps = 1e-5,
+                                      bool bias = true)
+      : options_(context.get_tensor_options()) {
+    ModelArgs model_args = context.get_model_args();
+    silu_ = register_module("silu", torch::nn::SiLU());
+    linear_ = register_module(
+        "linear",
+        layer::WeightTransposeAddMatmul(
+            conditioning_embedding_dim, 2 * embedding_dim, bias, options_));
+    norm_ = register_module(
+        "norm",
+        torch::nn::LayerNorm(torch::nn::LayerNormOptions({embedding_dim})
+                                 .elementwise_affine(false)
+                                 .eps(eps)));
+  }
+
+  torch::Tensor forward(const torch::Tensor& x,
+                        const torch::Tensor& conditioning_embedding) {
+    auto cond_emb = silu_->forward(conditioning_embedding);
+    cond_emb = cond_emb.to(x.dtype());
+
+    auto emb = linear_->forward(cond_emb);
+    auto chunks = torch::chunk(emb, 2, 1);
+    torch::Tensor scale, shift;
+
+    scale = chunks[0];
+    shift = chunks[1];
+    auto x_norm = norm_->forward(x);
+    return x_norm * (1 + scale).unsqueeze(1) + shift.unsqueeze(1);
+  }
+
+  void load_state_dict(const StateDict& state_dict) {
+    //  linear
+    linear_->load_state_dict(state_dict.get_dict_with_prefix("linear."));
+  }
+
+  void verify_loaded_weights(const std::string& prefix) {
+    linear_->verify_loaded_weights(prefix + "linear.");
+  }
+
+ private:
+  layer::WeightTransposeAddMatmul linear_{nullptr};
+  torch::nn::SiLU silu_{nullptr};
+  torch::nn::LayerNorm norm_{nullptr};
+  double eps_;
+  std::string norm_type_;
+  bool elementwise_affine_;
+  torch::Tensor rms_scale_{nullptr};
+  torch::TensorOptions options_;
+};
+TORCH_MODULE(AdaLayerNormContinuous);
+
+// TODO: This class should be extracted from dit class and integrated into a
+// common class.
+class AdaLayerNormImpl : public torch::nn::Module {
+ public:
+  AdaLayerNormImpl(const ModelContext& contex,
+                   int64_t hidden_size,
+                   double eps = 1e-6)
+      : hidden_size_(hidden_size), eps_(eps) {
+    norm_ = register_module(
+        "norm",
+        torch::nn::LayerNorm(torch::nn::LayerNormOptions({hidden_size})
+                                 .elementwise_affine(false)
+                                 .eps(eps)));
+  }
+
+  std::tuple<torch::Tensor, torch::Tensor> forward(
+      const torch::Tensor& x,
+      const torch::Tensor& mod_params,
+      const torch::Tensor& index = torch::Tensor()) {
+    auto chunks = mod_params.chunk(3, -1);
+    auto shift = chunks[0];
+    auto scale = chunks[1];
+    auto gate = chunks[2];
+    torch::Tensor shift_result, scale_result, gate_result;
+
+    if (index.defined()) {
+      // Assuming mod_params batch dim is 2*actual_batch (chunked into 2 parts)
+      // So shift, scale, gate have shape [2*actual_batch, d]
+      int64_t actual_batch = shift.size(0) / 2;
+
+      // Split into two parts
+      auto shift_0 = shift.slice(0, 0, actual_batch);
+      auto shift_1 = shift.slice(0, actual_batch, shift.size(0));
+
+      auto scale_0 = scale.slice(0, 0, actual_batch);
+      auto scale_1 = scale.slice(0, actual_batch, scale.size(0));
+
+      auto gate_0 = gate.slice(0, 0, actual_batch);
+      auto gate_1 = gate.slice(0, actual_batch, gate.size(0));
+
+      // index: [b, l] where b is actual batch size
+      // Expand to [b, l, 1] to match feature dimension
+      auto index_expanded = index.unsqueeze(-1);  // [b, l, 1]
+
+      // Expand chunks to [b, 1, d] then broadcast to [b, l, d]
+      auto shift_0_exp = shift_0.unsqueeze(1);  // [b, 1, d]
+      auto shift_1_exp = shift_1.unsqueeze(1);  // [b, 1, d]
+      auto scale_0_exp = scale_0.unsqueeze(1);
+      auto scale_1_exp = scale_1.unsqueeze(1);
+      auto gate_0_exp = gate_0.unsqueeze(1);
+      auto gate_1_exp = gate_1.unsqueeze(1);
+
+      // Use torch::where to select based on index
+      shift_result =
+          torch::where(index_expanded == 0, shift_0_exp, shift_1_exp);
+      scale_result =
+          torch::where(index_expanded == 0, scale_0_exp, scale_1_exp);
+      gate_result = torch::where(index_expanded == 0, gate_0_exp, gate_1_exp);
+    } else {
+      shift_result = shift.unsqueeze(1);
+      scale_result = scale.unsqueeze(1);
+      gate_result = gate.unsqueeze(1);
+    }
+
+    scale_result = 1 + scale_result;
+
+    // auto result = at_npu::native::custom_ops::npu_layer_norm_eval(
+    //     x, {hidden_size_}, scale_result, shift_result, eps_);
+    auto x_norm = norm_->forward(x);
+    auto result = x_norm * scale_result + shift_result;
+    return std::make_tuple(result, gate_result);
+  }
+
+ private:
+  double eps_;
+  int64_t hidden_size_;
+  torch::nn::LayerNorm norm_{nullptr};
+};
+TORCH_MODULE(AdaLayerNorm);
+
+torch::Tensor apply_rotary_emb_qwen(const torch::Tensor& x,
+                                    const torch::Tensor& freqs_cis,
+                                    bool use_real = true,
+                                    int64_t use_real_unbind_dim = -1) {
+  auto cos = torch::real(freqs_cis);
+  auto sin = torch::imag(freqs_cis);
+
+  int64_t seqlen = cos.size(0);
+
+  auto cos_expanded = cos.unsqueeze(0)
+                          .unsqueeze(2)
+                          .unsqueeze(-1)
+                          .expand({-1, -1, -1, -1, 2})
+                          .reshape({1, seqlen, 1, -1});
+  auto sin_expanded = sin.unsqueeze(0)
+                          .unsqueeze(2)
+                          .unsqueeze(-1)
+                          .expand({-1, -1, -1, -1, 2})
+                          .reshape({1, seqlen, 1, -1});
+  auto x_out = at_npu::native::custom_ops::npu_rotary_mul(
+      x, cos_expanded, sin_expanded, "interleave");
+  return x_out.to(x.dtype());
+}
+
+class TimestepsImpl : public torch::nn::Module {
+ public:
+  TimestepsImpl(const ModelContext& context,
+                int64_t num_channels,
+                bool flip_sin_to_cos,
+                double downscale_freq_shift,
+                double scale,
+                int64_t max_period = 10000)
+      : embedding_dim_(num_channels),
+        flip_sin_to_cos_(flip_sin_to_cos),
+        downscale_freq_shift_(downscale_freq_shift),
+        scale_(scale),
+        max_period_(max_period) {}
+
+  torch::Tensor forward(const torch::Tensor& timesteps) {
+    CHECK(timesteps.dim() == 1) << "Timesteps should be a 1d-array";
+
+    int64_t half_dim = embedding_dim_ / 2;
+
+    auto exponent =
+        -std::log(max_period_) * torch::arange(0,
+                                               half_dim,
+                                               torch::TensorOptions()
+                                                   .dtype(torch::kFloat32)
+                                                   .device(timesteps.device()));
+
+    exponent = exponent / (half_dim - downscale_freq_shift_);
+    auto emb = torch::exp(exponent);
+    emb = timesteps.unsqueeze(1).to(torch::kFloat) * emb.unsqueeze(0);
+
+    emb = scale_ * emb;
+
+    // concat sine and cosine embeddings
+    auto sin_emb = torch::sin(emb);
+    auto cos_emb = torch::cos(emb);
+    emb = torch::cat({sin_emb, cos_emb}, /*dim=*/-1);
+    // flip sine and cosine embeddings
+    if (flip_sin_to_cos_) {
+      emb = torch::cat({cos_emb, sin_emb}, /*dim=*/-1);
+    }
+    // zero pad
+    if (embedding_dim_ % 2 == 1) {
+      emb = torch::nn::functional::pad(
+          emb, torch::nn::functional::PadFuncOptions({0, 1}));
+    }
+    return emb;
+  }
+
+ private:
+  int64_t embedding_dim_;
+  int64_t max_period_;
+  bool flip_sin_to_cos_;
+  double scale_;
+  double downscale_freq_shift_;
+};
+TORCH_MODULE(Timesteps);
+
+// TODO: a factory function that provides activation functions based on string
+// input
+std::function<torch::Tensor(const torch::Tensor&)> get_activation(
+    const std::string& act_fn) {
+  if (act_fn == "silu") {
+    return [](const torch::Tensor& x) { return torch::silu(x); };
+  } else if (act_fn == "relu") {
+    return [](const torch::Tensor& x) { return torch::relu(x); };
+  } else if (act_fn == "gelu") {
+    return [](const torch::Tensor& x) { return torch::gelu(x); };
+  } else if (act_fn == "tanh") {
+    return [](const torch::Tensor& x) { return torch::tanh(x); };
+  } else if (act_fn == "sigmoid") {
+    return [](const torch::Tensor& x) { return torch::sigmoid(x); };
+  } else if (act_fn == "none" || act_fn.empty()) {
+    return [](const torch::Tensor& x) { return x; };
+  } else {
+    LOG(ERROR) << "Unsupported activation function: " << act_fn;
+    throw std::out_of_range(
+        "activation function out of range, given activation function:  " +
+        act_fn);
+  }
+}
+
+class TimestepEmbeddingImpl : public torch::nn::Module {
+ public:
+  TimestepEmbeddingImpl(const ModelContext& context,
+                        int64_t in_channels,
+                        int64_t time_embed_dim,
+                        const std::string& act_fn = "silu",
+                        int64_t out_dim = -1,
+                        const std::string& post_act_fn = "",
+                        int64_t cond_proj_dim = -1,
+                        bool sample_proj_bias = true)
+      : options_(context.get_tensor_options()) {
+    linear_1_ = register_module(
+        "linear_1",
+        layer::WeightTransposeAddMatmul(
+            in_channels, time_embed_dim, sample_proj_bias, options_));
+
+    if (cond_proj_dim > 0) {
+      cond_proj_ =
+          register_module("cond_proj",
+                          layer::WeightTransposeAddMatmul(
+                              cond_proj_dim, in_channels, false, options_));
+    }
+
+    act_fn_ = register_module("act_fn", torch::nn::SiLU());
+
+    int64_t time_embed_dim_out = (out_dim > 0) ? out_dim : time_embed_dim;
+
+    linear_2_ = register_module(
+        "linear_2",
+        layer::WeightTransposeAddMatmul(
+            time_embed_dim, time_embed_dim_out, sample_proj_bias, options_));
+  }
+
+  torch::Tensor forward(const torch::Tensor& sample,
+                        const torch::Tensor& condition = torch::Tensor()) {
+    torch::Tensor x = sample;
+
+    if (cond_proj_) {
+      x = x + cond_proj_->forward(condition);
+    }
+    x = linear_1_->forward(x);
+    x = act_fn_(x);
+    x = linear_2_->forward(x);
+
+    return x;
+  }
+
+  void load_state_dict(const StateDict& state_dict) {
+    // linear1
+    linear_1_->load_state_dict(state_dict.get_dict_with_prefix("linear_1."));
+    // linear2
+    linear_2_->load_state_dict(state_dict.get_dict_with_prefix("linear_2."));
+  }
+
+  void verify_loaded_weights(const std::string& prefix) const {
+    linear_1_->verify_loaded_weights(prefix + "linear_1.");
+    linear_2_->verify_loaded_weights(prefix + "linear_2.");
+  }
+
+ private:
+  torch::TensorOptions options_;
+  torch::nn::SiLU act_fn_{nullptr};
+  layer::WeightTransposeAddMatmul linear_1_{nullptr};
+  layer::WeightTransposeAddMatmul linear_2_{nullptr};
+  layer::WeightTransposeAddMatmul cond_proj_{nullptr};
+};
+TORCH_MODULE(TimestepEmbedding);
+
+std::tuple<int64_t, std::optional<torch::Tensor>, std::optional<torch::Tensor>>
+compute_text_seq_len_from_mask(
+    const torch::Tensor& encoder_hidden_states,
+    const std::optional<torch::Tensor>& encoder_hidden_states_mask) {
+  auto batch_size = encoder_hidden_states.size(0);
+  auto text_seq_len = encoder_hidden_states.size(1);
+
+  if (!encoder_hidden_states_mask.has_value()) {
+    return std::make_tuple(text_seq_len, std::nullopt, std::nullopt);
+  }
+
+  auto mask =
+      encoder_hidden_states_mask.value().to(encoder_hidden_states.device());
+
+  if (mask.size(0) != batch_size || mask.size(1) != text_seq_len) {
+    LOG(ERROR) << "`encoder_hidden_states_mask` shape " << mask.sizes()
+               << " must match (batch_size, text_seq_len)=(" << batch_size
+               << ", " << text_seq_len << ").";
+  }
+
+  if (mask.dtype() != torch::kBool) {
+    mask = mask.to(torch::kBool);
+  }
+
+  auto device = encoder_hidden_states.device();
+  auto position_ids = torch::arange(
+      text_seq_len, torch::TensorOptions().device(device).dtype(torch::kLong));
+
+  // Compute active positions (use position ID where mask is True, else 0)
+  auto zero_tensor = torch::zeros(
+      {}, torch::TensorOptions().device(device).dtype(torch::kLong));
+
+  auto active_positions = torch::where(mask, position_ids, zero_tensor);
+
+  // Check which samples have active positions
+  auto has_active = mask.any(/*dim=*/1);
+
+  // Compute per-sample length: max position + 1 if active, else use full length
+  auto max_positions = std::get<0>(active_positions.max(/*dim=*/1));
+  auto per_sample_len = torch::where(
+      has_active,
+      max_positions + 1,
+      torch::tensor(text_seq_len,
+                    torch::TensorOptions().device(device).dtype(torch::kLong)));
+
+  return std::make_tuple(text_seq_len, per_sample_len, mask);
+}
+
+class QwenTimestepProjEmbeddingsImpl : public torch::nn::Module {
+ public:
+  QwenTimestepProjEmbeddingsImpl(const ModelContext& context,
+                                 int64_t embedding_dim,
+                                 bool use_additional_t_cond = false)
+      : use_additional_t_cond_(use_additional_t_cond) {
+    time_proj_ = register_module("time_proj",
+                                 Timesteps(context,
+                                           /*num_channels=*/256,
+                                           /*flip_sin_to_cos=*/true,
+                                           /*downscale_freq_shift=*/0.0,
+                                           /*scale=*/1000));
+    timestep_embedder_ =
+        register_module("timestep_embedder",
+                        TimestepEmbedding(context,
+                                          /*in_channels=*/256,
+                                          /*time_embed_dim*/ embedding_dim));
+    if (use_additional_t_cond) {
+      addition_t_embedding_ =
+          register_module("addition_t_embedding",
+                          torch::nn::Embedding(torch::nn::EmbeddingOptions(
+                              /*num=*/2, embedding_dim)));
+    }
+  }
+
+  torch::Tensor forward(
+      const torch::Tensor& timestep,
+      const torch::Tensor& hidden_states,
+      const torch::Tensor& addition_t_cond = torch::Tensor()) {
+    auto timesteps_proj = time_proj_->forward(timestep);
+    auto timesteps_emb =
+        timestep_embedder_->forward(timesteps_proj.to(hidden_states.dtype()));
+
+    torch::Tensor conditioning = timesteps_emb;
+    if (use_additional_t_cond_) {
+      CHECK(addition_t_cond.defined())
+          << "expected to pass addition_t_cond when"
+          << " use_additional_t_cond_ is setup to true";
+      auto addition_t_emb = addition_t_embedding_->forward(addition_t_cond);
+      addition_t_emb = addition_t_emb.to(hidden_states.dtype());
+      conditioning = conditioning + addition_t_emb;
+    }
+
+    return conditioning;
+  }
+  void load_state_dict(const StateDict& state_dict) {
+    timestep_embedder_->load_state_dict(
+        state_dict.get_dict_with_prefix("timestep_embedder."));
+    if (use_additional_t_cond_) {
+      weight::load_weight(state_dict,
+                          "addition_t_embedding.weight",
+                          addition_t_embedding_->weight,
+                          weight_is_loaded_);
+    }
+  }
+
+  void verify_loaded_weights(const std::string& prefix) const {
+    timestep_embedder_->verify_loaded_weights(prefix + "timestep_embedder.");
+    if (use_additional_t_cond_) {
+      CHECK(weight_is_loaded_)
+          << "weight is not loaded for " << prefix + "weight";
+    }
+  }
+
+ private:
+  Timesteps time_proj_{nullptr};
+  TimestepEmbedding timestep_embedder_{nullptr};
+  torch::nn::Embedding addition_t_embedding_{nullptr};
+  bool use_additional_t_cond_;
+  bool weight_is_loaded_{false};
+};
+TORCH_MODULE(QwenTimestepProjEmbeddings);
+
+class QwenEmbedRopeImpl : public torch::nn::Module {
+ public:
+  QwenEmbedRopeImpl(const ModelContext& context,
+                    int64_t theta,
+                    std::vector<int64_t> axes_dim,
+                    bool scale_rope = false)
+      : theta_(theta), axes_dim_(axes_dim), scale_rope_(scale_rope) {
+    auto pos_index = torch::arange(4096);
+    auto neg_index = torch::arange(4096).flip(0) * -1 - 1;
+
+    pos_freqs_ = torch::cat({rope_params(pos_index, axes_dim[0], theta),
+                             rope_params(pos_index, axes_dim[1], theta),
+                             rope_params(pos_index, axes_dim[2], theta)},
+                            1);
+
+    neg_freqs_ = torch::cat({rope_params(neg_index, axes_dim[0], theta),
+                             rope_params(neg_index, axes_dim[1], theta),
+                             rope_params(neg_index, axes_dim[2], theta)},
+                            1);
+  }
+
+  std::tuple<torch::Tensor, torch::Tensor> forward(
+      const std::vector<std::vector<int64_t>>& video_fhw,
+      const std::optional<int64_t>& txt_seq_lens,
+      torch::Device device,
+      const std::optional<int64_t>& max_txt_seq_len) {
+    if (pos_freqs_.device() != device) {
+      pos_freqs_ = pos_freqs_.to(device);
+      neg_freqs_ = neg_freqs_.to(device);
+    }
+
+    std::vector<torch::Tensor> vid_freqs;
+    int64_t max_vid_index = 0;
+
+    for (size_t idx = 0; idx < video_fhw.size(); idx++) {
+      const auto& fhw = video_fhw[idx];
+      int64_t frame = fhw[0], height = fhw[1], width = fhw[2];
+
+      std::string rope_key = std::to_string(idx) + "_" +
+                             std::to_string(height) + "_" +
+                             std::to_string(width);
+
+      auto video_freq = _compute_video_freqs(frame, height, width, idx, device);
+      vid_freqs.push_back(video_freq);
+
+      if (scale_rope_) {
+        max_vid_index = std::max({height / 2, width / 2, max_vid_index});
+      } else {
+        max_vid_index = std::max({height, width, max_vid_index});
+      }
+    }
+
+    int64_t max_len;
+    if (txt_seq_lens.has_value() && !max_txt_seq_len.has_value()) {
+      max_len = txt_seq_lens.value();
+    } else if (max_txt_seq_len.has_value()) {
+      max_len = max_txt_seq_len.value();
+    } else {
+      LOG(ERROR) << "need to pass txt_seq_lens or max_txt_seq_len "
+                 << "to calculate the mrope";
+    }
+
+    auto txt_freqs =
+        pos_freqs_.slice(0, max_vid_index, max_vid_index + max_len);
+    auto vid_freqs_cat = torch::cat(vid_freqs, 0);
+    return std::make_tuple(vid_freqs_cat, txt_freqs);
+  }
+
+ protected:
+  torch::Tensor rope_params(const torch::Tensor& index,
+                            int64_t dim,
+                            int64_t theta) {
+    CHECK(dim % 2 == 0) << "dim must be even";
+
+    auto exponents =
+        torch::arange(
+            0, dim, 2, torch::TensorOptions().dtype(torch::kFloat32)) /
+        static_cast<float>(dim);
+    auto freqs = 1.0 / torch::pow(theta, exponents);
+
+    auto outer_result = torch::outer(index.to(torch::kFloat32), freqs);
+
+    auto complex_freqs =
+        torch::polar(torch::ones_like(outer_result), outer_result);
+
+    return complex_freqs;
+  }
+
+  torch::Tensor _compute_video_freqs(int64_t frame,
+                                     int64_t height,
+                                     int64_t width,
+                                     int64_t idx,
+                                     torch::Device device) {
+    int64_t seq_lens = frame * height * width;
+
+    auto pos_freqs = pos_freqs_.to(device);
+    auto neg_freqs = neg_freqs_.to(device);
+
+    std::vector<int64_t> split_sizes;
+    for (auto dim : axes_dim_) {
+      split_sizes.push_back(dim / 2);
+    }
+
+    auto freqs_pos_chunks = pos_freqs_.split_with_sizes(split_sizes, 1);
+    auto freqs_neg_chunks = neg_freqs_.split_with_sizes(split_sizes, 1);
+
+    auto freqs_frame = freqs_pos_chunks[0]
+                           .slice(0, idx, idx + frame)
+                           .view({frame, 1, 1, -1})
+                           .expand({frame, height, width, -1});
+
+    torch::Tensor freqs_height, freqs_width;
+    if (scale_rope_) {
+      auto height_neg_part = freqs_neg_chunks[1].slice(
+          0, -(height - height / 2), torch::indexing::None);
+      auto height_pos_part = freqs_pos_chunks[1].slice(0, 0, height / 2);
+      freqs_height = torch::cat({height_neg_part, height_pos_part}, 0)
+                         .view({1, height, 1, -1})
+                         .expand({frame, height, width, -1});
+
+      auto width_neg_part = freqs_neg_chunks[2].slice(
+          0, -(width - width / 2), torch::indexing::None);
+      auto width_pos_part = freqs_pos_chunks[2].slice(0, 0, width / 2);
+      freqs_width = torch::cat({width_neg_part, width_pos_part}, 0)
+                        .view({1, 1, width, -1})
+                        .expand({frame, height, width, -1});
+    } else {
+      freqs_height = freqs_pos_chunks[1]
+                         .slice(0, 0, height)
+                         .view({1, height, 1, -1})
+                         .expand({frame, height, width, -1});
+
+      freqs_width = freqs_pos_chunks[2]
+                        .slice(0, 0, width)
+                        .view({1, 1, width, -1})
+                        .expand({frame, height, width, -1});
+    }
+    auto freqs = torch::cat({freqs_frame, freqs_height, freqs_width}, -1)
+                     .reshape({seq_lens, -1});
+    return freqs.contiguous();
+  }
+
+  int64_t theta_;
+  std::vector<int64_t> axes_dim_;
+  bool scale_rope_;
+  torch::Tensor pos_freqs_;
+  torch::Tensor neg_freqs_;
+  std::unordered_map<std::string, torch::Tensor> rope_cache_;
+};
+
+TORCH_MODULE(QwenEmbedRope);
+
+class QwenEmbedRopeWithCacheImpl : public QwenEmbedRopeImpl {
+ public:
+  QwenEmbedRopeWithCacheImpl(const ModelContext& context,
+                             int64_t theta,
+                             std::vector<int64_t> axes_dim,
+                             bool scale_rope = false)
+      : QwenEmbedRopeImpl(context, theta, axes_dim, scale_rope) {}
+
+ private:
+  torch::Tensor _compute_video_freqs_cached(int64_t frame,
+                                            int64_t height,
+                                            int64_t width,
+                                            int64_t idx,
+                                            torch::Device device) {
+    std::string key = std::to_string(idx) + "_" + std::to_string(height) + "_" +
+                      std::to_string(width);
+
+    auto it = rope_cache_.find(key);
+    if (it != rope_cache_.end()) {
+      return it->second;
+    } else {
+      auto result = _compute_video_freqs(frame, height, width, idx, device);
+      rope_cache_[key] = result;
+      return result;
+    }
+  }
+
+  std::unordered_map<std::string, torch::Tensor> rope_cache_;
+};
+TORCH_MODULE(QwenEmbedRopeWithCache);
+
+class QwenEmbedLayer3DRopeImpl : public torch::nn::Module {
+ public:
+  QwenEmbedLayer3DRopeImpl(const ModelContext& context,
+                           int64_t theta,
+                           std::vector<int64_t>& axes_dim,
+                           bool scale_rope = false)
+      : theta_(theta), axes_dim_(axes_dim), scale_rope_(scale_rope) {
+    auto pos_index = torch::arange(4096);
+    auto neg_index = torch::arange(4096).flip(0) * -1 - 1;
+
+    std::vector<torch::Tensor> pos_freqs_parts;
+    pos_freqs_ = torch::cat({rope_params(pos_index, axes_dim[0], theta),
+                             rope_params(pos_index, axes_dim[1], theta),
+                             rope_params(pos_index, axes_dim[2], theta)},
+                            1);
+
+    neg_freqs_ = torch::cat({rope_params(neg_index, axes_dim[0], theta),
+                             rope_params(neg_index, axes_dim[1], theta),
+                             rope_params(neg_index, axes_dim[2], theta)},
+                            1);
+  }
+
+  virtual std::pair<torch::Tensor, torch::Tensor> forward(
+      const std::vector<std::vector<int64_t>>& video_fhw,
+      int64_t max_txt_seq_len,
+      torch::Device device = torch::Device(torch::kCPU)) {
+    std::vector<torch::Tensor> vid_freqs_list;
+    int64_t max_vid_index = 0;
+    int64_t layer_num = video_fhw.size() - 1;
+
+    for (size_t idx = 0; idx < video_fhw.size(); idx++) {
+      const std::vector<int64_t>& fhw = video_fhw[idx];
+
+      int64_t frame = fhw[0];
+      int64_t height = fhw[1];
+      int64_t width = fhw[2];
+
+      torch::Tensor video_freq;
+
+      if (idx != layer_num) {
+        video_freq = _compute_video_freqs(frame, height, width, idx, device);
+      } else {
+        video_freq = _compute_condition_freqs(frame, height, width, device);
+      }
+      vid_freqs_list.push_back(video_freq);
+
+      if (scale_rope_) {
+        max_vid_index = std::max({height / 2, width / 2, max_vid_index});
+      } else {
+        max_vid_index = std::max({height, width, max_vid_index});
+      }
+    }
+
+    int64_t max_txt_seq_len_int = std::max(max_vid_index, layer_num);
+
+    torch::Tensor txt_freqs = pos_freqs_.to(device).slice(
+        0, max_vid_index, max_vid_index + max_txt_seq_len_int);
+
+    torch::Tensor vid_freqs = torch::cat(vid_freqs_list, 0);
+
+    return {vid_freqs, txt_freqs};
+  }
+
+ protected:
+  torch::Tensor rope_params(torch::Tensor index, int64_t dim, int64_t theta) {
+    CHECK(dim % 2 == 0) << "dim must be even";
+
+    auto exponents =
+        torch::arange(
+            0, dim, 2, torch::TensorOptions().dtype(torch::kFloat32)) /
+        static_cast<float>(dim);
+    auto freqs = 1.0 / torch::pow(theta, exponents);
+
+    auto outer_result = torch::outer(index.to(torch::kFloat32), freqs);
+
+    auto complex_freqs =
+        torch::polar(torch::ones_like(outer_result), outer_result);
+
+    return complex_freqs;
+  }
+
+  torch::Tensor _compute_video_freqs(int64_t frame,
+                                     int64_t height,
+                                     int64_t width,
+                                     int64_t idx,
+                                     torch::Device device) {
+    int64_t seq_lens = frame * height * width;
+
+    torch::Tensor pos_freqs = pos_freqs_.to(device);
+    torch::Tensor neg_freqs = neg_freqs_.to(device);
+
+    std::vector<int64_t> split_sizes;
+    for (int64_t dim : axes_dim_) {
+      split_sizes.push_back(dim / 2);
+    }
+
+    auto freqs_pos = pos_freqs.split_with_sizes(split_sizes, 1);
+    auto freqs_neg = neg_freqs.split_with_sizes(split_sizes, 1);
+
+    auto freqs_frame = freqs_pos[0]
+                           .slice(0, idx, idx + frame)
+                           .view({frame, 1, 1, -1})
+                           .expand({frame, height, width, -1});
+
+    torch::Tensor freqs_height;
+    if (scale_rope_) {
+      auto height_neg_part =
+          freqs_neg[1].slice(0, -(height / 2), freqs_neg[1].size(0));
+      auto height_pos_part = freqs_pos[1].slice(0, 0, height / 2);
+      freqs_height = torch::cat({height_neg_part, height_pos_part}, 0)
+                         .view({1, height, 1, -1})
+                         .expand({frame, height, width, -1});
+    } else {
+      freqs_height = freqs_pos[1]
+                         .slice(0, 0, height)
+                         .view({1, height, 1, -1})
+                         .expand({frame, height, width, -1});
+    }
+
+    torch::Tensor freqs_width;
+    if (scale_rope_) {
+      auto neg_part = freqs_neg[2].slice(0, -(width / 2), freqs_neg[2].size(0));
+      auto pos_part = freqs_pos[2].slice(0, 0, width / 2);
+      freqs_width = torch::cat({neg_part, pos_part}, 0)
+                        .view({1, 1, width, -1})
+                        .expand({frame, height, width, -1});
+    } else {
+      freqs_width = freqs_pos[2]
+                        .slice(0, 0, width)
+                        .view({1, 1, width, -1})
+                        .expand({frame, height, width, -1});
+    }
+    auto freqs =
+        torch::cat({freqs_frame, freqs_height, freqs_width}, /*dim=*/-1)
+            .reshape({seq_lens, -1})
+            .clone()
+            .contiguous();
+
+    return freqs;
+  }
+
+  torch::Tensor _compute_condition_freqs(int64_t frame,
+                                         int64_t height,
+                                         int64_t width,
+                                         torch::Device device) {
+    int64_t seq_lens = frame * height * width;
+
+    torch::Tensor pos_freqs = pos_freqs_.to(device);
+    torch::Tensor neg_freqs = neg_freqs_.to(device);
+
+    std::vector<int64_t> split_sizes;
+    for (int64_t dim : axes_dim_) {
+      split_sizes.push_back(dim / 2);
+    }
+
+    auto freqs_pos = pos_freqs.split_with_sizes(split_sizes, 1);
+    auto freqs_neg = neg_freqs.split_with_sizes(split_sizes, 1);
+
+    auto freqs_frame = freqs_neg[0]
+                           .slice(0, -1, freqs_neg[0].size(0))
+                           .view({frame, 1, 1, -1})
+                           .expand({frame, height, width, -1});
+
+    torch::Tensor freqs_height;
+    if (scale_rope_) {
+      auto neg_part =
+          freqs_neg[1].slice(0, -(height / 2), freqs_neg[1].size(0));
+      auto pos_part = freqs_pos[1].slice(0, 0, height / 2);
+      freqs_height = torch::cat({neg_part, pos_part}, 0)
+                         .view({1, height, 1, -1})
+                         .expand({frame, height, width, -1});
+    } else {
+      freqs_height = freqs_pos[1]
+                         .slice(0, 0, height)
+                         .view({1, height, 1, -1})
+                         .expand({frame, height, width, -1});
+    }
+    torch::Tensor freqs_width;
+    if (scale_rope_) {
+      auto neg_part = freqs_neg[2].slice(0, -(width / 2), freqs_neg[2].size(0));
+      auto pos_part = freqs_pos[2].slice(0, 0, width / 2);
+      freqs_width = torch::cat({neg_part, pos_part}, 0)
+                        .view({1, 1, width, -1})
+                        .expand({frame, height, width, -1});
+    } else {
+      freqs_width = freqs_pos[2]
+                        .slice(0, 0, width)
+                        .view({1, 1, width, -1})
+                        .expand({frame, height, width, -1});
+    }
+    auto freqs = torch::cat({freqs_frame, freqs_height, freqs_width}, -1)
+                     .reshape({seq_lens, -1})
+                     .clone()
+                     .contiguous();
+
+    return freqs;
+  }
+
+  int64_t theta_;
+  std::vector<int64_t>& axes_dim_;
+  bool scale_rope_;
+  torch::Tensor pos_freqs_;
+  torch::Tensor neg_freqs_;
+};
+
+TORCH_MODULE(QwenEmbedLayer3DRope);
+
+class QwenEmbedLayer3DRopeWithCacheImpl : public QwenEmbedLayer3DRopeImpl {
+ public:
+  QwenEmbedLayer3DRopeWithCacheImpl(const ModelContext& context,
+                                    int64_t theta,
+                                    std::vector<int64_t>& axes_dim,
+                                    bool scale_rope = false)
+      : QwenEmbedLayer3DRopeImpl(context, theta, axes_dim, scale_rope) {}
+
+  std::pair<torch::Tensor, torch::Tensor> forward(
+      const std::vector<std::vector<int64_t>>& video_fhw,
+      int64_t max_txt_seq_len,
+      torch::Device device = torch::Device(torch::kCPU)) override {
+    std::vector<torch::Tensor> vid_freqs_list;
+    int64_t max_vid_index = 0;
+    int64_t layer_num = video_fhw.size() - 1;
+
+    for (size_t idx = 0; idx < video_fhw.size(); idx++) {
+      const std::vector<int64_t>& fhw = video_fhw[idx];
+
+      int64_t frame = fhw[0];
+      int64_t height = fhw[1];
+      int64_t width = fhw[2];
+
+      torch::Tensor video_freq;
+
+      if (idx != layer_num) {
+        video_freq =
+            _compute_video_freqs_with_cache(frame, height, width, idx, device);
+      } else {
+        video_freq =
+            _compute_condition_freqs_with_cache(frame, height, width, device);
+      }
+      vid_freqs_list.push_back(video_freq);
+
+      if (scale_rope_) {
+        max_vid_index = std::max({height / 2, width / 2, max_vid_index});
+      } else {
+        max_vid_index = std::max({height, width, max_vid_index});
+      }
+    }
+
+    int64_t max_txt_seq_len_int = std::max(max_vid_index, layer_num);
+
+    torch::Tensor txt_freqs = pos_freqs_.to(device).slice(
+        0, max_vid_index, max_vid_index + max_txt_seq_len_int);
+
+    torch::Tensor vid_freqs = torch::cat(vid_freqs_list, 0);
+
+    return {vid_freqs, txt_freqs};
+  }
+
+ private:
+  torch::Tensor _compute_video_freqs_with_cache(int64_t frame,
+                                                int64_t height,
+                                                int64_t width,
+                                                int64_t idx,
+                                                torch::Device device) {
+    std::string key = std::to_string(frame) + "_" + std::to_string(idx) + "_" +
+                      std::to_string(height) + "_" + std::to_string(width);
+
+    // TODO: currently the freqs tensors are cached on device
+    // need to check whether to swap them to cpu to save device memory
+    auto it = video_freqs_cache_.find(key);
+    if (it != video_freqs_cache_.end()) {
+      return it->second.clone().contiguous();
+    } else {
+      auto result = _compute_video_freqs(frame, height, width, idx, device);
+      video_freqs_cache_[key] = result.clone();
+      return result;
+    }
+  }
+
+  torch::Tensor _compute_condition_freqs_with_cache(int64_t frame,
+                                                    int64_t height,
+                                                    int64_t width,
+                                                    torch::Device device) {
+    std::string key = std::to_string(frame) + "_" + std::to_string(height) +
+                      "_" + std::to_string(width);
+
+    // TODO: currently the freqs tensors are cached on device
+    // need to check whether to swap them to cpu to save device memory
+    auto it = condition_cache_.find(key);
+    if (it != condition_cache_.end()) {
+      return it->second.clone().contiguous();
+    } else {
+      auto result = _compute_condition_freqs(frame, height, width, device);
+      condition_cache_[key] = result.clone();
+      return result;
+    }
+  }
+
+  std::unordered_map<std::string, torch::Tensor> video_freqs_cache_;
+  std::unordered_map<std::string, torch::Tensor> condition_cache_;
+};
+
+TORCH_MODULE(QwenEmbedLayer3DRopeWithCache);
+
+// A internel class that only register necessary modules for attention
+// implementation The attention forward shouldn't be implemented here, but in
+// processor classes
+// TODO: This class should be extracted from dit class and integrated into a
+// common class.
+class AttentionImpl : public torch::nn::Module {
+ public:
+  AttentionImpl(const ModelContext context,
+                int64_t query_dim,
+                std::optional<int64_t> cross_attention_dim = std::nullopt,
+                int64_t heads = 8,
+                std::optional<int64_t> kv_heads = std::nullopt,
+                int64_t dim_head = 64,
+                double dropout = 0.0,
+                bool bias = false,
+                const std::string& qk_norm = "",
+                const std::string& cross_attention_norm = "",
+                std::optional<int64_t> added_kv_proj_dim = std::nullopt,
+                bool added_proj_bias = true,
+                bool out_bias = true,
+                bool scale_qk = true,
+                bool only_cross_attention = false,
+                double eps = 1e-5,
+                double rescale_output_factor = 1.0,
+                bool residual_connection = false,
+                std::optional<int64_t> out_dim = std::nullopt,
+                std::optional<int64_t> out_context_dim = std::nullopt,
+                std::optional<bool> context_pre_only = std::nullopt,
+                bool pre_only = false,
+                bool elementwise_affine = true,
+                bool is_causal = false,
+                ProcessGroup* sp_group = nullptr)
+      : options_(context.get_tensor_options()),
+        heads_(heads),
+        bias_(bias),
+        out_bias_(out_bias),
+        added_proj_bias_(added_proj_bias),
+        sp_group_(sp_group) {
+    if (qk_norm == "layer_norm") {
+      layer_norm_q_ = register_module(
+          "norm_q",
+          torch::nn::LayerNorm(torch::nn::LayerNormOptions({dim_head})
+                                   .eps(eps)
+                                   .elementwise_affine(elementwise_affine)));
+      layer_norm_k_ = register_module(
+          "norm_k",
+          torch::nn::LayerNorm(torch::nn::LayerNormOptions({dim_head})
+                                   .eps(eps)
+                                   .elementwise_affine(elementwise_affine)));
+    } else if (qk_norm == "layer_norm_across_heads") {
+      // Lumina applies qk norm across all heads
+      CHECK(kv_heads.has_value())
+          << "qk_norm is set to: " + qk_norm + ", but get no kv_heads ";
+      layer_norm_q_ = register_module(
+          "norm_q",
+          torch::nn::LayerNorm(
+              torch::nn::LayerNormOptions({dim_head * heads}).eps(eps)));
+      layer_norm_k_ = register_module(
+          "norm_k",
+          torch::nn::LayerNorm(
+              torch::nn::LayerNormOptions({dim_head * kv_heads.value()})
+                  .eps(eps)));
+    } else if (qk_norm == "rms_norm") {
+      // Assuming you have an RMSNorm implementation
+      norm_q_ = register_module("norm_q", RMSNorm(dim_head, eps, true, false));
+      norm_k_ = register_module("norm_k", RMSNorm(dim_head, eps, true, false));
+    } else if (qk_norm == "rms_norm_across_heads") {
+      // LTX applies qk norm across all heads
+      CHECK(kv_heads.has_value())
+          << "qk_norm is set to: " + qk_norm + ", but get no kv_heads ";
+
+      norm_q_ = register_module("norm_q", RMSNorm(dim_head, eps, true, false));
+      norm_k_ = register_module(
+          "norm_k", RMSNorm(dim_head * kv_heads.value(), eps, true, false));
+    } else {
+      CHECK(qk_norm.empty()) << "unknown qk_norm: " + qk_norm +
+                                    ". Should be "
+                                    "'','layer_norm','rms_norm','layer_norm_"
+                                    "across_heads', 'rms_norm_across_heads'";
+    }
+
+    if (cross_attention_norm == "layer_norm") {
+      norm_cross_ = register_module(
+          "norm_cross",
+          torch::nn::LayerNorm(
+              torch::nn::LayerNormOptions({cross_attention_dim.value()})));
+    } else {
+      CHECK(cross_attention_norm.empty())
+          << "unknown cross_attention_norm: " + cross_attention_norm +
+                 ". Should be '', 'layer_norm'";
+    }
+
+    int64_t q_dim = out_dim.has_value() ? out_dim.value() : dim_head * heads;
+    int64_t kv_dim =
+        !kv_heads.has_value() ? q_dim : dim_head * kv_heads.value();
+    cross_attention_dim = cross_attention_dim.has_value()
+                              ? cross_attention_dim.value()
+                              : query_dim;
+    out_context_dim =
+        out_context_dim.has_value() ? out_context_dim.value() : query_dim;
+
+    xllm::dit::SpOptions q_sp_option;
+    xllm::dit::SpOptions kv_sp_option;
+    xllm::dit::LinearType linear_type = xllm::dit::LinearType::Default;
+    if (FLAGS_dit_sp_size > 1) {
+      q_sp_option = xllm::dit::SpOptions(/*head_num=*/heads,
+                                         /*head_dim=*/dim_head,
+                                         /*hidden_size=*/q_dim,
+                                         /*before_attention=*/true,
+                                         /*process_group=*/sp_group_);
+
+      kv_sp_option = xllm::dit::SpOptions(
+          /*head_num=*/kv_heads.has_value() ? kv_heads.value() : heads,
+          /*head_dim=*/dim_head,
+          /*hidden_size=*/kv_dim,
+          /*before_attention=*/true,
+          /*process_group=*/sp_group_);
+      linear_type = xllm::dit::LinearType::SequenceParallel;
+    }
+
+    auto q_linear =
+        layer::WeightTransposeAddMatmul(query_dim, q_dim, bias, options_);
+
+    to_q_ = register_module("q_linear",
+                            xllm::dit::DiTParallelLinear(std::move(q_linear),
+                                                         /*module_name=*/"to_q",
+                                                         linear_type,
+                                                         q_sp_option));
+
+    // Key-Value projections (if not only cross attention)
+    if (!only_cross_attention) {
+      auto k_linear = layer::WeightTransposeAddMatmul(
+          cross_attention_dim.value(), kv_dim, bias, options_);
+
+      to_k_ =
+          register_module("k_linear",
+                          xllm::dit::DiTParallelLinear(std::move(k_linear),
+                                                       /*module_name=*/"to_k",
+                                                       linear_type,
+                                                       kv_sp_option));
+
+      auto v_linear = layer::WeightTransposeAddMatmul(
+          cross_attention_dim.value(), kv_dim, bias, options_);
+
+      to_v_ =
+          register_module("v_linear",
+                          xllm::dit::DiTParallelLinear(std::move(v_linear),
+                                                       /*module_name=*/"to_v",
+                                                       linear_type,
+                                                       kv_sp_option));
+    }
+
+    if (added_kv_proj_dim.has_value()) {
+      auto add_k_linear = layer::WeightTransposeAddMatmul(
+          added_kv_proj_dim.value(), kv_dim, added_proj_bias, options_);
+
+      add_k_proj_ = register_module(
+          "add_k_linear",
+          xllm::dit::DiTParallelLinear(std::move(add_k_linear),
+                                       /*module_name=*/"add_k_proj",
+                                       linear_type,
+                                       kv_sp_option));
+
+      auto add_v_linear = layer::WeightTransposeAddMatmul(
+          added_kv_proj_dim.value(), kv_dim, added_proj_bias, options_);
+
+      add_v_proj_ = register_module(
+          "add_v_linear",
+          xllm::dit::DiTParallelLinear(std::move(add_v_linear),
+                                       /*module_name=*/"add_v_proj",
+                                       linear_type,
+                                       kv_sp_option));
+      if (context_pre_only.has_value()) {
+        auto add_q_linear = layer::WeightTransposeAddMatmul(
+            added_kv_proj_dim.value(), q_dim, added_proj_bias, options_);
+
+        add_q_proj_ = register_module(
+            "add_q_linear",
+            xllm::dit::DiTParallelLinear(std::move(add_q_linear),
+                                         /*module_name=*/"add_q_proj",
+                                         linear_type,
+                                         q_sp_option));
+      }
+    }
+
+    xllm::dit::SpOptions out_sp_option;
+    if (FLAGS_dit_sp_size > 1) {
+      out_sp_option = xllm::dit::SpOptions(/*head_num=*/heads,
+                                           /*head_dim=*/dim_head,
+                                           /*hidden_size=*/q_dim,
+                                           /*before_attention=*/false,
+                                           /*process_group=*/sp_group_);
+    }
+
+    // Output projections
+    if (!pre_only) {
+      to_out_ = register_module("to_out", torch::nn::Sequential());
+
+      auto to_out_linear = layer::WeightTransposeAddMatmul(
+          q_dim, out_dim.value(), out_bias, options_);
+
+      to_out_->push_back(xllm::dit::DiTParallelLinear(std::move(to_out_linear),
+                                                      /*module_name=*/"out",
+                                                      linear_type,
+                                                      out_sp_option));
+      to_out_->push_back(
+          torch::nn::Dropout(torch::nn::DropoutOptions(dropout)));
+    }
+
+    // Additional output for context
+    if (context_pre_only.has_value() && context_pre_only) {
+      auto to_add_out_linear = layer::WeightTransposeAddMatmul(
+          q_dim, out_context_dim.value(), out_bias, options_);
+
+      to_add_out_ = register_module(
+          "to_add_out_linear",
+          xllm::dit::DiTParallelLinear(std::move(to_add_out_linear),
+                                       /*module_name=*/"to_add_out",
+                                       linear_type,
+                                       out_sp_option));
+    }
+
+    // Added QK normalization for added KV projections
+    if (!qk_norm.empty() && added_kv_proj_dim.has_value()) {
+      if (qk_norm == "rms_norm") {
+        norm_added_q_ = register_module("norm_added_q",
+                                        RMSNorm(dim_head, eps, true, false));
+        norm_added_k_ = register_module("norm_added_k",
+                                        RMSNorm(dim_head, eps, true, false));
+      } else {
+        CHECK(qk_norm.empty()) << "unknown qk_norm: " + qk_norm +
+                                      ". Should be one of '','rms_norm'";
+        // For layer_norm, we would register similar layers here
+      }
+    }
+  }
+
+  void load_state_dict(const StateDict& state_dict) {
+    // to_out
+    to_out_[0]->as<xllm::dit::DiTParallelLinear>()->load_state_dict(
+        state_dict.get_dict_with_prefix("to_out.0."));
+    // to_add_out
+    to_add_out_->load_state_dict(
+        state_dict.get_dict_with_prefix("to_add_out."));
+    // norm_q
+    norm_q_->load_state_dict(state_dict.get_dict_with_prefix("norm_q."));
+    // norm_k
+    norm_k_->load_state_dict(state_dict.get_dict_with_prefix("norm_k."));
+    // norm_added_q
+    norm_added_q_->load_state_dict(
+        state_dict.get_dict_with_prefix("norm_added_q."));
+    // norm_added_k
+    norm_added_k_->load_state_dict(
+        state_dict.get_dict_with_prefix("norm_added_k."));
+
+    to_q_->load_state_dict(state_dict.get_dict_with_prefix("to_q."));
+    to_k_->load_state_dict(state_dict.get_dict_with_prefix("to_k."));
+    to_v_->load_state_dict(state_dict.get_dict_with_prefix("to_v."));
+
+    add_q_proj_->load_state_dict(
+        state_dict.get_dict_with_prefix("add_q_proj."));
+    add_k_proj_->load_state_dict(
+        state_dict.get_dict_with_prefix("add_k_proj."));
+    add_v_proj_->load_state_dict(
+        state_dict.get_dict_with_prefix("add_v_proj."));
+  }
+
+  void verify_loaded_weights(const std::string& prefix) {
+    // to_out
+    to_out_[0]->as<xllm::dit::DiTParallelLinear>()->verify_loaded_weights(
+        prefix + "to_out.0.");
+    // to_add_out
+    to_add_out_->verify_loaded_weights(prefix + "to_add_out.");
+    // norm_q
+    norm_q_->verify_loaded_weights(prefix + "norm_q.");
+    // norm_k
+    norm_k_->verify_loaded_weights(prefix + "norm_k.");
+    // norm_added_q
+    norm_added_q_->verify_loaded_weights(prefix + "norm_added_q.");
+    // norm_added_k
+    norm_added_k_->verify_loaded_weights(prefix + "norm_added_k.");
+
+    to_q_->verify_loaded_weights(prefix + "to_q.");
+    to_k_->verify_loaded_weights(prefix + "to_k.");
+    to_v_->verify_loaded_weights(prefix + "to_v.");
+
+    add_q_proj_->verify_loaded_weights(prefix + "add_q_proj.");
+    add_k_proj_->verify_loaded_weights(prefix + "add_k_proj.");
+    add_v_proj_->verify_loaded_weights(prefix + "add_v_proj.");
+  }
+
+ public:
+  int64_t heads_;
+  bool bias_;
+  bool out_bias_;
+  bool added_proj_bias_;
+  ProcessGroup* sp_group_;
+
+  torch::TensorOptions options_;
+  torch::nn::LayerNorm layer_norm_q_{nullptr}, layer_norm_k_{nullptr},
+      norm_cross_{nullptr};
+  xllm::dit::DiTParallelLinear to_q_{nullptr}, to_k_{nullptr}, to_v_{nullptr};
+  xllm::dit::DiTParallelLinear add_k_proj_{nullptr}, add_v_proj_{nullptr},
+      add_q_proj_{nullptr};
+  torch::nn::Sequential to_out_{nullptr};
+  xllm::dit::DiTParallelLinear to_add_out_{nullptr};
+
+  // Assuming you have RMSNorm implemented
+  RMSNorm norm_q_{nullptr}, norm_k_{nullptr}, norm_added_q_{nullptr},
+      norm_added_k_{nullptr};
+};
+TORCH_MODULE(Attention);
+
+// Implementation of attention forward
+class QwenDoubleStreamAttnProcessor2_0Impl : public torch::nn::Module {
+ public:
+  QwenDoubleStreamAttnProcessor2_0Impl(Attention&& attn_module,
+                                       const ParallelArgs& parallel_args)
+      : parallel_args_(parallel_args) {
+    attn_ = register_module("attn", std::move(attn_module));
+  }
+
+  virtual std::tuple<torch::Tensor, torch::Tensor> forward(
+      const torch::Tensor& hidden_states,          // Image stream
+      const torch::Tensor& encoder_hidden_states,  // Text stream
+      const torch::Tensor& encoder_hidden_states_mask = torch::Tensor(),
+      const torch::Tensor& attention_mask = torch::Tensor(),
+      const std::tuple<at::Tensor, at::Tensor>& image_rotary_emb = {}) {
+    // int64_t seq_txt = encoder_hidden_states.size(1);
+    // int64_t seq_img = hidden_states.size(1);
+    //  Compute QKV for image stream (sample projections)
+    auto img_query = attn_->to_q_->forward(hidden_states);
+    auto img_key = attn_->to_k_->forward(hidden_states);
+    auto img_value = attn_->to_v_->forward(hidden_states);
+
+    // Compute QKV for text stream (context projections)
+    auto txt_query = attn_->add_q_proj_->forward(encoder_hidden_states);
+    auto txt_key = attn_->add_k_proj_->forward(encoder_hidden_states);
+    auto txt_value = attn_->add_v_proj_->forward(encoder_hidden_states);
+
+    // Reshape for multi-head attention
+    int64_t heads = attn_->heads_;
+    auto reshape_dims = std::vector<int64_t>{heads / FLAGS_dit_sp_size, -1};
+
+    img_query = img_query.unflatten(-1, reshape_dims);
+    img_key = img_key.unflatten(-1, reshape_dims);
+    img_value = img_value.unflatten(-1, reshape_dims);
+    txt_query = txt_query.unflatten(-1, reshape_dims);
+    txt_key = txt_key.unflatten(-1, reshape_dims);
+    txt_value = txt_value.unflatten(-1, reshape_dims);
+    // Apply QK normalization
+    if (attn_->norm_q_) {
+      img_query = attn_->norm_q_->forward(img_query);
+    }
+    if (attn_->norm_k_) {
+      img_key = attn_->norm_k_->forward(img_key);
+    }
+    if (attn_->norm_added_q_) {
+      txt_query = attn_->norm_added_q_->forward(txt_query);
+    }
+    if (attn_->norm_added_k_) {
+      txt_key = attn_->norm_added_k_->forward(txt_key);
+    }
+
+    // Apply RoPE if provided
+    auto img_freqs = std::get<0>(image_rotary_emb);
+    auto txt_freqs = std::get<1>(image_rotary_emb);
+
+    xllm::dit::SequenceParallelPadManager::getInstance().unpad_tensor(
+        txt_query, /*tensor_name=*/"encoder_hidden_states", /*dim=*/1);
+    xllm::dit::SequenceParallelPadManager::getInstance().unpad_tensor(
+        txt_key, /*tensor_name=*/"encoder_hidden_states", /*dim=*/1);
+    xllm::dit::SequenceParallelPadManager::getInstance().unpad_tensor(
+        txt_value, /*tensor_name=*/"encoder_hidden_states", /*dim=*/1);
+
+    xllm::dit::SequenceParallelPadManager::getInstance().unpad_tensor(
+        img_query, /*tensor_name=*/"hidden_states", /*dim=*/1);
+    xllm::dit::SequenceParallelPadManager::getInstance().unpad_tensor(
+        img_key, /*tensor_name=*/"hidden_states", /*dim=*/1);
+    xllm::dit::SequenceParallelPadManager::getInstance().unpad_tensor(
+        img_value, /*tensor_name=*/"hidden_states", /*dim=*/1);
+
+    img_query = apply_rotary_emb_qwen(img_query, img_freqs, false);
+    img_key = apply_rotary_emb_qwen(img_key, img_freqs, false);
+    txt_query = apply_rotary_emb_qwen(txt_query, txt_freqs, false);
+    txt_key = apply_rotary_emb_qwen(txt_key, txt_freqs, false);
+
+    // Concatenate for joint attention - Order: [text, image]
+    auto joint_query = torch::cat({txt_query, img_query}, 1);
+    auto joint_key = torch::cat({txt_key, img_key}, 1);
+    auto joint_value = torch::cat({txt_value, img_value}, 1);
+
+    auto results = at_npu::native::custom_ops::npu_fusion_attention(
+        joint_query,
+        joint_key,
+        joint_value,
+        heads / FLAGS_dit_sp_size,
+        /*input_layout=*/"BSND",
+        /*pse=*/torch::nullopt,
+        /*padding_mask=*/torch::nullopt,
+        /*atten_mask*/ torch::nullopt,
+        /*scale=*/pow(joint_query.size(3), -0.5),
+        /*keep_prob=*/1.0,
+        /*pre_tockens=*/65535,
+        /*next_tockens=*/65535);
+
+    auto joint_hidden_states = std::get<0>(results);
+    // Reshape back
+    joint_hidden_states = joint_hidden_states.flatten(2, 3);
+    joint_hidden_states = joint_hidden_states.to(joint_query.dtype());
+
+    int64_t seq_txt = txt_query.size(1);
+    int64_t seq_img = img_query.size(1);
+    // Split attention outputs back
+    auto chunks = torch::split(joint_hidden_states, {seq_txt, seq_img}, 1);
+    auto txt_attn_output = chunks[0];
+    auto img_attn_output = chunks[1];
+
+    txt_attn_output =
+        xllm::dit::SequenceParallelPadManager::getInstance().pad_tensor(
+            txt_attn_output,
+            /*tensor_name=*/"encoder_hidden_states",
+            /*dim=*/1);
+
+    img_attn_output =
+        xllm::dit::SequenceParallelPadManager::getInstance().pad_tensor(
+            img_attn_output, /*tensor_name=*/"hidden_states", /*dim=*/1);
+
+    // Apply output projections
+    img_attn_output = attn_->to_out_->forward(img_attn_output);
+
+    txt_attn_output = attn_->to_add_out_->forward(txt_attn_output);
+    return std::make_tuple(img_attn_output, txt_attn_output);
+  }
+
+  void load_state_dict(const StateDict& state_dict) {
+    attn_->load_state_dict(state_dict);
+  }
+
+  void verify_loaded_weights(const std::string& prefix) {
+    attn_->verify_loaded_weights(prefix);
+  }
+
+ protected:
+  Attention attn_{nullptr};
+  const ParallelArgs parallel_args_;
+};
+TORCH_MODULE(QwenDoubleStreamAttnProcessor2_0);
+
+class FeedForwardImpl : public torch::nn::Module {
+ public:
+  explicit FeedForwardImpl(const ModelContext& context,
+                           int64_t dim,
+                           int64_t dim_out,
+                           int64_t mult = 4,
+                           double dropout = 0.0)
+      : options_(context.get_tensor_options()) {
+    auto model_args = context.get_model_args();
+    auto inner_dim = dim * 4;
+
+    // linear1
+    linear1_ = register_module(
+        "linear1",
+        layer::WeightTransposeAddMatmul(dim, inner_dim, true, options_));
+
+    // activation
+    activation_ = register_module(
+        "activation",
+        torch::nn::Functional(std::function<at::Tensor(const at::Tensor&)>(
+            [](const at::Tensor& x) { return torch::gelu(x, "tanh"); })));
+
+    // linear2
+    linear2_ = register_module(
+        "linear2",
+        layer::WeightTransposeAddMatmul(inner_dim, dim_out, true, options_));
+  }
+
+  torch::Tensor forward(const torch::Tensor& hidden_states) {
+    torch::Tensor out = linear1_->forward(hidden_states);
+    out = activation_(out);
+    out = linear2_->forward(out);
+    return out;
+  }
+
+  void load_state_dict(const StateDict& state_dict) {
+    // linear1
+    linear1_->load_state_dict(state_dict.get_dict_with_prefix("net.0.proj."));
+    // linear2
+    linear2_->load_state_dict(state_dict.get_dict_with_prefix("net.2."));
+  }
+
+  void verify_loaded_weights(const std::string& prefix) {
+    linear1_->verify_loaded_weights(prefix + "net.0.proj.");
+    linear2_->verify_loaded_weights(prefix + "net.2.");
+  }
+
+ private:
+  layer::WeightTransposeAddMatmul linear1_{nullptr};
+  layer::WeightTransposeAddMatmul linear2_{nullptr};
+  torch::nn::Functional activation_{nullptr};
+  torch::TensorOptions options_;
+};
+TORCH_MODULE(FeedForward);
+
+bool ADALN_FUSE = true;
+
+class QwenImageTransformerBlockImpl : public torch::nn::Module {
+ public:
+  QwenImageTransformerBlockImpl(const ModelContext& context,
+                                int64_t dim,
+                                int64_t num_attention_heads,
+                                int64_t attention_head_dim,
+                                const ParallelArgs& parallel_args,
+                                bool zero_cond_t = false,
+                                const std::string& qk_norm = "rms_norm",
+                                double eps = 1e-6)
+      : options_(context.get_tensor_options()),
+        zero_cond_t_(zero_cond_t),
+        parallel_args_(parallel_args) {
+    // Image processing modules
+    img_mod_ = register_module(
+        "img_mod",
+        torch::nn::Sequential(
+            torch::nn::SiLU(),
+            layer::WeightTransposeAddMatmul(dim, 6 * dim, true, options_)));
+
+    // Image normalization
+    img_norm1_ = register_module("img_norm1", AdaLayerNorm(context, dim, eps));
+    // Attention module
+    auto attn_ = Attention(context,
+                           /*query_dim=*/dim,
+                           /*cross_attention_dim=*/std::nullopt,
+                           /*heads=*/num_attention_heads,
+                           /*kv_heads=*/std::nullopt,
+                           /*dim_head=*/attention_head_dim,
+                           /*drop_out=*/0.0,
+                           /*bias=*/true,
+                           /*qk_norm=*/qk_norm,
+                           /*cross_attention_norm=*/"",
+                           /*added_kv_proj_dim=*/dim,
+                           /*added_proj_bias*/ true,
+                           /*out_bias*/ true,
+                           /*scale_qk*/ true,
+                           /*only_cross_attention=*/false,
+                           eps,
+                           /*rescale_output_factor=*/1.0,
+                           /*residual_connection=*/false,
+                           /*out_dim=*/dim,
+                           /*out_context_dim=*/std::nullopt,
+                           /*context_pre_only=*/true,
+                           /*pre_only=*/false,
+                           /*elementwise_affine=*/true,
+                           /*is_causal=*/false,
+                           /*sp_group=*/parallel_args_.dit_sp_group_);
+    attn_processor_ = register_module(
+        "attn_processor_",
+        QwenDoubleStreamAttnProcessor2_0(std::move(attn_), parallel_args_));
+    // Image normalization 2
+    img_norm2_ = register_module("img_norm2", AdaLayerNorm(context, dim, eps));
+
+    // Image MLP
+    img_mlp_ = register_module("img_mlp", FeedForward(context, dim, dim));
+
+    // Text processing modules
+    txt_mod_ = register_module(
+        "txt_mod",
+        torch::nn::Sequential(
+            torch::nn::SiLU(),
+            layer::WeightTransposeAddMatmul(dim, 6 * dim, true, options_)));
+
+    // Text normalization 1
+    txt_norm1_ = register_module("txt_norm1", AdaLayerNorm(context, dim, eps));
+
+    // Text normalization 2
+    txt_norm2_ = register_module("txt_norm2", AdaLayerNorm(context, dim, eps));
+
+    // Text MLP
+    txt_mlp_ = register_module("txt_mlp", FeedForward(context, dim, dim));
+  }
+
+  std::pair<torch::Tensor, torch::Tensor> _modulate(
+      const torch::Tensor& x,
+      const torch::Tensor& mod_params,
+      const torch::Tensor& index = torch::Tensor()) {
+    // x: b l d, shift: b d, scale: b d, gate: b d
+    auto chunks = mod_params.chunk(3, -1);
+    auto shift = chunks[0];
+    auto scale = chunks[1];
+    auto gate = chunks[2];
+
+    torch::Tensor shift_result, scale_result, gate_result;
+
+    if (index.defined()) {
+      // Assuming mod_params batch dim is 2*actual_batch (chunked into 2 parts)
+      // So shift, scale, gate have shape [2*actual_batch, d]
+      int64_t actual_batch = shift.size(0) / 2;
+
+      // Split into two parts
+      auto shift_0 = shift.slice(0, 0, actual_batch);
+      auto shift_1 = shift.slice(0, actual_batch, shift.size(0));
+
+      auto scale_0 = scale.slice(0, 0, actual_batch);
+      auto scale_1 = scale.slice(0, actual_batch, scale.size(0));
+
+      auto gate_0 = gate.slice(0, 0, actual_batch);
+      auto gate_1 = gate.slice(0, actual_batch, gate.size(0));
+
+      // index: [b, l] where b is actual batch size
+      // Expand to [b, l, 1] to match feature dimension
+      auto index_expanded = index.unsqueeze(-1);  // [b, l, 1]
+
+      // Expand chunks to [b, 1, d] then broadcast to [b, l, d]
+      auto shift_0_exp = shift_0.unsqueeze(1);  // [b, 1, d]
+      auto shift_1_exp = shift_1.unsqueeze(1);  // [b, 1, d]
+      auto scale_0_exp = scale_0.unsqueeze(1);
+      auto scale_1_exp = scale_1.unsqueeze(1);
+      auto gate_0_exp = gate_0.unsqueeze(1);
+      auto gate_1_exp = gate_1.unsqueeze(1);
+
+      // Use torch::where to select based on index
+      shift_result =
+          torch::where(index_expanded == 0, shift_0_exp, shift_1_exp);
+      scale_result =
+          torch::where(index_expanded == 0, scale_0_exp, scale_1_exp);
+      gate_result = torch::where(index_expanded == 0, gate_0_exp, gate_1_exp);
+    } else {
+      shift_result = shift.unsqueeze(1);
+      scale_result = scale.unsqueeze(1);
+      gate_result = gate.unsqueeze(1);
+    }
+
+    // Apply modulation: x * (1 + scale_result) + shift_result
+    auto modulated_x = x * (1 + scale_result) + shift_result;
+
+    return {modulated_x, gate_result};
+  }
+
+  std::tuple<torch::Tensor, torch::Tensor> forward(
+      const torch::Tensor& hidden_states,
+      const torch::Tensor& encoder_hidden_states,
+      const torch::Tensor& encoder_hidden_states_mask,
+      const torch::Tensor& temb,
+      const std::tuple<torch::Tensor, torch::Tensor>& image_rotary_emb = {},
+      const std::unordered_map<std::string, torch::Tensor>&
+          joint_attention_kwargs = {},
+      const torch::Tensor& modulate_index = torch::Tensor()) {
+    // Get modulation parameters for both streams
+    auto img_mod_params = img_mod_->forward(temb);  // [B, 6*dim]
+    torch::Tensor new_temb;
+    if (zero_cond_t_) {
+      new_temb = temb.chunk(2, 0)[0];
+    } else {
+      new_temb = temb;
+    }
+    auto txt_mod_params = txt_mod_->forward(new_temb);  // [B, 6*dim]
+    //  Split modulation parameters for norm1 and norm2
+    auto img_mod_chunks = img_mod_params.chunk(2, -1);
+    auto img_mod1 = img_mod_chunks[0];  // [B, 3*dim]
+    auto img_mod2 = img_mod_chunks[1];  // [B, 3*dim]
+
+    auto txt_mod_chunks = txt_mod_params.chunk(2, -1);
+    auto txt_mod1 = txt_mod_chunks[0];  // [B, 3*dim]
+    auto txt_mod2 = txt_mod_chunks[1];  // [B, 3*dim]
+
+    // Process image stream - norm1 + modulation
+    torch::Tensor img_modulated, img_gate1;
+    std::tie(img_modulated, img_gate1) =
+        img_norm1_->forward(hidden_states, img_mod1, modulate_index);
+    //  Process text stream - norm1 + modulation
+    torch::Tensor txt_modulated, txt_gate1;
+    std::tie(txt_modulated, txt_gate1) =
+        txt_norm1_->forward(encoder_hidden_states, txt_mod1);
+
+    // Use QwenAttnProcessor2_0 for joint attention computation
+    auto attn_output = attn_processor_->forward(img_modulated,  // Image stream
+                                                txt_modulated,  // Text stream
+                                                encoder_hidden_states_mask,
+                                                torch::Tensor(),  // timestep
+                                                image_rotary_emb);
+
+    // QwenAttnProcessor2_0 returns (img_output, txt_output)
+    auto img_attn_output = std::get<0>(attn_output);
+    auto txt_attn_output = std::get<1>(attn_output);
+
+    //  Apply attention gates and add residual
+    auto new_hidden_states = hidden_states + img_gate1 * img_attn_output;
+    auto new_encoder_hidden_states =
+        encoder_hidden_states + txt_gate1 * txt_attn_output;
+
+    // Process image stream - norm2 + MLP
+    torch::Tensor img_modulated2, img_gate2;
+    std::tie(img_modulated2, img_gate2) =
+        img_norm2_->forward(new_hidden_states, img_mod2, modulate_index);
+
+    auto img_mlp_output = img_mlp_->forward(img_modulated2);
+    new_hidden_states = new_hidden_states + img_gate2 * img_mlp_output;
+
+    // Process text stream - norm2 + MLP
+    torch::Tensor txt_modulated2, txt_gate2;
+    std::tie(txt_modulated2, txt_gate2) =
+        txt_norm2_->forward(new_encoder_hidden_states, txt_mod2);
+
+    auto txt_mlp_output = txt_mlp_->forward(txt_modulated2);
+    new_encoder_hidden_states =
+        new_encoder_hidden_states + txt_gate2 * txt_mlp_output;
+
+    //  Clip to prevent overflow for fp16
+    if (new_encoder_hidden_states.dtype() == torch::kFloat16) {
+      new_encoder_hidden_states =
+          new_encoder_hidden_states.clamp(-65504, 65504);
+    }
+    if (new_hidden_states.dtype() == torch::kFloat16) {
+      new_hidden_states = new_hidden_states.clamp(-65504, 65504);
+    }
+
+    return std::make_tuple(new_hidden_states, new_encoder_hidden_states);
+  }
+
+  void load_state_dict(const StateDict& state_dict) {
+    img_mod_[1]->as<layer::WeightTransposeAddMatmul>()->load_state_dict(
+        state_dict.get_dict_with_prefix("img_mod.1."));
+    img_mlp_->load_state_dict(state_dict.get_dict_with_prefix("img_mlp."));
+    txt_mod_[1]->as<layer::WeightTransposeAddMatmul>()->load_state_dict(
+        state_dict.get_dict_with_prefix("txt_mod.1."));
+    txt_mlp_->load_state_dict(state_dict.get_dict_with_prefix("txt_mlp."));
+    attn_processor_->load_state_dict(state_dict.get_dict_with_prefix("attn."));
+  }
+
+  void verify_loaded_weights(const std::string& prefix) {
+    img_mod_[1]->as<layer::WeightTransposeAddMatmul>()->verify_loaded_weights(
+        prefix + "img_mod.1.");
+    img_mlp_->verify_loaded_weights(prefix + "img_mlp.");
+    txt_mod_[1]->as<layer::WeightTransposeAddMatmul>()->verify_loaded_weights(
+        prefix + "txt_mod.1.");
+    txt_mlp_->verify_loaded_weights(prefix + "txt_mlp.");
+    attn_processor_->verify_loaded_weights(prefix + "attn.");
+  }
+
+ private:
+  torch::TensorOptions options_;
+  torch::nn::Sequential img_mod_{nullptr};
+  AdaLayerNorm img_norm1_{nullptr};
+  AdaLayerNorm img_norm2_{nullptr};
+  std::shared_ptr<Attention> attn_{nullptr};
+  QwenDoubleStreamAttnProcessor2_0 attn_processor_{nullptr};
+  FeedForward img_mlp_{nullptr};
+
+  torch::nn::Sequential txt_mod_{nullptr};
+  AdaLayerNorm txt_norm1_{nullptr};
+  AdaLayerNorm txt_norm2_{nullptr};
+  FeedForward txt_mlp_{nullptr};
+  bool zero_cond_t_;
+  const ParallelArgs parallel_args_;
+};
+
+TORCH_MODULE(QwenImageTransformerBlock);
+
+class QwenImageTransformer2DModelImpl : public torch::nn::Module {
+ public:
+  QwenImageTransformer2DModelImpl(const ModelContext& context,
+                                  const ParallelArgs& parallel_args)
+      : options_(context.get_tensor_options()), parallel_args_(parallel_args) {
+    auto model_args = context.get_model_args();
+    int64_t num_attention_heads = model_args.n_heads();
+    int64_t attention_head_dim = model_args.head_dim();
+    int64_t joint_attention_dim = model_args.joint_attention_dim();
+    std::vector<int64_t> axes_dims_rope = model_args.axes_dims_rope();
+    int64_t num_layers = model_args.num_layers();
+    int64_t patch_size = model_args.mm_patch_size();
+    int64_t in_channels = model_args.in_channels();
+    int64_t out_channels = model_args.out_channels();
+    bool zero_cond_t = model_args.zero_cond_t();
+    bool use_additional_t_cond = model_args.use_additional_t_cond();
+    use_layer3d_rope_ = model_args.use_layer3d_rope();
+
+    out_channels = (out_channels > 0) ? out_channels : in_channels;
+    auto inner_dim = num_attention_heads * attention_head_dim;
+
+    // Positional embedding
+    if (use_layer3d_rope_) {
+      pos_embed_3d_rope_ = register_module(
+          "pos_embed",
+          QwenEmbedLayer3DRope(context, /*theta=*/10000, axes_dims_rope, true));
+    } else {
+      pos_embed_ = register_module(
+          "pos_embed",
+          QwenEmbedRope(context, /*theta=*/10000, axes_dims_rope, true));
+    }
+
+    // Time-text embedding
+    time_text_embed_ = register_module(
+        "time_text_embed",
+        QwenTimestepProjEmbeddings(context, inner_dim, use_additional_t_cond));
+
+    // Text normalization
+    txt_norm_ = register_module(
+        "txt_norm", RMSNorm(joint_attention_dim, 1e-6, true, false));
+
+    // Input projections
+    img_in_ = register_module("img_in",
+                              layer::WeightTransposeAddMatmul(
+                                  in_channels, inner_dim, true, options_));
+    txt_in_ =
+        register_module("txt_in",
+                        layer::WeightTransposeAddMatmul(
+                            joint_attention_dim, inner_dim, true, options_));
+    // Transformer blocks
+    transformer_blocks_ =
+        register_module("transformer_blocks", torch::nn::ModuleList());
+    for (int64_t i = 0; i < num_layers; ++i) {
+      transformer_blocks_->push_back(
+          QwenImageTransformerBlock(context,
+                                    inner_dim,
+                                    num_attention_heads,
+                                    attention_head_dim,
+                                    parallel_args_,
+                                    zero_cond_t));
+    }
+
+    // Output layers
+    norm_out_ = register_module(
+        "norm_out",
+        AdaLayerNormContinuous(context, inner_dim, inner_dim, false, 1e-6));
+    proj_out_ = register_module(
+        "proj_out",
+        layer::WeightTransposeAddMatmul(
+            inner_dim, patch_size * patch_size * out_channels, true, options_));
+
+    // Cache for conditional and unconditional
+    cache_cond_ = false;
+    cache_uncond_ = false;
+
+    zero_cond_t_ = zero_cond_t;
+  }
+  torch::Tensor forward(
+      const torch::Tensor& hidden_states,
+      const torch::Tensor& encoder_hidden_states = torch::Tensor(),
+      const torch::Tensor& encoder_hidden_states_mask = torch::Tensor(),
+      torch::Tensor timestep = torch::Tensor(),
+      std::vector<std::vector<int64_t>> img_shapes = {},
+      torch::Tensor txt_seq_lens = torch::Tensor(),
+      bool use_cfg = false,
+      int64_t step_idx = 0,
+      torch::Tensor addition_t_cond = torch::Tensor(),
+      torch::Tensor guidance = torch::Tensor(),
+      const std::unordered_map<std::string, torch::Tensor>& attention_kwargs =
+          {},
+      const std::vector<torch::Tensor>& controlnet_block_samples = {}) {
+    auto new_hidden_states = img_in_->forward(hidden_states);
+    auto new_timestep = timestep.to(new_hidden_states.dtype());
+    torch::Tensor modulate_index;
+    if (zero_cond_t_) {
+      new_timestep = torch::cat({new_timestep, new_timestep * 0}, /*dim=*/0);
+      std::vector<torch::Tensor> modulate_index_list;
+      for (size_t sample_index = 0; sample_index < 1; sample_index++) {
+        auto zero_prods = torch::zeros({img_shapes[0][1] * img_shapes[0][2]},
+                                       torch::TensorOptions()
+                                           .device(new_timestep.device())
+                                           .dtype(torch::kInt64));
+        int64_t one_prods_size = 0;
+        for (size_t index = 1; index < img_shapes.size(); index++) {
+          one_prods_size += img_shapes[index][1] * img_shapes[index][2];
+        }
+        auto ones_prods = torch::ones({one_prods_size},
+                                      torch::TensorOptions()
+                                          .device(new_timestep.device())
+                                          .dtype(torch::kInt64));
+        modulate_index_list.emplace_back(
+            torch::cat({zero_prods, ones_prods}, /*dim=*/0));
+      }
+      modulate_index = torch::stack(modulate_index_list, /*dim=*/0);
+    } else {
+      modulate_index = torch::Tensor();
+    }
+
+    auto origin_text_seq_len = encoder_hidden_states.size(1);
+
+    // padding mask for sequence parallel scene
+    auto padded_encoder_hidden_states_mask =
+        xllm::dit::SequenceParallelPadManager::getInstance().pad_tensor(
+            encoder_hidden_states_mask,
+            /*tensor_name=*/"encoder_hidden_states_mask",
+            /*dim=*/1);
+
+    auto new_encoder_hidden_states =
+        xllm::dit::SequenceParallelPadManager::getInstance().pad_tensor(
+            encoder_hidden_states,
+            /*tensor_name=*/"encoder_hidden_states",
+            /*dim=*/1);
+
+    new_hidden_states =
+        xllm::dit::SequenceParallelPadManager::getInstance().pad_tensor(
+            new_hidden_states, /*tensor_name=*/"hidden_states", /*dim=*/1);
+
+    modulate_index =
+        xllm::dit::SequenceParallelPadManager::getInstance().pad_tensor(
+            modulate_index, /*tensor_name=*/"modulate_index", /*dim=*/1);
+
+    new_encoder_hidden_states = txt_norm_->forward(new_encoder_hidden_states);
+    new_encoder_hidden_states = txt_in_->forward(new_encoder_hidden_states);
+
+    // Use the encoder_hidden_states sequence length for RoPE computation and
+    // normalize mask
+    auto [text_seq_len, per_sample_len, new_encoder_hidden_states_mask] =
+        compute_text_seq_len_from_mask(new_encoder_hidden_states,
+                                       padded_encoder_hidden_states_mask);
+    auto temb = time_text_embed_->forward(
+        new_timestep, new_hidden_states, addition_t_cond);
+    std::tuple<torch::Tensor, torch::Tensor> image_rotary_emb;
+    if (use_layer3d_rope_) {
+      image_rotary_emb = pos_embed_3d_rope_->forward(
+          img_shapes, origin_text_seq_len, new_hidden_states.device());
+    } else {
+      image_rotary_emb = pos_embed_->forward(img_shapes,
+                                             origin_text_seq_len,
+                                             new_hidden_states.device(),
+                                             /*max_txt_seq_len=*/std::nullopt);
+    }
+
+    std::unordered_map<std::string, torch::Tensor> block_attention_kwargs;
+    if (new_encoder_hidden_states_mask.has_value() &&
+        new_encoder_hidden_states_mask.value().defined()) {
+      int64_t batch_size = new_hidden_states.size(0);
+      int64_t image_seq_len = new_hidden_states.size(1);
+      auto image_mask = torch::ones({batch_size, image_seq_len},
+                                    torch::TensorOptions()
+                                        .device(new_hidden_states.device())
+                                        .dtype(torch::kBool));
+      auto joint_attention_mask = torch::cat(
+          {new_encoder_hidden_states_mask.value(), image_mask}, /*dim=*/1);
+      block_attention_kwargs["attention_mask"] = joint_attention_mask;
+    }
+
+    if (FLAGS_dit_sp_size > 1) {
+      new_hidden_states = split_sequence(new_hidden_states,
+                                         /*dim=*/1,
+                                         parallel_args_.dit_sp_group_);
+      new_encoder_hidden_states = split_sequence(new_encoder_hidden_states,
+                                                 /*dim=*/1,
+                                                 parallel_args_.dit_sp_group_);
+      if (modulate_index.defined()) {
+        modulate_index = split_sequence(modulate_index,
+                                        /*dim=*/1,
+                                        parallel_args_.dit_sp_group_);
+      }
+    }
+
+    auto image_rot = std::get<0>(image_rotary_emb);
+    auto txt_rot = std::get<1>(image_rotary_emb);
+
+    bool use_step_cache = false;
+    bool use_block_cache = false;
+
+    torch::Tensor original_hidden_states = new_hidden_states;
+    torch::Tensor original_encoder_hidden_states = new_encoder_hidden_states;
+    // Step start: prepare inputs (hidden_states, original_hidden_states)
+    TensorMap step_in_map = {
+        {"hidden_states", new_hidden_states},
+        {"original_hidden_states", original_hidden_states}};
+    CacheStepIn stepin_before(step_idx, step_in_map);
+    use_step_cache =
+        DiTCache::get_instance().on_before_step(stepin_before, use_cfg);
+
+    if (!use_step_cache) {
+      for (int64_t index_block = 0; index_block < transformer_blocks_->size();
+           ++index_block) {
+        TensorMap block_in_before_map = {};
+        CacheBlockIn blockin_before(index_block, block_in_before_map);
+        use_block_cache =
+            DiTCache::get_instance().on_before_block(blockin_before, use_cfg);
+
+        if (!use_block_cache) {
+          std::tie(new_hidden_states, new_encoder_hidden_states) =
+              transformer_blocks_[index_block]
+                  ->as<QwenImageTransformerBlock>()
+                  ->forward(new_hidden_states,
+                            new_encoder_hidden_states,
+                            /*encoder_hidden_states_mask=*/torch::Tensor(),
+                            temb,
+                            image_rotary_emb,
+                            block_attention_kwargs,
+                            modulate_index);
+        }
+
+        TensorMap block_in_after_map = {
+            {"hidden_states", new_hidden_states},
+            {"encoder_hidden_states", new_encoder_hidden_states},
+            {"original_hidden_states", original_hidden_states},
+            {"original_encoder_hidden_states", original_encoder_hidden_states}};
+        CacheBlockIn blockin_after(index_block, block_in_after_map);
+        CacheBlockOut blockout_after =
+            DiTCache::get_instance().on_after_block(blockin_after, use_cfg);
+
+        new_hidden_states = blockout_after.tensors.at("hidden_states");
+        new_encoder_hidden_states =
+            blockout_after.tensors.at("encoder_hidden_states");
+      }
+    }
+
+    // Step end: update outputs (hidden_states, original_hidden_states)
+    TensorMap step_after_map = {
+        {"hidden_states", new_hidden_states},
+        {"original_hidden_states", original_hidden_states}};
+    CacheStepIn stepin_after(step_idx, step_after_map);
+    CacheStepOut stepout_after =
+        DiTCache::get_instance().on_after_step(stepin_after, use_cfg);
+    new_hidden_states = stepout_after.tensors.at("hidden_states");
+
+    if (zero_cond_t_) {
+      temb = temb.chunk(2, 0)[0];
+    }
+
+    new_hidden_states = norm_out_->forward(new_hidden_states, temb);
+    new_hidden_states = proj_out_->forward(new_hidden_states);
+    if (FLAGS_dit_sp_size > 1) {
+      new_hidden_states = gather_sequence(
+          new_hidden_states, /*dim=*/1, parallel_args_.dit_sp_group_);
+    }
+    return new_hidden_states;
+  }
+
+  void verify_loaded_weights(const std::string& prefix) {
+    time_text_embed_->verify_loaded_weights(prefix + "time_text_embed.");
+    txt_norm_->verify_loaded_weights(prefix + "txt_norm.");
+    img_in_->verify_loaded_weights(prefix + "img_in.");
+    txt_in_->verify_loaded_weights(prefix + "txt_in.");
+    norm_out_->verify_loaded_weights(prefix + "norm_out.");
+    proj_out_->verify_loaded_weights(prefix + "proj_out.");
+    for (size_t i = 0; i < transformer_blocks_->size(); i++) {
+      auto block_prefix = "transformer_blocks." + std::to_string(i) + ".";
+      transformer_blocks_[i]
+          ->as<QwenImageTransformerBlock>()
+          ->verify_loaded_weights(prefix + block_prefix);
+    }
+  }
+
+  void load_model(std::unique_ptr<DiTFolderLoader> loader) {
+    for (const auto& state_dict : loader->get_state_dicts()) {
+      time_text_embed_->load_state_dict(
+          state_dict->get_dict_with_prefix("time_text_embed."));
+      txt_norm_->load_state_dict(state_dict->get_dict_with_prefix("txt_norm."));
+
+      img_in_->load_state_dict(state_dict->get_dict_with_prefix("img_in."));
+      txt_in_->load_state_dict(state_dict->get_dict_with_prefix("txt_in."));
+
+      norm_out_->load_state_dict(state_dict->get_dict_with_prefix("norm_out."));
+      proj_out_->load_state_dict(state_dict->get_dict_with_prefix("proj_out."));
+
+      for (size_t i = 0; i < transformer_blocks_->size(); i++) {
+        auto prefix = "transformer_blocks." + std::to_string(i) + ".";
+        transformer_blocks_[i]
+            ->as<QwenImageTransformerBlock>()
+            ->load_state_dict(state_dict->get_dict_with_prefix(prefix));
+      }
+    }
+    verify_loaded_weights("");
+    LOG(INFO) << "qwen image vae model loaded successfully.";
+  }
+
+ private:
+  torch::TensorOptions options_;
+  QwenEmbedRope pos_embed_{nullptr};
+  QwenEmbedLayer3DRope pos_embed_3d_rope_{nullptr};
+  QwenTimestepProjEmbeddings time_text_embed_{nullptr};
+  RMSNorm txt_norm_{nullptr};
+  layer::WeightTransposeAddMatmul img_in_{nullptr};
+  layer::WeightTransposeAddMatmul txt_in_{nullptr};
+  torch::nn::ModuleList transformer_blocks_{nullptr};
+  AdaLayerNormContinuous norm_out_{nullptr};
+  layer::WeightTransposeAddMatmul proj_out_{nullptr};
+
+  const ParallelArgs parallel_args_;
+
+  // Cache objects
+  bool cache_cond_;
+  bool cache_uncond_;
+
+  bool zero_cond_t_;
+  bool use_layer3d_rope_;
+};
+
+TORCH_MODULE(QwenImageTransformer2DModel);
+
+REGISTER_MODEL_ARGS(QwenImageTransformer2DModel, [&] {
+  // qwen-image 2509 params
+  LOAD_ARG_OR(dtype, "dtype", "bfloat16");
+  LOAD_ARG_OR(in_channels, "in_channels", 64);
+  LOAD_ARG_OR(out_channels, "out_channels", 16);
+  LOAD_ARG_OR(num_layers, "num_layers", 60);
+  LOAD_ARG_OR(num_single_layers, "num_single_layers", 24);
+  LOAD_ARG_OR(head_dim, "attention_head_dim", 128);
+  LOAD_ARG_OR(n_heads, "num_attention_heads", 24);
+  LOAD_ARG_OR(joint_attention_dim, "joint_attention_dim", 3584);
+  LOAD_ARG_OR(mm_patch_size, "patch_size", 2);
+  LOAD_ARG_OR(guidance_embeds, "guidance_embeds", false);
+  LOAD_ARG_OR(
+      axes_dims_rope, "axes_dims_rope", (std::vector<int64_t>{16, 56, 56}));
+
+  // qwen-image 2511 params
+  LOAD_ARG_OR(zero_cond_t, "zero_cond_t", false);
+  LOAD_ARG_OR(use_additional_t_cond, "use_additional_t_cond", false);
+  LOAD_ARG_OR(use_layer3d_rope, "use_layer3d_rope", false);
+});
+
+}  // namespace qwenimage
+}  // namespace xllm::dit::npu

--- a/xllm/models/dit/utils/common_util.h
+++ b/xllm/models/dit/utils/common_util.h
@@ -1,0 +1,240 @@
+/* Copyright 2026 The xLLM Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://github.com/jd-opensource/xllm/blob/main/LICENSE
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+#pragma once
+
+#include <torch/torch.h>
+
+#include "models/dit/flowmatch_euler_discrete_scheduler.h"
+
+namespace xllm::dit {
+
+float calculate_shift(int64_t image_seq_len,
+                      int64_t base_seq_len = 256,
+                      int64_t max_seq_len = 4096,
+                      float base_shift = 0.5f,
+                      float max_shift = 1.15f) {
+  float m =
+      (max_shift - base_shift) / static_cast<float>(max_seq_len - base_seq_len);
+  float b = base_shift - m * static_cast<float>(base_seq_len);
+  float mu = static_cast<float>(image_seq_len) * m + b;
+  return mu;
+}
+
+std::pair<torch::Tensor, int64_t> retrieve_timesteps(
+    xllm::FlowMatchEulerDiscreteScheduler scheduler,
+    int64_t num_inference_steps = 0,
+    torch::Device device = torch::kCPU,
+    std::optional<std::vector<float>> sigmas = std::nullopt,
+    std::optional<float> mu = std::nullopt) {
+  torch::Tensor scheduler_timesteps;
+  int64_t steps;
+  if (sigmas.has_value()) {
+    steps = sigmas->size();
+    scheduler->set_timesteps(
+        static_cast<int64_t>(steps), device, *sigmas, mu, std::nullopt);
+
+    scheduler_timesteps = scheduler->timesteps();
+  } else {
+    steps = num_inference_steps;
+    scheduler->set_timesteps(
+        static_cast<int64_t>(steps), device, std::nullopt, mu, std::nullopt);
+    scheduler_timesteps = scheduler->timesteps();
+  }
+  if (scheduler_timesteps.device() != device) {
+    scheduler_timesteps = scheduler_timesteps.to(device);
+  }
+  return {scheduler_timesteps, steps};
+}
+
+std::pair<int64_t, int64_t> calculate_dimensions(double target_area,
+                                                 double ratio) {
+  double width = std::sqrt(target_area * ratio);
+  double height = width / ratio;
+
+  width = std::round(width / 32) * 32;
+  height = std::round(height / 32) * 32;
+
+  return {static_cast<int64_t>(width), static_cast<int64_t>(height)};
+}
+
+torch::Tensor randn_tensor(const std::vector<int64_t>& shape,
+                           int64_t seed,
+                           torch::TensorOptions& options) {
+  if (shape.empty()) {
+    LOG(FATAL) << "Shape must not be empty.";
+  }
+  at::Generator gen = at::detail::createCPUGenerator();
+  gen = gen.clone();
+  gen.set_current_seed(seed);
+  torch::Tensor latents;
+  latents = torch::randn(shape, gen, options.device(torch::kCPU));
+  latents = latents.to(options);
+  return latents;
+}
+
+class VAEImageProcessorImpl : public torch::nn::Module {
+ public:
+  explicit VAEImageProcessorImpl(ModelContext context,
+                                 bool do_resize = true,
+                                 bool do_normalize = true,
+                                 bool do_binarize = false,
+                                 bool do_convert_rgb = false,
+                                 bool do_convert_grayscale = false,
+                                 int64_t latent_channels = 4) {
+    const auto& model_args = context.get_model_args();
+    dtype_ = context.get_tensor_options().dtype().toScalarType();
+    scale_factor_ = 1 << model_args.block_out_channels().size();
+    latent_channels_ = latent_channels;
+    do_resize_ = do_resize;
+    do_normalize_ = do_normalize;
+    do_binarize_ = do_binarize;
+    do_convert_rgb_ = do_convert_rgb;
+    do_convert_grayscale_ = do_convert_grayscale;
+  }
+
+  std::pair<int64_t, int64_t> adjust_dimensions(int64_t height,
+                                                int64_t width) const {
+    height = height - (height % scale_factor_);
+    width = width - (width % scale_factor_);
+    return {height, width};
+  }
+
+  torch::Tensor preprocess(
+      const torch::Tensor& image,
+      std::optional<int64_t> height = std::nullopt,
+      std::optional<int64_t> width = std::nullopt,
+      const std::string& resize_mode = "default",
+      std::optional<std::tuple<int64_t, int64_t, int64_t, int64_t>>
+          crop_coords = std::nullopt) {
+    torch::Tensor processed = image.clone();
+    if (processed.dtype() != torch::kFloat32) {
+      processed = processed.to(torch::kFloat32);
+    }
+    if (processed.max().item<float>() > 1.1f) {
+      processed = processed / 255.0f;
+    }
+    if (crop_coords.has_value()) {
+      auto [x1, y1, x2, y2] = crop_coords.value();
+      x1 = std::max(int64_t(0), x1);
+      y1 = std::max(int64_t(0), y1);
+      x2 = std::min(processed.size(-1), x2);
+      y2 = std::min(processed.size(-2), y2);
+
+      if (processed.dim() == 3) {
+        processed = processed.index({torch::indexing::Slice(),
+                                     torch::indexing::Slice(y1, y2),
+                                     torch::indexing::Slice(x1, x2)});
+      } else if (processed.dim() == 4) {
+        processed = processed.index({torch::indexing::Slice(),
+                                     torch::indexing::Slice(),
+                                     torch::indexing::Slice(y1, y2),
+                                     torch::indexing::Slice(x1, x2)});
+      }
+    }
+    int64_t channel = processed.size(1);
+    if (channel == latent_channels_) {
+      return image;
+    }
+    auto [target_h, target_w] =
+        get_default_height_width(processed, height, width);
+    if (do_resize_) {
+      processed = resize(processed, target_h, target_w);
+    }
+
+    if (do_normalize_) {
+      processed = normalize(processed);
+    }
+    if (do_binarize_) {
+      processed = (processed >= 0.5f).to(torch::kFloat32);
+    }
+    processed = processed.to(dtype_);
+    return processed;
+  }
+
+  torch::Tensor postprocess(
+      const torch::Tensor& tensor,
+      const std::string& output_type = "pt",
+      std::optional<std::vector<bool>> do_denormalize = std::nullopt) {
+    torch::Tensor processed = tensor.clone();
+    if (do_normalize_) {
+      if (!do_denormalize.has_value()) {
+        processed = denormalize(processed);
+      } else {
+        for (int64_t i = 0; i < processed.size(0); ++i) {
+          if (i < do_denormalize.value().size() && do_denormalize.value()[i]) {
+            processed[i] = denormalize(processed[i]);
+          }
+        }
+      }
+    }
+    if (output_type == "np") {
+      return processed.permute({0, 2, 3, 1}).contiguous();
+    }
+    return processed;
+  }
+
+ private:
+  std::pair<int64_t, int64_t> get_default_height_width(
+      const torch::Tensor& image,
+      std::optional<int64_t> height = std::nullopt,
+      std::optional<int64_t> width = std::nullopt) const {
+    int64_t h, w;
+    if (image.dim() == 3) {
+      h = image.size(1);
+      w = image.size(2);
+    } else if (image.dim() == 4) {
+      h = image.size(2);
+      w = image.size(3);
+    } else {
+      LOG(FATAL) << "Unsupported image dimension: " << image.dim();
+    }
+
+    int64_t target_h = height.value_or(h);
+    int64_t target_w = width.value_or(w);
+    return adjust_dimensions(target_h, target_w);
+  }
+
+  torch::Tensor normalize(const torch::Tensor& tensor) const {
+    return 2.0 * tensor - 1.0;
+  }
+
+  torch::Tensor denormalize(const torch::Tensor& tensor) const {
+    return (tensor * 0.5 + 0.5).clamp(0.0, 1.0);
+  }
+
+ public:
+  torch::Tensor resize(const torch::Tensor& image,
+                       int64_t target_height,
+                       int64_t target_width) const {
+    return torch::nn::functional::interpolate(
+        image,
+        torch::nn::functional::InterpolateFuncOptions()
+            .size(std::vector<int64_t>{target_height, target_width})
+            .mode(torch::kNearest));
+  }
+
+ private:
+  int64_t scale_factor_ = 8;
+  int64_t latent_channels_ = 4;
+  bool do_resize_ = true;
+  bool do_normalize_ = true;
+  bool do_binarize_ = false;
+  bool do_convert_rgb_ = false;
+  bool do_convert_grayscale_ = false;
+  torch::ScalarType dtype_ = torch::kFloat32;
+};
+TORCH_MODULE(VAEImageProcessor);
+
+}  // namespace xllm::dit

--- a/xllm/models/dit/utils/dit_parallel_linear.h
+++ b/xllm/models/dit/utils/dit_parallel_linear.h
@@ -1,0 +1,175 @@
+/* Copyright 2026 The xLLM Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://github.com/jd-opensource/xllm/blob/main/LICENSE
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#pragma once
+
+#include <torch/torch.h>
+
+#include "core/framework/state_dict/utils.h"
+#include "core/layers/common/add_matmul.h"
+#include "framework/parallel_state/parallel_state.h"
+
+namespace xllm::dit {
+namespace F = torch::nn::functional;
+
+enum class LinearType { Default, SequenceParallel };
+
+// NOTE: The order of linear and all2all Operations depends on the
+// before_attention param if before_attention is true, order is: linear->all2all
+// if before_attention is false, order is: all2all->linear
+struct SpOptions {
+  // the num of attention heads
+  int64_t head_num = 0;
+
+  // the size of single attention head
+  int64_t head_dim = 0;
+
+  // hidden_size
+  int64_t hidden_size = 0;
+
+  // before_attention: a Bool value that indicates where to apply the all2all,
+  //  According to the classic ulysses sequence parallel, we should apply
+  //  all2all communication for q, k, v, text_q (optional), text_k (optional),
+  //  text_v (optional), before attention operation to gather full sequence
+  //  (splited_sequence * group_size) and scatter the head nums (head_nums /
+  //  group_size) , and we should apply all2all communication for attn_output,
+  //  text_attn_output (optional) after the attention operation to split the
+  //  full sequence (full_sequence / group_size) , and gather the head nums
+  //  (splited_head_num * group_size)
+  bool before_attention = false;
+
+  // the process_group for sequence parallel
+  ProcessGroup* process_group = nullptr;
+
+  SpOptions() = default;
+
+  SpOptions(int64_t head_num,
+            int64_t head_dim,
+            int64_t hidden_size,
+            bool before_attention,
+            ProcessGroup* process_group = nullptr)
+      : head_num(head_num),
+        head_dim(head_dim),
+        hidden_size(hidden_size),
+        before_attention(before_attention),
+        process_group(process_group) {}
+
+  void valid() const {
+    CHECK(head_num > 0) << "head_num should be greater than 0 to initialize "
+                           "DiTParallelLinear for "
+                           "linear type 'sequence_parallel' "
+                        << " but got " << head_num;
+    CHECK(head_dim > 0) << "head_dim should be greater than 0 to initialize "
+                           "DiTParallelLinear for "
+                           "linear type 'sequence_parallel' "
+                        << " but got " << head_dim;
+    CHECK(hidden_size > 0) << "head_size should be greater than 0 to "
+                              "initialize DiTParallelLinear for "
+                              "linear type 'sequence_parallel' "
+                           << " but got " << hidden_size;
+    CHECK(hidden_size == head_dim * head_num)
+        << "hidden_size should equal to head_dim * head_num"
+        << "got head_dim " << head_dim << ", head num" << head_num
+        << ", hidden_size " << hidden_size;
+    if (!process_group) {
+      LOG(ERROR)
+          << "DiTSpLinear expected to receive an initialized processgroup for"
+          << "all2all communication, but got nullptr";
+    }
+  }
+};
+
+// TODO : Need to Implement a template funciton, but
+// libtorch doesn't allow to creat module holder for
+// template class.
+// template <typename Linear>
+class DiTParallelLinearImpl : public torch::nn::Module {
+ public:
+  DiTParallelLinearImpl(layer::WeightTransposeAddMatmul linear,
+                        const string& module_name,
+                        LinearType linear_type = LinearType::Default,
+                        const SpOptions& sp_options = SpOptions())
+      : sp_options_(sp_options), linear_type_(linear_type) {
+    linear_ = register_module(module_name, std::move(linear));
+    if (linear_type == LinearType::SequenceParallel) {
+      sp_options_.valid();
+    }
+  }
+
+  torch::Tensor linear_forward(const torch::Tensor& input) {
+    return linear_->forward(input);
+  }
+
+  // sp_forward combines the linear operation with all2all communication,
+  // output: A torch tensor with shape {batch, seq_len, hidden_size}
+  torch::Tensor sp_forward(const torch::Tensor& input) {
+    CHECK(input.sizes().size() == 3)
+        << "Sp linear input is expected to be a tensor "
+        << "with shape {batch, seq_len, hidden_size}";
+    auto group_size = sp_options_.process_group->world_size();
+    if (sp_options_.before_attention) {
+      auto linear_output = this->linear_forward(input);
+      auto all_to_all_func = parallel_state::all_to_all_4D(
+          /*input=*/linear_output.view(
+              {input.size(0), -1, sp_options_.head_num, sp_options_.head_dim}),
+          /*scatter_dim=*/2,
+          /*gather_dim=*/1,
+          /*async_ops=*/false,
+          sp_options_.process_group);
+      auto output = all_to_all_func();
+      return output.view(
+          {input.size(0), -1, sp_options_.hidden_size / group_size});
+    } else {
+      auto all_to_all_func = parallel_state::all_to_all_4D(
+          /*input=*/input.view({input.size(0),
+                                -1,
+                                sp_options_.head_num / group_size,
+                                sp_options_.head_dim}),
+          /*scatter_dim=*/1,
+          /*gather_dim=*/2,
+          /*async_ops=*/false,
+          sp_options_.process_group);
+      auto all_to_all_output = all_to_all_func();
+      all_to_all_output =
+          all_to_all_output.view({input.size(0), -1, sp_options_.hidden_size});
+      auto output = this->linear_forward(all_to_all_output);
+      return output;
+    }
+  }
+
+  torch::Tensor forward(const torch::Tensor& input) {
+    if (linear_type_ == LinearType::Default) {
+      return this->linear_forward(input);
+    } else {
+      return this->sp_forward(input);
+    }
+  }
+
+  void load_state_dict(const StateDict& state_dict) {
+    linear_->load_state_dict(state_dict);
+  }
+
+  void verify_loaded_weights(const std::string& prefix) const {
+    linear_->verify_loaded_weights(prefix);
+  }
+
+ private:
+  layer::WeightTransposeAddMatmul linear_{nullptr};
+  SpOptions sp_options_;
+  LinearType linear_type_;
+};
+
+TORCH_MODULE(DiTParallelLinear);
+}  // namespace xllm::dit

--- a/xllm/models/dit/utils/sequence_parallel_pad_manager.h
+++ b/xllm/models/dit/utils/sequence_parallel_pad_manager.h
@@ -1,0 +1,94 @@
+/* Copyright 2026 The xLLM Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://github.com/jd-opensource/xllm/blob/main/LICENSE
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#pragma once
+
+#include <string>
+#include <unordered_map>
+
+namespace xllm::dit {
+
+class SequenceParallelPadManager {
+ public:
+  static SequenceParallelPadManager& getInstance() {
+    static SequenceParallelPadManager instance;
+    return instance;
+  }
+
+  torch::Tensor pad_tensor(const torch::Tensor& ref_tensor,
+                           const string& tensor_name,
+                           int64_t dim = -1,
+                           bool right_pad = true) {
+    auto pad_dim = dim;
+    if (pad_dim == -1) {
+      pad_dim = ref_tensor.dim() - 1;
+    }
+
+    if (ref_tensor.defined()) {
+      if (ref_tensor.size(dim) % FLAGS_dit_sp_size != 0) {
+        int64_t pad_len =
+            FLAGS_dit_sp_size - ref_tensor.size(dim) % FLAGS_dit_sp_size;
+        set(tensor_name, pad_len);
+
+        std::vector<int64_t> pad_shape(ref_tensor.dim() * 2);
+        int64_t pad_shift = right_pad ? 1 : 0;
+        pad_shape[2 * (ref_tensor.dim() - pad_dim - 1) + pad_shift] = pad_len;
+        auto pad_tensor = torch::pad(ref_tensor, pad_shape, "constant", 0);
+        return pad_tensor;
+      }
+      set(tensor_name, 0);
+    }
+
+    return ref_tensor;
+  }
+
+  void unpad_tensor(torch::Tensor& ref_tensor,
+                    const string& tensor_name,
+                    int64_t dim = -1,
+                    bool right_pad = true) {
+    if (ref_tensor.defined()) {
+      auto pad = get(tensor_name);
+      ref_tensor = ref_tensor.narrow(dim, 0, ref_tensor.size(dim) - pad);
+    }
+  }
+
+  void set(const std::string& key, int64_t length) {
+    pad_lengths_[key] = length;
+  }
+
+  int64_t get(const std::string& key) const {
+    auto it = pad_lengths_.find(key);
+    return it != pad_lengths_.end() ? it->second : 0;
+  }
+
+  bool has(const std::string& key) const {
+    return pad_lengths_.find(key) != pad_lengths_.end();
+  }
+
+  void remove(const std::string& key) { pad_lengths_.erase(key); }
+
+  void clear() { pad_lengths_.clear(); }
+
+ private:
+  SequenceParallelPadManager() = default;
+  ~SequenceParallelPadManager() = default;
+  SequenceParallelPadManager(const SequenceParallelPadManager&) = delete;
+  SequenceParallelPadManager& operator=(const SequenceParallelPadManager&) =
+      delete;
+
+  std::unordered_map<std::string, int64_t> pad_lengths_;
+};
+
+}  // namespace xllm::dit

--- a/xllm/models/model_registry.cpp
+++ b/xllm/models/model_registry.cpp
@@ -373,6 +373,12 @@ TokenizerArgsLoader ModelRegistry::get_tokenizer_args_loader(
   return instance->model_registry_[name].tokenizer_args_loader;
 }
 
+bool ModelRegistry::has_dit_model_factory(const std::string& name) {
+  ModelRegistry* instance = get_instance();
+  return (instance->model_registry_.find(name) !=
+          instance->model_registry_.end());
+}
+
 std::string ModelRegistry::get_model_backend(const std::string& name) {
   ModelRegistry* instance = get_instance();
   return instance->model_backend_[name];

--- a/xllm/models/model_registry.h
+++ b/xllm/models/model_registry.h
@@ -146,6 +146,8 @@ class ModelRegistry {
   static ImageProcessorFactory get_image_processor_factory(
       const std::string& name);
 
+  static bool has_dit_model_factory(const std::string& name);
+
   static std::string get_model_backend(const std::string& name);
 
  private:

--- a/xllm/models/models.h
+++ b/xllm/models/models.h
@@ -16,6 +16,7 @@ limitations under the License.
 #pragma once
 
 #if defined(USE_NPU)
+#include "dit/npu/qwen_image_edit/pipeline_qwenimage_edit_plus.h"  // IWYU pragma: keep
 #include "dit/pipeline_flux.h"                // IWYU pragma: keep
 #include "dit/pipeline_flux_control.h"        // IWYU pragma: keep
 #include "dit/pipeline_flux_fill.h"           // IWYU pragma: keep
@@ -49,6 +50,7 @@ limitations under the License.
 #include "vlm/npu/minicpmv.h"                 // IWYU pragma: keep
 #include "vlm/npu/oxygen_vlm.h"               // IWYU pragma: keep
 #include "vlm/npu/qwen2_5_vl.h"               // IWYU pragma: keep
+#include "vlm/npu/qwen2_5_vl_embedding.h"     // IWYU pragma: keep
 #include "vlm/npu/qwen2_5_vl_mm_embedding.h"  // IWYU pragma: keep
 #include "vlm/npu/qwen2_vl.h"                 // IWYU pragma: keep
 #include "vlm/npu/qwen2_vl_embedding.h"       // IWYU pragma: keep

--- a/xllm/models/vlm/npu/qwen2_5_vl.h
+++ b/xllm/models/vlm/npu/qwen2_5_vl.h
@@ -482,6 +482,7 @@ class Qwen2_5_VisionTransformerImpl : public torch::nn::Module {
     std::vector<int> cu_w_seqlens_vec(
         cu_window_seqlens_cpu.data_ptr<int>(),  // windows seqlen vec
         cu_window_seqlens_cpu.data_ptr<int>() + cu_window_seqlens_cpu.numel());
+
     for (int idx = 0; idx < blocks_->size(); ++idx) {
       torch::Tensor cu_seqlens_now;
       std::vector<int> cu_seqlens_now_vec;

--- a/xllm/models/vlm/npu/qwen2_5_vl_embedding.h
+++ b/xllm/models/vlm/npu/qwen2_5_vl_embedding.h
@@ -1,0 +1,286 @@
+/* Copyright 2025 The xLLM Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://github.com/jd-opensource/xllm/blob/main/LICENSE
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#pragma once
+
+#include "core/framework/model/embedding_vlm.h"
+#include "core/framework/model/model_output.h"
+#include "models/vlm/npu/qwen2_5_vl.h"
+#include "models/vlm/npu/qwen2_vl.h"
+
+namespace xllm::npu::model {
+
+class Qwen2_5_VLForEmbeddingImpl : public torch::nn::Module {
+ public:
+  Qwen2_5_VLForEmbeddingImpl(const ModelContext& context)
+      : model_args_(context.get_model_args()),
+        options_(context.get_tensor_options()) {
+    visual_ = register_module("visual", Qwen2_5_VisionTransformer(context));
+    language_model_ =
+        register_module("language_model", QWen2ForCausalLM(context));
+  }
+
+  void prepare_encoder_input(
+      const ModelInputParams& input_params,
+      std::optional<Qwen2_5_VLImageInputs>& image_inputs,
+      std::optional<Qwen2_5_VLVideoInputs>& video_inputs) {
+    const auto& mm_data = input_params.mm_data;
+    torch::Tensor pixel_values;
+    if (const auto& res = mm_data.get<torch::Tensor>("pixel_values"))
+      pixel_values = res.value();
+    torch::Tensor image_grid_thw;
+    if (const auto& res = mm_data.get<torch::Tensor>("image_grid_thw"))
+      image_grid_thw = res.value();
+
+    torch::Tensor pixel_values_videos;
+    if (const auto& res = mm_data.get<torch::Tensor>("pixel_values_videos"))
+      pixel_values_videos = res.value();
+
+    torch::Tensor video_grid_thw;
+    if (const auto& res = mm_data.get<torch::Tensor>("video_grid_thw"))
+      video_grid_thw = res.value();
+
+    torch::Tensor second_per_grid_ts;
+    if (const auto& res = mm_data.get<torch::Tensor>("second_per_grid_ts"))
+      second_per_grid_ts = res.value();
+
+    if (pixel_values.defined() && image_grid_thw.defined())
+      image_inputs = Qwen2_5_VLImageInputs{pixel_values, image_grid_thw};
+
+    if (pixel_values_videos.defined() && video_grid_thw.defined() &&
+        second_per_grid_ts.defined())
+      video_inputs = Qwen2_5_VLVideoInputs{
+          pixel_values_videos, video_grid_thw, second_per_grid_ts};
+  }
+
+  MMDict get_multimodal_embeddings(const ModelInputParams& input_params) {
+    std::optional<Qwen2_5_VLImageInputs> image_input;
+    std::optional<Qwen2_5_VLVideoInputs> video_input;
+    prepare_encoder_input(input_params, image_input, video_input);
+    auto merge_size = model_args_.mm_image_merge_size();
+    MMDict multimodal_embeds;
+    if (image_input) {
+      // visual
+      auto image_embeds = visual_(image_input->pixel_values.to(options_),
+                                  image_input->image_grid_thw,
+                                  input_params);
+      auto image_tokens =
+          (image_input->image_grid_thw.prod(-1) / merge_size / merge_size)
+              .cpu()
+              .contiguous()
+              .to(torch::kLong);
+      std::vector<int64_t> image_tokens_vec(
+          image_tokens.data_ptr<int64_t>(),
+          image_tokens.data_ptr<int64_t>() + image_tokens.numel());
+      multimodal_embeds["image|embedding"] =
+          image_embeds.split(image_tokens_vec, 0 /*dim*/);
+    }
+    if (video_input) {
+      // visual
+      auto video_embeds = visual_(video_input->pixel_values_videos.to(options_),
+                                  video_input->video_grid_thw,
+                                  input_params);
+      auto video_tokens =
+          (video_input->video_grid_thw.prod(-1) / merge_size / merge_size)
+              .cpu()
+              .contiguous()
+              .to(torch::kLong);
+      std::vector<int64_t> video_tokens_vec(
+          video_tokens.data_ptr<int64_t>(),
+          video_tokens.data_ptr<int64_t>() + video_tokens.numel());
+
+      multimodal_embeds["video|embedding"] =
+          video_embeds.split(video_tokens_vec, 0 /*dim*/);
+    }
+    return multimodal_embeds;
+  }
+
+  torch::Tensor generate_multimodal_mask(torch::Tensor input_ids) {
+    auto special_token_ids = torch::tensor(
+        {model_args_.image_token_id(), model_args_.video_token_id()},
+        input_ids.options().dtype(torch::kInt64));
+    auto is_multimodal = torch::isin(input_ids, special_token_ids);
+    return is_multimodal;
+  }
+
+  torch::Tensor merge_multimodal_embeddings(
+      torch::Tensor inputs_embeds,
+      const torch::Tensor& multimodal_embeds,
+      const torch::Tensor& is_multimodal) {
+    inputs_embeds.index_put_({is_multimodal}, multimodal_embeds);
+    return inputs_embeds;
+  }
+
+  torch::Tensor get_input_embeddings(const torch::Tensor input_ids,
+                                     const ModelInputParams& input_params) {
+    const auto& mm_data = input_params.mm_data;
+    torch::Tensor multimodal_embeds;
+    if (const auto& emb = mm_data.get<torch::Tensor>("embedding")) {
+      multimodal_embeds = emb.value();
+    }
+    auto inputs_embeds = language_model_->get_input_embeddings(input_ids);
+    if (!multimodal_embeds.defined()) {
+      return inputs_embeds;
+    }
+    auto is_multimodal = generate_multimodal_mask(input_ids);
+    inputs_embeds = merge_multimodal_embeddings(
+        inputs_embeds, multimodal_embeds, is_multimodal);
+    return inputs_embeds;
+  }
+
+  ModelOutput forward(const torch::Tensor& tokens,
+                      const torch::Tensor& positions,
+                      std::vector<KVCache>& kv_caches,
+                      const ModelInputParams& input_params) {
+    return language_model_(tokens, positions, kv_caches, input_params);
+  }
+
+  torch::Tensor pooler(const torch::Tensor& hidden_states,
+                       const torch::Tensor& seleted_idxes) {
+    auto h = hidden_states;
+    // return full embeddings if set flag
+    if (FLAGS_enable_return_mm_full_embeddings) {
+      return h;
+    }
+
+    if (seleted_idxes.defined()) {
+      h = h.index_select(/*dim=*/0, seleted_idxes);
+    }
+    auto pooler_output = torch::nn::functional::normalize(
+        h, torch::nn::functional::NormalizeFuncOptions().p(2).dim(1));
+    return pooler_output;
+  }
+
+  torch::Tensor logits(const torch::Tensor&, const torch::Tensor&) {
+    NOT_IMPLEMENTED();
+    return torch::Tensor();
+  }
+
+  torch::Device device() const { return options_.device(); }
+
+  const torch::TensorOptions& options() const { return options_; }
+
+  void load_model(std::unique_ptr<ModelLoader> loader) {
+    for (const auto& state_dict : loader->get_state_dicts()) {
+      visual_->load_state_dict(state_dict->get_dict_with_prefix("visual."));
+    }
+    // verify
+    visual_->verify_loaded_weights("visual.");
+    visual_->merge_loaded_weights();
+    // if (!model_args_.image_embedding_mode()) {
+    language_model_->load_model(std::move(loader));
+    // }
+  }
+
+  layer::NpuLmHead get_npu_lm_head() {
+    return language_model_->get_npu_lm_head();
+  }
+  void set_npu_lm_head(layer::NpuLmHead& head) {
+    language_model_->set_npu_lm_head(head);
+  }
+
+  layer::NpuWordEmbedding get_npu_word_embedding() {
+    return language_model_->get_npu_word_embedding();
+  }
+
+  void set_npu_word_embedding(layer::NpuWordEmbedding& npu_word_embedding) {
+    language_model_->set_npu_word_embedding(npu_word_embedding);
+  }
+
+ private:
+  ModelArgs model_args_;
+  torch::TensorOptions options_;
+
+  Qwen2_5_VisionTransformer visual_{nullptr};
+  QWen2ForCausalLM language_model_{nullptr};
+};
+TORCH_MODULE(Qwen2_5_VLForEmbedding);
+
+} // namespace xllm::npu::model
+
+namespace xllm {
+
+template <>
+class EmbeddingVLMImpl<npu::model::Qwen2_5_VLForEmbedding> : public EmbeddingVLM {
+ public:
+  EmbeddingVLMImpl(npu::model::Qwen2_5_VLForEmbedding model,
+                   const torch::TensorOptions& options)
+      : model_(std::move(model)), options_(options) {}
+
+  MMDict encode(const ModelInputParams& input_params) override {
+    return model_->get_multimodal_embeddings(input_params);
+  };
+
+  torch::Tensor get_input_embeddings(const torch::Tensor& input_ids,
+                                     const ModelInputParams& input_params) {
+    return model_->get_input_embeddings(input_ids, input_params);
+  }
+
+  ModelOutput forward(const torch::Tensor& tokens,
+                      const torch::Tensor& positions,
+                      std::vector<KVCache>& kv_caches,
+                      const ModelInputParams& parameters) override {
+    return model_->forward(tokens, positions, kv_caches, parameters);
+  }
+
+  torch::Tensor logits(const torch::Tensor& hidden_states,
+                       const torch::Tensor& seleted_idxes) override {
+    return model_->logits(hidden_states, seleted_idxes);
+  }
+
+  torch::Tensor pooler(const torch::Tensor& hidden_states,
+                       const torch::Tensor& seleted_idxes) override {
+    return model_->pooler(hidden_states, seleted_idxes);
+  }
+
+  void load_model(std::unique_ptr<ModelLoader> loader) override {
+    model_->load_model(std::move(loader));
+  }
+
+  torch::Device device() const override { return model_->device(); }
+
+  const torch::TensorOptions& options() const override {
+    return model_->options();
+  }
+
+  virtual void prepare_expert_weight(int32_t layer_id,
+                                     const std::vector<int32_t>& expert_ids) {
+    return;
+  }
+  virtual void update_expert_weight(int32_t layer_id) { return; }
+
+  // Delegate head/embedding accessors to underlying model implementation.
+  layer::NpuLmHead get_npu_lm_head() override {
+    return model_->get_npu_lm_head();
+  }
+  void set_npu_lm_head(layer::NpuLmHead& head) override {
+    model_->set_npu_lm_head(head);
+  }
+  layer::NpuWordEmbedding get_npu_word_embedding() override {
+    return model_->get_npu_word_embedding();
+  }
+  void set_npu_word_embedding(layer::NpuWordEmbedding& embedding) override {
+    model_->set_npu_word_embedding(embedding);
+  }
+
+ private:
+  npu::model::Qwen2_5_VLForEmbedding model_;
+  torch::TensorOptions options_;
+};
+
+REGISTER_EMBEDDING_VLM_MODEL_WITH_VARNAME(qwen2_5_vl_embedding,
+                                          qwen2_5_vl,
+                                          npu::model::Qwen2_5_VLForEmbedding);
+}  // namespace xllm

--- a/xllm/nohup.out
+++ b/xllm/nohup.out
@@ -1,0 +1,1 @@
+python: can't open file '/export/home/shanchenfeng/qwen_image_dev/xllm/xllm/setup.py': [Errno 2] No such file or directory

--- a/xllm/proto/image_generation.proto
+++ b/xllm/proto/image_generation.proto
@@ -46,6 +46,9 @@ message Input {
 
   // Control Image
   optional string control_image = 13;
+
+  // Condition Image
+  optional string condition_image = 14;
 }
 
 // Generation parameters container

--- a/xllm/proto/worker.proto
+++ b/xllm/proto/worker.proto
@@ -193,6 +193,55 @@ message MMData {
   map<string, MMValue> dict = 2;
 }
 
+message DiTForwardInput {
+  int32 batch_size = 1;
+  
+  // Primary input text description for image generation
+  repeated string prompts = 2;
+  
+  // Secondary prompt for additional details (e.g., color, lighting)
+  repeated string prompts_2 = 3;
+  
+  // Negative prompt to exclude low-quality features
+  repeated string negative_prompts = 4;
+  
+  // Secondary negative prompt to exclude additional unwanted features
+  repeated string negative_prompts_2 = 5;
+  
+  // Tensor fields
+  Tensor images = 6;
+  Tensor condition_images = 7;
+  Tensor mask_images = 8;
+  Tensor control_image = 9;
+  Tensor masked_image_latents = 10;
+  Tensor prompt_embeds = 11;
+  Tensor pooled_prompt_embeds = 12;
+  Tensor negative_prompt_embeds = 13;
+  Tensor negative_pooled_prompt_embeds = 14;
+  Tensor latents = 15;
+  
+  // generation params
+  DiTGenerationParams generation_params = 16;
+}
+
+message DiTForwardOutput {
+  TensorList tensors = 1; 
+}
+
+message DiTGenerationParams {
+  int32 width = 1;
+  int32 height = 2;
+  int32 num_inference_steps = 3;
+  float true_cfg_scale = 4;
+  float guidance_scale = 5;
+  uint32 num_images_per_prompt = 6;
+  int64 seed = 7;
+  int32 max_sequence_length = 8;
+  float strength = 9;
+  bool enable_cfg_renorm = 10;
+  float cfg_renorm_min = 11;
+}
+
 message ForwardInput {
   // flatten the token ids and positions
   repeated int32 flatten_tokens_vec = 1;
@@ -241,6 +290,7 @@ message ForwardInput {
   repeated int32 dp_is_decode = 42;
   repeated int32 kv_cache_tokens_nums = 43;
   repeated string request_ids = 44;
+  DiTForwardInput dit_forward_input = 45;
 }
 
  message BatchedForwardInputs {
@@ -273,6 +323,7 @@ message ForwardOutput {
   repeated int32 src_seq_idxes = 5;
   repeated int32 out_tokens = 6;
   repeated float out_logprobs = 7;
+  DiTForwardOutput dit_forward_output = 8;
 }
 
 // master create Collective service

--- a/xllm/xllm.cpp
+++ b/xllm/xllm.cpp
@@ -31,6 +31,7 @@ limitations under the License.
 #include "core/common/metrics.h"
 #include "core/common/options.h"
 #include "core/common/types.h"
+#include "core/distributed_runtime/dit_master.h"
 #include "core/distributed_runtime/master.h"
 #include "core/framework/xtensor/global_xtensor.h"
 #include "core/framework/xtensor/options.h"
@@ -163,9 +164,9 @@ int run() {
 #if !defined(USE_NPU)
   FLAGS_enable_block_copy_kernel = false;
 #endif
-
-  std::string model_type = xllm::util::get_model_type(model_path);
+  std::string model_type = "";
   if (FLAGS_backend != "dit") {
+    model_type = xllm::util::get_model_type(model_path);
     FLAGS_tool_call_parser = function_call::FunctionCallParser::get_parser_auto(
         FLAGS_tool_call_parser, model_type);
     FLAGS_reasoning_parser =
@@ -227,6 +228,10 @@ int run() {
       .dp_size(FLAGS_dp_size)
       .cp_size(FLAGS_cp_size)
       .ep_size(FLAGS_ep_size)
+      .dit_dp_size(FLAGS_dit_dp_size)
+      .dit_tp_size(FLAGS_dit_tp_size)
+      .dit_sp_size(FLAGS_dit_sp_size)
+      .dit_cfg_size(FLAGS_dit_cfg_size)
       .instance_name(FLAGS_host + ":" + std::to_string(FLAGS_port))
       .enable_disagg_pd(FLAGS_enable_disagg_pd)
       .enable_pd_ooc(FLAGS_enable_pd_ooc)
@@ -308,7 +313,11 @@ int run() {
   std::unique_ptr<Master> master;
   // working node
   if (options.node_rank() != 0) {
-    master = std::make_unique<LLMAssistantMaster>(options);
+    if (FLAGS_backend == "dit") {
+      master = std::make_unique<DiTAssistantMaster>(options);
+    } else {
+      master = std::make_unique<LLMAssistantMaster>(options);
+    }
   } else {
     if (FLAGS_random_seed < 0) {
       FLAGS_random_seed = std::random_device{}() % (1 << 30);


### PR DESCRIPTION
feat: support qwen2_5_vl_embedding model on NPU device.

feat: support dit residual cache.

feat: support dit mapping manager.

feat: support cfg parallel.

feat: support dit comm manager.

feat: support sequence parallel for QwenImageEditPipeline.

feat: support two images infer for QwenImageEditPipeline.

feat: support dit multiprocess service.

feat: support dit multiprocess hccl communication.

feat: support dit sequence parallel framework.

refactor: clean code & add debug print for dit models.

refactor: change dit cache back to multi process version.

refactor: add gflags for VLM full embedding infer.