### PR TITLE
perf: optimize cal_seq_exchange_index using unordered_map.

### DIFF
--- a/xllm/core/framework/batch/batch.cpp
+++ b/xllm/core/framework/batch/batch.cpp
@@ -242,7 +242,7 @@ void Batch::dp_balance_shuffle_seqs() {
 #endif
 }
 
-std::map<uint32_t, uint32_t> Batch::cal_seq_exchange_index(
+std::unordered_map<uint32_t, uint32_t> Batch::cal_seq_exchange_index(
     std::vector<uint32_t>& kv_cache_tokens_num) {
   const auto num_npu_cores = 24;  // npu cube core num
   const auto num_seqs = kv_cache_tokens_num.size();
@@ -286,7 +286,7 @@ std::map<uint32_t, uint32_t> Batch::cal_seq_exchange_index(
 
   // record the index map, first one is original index,
   // second one is the target index to be exchanged to
-  std::map<uint32_t, uint32_t> index_shift;
+  std::unordered_map<uint32_t, uint32_t> index_shift;
   // add base part data
   for (auto i = 0; i < num_npu_cores; ++i) {
     for (auto j = 0; j < base_per_core; ++j) {

--- a/xllm/core/framework/batch/batch.h
+++ b/xllm/core/framework/batch/batch.h
@@ -129,7 +129,7 @@ class Batch {
     return allowed_max_tokens_;
   }
 
-  std::map<uint32_t, uint32_t> cal_seq_exchange_index_test(
+  std::unordered_map<uint32_t, uint32_t> cal_seq_exchange_index_test(
       std::vector<uint32_t>& kv_cache_tokens_num) {
     return cal_seq_exchange_index(kv_cache_tokens_num);
   }
@@ -149,7 +149,7 @@ class Batch {
   void process_beam_search();
   bool has_partial_finished_beam_group() const;
 
-  std::map<uint32_t, uint32_t> cal_seq_exchange_index(
+  std::unordered_map<uint32_t, uint32_t> cal_seq_exchange_index(
       std::vector<uint32_t>& kv_cache_tokens_num);
 
   void dp_balance_shuffle_seqs();


### PR DESCRIPTION
Replace `std::map` with `std::unordered_map` in `cal_seq_exchange_index` for performance improvement.

The performance comparison of map and unordered_map on insert and iteration is as follows. 
<img width="806" height="403" alt="image" src="https://github.com/user-attachments/assets/50a0b3e6-744f-40a9-9dd0-aae40acec84b" />
<img width="806" height="403" alt="image" src="https://github.com/user-attachments/assets/1d4546c8-9492-4dbf-9549-6b5557962fb0" />

 The detailed benchmark code and results are shown: https://quick-bench.com/q/dzdKy7W0Vs05kwr3ICLLzXQIziw
