### PR TITLE
bugfix: fix ilu DISABLE_INFER_GEMM_EX env var error.

### DIFF
--- a/xllm/core/kernels/ilu/matmul.cpp
+++ b/xllm/core/kernels/ilu/matmul.cpp
@@ -54,15 +54,13 @@ torch::Tensor matmul(torch::Tensor a,
 
   bool use_gemv = true;
   const int64_t gemv_max_batch = 1;
-  const char* disable_infer_gemm_ex_str =
-      get_string_env("DISABLE_INFER_GEMM_EX");
-  std::string disable_infer_gemm_ex =
-      (disable_infer_gemm_ex_str == nullptr) ? "0" : disable_infer_gemm_ex_str;
+  const bool disable_infer_gemm_ex =
+      xllm::util::get_bool_env("DISABLE_INFER_GEMM_EX", false);
 
   use_gemv =
       use_gemv &&
       gemv_conditions(a, b, bias.value_or(at::Tensor()), gemv_max_batch) &&
-      (disable_infer_gemm_ex != "1") && (act_type == -1);
+      !disable_infer_gemm_ex && (act_type == -1);
 
   if (use_gemv) {
     output = infer::ixformer_linear_ex(a, b, bias, output);


### PR DESCRIPTION
this pr fix ilu build error introduced by #1027  like following:
```
xllm/xllm/core/kernels/ilu/matmul.cpp:58:7: error: ‘get_string_env’ was not declared in this scope; did you mean ‘xllm::util::get_string_env’?
     58 |       get_string_env("DISABLE_INFER_GEMM_EX");
        |       ^~~~~~~~~~~~~~
        |       xllm::util::get_string_env
  In file included from /export/home/actions-runner/_work/xllm/xllm/xllm/core/kernels/ilu/matmul.cpp:17:
  /export/home/actions-runner/_work/xllm/xllm/xllm/core/util/env_var.h:31:13: note: ‘xllm::util::get_string_env’ declared here
     31 | std::string get_string_env(const std::string& name);
```