### PR TITLE
feat: add onerec model implement[4/N].

### DIFF
--- a/xllm/core/layers/npu/npu_onerec_block_layer_impl.cpp
+++ b/xllm/core/layers/npu/npu_onerec_block_layer_impl.cpp
@@ -138,163 +138,163 @@ enum class OneRecBlockLayerTensorId : int32_t {
   IN_FFN_WO_COMPRESS_IDX,
 };
 
-constexpr int32_t IN_LAYER_NORM_WEIGHT =
+constexpr int32_t kInLayerNormWeight =
     static_cast<int32_t>(OneRecBlockLayerTensorId::IN_LAYER_NORM_WEIGHT);
-constexpr int32_t IN_LAYER_NORM_BIAS =
+constexpr int32_t kInLayerNormBias =
     static_cast<int32_t>(OneRecBlockLayerTensorId::IN_LAYER_NORM_BIAS);
-constexpr int32_t IN_INPUT_NORM_NEW_WEIGHT =
+constexpr int32_t kInInputNormNewWeight =
     static_cast<int32_t>(OneRecBlockLayerTensorId::IN_INPUT_NORM_NEW_WEIGHT);
-constexpr int32_t IN_INPUT_NORM_NEW_BIAS =
+constexpr int32_t kInInputNormNewBias =
     static_cast<int32_t>(OneRecBlockLayerTensorId::IN_INPUT_NORM_NEW_BIAS);
-constexpr int32_t IN_Q_WEIGHT =
+constexpr int32_t kInQWeight =
     static_cast<int32_t>(OneRecBlockLayerTensorId::IN_Q_WEIGHT);
-constexpr int32_t IN_Q_BIAS =
+constexpr int32_t kInQBias =
     static_cast<int32_t>(OneRecBlockLayerTensorId::IN_Q_BIAS);
-constexpr int32_t IN_Q_DEQSCALE =
+constexpr int32_t kInQDeqScale =
     static_cast<int32_t>(OneRecBlockLayerTensorId::IN_Q_DEQSCALE);
-constexpr int32_t IN_Q_OFFSET =
+constexpr int32_t kInQOffset =
     static_cast<int32_t>(OneRecBlockLayerTensorId::IN_Q_OFFSET);
-constexpr int32_t IN_Q_SCALE =
+constexpr int32_t kInQScale =
     static_cast<int32_t>(OneRecBlockLayerTensorId::IN_Q_SCALE);
-constexpr int32_t IN_Q_COMPRESS_IDX =
+constexpr int32_t kInQCompressIdx =
     static_cast<int32_t>(OneRecBlockLayerTensorId::IN_Q_COMPRESS_IDX);
-constexpr int32_t IN_K_WEIGHT =
+constexpr int32_t kInKWeight =
     static_cast<int32_t>(OneRecBlockLayerTensorId::IN_K_WEIGHT);
-constexpr int32_t IN_K_BIAS =
+constexpr int32_t kInKBias =
     static_cast<int32_t>(OneRecBlockLayerTensorId::IN_K_BIAS);
-constexpr int32_t IN_K_DEQSCALE =
+constexpr int32_t kInKDeqScale =
     static_cast<int32_t>(OneRecBlockLayerTensorId::IN_K_DEQSCALE);
-constexpr int32_t IN_K_OFFSET =
+constexpr int32_t kInKOffset =
     static_cast<int32_t>(OneRecBlockLayerTensorId::IN_K_OFFSET);
-constexpr int32_t IN_K_SCALE =
+constexpr int32_t kInKScale =
     static_cast<int32_t>(OneRecBlockLayerTensorId::IN_K_SCALE);
-constexpr int32_t IN_K_COMPRESS_IDX =
+constexpr int32_t kInKCompressIdx =
     static_cast<int32_t>(OneRecBlockLayerTensorId::IN_K_COMPRESS_IDX);
-constexpr int32_t IN_V_WEIGHT =
+constexpr int32_t kInVWeight =
     static_cast<int32_t>(OneRecBlockLayerTensorId::IN_V_WEIGHT);
-constexpr int32_t IN_V_BIAS =
+constexpr int32_t kInVBias =
     static_cast<int32_t>(OneRecBlockLayerTensorId::IN_V_BIAS);
-constexpr int32_t IN_V_DEQSCALE =
+constexpr int32_t kInVDeqScale =
     static_cast<int32_t>(OneRecBlockLayerTensorId::IN_V_DEQSCALE);
-constexpr int32_t IN_V_OFFSET =
+constexpr int32_t kInVOffset =
     static_cast<int32_t>(OneRecBlockLayerTensorId::IN_V_OFFSET);
-constexpr int32_t IN_V_SCALE =
+constexpr int32_t kInVScale =
     static_cast<int32_t>(OneRecBlockLayerTensorId::IN_V_SCALE);
-constexpr int32_t IN_V_COMPRESS_IDX =
+constexpr int32_t kInVCompressIdx =
     static_cast<int32_t>(OneRecBlockLayerTensorId::IN_V_COMPRESS_IDX);
-constexpr int32_t IN_SELF_ATTN_OUT_WEIGHT =
+constexpr int32_t kInSelfAttnOutWeight =
     static_cast<int32_t>(OneRecBlockLayerTensorId::IN_SELF_ATTN_OUT_WEIGHT);
-constexpr int32_t IN_SELF_ATTN_OUT_BIAS =
+constexpr int32_t kInSelfAttnOutBias =
     static_cast<int32_t>(OneRecBlockLayerTensorId::IN_SELF_ATTN_OUT_BIAS);
-constexpr int32_t IN_SELF_ATTN_OUT_DEQSCALE =
+constexpr int32_t kInSelfAttnOutDeqScale =
     static_cast<int32_t>(OneRecBlockLayerTensorId::IN_SELF_ATTN_OUT_DEQSCALE);
-constexpr int32_t IN_SELF_ATTN_OUT_OFFSET =
+constexpr int32_t kInSelfAttnOutOffset =
     static_cast<int32_t>(OneRecBlockLayerTensorId::IN_SELF_ATTN_OUT_OFFSET);
-constexpr int32_t IN_SELF_ATTN_OUT_SCALE =
+constexpr int32_t kInSelfAttnOutScale =
     static_cast<int32_t>(OneRecBlockLayerTensorId::IN_SELF_ATTN_OUT_SCALE);
-constexpr int32_t IN_SELF_ATTN_OUT_COMPRESS_IDX = static_cast<int32_t>(
+constexpr int32_t kInSelfAttnOutCompressIdx = static_cast<int32_t>(
     OneRecBlockLayerTensorId::IN_SELF_ATTN_OUT_COMPRESS_IDX);
-constexpr int32_t IN_RELATIVE_ATTENTION_BIAS_WEIGHT = static_cast<int32_t>(
+constexpr int32_t kInRelativeAttentionBiasWeight = static_cast<int32_t>(
     OneRecBlockLayerTensorId::IN_RELATIVE_ATTENTION_BIAS_WEIGHT);
-constexpr int32_t IN_CROSS_LAYER_NORM_WEIGHT =
+constexpr int32_t kInCrossLayerNormWeight =
     static_cast<int32_t>(OneRecBlockLayerTensorId::IN_CROSS_LAYER_NORM_WEIGHT);
-constexpr int32_t IN_CROSS_LAYER_NORM_BIAS =
+constexpr int32_t kInCrossLayerNormBias =
     static_cast<int32_t>(OneRecBlockLayerTensorId::IN_CROSS_LAYER_NORM_BIAS);
-constexpr int32_t IN_CROSS_LAYER_NORM_NEW_WEIGHT = static_cast<int32_t>(
+constexpr int32_t kInCrossLayerNormNewWeight = static_cast<int32_t>(
     OneRecBlockLayerTensorId::IN_CROSS_LAYER_NORM_NEW_WEIGHT);
-constexpr int32_t IN_CROSS_LAYER_NORM_NEW_BIAS = static_cast<int32_t>(
+constexpr int32_t kInCrossLayerNormNewBias = static_cast<int32_t>(
     OneRecBlockLayerTensorId::IN_CROSS_LAYER_NORM_NEW_BIAS);
-constexpr int32_t IN_CROSS_Q_WEIGHT =
+constexpr int32_t kInCrossQWeight =
     static_cast<int32_t>(OneRecBlockLayerTensorId::IN_CROSS_Q_WEIGHT);
-constexpr int32_t IN_CROSS_Q_BIAS =
+constexpr int32_t kInCrossQBias =
     static_cast<int32_t>(OneRecBlockLayerTensorId::IN_CROSS_Q_BIAS);
-constexpr int32_t IN_CROSS_Q_DEQSCALE =
+constexpr int32_t kInCrossQDeqScale =
     static_cast<int32_t>(OneRecBlockLayerTensorId::IN_CROSS_Q_DEQSCALE);
-constexpr int32_t IN_CROSS_Q_OFFSET =
+constexpr int32_t kInCrossQOffset =
     static_cast<int32_t>(OneRecBlockLayerTensorId::IN_CROSS_Q_OFFSET);
-constexpr int32_t IN_CROSS_Q_SCALE =
+constexpr int32_t kInCrossQScale =
     static_cast<int32_t>(OneRecBlockLayerTensorId::IN_CROSS_Q_SCALE);
-constexpr int32_t IN_CROSS_Q_COMPRESS_IDX =
+constexpr int32_t kInCrossQCompressIdx =
     static_cast<int32_t>(OneRecBlockLayerTensorId::IN_CROSS_Q_COMPRESS_IDX);
-constexpr int32_t IN_CROSS_K_WEIGHT =
+constexpr int32_t kInCrossKWeight =
     static_cast<int32_t>(OneRecBlockLayerTensorId::IN_CROSS_K_WEIGHT);
-constexpr int32_t IN_CROSS_K_BIAS =
+constexpr int32_t kInCrossKBias =
     static_cast<int32_t>(OneRecBlockLayerTensorId::IN_CROSS_K_BIAS);
-constexpr int32_t IN_CROSS_K_DEQSCALE =
+constexpr int32_t kInCrossKDeqScale =
     static_cast<int32_t>(OneRecBlockLayerTensorId::IN_CROSS_K_DEQSCALE);
-constexpr int32_t IN_CROSS_K_OFFSET =
+constexpr int32_t kInCrossKOffset =
     static_cast<int32_t>(OneRecBlockLayerTensorId::IN_CROSS_K_OFFSET);
-constexpr int32_t IN_CROSS_K_SCALE =
+constexpr int32_t kInCrossKScale =
     static_cast<int32_t>(OneRecBlockLayerTensorId::IN_CROSS_K_SCALE);
-constexpr int32_t IN_CROSS_K_COMPRESS_IDX =
+constexpr int32_t kInCrossKCompressIdx =
     static_cast<int32_t>(OneRecBlockLayerTensorId::IN_CROSS_K_COMPRESS_IDX);
-constexpr int32_t IN_CROSS_V_WEIGHT =
+constexpr int32_t kInCrossVWeight =
     static_cast<int32_t>(OneRecBlockLayerTensorId::IN_CROSS_V_WEIGHT);
-constexpr int32_t IN_CROSS_V_BIAS =
+constexpr int32_t kInCrossVBias =
     static_cast<int32_t>(OneRecBlockLayerTensorId::IN_CROSS_V_BIAS);
-constexpr int32_t IN_CROSS_V_DEQSCALE =
+constexpr int32_t kInCrossVDeqScale =
     static_cast<int32_t>(OneRecBlockLayerTensorId::IN_CROSS_V_DEQSCALE);
-constexpr int32_t IN_CROSS_V_OFFSET =
+constexpr int32_t kInCrossVOffset =
     static_cast<int32_t>(OneRecBlockLayerTensorId::IN_CROSS_V_OFFSET);
-constexpr int32_t IN_CROSS_V_SCALE =
+constexpr int32_t kInCrossVScale =
     static_cast<int32_t>(OneRecBlockLayerTensorId::IN_CROSS_V_SCALE);
-constexpr int32_t IN_CROSS_V_COMPRESS_IDX =
+constexpr int32_t kInCrossVCompressIdx =
     static_cast<int32_t>(OneRecBlockLayerTensorId::IN_CROSS_V_COMPRESS_IDX);
-constexpr int32_t IN_CROSS_ATTN_OUT_WEIGHT =
+constexpr int32_t kInCrossAttnOutWeight =
     static_cast<int32_t>(OneRecBlockLayerTensorId::IN_CROSS_ATTN_OUT_WEIGHT);
-constexpr int32_t IN_CROSS_ATTN_OUT_BIAS =
+constexpr int32_t kInCrossAttnOutBias =
     static_cast<int32_t>(OneRecBlockLayerTensorId::IN_CROSS_ATTN_OUT_BIAS);
-constexpr int32_t IN_CROSS_ATTN_OUT_DEQSCALE =
+constexpr int32_t kInCrossAttnOutDeqScale =
     static_cast<int32_t>(OneRecBlockLayerTensorId::IN_CROSS_ATTN_OUT_DEQSCALE);
-constexpr int32_t IN_CROSS_ATTN_OUT_OFFSET =
+constexpr int32_t kInCrossAttnOutOffset =
     static_cast<int32_t>(OneRecBlockLayerTensorId::IN_CROSS_ATTN_OUT_OFFSET);
-constexpr int32_t IN_CROSS_ATTN_OUT_SCALE =
+constexpr int32_t kInCrossAttnOutScale =
     static_cast<int32_t>(OneRecBlockLayerTensorId::IN_CROSS_ATTN_OUT_SCALE);
-constexpr int32_t IN_CROSS_ATTN_OUT_COMPRESS_IDX = static_cast<int32_t>(
+constexpr int32_t kInCrossAttnOutCompressIdx = static_cast<int32_t>(
     OneRecBlockLayerTensorId::IN_CROSS_ATTN_OUT_COMPRESS_IDX);
-constexpr int32_t IN_FINAL_LAYER_NORM_WEIGHT =
+constexpr int32_t kInFinalLayerNormWeight =
     static_cast<int32_t>(OneRecBlockLayerTensorId::IN_FINAL_LAYER_NORM_WEIGHT);
-constexpr int32_t IN_FINAL_LAYER_NORM_BIAS =
+constexpr int32_t kInFinalLayerNormBias =
     static_cast<int32_t>(OneRecBlockLayerTensorId::IN_FINAL_LAYER_NORM_BIAS);
-constexpr int32_t IN_FINAL_LAYER_NORM_NEW_WEIGHT = static_cast<int32_t>(
+constexpr int32_t kInFinalLayerNormNewWeight = static_cast<int32_t>(
     OneRecBlockLayerTensorId::IN_FINAL_LAYER_NORM_NEW_WEIGHT);
-constexpr int32_t IN_FINAL_LAYER_NORM_NEW_BIAS = static_cast<int32_t>(
+constexpr int32_t kInFinalLayerNormNewBias = static_cast<int32_t>(
     OneRecBlockLayerTensorId::IN_FINAL_LAYER_NORM_NEW_BIAS);
-constexpr int32_t IN_FFN_WI_0_WEIGHT =
+constexpr int32_t kInFfnWi0Weight =
     static_cast<int32_t>(OneRecBlockLayerTensorId::IN_FFN_WI_0_WEIGHT);
-constexpr int32_t IN_FFN_WI_0_BIAS =
+constexpr int32_t kInFfnWi0Bias =
     static_cast<int32_t>(OneRecBlockLayerTensorId::IN_FFN_WI_0_BIAS);
-constexpr int32_t IN_FFN_WI_0_DEQSCALE =
+constexpr int32_t kInFfnWi0DeqScale =
     static_cast<int32_t>(OneRecBlockLayerTensorId::IN_FFN_WI_0_DEQSCALE);
-constexpr int32_t IN_FFN_WI_0_OFFSET =
+constexpr int32_t kInFfnWi0Offset =
     static_cast<int32_t>(OneRecBlockLayerTensorId::IN_FFN_WI_0_OFFSET);
-constexpr int32_t IN_FFN_WI_0_SCALE =
+constexpr int32_t kInFfnWi0Scale =
     static_cast<int32_t>(OneRecBlockLayerTensorId::IN_FFN_WI_0_SCALE);
-constexpr int32_t IN_FFN_WI_0_COMPRESS_IDX =
+constexpr int32_t kInFfnWi0CompressIdx =
     static_cast<int32_t>(OneRecBlockLayerTensorId::IN_FFN_WI_0_COMPRESS_IDX);
-constexpr int32_t IN_FFN_WI_1_WEIGHT =
+constexpr int32_t kInFfnWi1Weight =
     static_cast<int32_t>(OneRecBlockLayerTensorId::IN_FFN_WI_1_WEIGHT);
-constexpr int32_t IN_FFN_WI_1_BIAS =
+constexpr int32_t kInFfnWi1Bias =
     static_cast<int32_t>(OneRecBlockLayerTensorId::IN_FFN_WI_1_BIAS);
-constexpr int32_t IN_FFN_WI_1_DEQSCALE =
+constexpr int32_t kInFfnWi1DeqScale =
     static_cast<int32_t>(OneRecBlockLayerTensorId::IN_FFN_WI_1_DEQSCALE);
-constexpr int32_t IN_FFN_WI_1_OFFSET =
+constexpr int32_t kInFfnWi1Offset =
     static_cast<int32_t>(OneRecBlockLayerTensorId::IN_FFN_WI_1_OFFSET);
-constexpr int32_t IN_FFN_WI_1_SCALE =
+constexpr int32_t kInFfnWi1Scale =
     static_cast<int32_t>(OneRecBlockLayerTensorId::IN_FFN_WI_1_SCALE);
-constexpr int32_t IN_FFN_WI_1_COMPRESS_IDX =
+constexpr int32_t kInFfnWi1CompressIdx =
     static_cast<int32_t>(OneRecBlockLayerTensorId::IN_FFN_WI_1_COMPRESS_IDX);
-constexpr int32_t IN_FFN_WO_WEIGHT =
+constexpr int32_t kInFfnWoWeight =
     static_cast<int32_t>(OneRecBlockLayerTensorId::IN_FFN_WO_WEIGHT);
-constexpr int32_t IN_FFN_WO_BIAS =
+constexpr int32_t kInFfnWoBias =
     static_cast<int32_t>(OneRecBlockLayerTensorId::IN_FFN_WO_BIAS);
-constexpr int32_t IN_FFN_WO_DEQSCALE =
+constexpr int32_t kInFfnWoDeqScale =
     static_cast<int32_t>(OneRecBlockLayerTensorId::IN_FFN_WO_DEQSCALE);
-constexpr int32_t IN_FFN_WO_OFFSET =
+constexpr int32_t kInFfnWoOffset =
     static_cast<int32_t>(OneRecBlockLayerTensorId::IN_FFN_WO_OFFSET);
-constexpr int32_t IN_FFN_WO_SCALE =
+constexpr int32_t kInFfnWoScale =
     static_cast<int32_t>(OneRecBlockLayerTensorId::IN_FFN_WO_SCALE);
-constexpr int32_t IN_FFN_WO_COMPRESS_IDX =
+constexpr int32_t kInFfnWoCompressIdx =
     static_cast<int32_t>(OneRecBlockLayerTensorId::IN_FFN_WO_COMPRESS_IDX);
 
 enum class OneRecMoeBlockLayerTensorId : int32_t {
@@ -358,193 +358,194 @@ enum class OneRecMoeBlockLayerTensorId : int32_t {
   IN_MOE_SHARED_W2_WEIGHT = IN_MLP_DOWN_WEIGHT_SHARED_EXPERT,
 };
 
-constexpr int32_t IN_BLOCK_SPARSE_MOE_GATE_WEIGHT = static_cast<int32_t>(
+constexpr int32_t kInBlockSparseMoeGateWeight = static_cast<int32_t>(
     OneRecMoeBlockLayerTensorId::IN_BLOCK_SPARSE_MOE_GATE_WEIGHT);
-constexpr int32_t IN_BLOCK_SPARSE_MOE_GATE_BIAS = static_cast<int32_t>(
+constexpr int32_t kInBlockSparseMoeGateBias = static_cast<int32_t>(
     OneRecMoeBlockLayerTensorId::IN_BLOCK_SPARSE_MOE_GATE_BIAS);
-constexpr int32_t IN_BLOCK_SPARSE_MOE_GATE_DESCALE = static_cast<int32_t>(
+constexpr int32_t kInBlockSparseMoeGateDescale = static_cast<int32_t>(
     OneRecMoeBlockLayerTensorId::IN_BLOCK_SPARSE_MOE_GATE_DESCALE);
-constexpr int32_t IN_BLOCK_SPARSE_MOE_GATE_OFFSET = static_cast<int32_t>(
+constexpr int32_t kInBlockSparseMoeGateOffset = static_cast<int32_t>(
     OneRecMoeBlockLayerTensorId::IN_BLOCK_SPARSE_MOE_GATE_OFFSET);
-constexpr int32_t IN_BLOCK_SPARSE_MOE_GATE_SCALE = static_cast<int32_t>(
+constexpr int32_t kInBlockSparseMoeGateScale = static_cast<int32_t>(
     OneRecMoeBlockLayerTensorId::IN_BLOCK_SPARSE_MOE_GATE_SCALE);
-constexpr int32_t IN_BLOCK_SPARSE_MOE_GATE_COMPRESS_IDX = static_cast<int32_t>(
+constexpr int32_t kInBlockSparseMoeGateCompressIdx = static_cast<int32_t>(
     OneRecMoeBlockLayerTensorId::IN_BLOCK_SPARSE_MOE_GATE_COMPRESS_IDX);
-constexpr int32_t IN_MLP_GATEUP_WEIGHT_SHARED_EXPERT = static_cast<int32_t>(
+constexpr int32_t kInMlpGateUpWeightSharedExpert = static_cast<int32_t>(
     OneRecMoeBlockLayerTensorId::IN_MLP_GATEUP_WEIGHT_SHARED_EXPERT);
-constexpr int32_t IN_MLP_GATEUP_BIAS_SHARED_EXPERT = static_cast<int32_t>(
+constexpr int32_t kInMlpGateUpBiasSharedExpert = static_cast<int32_t>(
     OneRecMoeBlockLayerTensorId::IN_MLP_GATEUP_BIAS_SHARED_EXPERT);
-constexpr int32_t IN_MLP_GATEUP_DESCALE_SHARED_EXPERT = static_cast<int32_t>(
+constexpr int32_t kInMlpGateUpDescaleSharedExpert = static_cast<int32_t>(
     OneRecMoeBlockLayerTensorId::IN_MLP_GATEUP_DESCALE_SHARED_EXPERT);
-constexpr int32_t IN_MLP_GATEUP_OFFSET_SHARED_EXPERT = static_cast<int32_t>(
+constexpr int32_t kInMlpGateUpOffsetSharedExpert = static_cast<int32_t>(
     OneRecMoeBlockLayerTensorId::IN_MLP_GATEUP_OFFSET_SHARED_EXPERT);
-constexpr int32_t IN_MLP_GATEUP_SCALE_SHARED_EXPERT = static_cast<int32_t>(
+constexpr int32_t kInMlpGateUpScaleSharedExpert = static_cast<int32_t>(
     OneRecMoeBlockLayerTensorId::IN_MLP_GATEUP_SCALE_SHARED_EXPERT);
-constexpr int32_t IN_MLP_GATEUP_COMPRESS_IDX_SHARED_EXPERT =
+constexpr int32_t kInMlpGateUpCompressIdxSharedExpert =
     static_cast<int32_t>(
         OneRecMoeBlockLayerTensorId::IN_MLP_GATEUP_COMPRESS_IDX_SHARED_EXPERT);
-constexpr int32_t IN_MLP_DOWN_WEIGHT_SHARED_EXPERT = static_cast<int32_t>(
+constexpr int32_t kInMlpDownWeightSharedExpert = static_cast<int32_t>(
     OneRecMoeBlockLayerTensorId::IN_MLP_DOWN_WEIGHT_SHARED_EXPERT);
-constexpr int32_t IN_MLP_DOWN_BIAS_SHARED_EXPERT = static_cast<int32_t>(
+constexpr int32_t kInMlpDownBiasSharedExpert = static_cast<int32_t>(
     OneRecMoeBlockLayerTensorId::IN_MLP_DOWN_BIAS_SHARED_EXPERT);
-constexpr int32_t IN_MLP_DOWN_DESCALE_SHARED_EXPERT = static_cast<int32_t>(
+constexpr int32_t kInMlpDownDescaleSharedExpert = static_cast<int32_t>(
     OneRecMoeBlockLayerTensorId::IN_MLP_DOWN_DESCALE_SHARED_EXPERT);
-constexpr int32_t IN_MLP_DOWN_OFFSET_SHARED_EXPERT = static_cast<int32_t>(
+constexpr int32_t kInMlpDownOffsetSharedExpert = static_cast<int32_t>(
     OneRecMoeBlockLayerTensorId::IN_MLP_DOWN_OFFSET_SHARED_EXPERT);
-constexpr int32_t IN_MLP_DOWN_SCALE_SHARED_EXPERT = static_cast<int32_t>(
+constexpr int32_t kInMlpDownScaleSharedExpert = static_cast<int32_t>(
     OneRecMoeBlockLayerTensorId::IN_MLP_DOWN_SCALE_SHARED_EXPERT);
-constexpr int32_t IN_MLP_DOWN_COMPRESS_IDX_SHARED_EXPERT = static_cast<int32_t>(
+constexpr int32_t kInMlpDownCompressIdxSharedExpert = static_cast<int32_t>(
     OneRecMoeBlockLayerTensorId::IN_MLP_DOWN_COMPRESS_IDX_SHARED_EXPERT);
-constexpr int32_t IN_SHARED_EXPERT_GATE_WEIGHT = static_cast<int32_t>(
+constexpr int32_t kInSharedExpertGateWeight = static_cast<int32_t>(
     OneRecMoeBlockLayerTensorId::IN_SHARED_EXPERT_GATE_WEIGHT);
-constexpr int32_t IN_SHARED_EXPERT_GATE_BIAS = static_cast<int32_t>(
+constexpr int32_t kInSharedExpertGateBias = static_cast<int32_t>(
     OneRecMoeBlockLayerTensorId::IN_SHARED_EXPERT_GATE_BIAS);
-constexpr int32_t IN_SHARED_EXPERT_GATE_DESCALE = static_cast<int32_t>(
+constexpr int32_t kInSharedExpertGateDescale = static_cast<int32_t>(
     OneRecMoeBlockLayerTensorId::IN_SHARED_EXPERT_GATE_DESCALE);
-constexpr int32_t IN_SHARED_EXPERT_GATE_OFFSET = static_cast<int32_t>(
+constexpr int32_t kInSharedExpertGateOffset = static_cast<int32_t>(
     OneRecMoeBlockLayerTensorId::IN_SHARED_EXPERT_GATE_OFFSET);
-constexpr int32_t IN_SHARED_EXPERT_GATE_SCALE = static_cast<int32_t>(
+constexpr int32_t kInSharedExpertGateScale = static_cast<int32_t>(
     OneRecMoeBlockLayerTensorId::IN_SHARED_EXPERT_GATE_SCALE);
-constexpr int32_t IN_SHARED_EXPERT_GATE_COMPRESS_IDX = static_cast<int32_t>(
+constexpr int32_t kInSharedExpertGateCompressIdx = static_cast<int32_t>(
     OneRecMoeBlockLayerTensorId::IN_SHARED_EXPERT_GATE_COMPRESS_IDX);
-constexpr int32_t IN_MLP_GATEUP_WEIGHT_EXPERT = static_cast<int32_t>(
+constexpr int32_t kInMlpGateUpWeightExpert = static_cast<int32_t>(
     OneRecMoeBlockLayerTensorId::IN_MLP_GATEUP_WEIGHT_EXPERT);
-constexpr int32_t IN_MLP_GATEUP_BIAS_EXPERT = static_cast<int32_t>(
+constexpr int32_t kInMlpGateUpBiasExpert = static_cast<int32_t>(
     OneRecMoeBlockLayerTensorId::IN_MLP_GATEUP_BIAS_EXPERT);
-constexpr int32_t IN_MLP_GATEUP_DESCALE_EXPERT = static_cast<int32_t>(
+constexpr int32_t kInMlpGateUpDescaleExpert = static_cast<int32_t>(
     OneRecMoeBlockLayerTensorId::IN_MLP_GATEUP_DESCALE_EXPERT);
-constexpr int32_t IN_MLP_GATEUP_OFFSET_EXPERT = static_cast<int32_t>(
+constexpr int32_t kInMlpGateUpOffsetExpert = static_cast<int32_t>(
     OneRecMoeBlockLayerTensorId::IN_MLP_GATEUP_OFFSET_EXPERT);
-constexpr int32_t IN_MLP_GATEUP_SCALE_EXPERT = static_cast<int32_t>(
+constexpr int32_t kInMlpGateUpScaleExpert = static_cast<int32_t>(
     OneRecMoeBlockLayerTensorId::IN_MLP_GATEUP_SCALE_EXPERT);
-constexpr int32_t IN_MLP_GATEUP_COMPRESS_IDX_EXPERT = static_cast<int32_t>(
+constexpr int32_t kInMlpGateUpCompressIdxExpert = static_cast<int32_t>(
     OneRecMoeBlockLayerTensorId::IN_MLP_GATEUP_COMPRESS_IDX_EXPERT);
-constexpr int32_t IN_MLP_DOWN_WEIGHT_EXPERT = static_cast<int32_t>(
+constexpr int32_t kInMlpDownWeightExpert = static_cast<int32_t>(
     OneRecMoeBlockLayerTensorId::IN_MLP_DOWN_WEIGHT_EXPERT);
-constexpr int32_t IN_MLP_DOWN_BIAS_EXPERT =
+constexpr int32_t kInMlpDownBiasExpert =
     static_cast<int32_t>(OneRecMoeBlockLayerTensorId::IN_MLP_DOWN_BIAS_EXPERT);
-constexpr int32_t IN_MLP_DOWN_DESCALE_EXPERT = static_cast<int32_t>(
+constexpr int32_t kInMlpDownDescaleExpert = static_cast<int32_t>(
     OneRecMoeBlockLayerTensorId::IN_MLP_DOWN_DESCALE_EXPERT);
-constexpr int32_t IN_MLP_DOWN_OFFSET_EXPERT = static_cast<int32_t>(
+constexpr int32_t kInMlpDownOffsetExpert = static_cast<int32_t>(
     OneRecMoeBlockLayerTensorId::IN_MLP_DOWN_OFFSET_EXPERT);
-constexpr int32_t IN_MLP_DOWN_SCALE_EXPERT =
+constexpr int32_t kInMlpDownScaleExpert =
     static_cast<int32_t>(OneRecMoeBlockLayerTensorId::IN_MLP_DOWN_SCALE_EXPERT);
-constexpr int32_t IN_MLP_DOWN_COMPRESS_IDX_EXPERT = static_cast<int32_t>(
+constexpr int32_t kInMlpDownCompressIdxExpert = static_cast<int32_t>(
     OneRecMoeBlockLayerTensorId::IN_MLP_DOWN_COMPRESS_IDX_EXPERT);
-constexpr int32_t IN_EXPERT_ARRAY =
+constexpr int32_t kInExpertArray =
     static_cast<int32_t>(OneRecMoeBlockLayerTensorId::IN_EXPERT_ARRAY);
-constexpr int32_t IN_EXPERT_GROUP =
+constexpr int32_t kInExpertGroup =
     static_cast<int32_t>(OneRecMoeBlockLayerTensorId::IN_EXPERT_GROUP);
-constexpr int32_t IN_ONE_HOT =
+constexpr int32_t kInOneHot =
     static_cast<int32_t>(OneRecMoeBlockLayerTensorId::IN_ONE_HOT);
-constexpr int32_t IN_ZERO_HOT =
+constexpr int32_t kInZeroHot =
     static_cast<int32_t>(OneRecMoeBlockLayerTensorId::IN_ZERO_HOT);
-constexpr int32_t IN_MOE_EXPERT_W1_WEIGHT =
+constexpr int32_t kInMoeExpertW1Weight =
     static_cast<int32_t>(OneRecMoeBlockLayerTensorId::IN_MOE_EXPERT_W1_WEIGHT);
-constexpr int32_t IN_MOE_EXPERT_W2_WEIGHT =
+constexpr int32_t kInMoeExpertW2Weight =
     static_cast<int32_t>(OneRecMoeBlockLayerTensorId::IN_MOE_EXPERT_W2_WEIGHT);
-constexpr int32_t IN_MOE_EXPERT_W3_WEIGHT =
+constexpr int32_t kInMoeExpertW3Weight =
     static_cast<int32_t>(OneRecMoeBlockLayerTensorId::IN_MOE_EXPERT_W3_WEIGHT);
-constexpr int32_t IN_MOE_SHARED_W1_WEIGHT =
+constexpr int32_t kInMoeSharedW1Weight =
     static_cast<int32_t>(OneRecMoeBlockLayerTensorId::IN_MOE_SHARED_W1_WEIGHT);
-constexpr int32_t IN_MOE_SHARED_W2_WEIGHT =
+constexpr int32_t kInMoeSharedW2Weight =
     static_cast<int32_t>(OneRecMoeBlockLayerTensorId::IN_MOE_SHARED_W2_WEIGHT);
 
 static const std::unordered_map<std::string, int32_t>
     kOneRecEncoderWeightMapping = {
-        {"layer.0.layer_norm.weight", IN_LAYER_NORM_WEIGHT},
-        {"layer.0.SelfAttention.q.weight", IN_Q_WEIGHT},
-        {"layer.0.SelfAttention.k.weight", IN_K_WEIGHT},
-        {"layer.0.SelfAttention.v.weight", IN_V_WEIGHT},
-        {"layer.0.SelfAttention.o.weight", IN_SELF_ATTN_OUT_WEIGHT},
+        {"layer.0.layer_norm.weight", kInLayerNormWeight},
+        {"layer.0.SelfAttention.q.weight", kInQWeight},
+        {"layer.0.SelfAttention.k.weight", kInKWeight},
+        {"layer.0.SelfAttention.v.weight", kInVWeight},
+        {"layer.0.SelfAttention.o.weight", kInSelfAttnOutWeight},
         {"layer.0.SelfAttention.relative_attention_bias.weight",
-         IN_RELATIVE_ATTENTION_BIAS_WEIGHT},
-        {"layer.1.layer_norm.weight", IN_FINAL_LAYER_NORM_WEIGHT},
-        {"layer.1.DenseReluDense.wi.weight", IN_FFN_WI_1_WEIGHT},
-        {"layer.1.DenseReluDense.wo.weight", IN_FFN_WO_WEIGHT},
-        {"layer.1.DenseReluDense.gate_proj.weight", IN_FFN_WI_0_WEIGHT},
-        {"layer.1.ffn.wi.weight", IN_FFN_WI_1_WEIGHT},
-        {"layer.1.ffn.wo.weight", IN_FFN_WO_WEIGHT},
-        {"layer.1.ffn.gate_proj.weight", IN_FFN_WI_0_WEIGHT},
+         kInRelativeAttentionBiasWeight},
+        {"layer.1.layer_norm.weight", kInFinalLayerNormWeight},
+        {"layer.1.DenseReluDense.wi.weight", kInFfnWi1Weight},
+        {"layer.1.DenseReluDense.wo.weight", kInFfnWoWeight},
+        {"layer.1.DenseReluDense.gate_proj.weight", kInFfnWi0Weight},
+        {"layer.1.ffn.wi.weight", kInFfnWi1Weight},
+        {"layer.1.ffn.wo.weight", kInFfnWoWeight},
+        {"layer.1.ffn.gate_proj.weight", kInFfnWi0Weight},
         // Alternative format
-        {"0.layer_norm.weight", IN_LAYER_NORM_WEIGHT},
-        {"0.SelfAttention.q.weight", IN_Q_WEIGHT},
-        {"0.SelfAttention.k.weight", IN_K_WEIGHT},
-        {"0.SelfAttention.v.weight", IN_V_WEIGHT},
-        {"0.SelfAttention.o.weight", IN_SELF_ATTN_OUT_WEIGHT},
+        {"0.layer_norm.weight", kInLayerNormWeight},
+        {"0.SelfAttention.q.weight", kInQWeight},
+        {"0.SelfAttention.k.weight", kInKWeight},
+        {"0.SelfAttention.v.weight", kInVWeight},
+        {"0.SelfAttention.o.weight", kInSelfAttnOutWeight},
         {"0.SelfAttention.relative_attention_bias.weight",
-         IN_RELATIVE_ATTENTION_BIAS_WEIGHT},
-        {"1.layer_norm.weight", IN_FINAL_LAYER_NORM_WEIGHT},
-        {"1.DenseReluDense.wi.weight", IN_FFN_WI_1_WEIGHT},
-        {"1.DenseReluDense.wo.weight", IN_FFN_WO_WEIGHT},
-        {"1.DenseReluDense.gate_proj.weight", IN_FFN_WI_0_WEIGHT},
-        {"1.ffn.wi.weight", IN_FFN_WI_1_WEIGHT},
-        {"1.ffn.wo.weight", IN_FFN_WO_WEIGHT},
-        {"1.ffn.gate_proj.weight", IN_FFN_WI_0_WEIGHT},
+         kInRelativeAttentionBiasWeight},
+        {"1.layer_norm.weight", kInFinalLayerNormWeight},
+        {"1.DenseReluDense.wi.weight", kInFfnWi1Weight},
+        {"1.DenseReluDense.wo.weight", kInFfnWoWeight},
+        {"1.DenseReluDense.gate_proj.weight", kInFfnWi0Weight},
+        {"1.ffn.wi.weight", kInFfnWi1Weight},
+        {"1.ffn.wo.weight", kInFfnWoWeight},
+        {"1.ffn.gate_proj.weight", kInFfnWi0Weight},
 };
 
 static const std::unordered_map<std::string, int32_t>
     kOneRecDecoderWeightMapping = {
-        {"layer.0.layer_norm.weight", IN_LAYER_NORM_WEIGHT},
-        {"layer.0.SelfAttention.q.weight", IN_Q_WEIGHT},
-        {"layer.0.SelfAttention.k.weight", IN_K_WEIGHT},
-        {"layer.0.SelfAttention.v.weight", IN_V_WEIGHT},
-        {"layer.0.SelfAttention.o.weight", IN_SELF_ATTN_OUT_WEIGHT},
+        {"layer.0.layer_norm.weight", kInLayerNormWeight},
+        {"layer.0.SelfAttention.q.weight", kInQWeight},
+        {"layer.0.SelfAttention.k.weight", kInKWeight},
+        {"layer.0.SelfAttention.v.weight", kInVWeight},
+        {"layer.0.SelfAttention.o.weight", kInSelfAttnOutWeight},
         {"layer.0.SelfAttention.relative_attention_bias.weight",
-         IN_RELATIVE_ATTENTION_BIAS_WEIGHT},
-        {"layer.1.layer_norm.weight", IN_CROSS_LAYER_NORM_WEIGHT},
-        {"layer.1.EncDecAttention.q.weight", IN_CROSS_Q_WEIGHT},
-        {"layer.1.EncDecAttention.k.weight", IN_CROSS_K_WEIGHT},
-        {"layer.1.EncDecAttention.v.weight", IN_CROSS_V_WEIGHT},
-        {"layer.1.EncDecAttention.o.weight", IN_CROSS_ATTN_OUT_WEIGHT},
-        {"layer.2.layer_norm.weight", IN_FINAL_LAYER_NORM_WEIGHT},
-        {"layer.2.DenseReluDense.wi.weight", IN_FFN_WI_1_WEIGHT},
-        {"layer.2.DenseReluDense.wo.weight", IN_FFN_WO_WEIGHT},
-        {"layer.2.DenseReluDense.gate_proj.weight", IN_FFN_WI_0_WEIGHT},
+         kInRelativeAttentionBiasWeight},
+        {"layer.1.layer_norm.weight", kInCrossLayerNormWeight},
+        {"layer.1.EncDecAttention.q.weight", kInCrossQWeight},
+        {"layer.1.EncDecAttention.k.weight", kInCrossKWeight},
+        {"layer.1.EncDecAttention.v.weight", kInCrossVWeight},
+        {"layer.1.EncDecAttention.o.weight", kInCrossAttnOutWeight},
+        {"layer.2.layer_norm.weight", kInFinalLayerNormWeight},
+        {"layer.2.DenseReluDense.wi.weight", kInFfnWi1Weight},
+        {"layer.2.DenseReluDense.wo.weight", kInFfnWoWeight},
+        {"layer.2.DenseReluDense.gate_proj.weight", kInFfnWi0Weight},
         // Alternative format
-        {"0.layer_norm.weight", IN_LAYER_NORM_WEIGHT},
-        {"0.SelfAttention.q.weight", IN_Q_WEIGHT},
-        {"0.SelfAttention.k.weight", IN_K_WEIGHT},
-        {"0.SelfAttention.v.weight", IN_V_WEIGHT},
-        {"0.SelfAttention.o.weight", IN_SELF_ATTN_OUT_WEIGHT},
+        {"0.layer_norm.weight", kInLayerNormWeight},
+        {"0.SelfAttention.q.weight", kInQWeight},
+        {"0.SelfAttention.k.weight", kInKWeight},
+        {"0.SelfAttention.v.weight", kInVWeight},
+        {"0.SelfAttention.o.weight", kInSelfAttnOutWeight},
         {"0.SelfAttention.relative_attention_bias.weight",
-         IN_RELATIVE_ATTENTION_BIAS_WEIGHT},
-        {"1.layer_norm.weight", IN_CROSS_LAYER_NORM_WEIGHT},
-        {"1.EncDecAttention.q.weight", IN_CROSS_Q_WEIGHT},
-        {"1.EncDecAttention.k.weight", IN_CROSS_K_WEIGHT},
-        {"1.EncDecAttention.v.weight", IN_CROSS_V_WEIGHT},
-        {"1.EncDecAttention.o.weight", IN_CROSS_ATTN_OUT_WEIGHT},
-        {"2.layer_norm.weight", IN_FINAL_LAYER_NORM_WEIGHT},
-        {"2.DenseReluDense.wi.weight", IN_FFN_WI_1_WEIGHT},
-        {"2.DenseReluDense.wo.weight", IN_FFN_WO_WEIGHT},
-        {"2.DenseReluDense.gate_proj.weight", IN_FFN_WI_0_WEIGHT},
-        {"2.ffn.wi.weight", IN_FFN_WI_1_WEIGHT},
-        {"2.ffn.wo.weight", IN_FFN_WO_WEIGHT},
-        {"2.ffn.gate_proj.weight", IN_FFN_WI_0_WEIGHT},
+         kInRelativeAttentionBiasWeight},
+        {"1.layer_norm.weight", kInCrossLayerNormWeight},
+        {"1.EncDecAttention.q.weight", kInCrossQWeight},
+        {"1.EncDecAttention.k.weight", kInCrossKWeight},
+        {"1.EncDecAttention.v.weight", kInCrossVWeight},
+        {"1.EncDecAttention.o.weight", kInCrossAttnOutWeight},
+        {"2.layer_norm.weight", kInFinalLayerNormWeight},
+        {"2.DenseReluDense.wi.weight", kInFfnWi1Weight},
+        {"2.DenseReluDense.wo.weight", kInFfnWoWeight},
+        {"2.DenseReluDense.gate_proj.weight", kInFfnWi0Weight},
+        {"2.ffn.wi.weight", kInFfnWi1Weight},
+        {"2.ffn.wo.weight", kInFfnWoWeight},
+        {"2.ffn.gate_proj.weight", kInFfnWi0Weight},
 };
 
-static std::unordered_map<std::string, int>
+static std::unordered_map<std::string, int32_t>
 get_onerec_decoder_moe_weight_mapping() {
-  std::unordered_map<std::string, int> mapping = kOneRecDecoderWeightMapping;
+  std::unordered_map<std::string, int32_t> mapping =
+      kOneRecDecoderWeightMapping;
 
-  mapping.emplace("layer.2.ffn.gate.weight", IN_BLOCK_SPARSE_MOE_GATE_WEIGHT);
-  mapping.emplace("2.ffn.gate.weight", IN_BLOCK_SPARSE_MOE_GATE_WEIGHT);
+  mapping.emplace("layer.2.ffn.gate.weight", kInBlockSparseMoeGateWeight);
+  mapping.emplace("2.ffn.gate.weight", kInBlockSparseMoeGateWeight);
 
   mapping.emplace("layer.2.ffn.shared_experts.w1.weight",
-                  IN_MLP_GATEUP_WEIGHT_SHARED_EXPERT);
+                  kInMlpGateUpWeightSharedExpert);
   mapping.emplace("layer.2.ffn.shared_experts.w3.weight",
-                  IN_MLP_GATEUP_WEIGHT_SHARED_EXPERT);
+                  kInMlpGateUpWeightSharedExpert);
   mapping.emplace("layer.2.ffn.shared_experts.w2.weight",
-                  IN_MLP_DOWN_WEIGHT_SHARED_EXPERT);
+                  kInMlpDownWeightSharedExpert);
 
   mapping.emplace("layer.2.ffn.shared_expert.gate.weight",
-                  IN_SHARED_EXPERT_GATE_WEIGHT);
+                  kInSharedExpertGateWeight);
   mapping.emplace("layer.2.ffn.shared_expert.gate.bias",
-                  IN_SHARED_EXPERT_GATE_BIAS);
+                  kInSharedExpertGateBias);
   mapping.emplace("layer.2.ffn.shared_expert.gate.weight_scale",
-                  IN_SHARED_EXPERT_GATE_SCALE);
+                  kInSharedExpertGateScale);
   mapping.emplace("layer.2.ffn.shared_expert.gate.weight_offset",
-                  IN_SHARED_EXPERT_GATE_OFFSET);
+                  kInSharedExpertGateOffset);
 
   // Expert weights are handled by
   // process_expert_weights()/merge_experts_weights to avoid ambiguous suffix
@@ -553,36 +554,36 @@ get_onerec_decoder_moe_weight_mapping() {
   return mapping;
 }
 
-static const std::unordered_map<std::string, int>
+static const std::unordered_map<std::string, int32_t>
     kOneRecDecoderMoeWeightMapping = get_onerec_decoder_moe_weight_mapping();
 
 static const std::unordered_map<int32_t, int32_t> kOneRecWeightShard = {
-    {IN_Q_WEIGHT, 0},
-    {IN_K_WEIGHT, 0},
-    {IN_V_WEIGHT, 0},
-    {IN_SELF_ATTN_OUT_WEIGHT, 1},
-    {IN_CROSS_Q_WEIGHT, 0},
-    {IN_CROSS_K_WEIGHT, 0},
-    {IN_CROSS_V_WEIGHT, 0},
-    {IN_CROSS_ATTN_OUT_WEIGHT, 1},
-    {IN_FFN_WI_0_WEIGHT, 0},
-    {IN_FFN_WI_1_WEIGHT, 0},
-    {IN_FFN_WO_WEIGHT, 1},
+    {kInQWeight, 0},
+    {kInKWeight, 0},
+    {kInVWeight, 0},
+    {kInSelfAttnOutWeight, 1},
+    {kInCrossQWeight, 0},
+    {kInCrossKWeight, 0},
+    {kInCrossVWeight, 0},
+    {kInCrossAttnOutWeight, 1},
+    {kInFfnWi0Weight, 0},
+    {kInFfnWi1Weight, 0},
+    {kInFfnWoWeight, 1},
     // MoE
-    {IN_BLOCK_SPARSE_MOE_GATE_WEIGHT, 0},
-    {IN_MLP_GATEUP_WEIGHT_EXPERT, 0},
-    {IN_MLP_DOWN_WEIGHT_EXPERT, 1},
+    {kInBlockSparseMoeGateWeight, 0},
+    {kInMlpGateUpWeightExpert, 0},
+    {kInMlpDownWeightExpert, 1},
     // Shared experts
-    {IN_MLP_GATEUP_WEIGHT_SHARED_EXPERT, 0},
-    {IN_MLP_GATEUP_OFFSET_SHARED_EXPERT, 0},
-    {IN_MLP_GATEUP_SCALE_SHARED_EXPERT, 0},
-    {IN_MLP_DOWN_WEIGHT_SHARED_EXPERT, 1},
-    {IN_MLP_DOWN_OFFSET_SHARED_EXPERT, 1},
-    {IN_MLP_DOWN_SCALE_SHARED_EXPERT, 1},
-    {IN_SHARED_EXPERT_GATE_WEIGHT, 0},
-    {IN_SHARED_EXPERT_GATE_BIAS, 0},
-    {IN_SHARED_EXPERT_GATE_SCALE, 0},
-    {IN_SHARED_EXPERT_GATE_OFFSET, 0},
+    {kInMlpGateUpWeightSharedExpert, 0},
+    {kInMlpGateUpOffsetSharedExpert, 0},
+    {kInMlpGateUpScaleSharedExpert, 0},
+    {kInMlpDownWeightSharedExpert, 1},
+    {kInMlpDownOffsetSharedExpert, 1},
+    {kInMlpDownScaleSharedExpert, 1},
+    {kInSharedExpertGateWeight, 0},
+    {kInSharedExpertGateBias, 0},
+    {kInSharedExpertGateScale, 0},
+    {kInSharedExpertGateOffset, 0},
 };
 
 }  // namespace
@@ -596,7 +597,7 @@ NpuOneRecBlockLayerImpl::NpuOneRecBlockLayerImpl(const ModelContext& context,
   param_from_args(prefill_param_, args, parallel_args, /*is_prefill=*/true);
   param_from_args(decode_param_, args, parallel_args, /*is_prefill=*/false);
 
-  const int weight_count = prefill_param_.use_moe
+  const int32_t weight_count = prefill_param_.use_moe
                                ? kOneRecMoeWeightCountPerLayer
                                : kOneRecWeightCountPerLayer;
   at_weight_tensors_.resize(weight_count);
@@ -610,7 +611,7 @@ NpuOneRecBlockLayerImpl::NpuOneRecBlockLayerImpl(const ModelContext& context,
   placeholder_ = atb_speed::Utils::AtTensor2Tensor(placeholder_tensor);
   at_placeholder_ = torch::empty({1, args.hidden_size()}, dtype_).to(device_);
 
-  for (int i = 0; i < weight_count; ++i) {
+  for (int32_t i = 0; i < weight_count; ++i) {
     at_weight_tensors_[i] =
         torch::zeros({1, args.hidden_size()}).to(context.get_tensor_options());
   }
@@ -724,7 +725,7 @@ void NpuOneRecBlockLayerImpl::param_from_args(
 void NpuOneRecBlockLayerImpl::verify_loaded_weights(
     const std::string& prefix) const {
   const auto& weight_mapping =
-      [this]() -> const std::unordered_map<std::string, int>& {
+      [this]() -> const std::unordered_map<std::string, int32_t>& {
     if (prefill_param_.use_moe) {
       return kOneRecDecoderMoeWeightMapping;
     }
@@ -735,12 +736,12 @@ void NpuOneRecBlockLayerImpl::verify_loaded_weights(
   // verify_loaded_weights() runs before merge_loaded_weights().
   // Only allow placeholders for tensors that are intentionally absent before
   // merge in the current mode.
-  std::set<int> allowed_placeholders;
+  std::set<int32_t> allowed_placeholders;
   if (prefill_param_.use_moe) {
     // MoE decoder path does not consume dense FFN gate/up/down tensors.
-    allowed_placeholders.insert(IN_FFN_WI_0_WEIGHT);
-    allowed_placeholders.insert(IN_FFN_WI_1_WEIGHT);
-    allowed_placeholders.insert(IN_FFN_WO_WEIGHT);
+    allowed_placeholders.insert(kInFfnWi0Weight);
+    allowed_placeholders.insert(kInFfnWi1Weight);
+    allowed_placeholders.insert(kInFfnWoWeight);
   }
   const bool has_shared_experts =
       prefill_param_.moe_config != nullptr &&
@@ -750,15 +751,15 @@ void NpuOneRecBlockLayerImpl::verify_loaded_weights(
     const auto sizes = at_weight_tensors_[index].sizes();
     const bool is_placeholder = (sizes.size() == 2 && sizes[0] == 1);
     const bool expected_placeholder = allowed_placeholders.count(index) > 0;
-    const bool is_relative_bias = (index == IN_RELATIVE_ATTENTION_BIAS_WEIGHT);
+    const bool is_relative_bias = (index == kInRelativeAttentionBiasWeight);
     const bool is_shared_optional =
         prefill_param_.use_moe && !has_shared_experts &&
-        (index == IN_MLP_GATEUP_WEIGHT_SHARED_EXPERT ||
-         index == IN_MLP_DOWN_WEIGHT_SHARED_EXPERT ||
-         index == IN_SHARED_EXPERT_GATE_WEIGHT ||
-         index == IN_SHARED_EXPERT_GATE_BIAS ||
-         index == IN_SHARED_EXPERT_GATE_OFFSET ||
-         index == IN_SHARED_EXPERT_GATE_SCALE);
+        (index == kInMlpGateUpWeightSharedExpert ||
+         index == kInMlpDownWeightSharedExpert ||
+         index == kInSharedExpertGateWeight ||
+         index == kInSharedExpertGateBias ||
+         index == kInSharedExpertGateOffset ||
+         index == kInSharedExpertGateScale);
     if (is_placeholder && !expected_placeholder && !is_relative_bias &&
         !is_shared_optional) {
       CHECK(false) << "weight is not loaded for " << prefix << name;
@@ -818,26 +819,26 @@ bool NpuOneRecBlockLayerImpl::validate_decoder_moe_weights(
 }
 
 void NpuOneRecBlockLayerImpl::merge_loaded_weights() {
-  const bool q_loaded = !(at_weight_tensors_[IN_Q_WEIGHT].sizes().size() == 2 &&
-                          at_weight_tensors_[IN_Q_WEIGHT].sizes()[0] == 1);
-  const bool k_loaded = !(at_weight_tensors_[IN_K_WEIGHT].sizes().size() == 2 &&
-                          at_weight_tensors_[IN_K_WEIGHT].sizes()[0] == 1);
-  const bool v_loaded = !(at_weight_tensors_[IN_V_WEIGHT].sizes().size() == 2 &&
-                          at_weight_tensors_[IN_V_WEIGHT].sizes()[0] == 1);
+  const bool q_loaded = !(at_weight_tensors_[kInQWeight].sizes().size() == 2 &&
+                          at_weight_tensors_[kInQWeight].sizes()[0] == 1);
+  const bool k_loaded = !(at_weight_tensors_[kInKWeight].sizes().size() == 2 &&
+                          at_weight_tensors_[kInKWeight].sizes()[0] == 1);
+  const bool v_loaded = !(at_weight_tensors_[kInVWeight].sizes().size() == 2 &&
+                          at_weight_tensors_[kInVWeight].sizes()[0] == 1);
   CHECK(q_loaded && k_loaded && v_loaded)
       << "OneRec QKV weights are not properly loaded.";
 
-  auto new_q_weight = torch::cat({at_weight_tensors_[IN_Q_WEIGHT],
-                                  at_weight_tensors_[IN_K_WEIGHT],
-                                  at_weight_tensors_[IN_V_WEIGHT]},
+  auto new_q_weight = torch::cat({at_weight_tensors_[kInQWeight],
+                                  at_weight_tensors_[kInKWeight],
+                                  at_weight_tensors_[kInVWeight]},
                                  0);
-  at_weight_tensors_[IN_Q_WEIGHT] = new_q_weight;
-  at_weight_tensors_[IN_K_WEIGHT] =
-      torch::zeros({1, at_weight_tensors_[IN_Q_WEIGHT].size(1)})
+  at_weight_tensors_[kInQWeight] = new_q_weight;
+  at_weight_tensors_[kInKWeight] =
+      torch::zeros({1, at_weight_tensors_[kInQWeight].size(1)})
           .to(device_)
           .to(dtype_);
-  at_weight_tensors_[IN_V_WEIGHT] =
-      torch::zeros({1, at_weight_tensors_[IN_Q_WEIGHT].size(1)})
+  at_weight_tensors_[kInVWeight] =
+      torch::zeros({1, at_weight_tensors_[kInQWeight].size(1)})
           .to(device_)
           .to(dtype_);
 
@@ -846,21 +847,21 @@ void NpuOneRecBlockLayerImpl::merge_loaded_weights() {
 
   if (!prefill_param_.use_moe) {
     const bool wi0_loaded =
-        !(at_weight_tensors_[IN_FFN_WI_0_WEIGHT].sizes().size() == 2 &&
-          at_weight_tensors_[IN_FFN_WI_0_WEIGHT].sizes()[0] == 1);
+        !(at_weight_tensors_[kInFfnWi0Weight].sizes().size() == 2 &&
+          at_weight_tensors_[kInFfnWi0Weight].sizes()[0] == 1);
     const bool wi1_loaded =
-        !(at_weight_tensors_[IN_FFN_WI_1_WEIGHT].sizes().size() == 2 &&
-          at_weight_tensors_[IN_FFN_WI_1_WEIGHT].sizes()[0] == 1);
+        !(at_weight_tensors_[kInFfnWi1Weight].sizes().size() == 2 &&
+          at_weight_tensors_[kInFfnWi1Weight].sizes()[0] == 1);
     CHECK(wi0_loaded && wi1_loaded)
         << "OneRec FFN gate/up weights are not properly loaded.";
 
     auto new_gate_up_weight =
-        torch::cat({at_weight_tensors_[IN_FFN_WI_0_WEIGHT],
-                    at_weight_tensors_[IN_FFN_WI_1_WEIGHT]},
+        torch::cat({at_weight_tensors_[kInFfnWi0Weight],
+                    at_weight_tensors_[kInFfnWi1Weight]},
                    0);
-    at_weight_tensors_[IN_FFN_WI_0_WEIGHT] = new_gate_up_weight;
-    at_weight_tensors_[IN_FFN_WI_1_WEIGHT] =
-        torch::zeros({1, at_weight_tensors_[IN_FFN_WI_0_WEIGHT].size(1)})
+    at_weight_tensors_[kInFfnWi0Weight] = new_gate_up_weight;
+    at_weight_tensors_[kInFfnWi1Weight] =
+        torch::zeros({1, at_weight_tensors_[kInFfnWi0Weight].size(1)})
             .to(device_)
             .to(dtype_);
   } else {
@@ -871,7 +872,7 @@ void NpuOneRecBlockLayerImpl::merge_loaded_weights() {
   const uint64_t weight_count = prefill_param_.use_moe
                                     ? kOneRecMoeWeightCountPerLayer
                                     : kOneRecWeightCountPerLayer;
-  for (int i = 0; i < static_cast<int>(weight_count); ++i) {
+  for (int32_t i = 0; i < static_cast<int32_t>(weight_count); ++i) {
     if (!at_weight_tensors_[i].defined()) {
       at_weight_tensors_[i] = torch::zeros(
           {1, 1}, torch::TensorOptions().device(device_).dtype(dtype_));
@@ -881,7 +882,7 @@ void NpuOneRecBlockLayerImpl::merge_loaded_weights() {
     }
   }
 
-  for (int i = 0; i < static_cast<int>(weight_count); ++i) {
+  for (int32_t i = 0; i < static_cast<int32_t>(weight_count); ++i) {
     atb_weight_tensors_[i] =
         atb_speed::Utils::AtTensor2Tensor(at_weight_tensors_[i]);
   }
@@ -951,8 +952,8 @@ void NpuOneRecBlockLayerImpl::load_state_dict(const StateDict& state_dict) {
   };
   const auto load_weight = [this, &state_dict, &correct_tensor_dtype](
                                const std::string& tensor_name,
-                               int weight_position,
-                               int shard_dim = -1) {
+                               int32_t weight_position,
+                               int32_t shard_dim = -1) {
     for (const auto& [name, tensor] : state_dict) {
       if (!absl::EndsWith(name, tensor_name)) {
         continue;
@@ -971,7 +972,7 @@ void NpuOneRecBlockLayerImpl::load_state_dict(const StateDict& state_dict) {
   };
 
   const auto& weight_mapping =
-      [this]() -> const std::unordered_map<std::string, int>& {
+      [this]() -> const std::unordered_map<std::string, int32_t>& {
     if (prefill_param_.use_moe) {
       return kOneRecDecoderMoeWeightMapping;
     }
@@ -1007,14 +1008,14 @@ void NpuOneRecBlockLayerImpl::load_state_dict(const StateDict& state_dict) {
     }
   }
 
-  std::vector<std::pair<std::string, int>> ordered_mapping(
+  std::vector<std::pair<std::string, int32_t>> ordered_mapping(
       weight_mapping.begin(), weight_mapping.end());
   std::sort(
       ordered_mapping.begin(),
       ordered_mapping.end(),
       [](const auto& lhs, const auto& rhs) { return lhs.first < rhs.first; });
   for (const auto& [name, index] : ordered_mapping) {
-    const bool is_relative_bias = (index == IN_RELATIVE_ATTENTION_BIAS_WEIGHT);
+    const bool is_relative_bias = (index == kInRelativeAttentionBiasWeight);
     bool weight_exists = false;
     for (const auto& [state_key, tensor] : state_dict) {
       (void)tensor;
@@ -1111,7 +1112,7 @@ torch::Tensor NpuOneRecBlockLayerImpl::forward(
     KVCache& kv_cache,
     ModelInputParams& input_params,
     torch::Tensor* encoder_output,
-    int node_id,
+    int32_t node_id,
     aclrtEvent* event,
     std::atomic<bool>* event_flag,
     const torch::Tensor& expert_array) {
@@ -1194,7 +1195,7 @@ void NpuOneRecBlockLayerImpl::build_encoder_node_variant_pack(
     at::Tensor& attn_mask,
     ModelInputParams& input_params,
     bool is_prefill,
-    int layer_id) {
+    int32_t layer_id) {
   (void)is_prefill;
   (void)layer_id;
 
@@ -1249,7 +1250,7 @@ void NpuOneRecBlockLayerImpl::build_decoder_moe_node_variant_pack(
     ModelInputParams& input_params,
     bool is_prefill,
     torch::Tensor* encoder_output,
-    int layer_id,
+    int32_t layer_id,
     const torch::Tensor& expert_array) {
   (void)kv_cache;
   (void)is_prefill;
@@ -1261,7 +1262,8 @@ void NpuOneRecBlockLayerImpl::build_decoder_moe_node_variant_pack(
     node.variantPack.inTensors.at(i) = *node.inTensors.at(i);
   }
 
-  const int moe_tensor_start = static_cast<int>(kOneRecMoeWeightCountPerLayer);
+  const int32_t moe_tensor_start =
+      static_cast<int32_t>(kOneRecMoeWeightCountPerLayer);
   if (expert_array.defined()) {
     node.variantPack.inTensors.at(moe_tensor_start) =
         atb_speed::Utils::AtTensor2Tensor(expert_array);
@@ -1279,10 +1281,10 @@ void NpuOneRecBlockLayerImpl::build_decoder_moe_node_variant_pack(
       zero_hot_.defined() ? atb_speed::Utils::AtTensor2Tensor(zero_hot_)
                           : placeholder_;
 
-  int tensor_idx = setup_common_decoder_tensors(
+  int32_t tensor_idx = setup_common_decoder_tensors(
       node, x, attn_mask, input_params, encoder_output, moe_tensor_start + 4);
 
-  while (tensor_idx < static_cast<int>(node.variantPack.inTensors.size())) {
+  while (tensor_idx < static_cast<int32_t>(node.variantPack.inTensors.size())) {
     node.variantPack.inTensors.at(tensor_idx) = placeholder_;
     node.variantPack.inTensors.at(tensor_idx).hostData =
         placeholder_vec_.data();
@@ -1290,16 +1292,16 @@ void NpuOneRecBlockLayerImpl::build_decoder_moe_node_variant_pack(
   }
 }
 
-int NpuOneRecBlockLayerImpl::setup_common_decoder_tensors(
+int32_t NpuOneRecBlockLayerImpl::setup_common_decoder_tensors(
     atb_speed::Model::Node& node,
     torch::Tensor& x,
     at::Tensor& attn_mask,
     ModelInputParams& input_params,
     torch::Tensor* encoder_output,
-    int start_tensor_idx) {
+    int32_t start_tensor_idx) {
   internal_tensors_ = atb_speed::Utils::AtTensor2Tensor(x);
 
-  int idx = start_tensor_idx;
+  int32_t idx = start_tensor_idx;
   node.variantPack.inTensors.at(idx++) = internal_tensors_;
   node.variantPack.inTensors.at(idx++) =
       atb_speed::Utils::AtTensor2Tensor(attn_mask);
@@ -1354,7 +1356,7 @@ int NpuOneRecBlockLayerImpl::setup_common_decoder_tensors(
   }
   idx++;
 
-  for (int i = 0; i < 3; i++) {
+  for (int32_t i = 0; i < 3; i++) {
     node.variantPack.inTensors.at(idx) = placeholder_;
     node.variantPack.inTensors.at(idx++).hostData = placeholder_vec_.data();
   }
@@ -1383,7 +1385,7 @@ void NpuOneRecBlockLayerImpl::build_decoder_node_variant_pack(
     ModelInputParams& input_params,
     bool is_prefill,
     torch::Tensor* encoder_output,
-    int layer_id) {
+    int32_t layer_id) {
   (void)kv_cache;
   (void)is_prefill;
   (void)layer_id;
@@ -1394,14 +1396,14 @@ void NpuOneRecBlockLayerImpl::build_decoder_node_variant_pack(
     node.variantPack.inTensors.at(i) = *node.inTensors.at(i);
   }
 
-  int tensor_idx = setup_common_decoder_tensors(
+  int32_t tensor_idx = setup_common_decoder_tensors(
       node,
       x,
       attn_mask,
       input_params,
       encoder_output,
-      static_cast<int>(kOneRecWeightCountPerLayer));
-  while (tensor_idx < static_cast<int>(node.variantPack.inTensors.size())) {
+      static_cast<int32_t>(kOneRecWeightCountPerLayer));
+  while (tensor_idx < static_cast<int32_t>(node.variantPack.inTensors.size())) {
     node.variantPack.inTensors.at(tensor_idx) = placeholder_;
     node.variantPack.inTensors.at(tensor_idx).hostData =
         placeholder_vec_.data();
@@ -1410,7 +1412,7 @@ void NpuOneRecBlockLayerImpl::build_decoder_node_variant_pack(
 }
 
 void NpuOneRecBlockLayerImpl::resize_experts_weights(
-    int num_of_device_experts) {
+    int32_t num_of_device_experts) {
   experts_weights_["gate_proj.weight"] =
       std::vector<torch::Tensor>(num_of_device_experts);
   experts_weights_["up_proj.weight"] =
@@ -1426,12 +1428,12 @@ void NpuOneRecBlockLayerImpl::process_expert_weights(
   (void)state_dict;
   std::lock_guard<std::mutex> lock(experts_mutex_);
 
-  int expert_id = extract_expert_index(name);
+  int32_t expert_id = extract_expert_index(name);
   if (expert_id < 0) {
     return;
   }
 
-  const int local_index = expert_id % num_experts_per_partition_;
+  const int32_t local_index = expert_id % num_experts_per_partition_;
   std::string weight_suffix = extract_endswith(name);
 
   std::string suffix;
@@ -1449,7 +1451,7 @@ void NpuOneRecBlockLayerImpl::process_expert_weights(
 
   auto it = experts_weights_.find(suffix);
   if (it == experts_weights_.end() || local_index < 0 ||
-      local_index >= static_cast<int>(it->second.size())) {
+      local_index >= static_cast<int32_t>(it->second.size())) {
     LOG(ERROR) << "Invalid OneRec MoE local expert index " << local_index
                << " for " << suffix << " at layer " << layer_id_ << ".";
     return;
@@ -1485,7 +1487,8 @@ void NpuOneRecBlockLayerImpl::process_shared_expert_weights(
   shared_expert_weights_map_[canonical_name] = tmp_tensor;
 }
 
-int NpuOneRecBlockLayerImpl::extract_expert_index(const std::string& name) {
+int32_t NpuOneRecBlockLayerImpl::extract_expert_index(
+    const std::string& name) {
   size_t experts_pos = name.find(".experts.");
   if (experts_pos == std::string::npos) {
     return -1;
@@ -1577,14 +1580,14 @@ void NpuOneRecBlockLayerImpl::merge_experts_weights() {
                             experts_weights_["up_proj.weight"],
                             /*transpose=*/false);
   CHECK(merged_gate_up.defined()) << "OneRec MoE gate/up experts merge failed.";
-  at_weight_tensors_[IN_MOE_EXPERT_W1_WEIGHT] =
+  at_weight_tensors_[kInMoeExpertW1Weight] =
       at_npu::native::npu_format_cast(merged_gate_up, /*format=*/2)
           .contiguous();
 
   auto merged_down = merge_experts_weights(experts_weights_["down_proj.weight"],
                                            /*transpose=*/false);
   CHECK(merged_down.defined()) << "OneRec MoE down experts merge failed.";
-  at_weight_tensors_[IN_MOE_EXPERT_W2_WEIGHT] =
+  at_weight_tensors_[kInMoeExpertW2Weight] =
       at_npu::native::npu_format_cast(merged_down, /*format=*/2).contiguous();
 }
 
@@ -1619,14 +1622,14 @@ void NpuOneRecBlockLayerImpl::merge_shared_experts_weights() {
                                                 /*transpose=*/false);
     CHECK(merged_gate_up.defined())
         << "OneRec shared gate/up experts merge failed at layer " << layer_id_;
-    at_weight_tensors_[IN_MLP_GATEUP_WEIGHT_SHARED_EXPERT] = merged_gate_up;
+    at_weight_tensors_[kInMlpGateUpWeightSharedExpert] = merged_gate_up;
   } else if (!shared_expert_gate_weights_.empty()) {
-    at_weight_tensors_[IN_MLP_GATEUP_WEIGHT_SHARED_EXPERT] =
+    at_weight_tensors_[kInMlpGateUpWeightSharedExpert] =
         merge_experts_weights(shared_expert_gate_weights_, false);
   }
 
   if (!shared_expert_down_weights_.empty()) {
-    at_weight_tensors_[IN_MLP_DOWN_WEIGHT_SHARED_EXPERT] =
+    at_weight_tensors_[kInMlpDownWeightSharedExpert] =
         merge_experts_weights(shared_expert_down_weights_, false);
   }
 

--- a/xllm/core/layers/npu/npu_onerec_block_layer_impl.h
+++ b/xllm/core/layers/npu/npu_onerec_block_layer_impl.h
@@ -59,7 +59,7 @@ class NpuOneRecBlockLayerImpl final : public BaseLayer {
                         KVCache& kv_cache,
                         ModelInputParams& input_params,
                         torch::Tensor* encoder_output = nullptr,
-                        int node_id = 0,
+                        int32_t node_id = 0,
                         aclrtEvent* event = nullptr,
                         std::atomic<bool>* event_flag = nullptr,
                         const torch::Tensor& expert_array = torch::Tensor());
@@ -103,14 +103,14 @@ class NpuOneRecBlockLayerImpl final : public BaseLayer {
 
   int64_t init_attn_mask();
 
-  int setup_common_decoder_tensors(atb_speed::Model::Node& node,
-                                   torch::Tensor& x,
-                                   at::Tensor& attn_mask,
-                                   ModelInputParams& input_params,
-                                   torch::Tensor* encoder_output = nullptr,
-                                   int start_tensor_idx = 0);
+  int32_t setup_common_decoder_tensors(atb_speed::Model::Node& node,
+                                       torch::Tensor& x,
+                                       at::Tensor& attn_mask,
+                                       ModelInputParams& input_params,
+                                       torch::Tensor* encoder_output = nullptr,
+                                       int32_t start_tensor_idx = 0);
 
-  void resize_experts_weights(int num_of_device_experts);
+  void resize_experts_weights(int32_t num_of_device_experts);
   void process_expert_weights(const StateDict& state_dict,
                               const std::string& state_key,
                               const torch::Tensor& tensor);
@@ -125,7 +125,7 @@ class NpuOneRecBlockLayerImpl final : public BaseLayer {
   torch::Tensor merge_experts_weights(std::vector<torch::Tensor>& experts_gate,
                                       std::vector<torch::Tensor>& experts_up,
                                       bool transpose = false);
-  int extract_expert_index(const std::string& name);
+  int32_t extract_expert_index(const std::string& name);
   std::string extract_endswith(const std::string& input);
 
   atb_speed::Model::Node prefill_node_;
@@ -141,7 +141,7 @@ class NpuOneRecBlockLayerImpl final : public BaseLayer {
   at::Tensor at_placeholder_;
   std::vector<int32_t> placeholder_vec_;
 
-  int device_id_ = 0;
+  int32_t device_id_ = 0;
   bool is_decoder_ = false;
   int32_t layer_id_ = 0;
 


### PR DESCRIPTION
  This PR is the second step of the OneRec rebaseline stack, it will rebase after pr #1050  is merged.

  It is a stacked PR on top of `onerec/pr5-runtime-no-submodule-v2`, and replaces the temporary local OneRec NPU stubs with the actual `xllm_atb_layers`-based implementation.

  ## What's included

  - **Real OneRec NPU block-layer integration**
    - Replace the local compile-closure stub in:
      - `xllm/core/layers/npu/npu_onerec_block_layer_impl.h`
      - `xllm/core/layers/npu/npu_onerec_block_layer_impl.cpp`
    - Introduce the actual OneRec NPU bridge based on the `xllm_atb_layers` block-layer implementation
    - Cover weight loading, weight merge, graph init, and runtime forward entry points

  - **OneRec model / NPU bridge hookup**
    - Update `xllm/models/rec/onerec.h` to use the real NPU-backed OneRec stack
    - Add encoder/decoder stack wiring, OneRec-specific position-bias handling, and encoder-output reuse in the current implementation path

  - **`xllm_atb_layers` submodule integration**
    - Update `.gitmodules`
    - Update `third_party/xllm_atb_layers` to the required OneRec-capable revision
    - Align the OneRec NPU integration with the source-level submodule layout rather than the legacy `xllm_kernels` path model

  ## Scope / Restrictions

  - This PR is intentionally **NPU / submodule focused**.
  - It depends on the foundation/runtime work from `onerec/pr5-runtime-no-submodule-v2`.
  - It should be reviewed as a follow-up integration PR, not as a standalone feature branch against `main`.

  ## Backward Compatibility

  - The intention is to keep non-OneRec paths unchanged.
  - This PR only replaces the temporary local OneRec NPU stub introduced in PR1.
  - Existing non-OneRec NPU implementations are not the target of this PR.

  ## Testing

  - [x] Source-level review of OneRec NPU block-layer integration points
  - [x] Source-level review of submodule-based include / integration path
  - [x] Source-level validation that PR2 cleanly layers on top of PR1
  - [ ] Full target build validation in NPU environment
  - [ ] Runtime graph creation validation
  - [ ] End-to-end OneRec inference validation

  ## Stacked PR note

  This PR is intended to be reviewed with:

  - PR1: `onerec/pr5-runtime-no-submodule-v2` #1050 
  - PR2: `onerec/pr5-npu-submodule-v2` (this PR)

  After PR1 merges, this PR can be rebased onto `main` with minimal boundary change.