### PR TITLE
refactor: replace typedef with using.

### DIFF
--- a/xllm/cc_api/llm.h
+++ b/xllm/cc_api/llm.h
@@ -25,7 +25,7 @@ limitations under the License.
 namespace xllm {
 
 // Forward declaration
-typedef struct LLMCore LLMCore;
+struct LLMCore;
 
 // A wrapper for loading, initializing, and text generation functions of large
 // language models

--- a/xllm/core/runtime/base_executor_impl.h
+++ b/xllm/core/runtime/base_executor_impl.h
@@ -56,6 +56,6 @@ class BaseExecutorImpl : public ExecutorImpl {
 };
 REGISTER_EXECUTOR("llm", BaseExecutorImpl);
 
-typedef BaseExecutorImpl RecExecutorImpl;
+using RecExecutorImpl = BaseExecutorImpl;
 REGISTER_EXECUTOR("rec", RecExecutorImpl);
 }  // namespace xllm

--- a/xllm/core/util/spin_rw_lock.h
+++ b/xllm/core/util/spin_rw_lock.h
@@ -24,7 +24,7 @@ limitations under the License.
 #define cpu_relax() asm volatile("yield\n" : : : "memory")
 #endif
 
-typedef volatile int64_t easy_atomic_t;
+using easy_atomic_t = volatile int64_t;
 static __inline__ void easy_atomic_add(easy_atomic_t* v, int64_t i) {
 #if defined(__x86_64__)
   __asm__ __volatile__(EASY_SMP_LOCK "addq %1,%0"
@@ -85,10 +85,10 @@ static __inline__ void easy_atomic_dec(easy_atomic_t* v) {
 #define EASY_QUEUE_FULL (-6)
 #define EASY_AGAIN (-EAGAIN)
 
-typedef struct easy_spinrwlock_t {
+struct easy_spinrwlock_t {
   easy_atomic_t ref_cnt;
   easy_atomic_t wait_write;
-} easy_spinrwlock_t;
+};
 #define EASY_SPINRWLOCK_INITIALIZER {0, 0}
 static __inline__ int easy_spinrwlock_rdlock(easy_spinrwlock_t* lock) {
   int ret = EASY_OK;
@@ -228,7 +228,7 @@ namespace xllm {
 
 class spin_rd_lock {
  public:
-  typedef easy_spinrwlock_t lock_type;
+  using lock_type = easy_spinrwlock_t;
 
   explicit spin_rd_lock(lock_type* lock) : lock_(lock) {
     easy_spinrwlock_rdlock(lock_);
@@ -244,7 +244,7 @@ class spin_rd_lock {
 
 class spin_wr_lock {
  public:
-  typedef easy_spinrwlock_t lock_type;
+  using lock_type = easy_spinrwlock_t;
 
   explicit spin_wr_lock(lock_type* lock) : lock_(lock) {
     easy_spinrwlock_wrlock(lock_);

--- a/xllm/models/vlm/npu/minicpmv.h
+++ b/xllm/models/vlm/npu/minicpmv.h
@@ -779,11 +779,10 @@ class Idefics2EncoderImpl : public torch::nn::Module {
 TORCH_MODULE(Idefics2Encoder);
 
 class VisionAdapterMLPImpl : public torch::nn::Module {
-  typedef std::tuple<torch::nn::LayerNorm,
-                     torch::nn::Linear,
-                     torch::nn::GELU,
-                     torch::nn::Linear>
-      MLPDef;
+  using MLPDef = std::tuple<torch::nn::LayerNorm,
+                            torch::nn::Linear,
+                            torch::nn::GELU,
+                            torch::nn::Linear>;
 
  public:
   VisionAdapterMLPImpl(const ModelContext& context) {


### PR DESCRIPTION
Replace typedef with using following "Effective Modern C++" Item 9 guidelines.

>Item 9: Prefer alias declarations to typedefs.