### PR TITLE
perf: optimize some cases using unordered_set.

### DIFF
--- a/xllm/core/framework/sampling/rec_constrained_decoding.cpp
+++ b/xllm/core/framework/sampling/rec_constrained_decoding.cpp
@@ -57,7 +57,7 @@ bool RecConstrainedDecoding::build_mask_cache() {
   Slice<int32_t> prefix_token_ids = {empty_token_ids.data(),
                                      empty_token_ids.size()};
 
-  const std::set<int32_t>& first_token_ids =
+  const std::unordered_set<int32_t>& first_token_ids =
       VersionSingleton<RecVocabDict>::GetInstance(
           std::to_string(model_version_))
           ->get_next_tokens_by_prefix_tokens(prefix_token_ids);
@@ -122,7 +122,7 @@ torch::Tensor RecConstrainedDecoding::generate_decode_mask(
     for (size_t token_idx = start_idx; token_idx < end_idx; ++token_idx) {
       Slice<int32_t> tokens_slice(generated_token_list[token_idx]);
 
-      const std::set<int32_t>& next_token_ids =
+      const std::unordered_set<int32_t>& next_token_ids =
           VersionSingleton<RecVocabDict>::GetInstance(
               std::to_string(model_version_))
               ->get_next_tokens_by_prefix_tokens(tokens_slice);

--- a/xllm/core/framework/state_dict/rec_vocab_dict.cpp
+++ b/xllm/core/framework/state_dict/rec_vocab_dict.cpp
@@ -120,7 +120,8 @@ bool RecVocabDict::get_tokens_by_item(int64_t item_id,
   return true;
 }
 
-const std::set<int32_t>& RecVocabDict::get_next_tokens_by_prefix_tokens(
+const std::unordered_set<int32_t>&
+RecVocabDict::get_next_tokens_by_prefix_tokens(
     const Slice<int32_t>& prefix_token_ids) const {
   CHECK_EQ(initialized_, true);
   CHECK_LT(prefix_token_ids.size(), REC_TOKEN_SIZE);
@@ -128,7 +129,7 @@ const std::set<int32_t>& RecVocabDict::get_next_tokens_by_prefix_tokens(
   std::vector<int32_t> prefix_tokens_ids_vec = prefix_token_ids;
   auto iter = prefix_tokens_to_next_tokens_map_.find(prefix_tokens_ids_vec);
   if (iter == prefix_tokens_to_next_tokens_map_.end()) {
-    static std::set<int32_t> empty_set;
+    static std::unordered_set<int32_t> empty_set;
     return empty_set;
   }
 

--- a/xllm/core/framework/state_dict/rec_vocab_dict.h
+++ b/xllm/core/framework/state_dict/rec_vocab_dict.h
@@ -81,7 +81,7 @@ class RecVocabDict final {
    * the token triplets
    * @return  next token id list
    */
-  const std::set<int32_t>& get_next_tokens_by_prefix_tokens(
+  const std::unordered_set<int32_t>& get_next_tokens_by_prefix_tokens(
       const Slice<int32_t>& prefix_token_ids) const;
 
  private:
@@ -103,7 +103,7 @@ class RecVocabDict final {
   // Convert prifix tokens to next tokens map, key: prefix token id list, value:
   // next token id list
   std::unordered_map<std::vector<int32_t>,
-                     std::set<int32_t>,
+                     std::unordered_set<int32_t>,
                      boost::hash<std::vector<int32_t>>>
       prefix_tokens_to_next_tokens_map_;
 };

--- a/xllm/core/framework/xtensor/page_allocator.h
+++ b/xllm/core/framework/xtensor/page_allocator.h
@@ -206,7 +206,7 @@ class PageAllocator {
     std::deque<int64_t> free_virt_page_list;  // Unmapped virtual pages
     std::deque<int64_t>
         reserved_virt_page_list;  // Mapped virtual pages ready for use
-    std::set<int64_t>
+    std::unordered_set<int64_t>
         allocated_virt_page_list;  // Mapped virtual pages in use by block mgr
   };
 

--- a/xllm/core/layers/common/qwen2_attention.cpp
+++ b/xllm/core/layers/common/qwen2_attention.cpp
@@ -24,7 +24,7 @@ limitations under the License.
 #endif
 namespace {
 inline bool is_qwen3_model(const std::string& model_type) {
-  static const std::set<std::string> qwen3_type_set = {
+  static const std::unordered_set<std::string> qwen3_type_set = {
       "qwen3", "qwen3_vl", "qwen3_moe", "qwen3_vl_moe"};
   return qwen3_type_set.contains(model_type);
 }

--- a/xllm/core/layers/npu/loader/siglip_encoder_loader.cpp
+++ b/xllm/core/layers/npu/loader/siglip_encoder_loader.cpp
@@ -9,14 +9,14 @@ SiglipEncoderUpLoader::SiglipEncoderUpLoader(const ModelContext& context)
 }
 
 void SiglipEncoderUpLoader::load_state_dict(const StateDict& state_dict) {
-  const std::set<std::string> key_names = {"layer_norm1.weight",
-                                           "layer_norm1.bias",
-                                           "self_attn.q_proj.weight",
-                                           "self_attn.q_proj.bias",
-                                           "self_attn.k_proj.weight",
-                                           "self_attn.k_proj.bias",
-                                           "self_attn.v_proj.weight",
-                                           "self_attn.v_proj.bias"};
+  const std::unordered_set<std::string> key_names = {"layer_norm1.weight",
+                                                     "layer_norm1.bias",
+                                                     "self_attn.q_proj.weight",
+                                                     "self_attn.q_proj.bias",
+                                                     "self_attn.k_proj.weight",
+                                                     "self_attn.k_proj.bias",
+                                                     "self_attn.v_proj.weight",
+                                                     "self_attn.v_proj.bias"};
 
   for (const auto& [name, tensor] : state_dict) {
     if (key_names.find(name) == key_names.end()) continue;
@@ -33,14 +33,15 @@ SiglipEncoderDownLoader::SiglipEncoderDownLoader(const ModelContext& context)
 }
 
 void SiglipEncoderDownLoader::load_state_dict(const StateDict& state_dict) {
-  const std::set<std::string> key_names = {"self_attn.out_proj.weight",
-                                           "self_attn.out_proj.bias",
-                                           "layer_norm2.weight",
-                                           "layer_norm2.bias",
-                                           "mlp.fc1.weight",
-                                           "mlp.fc1.bias",
-                                           "mlp.fc2.weight",
-                                           "mlp.fc2.bias"};
+  const std::unordered_set<std::string> key_names = {
+      "self_attn.out_proj.weight",
+      "self_attn.out_proj.bias",
+      "layer_norm2.weight",
+      "layer_norm2.bias",
+      "mlp.fc1.weight",
+      "mlp.fc1.bias",
+      "mlp.fc2.weight",
+      "mlp.fc2.bias"};
 
   for (const auto& [name, tensor] : state_dict) {
     if (key_names.find(name) == key_names.end()) continue;

--- a/xllm/core/scheduler/disagg_pd_scheduler.h
+++ b/xllm/core/scheduler/disagg_pd_scheduler.h
@@ -162,7 +162,7 @@ class DisaggPDScheduler : public ContinuousScheduler {
       received_request_map_;
   // prefill_instance_name -> set of request_ids.
   // Used for bulk cleanup when a prefill instance is unlinked.
-  std::unordered_map<std::string, std::set<std::string>>
+  std::unordered_map<std::string, std::unordered_set<std::string>>
       instance_to_received_requests_map_;
   // request_id -> prefill_instance_name.
   // Used to efficiently remove a request from
@@ -177,7 +177,7 @@ class DisaggPDScheduler : public ContinuousScheduler {
 
   // Lock for multi-threaded read-write linked instances
   std::mutex linked_instances_mutex_;
-  std::set<std::string> linked_instance_;
+  std::unordered_set<std::string> linked_instance_;
 
   std::string server_name_;
 };

--- a/xllm/core/util/device_name_utils.cpp
+++ b/xllm/core/util/device_name_utils.cpp
@@ -44,7 +44,7 @@ std::vector<torch::Device> DeviceNameUtils::parse_devices(
 
   // parse device string
   const std::vector<std::string> device_strs = absl::StrSplit(device_str, ',');
-  std::set<torch::DeviceType> device_types;
+  std::unordered_set<torch::DeviceType> device_types;
   devices.reserve(device_strs.size());
   for (const auto& device_str : device_strs) {
     std::vector<std::string> parts = absl::StrSplit(device_str, ':');

--- a/xllm/models/vlm/npu/qwen2_5_vl.h
+++ b/xllm/models/vlm/npu/qwen2_5_vl.h
@@ -684,7 +684,7 @@ class Qwen2_5_VisionTransformerImpl : public torch::nn::Module {
   int window_size_ = 0;
   int patch_size_ = 0;
   int spatial_merge_size_ = 0;
-  std::set<int> fullatt_block_indexes_;
+  std::unordered_set<int> fullatt_block_indexes_;
   int spatial_merge_unit_ = 0;
 
   Qwen2_5_VisionPatchEmbed patch_embed_{nullptr};

--- a/xllm/models/vlm/npu/qwen2_vl.h
+++ b/xllm/models/vlm/npu/qwen2_vl.h
@@ -441,7 +441,7 @@ class Qwen2_VisionTransformerImpl : public torch::nn::Module {
   int window_size_ = 0;
   int patch_size_ = 0;
   int spatial_merge_size_ = 0;
-  std::set<int> fullatt_block_indexes_;
+  std::unordered_set<int> fullatt_block_indexes_;
   int spatial_merge_unit_ = 0;
   // int mlp_ratio_ = 4;
 

--- a/xllm/models/vlm/qwen2_5_vl.h
+++ b/xllm/models/vlm/qwen2_5_vl.h
@@ -595,7 +595,7 @@ class Qwen2_5_VisionTransformerImpl : public torch::nn::Module {
   int window_size_ = 0;
   int patch_size_ = 0;
   int spatial_merge_size_ = 0;
-  std::set<int> fullatt_block_indexes_;
+  std::unordered_set<int> fullatt_block_indexes_;
   int spatial_merge_unit_ = 0;
 
   Qwen2_5_VisionPatchEmbed patch_embed_{nullptr};

--- a/xllm/models/vlm/qwen2_vl.h
+++ b/xllm/models/vlm/qwen2_vl.h
@@ -375,7 +375,7 @@ class Qwen2_VisionTransformerImpl : public torch::nn::Module {
   int window_size_ = 0;
   int patch_size_ = 0;
   int spatial_merge_size_ = 0;
-  std::set<int> fullatt_block_indexes_;
+  std::unordered_set<int> fullatt_block_indexes_;
   int spatial_merge_unit_ = 0;
   // int mlp_ratio_ = 4;
 


### PR DESCRIPTION
Replace `std::set` with `std::unordered_set` in some cases for performance improvement.

The performance comparison of set and unordered_set is as follows.
<img width="806" height="403" alt="image" src="https://github.com/user-attachments/assets/dba31985-abaa-4c36-b17d-8e2f4b0cbf11" />
The detailed benchmark code and results are shown: https://quick-bench.com/q/95CoBluJBvYVw0xLkqEuqtDshsQ