### PR TITLE
feat: support xattention for qwen3 in NPU.

### DIFF
--- a/xllm/core/distributed_runtime/rec_engine.cpp
+++ b/xllm/core/distributed_runtime/rec_engine.cpp
@@ -32,6 +32,7 @@ limitations under the License.
 #include "framework/request/rec_type.h"
 #include "master.h"  // For MasterStatus::WAKEUP constant
 #include "util/env_var.h"
+#include "util/net.h"
 #include "util/pretty_print.h"
 #include "util/timer.h"
 #include "util/utils.h"
@@ -524,8 +525,13 @@ bool RecEngine::OneRecEnginePipeline::init_model_workers(
     const std::string& model_path) {
   const auto& devices = engine_.options_.devices();
   if (devices.size() > 1) {
+#if defined(USE_NPU)
     engine_.process_groups_ =
         parallel_state::create_npu_process_groups(devices);
+#else
+    engine_.process_groups_ =
+        parallel_state::create_local_process_groups(devices, engine_.options_);
+#endif
   }
 
   engine_.workers_.clear();
@@ -735,9 +741,34 @@ bool RecEngine::RecMultiRoundEnginePipeline::init_model_workers(
   const auto& devices = engine_.options_.devices();
   const int32_t world_size = static_cast<int32_t>(devices.size());
 
-  // Always create process_groups (supports both single and multi-device)
+  // Single-card REC multi-round still needs a non-null tp_group_ during
+  // model/layer construction. For NPU, construct a real rank_size=1 backend
+  // process group here so process_group semantics stay strict without touching
+  // process_group.*. Multi-card NPU keeps the direct HCCL path.
+#if defined(USE_NPU)
+  if (world_size == 1) {
+    std::string host;
+    int port;
+    net::parse_host_port_from_addr(
+        engine_.options_.master_node_addr().value(), host, port);
+    engine_.process_groups_.clear();
+    engine_.process_groups_.emplace_back(create_process_group(
+        /*rank=*/0,
+        /*world_size=*/1,
+        /*rank_size=*/1,
+        /*port=*/port,
+        /*trans=*/false,
+        host,
+        /*group_name=*/"rec_single_local_pg",
+        devices[0]));
+  } else {
+    engine_.process_groups_ =
+        parallel_state::create_npu_process_groups(devices);
+  }
+#else
   engine_.process_groups_ =
       parallel_state::create_local_process_groups(devices, engine_.options_);
+#endif
 
   engine_.workers_.clear();
   WorkerType worker_type = WorkerType::REC;

--- a/xllm/core/framework/model/model_input_params.h
+++ b/xllm/core/framework/model/model_input_params.h
@@ -152,10 +152,13 @@ struct LlmRecMultiRoundParams {
   std::vector<torch::Tensor> full_v_caches;
   std::vector<torch::Tensor> unshared_k_caches;
   std::vector<torch::Tensor> unshared_v_caches;
+  std::vector<torch::Tensor> shared_k_caches;
+  std::vector<torch::Tensor> shared_v_caches;
   std::vector<torch::Tensor> decode_positions_tensor_list;
   // beam width for step-level decode
   int32_t batch_size = 0;
   int32_t beam_width = 1;
+  torch::Tensor beam_width_tensor;
   // current round for step-level decode
   torch::Tensor current_round_tensor;
   int32_t total_round = 0;
@@ -183,13 +186,24 @@ struct LlmRecMultiRoundParams {
     }
     result.unshared_k_caches.clear();
     result.unshared_v_caches.clear();
+    result.shared_k_caches.clear();
+    result.shared_v_caches.clear();
     for (const auto& t : unshared_k_caches) {
       result.unshared_k_caches.push_back(safe_to(t, device));
     }
     for (const auto& t : unshared_v_caches) {
       result.unshared_v_caches.push_back(safe_to(t, device));
     }
+    for (const auto& t : shared_k_caches) {
+      result.shared_k_caches.push_back(safe_to(t, device));
+    }
+    for (const auto& t : shared_v_caches) {
+      result.shared_v_caches.push_back(safe_to(t, device));
+    }
 
+    if (beam_width_tensor.defined()) {
+      result.beam_width_tensor = safe_to(beam_width_tensor, device, true);
+    }
     if (current_round_tensor.defined()) {
       result.current_round_tensor = safe_to(current_round_tensor, device, true);
     }

--- a/xllm/core/kernels/npu/xllm_ops/CMakeLists.txt
+++ b/xllm/core/kernels/npu/xllm_ops/CMakeLists.txt
@@ -11,6 +11,8 @@ cc_library(
     top_k_top_p.cpp
     ../utils.cpp
     beam_search.cpp
+    select_unshared_kv.cpp
+    beam_search_rec.cpp
   DEPS
     atb
     torch_npu

--- a/xllm/core/kernels/npu/xllm_ops/beam_search.cpp
+++ b/xllm/core/kernels/npu/xllm_ops/beam_search.cpp
@@ -29,19 +29,23 @@ limitations under the License.
 
 #include "acl/acl.h"
 #include "aclnn_beam_search.h"
+#include "core/common/macros.h"
 #include "core/kernels/npu/utils.h"
 #include "xllm_ops_api.h"
 
-#define CHECK_ACL_SUCCESS(expr, msg) \
-  do {                               \
-    auto _ret = (expr);              \
-    if (_ret != ACL_SUCCESS) {       \
-      LOG(ERROR) << msg;             \
-      throw std::runtime_error(msg); \
-    }                                \
-  } while (0)
 namespace xllm::kernel::npu {
 
+// Used by the standard BeamSearcher sampling path on NPU.
+// This wrapper runs one regular beam-search update from the current beam
+// scores and candidate token scores.
+// Inputs:
+//   logprobs: accumulated scores for the current live beams.
+//   top_tokens: candidate token ids for this step.
+//   top_logprobs: candidate token scores for this step.
+// Outputs:
+//   src_seq_idxes: source beam selected for each new beam.
+//   out_logprobs: updated accumulated beam scores.
+//   out_tokens: chosen next token ids for the next sampling step.
 void beam_search(const torch::Tensor& logprobs,
                  const torch::Tensor& top_tokens,
                  const torch::Tensor& top_logprobs,

--- a/xllm/core/kernels/npu/xllm_ops/beam_search_rec.cpp
+++ b/xllm/core/kernels/npu/xllm_ops/beam_search_rec.cpp
@@ -1,0 +1,129 @@
+/* Copyright 2026 The xLLM Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://github.com/jd-opensource/xllm/blob/main/LICENSE
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include <c10/core/Device.h>
+#include <glog/logging.h>
+#include <torch/torch.h>
+#include <torch_npu/csrc/libs/init_npu.h>
+#include <torch_npu/torch_npu.h>
+
+#include <nlohmann/json.hpp>
+#ifdef TORCH_HIGHER_THAN_PTA6
+#include <torch_npu/csrc/framework/OpCommand.h>
+#else
+#include <torch_npu/csrc/aten/NPUNativeFunctions.h>
+#include <torch_npu/csrc/framework/utils/OpPreparation.h>
+#endif
+
+#include "acl/acl.h"
+#include "aclnn_beam_search_group.h"
+#include "core/common/macros.h"
+#include "core/kernels/npu/utils.h"
+#include "xllm_ops_api.h"
+
+namespace xllm::kernel::npu {
+
+// Run one beam-search update in REC multi-round decoding on NPU.
+// Inputs:
+//   logprobs: accumulated beam scores from the previous round.
+//   top_tokens/top_logprobs: current candidate tokens and their scores.
+//   sequence_group: beam-to-sequence layout before this round.
+//   current_step: decode round index passed to the NPU kernel.
+// Outputs:
+//   out_token_ids/out_token_index/out_log_probs: selected next tokens, source
+//   beam indices, and updated accumulated scores.
+//   out_beam_count_prefix_sums/out_sequence: per-request beam offsets and the
+//   next sequence layout after this step.
+void beam_search_rec(const torch::Tensor& logprobs,
+                     const torch::Tensor& top_tokens,
+                     const torch::Tensor& top_logprobs,
+                     torch::Tensor& sequence_group,
+                     int64_t current_step,
+                     torch::Tensor& out_token_ids,
+                     torch::Tensor& out_token_index,
+                     torch::Tensor& out_log_probs,
+                     torch::Tensor& out_beam_count_prefix_sums,
+                     torch::Tensor& out_sequence) {
+  check_tensor(logprobs, "logprobs", "beam_search_rec");
+  check_tensor(top_tokens, "top_tokens", "beam_search_rec");
+  check_tensor(top_logprobs, "top_logprobs", "beam_search_rec");
+  check_tensor(sequence_group, "sequence_group", "beam_search_rec");
+
+  aclTensor* logprobs_ids = nullptr;
+  aclTensor* top_tokens_ids = nullptr;
+  aclTensor* top_logprobs_ids = nullptr;
+  aclTensor* sequence_group_ids = nullptr;
+  aclTensor* out_token_ids_ids = nullptr;
+  aclTensor* out_token_index_ids = nullptr;
+  aclTensor* out_log_probs_ids = nullptr;
+  aclTensor* out_beam_count_prefix_sums_ids = nullptr;
+  aclTensor* out_sequence_ids = nullptr;
+  int32_t device_id = logprobs.device().index();
+  aclrtStream stream = c10_npu::getCurrentNPUStream(device_id).stream();
+
+  create_acltensor(&logprobs_ids, logprobs);
+  create_acltensor(&top_tokens_ids, top_tokens);
+  create_acltensor(&top_logprobs_ids, top_logprobs);
+  create_acltensor(&sequence_group_ids, sequence_group);
+  create_acltensor(&out_token_ids_ids, out_token_ids);
+  create_acltensor(&out_token_index_ids, out_token_index);
+  create_acltensor(&out_log_probs_ids, out_log_probs);
+  create_acltensor(&out_beam_count_prefix_sums_ids, out_beam_count_prefix_sums);
+  create_acltensor(&out_sequence_ids, out_sequence);
+
+  uint64_t workspace_size = 0;
+  aclOpExecutor* executor = nullptr;
+  CHECK_ACL_SUCCESS(
+      aclnnBeamSearchGroupGetWorkspaceSize(logprobs_ids,
+                                           top_tokens_ids,
+                                           top_logprobs_ids,
+                                           sequence_group_ids,
+                                           current_step,
+                                           out_token_ids_ids,
+                                           out_token_index_ids,
+                                           out_log_probs_ids,
+                                           out_beam_count_prefix_sums_ids,
+                                           out_sequence_ids,
+                                           &workspace_size,
+                                           &executor),
+      "beam_search_rec: failed to get workspace size for REC beam search");
+  void* workspace_addr = nullptr;
+  if (workspace_size > 0) {
+    CHECK_ACL_SUCCESS(
+        aclrtMalloc(&workspace_addr, workspace_size, ACL_MEM_MALLOC_HUGE_FIRST),
+        "beam_search_rec: failed to allocate workspace for REC beam search");
+  }
+  CHECK_ACL_SUCCESS(
+      aclnnBeamSearchGroup(workspace_addr, workspace_size, executor, stream),
+      "beam_search_rec: failed to execute REC beam search");
+  CHECK_ACL_SUCCESS(
+      aclrtSynchronizeStream(stream),
+      "beam_search_rec: failed to synchronize stream for REC beam search");
+  aclDestroyTensor(logprobs_ids);
+  aclDestroyTensor(top_tokens_ids);
+  aclDestroyTensor(top_logprobs_ids);
+  aclDestroyTensor(sequence_group_ids);
+  aclDestroyTensor(out_token_ids_ids);
+  aclDestroyTensor(out_token_index_ids);
+  aclDestroyTensor(out_log_probs_ids);
+  aclDestroyTensor(out_beam_count_prefix_sums_ids);
+  aclDestroyTensor(out_sequence_ids);
+  if (workspace_size > 0) {
+    CHECK_ACL_SUCCESS(
+        aclrtFree(workspace_addr),
+        "beam_search_rec: failed to free workspace for REC beam search");
+  }
+}
+}  // namespace xllm::kernel::npu

--- a/xllm/core/kernels/npu/xllm_ops/replace_token.cpp
+++ b/xllm/core/kernels/npu/xllm_ops/replace_token.cpp
@@ -35,6 +35,13 @@ limitations under the License.
 
 namespace xllm::kernel::npu {
 
+// Used by schedule overlap on NPU.
+// This wrapper prepares the next decode-step input under the ACLNN update
+// rule.
+// Inputs:
+//   src: sampled tokens from the previous step.
+// Outputs:
+//   dst: current-step input token tensor, updated in place after replacement.
 void replace_token(torch::Tensor& dst, torch::Tensor& src) {
   check_tensor(dst, "dst", "replace_token");
   check_tensor(src, "src", "replace_token");

--- a/xllm/core/kernels/npu/xllm_ops/select_unshared_kv.cpp
+++ b/xllm/core/kernels/npu/xllm_ops/select_unshared_kv.cpp
@@ -1,0 +1,132 @@
+/* Copyright 2026 The xLLM Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://github.com/jd-opensource/xllm/blob/main/LICENSE
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include <c10/core/Device.h>
+#include <glog/logging.h>
+#include <torch/torch.h>
+#include <torch_npu/csrc/libs/init_npu.h>
+#include <torch_npu/torch_npu.h>
+
+#include <nlohmann/json.hpp>
+#ifdef TORCH_HIGHER_THAN_PTA6
+#include <torch_npu/csrc/framework/OpCommand.h>
+#else
+#include <torch_npu/csrc/aten/NPUNativeFunctions.h>
+#include <torch_npu/csrc/framework/utils/OpPreparation.h>
+#endif
+
+#include "acl/acl.h"
+#include "aclnn_select_unshared_kv.h"
+#include "core/common/macros.h"
+#include "core/kernels/npu/utils.h"
+#include "xllm_ops_api.h"
+
+namespace xllm::kernel::npu {
+
+// Reorder per-layer unshared KV caches after beam selection in REC
+// multi-round decoding.
+// Inputs:
+//   beam_index: source beam chosen for each output beam.
+//   x_key_block/x_value_block: per-layer unshared K/V caches to update.
+//   block_table/group_offset: request mapping and per-request beam offsets
+//   expected by the NPU kernel.
+//   decode_step/beam_size/layer_num: cache slot and layout metadata.
+// Output:
+//   x_key_block/x_value_block are updated in place to match the selected
+//   beams for the next round.
+void select_unshared_kv(const torch::Tensor& beam_index,
+                        const std::vector<torch::Tensor>& x_key_block,
+                        const std::vector<torch::Tensor>& x_value_block,
+                        const torch::Tensor& block_table,
+                        const torch::Tensor& group_offset,
+                        int64_t decode_step,
+                        int64_t beam_size,
+                        int64_t layer_num) {
+  check_tensor(beam_index, "beam_index", "select_unshared_kv");
+  check_tensor(block_table, "block_table", "select_unshared_kv");
+  check_tensor(group_offset, "group_offset", "select_unshared_kv");
+  for (const auto& t : x_key_block) {
+    check_tensor(t, "x_key_block[i]", "select_unshared_kv");
+  }
+  for (const auto& t : x_value_block) {
+    check_tensor(t, "x_value_block[i]", "select_unshared_kv");
+  }
+
+  aclTensor* beam_index_ids = nullptr;
+  aclTensor* group_offset_ids = nullptr;
+  aclTensor* block_table_ids = nullptr;
+  aclTensorList* x_key_block_list_ids = nullptr;
+  aclTensorList* x_value_block_list_ids = nullptr;
+  std::vector<aclTensor*> x_key_block_list_ids_vec;
+  std::vector<aclTensor*> x_value_block_list_ids_vec;
+  for (auto& x_key_block_tensor : x_key_block) {
+    aclTensor* x_key_block_id = nullptr;
+    create_acltensor(&x_key_block_id, x_key_block_tensor);
+    x_key_block_list_ids_vec.push_back(x_key_block_id);
+  }
+  for (auto& x_value_block_tensor : x_value_block) {
+    aclTensor* x_value_block_id = nullptr;
+    create_acltensor(&x_value_block_id, x_value_block_tensor);
+    x_value_block_list_ids_vec.push_back(x_value_block_id);
+  }
+  x_key_block_list_ids = aclCreateTensorList(x_key_block_list_ids_vec.data(),
+                                             x_key_block_list_ids_vec.size());
+  x_value_block_list_ids = aclCreateTensorList(
+      x_value_block_list_ids_vec.data(), x_value_block_list_ids_vec.size());
+  create_acltensor(&beam_index_ids, beam_index);
+  create_acltensor(&group_offset_ids, group_offset);
+  create_acltensor(&block_table_ids, block_table);
+
+  int32_t device_id = beam_index.device().index();
+  aclrtStream stream = c10_npu::getCurrentNPUStream(device_id).stream();
+  uint64_t workspace_size = 0;
+  aclOpExecutor* executor = nullptr;
+
+  CHECK_ACL_SUCCESS(
+      aclnnSelectUnsharedKVGetWorkspaceSize(beam_index_ids,
+                                            block_table_ids,
+                                            x_key_block_list_ids,
+                                            x_value_block_list_ids,
+                                            group_offset_ids,
+                                            decode_step,
+                                            beam_size,
+                                            layer_num,
+                                            x_key_block_list_ids,
+                                            x_value_block_list_ids,
+                                            &workspace_size,
+                                            &executor),
+      "select_unshared_kv: failed to get workspace size");
+  void* workspace_addr = nullptr;
+  if (workspace_size > 0) {
+    CHECK_ACL_SUCCESS(
+        aclrtMalloc(&workspace_addr, workspace_size, ACL_MEM_MALLOC_HUGE_FIRST),
+        "select_unshared_kv: failed to allocate workspace");
+  }
+  CHECK_ACL_SUCCESS(
+      aclnnSelectUnsharedKV(workspace_addr, workspace_size, executor, stream),
+      "select_unshared_kv: failed to reorder caches");
+  CHECK_ACL_SUCCESS(aclrtSynchronizeStream(stream),
+                    "select_unshared_kv: failed to synchronize stream");
+  aclDestroyTensor(beam_index_ids);
+  aclDestroyTensor(group_offset_ids);
+  aclDestroyTensor(block_table_ids);
+  aclDestroyTensorList(x_key_block_list_ids);
+  aclDestroyTensorList(x_value_block_list_ids);
+  if (workspace_size > 0) {
+    CHECK_ACL_SUCCESS(aclrtFree(workspace_addr),
+                      "select_unshared_kv: failed to free workspace");
+  }
+}
+}  // namespace xllm::kernel::npu

--- a/xllm/core/kernels/npu/xllm_ops/top_k_top_p.cpp
+++ b/xllm/core/kernels/npu/xllm_ops/top_k_top_p.cpp
@@ -34,6 +34,15 @@ limitations under the License.
 #include "xllm_ops_api.h"
 
 namespace xllm::kernel::npu {
+
+// Used by the sampling logits preprocessing path on NPU.
+// This wrapper applies top-k and top-p filtering before token sampling so the
+// downstream sampler only sees the kept candidates.
+// Inputs:
+//   topK: top-k threshold tensor for this sampling step.
+//   topP: top-p threshold tensor for this sampling step.
+// Outputs:
+//   logits: logits tensor filtered in place and consumed by the sampler.
 void top_k_top_p(torch::Tensor& logits,
                  const torch::Tensor& topK,
                  const torch::Tensor& topP) {

--- a/xllm/core/kernels/npu/xllm_ops/xllm_ops_api.h
+++ b/xllm/core/kernels/npu/xllm_ops/xllm_ops_api.h
@@ -17,6 +17,8 @@ limitations under the License.
 
 #include <torch/torch.h>
 
+#include <vector>
+
 namespace xllm::kernel::npu {
 
 void beam_search(const torch::Tensor& logprobs,
@@ -32,4 +34,23 @@ void top_k_top_p(torch::Tensor& logits,
 
 void replace_token(torch::Tensor& dst, torch::Tensor& src);
 
+void beam_search_rec(const torch::Tensor& logprobs,
+                     const torch::Tensor& top_tokens,
+                     const torch::Tensor& top_logprobs,
+                     torch::Tensor& sequence_group,
+                     int64_t current_step,
+                     torch::Tensor& out_token_ids,
+                     torch::Tensor& out_token_index,
+                     torch::Tensor& out_log_probs,
+                     torch::Tensor& out_beam_count_prefix_sums,
+                     torch::Tensor& out_sequence);
+
+void select_unshared_kv(const torch::Tensor& beam_index,
+                        const std::vector<torch::Tensor>& x_key_block,
+                        const std::vector<torch::Tensor>& x_value_block,
+                        const torch::Tensor& block_table,
+                        const torch::Tensor& group_offset,
+                        int64_t decode_step,
+                        int64_t beam_size,
+                        int64_t layer_num);
 }  // namespace xllm::kernel::npu

--- a/xllm/core/layers/npu/npu_qwen3_decoder_layer_impl.cpp
+++ b/xllm/core/layers/npu/npu_qwen3_decoder_layer_impl.cpp
@@ -21,6 +21,7 @@ limitations under the License.
 #include <map>
 
 #include "common/global_flags.h"
+#include "common/rec_model_utils.h"
 
 // #include "attn_mask.h"
 #include "torch_npu/csrc/core/npu/NPUCachingAllocator.h"
@@ -49,6 +50,7 @@ void NpuQwen3DecoderLayerImpl::param_from_args(
   param.isBF16 = args.dtype() == "bfloat16";
   param.enableSplitFuse = FLAGS_enable_chunked_prefill && isPrefill;
   param.loraEnableGMM = false;
+  param.enableXattention = is_rec_multi_round_mode();
 
   param.linearTransposeType = {static_cast<int>(TransposeType::NOT_TRANSPOSE),
                                static_cast<int>(TransposeType::INVALID),
@@ -235,7 +237,12 @@ torch::Tensor NpuQwen3DecoderLayerImpl::forward(torch::Tensor& x,
                                                 std::atomic<bool>* event_flag,
                                                 int node_id) {
   atb::Status st;
-  if (!input_params.batch_forward_type.is_decode()) {
+  // decide prefill vs decode; for multi-round mode, use explicit is_prefill.
+  bool is_prefill =
+      input_params.is_prefill || !input_params.batch_forward_type.is_decode();
+  if (is_prefill) {
+    // if (input_params.empty_kv_cache) {
+    // mstxRangeId id = mstxRangeStartA("prefill build variant", nullptr);
     build_node_variant_pack(prefill_node_,
                             x,
                             cos_pos,
@@ -243,7 +250,9 @@ torch::Tensor NpuQwen3DecoderLayerImpl::forward(torch::Tensor& x,
                             attn_mask,
                             kv_cache,
                             input_params,
-                            true);
+                            /*is_prefill=*/true,
+                            node_id);
+    // mstxRangeEnd(id);
     st = execute_node(prefill_node_, node_id, event, event_flag);
     LOG_IF(FATAL, st != 0) << model_name_
                            << "excute prefill layer fail, error code: " << st;
@@ -255,7 +264,8 @@ torch::Tensor NpuQwen3DecoderLayerImpl::forward(torch::Tensor& x,
                             decode_attn_mask_,
                             kv_cache,
                             input_params,
-                            false);
+                            /*is_prefill=*/false,
+                            node_id);
     st = execute_node(decode_node_, node_id + 1000, event, event_flag);
     LOG_IF(FATAL, st != 0) << model_name_
                            << "excute decode layer fail, error code: " << st;
@@ -272,9 +282,9 @@ void NpuQwen3DecoderLayerImpl::build_node_variant_pack(
     at::Tensor& attn_mask,
     KVCache& kv_cache,
     ModelInputParams& input_params,
-    bool is_prefill) {
+    bool is_prefill,
+    int node_id) {
   internal_tensors_ = atb_speed::Utils::AtTensor2Tensor(x);
-  // std::cout<<"node.variantPack.inTensors.size:"<<node.variantPack.inTensors.size()<<std::endl;
   node.variantPack.inTensors.at(WEIGHT_COUNT_PER_LAYER) = internal_tensors_;
   node.variantPack.inTensors.at(WEIGHT_COUNT_PER_LAYER + 1) =
       atb_speed::Utils::AtTensor2Tensor(cos_pos);
@@ -282,10 +292,6 @@ void NpuQwen3DecoderLayerImpl::build_node_variant_pack(
       atb_speed::Utils::AtTensor2Tensor(sin_pos);
   node.variantPack.inTensors.at(WEIGHT_COUNT_PER_LAYER + 3) =
       atb_speed::Utils::AtTensor2Tensor(attn_mask);
-  node.variantPack.inTensors.at(WEIGHT_COUNT_PER_LAYER + 4) =
-      atb_speed::Utils::AtTensor2Tensor(kv_cache.get_k_cache());
-  node.variantPack.inTensors.at(WEIGHT_COUNT_PER_LAYER + 5) =
-      atb_speed::Utils::AtTensor2Tensor(kv_cache.get_v_cache());
   node.variantPack.inTensors.at(WEIGHT_COUNT_PER_LAYER + 6) =
       atb_speed::Utils::AtTensor2Tensor(input_params.kv_seq_lens);
   node.variantPack.inTensors.at(WEIGHT_COUNT_PER_LAYER + 6).hostData =
@@ -296,10 +302,43 @@ void NpuQwen3DecoderLayerImpl::build_node_variant_pack(
   node.variantPack.inTensors.at(WEIGHT_COUNT_PER_LAYER + 8) = placeholder_;
   node.variantPack.inTensors.at(WEIGHT_COUNT_PER_LAYER + 9) =
       atb_speed::Utils::AtTensor2Tensor(input_params.block_tables);
-  node.variantPack.inTensors.at(WEIGHT_COUNT_PER_LAYER + 10) =
-      atb_speed::Utils::AtTensor2Tensor(input_params.new_cache_slots);
 
-  int32_t input_idx = WEIGHT_COUNT_PER_LAYER + 11;
+  int input_idx = WEIGHT_COUNT_PER_LAYER + 11;
+  if (is_rec_multi_round_mode()) {
+    const auto* llmrec = input_params.llmrec_params();
+
+    if (is_prefill) {
+      node.variantPack.inTensors.at(WEIGHT_COUNT_PER_LAYER + 4) =
+          atb_speed::Utils::AtTensor2Tensor(kv_cache.get_k_cache());
+      node.variantPack.inTensors.at(WEIGHT_COUNT_PER_LAYER + 5) =
+          atb_speed::Utils::AtTensor2Tensor(kv_cache.get_v_cache());
+    } else {
+      CHECK_LT(static_cast<size_t>(node_id), llmrec->unshared_k_caches.size());
+      CHECK_LT(static_cast<size_t>(node_id), llmrec->unshared_v_caches.size());
+      node.variantPack.inTensors.at(WEIGHT_COUNT_PER_LAYER + 4) =
+          atb_speed::Utils::AtTensor2Tensor(llmrec->unshared_k_caches[node_id]);
+      node.variantPack.inTensors.at(WEIGHT_COUNT_PER_LAYER + 5) =
+          atb_speed::Utils::AtTensor2Tensor(llmrec->unshared_v_caches[node_id]);
+    }
+    node.variantPack.inTensors.at(WEIGHT_COUNT_PER_LAYER + 10) = placeholder_;
+    node.variantPack.inTensors.at(WEIGHT_COUNT_PER_LAYER + 11) =
+        atb_speed::Utils::AtTensor2Tensor(llmrec->shared_k_caches[node_id]);
+    node.variantPack.inTensors.at(WEIGHT_COUNT_PER_LAYER + 12) =
+        atb_speed::Utils::AtTensor2Tensor(llmrec->shared_v_caches[node_id]);
+    node.variantPack.inTensors.at(WEIGHT_COUNT_PER_LAYER + 13) =
+        atb_speed::Utils::AtTensor2Tensor(llmrec->beam_width_tensor);
+    node.variantPack.inTensors.at(WEIGHT_COUNT_PER_LAYER + 14) =
+        atb_speed::Utils::AtTensor2Tensor(llmrec->current_round_tensor);
+    input_idx = WEIGHT_COUNT_PER_LAYER + 15;
+  } else {
+    node.variantPack.inTensors.at(WEIGHT_COUNT_PER_LAYER + 4) =
+        atb_speed::Utils::AtTensor2Tensor(kv_cache.get_k_cache());
+    node.variantPack.inTensors.at(WEIGHT_COUNT_PER_LAYER + 5) =
+        atb_speed::Utils::AtTensor2Tensor(kv_cache.get_v_cache());
+    node.variantPack.inTensors.at(WEIGHT_COUNT_PER_LAYER + 10) =
+        atb_speed::Utils::AtTensor2Tensor(input_params.new_cache_slots);
+  }
+
   if (is_prefill &&
       (FLAGS_enable_chunked_prefill || FLAGS_enable_prefix_cache)) {
     node.variantPack.inTensors.at(input_idx++) =

--- a/xllm/core/layers/npu/npu_qwen3_decoder_layer_impl.h
+++ b/xllm/core/layers/npu/npu_qwen3_decoder_layer_impl.h
@@ -75,7 +75,8 @@ class NpuQwen3DecoderLayerImpl : public BaseLayer {
                                torch::Tensor& attn_mask,
                                KVCache& kv_cache,
                                ModelInputParams& input_params,
-                               bool is_prefill);
+                               bool is_prefill,
+                               int node_id);
 
   void initialize_parallel_parameters(atb_speed::qwen::QwenLayerParam& param,
                                       const ParallelArgs& parallel_args);

--- a/xllm/core/runtime/rec_worker_impl.cpp
+++ b/xllm/core/runtime/rec_worker_impl.cpp
@@ -21,6 +21,7 @@ limitations under the License.
 #include <map>
 #include <memory>
 #include <optional>
+#include <sstream>
 #include <vector>
 
 #include "common/device_monitor.h"
@@ -38,6 +39,7 @@ limitations under the License.
 #include "platform/cuda/device_capture_lock.h"
 #endif
 #if defined(USE_NPU)
+#include "kernels/npu/xllm_ops/xllm_ops_api.h"
 #include "platform/npu/device_capture_lock.h"
 #endif
 #include "framework/model_loader.h"
@@ -550,19 +552,33 @@ void RecWorkerImpl::LlmRecMultiRoundPipeline::allocate_kv_caches_related() {
   cached_full_v_caches_.resize(num_layers);
 
   for (int32_t layer_id = 0; layer_id < num_layers; ++layer_id) {
+#if defined(USE_NPU)
+    const int64_t full_kv_elems =
+        static_cast<int64_t>(full_kv_len) * num_kv_heads * head_dim;
+    auto target_layer_full_k_cache =
+        torch::zeros({full_kv_elems}, kv_cache_options);
+    auto target_layer_full_v_cache =
+        torch::zeros({full_kv_elems}, kv_cache_options);
+#else
     auto target_layer_full_k_cache =
         torch::zeros({full_kv_len, num_kv_heads, head_dim}, kv_cache_options);
     auto target_layer_full_v_cache =
         torch::zeros({full_kv_len, num_kv_heads, head_dim}, kv_cache_options);
+#endif
 
     cached_full_k_caches_[layer_id] = target_layer_full_k_cache;
     cached_full_v_caches_[layer_id] = target_layer_full_v_cache;
   }
 
+#if defined(USE_NPU)
+  cached_naive_block_table_ = torch::arange(max_seqs_per_batch_, int_options);
+#else
   cached_naive_block_table_ =
       torch::arange(max_seqs_per_batch_ * beam_width_, int_options)
           .unsqueeze(1);
+#endif
   cached_current_round_tensor_ = torch::zeros({1}, int_options);
+  cached_beam_width_tensor_ = torch::zeros({1}, int_options);
 
   if (FLAGS_enable_xattention_one_stage) {
     return;
@@ -622,8 +638,54 @@ void RecWorkerImpl::LlmRecMultiRoundPipeline::
     llm_rec_params.full_v_caches.reserve(num_layers);
     llm_rec_params.unshared_k_caches.reserve(num_layers);
     llm_rec_params.unshared_v_caches.reserve(num_layers);
+    llm_rec_params.shared_k_caches.reserve(num_layers);
+    llm_rec_params.shared_v_caches.reserve(num_layers);
 
     for (int32_t layer_id = 0; layer_id < num_layers; ++layer_id) {
+#if defined(USE_NPU)
+      auto layer_full_k_cache_flat = cached_full_k_caches_[layer_id];
+      auto layer_full_v_cache_flat = cached_full_v_caches_[layer_id];
+
+      const int64_t shared_kv_tokens = static_cast<int64_t>(unshared_offset);
+      const int64_t shared_kv_elems =
+          shared_kv_tokens * num_kv_heads * head_dim;
+      const int64_t full_kv_elems =
+          static_cast<int64_t>(full_kv_len) * num_kv_heads * head_dim;
+
+      auto layer_full_k_cache =
+          layer_full_k_cache_flat.view({full_kv_len, num_kv_heads, head_dim});
+      auto layer_full_v_cache =
+          layer_full_v_cache_flat.view({full_kv_len, num_kv_heads, head_dim});
+
+      auto layer_shared_k_cache =
+          layer_full_k_cache_flat.narrow(0, 0, shared_kv_elems)
+              .view({shared_kv_tokens, num_kv_heads, head_dim});
+      auto layer_shared_v_cache =
+          layer_full_v_cache_flat.narrow(0, 0, shared_kv_elems)
+              .view({shared_kv_tokens, num_kv_heads, head_dim});
+
+      // unshared view: [block_num, beam, kv_head, max_decode_step, head_dim]
+      auto layer_unshared_k_cache =
+          layer_full_k_cache_flat
+              .narrow(0, shared_kv_elems, full_kv_elems - shared_kv_elems)
+              .view({static_cast<int64_t>(max_seqs_per_batch_),
+                     static_cast<int64_t>(beam_width),
+                     num_kv_heads,
+                     static_cast<int64_t>(max_decode_step),
+                     head_dim})
+              .slice(0, 0, batch_size);
+      auto layer_unshared_v_cache =
+          layer_full_v_cache_flat
+              .narrow(0, shared_kv_elems, full_kv_elems - shared_kv_elems)
+              .view({static_cast<int64_t>(max_seqs_per_batch_),
+                     static_cast<int64_t>(beam_width),
+                     num_kv_heads,
+                     static_cast<int64_t>(max_decode_step),
+                     head_dim})
+              .slice(0, 0, batch_size);
+      llm_rec_params.shared_k_caches.emplace_back(layer_shared_k_cache);
+      llm_rec_params.shared_v_caches.emplace_back(layer_shared_v_cache);
+#else
       auto layer_full_k_cache = cached_full_k_caches_[layer_id];
       auto layer_full_v_cache = cached_full_v_caches_[layer_id];
 
@@ -648,6 +710,7 @@ void RecWorkerImpl::LlmRecMultiRoundPipeline::
                      num_kv_heads,
                      head_dim})
               .slice(0, 0, batch_size);
+#endif
 
       llm_rec_params.full_k_caches.emplace_back(layer_full_k_cache);
       llm_rec_params.full_v_caches.emplace_back(layer_full_v_cache);
@@ -656,8 +719,12 @@ void RecWorkerImpl::LlmRecMultiRoundPipeline::
     }
   }
 
+#if defined(USE_NPU)
+  input_params.block_tables = cached_naive_block_table_.slice(0, 0, batch_size);
+#else
   input_params.block_tables =
       cached_naive_block_table_.slice(0, 0, batch_size * beam_width);
+#endif
 
   const auto& decode_positions = step_meta->decode_positions_vec;
   llm_rec_params.decode_positions_tensor_list.clear();
@@ -715,8 +782,10 @@ std::optional<ForwardOutput> RecWorkerImpl::LlmRecMultiRoundPipeline::step(
                                       ? mutable_input.decoder_sampling_params
                                       : mutable_input.sampling_params;
 
-    // Consume async result for current round and schedule next round's async
-    // computation.
+    // Prepare round input according to the active backend.
+#if defined(USE_NPU)
+    prepare_round_input_for_npu(mutable_input, round, top_tokens, beam_tensors);
+#else
     prepare_round_input_and_schedule_next(mutable_input,
                                           round,
                                           total_rounds,
@@ -726,6 +795,7 @@ std::optional<ForwardOutput> RecWorkerImpl::LlmRecMultiRoundPipeline::step(
                                           top_tokens,
                                           beam_tensors,
                                           next_round_async_result);
+#endif
 
     auto model_output = runtime_.executor->forward(mutable_input.token_ids,
                                                    mutable_input.positions,
@@ -755,9 +825,23 @@ std::optional<ForwardOutput> RecWorkerImpl::LlmRecMultiRoundPipeline::step(
           << ") must be divisible by beam_width (" << step_meta->beam_width
           << ")";
 
+#if defined(USE_NPU)
+      if (round == 0) {
+        // NPU beam_search_rec prefill only accepts top_k == 1. Flatten the
+        // sampler's per-request top-k output into one candidate per beam so
+        // the kernel can seed sequence_group without discarding beam diversity.
+        top_tokens =
+            sample_output.top_tokens.to(torch::kInt32).reshape({-1, 1});
+        top_logprobs = sample_output.top_logprobs.reshape({-1, 1});
+      } else {
+        top_tokens = sample_output.top_tokens.to(torch::kInt32);
+        top_logprobs = sample_output.top_logprobs;
+      }
+#else
       top_tokens = sample_output.top_tokens.to(torch::kInt32)
                        .reshape({-1, step_meta->beam_width});
       top_logprobs = sample_output.top_logprobs.reshape({-1, beam_width});
+#endif
       execute_beam_search(
           top_tokens, top_logprobs, beam_tensors, round, batch_size);
 
@@ -810,7 +894,18 @@ void RecWorkerImpl::LlmRecMultiRoundPipeline::execute_beam_search(
     int32_t round,
     int32_t batch_size) {
 #if defined(USE_NPU)
-// TODO: implement beam search for NPU
+  xllm::kernel::npu::beam_search_rec(
+      /*logprobs=*/beam_tensors.acc_logprob,
+      /*top_tokens=*/top_tokens.to(torch::kInt32),
+      /*top_logprobs=*/top_logprobs,
+      /*sequence_group=*/beam_tensors.sequence_group,
+      /*current_step=*/static_cast<int64_t>(round),
+      /*out_token_ids=*/beam_tensors.out_token_ids,
+      /*out_token_index=*/beam_tensors.out_token_index,
+      /*out_log_probs=*/beam_tensors.out_log_probs,
+      /*out_beam_count_prefix_sums=*/
+      beam_tensors.out_beam_count_prefix_sums,
+      /*out_sequence=*/beam_tensors.out_seqgroup);
 #elif defined(USE_CUDA)
   xllm::kernel::cuda::beam_search(beam_tensors.acc_logprob,
                                   beam_tensors.sequence_group,
@@ -835,7 +930,37 @@ void RecWorkerImpl::LlmRecMultiRoundPipeline::execute_cache_select(
     int32_t beam_width,
     int32_t num_layers) {
 #if defined(USE_NPU)
-// TODO: implement cache select for NPU
+  auto device = runtime_.worker.device();
+  auto int32_options =
+      torch::TensorOptions().dtype(torch::kInt32).device(device);
+  const int32_t batch_size =
+      static_cast<int32_t>(beam_tensors.sequence_group.size(0));
+  auto batch_offsets = torch::arange(batch_size, int32_options) * beam_width;
+  auto batch_offsets_2d = batch_offsets.unsqueeze(1);
+
+  auto beam_index_global =
+      beam_tensors.out_token_index.reshape({batch_size, beam_width});
+  auto beam_index_local = beam_index_global - batch_offsets_2d;
+  auto group_prefix_global =
+      beam_tensors.out_beam_count_prefix_sums.reshape({batch_size, beam_width});
+  auto group_prefix_local = group_prefix_global - batch_offsets_2d;
+
+  auto block_table = torch::arange(batch_size, int32_options);
+
+  const auto& unshared_k_caches =
+      input.input_params.mutable_llmrec_params().unshared_k_caches;
+  const auto& unshared_v_caches =
+      input.input_params.mutable_llmrec_params().unshared_v_caches;
+
+  xllm::kernel::npu::select_unshared_kv(
+      /*beam_index=*/beam_index_local.reshape({-1}),
+      /*x_key_block=*/unshared_k_caches,
+      /*x_value_block=*/unshared_v_caches,
+      /*block_table=*/block_table,
+      /*group_offset=*/group_prefix_local.reshape({-1}),
+      /*decode_step=*/static_cast<int64_t>(round),
+      /*beam_size=*/beam_width,
+      /*layer_num=*/num_layers);
 #elif defined(USE_CUDA)
   xllm::kernel::cuda::cache_select(
       beam_tensors.out_token_index,
@@ -969,15 +1094,53 @@ void RecWorkerImpl::LlmRecMultiRoundPipeline::prepare_two_stage_round_input(
 #endif
 }
 
+void RecWorkerImpl::LlmRecMultiRoundPipeline::prepare_round_input_for_npu(
+    ForwardInput& input,
+    int32_t round,
+    const torch::Tensor& top_tokens,
+    const BeamSearchTensors& beam_tensors) {
+  auto& llm_rec_params = input.input_params.mutable_llmrec_params();
+  CHECK(cached_current_round_tensor_.defined());
+  CHECK(cached_beam_width_tensor_.defined());
+
+  cached_beam_width_tensor_.fill_(llm_rec_params.beam_width);
+  llm_rec_params.beam_width_tensor = cached_beam_width_tensor_;
+  cached_current_round_tensor_.fill_(round);
+  llm_rec_params.current_round_tensor = cached_current_round_tensor_;
+  input.input_params.attn_metadata = nullptr;
+
+  if (round == 0) {
+    input.input_params.is_prefill = true;
+    return;
+  }
+
+  input.input_params.is_prefill = false;
+  if (round == 1) {
+    if (top_tokens.defined()) {
+      input.token_ids = top_tokens.reshape({-1});
+    }
+  } else {
+    input.token_ids = beam_tensors.out_token_ids.reshape({-1});
+  }
+
+  const int32_t decode_step = round - 1;
+  if (!llm_rec_params.decode_positions_tensor_list.empty() &&
+      decode_step < static_cast<int32_t>(
+                        llm_rec_params.decode_positions_tensor_list.size())) {
+    input.positions = llm_rec_params.decode_positions_tensor_list[decode_step];
+  }
+
+  input.input_params.batch_forward_type = BatchForwardType(2);
+  input.input_params.input_embedding = torch::Tensor();
+}
+
 void RecWorkerImpl::LlmRecMultiRoundPipeline::prepare_input_for_current_round(
     ForwardInput& input,
     const NextRoundInputResults& results,
     int32_t round,
     const torch::Tensor& top_tokens,
     const BeamSearchTensors& beam_tensors) {
-#if defined(USE_NPU)
-// TODO: implement prepare_input_for_current_round for NPU
-#elif defined(USE_CUDA)
+#if defined(USE_CUDA)
   if (FLAGS_enable_xattention_one_stage) {
     input.input_params.paged_kv_indices = results.paged_kv_indices;
     input.input_params.paged_kv_indptr = results.paged_kv_indptr;
@@ -1029,9 +1192,7 @@ RecWorkerImpl::LlmRecMultiRoundPipeline::compute_next_round_input_async(
   folly::Promise<NextRoundInputResults> promise;
   auto future = promise.getSemiFuture();
 
-#if defined(USE_NPU)
-// TODO: implement compute_next_round_input_async for NPU
-#elif defined(USE_CUDA)
+#if defined(USE_CUDA)
   if (FLAGS_enable_xattention_one_stage) {
     // Capture necessary data for async computation
     auto full_kv_offsets = full_kv_cache_offsets_->full_kv_offsets;

--- a/xllm/core/runtime/rec_worker_impl.h
+++ b/xllm/core/runtime/rec_worker_impl.h
@@ -208,6 +208,11 @@ class RecWorkerImpl : public LLMWorkerImpl {
                                          const torch::Tensor& top_tokens,
                                          const BeamSearchTensors& beam_tensors);
 
+    void prepare_round_input_for_npu(ForwardInput& input,
+                                     int32_t round,
+                                     const torch::Tensor& top_tokens,
+                                     const BeamSearchTensors& beam_tensors);
+
     void prepare_two_stage_round_input(ForwardInput& input,
                                        int32_t round,
                                        const torch::Tensor& top_tokens,
@@ -258,6 +263,7 @@ class RecWorkerImpl : public LLMWorkerImpl {
     torch::Tensor cached_two_stage_paged_kv_indptr_expanded_;
     torch::Tensor cached_two_stage_paged_kv_indices_expanded_;
     torch::Tensor cached_two_stage_paged_kv_last_page_len_expanded_;
+    torch::Tensor cached_beam_width_tensor_;
 
     std::unique_ptr<RecSampler> rec_sampler_;
 


### PR DESCRIPTION
## Summary

  This PR adds xattention support for Qwen3 on NPU in the REC multi-round path.

  ## Background

  Previously, the Qwen3 NPU REC flow did not have the full runtime support required by xattention.
  The path was missing xattention-specific decode metadata and KV cache wiring, and the NPU multi-round path also lacked dedicated beam-search and cache-select kernels. In addition, single-card REC multi-round initialization still needed
  a valid backend process group during model construction.