### PR TITLE
feat: add functional MiniMax-M2.5 baseline

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -350,6 +350,7 @@ if(USE_NPU)
       ${XLLM_ATB_LAYERS_SOURCE_DIR}
       ${XLLM_ATB_LAYERS_SOURCE_DIR}/core/include
   )
+  set(PYTORCH_TORCH_LIBS_PATH "$ENV{PYTORCH_INSTALL_PATH}/../torch.libs")
   link_directories(
       $ENV{PYTHON_LIB_PATH}
       $ENV{PYTORCH_INSTALL_PATH}/lib
@@ -359,6 +360,10 @@ if(USE_NPU)
       $ENV{NPU_TOOLKIT_HOME}/lib64
       $ENV{NPU_HOME_PATH}/opp/vendors/xllm/op_api/lib/
   )
+  if(EXISTS "${PYTORCH_TORCH_LIBS_PATH}")
+    link_directories("${PYTORCH_TORCH_LIBS_PATH}")
+    add_link_options("-Wl,-rpath-link,${PYTORCH_TORCH_LIBS_PATH}")
+  endif()
   link_libraries(cust_opapi)
   # avoid conflicts with xllm libruntime.a
   find_library(

--- a/scripts/build_support/env.py
+++ b/scripts/build_support/env.py
@@ -108,6 +108,9 @@ def set_npu_envs() -> None:
 
     set_common_envs()
     set_npu_torch_ld_library_path()
+    os.environ.setdefault(
+        "TRITON_CACHE_DIR",
+        os.path.join(os.path.expanduser("~"), ".triton", "cache"))
     NPU_TOOLKIT_HOME = os.getenv("NPU_TOOLKIT_HOME")
     if not NPU_TOOLKIT_HOME:
         os.environ["NPU_TOOLKIT_HOME"] = "/usr/local/Ascend/ascend-toolkit/latest"

--- a/tools/dequant_minimax_fp8.py
+++ b/tools/dequant_minimax_fp8.py
@@ -1,0 +1,263 @@
+#!/usr/bin/env python3
+"""Offline dequantize a MiniMax-M2.5 FP8 checkpoint into BF16 safetensors.
+
+The current xLLM MiniMax path dequantizes FP8 block weights during
+`load_state_dict`. This tool moves that work offline so repeated server
+restarts can reuse a dequantized checkpoint directory.
+
+Usage:
+    python tools/dequant_minimax_fp8.py \
+        --input-dir /models/MiniMax-M2.5 \
+        --output-dir /models/MiniMax-M2.5-bf16
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import shutil
+from pathlib import Path
+
+import torch
+from safetensors import safe_open
+from safetensors.torch import save_file
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Offline dequantize MiniMax-M2.5 FP8 safetensors to BF16."
+    )
+    parser.add_argument(
+        "--input-dir",
+        type=Path,
+        required=True,
+        help="Input MiniMax checkpoint directory.",
+    )
+    parser.add_argument(
+        "--output-dir",
+        type=Path,
+        required=True,
+        help="Output directory for the dequantized checkpoint.",
+    )
+    return parser.parse_args()
+
+
+def load_json(path: Path) -> dict:
+    with path.open("r", encoding="utf-8") as f:
+        return json.load(f)
+
+
+def save_json(path: Path, data: dict) -> None:
+    with path.open("w", encoding="utf-8") as f:
+        json.dump(data, f, indent=2, ensure_ascii=False, sort_keys=True)
+        f.write("\n")
+
+
+def is_fp8_dtype(dtype: torch.dtype) -> bool:
+    return dtype in {
+        torch.float8_e4m3fn,
+        torch.float8_e4m3fnuz,
+        torch.float8_e5m2,
+        torch.float8_e5m2fnuz,
+    }
+
+
+def dequantize_fp8_block_weight(
+    fp8_weight: torch.Tensor,
+    weight_scale_inv: torch.Tensor,
+    block_size: tuple[int, int],
+) -> torch.Tensor:
+    if fp8_weight.dim() != 2:
+        raise ValueError(
+            f"Only 2D fp8 weights are supported, got shape {tuple(fp8_weight.shape)}"
+        )
+    if weight_scale_inv.dim() != 2:
+        raise ValueError(
+            "FP8 weight scale tensor must be 2D, "
+            f"got shape {tuple(weight_scale_inv.shape)}"
+        )
+
+    block_n, block_k = block_size
+    n, k = fp8_weight.shape
+    n_tiles = (n + block_n - 1) // block_n
+    k_tiles = (k + block_k - 1) // block_k
+
+    if tuple(weight_scale_inv.shape) != (n_tiles, k_tiles):
+        raise ValueError(
+            "Unexpected fp8 scale shape "
+            f"{tuple(weight_scale_inv.shape)} for weight shape {tuple(fp8_weight.shape)}"
+        )
+
+    if n % block_n == 0 and k % block_k == 0:
+        weight_bf16 = fp8_weight.to(torch.bfloat16).reshape(
+            n_tiles, block_n, k_tiles, block_k
+        )
+        scale_bf16 = weight_scale_inv.to(torch.bfloat16).reshape(
+            n_tiles, 1, k_tiles, 1
+        )
+        return (weight_bf16 * scale_bf16).reshape(n, k)
+
+    expanded_scale = weight_scale_inv.repeat_interleave(block_n, 0).repeat_interleave(
+        block_k, 1
+    )
+    expanded_scale = expanded_scale[:n, :k].to(torch.bfloat16)
+    return fp8_weight.to(torch.bfloat16) * expanded_scale
+
+
+def discover_safetensor_files(input_dir: Path) -> tuple[list[str], dict[str, str]]:
+    index_path = input_dir / "model.safetensors.index.json"
+    if index_path.exists():
+        index_data = load_json(index_path)
+        weight_map = index_data["weight_map"]
+        files = sorted(set(weight_map.values()))
+        return files, weight_map
+
+    shard_paths = sorted(p.name for p in input_dir.glob("*.safetensors"))
+    if len(shard_paths) != 1:
+        raise ValueError(
+            "Expected model.safetensors.index.json or a single .safetensors shard "
+            f"under {input_dir}"
+        )
+    return shard_paths, {}
+
+
+def prepare_output_dir(output_dir: Path) -> None:
+    if output_dir.exists():
+        if any(output_dir.iterdir()):
+            raise ValueError(
+                f"Output directory {output_dir} already exists and is not empty"
+            )
+    else:
+        output_dir.mkdir(parents=True, exist_ok=True)
+
+
+def copy_non_safetensors_files(input_dir: Path, output_dir: Path) -> None:
+    for path in input_dir.iterdir():
+        if path.is_file() and path.suffix != ".safetensors":
+            if path.name in {"config.json", "model.safetensors.index.json"}:
+                continue
+            shutil.copy2(path, output_dir / path.name)
+
+
+def update_config(input_dir: Path, output_dir: Path) -> tuple[int, int]:
+    config_path = input_dir / "config.json"
+    if not config_path.exists():
+        raise ValueError(f"Missing config.json under {input_dir}")
+
+    config = load_json(config_path)
+    quant_config = config.get("quantization_config", {})
+    if quant_config.get("quant_method") != "fp8":
+        raise ValueError(
+            "This converter expects quantization_config.quant_method == 'fp8'"
+        )
+
+    block_size = quant_config.get("weight_block_size")
+    if not isinstance(block_size, list) or len(block_size) != 2:
+        raise ValueError(
+            "This converter expects quantization_config.weight_block_size to be a "
+            "2-element list"
+        )
+
+    config["torch_dtype"] = "bfloat16"
+    config.pop("quantization_config", None)
+    save_json(output_dir / "config.json", config)
+    return int(block_size[0]), int(block_size[1])
+
+
+def tensor_nbytes(tensor: torch.Tensor) -> int:
+    return tensor.numel() * tensor.element_size()
+
+
+def convert_shard(
+    input_path: Path, output_path: Path, block_size: tuple[int, int]
+) -> tuple[dict[str, str], int, int]:
+    converted: dict[str, torch.Tensor] = {}
+    shard_weight_map: dict[str, str] = {}
+    converted_fp8_tensors = 0
+    total_bytes = 0
+
+    with safe_open(input_path, framework="pt") as f:
+        keys = list(f.keys())
+        key_set = set(keys)
+        skipped = set()
+
+        for name in keys:
+            if name in skipped:
+                continue
+
+            if name.endswith(".weight_scale_inv"):
+                paired_weight_name = name[: -len("_scale_inv")]
+                if paired_weight_name in key_set:
+                    paired_weight = f.get_tensor(paired_weight_name)
+                    if is_fp8_dtype(paired_weight.dtype):
+                        skipped.add(name)
+                        continue
+
+            tensor = f.get_tensor(name)
+            if is_fp8_dtype(tensor.dtype):
+                scale_name = f"{name}_scale_inv"
+                if scale_name not in key_set:
+                    raise ValueError(
+                        f"Missing paired scale tensor {scale_name} for FP8 weight {name}"
+                    )
+                scale = f.get_tensor(scale_name)
+                tensor = dequantize_fp8_block_weight(tensor, scale, block_size)
+                skipped.add(scale_name)
+                converted_fp8_tensors += 1
+
+            converted[name] = tensor
+            shard_weight_map[name] = output_path.name
+            total_bytes += tensor_nbytes(tensor)
+
+    save_file(converted, str(output_path), metadata={"format": "pt"})
+    return shard_weight_map, converted_fp8_tensors, total_bytes
+
+
+def main() -> None:
+    args = parse_args()
+    input_dir = args.input_dir.resolve()
+    output_dir = args.output_dir.resolve()
+
+    if input_dir == output_dir:
+        raise ValueError("--input-dir and --output-dir must differ")
+
+    prepare_output_dir(output_dir)
+    copy_non_safetensors_files(input_dir, output_dir)
+    block_size = update_config(input_dir, output_dir)
+
+    shard_names, _ = discover_safetensor_files(input_dir)
+
+    total_weight_map: dict[str, str] = {}
+    total_size = 0
+    total_fp8_tensors = 0
+    total_shards = len(shard_names)
+
+    print(
+        f"Dequantizing MiniMax FP8 checkpoint from {input_dir} to {output_dir} "
+        f"with block_size={list(block_size)}"
+    )
+    for i, shard_name in enumerate(shard_names, start=1):
+        input_path = input_dir / shard_name
+        output_path = output_dir / shard_name
+        print(f"[{i}/{total_shards}] Processing {shard_name}")
+        shard_weight_map, converted_fp8_tensors, shard_bytes = convert_shard(
+            input_path, output_path, block_size
+        )
+        total_weight_map.update(shard_weight_map)
+        total_fp8_tensors += converted_fp8_tensors
+        total_size += shard_bytes
+
+    index_data = {
+        "metadata": {"total_size": total_size},
+        "weight_map": total_weight_map,
+    }
+    save_json(output_dir / "model.safetensors.index.json", index_data)
+    print(
+        "Done. Converted "
+        f"{total_fp8_tensors} fp8 tensors. "
+        f"Point MODEL_PATH to {output_dir} to use the bf16 checkpoint cache."
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/xllm/core/distributed_runtime/llm_engine.cpp
+++ b/xllm/core/distributed_runtime/llm_engine.cpp
@@ -62,6 +62,13 @@ int64_t get_kv_cache_dtype_size_in_bytes(const std::string& kv_cache_dtype,
   }
   return model_dtype_size;
 }
+
+#if defined(USE_NPU)
+bool should_keep_minimax_decode_graph_enabled() {
+  return xllm::util::get_bool_env("XLLM_MINIMAX_NATIVE_DECODE_ATTN", true) &&
+         !xllm::util::get_bool_env("XLLM_MINIMAX_EP_MOE_REFERENCE", false);
+}
+#endif
 }  // namespace
 
 namespace xllm {
@@ -189,6 +196,23 @@ bool LLMEngine::init_model(MasterStatus master_status) {
   args_ = model_loader->model_args();
   quant_args_ = model_loader->quant_args();
   tokenizer_args_ = model_loader->tokenizer_args();
+
+#if defined(USE_NPU)
+  if (args_.model_type() == "minimax_m2" && FLAGS_enable_graph) {
+    if (should_keep_minimax_decode_graph_enabled()) {
+      LOG(INFO) << "Keeping ACL graph enabled for MiniMax-M2.5 decode: "
+                   "native paged-attention and a graph-safe MiniMax decode MoE "
+                   "path are enabled.";
+    } else {
+      LOG(WARNING) << "Disabling ACL graph for MiniMax-M2.5 decode because "
+                      "either XLLM_MINIMAX_NATIVE_DECODE_ATTN=0, "
+                      "or XLLM_MINIMAX_EP_MOE_REFERENCE=1. The eager/reference/"
+                      "compare decode paths must run outside ACL graph "
+                      "capture.";
+      FLAGS_enable_graph = false;
+    }
+  }
+#endif
 
   // compute the number of local kv heads and head dim
   const uint32_t world_size = dp_local_tp_size_;

--- a/xllm/core/distributed_runtime/worker_server.cpp
+++ b/xllm/core/distributed_runtime/worker_server.cpp
@@ -40,6 +40,7 @@ limitations under the License.
 #endif
 #include "framework/kv_cache/kv_cache.h"
 #include "framework/model/model_input_params.h"
+#include "framework/model_loader.h"
 #include "framework/parallel_state/collective_communicator.h"
 #include "framework/parallel_state/dit_collective_communicator.h"
 #include "framework/parallel_state/mapping_npu.h"
@@ -62,6 +63,19 @@ extern char** environ;
 namespace xllm {
 namespace {
 void handle_signal(int signum) { _exit(0); }
+
+#if defined(USE_NPU)
+bool should_force_torch_process_groups_for_minimax(
+    const runtime::Options& options) {
+  if (options.npu_kernel_backend() != "ATB" || options.model_path().empty()) {
+    return false;
+  }
+
+  std::unique_ptr<ModelLoader> model_loader =
+      ModelLoader::create(options.model_path());
+  return model_loader->model_args().model_type() == "minimax_m2";
+}
+#endif
 }  // namespace
 
 void WorkerServer::create_server(
@@ -81,6 +95,14 @@ void WorkerServer::create_server(
   FLAGS_enable_prefill_sp = options.enable_prefill_sp();
 #if defined(USE_NPU)
   FLAGS_npu_kernel_backend = options.npu_kernel_backend();
+  const bool force_torch_process_groups_for_minimax =
+      should_force_torch_process_groups_for_minimax(options);
+  if (force_torch_process_groups_for_minimax) {
+    LOG(INFO) << "Force torch process-group initialization for MiniMax-M2 "
+                 "while keeping the ATB runtime backend. MiniMax uses "
+                 "torch tensor-parallel layers that require tp_group_.";
+    FLAGS_npu_kernel_backend = "TORCH";
+  }
 #endif
   Device device(d);
   device.set_device();
@@ -157,6 +179,12 @@ void WorkerServer::create_server(
 
   comm->create_process_groups(master_node_addr, device);
   parallel_args = comm->parallel_args();
+
+#if defined(USE_NPU)
+  if (force_torch_process_groups_for_minimax) {
+    FLAGS_npu_kernel_backend = options.npu_kernel_backend();
+  }
+#endif
 
   std::unique_ptr<Worker> worker =
       std::make_unique<Worker>(*parallel_args, device, options, worker_type);

--- a/xllm/core/framework/hf_model_loader.cpp
+++ b/xllm/core/framework/hf_model_loader.cpp
@@ -45,6 +45,7 @@ limitations under the License.
 #include "core/framework/tokenizer/tokenizer_factory.h"
 #include "core/platform/device.h"
 #include "core/util/blocking_counter.h"
+#include "core/util/env_var.h"
 #include "core/util/json_reader.h"
 #include "core/util/rec_model_utils.h"
 #include "core/util/scope_guard.h"
@@ -139,6 +140,9 @@ bool try_load_compressed_tensors_quant_cfg(const JsonReader& reader,
                 "quantization.";
   return false;
 }
+
+constexpr const char* kStreamStateDictLoadEnv =
+    "XLLM_STREAM_HF_STATE_DICT_LOAD";
 
 bool validate_smoothquant_mixed_w4a8(const JsonReader& reader,
                                      QuantArgs& quant_args,
@@ -457,6 +461,26 @@ std::vector<std::unique_ptr<StateDict>>& HFModelLoader::get_state_dicts() {
     counter.wait();
   }
   return state_dicts_;
+}
+
+void HFModelLoader::for_each_state_dict(
+    const std::function<void(const StateDict&)>& visitor) {
+  CHECK(static_cast<bool>(visitor)) << "state-dict visitor must not be empty";
+  if (!util::get_bool_env(kStreamStateDictLoadEnv, false)) {
+    for (const auto& state_dict : get_state_dicts()) {
+      visitor(*state_dict);
+    }
+    return;
+  }
+
+  LOG(INFO) << "Streaming HF safetensor shards one by one during model load: "
+            << "num_files=" << model_weights_files_.size()
+            << ", env=" << kStreamStateDictLoadEnv;
+  for (const auto& weights_file : model_weights_files_) {
+    LOG(INFO) << "Streaming model weights from " << weights_file;
+    auto state_dict = StateDictFromSafeTensor::load(weights_file);
+    visitor(*state_dict);
+  }
 }
 
 int64_t HFModelLoader::get_total_weight_size() const {

--- a/xllm/core/framework/hf_model_loader.h
+++ b/xllm/core/framework/hf_model_loader.h
@@ -18,6 +18,7 @@ limitations under the License.
 
 #include <torch/torch.h>
 
+#include <functional>
 #include <vector>
 
 #include "core/framework/state_dict/state_dict.h"
@@ -36,6 +37,9 @@ class HFModelLoader : public ModelLoader {
   std::unique_ptr<Tokenizer> tokenizer() const override;
 
   std::vector<std::unique_ptr<StateDict>>& get_state_dicts() override;
+
+  void for_each_state_dict(
+      const std::function<void(const StateDict&)>& visitor);
 
   int64_t get_total_weight_size() const override;
 

--- a/xllm/core/framework/model/model_args.h
+++ b/xllm/core/framework/model/model_args.h
@@ -62,6 +62,7 @@ struct ModelArgs {
   PROPERTY(int64_t, draft_vocab_size) = 0;
 
   PROPERTY(bool, use_qk_norm) = false;
+  PROPERTY(std::string, qk_norm_type);
   PROPERTY(float, rms_norm_eps) = 0.0f;
 
   PROPERTY(float, layer_norm_eps) = 0.0f;

--- a/xllm/core/framework/request/sequence.cpp
+++ b/xllm/core/framework/request/sequence.cpp
@@ -457,12 +457,16 @@ std::optional<SequenceOutput> Sequence::generate_streaming_output(
   // We consider both of these cases to be valid,
   // subsequent callbacks only need to skip to return tokens.
   //
-  if (delta.empty()) {
+  const bool is_finished = finished();
+  if (delta.empty() && !is_finished) {
     return std::nullopt;
   }
 
   output.index = index_;
   output.text = std::move(delta);
+  if (is_finished && finish_reason_ != FinishReason::NONE) {
+    output.finish_reason = finish_reason_.to_string();
+  }
 
   const size_t end = decoder_.output_offset();
   output.token_ids = ids.slice(start, end);

--- a/xllm/core/framework/tokenizer/CMakeLists.txt
+++ b/xllm/core/framework/tokenizer/CMakeLists.txt
@@ -24,6 +24,7 @@ cc_library(
     rec_tokenizer.cpp
   DEPS
     :common
+    :state_dict
     :sentencepiece
     state_dict
     absl::flat_hash_map

--- a/xllm/core/kernels/npu/npu_recurrent_gated_delta_rule.cpp
+++ b/xllm/core/kernels/npu/npu_recurrent_gated_delta_rule.cpp
@@ -28,7 +28,11 @@ limitations under the License.
 #endif
 
 #include "acl/acl.h"
+#if __has_include("aclnn_recurrent_gated_delta_rule.h")
 #include "aclnn_recurrent_gated_delta_rule.h"
+#else
+#include "aclnnop/aclnn_recurrent_gated_delta_rule.h"
+#endif
 #include "core/common/macros.h"
 #include "core/kernels/npu/utils.h"
 #include "npu_ops_api.h"

--- a/xllm/core/layers/common/attention_metadata.h
+++ b/xllm/core/layers/common/attention_metadata.h
@@ -144,6 +144,7 @@ struct AttentionMetadata {
 
 #if defined(USE_NPU)
   // for npu
+  torch::Tensor q_seq_lens_host;
   torch::Tensor kv_seq_lens_host;
   // For ACL graph execution - tiling data for CustomPagedAttention.
   // If defined, use this instead of kv_seq_lens_host to avoid .to(kCPU)

--- a/xllm/core/layers/common/attention_metadata_builder.cpp
+++ b/xllm/core/layers/common/attention_metadata_builder.cpp
@@ -89,6 +89,10 @@ AttentionMetadata build_attention_metadata(
     // ACL graph mode: use CustomPagedAttention with tiling_data on device
     attn_metadata.paged_attention_tiling_data = params.graph_buffer.tiling_data;
   }
+  if (!params.q_seq_lens_vec.empty()) {
+    attn_metadata.q_seq_lens_host =
+        torch::tensor(params.q_seq_lens_vec, torch::kInt);
+  }
   // Provide host seq_lens for NPU kernels (required by CustomPagedAttention).
   if (!params.kv_seq_lens_vec.empty()) {
     attn_metadata.kv_seq_lens_host =

--- a/xllm/core/layers/common/linear.cpp
+++ b/xllm/core/layers/common/linear.cpp
@@ -503,12 +503,13 @@ QKVParallelLinearImpl::QKVParallelLinearImpl(
       head_size_(head_size),
       num_kv_head_replicas_(num_kv_head_replicas),
       gather_output_(gather_output),
-      parallel_args_(parallel_args),
+      tp_group_(parallel_args.tp_group_),
       options_(options),
       device_(options.device()),
       quant_args_(quant_args) {
-  rank_ = parallel_args_.tp_group_->rank();
-  world_size_ = parallel_args_.tp_group_->world_size();
+  CHECK(tp_group_ != nullptr) << "QKVParallelLinear requires tp_group_";
+  rank_ = tp_group_->rank();
+  world_size_ = tp_group_->world_size();
   const int64_t out_features_per_partition =
       (num_heads + 2 * num_kv_heads) * head_size;
   // Note: torch.nn.functional.linear performs XA^T + b and as a result
@@ -580,7 +581,7 @@ torch::Tensor QKVParallelLinearImpl::forward(torch::Tensor input) {
   }
 
   if (world_size_ > 1 && gather_output_) {
-    output = xllm::parallel_state::gather(output, parallel_args_.tp_group_);
+    output = xllm::parallel_state::gather(output, tp_group_);
   }
   return output;
 }

--- a/xllm/core/layers/common/linear.h
+++ b/xllm/core/layers/common/linear.h
@@ -177,8 +177,7 @@ class QKVParallelLinearImpl : public torch::nn::Module {
   // whether to gather the output
   bool gather_output_;
   at::Device device_;
-  // parallel args
-  ParallelArgs parallel_args_;
+  ProcessGroup* tp_group_;
   torch::TensorOptions options_;
   // quantization args
   QuantArgs quant_args_;

--- a/xllm/core/layers/common/word_embedding_impl.cpp
+++ b/xllm/core/layers/common/word_embedding_impl.cpp
@@ -27,10 +27,11 @@ WordEmbeddingImpl::WordEmbeddingImpl(const ModelContext& context)
 WordEmbeddingImpl::WordEmbeddingImpl(int64_t num_embeddings,
                                      int64_t embedding_dim,
                                      const ParallelArgs& parallel_args,
-                                     const torch::TensorOptions& options)
-    : parallel_args_(parallel_args) {
-  rank_ = parallel_args_.tp_group_->rank();
-  world_size_ = parallel_args_.tp_group_->world_size();
+                                     const torch::TensorOptions& options) {
+  tp_group_ = parallel_args.tp_group_;
+  CHECK(tp_group_ != nullptr) << "WordEmbedding requires tp_group_";
+  rank_ = tp_group_->rank();
+  world_size_ = tp_group_->world_size();
 
   CHECK(embedding_dim % world_size_ == 0)
       << "out_features " << embedding_dim << " not divisible by world_size "
@@ -50,7 +51,7 @@ torch::Tensor WordEmbeddingImpl::forward(torch::Tensor input) {
   namespace F = torch::nn::functional;
   auto output = F::embedding(input, weight_);
   if (world_size_ > 1) {
-    output = xllm::parallel_state::gather(output, parallel_args_.tp_group_);
+    output = xllm::parallel_state::gather(output, tp_group_);
   }
   return output;
 }

--- a/xllm/core/layers/common/word_embedding_impl.h
+++ b/xllm/core/layers/common/word_embedding_impl.h
@@ -59,11 +59,11 @@ class WordEmbeddingImpl : public torch::nn::Module {
   // world size
   PROPERTY(int32_t, world_size) = 0;
 
+  // tensor parallel process group
+  ProcessGroup* tp_group_ = nullptr;
+
   // parameter members, must be registered
   DEFINE_WEIGHT(weight);
-
-  // parallel args
-  ParallelArgs parallel_args_;
 };
 
 }  // namespace layer

--- a/xllm/core/layers/npu/CMakeLists.txt
+++ b/xllm/core/layers/npu/CMakeLists.txt
@@ -17,6 +17,7 @@ cc_library(
     npu_qwen2dot5_vision_encoder_layer_impl.h
     npu_qwen3_vision_encoder_layer_impl.h
     npu_qwen3_moe_decoder_layer_impl.h
+    npu_minimax_m2_decoder_layer_impl.h
     # atb_parallel_linear.h
     npu_block_copy_impl.h
     buffer/atb_buffer.h
@@ -42,6 +43,7 @@ cc_library(
     loader/qwen2_decoder_loader.h
     loader/qwen3_moe_decoder_loader.h
     loader/eagle3_decoder_loader.h
+    loader/minimax_m2_decoder_loader.h
     loader/word_embedding_loader.h
     loader/lm_head_loader.h
     loader/column_parallel_linear_loader.h
@@ -76,6 +78,7 @@ cc_library(
     npu_qwen2dot5_vision_encoder_layer_impl.cpp
     npu_qwen3_vision_encoder_layer_impl.cpp
     npu_qwen3_moe_decoder_layer_impl.cpp
+    npu_minimax_m2_decoder_layer_impl.cpp
     # atb_parallel_linear.cpp
     npu_block_copy_impl.cpp
     buffer/atb_buffer.cpp
@@ -101,6 +104,7 @@ cc_library(
     loader/qwen2_decoder_loader.cpp
     loader/qwen3_moe_decoder_loader.cpp
     loader/eagle3_decoder_loader.cpp
+    loader/minimax_m2_decoder_loader.cpp
     loader/word_embedding_loader.cpp
     loader/lm_head_loader.cpp
     loader/column_parallel_linear_loader.cpp

--- a/xllm/core/layers/npu/loader/minimax_m2_decoder_loader.cpp
+++ b/xllm/core/layers/npu/loader/minimax_m2_decoder_loader.cpp
@@ -1,0 +1,625 @@
+/* Copyright 2025 The xLLM Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://github.com/jd-opensource/xllm/blob/main/LICENSE
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include "minimax_m2_decoder_loader.h"
+
+#include <glog/logging.h>
+#include <torch/torch.h>
+#include <torch_npu/csrc/core/npu/NPUFormat.h>
+#include <torch_npu/torch_npu.h>
+
+#include <cctype>
+#include <sstream>
+#include <unordered_set>
+
+namespace xllm {
+namespace layer {
+
+enum DecoderLayerTensorId : int {
+  IN_INPUT_NORM_WEIGHT = 0,
+  IN_INPUT_NORM_BIAS = 1,
+  IN_INPUT_NORM_NEW_WEIGHT = 2,
+  IN_INPUT_NORM_NEW_BIAS = 3,
+
+  IN_QKV_WEIGHT_0 = 4,
+  IN_QKV_BIAS_0 = 5,
+  IN_QKV_DESCALE_0 = 6,
+  IN_QKV_OFFSET_0 = 7,
+  IN_QKV_SCALE_0 = 8,
+  IN_QKV_COMPRESS_IDX_0 = 9,
+
+  IN_QKV_WEIGHT_1 = 10,
+  IN_QKV_BIAS_1 = 11,
+  IN_QKV_DESCALE_1 = 12,
+  IN_QKV_OFFSET_1 = 13,
+  IN_QKV_SCALE_1 = 14,
+  IN_QKV_COMPRESS_IDX_1 = 15,
+
+  IN_QKV_WEIGHT_2 = 16,
+  IN_QKV_BIAS_2 = 17,
+  IN_QKV_DESCALE_2 = 18,
+  IN_QKV_OFFSET_2 = 19,
+  IN_QKV_SCALE_2 = 20,
+  IN_QKV_COMPRESS_IDX_2 = 21,
+
+  IN_QKV_DENSE_WEIGHT = 22,
+  IN_QKV_DENSE_BIAS = 23,
+  IN_QKV_DENSE_DESCALE = 24,
+  IN_QKV_DENSE_OFFSET = 25,
+  IN_QKV_DENSE_SCALE = 26,
+  IN_QKV_DENSE_COMPRESS_IDX = 27,
+
+  IN_POST_ATTN_NORM_WEIGHT = 28,
+  IN_POST_ATTN_NORM_BIAS = 29,
+  IN_POST_ATTN_NORM_NEW_WEIGHT = 30,
+  IN_POST_ATTN_NORM_NEW_BIAS = 31,
+
+  IN_MLP_GATEUP_WEIGHT_SHARED_EXPERT = 32,
+  IN_MLP_GATEUP_BIAS_SHARED_EXPERT = 33,
+  IN_MLP_GATEUP_DESCALE_SHARED_EXPERT = 34,
+  IN_MLP_GATEUP_OFFSET_SHARED_EXPERT = 35,
+  IN_MLP_GATEUP_SCALE_SHARED_EXPERT = 36,
+  IN_MLP_GATEUP_COMPRESS_IDX_SHARED_EXPERT = 37,
+
+  IN_MLP_DOWN_WEIGHT_SHARED_EXPERT = 38,
+  IN_MLP_DOWN_BIAS_SHARED_EXPERT = 39,
+  IN_MLP_DOWN_DESCALE_SHARED_EXPERT = 40,
+  IN_MLP_DOWN_OFFSET_SHARED_EXPERT = 41,
+  IN_MLP_DOWN_SCALE_SHARED_EXPERT = 42,
+  IN_MLP_DOWN_COMPRESS_IDX_SHARED_EXPERT = 43,
+
+  IN_SHARED_EXPERT_GATE_WEIGHT = 44,
+  IN_SHARED_EXPERT_GATE_BIAS = 45,
+  IN_SHARED_EXPERT_GATE_DESCALE = 46,
+  IN_SHARED_EXPERT_GATE_OFFSET = 47,
+  IN_SHARED_EXPERT_GATE_SCALE = 48,
+  IN_SHARED_EXPERT_GATE_COMPRESS_IDX = 49,
+
+  BLOCK_SPARSE_MOE_GATE_WEIGHT = 50,
+  BLOCK_SPARSE_MOE_GATE_BIAS = 51,
+  BLOCK_SPARSE_MOE_GATE_DESCALE = 52,
+  BLOCK_SPARSE_MOE_GATE_OFFSET = 53,
+  BLOCK_SPARSE_MOE_GATE_SCALE = 54,
+  BLOCK_SPARSE_MOE_GATE_COMPRESS_IDX = 55,
+
+  IN_MLP_GATEUP_WEIGHT = 56,
+  IN_MLP_GATEUP_BIAS = 57,
+  IN_MLP_GATEUP_DESCALE = 58,
+  IN_MLP_GATEUP_OFFSET = 59,
+  IN_MLP_GATEUP_SCALE = 60,
+  IN_MLP_GATEUP_COMPRESS_IDX = 61,
+
+  IN_MLP_DOWN_WEIGHT = 62,
+  IN_MLP_DOWN_BIAS = 63,
+  IN_MLP_DOWN_DESCALE = 64,
+  IN_MLP_DOWN_OFFSET = 65,
+  IN_MLP_DOWN_SCALE = 66,
+  IN_MLP_DOWN_COMPRESS_IDX = 67,
+
+  Q_NORM_WEIGHT = 68,
+  K_NORM_WEIGHT = 69
+};
+
+static std::unordered_map<std::string, int> WEIGHT_MAPPING = {
+    {"input_layernorm.weight", IN_INPUT_NORM_WEIGHT},
+    {"self_attn.q_proj.weight", IN_QKV_WEIGHT_0},
+    {"self_attn.k_proj.weight", IN_QKV_WEIGHT_1},
+    {"self_attn.v_proj.weight", IN_QKV_WEIGHT_2},
+    {"self_attn.o_proj.weight", IN_QKV_DENSE_WEIGHT},
+    {"self_attn.q_norm.weight", Q_NORM_WEIGHT},
+    {"self_attn.k_norm.weight", K_NORM_WEIGHT},
+    {"post_attention_layernorm.weight", IN_POST_ATTN_NORM_WEIGHT},
+    {"mlp.gate.weight", BLOCK_SPARSE_MOE_GATE_WEIGHT},
+    {"mlp.gate.e_score_correction_bias", BLOCK_SPARSE_MOE_GATE_BIAS},
+    {"gate_proj.weight", IN_MLP_GATEUP_WEIGHT},
+    {"up_proj.weight", IN_MLP_GATEUP_WEIGHT},
+    {"down_proj.weight", IN_MLP_DOWN_WEIGHT},
+};
+
+static std::unordered_map<std::string, int> WEIGHT_MAPPING_W8A8 = {
+    {"input_layernorm.weight", IN_INPUT_NORM_WEIGHT},
+    {"input_layernorm.bias", IN_INPUT_NORM_NEW_BIAS},
+    {"self_attn.q_proj.weight", IN_QKV_WEIGHT_0},
+    {"self_attn.q_proj.bias", IN_QKV_BIAS_0},
+    {"self_attn.q_proj.deq_scale", IN_QKV_DESCALE_0},
+    {"self_attn.q_proj.weight_offset", IN_QKV_OFFSET_0},
+    {"self_attn.q_proj.weight_scale", IN_QKV_SCALE_0},
+    {"self_attn.k_proj.weight", IN_QKV_WEIGHT_1},
+    {"self_attn.k_proj.bias", IN_QKV_BIAS_1},
+    {"self_attn.k_proj.deq_scale", IN_QKV_DESCALE_1},
+    {"self_attn.k_proj.weight_offset", IN_QKV_OFFSET_1},
+    {"self_attn.k_proj.weight_scale", IN_QKV_SCALE_1},
+    {"self_attn.v_proj.weight", IN_QKV_WEIGHT_2},
+    {"self_attn.v_proj.bias", IN_QKV_BIAS_2},
+    {"self_attn.v_proj.deq_scale", IN_QKV_DESCALE_2},
+    {"self_attn.v_proj.weight_offset", IN_QKV_OFFSET_2},
+    {"self_attn.v_proj.weight_scale", IN_QKV_SCALE_2},
+    {"self_attn.o_proj.weight", IN_QKV_DENSE_WEIGHT},
+    {"self_attn.o_proj.quant_bias", IN_QKV_DENSE_BIAS},
+    {"self_attn.o_proj.deq_scale", IN_QKV_DENSE_DESCALE},
+    {"self_attn.o_proj.weight_offset", IN_QKV_DENSE_OFFSET},
+    {"self_attn.o_proj.weight_scale", IN_QKV_DENSE_SCALE},
+    {"self_attn.q_norm.weight", Q_NORM_WEIGHT},
+    {"self_attn.k_norm.weight", K_NORM_WEIGHT},
+    {"post_attention_layernorm.weight", IN_POST_ATTN_NORM_WEIGHT},
+    {"post_attention_layernorm.bias", IN_POST_ATTN_NORM_NEW_BIAS},
+    {"mlp.gate.weight", BLOCK_SPARSE_MOE_GATE_WEIGHT},
+    {"mlp.gate.e_score_correction_bias", BLOCK_SPARSE_MOE_GATE_BIAS},
+    {"gate_proj.weight", IN_MLP_GATEUP_WEIGHT},
+    {"gate_proj.weight_offset", IN_MLP_GATEUP_OFFSET},
+    {"gate_proj.weight_scale", IN_MLP_GATEUP_SCALE},
+    {"up_proj.weight", IN_MLP_GATEUP_WEIGHT},
+    {"up_proj.weight_offset", IN_MLP_GATEUP_OFFSET},
+    {"up_proj.weight_scale", IN_MLP_GATEUP_SCALE},
+    {"down_proj.weight", IN_MLP_DOWN_WEIGHT},
+    {"down_proj.weight_offset", IN_MLP_DOWN_OFFSET},
+    {"down_proj.weight_scale", IN_MLP_DOWN_SCALE},
+};
+
+static const std::unordered_map<std::string, std::vector<int>>
+    SPECIAL_MULTI_ASSIGN_W8A8 = {
+        {"input_layernorm.weight",
+         {IN_INPUT_NORM_WEIGHT, IN_INPUT_NORM_NEW_WEIGHT}},
+        {"post_attention_layernorm.weight",
+         {IN_POST_ATTN_NORM_WEIGHT, IN_POST_ATTN_NORM_NEW_WEIGHT}},
+};
+
+static const std::map<int, int> WEIGHT_SHARD = {
+    {IN_QKV_WEIGHT_0, 0},
+    {IN_QKV_WEIGHT_1, 0},
+    {IN_QKV_WEIGHT_2, 0},
+    {IN_QKV_DENSE_WEIGHT, 1},
+    {IN_MLP_GATEUP_WEIGHT, 0},
+    {IN_MLP_DOWN_WEIGHT, 1},
+    {Q_NORM_WEIGHT, 0},
+    {K_NORM_WEIGHT, 0},
+};
+
+static const std::map<int, int> WEIGHT_SHARD_W8A8 = {
+    {IN_QKV_WEIGHT_0, 0},
+    {IN_QKV_OFFSET_0, 0},
+    {IN_QKV_SCALE_0, 0},
+    {IN_QKV_WEIGHT_1, 0},
+    {IN_QKV_OFFSET_1, 0},
+    {IN_QKV_SCALE_1, 0},
+    {IN_QKV_WEIGHT_2, 0},
+    {IN_QKV_OFFSET_2, 0},
+    {IN_QKV_SCALE_2, 0},
+    {IN_QKV_DENSE_WEIGHT, 1},
+    {IN_MLP_GATEUP_WEIGHT, 0},
+    {IN_MLP_GATEUP_OFFSET, 0},
+    {IN_MLP_GATEUP_SCALE, 0},
+    {IN_MLP_DOWN_WEIGHT, 1},
+    {Q_NORM_WEIGHT, 0},
+    {K_NORM_WEIGHT, 0},
+};
+
+MiniMaxM2DecoderLoader::MiniMaxM2DecoderLoader(uint64_t weight_count,
+                                               const ModelContext& context,
+                                               bool use_qk_norm)
+    : BaseLoader(weight_count, context) {
+  auto options = context.get_tensor_options();
+  use_qk_norm_ = use_qk_norm;
+  tensor_placeholder_ = torch::zeros({1}).to(options);
+
+  if (use_qk_norm_) {
+    weight_count_ = weight_count = 70;
+  } else {
+    weight_count_ = weight_count = 68;
+  }
+
+  at_weight_tensors_.resize(weight_count_);
+  for (size_t i = 0; i < at_weight_tensors_.size(); ++i) {
+    at_weight_tensors_[i] = tensor_placeholder_;
+  }
+
+  auto model_args = context.get_model_args();
+  num_experts_ = model_args.num_experts();
+  ep_size_ = parallel_args_.ep_size();
+  ep_local_tp_size_ = parallel_args_.world_size() / ep_size_;
+  CHECK_EQ(parallel_args_.world_size(), ep_size_ * ep_local_tp_size_);
+  ep_local_tp_rank_ = parallel_args_.rank() % ep_local_tp_size_;
+  num_experts_per_partition_ = model_args.num_experts() / ep_size_;
+  ep_rank_ = parallel_args_.rank() / ep_local_tp_size_;
+  start_expert_id_ = ep_rank_ * num_experts_per_partition_;
+  end_expert_id_ = start_expert_id_ + num_experts_per_partition_ - 1;
+  n_kv_heads_ = static_cast<int32_t>(model_args.n_kv_heads().value());
+
+  dp_size_ = parallel_args_.dp_size();
+  dp_local_tp_size_ = parallel_args_.world_size() / dp_size_;
+  CHECK_EQ(parallel_args_.world_size(), dp_size_ * dp_local_tp_size_);
+  dp_local_tp_rank_ = parallel_args_.rank() % dp_local_tp_size_;
+}
+
+void MiniMaxM2DecoderLoader::load_state_dict(const StateDict& state_dict) {
+  for (const auto& [name, tensor] : state_dict) {
+    if (absl::StartsWith(name, "mlp.experts")) {
+      process_expert_weights(state_dict, name, tensor);
+      continue;
+    }
+
+    if (absl::StartsWith(name, "mlp") && !absl::StrContains(name, "gate.")) {
+      process_mlp_common_weights(state_dict, name, tensor);
+      continue;
+    }
+
+    process_general_weights(state_dict, name, tensor);
+  }
+}
+
+void MiniMaxM2DecoderLoader::verify_loaded_weights(
+    const std::string& prefix) const {
+  for (const auto& [name, index] : WEIGHT_MAPPING) {
+    if (name == "down_proj.weight" || name == "gate_proj.weight" ||
+        name == "up_proj.weight" ||
+        (!use_qk_norm_ && (name == "self_attn.q_norm.weight" ||
+                           name == "self_attn.k_norm.weight"))) {
+      continue;
+    }
+    CHECK(at_weight_tensors_[index].sizes() != std::vector<int64_t>({1}))
+        << prefix << " weight is not loaded for " << name;
+  }
+}
+
+void MiniMaxM2DecoderLoader::resize_experts_weights(int num_of_device_experts) {
+  experts_weights_["gate_proj.weight"] =
+      std::vector<torch::Tensor>(num_of_device_experts);
+  experts_weights_["up_proj.weight"] =
+      std::vector<torch::Tensor>(num_of_device_experts);
+  experts_weights_["down_proj.weight"] =
+      std::vector<torch::Tensor>(num_of_device_experts);
+  if (quantize_type_.compare("w8a8_dynamic") == 0) {
+    experts_weights_["gate_proj.weight_offset"] =
+        std::vector<torch::Tensor>(num_of_device_experts);
+    experts_weights_["up_proj.weight_offset"] =
+        std::vector<torch::Tensor>(num_of_device_experts);
+    experts_weights_["down_proj.weight_offset"] =
+        std::vector<torch::Tensor>(num_of_device_experts);
+    experts_weights_["gate_proj.weight_scale"] =
+        std::vector<torch::Tensor>(num_of_device_experts);
+    experts_weights_["up_proj.weight_scale"] =
+        std::vector<torch::Tensor>(num_of_device_experts);
+    experts_weights_["down_proj.weight_scale"] =
+        std::vector<torch::Tensor>(num_of_device_experts);
+  }
+}
+
+void MiniMaxM2DecoderLoader::process_expert_weights(
+    const StateDict& state_dict,
+    const std::string& name,
+    const torch::Tensor& tensor) {
+  const int expert_index = extract_expert_index(name);
+  if (expert_index < start_expert_id_ || expert_index > end_expert_id_) {
+    return;
+  }
+
+  const std::string suffix = extract_endswith(name);
+  const auto& weight_mapping = (quantize_type_.compare("w8a8_dynamic") == 0)
+                                   ? WEIGHT_MAPPING_W8A8
+                                   : WEIGHT_MAPPING;
+  const auto& shard_map = (quantize_type_.compare("w8a8_dynamic") == 0)
+                              ? WEIGHT_SHARD_W8A8
+                              : WEIGHT_SHARD;
+  const int index = get_mapped_index(suffix, weight_mapping);
+  const int local_index = expert_index % num_experts_per_partition_;
+  const bool is_sharded = shard_map.count(index);
+
+  torch::Tensor tmp_tensor = is_sharded
+                                 ? get_sharded_tensor(state_dict,
+                                                      name,
+                                                      shard_map.at(index),
+                                                      ep_local_tp_rank_,
+                                                      ep_local_tp_size_)
+                                 : tensor;
+  experts_weights_[suffix][local_index] = tmp_tensor.clone();
+}
+
+void MiniMaxM2DecoderLoader::process_mlp_common_weights(
+    const StateDict& state_dict,
+    const std::string& name,
+    const torch::Tensor& tensor) {
+  const auto& weight_mapping = (quantize_type_.compare("w8a8_dynamic") == 0)
+                                   ? WEIGHT_MAPPING_W8A8
+                                   : WEIGHT_MAPPING;
+  if (weight_mapping.find(name) == weight_mapping.end()) {
+    return;
+  }
+
+  const auto& shard_map = (quantize_type_.compare("w8a8_dynamic") == 0)
+                              ? WEIGHT_SHARD_W8A8
+                              : WEIGHT_SHARD;
+  const int index = get_mapped_index(name, weight_mapping);
+  const bool is_sharded = shard_map.count(index);
+
+  torch::Tensor tmp_tensor = is_sharded
+                                 ? get_sharded_tensor(state_dict,
+                                                      name,
+                                                      shard_map.at(index),
+                                                      dp_local_tp_rank_,
+                                                      dp_local_tp_size_)
+                                       .to(device_)
+                                 : tensor.to(device_);
+  at_weight_tensors_[index] = tmp_tensor;
+}
+
+void MiniMaxM2DecoderLoader::process_general_weights(
+    const StateDict& state_dict,
+    const std::string& name,
+    const torch::Tensor& tensor) {
+  if (!use_qk_norm_ && (name == "self_attn.q_norm.weight" ||
+                        name == "self_attn.k_norm.weight")) {
+    return;
+  }
+
+  const auto& weight_mapping = (quantize_type_.compare("w8a8_dynamic") == 0)
+                                   ? WEIGHT_MAPPING_W8A8
+                                   : WEIGHT_MAPPING;
+  if (weight_mapping.find(name) == weight_mapping.end()) {
+    return;
+  }
+
+  const auto& shard_map = (quantize_type_.compare("w8a8_dynamic") == 0)
+                              ? WEIGHT_SHARD_W8A8
+                              : WEIGHT_SHARD;
+  const int index = get_mapped_index(name, weight_mapping);
+  const bool is_sharded = shard_map.count(index);
+
+  int32_t tp_rank = dp_local_tp_rank_;
+  int32_t tp_size = dp_local_tp_size_;
+  static const std::unordered_set<int> kv_parallel_indices = {IN_QKV_WEIGHT_1,
+                                                              IN_QKV_WEIGHT_2,
+                                                              IN_QKV_BIAS_1,
+                                                              IN_QKV_BIAS_2,
+                                                              IN_QKV_DESCALE_1,
+                                                              IN_QKV_DESCALE_2,
+                                                              IN_QKV_OFFSET_1,
+                                                              IN_QKV_OFFSET_2,
+                                                              IN_QKV_SCALE_1,
+                                                              IN_QKV_SCALE_2,
+                                                              K_NORM_WEIGHT};
+  if (kv_parallel_indices.count(index) > 0 && n_kv_heads_ < dp_local_tp_size_) {
+    const int32_t repeat_times = dp_local_tp_size_ / n_kv_heads_;
+    tp_rank = tp_rank / repeat_times;
+    tp_size = n_kv_heads_;
+  }
+
+  torch::Tensor tmp_tensor =
+      is_sharded ? get_sharded_tensor(
+                       state_dict, name, shard_map.at(index), tp_rank, tp_size)
+                       .to(device_)
+                 : tensor.to(device_);
+
+  if (index == BLOCK_SPARSE_MOE_GATE_BIAS) {
+    tmp_tensor = tmp_tensor - tmp_tensor.min();
+  }
+
+  correct_tensor_dtype(tmp_tensor, name);
+  if (quantize_type_.compare("w8a8_dynamic") == 0) {
+    auto it = SPECIAL_MULTI_ASSIGN_W8A8.find(name);
+    if (it != SPECIAL_MULTI_ASSIGN_W8A8.end()) {
+      for (int idx : it->second) {
+        at_weight_tensors_[idx] = tmp_tensor;
+      }
+      return;
+    }
+  }
+  at_weight_tensors_[index] = tmp_tensor;
+}
+
+void MiniMaxM2DecoderLoader::merge_experts_weights() {
+  try {
+    torch::Tensor mlp_gateup_weight;
+    if (quantize_type_.compare("w8a8_dynamic") == 0) {
+      mlp_gateup_weight =
+          merge_experts_weights(experts_weights_["gate_proj.weight"],
+                                experts_weights_["up_proj.weight"],
+                                true);
+      at_weight_tensors_[IN_MLP_GATEUP_OFFSET] =
+          merge_experts_weights(experts_weights_["gate_proj.weight_offset"],
+                                experts_weights_["up_proj.weight_offset"]);
+      at_weight_tensors_[IN_MLP_GATEUP_SCALE] =
+          merge_experts_weights(experts_weights_["gate_proj.weight_scale"],
+                                experts_weights_["up_proj.weight_scale"]);
+      at_weight_tensors_[IN_MLP_GATEUP_WEIGHT] =
+          at_npu::native::npu_format_cast(mlp_gateup_weight, 29);
+    } else {
+      mlp_gateup_weight =
+          merge_experts_weights(experts_weights_["gate_proj.weight"],
+                                experts_weights_["up_proj.weight"],
+                                false);
+      at_weight_tensors_[IN_MLP_GATEUP_WEIGHT] =
+          at_npu::native::npu_format_cast(mlp_gateup_weight, 2).contiguous();
+    }
+  } catch (const std::exception& e) {
+    LOG(ERROR) << "[ERROR] Exception in gateup weight processing: " << e.what();
+    throw;
+  }
+
+  try {
+    torch::Tensor mlp_down_weight =
+        merge_experts_weights(experts_weights_["down_proj.weight"], false);
+    at_weight_tensors_[IN_MLP_DOWN_WEIGHT] =
+        at_npu::native::npu_format_cast(mlp_down_weight, 2).contiguous();
+
+    if (quantize_type_.compare("w8a8_dynamic") == 0) {
+      at_weight_tensors_[IN_MLP_DOWN_OFFSET] =
+          merge_experts_weights(experts_weights_["down_proj.weight_offset"]);
+      at_weight_tensors_[IN_MLP_DOWN_SCALE] =
+          merge_experts_weights(experts_weights_["down_proj.weight_scale"]);
+    }
+  } catch (const std::exception& e) {
+    LOG(ERROR) << "[ERROR] Exception in down weight processing: " << e.what();
+    throw;
+  }
+}
+
+torch::Tensor MiniMaxM2DecoderLoader::merge_experts_weights(
+    std::vector<torch::Tensor>& experts,
+    bool transpose) {
+  torch::Tensor merged_tensor = torch::stack(experts, 0).to(device_);
+  if (transpose) {
+    merged_tensor = merged_tensor.transpose(1, 2);
+  }
+  merged_tensor = merged_tensor.contiguous();
+  experts.clear();
+  return merged_tensor;
+}
+
+torch::Tensor MiniMaxM2DecoderLoader::merge_experts_weights(
+    std::vector<torch::Tensor>& experts_gate,
+    std::vector<torch::Tensor>& experts_up,
+    bool transpose) {
+  for (size_t i = 0; i < experts_up.size(); ++i) {
+    experts_gate[i] = torch::cat({experts_gate[i], experts_up[i]}, 0);
+  }
+  torch::Tensor merged_tensor = torch::stack(experts_gate, 0).to(device_);
+  if (transpose) {
+    merged_tensor = merged_tensor.transpose(1, 2);
+  }
+  merged_tensor = merged_tensor.contiguous();
+  experts_gate.clear();
+  experts_up.clear();
+  return merged_tensor;
+}
+
+void MiniMaxM2DecoderLoader::merge_loaded_weights() {
+  merge_experts_weights();
+
+  at_weight_tensors_[IN_QKV_WEIGHT_0] =
+      torch::cat({at_weight_tensors_[IN_QKV_WEIGHT_0],
+                  at_weight_tensors_[IN_QKV_WEIGHT_1],
+                  at_weight_tensors_[IN_QKV_WEIGHT_2]},
+                 0)
+          .contiguous();
+  at_weight_tensors_[IN_QKV_WEIGHT_1] =
+      torch::zeros({1}, torch::kFloat16).to(device_);
+  at_weight_tensors_[IN_QKV_WEIGHT_2] =
+      torch::zeros({1}, torch::kFloat16).to(device_);
+
+  if (quantize_type_.compare("w8a8_dynamic") == 0) {
+    at_weight_tensors_[IN_QKV_BIAS_0] =
+        torch::zeros({1}, torch::kFloat16).to(device_);
+    at_weight_tensors_[IN_QKV_BIAS_1] =
+        torch::zeros({1}, torch::kFloat16).to(device_);
+    at_weight_tensors_[IN_QKV_BIAS_2] =
+        torch::zeros({1}, torch::kFloat16).to(device_);
+    at_weight_tensors_[IN_QKV_DENSE_BIAS] =
+        torch::zeros({1}, torch::kFloat16).to(device_);
+
+    at_weight_tensors_[IN_QKV_DESCALE_0] =
+        torch::zeros({1}, torch::kFloat16).to(device_);
+    at_weight_tensors_[IN_QKV_DESCALE_1] =
+        torch::zeros({1}, torch::kFloat16).to(device_);
+    at_weight_tensors_[IN_QKV_DESCALE_2] =
+        torch::zeros({1}, torch::kFloat16).to(device_);
+    at_weight_tensors_[IN_QKV_DENSE_DESCALE] =
+        torch::zeros({1}, torch::kFloat16).to(device_);
+
+    at_weight_tensors_[IN_QKV_OFFSET_0] =
+        torch::cat({at_weight_tensors_[IN_QKV_OFFSET_0],
+                    at_weight_tensors_[IN_QKV_OFFSET_1],
+                    at_weight_tensors_[IN_QKV_OFFSET_2]},
+                   0)
+            .contiguous()
+            .view(-1);
+    at_weight_tensors_[IN_QKV_OFFSET_1] =
+        torch::zeros({1}, torch::kFloat16).to(device_);
+    at_weight_tensors_[IN_QKV_OFFSET_2] =
+        torch::zeros({1}, torch::kFloat16).to(device_);
+    at_weight_tensors_[IN_QKV_DENSE_OFFSET] =
+        at_weight_tensors_[IN_QKV_DENSE_OFFSET].contiguous().view(-1);
+
+    at_weight_tensors_[IN_QKV_SCALE_0] =
+        torch::cat({at_weight_tensors_[IN_QKV_SCALE_0],
+                    at_weight_tensors_[IN_QKV_SCALE_1],
+                    at_weight_tensors_[IN_QKV_SCALE_2]},
+                   0)
+            .contiguous()
+            .view(-1);
+    at_weight_tensors_[IN_QKV_SCALE_1] =
+        torch::zeros({1}, torch::kFloat16).to(device_);
+    at_weight_tensors_[IN_QKV_SCALE_2] =
+        torch::zeros({1}, torch::kFloat16).to(device_);
+    at_weight_tensors_[IN_QKV_DENSE_SCALE] =
+        at_weight_tensors_[IN_QKV_DENSE_SCALE].contiguous().view(-1);
+  }
+}
+
+std::string MiniMaxM2DecoderLoader::extract_endswith(const std::string& input) {
+  std::vector<std::string> parts;
+  std::stringstream ss(input);
+  std::string part;
+  while (std::getline(ss, part, '.')) {
+    parts.push_back(part);
+  }
+  if (parts.size() < 2) {
+    return "";
+  }
+  return parts[parts.size() - 2] + "." + parts[parts.size() - 1];
+}
+
+int MiniMaxM2DecoderLoader::extract_expert_index(const std::string& name) {
+  const std::string prefix = "experts.";
+  size_t pos = name.find(prefix);
+  if (pos != std::string::npos) {
+    pos += prefix.length();
+    size_t end_pos = pos;
+    while (end_pos < name.length() && std::isdigit(name[end_pos])) {
+      ++end_pos;
+    }
+    if (end_pos > pos) {
+      return std::stoi(name.substr(pos, end_pos - pos));
+    }
+  }
+  return -1;
+}
+
+int MiniMaxM2DecoderLoader::get_mapped_index(
+    const std::string& name,
+    const std::unordered_map<std::string, int>& mapping) {
+  const auto it = mapping.find(name);
+  if (it == mapping.end()) {
+    LOG(ERROR) << "Missing mapping for: " << name;
+    return -1;
+  }
+  return it->second;
+}
+
+torch::Tensor MiniMaxM2DecoderLoader::get_sharded_tensor(
+    const StateDict& state_dict,
+    const std::string& name,
+    int dim) {
+  if (parallel_args_.world_size() > 1) {
+    return state_dict.get_sharded_tensor(
+        name, dim, parallel_args_.rank(), parallel_args_.world_size());
+  }
+  return state_dict.get_tensor(name);
+}
+
+torch::Tensor MiniMaxM2DecoderLoader::get_sharded_tensor(
+    const StateDict& state_dict,
+    const std::string& name,
+    int dim,
+    int loacal_tp_rank,
+    int local_tp_size) {
+  if (local_tp_size > 1) {
+    return state_dict.get_sharded_tensor(
+        name, dim, loacal_tp_rank, local_tp_size);
+  }
+  return state_dict.get_tensor(name);
+}
+
+}  // namespace layer
+}  // namespace xllm

--- a/xllm/core/layers/npu/loader/minimax_m2_decoder_loader.h
+++ b/xllm/core/layers/npu/loader/minimax_m2_decoder_loader.h
@@ -1,0 +1,98 @@
+/* Copyright 2025 The xLLM Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://github.com/jd-opensource/xllm/blob/main/LICENSE
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#pragma once
+
+#include <map>
+#include <unordered_map>
+#include <vector>
+
+#include "base_loader.h"
+
+namespace xllm {
+namespace layer {
+
+class MiniMaxM2DecoderLoader : public BaseLoader {
+ public:
+  MiniMaxM2DecoderLoader(uint64_t weight_count,
+                         const ModelContext& context,
+                         bool use_qk_norm);
+
+  void load_state_dict(const StateDict& state_dict) override;
+  void verify_loaded_weights(const std::string& prefix) const override;
+  void merge_loaded_weights() override;
+  void resize_experts_weights(int num_of_device_experts) override;
+
+ protected:
+  std::string extract_endswith(const std::string& input);
+
+  int extract_expert_index(const std::string& name);
+
+  int get_mapped_index(const std::string& name,
+                       const std::unordered_map<std::string, int>& mapping);
+
+  torch::Tensor get_sharded_tensor(const StateDict& state_dict,
+                                   const std::string& name,
+                                   int dim);
+  torch::Tensor get_sharded_tensor(const StateDict& state_dict,
+                                   const std::string& name,
+                                   int dim,
+                                   int local_tp_rank,
+                                   int local_tp_size);
+
+  void process_mlp_common_weights(const StateDict& state_dict,
+                                  const std::string& name,
+                                  const torch::Tensor& tensor);
+
+  void process_general_weights(const StateDict& state_dict,
+                               const std::string& name,
+                               const torch::Tensor& tensor);
+
+  void merge_experts_weights();
+
+  torch::Tensor merge_experts_weights(std::vector<torch::Tensor>& experts_up,
+                                      std::vector<torch::Tensor>& experts_gate,
+                                      bool transpose = false);
+
+  torch::Tensor merge_experts_weights(std::vector<torch::Tensor>& experts,
+                                      bool transpose = false);
+
+  void process_expert_weights(const StateDict& state_dict,
+                              const std::string& name,
+                              const torch::Tensor& tensor);
+
+  int32_t ep_size_;
+  int32_t num_experts_;
+  int32_t num_experts_per_partition_;
+  int32_t ep_local_tp_size_;
+  int32_t ep_local_tp_rank_;
+  int32_t start_expert_id_;
+  int32_t end_expert_id_;
+  int32_t ep_rank_;
+  int32_t n_kv_heads_;
+
+  int32_t dp_size_;
+  int32_t dp_local_tp_size_;
+  int32_t dp_rank_;
+  int32_t dp_local_tp_rank_;
+  bool use_qk_norm_ = true;
+  torch::Tensor tensor_placeholder_;
+
+  std::unordered_map<std::string, torch::Tensor> shared_experts_weights_;
+  std::unordered_map<std::string, std::vector<torch::Tensor>> experts_weights_;
+};
+
+}  // namespace layer
+}  // namespace xllm

--- a/xllm/core/layers/npu/npu_minimax_m2_decoder_layer_impl.cpp
+++ b/xllm/core/layers/npu/npu_minimax_m2_decoder_layer_impl.cpp
@@ -1,0 +1,516 @@
+/* Copyright 2025 The xLLM Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://github.com/jd-opensource/xllm/blob/main/LICENSE
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include "npu_minimax_m2_decoder_layer_impl.h"
+
+#include <gflags/gflags.h>
+
+#include <algorithm>
+#include <numeric>
+#include <unordered_set>
+
+#include "common/global_flags.h"
+
+namespace xllm {
+namespace layer {
+
+static uint64_t WEIGHT_COUNT_PER_LAYER = 68;
+
+namespace {
+
+std::vector<size_t> build_op_weight_tensor_ids(
+    const atb_speed::glm::MoeLayerParam& param) {
+  std::vector<size_t> ids;
+  ids.reserve(70);
+
+  // Base GLM MoE weights:
+  // 0-3   : input norm
+  // 4-27  : attention
+  // 28-31 : post-attention norm
+  for (size_t i = 0; i < 32; ++i) {
+    ids.push_back(i);
+  }
+
+  // 32-49 are only present in the kernel input list when shared experts or
+  // dense-layer replacement are enabled.
+  if (param.hasSharedExpert || param.isDenseLayer) {
+    for (size_t i = 32; i < 50; ++i) {
+      ids.push_back(i);
+    }
+  }
+
+  // 50-67 : routed MoE gate / expert weights.
+  for (size_t i = 50; i < 68; ++i) {
+    ids.push_back(i);
+  }
+
+  // 68-69 : q/k norm.
+  if (param.useQKNorm) {
+    ids.push_back(68);
+    ids.push_back(69);
+  }
+
+  return ids;
+}
+
+size_t get_runtime_input_offset(const atb_speed::Model::Node& node) {
+  size_t offset = 0;
+  while (offset < node.inTensors.size() &&
+         node.inTensors.at(offset) != nullptr) {
+    ++offset;
+  }
+  return offset;
+}
+
+}  // namespace
+
+NpuMiniMaxM2DecoderLayerImpl::NpuMiniMaxM2DecoderLayerImpl(
+    const ModelContext& context,
+    const int32_t layer_id)
+    : BaseLayer(context),
+      device_id_(context.get_tensor_options().device().index()),
+      layer_id_(layer_id),
+      num_speculative_tokens_(
+          context.get_model_args().num_speculative_tokens()) {
+  auto model_args = context.get_model_args();
+  auto parallel_args = context.get_parallel_args();
+  auto options = context.get_tensor_options();
+
+  use_glm_qk_norm_ =
+      model_args.use_qk_norm() && model_args.qk_norm_type() != "per_layer";
+  if (model_args.use_qk_norm() && !use_glm_qk_norm_ && layer_id_ == 0 &&
+      parallel_args.rank() == 0) {
+    LOG(WARNING)
+        << "MiniMax-M2 uses qk_norm_type="
+        << (model_args.qk_norm_type().empty() ? "<empty>"
+                                              : model_args.qk_norm_type())
+        << ", but the current GLM-based NPU fused path only supports per-head "
+           "Q/K RMSNorm. Disabling fused Q/K norm for MiniMax to avoid the "
+           "warmup crash. Generation correctness remains incomplete until a "
+           "MiniMax-native attention path is implemented.";
+  }
+  WEIGHT_COUNT_PER_LAYER = use_glm_qk_norm_ ? 70 : 68;
+
+  num_experts_ = model_args.num_experts();
+  ep_size_ = parallel_args.ep_size();
+  ep_local_tp_size_ = parallel_args.world_size() / ep_size_;
+  CHECK_EQ(parallel_args.world_size(), ep_size_ * ep_local_tp_size_);
+  ep_local_tp_rank_ = parallel_args.rank() % ep_local_tp_size_;
+  num_experts_per_partition_ = model_args.num_experts() / ep_size_;
+  ep_rank_ = parallel_args.rank() / ep_local_tp_size_;
+  start_expert_id_ = ep_rank_ * num_experts_per_partition_;
+  end_expert_id_ = start_expert_id_ + num_experts_per_partition_ - 1;
+
+  dp_size_ = parallel_args.dp_size();
+  dp_local_tp_size_ = parallel_args.world_size() / dp_size_;
+  CHECK_EQ(parallel_args.world_size(), dp_size_ * dp_local_tp_size_);
+  dp_local_tp_rank_ = parallel_args.rank() % dp_local_tp_size_;
+
+  param_from_args(prefill_param_, model_args, parallel_args, true);
+  param_from_args(decode_param_, model_args, parallel_args, false);
+  loader_ = std::make_unique<MiniMaxM2DecoderLoader>(
+      WEIGHT_COUNT_PER_LAYER, context, use_glm_qk_norm_);
+  initialize_tensors(options);
+}
+
+void NpuMiniMaxM2DecoderLayerImpl::initialize_tensors(
+    const torch::TensorOptions& options) {
+  atb_weight_tensors_.resize(WEIGHT_COUNT_PER_LAYER);
+  placeholder_vec_ = {1};
+  int_tensor_placeholder_ = torch::ones({1}).to(torch::kInt32).to(device_);
+  slot_tensor_placeholder_ = torch::full({1}, 0).to(torch::kInt32).to(device_);
+  block_tables_placeholder_ =
+      torch::zeros({1, 1}).to(torch::kInt32).to(device_);
+  tensor_placeholder_ = torch::zeros({1}).to(options);
+  loader_->resize_experts_weights(num_experts_per_partition_);
+  expert_group_ = torch::arange(1024, torch::kInt32).to(device_);
+  one_hot_ = torch::tensor({1}, torch::kInt32).to(device_);
+  zero_hot_ = torch::tensor({0}, torch::kInt32).to(device_);
+  at_start_expert_id_ =
+      torch::tensor({start_expert_id_}, torch::kInt64).to(device_);
+  at_in_device_expert_count_ =
+      torch::tensor({num_experts_per_partition_ - 1}, torch::kInt64)
+          .to(device_);
+}
+
+void NpuMiniMaxM2DecoderLayerImpl::param_from_args(
+    atb_speed::glm::MoeLayerParam& param,
+    const ModelArgs& args,
+    const ParallelArgs& parallel_args,
+    bool is_prefill) {
+  initialize_basic_parameters(param, args, parallel_args, is_prefill);
+  initialize_attention_parameters(param, args, parallel_args);
+  initialize_mlp_parameters(param, args, parallel_args);
+  initialize_parallel_parameters(param, parallel_args);
+  initialize_quantization_parameters(param);
+}
+
+void NpuMiniMaxM2DecoderLayerImpl::initialize_basic_parameters(
+    atb_speed::glm::MoeLayerParam& param,
+    const ModelArgs& args,
+    const ParallelArgs& parallel_args,
+    bool is_prefill) {
+  param.isFA = false;
+  param.isPrefill = is_prefill;
+  param.isBF16 = args.dtype() == "bfloat16";
+  param.enableSwiGLU = true;
+  param.enableLcoc = is_prefill;
+
+  param.mlpLinearTransposeType = {-1, -1, -1, -1};
+
+  // The current MiniMax bring-up reuses the GLM noAuxTc MoE path. Keep the
+  // prefill input layout conservative until MiniMax has a dedicated router
+  // implementation, otherwise warmup can bind an extra split-fuse q_len input
+  // that this path does not instantiate.
+  param.enableSplitFuse = false;
+  param.enableAclGraphPagedAttention = FLAGS_enable_graph && !is_prefill;
+
+  if (quantize_type_.empty()) {
+    param.moeLinearTransposeType = std::vector<int>{1, 1, -1, 1};
+  } else {
+    param.moeLinearTransposeType = std::vector<int>{1, 0, -1, 1};
+  }
+  param.normEps = args.rms_norm_eps();
+  param.backend = FLAGS_communication_backend;
+
+  param.layerId = layer_id_;
+  param.numHiddenLayers = args.n_layers();
+  if (quantize_type_.empty()) {
+    param.enableGMMSwigluQuant = false;
+  } else {
+    param.enableGMMSwigluQuant =
+        (is_prefill && parallel_args.world_size() > 16) || !is_prefill;
+  }
+
+  param.enableSpeculate = false;
+  param.enableSwiGLUQuantForSharedExperts = false;
+
+  // The reused GLM MoE kernel only supports per-head q/k RMSNorm, while
+  // MiniMax-M2 stores per-layer q/k RMSNorm tensors.
+  param.useQKNorm = use_glm_qk_norm_;
+  param.hiddenSizePerAttentionHead = args.head_dim();
+  std::optional<long int> optional_value = args.n_kv_heads();
+  param.numKeyValueHeadsPerRank = std::max(
+      1, static_cast<int>(optional_value.value()) / parallel_args.world_size());
+  param.numAttentionHeadsPerRank = args.n_heads() / dp_local_tp_size_;
+
+  param.linearTransposeType = {1, -1, -1, 1, -1, -1, -1};
+}
+
+void NpuMiniMaxM2DecoderLayerImpl::initialize_attention_parameters(
+    atb_speed::glm::MoeLayerParam& param,
+    const ModelArgs& args,
+    const ParallelArgs& parallel_args) {
+  param.linearHasBias = {args.attention_bias(), false, false, false};
+}
+
+void NpuMiniMaxM2DecoderLayerImpl::initialize_mlp_parameters(
+    atb_speed::glm::MoeLayerParam& param,
+    const ModelArgs& args,
+    const ParallelArgs& parallel_args) {
+  param.hasSharedExpert = (args.n_shared_experts() > 0);
+  param.hasSharedExpertGate = false;
+  param.processLogits = "normScaling";
+  param.numOfSelectedExperts = {args.num_experts_per_tok()};
+
+  param.expertParallelDegree =
+      ep_size_ > 1 ? std::max(FLAGS_expert_parallel_degree, 1) : 0;
+  param.enableFusedRouting = true;
+  param.numOfSharedExperts = args.n_shared_experts();
+  param.numOfExperts = args.num_experts();
+  param.numOfDeviceExperts = num_experts_per_partition_;
+  param.routedScalingFactor = args.routed_scaling_factor();
+  param.deviceExpert.resize(num_experts_per_partition_);
+  param.firstKDenseReplace = args.first_k_dense_replace();
+  param.numOfGroups = std::max(args.n_group(), 1);
+  param.topkGroups = atb::SVector<int>{std::max(args.topk_group(), 1)};
+  param.isDenseLayer = false;
+  param.enableDispatchCombineV2 = true;
+  std::iota(
+      param.deviceExpert.begin(), param.deviceExpert.end(), start_expert_id_);
+  param.routingMethod = "noAuxTc";
+
+  param.quantGroupSize = 0;
+  param.enableInitQuant = false;
+  param.enableSwigluQuant = false;
+  param.enableFusedTopk = false;
+  param.enableCVOverlap = false;
+}
+
+void NpuMiniMaxM2DecoderLayerImpl::initialize_parallel_parameters(
+    atb_speed::glm::MoeLayerParam& param,
+    const ParallelArgs& parallel_args) {
+  param.lmHeadLocalTp = dp_local_tp_size_;
+  param.mapping = parallel_args.mapping();
+  param.tensorParallelInfo = {parallel_args.rank(),
+                              parallel_args.world_size(),
+                              FLAGS_communication_backend,
+                              FLAGS_rank_tablefile,
+                              nullptr,
+                              ""};
+
+  param.maxDecodeDpTokenSize = 0;
+}
+
+void NpuMiniMaxM2DecoderLayerImpl::initialize_quantization_parameters(
+    atb_speed::glm::MoeLayerParam& param) {
+  if (quantize_type_.empty()) {
+    param.packQuantType = {static_cast<int>(PackType::ALL_FP),
+                           static_cast<int>(PackType::ALL_FP)};
+    param.linearQuantType = {static_cast<int>(LinearType::FP),
+                             static_cast<int>(LinearType::INVALID),
+                             static_cast<int>(LinearType::INVALID),
+                             static_cast<int>(LinearType::FP),
+                             static_cast<int>(LinearType::INVALID),
+                             static_cast<int>(LinearType::INVALID)};
+    param.mlpLinearQuantType = {static_cast<int>(LinearType::INVALID),
+                                static_cast<int>(LinearType::INVALID),
+                                static_cast<int>(LinearType::INVALID),
+                                static_cast<int>(LinearType::INVALID)};
+
+    param.moeLinearQuantType = {static_cast<int>(LinearType::FP),
+                                static_cast<int>(LinearType::FP),
+                                static_cast<int>(LinearType::INVALID),
+                                static_cast<int>(LinearType::FP)};
+  } else {
+    param.packQuantType = {static_cast<int>(PackType::ALL_W8A8_DYNAMIC_ANTI),
+                           static_cast<int>(PackType::ALL_W8A8_DYNAMIC_ANTI)};
+    param.linearQuantType = {static_cast<int>(LinearType::INT),
+                             static_cast<int>(LinearType::INVALID),
+                             static_cast<int>(LinearType::INVALID),
+                             static_cast<int>(LinearType::INT),
+                             static_cast<int>(LinearType::INVALID),
+                             static_cast<int>(LinearType::INVALID)};
+    param.mlpLinearQuantType = {static_cast<int>(LinearType::INVALID),
+                                static_cast<int>(LinearType::INVALID),
+                                static_cast<int>(LinearType::INVALID),
+                                static_cast<int>(LinearType::INVALID)};
+    param.moeLinearQuantType = {static_cast<int>(LinearType::FP),
+                                static_cast<int>(LinearType::INT),
+                                static_cast<int>(LinearType::INVALID),
+                                static_cast<int>(LinearType::INT)};
+  }
+}
+
+void NpuMiniMaxM2DecoderLayerImpl::merge_loaded_weights() {
+  loader_->merge_loaded_weights();
+  auto& at_weight_tensors = loader_->get_at_weight_tensors();
+  c10_npu::NPUCachingAllocator::emptyCache();
+  for (int i = 0; i < WEIGHT_COUNT_PER_LAYER; ++i) {
+    atb_weight_tensors_[i] =
+        atb_speed::Utils::AtTensor2Tensor(at_weight_tensors[i]);
+  }
+  init_layer();
+}
+
+int64_t NpuMiniMaxM2DecoderLayerImpl::init_layer() {
+  name_ = "minimax_m2_decoder_layer " + std::to_string(layer_id_);
+  model_name_ = "MiniMaxM2";
+  CHECK_OPERATION_STATUS_RETURN(init_node(prefill_node_, prefill_param_));
+  CHECK_OPERATION_STATUS_RETURN(init_node(decode_node_, decode_param_));
+
+  return atb::NO_ERROR;
+}
+
+int64_t NpuMiniMaxM2DecoderLayerImpl::init_node(
+    atb_speed::Model::Node& node,
+    atb_speed::glm::MoeLayerParam& param) {
+  atb::Operation* operation = nullptr;
+  const auto op_weight_tensor_ids = build_op_weight_tensor_ids(param);
+  atb_speed::glm::MoeDecoderLayer<atb::infer::RmsNormParam> decoder_layer(
+      param);
+  decoder_layer.BuildGraph(&operation);
+  node.operation.reset(operation);
+  CHECK_NOTNULL(node.operation);
+  CHECK_GT(node.operation->GetInputNum(), 0);
+  CHECK_LE(op_weight_tensor_ids.size(), node.operation->GetInputNum());
+  if (layer_id_ == 0) {
+    LOG(INFO) << "MiniMaxM2 " << (param.isPrefill ? "prefill" : "decode")
+              << " node input count=" << node.operation->GetInputNum()
+              << ", loader weight count=" << WEIGHT_COUNT_PER_LAYER
+              << ", op weight count=" << op_weight_tensor_ids.size()
+              << ", enableSplitFuse=" << param.enableSplitFuse;
+  }
+  node.inTensors.resize(node.operation->GetInputNum());
+  node.outTensors.resize(1);
+
+  for (size_t input_tensor_id = 0;
+       input_tensor_id < op_weight_tensor_ids.size();
+       ++input_tensor_id) {
+    node.inTensors.at(input_tensor_id) =
+        &atb_weight_tensors_[op_weight_tensor_ids.at(input_tensor_id)];
+  }
+
+  node.variantPack.inTensors.reserve(node.inTensors.size());
+  node.variantPack.inTensors.resize(node.inTensors.size());
+  node.variantPack.outTensors.reserve(1);
+  node.variantPack.outTensors.resize(1);
+
+  return atb::NO_ERROR;
+}
+
+torch::Tensor NpuMiniMaxM2DecoderLayerImpl::forward(
+    torch::Tensor& x,
+    torch::Tensor& cos_pos,
+    torch::Tensor& sin_pos,
+    torch::Tensor& attn_mask,
+    KVCache& kv_cache,
+    const ModelInputParams& input_params,
+    aclrtEvent* event,
+    std::atomic<bool>* event_flag,
+    int node_id) {
+  atb::Status st;
+  if (!input_params.batch_forward_type.is_decode()) {
+    build_node_variant_pack(prefill_node_,
+                            x,
+                            cos_pos,
+                            sin_pos,
+                            attn_mask,
+                            kv_cache,
+                            input_params,
+                            true);
+    st = execute_node(prefill_node_, node_id, event, event_flag);
+    LOG_IF(FATAL, st != 0) << model_name_
+                           << " excute prefill layer fail, error code: " << st;
+  } else {
+    build_node_variant_pack(decode_node_,
+                            x,
+                            cos_pos,
+                            sin_pos,
+                            tensor_placeholder_,
+                            kv_cache,
+                            input_params,
+                            false);
+    st = execute_node(decode_node_, node_id + 1000, event, event_flag);
+    LOG_IF(FATAL, st != 0) << model_name_
+                           << " excute decode layer fail, error code: " << st;
+  }
+
+  return tensor_placeholder_;
+}
+
+void NpuMiniMaxM2DecoderLayerImpl::build_node_variant_pack(
+    atb_speed::Model::Node& node,
+    torch::Tensor& x,
+    torch::Tensor& cos_pos,
+    torch::Tensor& sin_pos,
+    torch::Tensor& attn_mask,
+    KVCache& kv_cache,
+    const ModelInputParams& input_params,
+    bool is_prefill) {
+  internal_tensor_ = atb_speed::Utils::AtTensor2Tensor(x);
+  const size_t runtime_offset = get_runtime_input_offset(node);
+  const bool enable_split_fuse = is_prefill ? prefill_param_.enableSplitFuse
+                                            : decode_param_.enableSplitFuse;
+  node.variantPack.inTensors.at(runtime_offset) = internal_tensor_;
+  node.variantPack.inTensors.at(runtime_offset + 1) =
+      atb_speed::Utils::AtTensor2Tensor(cos_pos);
+  node.variantPack.inTensors.at(runtime_offset + 2) =
+      atb_speed::Utils::AtTensor2Tensor(sin_pos);
+  node.variantPack.inTensors.at(runtime_offset + 3) =
+      atb_speed::Utils::AtTensor2Tensor(attn_mask);
+  node.variantPack.inTensors.at(runtime_offset + 4) =
+      atb_speed::Utils::AtTensor2Tensor(kv_cache.get_k_cache());
+  node.variantPack.inTensors.at(runtime_offset + 5) =
+      atb_speed::Utils::AtTensor2Tensor(kv_cache.get_v_cache());
+
+  if (!input_params.kv_seq_lens.defined() ||
+      input_params.kv_seq_lens.storage().data() == nullptr) {
+    node.variantPack.inTensors.at(runtime_offset + 6) =
+        atb_speed::Utils::AtTensor2Tensor(int_tensor_placeholder_);
+    node.variantPack.inTensors.at(runtime_offset + 6).hostData =
+        const_cast<int32_t*>(placeholder_vec_.data());
+  } else {
+    node.variantPack.inTensors.at(runtime_offset + 6) =
+        atb_speed::Utils::AtTensor2Tensor(input_params.kv_seq_lens);
+    node.variantPack.inTensors.at(runtime_offset + 6).hostData =
+        const_cast<int32_t*>(input_params.kv_seq_lens_vec.data());
+  }
+  node.variantPack.inTensors.at(runtime_offset + 7) =
+      atb_speed::Utils::AtTensor2Tensor(tensor_placeholder_);
+  node.variantPack.inTensors.at(runtime_offset + 7).hostData =
+      const_cast<int32_t*>(placeholder_vec_.data());
+  node.variantPack.inTensors.at(runtime_offset + 8) =
+      atb_speed::Utils::AtTensor2Tensor(tensor_placeholder_);
+  if (!input_params.block_tables.defined() ||
+      input_params.block_tables.storage().data() == nullptr) {
+    node.variantPack.inTensors.at(runtime_offset + 9) =
+        atb_speed::Utils::AtTensor2Tensor(block_tables_placeholder_);
+    node.variantPack.inTensors.at(runtime_offset + 10) =
+        atb_speed::Utils::AtTensor2Tensor(slot_tensor_placeholder_);
+  } else {
+    node.variantPack.inTensors.at(runtime_offset + 9) =
+        atb_speed::Utils::AtTensor2Tensor(input_params.block_tables);
+    node.variantPack.inTensors.at(runtime_offset + 10) =
+        atb_speed::Utils::AtTensor2Tensor(input_params.new_cache_slots);
+  }
+
+  node.variantPack.inTensors.at(runtime_offset + 11) =
+      atb_speed::Utils::AtTensor2Tensor(input_params.expert_array);
+  node.variantPack.inTensors.at(runtime_offset + 12) =
+      atb_speed::Utils::AtTensor2Tensor(expert_group_);
+  node.variantPack.inTensors.at(runtime_offset + 13) =
+      atb_speed::Utils::AtTensor2Tensor(one_hot_);
+  node.variantPack.inTensors.at(runtime_offset + 14) =
+      atb_speed::Utils::AtTensor2Tensor(zero_hot_);
+
+  int32_t input_idx = runtime_offset + 15;
+  if (is_prefill && enable_split_fuse) {
+    node.variantPack.inTensors.at(input_idx) =
+        atb_speed::Utils::AtTensor2Tensor(input_params.q_seq_lens);
+    node.variantPack.inTensors.at(input_idx).hostData =
+        const_cast<int32_t*>(input_params.q_seq_lens_vec.data());
+    input_idx++;
+  }
+
+  node.variantPack.inTensors.at(input_idx++) =
+      atb_speed::Utils::AtTensor2Tensor(tensor_placeholder_);
+  node.variantPack.inTensors.at(input_idx++) =
+      atb_speed::Utils::AtTensor2Tensor(tensor_placeholder_);
+  node.variantPack.inTensors.at(input_idx++) =
+      atb_speed::Utils::AtTensor2Tensor(tensor_placeholder_);
+  node.variantPack.inTensors.at(input_idx++) =
+      atb_speed::Utils::AtTensor2Tensor(tensor_placeholder_);
+  node.variantPack.inTensors.at(input_idx++) =
+      atb_speed::Utils::AtTensor2Tensor(tensor_placeholder_);
+  node.variantPack.inTensors.at(input_idx++) =
+      atb_speed::Utils::AtTensor2Tensor(tensor_placeholder_);
+  node.variantPack.inTensors.at(input_idx++) =
+      atb_speed::Utils::AtTensor2Tensor(at_start_expert_id_);
+  node.variantPack.inTensors.at(input_idx++) =
+      atb_speed::Utils::AtTensor2Tensor(at_in_device_expert_count_);
+  node.variantPack.inTensors.at(input_idx++) =
+      atb_speed::Utils::AtTensor2Tensor(tensor_placeholder_);
+  node.variantPack.inTensors.at(input_idx++) =
+      atb_speed::Utils::AtTensor2Tensor(tensor_placeholder_);
+
+  if (FLAGS_enable_graph && !is_prefill &&
+      input_params.graph_buffer.tiling_data.defined()) {
+    node.variantPack.inTensors.at(input_idx++) =
+        atb_speed::Utils::AtTensor2Tensor(
+            input_params.graph_buffer.tiling_data);
+  }
+
+  for (size_t i = 0; i < runtime_offset; ++i) {
+    CHECK_THROW(node.inTensors.at(i) == nullptr,
+                model_name_ << " inTensor " << i << " is NULL");
+    node.variantPack.inTensors.at(i) = *node.inTensors.at(i);
+  }
+
+  node.variantPack.outTensors.at(0) = internal_tensor_;
+}
+
+}  // namespace layer
+}  // namespace xllm

--- a/xllm/core/layers/npu/npu_minimax_m2_decoder_layer_impl.h
+++ b/xllm/core/layers/npu/npu_minimax_m2_decoder_layer_impl.h
@@ -1,0 +1,141 @@
+/* Copyright 2025 The xLLM Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://github.com/jd-opensource/xllm/blob/main/LICENSE
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#pragma once
+
+#include <glog/logging.h>
+#include <torch/torch.h>
+#include <torch_npu/torch_npu.h>
+
+#include <nlohmann/json.hpp>
+
+#include "framework/model/model_args.h"
+#include "framework/model/model_input_params.h"
+#include "framework/model/npu_dp_ep_padding.h"
+#include "framework/quant_args.h"
+#include "framework/state_dict/state_dict.h"
+#include "loader/minimax_m2_decoder_loader.h"
+#include "npu_base_layer.h"
+#include "xllm_atb_layers/models/glm/layer/moe_decoder_layer.h"
+
+namespace xllm {
+namespace layer {
+
+class NpuMiniMaxM2DecoderLayerImpl : public BaseLayer {
+ public:
+  explicit NpuMiniMaxM2DecoderLayerImpl(const ModelContext& context,
+                                        const int32_t layer_id);
+
+  ~NpuMiniMaxM2DecoderLayerImpl() override = default;
+
+  void merge_loaded_weights() override;
+
+  int64_t init_layer() override;
+
+  torch::Tensor forward(torch::Tensor& x,
+                        torch::Tensor& cos_pos,
+                        torch::Tensor& sin_pos,
+                        torch::Tensor& attn_mask,
+                        KVCache& kv_cache,
+                        const ModelInputParams& input_params,
+                        aclrtEvent* event = nullptr,
+                        std::atomic<bool>* event_flag = nullptr,
+                        int node_id = 0);
+
+ private:
+  void initialize_tensors(const torch::TensorOptions& options);
+
+  void param_from_args(atb_speed::glm::MoeLayerParam& param,
+                       const ModelArgs& args,
+                       const ParallelArgs& parallel_args,
+                       bool is_prefill);
+
+  void initialize_basic_parameters(atb_speed::glm::MoeLayerParam& param,
+                                   const ModelArgs& args,
+                                   const ParallelArgs& parallel_args,
+                                   bool is_prefill);
+
+  void initialize_attention_parameters(atb_speed::glm::MoeLayerParam& param,
+                                       const ModelArgs& args,
+                                       const ParallelArgs& parallel_args);
+
+  void initialize_mlp_parameters(atb_speed::glm::MoeLayerParam& param,
+                                 const ModelArgs& args,
+                                 const ParallelArgs& parallel_args);
+
+  void initialize_parallel_parameters(atb_speed::glm::MoeLayerParam& param,
+                                      const ParallelArgs& parallel_args);
+
+  void initialize_quantization_parameters(atb_speed::glm::MoeLayerParam& param);
+
+  int64_t init_node(atb_speed::Model::Node& node,
+                    atb_speed::glm::MoeLayerParam& param);
+
+  void build_node_variant_pack(atb_speed::Model::Node& node,
+                               torch::Tensor& x,
+                               torch::Tensor& cos_pos,
+                               torch::Tensor& sin_pos,
+                               torch::Tensor& attn_mask,
+                               KVCache& kv_cache,
+                               const ModelInputParams& input_params,
+                               bool is_prefill);
+
+  torch::Tensor block_tables_placeholder_;
+  std::string model_name_;
+
+  int32_t device_id_;
+  int32_t layer_id_;
+
+  int32_t ep_size_;
+  int32_t num_experts_;
+  int32_t num_experts_per_partition_;
+  int32_t ep_local_tp_size_;
+  int32_t ep_local_tp_rank_;
+  int32_t start_expert_id_;
+  int32_t end_expert_id_;
+  int32_t ep_rank_;
+
+  int32_t dp_size_;
+  int32_t dp_local_tp_size_;
+  int32_t dp_rank_;
+  int32_t dp_local_tp_rank_;
+
+  int32_t num_speculative_tokens_ = 0;
+  atb_speed::glm::MoeLayerParam prefill_param_;
+  atb_speed::glm::MoeLayerParam decode_param_;
+
+  atb_speed::Model::Node prefill_node_;
+  atb_speed::Model::Node decode_node_;
+
+  atb::Tensor internal_tensor_;
+
+  torch::Tensor tensor_placeholder_;
+  torch::Tensor slot_tensor_placeholder_;
+  torch::Tensor int_tensor_placeholder_;
+  torch::Tensor decode_attn_mask_;
+  torch::Tensor expert_group_;
+  torch::Tensor one_hot_;
+  torch::Tensor zero_hot_;
+  torch::Tensor final_hidden_states_;
+  torch::Tensor at_start_expert_id_;
+  torch::Tensor at_in_device_expert_count_;
+  bool use_glm_qk_norm_ = false;
+
+  std::vector<int32_t> int_placeholder_;
+};
+TORCH_MODULE(NpuMiniMaxM2DecoderLayer);
+
+}  // namespace layer
+}  // namespace xllm

--- a/xllm/core/layers/npu_torch/fused_moe.cpp
+++ b/xllm/core/layers/npu_torch/fused_moe.cpp
@@ -17,17 +17,36 @@ limitations under the License.
 
 #include <glog/logging.h>
 
+#include <algorithm>
 #include <numeric>
 #include <vector>
 
+#include "common/global_flags.h"
+#include "framework/parallel_state/npu_process_group.h"
 #include "framework/parallel_state/parallel_state.h"
 #include "kernels/ops_api.h"
+#include "util/env_var.h"
+
+#if defined(USE_NPU)
+#include <torch_npu/csrc/core/npu/NPUCachingAllocator.h>
+#include <torch_npu/csrc/core/npu/NPUEvent.h>
+#include <torch_npu/csrc/core/npu/NPUStream.h>
+
+#endif
 
 namespace xllm {
 namespace layer {
 
 namespace {
 // Generic local tensor helpers.
+class CompletedWork final : public c10d::Work {
+ public:
+  CompletedWork() { finish(); }
+};
+
+inline c10::intrusive_ptr<c10d::Work> make_completed_work() {
+  return c10::make_intrusive<CompletedWork>();
+}
 torch::Tensor create_group_gemm_output(
     const torch::Tensor& a,
     const torch::Tensor& b,
@@ -126,34 +145,452 @@ bool load_fused_down_fallback(const StateDict& state_dict,
   return true;
 }
 
+bool should_limit_topk_by_group(int64_t num_total_experts,
+                                int64_t num_expert_group,
+                                int64_t topk_group) {
+  return num_expert_group > 1 && topk_group > 0 &&
+         topk_group < num_expert_group &&
+         num_total_experts % num_expert_group == 0;
+}
+
+torch::Tensor mask_scores_by_selected_groups(const torch::Tensor& scores,
+                                             int64_t num_expert_group,
+                                             int64_t topk_group) {
+  const int64_t experts_per_group = scores.size(-1) / num_expert_group;
+  const int64_t group_score_topk = std::min<int64_t>(2, experts_per_group);
+  auto grouped_scores =
+      scores.view({scores.size(0), num_expert_group, experts_per_group});
+  auto group_topk = std::get<0>(torch::topk(grouped_scores,
+                                            group_score_topk,
+                                            /*dim=*/-1,
+                                            /*largest=*/true,
+                                            /*sorted=*/false));
+  auto group_scores = group_topk.sum(/*dim=*/-1);
+  auto selected_groups = std::get<1>(torch::topk(group_scores,
+                                                 topk_group,
+                                                 /*dim=*/-1,
+                                                 /*largest=*/true,
+                                                 /*sorted=*/false));
+
+  auto selected_mask = torch::zeros(group_scores.sizes(),
+                                    group_scores.options().dtype(torch::kBool));
+  selected_mask.scatter_(
+      /*dim=*/1,
+      selected_groups,
+      torch::ones(selected_groups.sizes(), selected_mask.options()));
+
+  auto expert_mask =
+      selected_mask.unsqueeze(-1)
+          .expand({scores.size(0), num_expert_group, experts_per_group})
+          .reshape_as(scores);
+  return scores.masked_fill(expert_mask.logical_not(), 0.0);
+}
+
+bool should_use_minimax_ep_reference_moe() {
+  return xllm::util::get_bool_env("XLLM_MINIMAX_EP_MOE_REFERENCE", true);
+}
+
+bool should_compare_minimax_ep_reference_moe() {
+  return xllm::util::get_bool_env("XLLM_MINIMAX_COMPARE_EP_MOE_REFERENCE",
+                                  false);
+}
+
+#if defined(USE_NPU)
+bool is_npu_tensor(const torch::Tensor& tensor) {
+  return tensor.defined() && tensor.device().is_privateuseone();
+}
+
+void check_npu_input(const torch::Tensor& input) {
+  CHECK(is_npu_tensor(input)) << "input should be npu tensor";
+  CHECK(input.is_contiguous()) << "input should be contiguous";
+  CHECK(!input.is_sparse()) << "input have to be npu dense tensor";
+}
+
+torch::Tensor flatten_for_scatter_gather(std::vector<torch::Tensor>& tensors) {
+  auto& t = tensors[0];
+  std::vector<int64_t> sizes{static_cast<int64_t>(tensors.size())};
+  sizes.insert(sizes.end(), t.sizes().begin(), t.sizes().end());
+  return torch::empty(sizes, t.options());
+}
+
+HcclDataType to_hccl_data_type(const torch::Tensor& input) {
+  switch (input.scalar_type()) {
+    case torch::kFloat:
+      return HCCL_DATA_TYPE_FP32;
+    case torch::kHalf:
+      return HCCL_DATA_TYPE_FP16;
+    case torch::kDouble:
+      return HCCL_DATA_TYPE_FP64;
+    case torch::kLong:
+      return HCCL_DATA_TYPE_INT64;
+    case torch::kInt:
+      return HCCL_DATA_TYPE_INT32;
+    case torch::kChar:
+      return HCCL_DATA_TYPE_INT8;
+    case torch::kByte:
+      return HCCL_DATA_TYPE_UINT8;
+    case torch::kBool:
+      return HCCL_DATA_TYPE_UINT8;
+    case torch::kBFloat16:
+      return HCCL_DATA_TYPE_BFP16;
+    default:
+      LOG(FATAL) << "Unconvertible HCCL type " << input.scalar_type();
+  }
+  return HCCL_DATA_TYPE_RESERVED;
+}
+
+class ExternalHcclProcessGroup final : public xllm::ProcessGroup {
+ public:
+  ExternalHcclProcessGroup(int32_t rank,
+                           int32_t world_size,
+                           const torch::Device& device,
+                           HcclComm comm)
+      : ProcessGroup(rank, world_size, device),
+        comm_(comm),
+        comm_stream_(c10_npu::getNPUStreamFromPool(device.index())) {
+    CHECK(comm_ != nullptr) << "External HCCL process group requires comm";
+  }
+
+  void allgather(const torch::Tensor& input,
+                 std::vector<torch::Tensor>& outputs) override {
+    CHECK_EQ(input.device(), device())
+        << "input should be on the same device as the process group";
+    CHECK_EQ(outputs.size(), world_size())
+        << "outputs should have the same size as world_size";
+    check_npu_input(input);
+    torch::DeviceGuard device_guard(device());
+
+    torch::Tensor flattened_output = flatten_for_scatter_gather(outputs);
+    const auto count = input.numel();
+    const auto data_type = to_hccl_data_type(input);
+    auto compute_stream = c10_npu::getCurrentNPUStream();
+
+    auto ready = std::make_shared<c10_npu::NPUEvent>();
+    ready->record(compute_stream);
+    ready->block(comm_stream_);
+
+    c10_npu::NPUCachingAllocator::recordStream(input.storage().data_ptr(),
+                                               comm_stream_);
+    c10_npu::NPUCachingAllocator::recordStream(
+        flattened_output.storage().data_ptr(), comm_stream_);
+
+    HCCLCHECK(HcclAllGather(input.data_ptr(),
+                            flattened_output.data_ptr(),
+                            count,
+                            data_type,
+                            comm_,
+                            comm_stream_.stream()));
+
+    auto done = std::make_shared<c10_npu::NPUEvent>();
+    done->record(comm_stream_);
+    done->block(compute_stream);
+
+    for (int i = 0; i < static_cast<int>(outputs.size()); ++i) {
+      outputs[i].copy_(flattened_output[i], /*non_blocking=*/true);
+    }
+  }
+
+  c10::intrusive_ptr<c10d::Work> allgather_async(
+      const torch::Tensor& input,
+      std::vector<torch::Tensor>& outputs) override {
+    allgather(input, outputs);
+    return make_completed_work();
+  }
+
+  void allreduce(torch::Tensor& input) override {
+    CHECK_EQ(input.device(), device())
+        << "input should be on the same device as the process group";
+    check_npu_input(input);
+    torch::DeviceGuard device_guard(device());
+
+    const auto count = input.numel();
+    const auto data_type = to_hccl_data_type(input);
+    auto compute_stream = c10_npu::getCurrentNPUStream();
+
+    auto ready = std::make_shared<c10_npu::NPUEvent>();
+    ready->record(compute_stream);
+    ready->block(comm_stream_);
+
+    c10_npu::NPUCachingAllocator::recordStream(input.storage().data_ptr(),
+                                               comm_stream_);
+
+    HCCLCHECK(HcclAllReduce(input.data_ptr(),
+                            input.data_ptr(),
+                            count,
+                            data_type,
+                            HCCL_REDUCE_SUM,
+                            comm_,
+                            comm_stream_.stream()));
+
+    auto done = std::make_shared<c10_npu::NPUEvent>();
+    done->record(comm_stream_);
+    done->block(compute_stream);
+  }
+
+ private:
+  HcclComm comm_ = nullptr;
+  c10_npu::NPUStream comm_stream_;
+};
+
+class WorldHcclSubgroupProcessGroup final : public xllm::ProcessGroup {
+ public:
+  WorldHcclSubgroupProcessGroup(int32_t rank,
+                                const std::vector<uint32_t>& rank_ids,
+                                xllm::ProcessGroup* world_pg)
+      : ProcessGroup(rank,
+                     static_cast<int32_t>(rank_ids.size()),
+                     world_pg->device()),
+        member_ranks_(rank_ids.begin(), rank_ids.end()),
+        world_pg_(world_pg) {
+    CHECK(world_pg_ != nullptr)
+        << "WorldHcclSubgroupProcessGroup requires world_pg";
+    CHECK(!member_ranks_.empty())
+        << "WorldHcclSubgroupProcessGroup requires subgroup ranks";
+  }
+
+  void allgather(const torch::Tensor& input,
+                 std::vector<torch::Tensor>& outputs) override {
+    CHECK_EQ(outputs.size(), world_size())
+        << "outputs should have the same size as subgroup world_size";
+
+    std::vector<torch::Tensor> world_outputs(world_pg_->world_size());
+    for (int32_t i = 0; i < world_pg_->world_size(); ++i) {
+      world_outputs[i] = torch::empty_like(input);
+    }
+    world_pg_->allgather(input, world_outputs);
+
+    for (int32_t i = 0; i < world_size(); ++i) {
+      outputs[i].copy_(world_outputs[member_ranks_[i]], /*non_blocking=*/true);
+    }
+  }
+
+  c10::intrusive_ptr<c10d::Work> allgather_async(
+      const torch::Tensor& input,
+      std::vector<torch::Tensor>& outputs) override {
+    allgather(input, outputs);
+    return make_completed_work();
+  }
+
+  void allreduce(torch::Tensor& input) override {
+    std::vector<torch::Tensor> world_outputs(world_pg_->world_size());
+    for (int32_t i = 0; i < world_pg_->world_size(); ++i) {
+      world_outputs[i] = torch::empty_like(input);
+    }
+    world_pg_->allgather(input, world_outputs);
+
+    input.zero_();
+    for (int32_t global_rank : member_ranks_) {
+      input.add_(world_outputs[global_rank]);
+    }
+  }
+
+ private:
+  std::vector<int32_t> member_ranks_;
+  xllm::ProcessGroup* world_pg_ = nullptr;
+};
+
+std::unique_ptr<xllm::ProcessGroup> create_external_process_group(
+    const atb_speed::common::ParallelInfo& parallel_info,
+    const torch::Device& device,
+    HcclComm comm) {
+  CHECK(!parallel_info.rankIds.empty())
+      << "parallel_info.rankIds must not be empty";
+  CHECK(comm != nullptr) << "failed to fetch external HCCL comm";
+  return std::make_unique<ExternalHcclProcessGroup>(
+      static_cast<int32_t>(parallel_info.rank),
+      static_cast<int32_t>(parallel_info.rankIds.size()),
+      device,
+      comm);
+}
+
+bool has_same_group_membership(const atb_speed::common::ParallelInfo& lhs,
+                               const atb_speed::common::ParallelInfo& rhs) {
+  return lhs.rank == rhs.rank && lhs.rankIds == rhs.rankIds;
+}
+
+std::unique_ptr<xllm::ProcessGroup> try_create_external_process_group(
+    const atb_speed::common::ParallelInfo& parallel_info,
+    const torch::Device& device,
+    const std::string& backend,
+    std::string* comm_domain_out = nullptr) {
+  if (parallel_info.rankIds.empty()) {
+    return nullptr;
+  }
+
+  HcclComm comm = nullptr;
+  std::string comm_domain;
+  parallel_info.InitCommDomain(comm, comm_domain, backend);
+  if (comm_domain_out != nullptr) {
+    *comm_domain_out = comm_domain;
+  }
+  if (comm == nullptr) {
+    return nullptr;
+  }
+  return create_external_process_group(parallel_info, device, comm);
+}
+#endif
+
 }  // namespace
 
 FusedMoEImpl::FusedMoEImpl(const ModelArgs& model_args,
-                           const FusedMoEArgs& moe_args,
+                           const layer::FusedMoEArgs& moe_args,
                            const QuantArgs& quant_args,
                            const ParallelArgs& parallel_args,
                            const torch::TensorOptions& options)
     : num_total_experts_(model_args.n_routed_experts()),
       topk_(model_args.num_experts_per_tok()),
+      num_expert_group_(std::max<int64_t>(model_args.n_group(), 1)),
+      topk_group_(model_args.topk_group() > 0
+                      ? model_args.topk_group()
+                      : std::max<int64_t>(model_args.n_group(), 1)),
+      route_scale_(model_args.routed_scaling_factor()),
       hidden_size_(model_args.hidden_size()),
       n_shared_experts_(model_args.n_shared_experts()),
       is_gated_(moe_args.is_gated),
+      has_score_bias_(false),
+      has_bias_(false),
+      skip_bias_add_(false),
       renormalize_(model_args.norm_topk_prob() ? 1 : 0),
       hidden_act_(model_args.hidden_act()),
+      scoring_func_(model_args.scoring_func().empty()
+                        ? "softmax"
+                        : model_args.scoring_func()),
       is_smoothquant_(false),
+      is_minimax_m2_(model_args.model_type() == "minimax_m2"),
       quant_args_(quant_args),
-      parallel_args_(parallel_args),
+      dp_size_(parallel_args.dp_size()),
+      ep_size_(parallel_args.ep_size()),
+      use_minimax_ep_reference_(model_args.model_type() == "minimax_m2" &&
+                                parallel_args.ep_size() > 1 &&
+                                should_use_minimax_ep_reference_moe()),
+      compare_minimax_ep_reference_(model_args.model_type() == "minimax_m2" &&
+                                    parallel_args.ep_size() > 1 &&
+                                    should_compare_minimax_ep_reference_moe()),
       options_(options),
-      tp_pg_(parallel_args.tp_group_) {
+      world_pg_(parallel_args.process_group_),
+      tp_pg_(parallel_args.tp_group_),
+      dp_local_pg_(parallel_args.dp_local_process_group_),
+      moe_ep_pg_(parallel_args.moe_ep_group_) {
+  if (use_minimax_ep_reference_) {
+    LOG_FIRST_N(WARNING, 1)
+        << "MiniMax EP MoE is using the correctness-first local reference "
+           "path on NPU torch. This avoids the grouped-kernel EP path until "
+           "its output matches the reference.";
+  } else if (compare_minimax_ep_reference_) {
+    LOG_FIRST_N(INFO, 1)
+        << "MiniMax EP MoE grouped-kernel path will be compared against the "
+           "local reference implementation on NPU torch.";
+  }
+
   const int64_t num_experts = num_total_experts_;
   const int64_t intermediate_size =
       static_cast<int64_t>(model_args.moe_intermediate_size());
   const std::string& topk_method = model_args.topk_method();
-  int64_t ep_size = parallel_args.ep_size();
+  int64_t ep_size = ep_size_;
   int64_t ep_rank = 0;
+  CHECK(tp_pg_ != nullptr) << "FusedMoE requires tp_group_";
+#if defined(USE_NPU)
+  if (!parallel_args.mapping_data().empty() && dp_size_ > 1 && ep_size > 1) {
+    const auto attn_dp_info =
+        parallel_args.mapping().Get(atb_speed::base::ATTN_DP);
+    const auto moe_ep_info =
+        parallel_args.mapping().Get(atb_speed::base::MOE_EP);
+    const bool same_dispatch_group =
+        !attn_dp_info.rankIds.empty() && !moe_ep_info.rankIds.empty() &&
+        has_same_group_membership(attn_dp_info, moe_ep_info);
+    const HcclComm dispatch_and_combine_comm =
+        parallel_args.dispatchAndCombineHcclComm();
+    if (same_dispatch_group && dispatch_and_combine_comm != nullptr) {
+      shared_dispatch_pg_ = create_external_process_group(
+          attn_dp_info, options.device(), dispatch_and_combine_comm);
+      dp_local_pg_ = shared_dispatch_pg_.get();
+      moe_ep_pg_ = shared_dispatch_pg_.get();
+      LOG_FIRST_N(INFO, 1)
+          << "MiniMax FusedMoE reusing the ATB dispatch/combine HCCL comm for "
+             "the shared ATTN_DP/MOE_EP subgroup"
+          << " (attn_dp_buffer=" << attn_dp_info.bufferSize
+          << ", moe_ep_buffer=" << moe_ep_info.bufferSize << ")";
+    } else if (same_dispatch_group) {
+      std::string comm_domain;
+      shared_dispatch_pg_ =
+          try_create_external_process_group(moe_ep_info,
+                                            options.device(),
+                                            FLAGS_communication_backend,
+                                            &comm_domain);
+      if (shared_dispatch_pg_ != nullptr) {
+        dp_local_pg_ = shared_dispatch_pg_.get();
+        moe_ep_pg_ = shared_dispatch_pg_.get();
+        LOG_FIRST_N(INFO, 1)
+            << "MiniMax FusedMoE lazily initialized the shared ATTN_DP/MOE_EP "
+               "subgroup via MOE_EP ParallelInfo"
+            << " (backend=" << FLAGS_communication_backend << ", comm_domain="
+            << (comm_domain.empty() ? "<empty>" : comm_domain) << ")";
+      } else {
+        LOG_FIRST_N(WARNING, 1)
+            << "MiniMax FusedMoE could not lazily initialize the shared "
+               "ATTN_DP/MOE_EP subgroup via MOE_EP ParallelInfo"
+            << " (backend=" << FLAGS_communication_backend << ")";
+      }
+      if (shared_dispatch_pg_ == nullptr && dp_local_pg_ != nullptr &&
+          moe_ep_pg_ != nullptr) {
+        LOG_FIRST_N(INFO, 1)
+            << "MiniMax FusedMoE reusing the prebuilt HCCL subgroup process "
+               "groups for the shared ATTN_DP/MOE_EP membership because no "
+               "shared external dispatch/combine comm is available"
+            << " (attn_dp_world_size=" << dp_local_pg_->world_size()
+            << ", moe_ep_world_size=" << moe_ep_pg_->world_size()
+            << ", attn_dp_ranks=" << attn_dp_info.rankIds.size()
+            << ", moe_ep_ranks=" << moe_ep_info.rankIds.size() << ")";
+      } else if (shared_dispatch_pg_ == nullptr && world_pg_ != nullptr) {
+        // MiniMax's DP shards stay aligned across TP columns, so the live
+        // world HCCL group can emulate this shared subgroup without lazily
+        // bootstrapping a second communicator during warmup/capture.
+        shared_dispatch_pg_ = std::make_unique<WorldHcclSubgroupProcessGroup>(
+            static_cast<int32_t>(attn_dp_info.rank),
+            attn_dp_info.rankIds,
+            world_pg_);
+        dp_local_pg_ = shared_dispatch_pg_.get();
+        moe_ep_pg_ = shared_dispatch_pg_.get();
+        LOG_FIRST_N(WARNING, 1)
+            << "MiniMax FusedMoE emulating the shared ATTN_DP/MOE_EP subgroup "
+               "on top of the existing world HCCL process group"
+            << " (attn_dp_ranks=" << attn_dp_info.rankIds.size()
+            << ", moe_ep_ranks=" << moe_ep_info.rankIds.size()
+            << ", world_size=" << world_pg_->world_size() << ")";
+      }
+      if (shared_dispatch_pg_ == nullptr) {
+        LOG_FIRST_N(WARNING, 1)
+            << "MiniMax FusedMoE could not create a shared ATTN_DP/MOE_EP "
+               "external HCCL subgroup and has no world-group emulation "
+               "fallback; reusing the prebuilt subgroup process groups "
+               "instead"
+            << " (attn_dp_ranks=" << attn_dp_info.rankIds.size()
+            << ", moe_ep_ranks=" << moe_ep_info.rankIds.size()
+            << ", dp_local_pg=" << (dp_local_pg_ != nullptr ? "set" : "null")
+            << ", moe_ep_pg=" << (moe_ep_pg_ != nullptr ? "set" : "null")
+            << ")";
+      }
+    }
+
+    if (same_dispatch_group && dp_local_pg_ != nullptr) {
+      // The DP gather and the EP result-reduce land on the same rank set in
+      // the current dp=2,ep=2 topology, so one comm wrapper is sufficient.
+    } else {
+      LOG_FIRST_N(WARNING, 1)
+          << "MiniMax FusedMoE falling back to torch subgroup process groups"
+          << " (dispatch_comm="
+          << (dispatch_and_combine_comm != nullptr ? "set" : "null")
+          << ", attn_dp_ranks=" << attn_dp_info.rankIds.size()
+          << ", moe_ep_ranks=" << moe_ep_info.rankIds.size()
+          << ", same_group=" << same_dispatch_group << ")";
+    }
+  }
+#endif
   if (ep_size > 1) {
-    ep_rank = parallel_args.moe_ep_group_->rank();
-    tp_pg_ = parallel_args.moe_tp_group_;
+    CHECK(moe_ep_pg_ != nullptr) << "FusedMoE requires moe_ep_group_";
+    CHECK(tp_pg_ != nullptr)
+        << "FusedMoE requires moe_tp_group_ when ep_size > 1";
+    ep_rank = moe_ep_pg_->rank();
   }
 
   // smoothquant check: If quant_method is not empty, only w8a8 smoothquant is
@@ -180,11 +617,13 @@ FusedMoEImpl::FusedMoEImpl(const ModelArgs& model_args,
   if (topk_method == "noaux_tc") {
     e_score_correction_bias_ = register_parameter(
         "e_score_correction_bias", torch::empty({num_experts}, options), false);
+    has_score_bias_ = true;
   }
 
   gate_ = register_module(
       "gate_proj",
-      ReplicatedLinear(hidden_size_, num_experts, false, quant_args, options));
+      layer::ReplicatedLinear(
+          hidden_size_, num_experts, false, quant_args, options));
   if (n_shared_experts_ > 0) {
     /*
     The shared_experts are usually implemented using the RowParallelLinear
@@ -195,15 +634,15 @@ FusedMoEImpl::FusedMoEImpl(const ModelArgs& model_args,
     */
     shared_experts_ =
         register_module("shared_experts",
-                        DenseMLP(hidden_size_,
-                                 intermediate_size * n_shared_experts_,
-                                 is_gated_,
-                                 false,
-                                 hidden_act_,
-                                 /*enable_result_reduction=*/false,
-                                 quant_args,
-                                 tp_pg_,
-                                 options));
+                        layer::DenseMLP(hidden_size_,
+                                        intermediate_size * n_shared_experts_,
+                                        is_gated_,
+                                        false,
+                                        hidden_act_,
+                                        /*enable_result_reduction=*/false,
+                                        quant_args,
+                                        tp_pg_,
+                                        options));
     shared_expert_gate_ = register_module(
         "shared_expert_gate",
         torch::nn::Linear(
@@ -269,34 +708,99 @@ torch::Tensor FusedMoEImpl::select_experts(
     const torch::Tensor& hidden_states_2d,
     const torch::Tensor& router_logits_2d,
     SelectedExpertInfo& selected_expert_info) {
-  // prepare the parameters for select_experts
-  xllm::kernel::MoeFusedTopkParams moe_active_topk_params;
-  moe_active_topk_params.input = router_logits_2d;
-  moe_active_topk_params.finished = torch::Tensor();
-  moe_active_topk_params.topk = topk_;
-  moe_active_topk_params.scoring_func = "softmax";
-  auto [topk_weights, topk_ids] =
-      xllm::kernel::moe_active_topk(moe_active_topk_params);
-  topk_ids = topk_ids.to(torch::kInt32);
+  torch::Tensor topk_weights;
+  torch::Tensor topk_ids;
+  const bool need_reference_topk =
+      scoring_func_ != "softmax" || e_score_correction_bias_.defined() ||
+      should_limit_topk_by_group(
+          num_total_experts_, num_expert_group_, topk_group_);
+  if (!need_reference_topk) {
+    xllm::kernel::MoeFusedTopkParams moe_active_topk_params;
+    moe_active_topk_params.input = router_logits_2d;
+    moe_active_topk_params.finished = torch::Tensor();
+    moe_active_topk_params.topk = topk_;
+    moe_active_topk_params.scoring_func = "softmax";
+    auto topk_result = xllm::kernel::moe_active_topk(moe_active_topk_params);
+    topk_weights = std::move(std::get<0>(topk_result));
+    topk_ids = std::get<1>(topk_result).to(torch::kInt32);
+  } else {
+    torch::Tensor routing_scores;
+    if (scoring_func_ == "sigmoid") {
+      routing_scores = torch::sigmoid(router_logits_2d.to(torch::kFloat32));
+    } else if (scoring_func_ == "softmax") {
+      routing_scores =
+          torch::softmax(router_logits_2d.to(torch::kFloat32), /*dim=*/-1);
+    } else {
+      LOG(FATAL) << "Unsupported MoE scoring_func on NPU torch path: "
+                 << scoring_func_;
+    }
+
+    torch::Tensor choice_scores = routing_scores;
+    if (e_score_correction_bias_.defined()) {
+      choice_scores =
+          choice_scores +
+          e_score_correction_bias_.to(choice_scores.device(), torch::kFloat32);
+    }
+
+    if (should_limit_topk_by_group(
+            num_total_experts_, num_expert_group_, topk_group_)) {
+      choice_scores = mask_scores_by_selected_groups(
+          choice_scores, num_expert_group_, topk_group_);
+    }
+
+    auto topk_result = torch::topk(choice_scores,
+                                   topk_,
+                                   /*dim=*/-1,
+                                   /*largest=*/true,
+                                   /*sorted=*/false);
+    topk_ids = std::get<1>(topk_result).to(torch::kInt32).contiguous();
+    topk_weights = routing_scores.gather(
+        /*dim=*/1, topk_ids.to(torch::kLong).contiguous());
+  }
   if (renormalize_) {
     topk_weights = topk_weights / (topk_weights.sum(-1, true) + 1e-6);
+  }
+  if (route_scale_ != 1.0) {
+    topk_weights = topk_weights * route_scale_;
+  }
+  topk_weights = topk_weights.contiguous();
+
+  torch::Tensor routing_expert_idx = topk_ids;
+  int64_t routing_expert_num = num_experts_per_rank_;
+  std::array<int64_t, 2> active_expert_range = {0, num_experts_per_rank_};
+  if (ep_size_ > 1) {
+    // torch_npu's builtin moe_init_routing expects expert_idx and
+    // active_expert_range in the same local expert-id space, with
+    // active_expert_range[1] <= expert_num. MiniMax routes over the global
+    // expert space first, so remap local experts onto [0,
+    // num_experts_per_rank_) and send non-local experts to a sentinel just
+    // outside the active range.
+    auto local_expert_idx = topk_ids.to(torch::kInt64) - start_expert_id_;
+    auto local_expert_mask =
+        (local_expert_idx >= 0) & (local_expert_idx < num_experts_per_rank_);
+    auto invalid_expert_idx =
+        torch::full_like(local_expert_idx, num_experts_per_rank_);
+    routing_expert_idx =
+        torch::where(local_expert_mask, local_expert_idx, invalid_expert_idx)
+            .to(torch::kInt32)
+            .contiguous();
+    routing_expert_num += 1;
   }
 
   xllm::kernel::MoeInitRoutingV2Params moe_init_routing_params;
   moe_init_routing_params.x = hidden_states_2d;
-  moe_init_routing_params.expert_idx = topk_ids;
+  moe_init_routing_params.expert_idx = routing_expert_idx;
   moe_init_routing_params.scale = std::nullopt;
   moe_init_routing_params.offset = std::nullopt;
   moe_init_routing_params.active_num = hidden_states_2d.size(0) * topk_;
   moe_init_routing_params.expert_capacity = 0;
-  moe_init_routing_params.expert_num = num_experts_per_rank_;
+  moe_init_routing_params.expert_num = routing_expert_num;
   moe_init_routing_params.drop_pad_mode = 0;
   moe_init_routing_params.expert_tokens_num_type = 1;
   moe_init_routing_params.expert_tokens_num_flag = true;
   moe_init_routing_params.row_idx_type = 0;
-  std::vector<int64_t> expert_range = {
-      start_expert_id_, start_expert_id_ + num_experts_per_rank_};
-  moe_init_routing_params.active_expert_range = expert_range;
+  moe_init_routing_params.active_expert_range = torch::IntArrayRef(
+      active_expert_range.data(), active_expert_range.size());
   moe_init_routing_params.quant_mode = -1;
   // TODO: NPU moe_init_routing_v2 is equivalent to moe_gen_idx +
   // moe_expand_input (and the token_count/cusum outputs) on other backends.
@@ -329,57 +833,70 @@ torch::Tensor FusedMoEImpl::forward_expert(
   torch::Tensor expand_hidden_states =
       select_experts(hidden_states_2d, router_logits_2d, selected_expert_info);
 
-  // Step 4: group gemm 1
-  torch::Tensor gemm1_out =
-      create_group_gemm_output(expand_hidden_states,
-                               w13_,
-                               selected_expert_info.token_count_slice,
-                               hidden_states_dtype);
-
-  {
+  auto run_group_gemm = [&](const torch::Tensor& input,
+                            const torch::Tensor& weight) -> torch::Tensor {
     xllm::kernel::GroupGemmParams group_gemm_params;
-    group_gemm_params.a = expand_hidden_states;
-    if (w13_.size(1) != expand_hidden_states.size(1)) {
-      w13_ = w13_.transpose(1, 2);
-    }
-    group_gemm_params.b = w13_;
+    group_gemm_params.a = input;
+    group_gemm_params.b = weight;
     group_gemm_params.group_list = selected_expert_info.token_count_slice;
     group_gemm_params.split_item = 2;
     group_gemm_params.group_type = 0;
     group_gemm_params.group_list_type = 1;
-    gemm1_out = xllm::kernel::group_gemm(group_gemm_params);
+    return xllm::kernel::group_gemm(group_gemm_params);
+  };
+
+  // Step 4: group gemm 1
+  torch::Tensor w13_gemm = w13_;
+  if (w13_gemm.size(1) != expand_hidden_states.size(1)) {
+    w13_gemm = w13_gemm.transpose(1, 2).contiguous();
   }
 
-  // Step 5: activation
   torch::Tensor act_out;
+  if (is_minimax_m2_ && is_gated_ && hidden_act_ == "silu") {
+    const int64_t local_intermediate_size = w13_gemm.size(2) / 2;
+    auto gate_proj = run_group_gemm(
+        expand_hidden_states,
+        w13_gemm.slice(/*dim=*/2, /*start=*/0, /*end=*/local_intermediate_size)
+            .contiguous());
+    auto up_proj =
+        run_group_gemm(expand_hidden_states,
+                       w13_gemm
+                           .slice(/*dim=*/2,
+                                  /*start=*/local_intermediate_size,
+                                  /*end=*/local_intermediate_size * 2)
+                           .contiguous());
+    act_out = torch::silu(gate_proj) * up_proj;
+  } else {
+    torch::Tensor gemm1_out =
+        create_group_gemm_output(expand_hidden_states,
+                                 w13_gemm,
+                                 selected_expert_info.token_count_slice,
+                                 hidden_states_dtype);
+    gemm1_out = run_group_gemm(expand_hidden_states, w13_gemm);
 
-  xllm::kernel::ActivationParams activation_params;
-  activation_params.input = gemm1_out;
-  activation_params.output = act_out;
-  activation_params.act_mode = hidden_act_;
-  activation_params.is_gated = is_gated_;
-  xllm::kernel::active(activation_params);
-  act_out = activation_params.output;
+    // Step 5: activation or scaled quantization(fused with activation)
+    act_out = is_gated_
+                  ? gemm1_out.slice(1, 0, gemm1_out.size(1) / 2).contiguous()
+                  : gemm1_out;
+
+    xllm::kernel::ActivationParams activation_params;
+    activation_params.input = gemm1_out;
+    activation_params.output = act_out;
+    activation_params.act_mode = hidden_act_;
+    activation_params.is_gated = is_gated_;
+    xllm::kernel::active(activation_params);
+  }
   // Step 6: group gemm 2
+  torch::Tensor w2_gemm = w2_;
+  if (w2_gemm.size(1) != act_out.size(1)) {
+    w2_gemm = w2_gemm.transpose(1, 2).contiguous();
+  }
   torch::Tensor gemm2_out =
       create_group_gemm_output(act_out,
-                               w2_,
+                               w2_gemm,
                                selected_expert_info.token_count_slice,
                                hidden_states_dtype);
-
-  {
-    xllm::kernel::GroupGemmParams group_gemm_params;
-    group_gemm_params.a = act_out;
-    if (w2_.size(1) != act_out.size(1)) {
-      w2_ = w2_.transpose(1, 2);
-    }
-    group_gemm_params.b = w2_;
-    group_gemm_params.group_list = selected_expert_info.token_count_slice;
-    group_gemm_params.split_item = 2;
-    group_gemm_params.group_type = 0;
-    group_gemm_params.group_list_type = 1;
-    gemm2_out = xllm::kernel::group_gemm(group_gemm_params);
-  }
+  gemm2_out = run_group_gemm(act_out, w2_gemm);
 
   // Step 7: combine the intermediate results and get the final hidden states
   torch::Tensor final_hidden_states;
@@ -397,9 +914,118 @@ torch::Tensor FusedMoEImpl::forward_expert(
   if (tp_pg_->world_size() > 1) {
     final_hidden_states = parallel_state::reduce(final_hidden_states, tp_pg_);
   }
-  if (parallel_args_.ep_size() > 1) {
-    final_hidden_states = parallel_state::reduce(final_hidden_states,
-                                                 parallel_args_.moe_ep_group_);
+  if (ep_size_ > 1) {
+    final_hidden_states =
+        parallel_state::reduce(final_hidden_states, moe_ep_pg_);
+  }
+  return final_hidden_states;
+}
+
+torch::Tensor FusedMoEImpl::forward_expert_reference(
+    const torch::Tensor& hidden_states,
+    const torch::Tensor& router_logits,
+    const std::optional<torch::Tensor>& shared_output) {
+  CHECK_EQ(hidden_act_, "silu")
+      << "MiniMax EP MoE reference path only supports silu activation";
+  CHECK(is_gated_) << "MiniMax EP MoE reference path expects gated experts";
+
+  auto hidden_states_2d =
+      hidden_states.reshape({-1, hidden_states.size(-1)}).contiguous();
+  auto router_logits_2d =
+      router_logits.reshape({-1, router_logits.size(-1)}).contiguous();
+
+  torch::Tensor routing_scores;
+  if (scoring_func_ == "sigmoid") {
+    routing_scores = torch::sigmoid(router_logits_2d.to(torch::kFloat32));
+  } else if (scoring_func_ == "softmax") {
+    routing_scores =
+        torch::softmax(router_logits_2d.to(torch::kFloat32), /*dim=*/-1);
+  } else {
+    LOG(FATAL) << "Unsupported MoE scoring_func on NPU torch path: "
+               << scoring_func_;
+  }
+
+  auto choice_scores = routing_scores;
+  if (e_score_correction_bias_.defined()) {
+    choice_scores =
+        choice_scores +
+        e_score_correction_bias_.to(routing_scores.device(), torch::kFloat32);
+  }
+  if (should_limit_topk_by_group(
+          num_total_experts_, num_expert_group_, topk_group_)) {
+    choice_scores = mask_scores_by_selected_groups(
+        choice_scores, num_expert_group_, topk_group_);
+  }
+
+  auto topk_result = torch::topk(choice_scores,
+                                 topk_,
+                                 /*dim=*/-1,
+                                 /*largest=*/true,
+                                 /*sorted=*/false);
+  auto topk_ids = std::get<1>(topk_result).to(torch::kLong).contiguous();
+  auto topk_weights = routing_scores.gather(/*dim=*/1, topk_ids).contiguous();
+  if (renormalize_) {
+    topk_weights = topk_weights / (topk_weights.sum(-1, true) + 1e-6);
+  }
+  if (route_scale_ != 1.0) {
+    topk_weights = topk_weights * route_scale_;
+  }
+
+  auto output = torch::zeros_like(hidden_states_2d);
+  for (int64_t local_expert_idx = 0; local_expert_idx < num_experts_per_rank_;
+       ++local_expert_idx) {
+    const int64_t global_expert_idx = start_expert_id_ + local_expert_idx;
+    auto expert_matches = (topk_ids == global_expert_idx).nonzero();
+    if (expert_matches.numel() == 0) {
+      continue;
+    }
+
+    auto token_idx =
+        expert_matches.select(/*dim=*/1, /*index=*/0).to(torch::kLong);
+    auto topk_slot =
+        expert_matches.select(/*dim=*/1, /*index=*/1).to(torch::kLong);
+    auto current_states = hidden_states_2d.index_select(/*dim=*/0, token_idx);
+
+    auto current_w13 = w13_.index({local_expert_idx});
+    if (current_w13.size(0) != hidden_size_) {
+      current_w13 = current_w13.transpose(/*dim0=*/0, /*dim1=*/1);
+    }
+    current_w13 = current_w13.contiguous();
+
+    auto gate_up = torch::matmul(current_states, current_w13);
+    const int64_t local_intermediate_size = gate_up.size(-1) / 2;
+    auto gate_proj =
+        gate_up.slice(/*dim=*/-1, /*start=*/0, /*end=*/local_intermediate_size);
+    auto up_proj = gate_up.slice(/*dim=*/-1,
+                                 /*start=*/local_intermediate_size,
+                                 /*end=*/local_intermediate_size * 2);
+    auto activated = torch::silu(gate_proj) * up_proj;
+
+    auto current_w2 = w2_.index({local_expert_idx});
+    if (current_w2.size(0) != local_intermediate_size) {
+      current_w2 = current_w2.transpose(/*dim0=*/0, /*dim1=*/1);
+    }
+    current_w2 = current_w2.contiguous();
+
+    auto expert_out = torch::matmul(activated, current_w2);
+    auto combine_weight = topk_weights.index({token_idx, topk_slot})
+                              .to(expert_out.scalar_type())
+                              .unsqueeze(/*dim=*/-1);
+    output.index_add_(/*dim=*/0, token_idx, expert_out * combine_weight);
+  }
+
+  if (shared_output.has_value()) {
+    output = output + shared_output.value().reshape(
+                          {-1, shared_output.value().size(-1)});
+  }
+
+  auto final_hidden_states = output.reshape(hidden_states.sizes());
+  if (tp_pg_->world_size() > 1) {
+    final_hidden_states = parallel_state::reduce(final_hidden_states, tp_pg_);
+  }
+  if (ep_size_ > 1) {
+    final_hidden_states =
+        parallel_state::reduce(final_hidden_states, moe_ep_pg_);
   }
   return final_hidden_states;
 }
@@ -408,10 +1034,11 @@ torch::Tensor FusedMoEImpl::forward(const torch::Tensor& hidden_states,
                                     const ModelInputParams& input_params) {
   auto input = hidden_states;
   bool need_slice = false;
-  if (parallel_args_.dp_size() > 1 && parallel_args_.ep_size() > 1) {
-    input = parallel_state::gather(input,
-                                   parallel_args_.dp_local_process_group_,
-                                   input_params.dp_global_token_nums);
+  if (dp_size_ > 1 && ep_size_ > 1) {
+    CHECK(dp_local_pg_ != nullptr)
+        << "FusedMoE requires dp_local_process_group_ for dp+ep";
+    input = parallel_state::gather(
+        input, dp_local_pg_, input_params.dp_global_token_nums);
     need_slice = true;
   }
 
@@ -427,11 +1054,30 @@ torch::Tensor FusedMoEImpl::forward(const torch::Tensor& hidden_states,
     }
   }
   auto router_logits = gate_(input);
-  auto output = forward_expert(input, router_logits, shared_output);
+  torch::Tensor output;
+  torch::Tensor reference_output;
+  torch::Tensor grouped_output;
+  if (use_minimax_ep_reference_ || compare_minimax_ep_reference_) {
+    reference_output =
+        forward_expert_reference(input, router_logits, shared_output);
+  }
+  if (!use_minimax_ep_reference_ || compare_minimax_ep_reference_) {
+    grouped_output = forward_expert(input, router_logits, shared_output);
+  }
+  if (compare_minimax_ep_reference_) {
+    auto diff = (grouped_output.to(torch::kFloat32) -
+                 reference_output.to(torch::kFloat32))
+                    .abs();
+    LOG_FIRST_N(INFO, 1)
+        << "MiniMax EP MoE grouped path diff vs reference: max_abs="
+        << diff.max().to(torch::kCPU).item<double>()
+        << ", mean_abs=" << diff.mean().to(torch::kCPU).item<double>();
+  }
+  output = use_minimax_ep_reference_ ? reference_output : grouped_output;
 
   if (need_slice) {
     const auto& dp_tokens = input_params.dp_global_token_nums;
-    const int64_t dp_rank = parallel_args_.dp_local_process_group_->rank();
+    const int64_t dp_rank = dp_local_pg_->rank();
     auto start =
         std::accumulate(dp_tokens.begin(), dp_tokens.begin() + dp_rank, 0);
     auto end = start + dp_tokens[dp_rank];

--- a/xllm/core/layers/npu_torch/fused_moe.h
+++ b/xllm/core/layers/npu_torch/fused_moe.h
@@ -17,6 +17,7 @@ limitations under the License.
 
 #include <torch/torch.h>
 
+#include <memory>
 #include <optional>
 
 #include "framework/model/model_args.h"
@@ -36,12 +37,16 @@ class FusedMoEImpl : public torch::nn::Module {
  public:
   FusedMoEImpl() = default;
   FusedMoEImpl(const ModelArgs& model_args,
-               const FusedMoEArgs& moe_args,
+               const layer::FusedMoEArgs& moe_args,
                const QuantArgs& quant_args,
                const ParallelArgs& parallel_args,
                const torch::TensorOptions& options);
 
   torch::Tensor forward_expert(
+      const torch::Tensor& hidden_states,
+      const torch::Tensor& router_logits,
+      const std::optional<torch::Tensor>& shared_output);
+  torch::Tensor forward_expert_reference(
       const torch::Tensor& hidden_states,
       const torch::Tensor& router_logits,
       const std::optional<torch::Tensor>& shared_output);
@@ -80,17 +85,25 @@ class FusedMoEImpl : public torch::nn::Module {
   std::string hidden_act_;
   std::string scoring_func_;
   bool is_smoothquant_;
+  bool is_minimax_m2_ = false;
 
   int64_t num_experts_per_rank_;
   int64_t start_expert_id_;
 
-  ReplicatedLinear gate_{nullptr};
-  DenseMLP shared_experts_{nullptr};
+  layer::ReplicatedLinear gate_{nullptr};
+  layer::DenseMLP shared_experts_{nullptr};
   torch::nn::Linear shared_expert_gate_{nullptr};
   QuantArgs quant_args_;
-  ParallelArgs parallel_args_;
+  int64_t dp_size_ = 1;
+  int64_t ep_size_ = 1;
+  bool use_minimax_ep_reference_ = false;
+  bool compare_minimax_ep_reference_ = false;
   torch::TensorOptions options_;
+  ProcessGroup* world_pg_ = nullptr;
   ProcessGroup* tp_pg_;
+  ProcessGroup* dp_local_pg_ = nullptr;
+  ProcessGroup* moe_ep_pg_ = nullptr;
+  std::unique_ptr<ProcessGroup> shared_dispatch_pg_;
 
   DEFINE_WEIGHT(w13);
   DEFINE_FUSED_WEIGHT(w1);

--- a/xllm/core/runtime/acl_graph_executor_impl.cpp
+++ b/xllm/core/runtime/acl_graph_executor_impl.cpp
@@ -22,6 +22,7 @@ limitations under the License.
 #include <torch_npu/csrc/libs/init_npu.h>
 #include <torch_npu/torch_npu.h>
 
+#include <algorithm>
 #include <numeric>
 
 #include "core/common/global_flags.h"
@@ -68,6 +69,59 @@ int64_t get_decode_graph_capacity(const runtime::Options& options) {
     return options.max_seqs_per_batch();
   }
   return options.max_seqs_per_batch() * options.num_decoding_tokens();
+}
+
+bool tensor_on_device(const torch::Tensor& tensor,
+                      const torch::Device& device) {
+  return !tensor.defined() || tensor.device() == device;
+}
+
+bool model_input_params_on_device(const ModelInputParams& params,
+                                  const torch::Device& device) {
+  return tensor_on_device(params.kv_seq_lens, device) &&
+         tensor_on_device(params.q_seq_lens, device) &&
+         tensor_on_device(params.q_cu_seq_lens, device) &&
+         tensor_on_device(params.new_cache_slots, device) &&
+         tensor_on_device(params.block_tables, device) &&
+         tensor_on_device(params.input_embedding, device) &&
+         tensor_on_device(params.kv_cache_tokens_nums, device) &&
+         tensor_on_device(params.history_compressed_kv, device) &&
+         tensor_on_device(params.history_k_rope, device) &&
+         tensor_on_device(params.ring_cur_seqlen, device) &&
+         tensor_on_device(params.ring_cache_seqlen, device) &&
+         tensor_on_device(params.expert_load_data, device) &&
+         tensor_on_device(params.expert_array, device) &&
+         tensor_on_device(params.src_block_indices, device) &&
+         tensor_on_device(params.dst_block_indices, device) &&
+         tensor_on_device(params.cum_sum, device) &&
+         tensor_on_device(params.new_cache_slot_offsets, device) &&
+         tensor_on_device(params.kv_cache_start_offsets, device) &&
+         tensor_on_device(params.graph_buffer.attn_mask, device) &&
+         tensor_on_device(params.graph_buffer.tiling_data, device) &&
+         tensor_on_device(params.paged_kv_indptr, device) &&
+         tensor_on_device(params.paged_kv_indices, device) &&
+         tensor_on_device(params.paged_kv_last_page_len, device);
+}
+
+const torch::Tensor& maybe_to_device(const torch::Tensor& tensor,
+                                     const torch::Device& device,
+                                     torch::Tensor& storage) {
+  if (tensor_on_device(tensor, device)) {
+    return tensor;
+  }
+  storage = safe_to(tensor, device, true);
+  return storage;
+}
+
+const ModelInputParams& maybe_to_device(
+    const ModelInputParams& params,
+    const torch::Device& device,
+    std::optional<ModelInputParams>& storage) {
+  if (model_input_params_on_device(params, device)) {
+    return params;
+  }
+  storage.emplace(params.to(device));
+  return *storage;
 }
 }  // namespace
 
@@ -245,7 +299,6 @@ std::optional<ModelInputParams> GraphPersistentParam::update(
     }
   }
 
-  // Copy block table data
   const int64_t actual_block_table_len = params.block_tables.size(1);
   auto slice_persistent_block_tables =
       persistent_block_tables_
@@ -613,9 +666,11 @@ void GraphPersistentParam::plan_paged_attention_tiling(
   atb::Tensor atb_v_cache = atb_speed::Utils::AtTensor2Tensor(v_cache);
   atb::Tensor atb_block_tables =
       atb_speed::Utils::AtTensor2Tensor(block_tables);
-  // Get context_lens from input_params.kv_seq_lens
-  atb::Tensor atb_context_lens =
-      atb_speed::Utils::AtTensor2Tensor(input_params.kv_seq_lens);
+  // Use the persistent device slice for tensor metadata so replay can keep the
+  // original decode params on host while still exposing the current lengths to
+  // the paged-attention planner.
+  atb::Tensor atb_context_lens = atb_speed::Utils::AtTensor2Tensor(
+      kv_seq_lens(input_params.num_sequences));
   atb_context_lens.hostData =
       const_cast<int32_t*>(input_params.kv_seq_lens_vec.data());
   atb::Tensor atb_tiling_data = atb_speed::Utils::AtTensor2Tensor(tiling_data_);
@@ -860,6 +915,7 @@ bool AclGraph::capture(CausalLM* model,
 
   // Use cached capture stream for graph capture
   // capture_stream_ is initialized in constructor
+  aclrtStream capture_stream = stream;
   bool need_restore_stream = false;
 
   // capture lock scope
@@ -871,8 +927,11 @@ bool AclGraph::capture(CausalLM* model,
     if (c10_npu::getCurrentNPUStream(device_idx) ==
         c10_npu::getDefaultNPUStream(device_idx)) {
       c10_npu::setCurrentNPUStream(capture_stream_.value());
-      aclrtSynchronizeStream(capture_stream_.value().stream());
+      capture_stream = capture_stream_.value().stream();
+      aclrtSynchronizeStream(capture_stream);
       need_restore_stream = true;
+    } else {
+      capture_stream = c10_npu::getCurrentNPUStream(device_idx).stream();
     }
     LOG(INFO) << "capture begin, bucket_num_tokens: " << bucket_num_tokens
               << ", actual_num_tokens: " << actual_num_tokens;
@@ -901,12 +960,10 @@ bool AclGraph::capture(CausalLM* model,
           c10_npu::getDefaultNPUStream(tensor_options.device().index()));
     }
   }
-  // Synchronize and test replay to verify graph capture
-  aclrtSynchronizeStream(stream);
-
+  aclrtSynchronizeStream(capture_stream);
+  aclrtStream replay_stream = c10_npu::getCurrentNPUStream(device_idx).stream();
   graph_.replay();
-
-  // aclrtSynchronizeStream(stream);
+  aclrtSynchronizeStream(replay_stream);
   return true;
 }
 
@@ -919,7 +976,7 @@ void AclGraph::initialize_capture_stream(c10::DeviceIndex device_index) {
   device_index_ = device_index;
   LOG(INFO) << "Initialized capture_stream: " << capture_stream_.value()
             << ", id: " << capture_stream_.value().id()
-            << ", device_index: " << device_index;
+            << ", device_index: " << static_cast<int>(device_index);
 }
 
 ModelOutput AclGraph::replay(const torch::Tensor& tokens,
@@ -990,7 +1047,13 @@ ModelOutput AclGraphExecutorImpl::run(const torch::Tensor& tokens,
   const torch::Tensor& tokens_tensor = tokens;
   const torch::Tensor& positions_tensor = positions;
   const ModelInputParams& params_single = params;
+  torch::Tensor tokens_on_device;
+  torch::Tensor positions_on_device;
+  std::optional<ModelInputParams> params_on_device;
   const bool in_decoding_phase = params_single.batch_forward_type.is_decode();
+  const uint32_t n_tokens = tokens_tensor.size(/*dim=*/0);
+  const uint32_t bucket_num_tokens = get_bucket_num_tokens(n_tokens);
+  auto graph_it = graphs_.find(bucket_num_tokens);
   VLOG(50) << "in_decoding_phase: " << in_decoding_phase
            << " q_max_seq_len: " << params_single.q_max_seq_len
            << " n_layers: " << args_.n_layers();
@@ -1000,14 +1063,16 @@ ModelOutput AclGraphExecutorImpl::run(const torch::Tensor& tokens,
     VLOG(kGraphExecutorLogVerboseLevel)
         << "AclGraphExecutorImpl::run() in eager mode";
     COUNTER_INC(num_model_execution_total_eager);
-    return model_->forward(tokens, positions, kv_caches, params);
+    return model_->forward(
+        maybe_to_device(tokens_tensor, device_, tokens_on_device),
+        maybe_to_device(positions_tensor, device_, positions_on_device),
+        kv_caches,
+        maybe_to_device(params_single, device_, params_on_device));
   }
 
   // Only use acl graph in decode phase for performance optimization
-  // Get actual num_tokens from tokens shape
-  const uint32_t n_tokens = tokens_tensor.size(/*dim=*/0);
   const uint32_t actual_batch_size = n_tokens / options_.num_decoding_tokens();
-  const uint32_t bucket_num_tokens = get_bucket_num_tokens(n_tokens);
+  (void)actual_batch_size;
 
   // Check if conditions are suitable for graph execution (replay or capture)
   const auto max_seq_len = args_.max_position_embeddings();
@@ -1025,16 +1090,19 @@ ModelOutput AclGraphExecutorImpl::run(const torch::Tensor& tokens,
         << "). This message is logged only once. "
         << "Monitor counter 'num_model_execution_total_eager' for frequency.";
     COUNTER_INC(num_model_execution_total_eager);
-    return model_->forward(tokens, positions, kv_caches, params);
+    return model_->forward(
+        maybe_to_device(tokens_tensor, device_, tokens_on_device),
+        maybe_to_device(positions_tensor, device_, positions_on_device),
+        kv_caches,
+        maybe_to_device(params_single, device_, params_on_device));
   }
 
   // Check if captured graph exists for this bucket num_tokens
-  auto it = graphs_.find(bucket_num_tokens);
-  if (it != graphs_.end()) {
+  if (graph_it != graphs_.end()) {
     // Replay the existing graph
     VLOG(kGraphExecutorLogVerboseLevel)
         << "AclGraphExecutorImpl::run() in replay mode";
-    auto result = it->second->replay(
+    auto result = graph_it->second->replay(
         tokens_tensor, positions_tensor, kv_caches, params_single);
     // Handle aux_hidden_states based on options
     if (options_.enable_graph_aux_hidden_states()) {
@@ -1051,14 +1119,15 @@ ModelOutput AclGraphExecutorImpl::run(const torch::Tensor& tokens,
   auto graph = std::make_unique<AclGraph>(*persistent_param_, device_.index());
   VLOG(kGraphExecutorLogVerboseLevel)
       << "AclGraphExecutorImpl::run() in capture mode";
-  bool capture_success = graph->capture(model_,
-                                        args_,
-                                        options_,
-                                        tokens_tensor,
-                                        positions_tensor,
-                                        params_single,
-                                        kv_caches,
-                                        bucket_num_tokens);
+  bool capture_success = graph->capture(
+      model_,
+      args_,
+      options_,
+      maybe_to_device(tokens_tensor, device_, tokens_on_device),
+      maybe_to_device(positions_tensor, device_, positions_on_device),
+      maybe_to_device(params_single, device_, params_on_device),
+      kv_caches,
+      bucket_num_tokens);
 
   if (capture_success) {
     LOG(INFO) << "Lazy capturing ACL graph for bucket num_tokens: "
@@ -1085,7 +1154,11 @@ ModelOutput AclGraphExecutorImpl::run(const torch::Tensor& tokens,
   LOG(ERROR) << "Failed to capture ACL graph for bucket num_tokens: "
              << bucket_num_tokens;
   COUNTER_INC(num_model_execution_total_eager);
-  return model_->forward(tokens, positions, kv_caches, params);
+  return model_->forward(
+      maybe_to_device(tokens_tensor, device_, tokens_on_device),
+      maybe_to_device(positions_tensor, device_, positions_on_device),
+      kv_caches,
+      maybe_to_device(params_single, device_, params_on_device));
 }
 
 void AclGraph::print_graph_tensors() const {

--- a/xllm/core/runtime/acl_graph_executor_impl.h
+++ b/xllm/core/runtime/acl_graph_executor_impl.h
@@ -22,6 +22,7 @@ limitations under the License.
 #include <cstdint>
 #include <memory>
 #include <optional>
+#include <vector>
 
 #include "core/common/macros.h"
 #include "core/framework/kv_cache/kv_cache.h"

--- a/xllm/core/runtime/llm_worker_impl.cpp
+++ b/xllm/core/runtime/llm_worker_impl.cpp
@@ -21,6 +21,7 @@ limitations under the License.
 #include <glog/logging.h>
 #include <torch/torch.h>
 
+#include <limits>
 #include <memory>
 #include <optional>
 #include <utility>
@@ -141,6 +142,10 @@ std::optional<ForwardOutput> LLMWorkerImpl::step_internal(
   if (sampling_params.selected_token_idxes.defined()) {
     logits = model_->logits(model_output.hidden_states,
                             sampling_params.selected_token_idxes);
+    if (tokenizer_vocab_size_ > 0 && tokenizer_vocab_size_ < logits.size(-1)) {
+      logits.slice(/*dim=*/-1, tokenizer_vocab_size_, logits.size(-1))
+          .fill_(-std::numeric_limits<float>::infinity());
+    }
   }
 
   ForwardOutput output;

--- a/xllm/core/runtime/worker_impl.cpp
+++ b/xllm/core/runtime/worker_impl.cpp
@@ -58,6 +58,7 @@ limitations under the License.
 #if defined(USE_NPU)
 #include "layers/npu/loader/rolling_weight_buffer.h"
 #endif
+#include "util/env_var.h"
 #include "util/net.h"
 #include "util/tensor_helper.h"
 #include "util/threadpool.h"
@@ -74,6 +75,33 @@ constexpr uint32_t TIMEOUT_S = 60;      // second
 constexpr uint32_t TIMEOUT_MS = 60000;  // millisecond
 
 namespace {
+
+#if defined(USE_NPU)
+bool should_keep_minimax_decode_graph_enabled() {
+  return xllm::util::get_bool_env("XLLM_MINIMAX_NATIVE_DECODE_ATTN", true) &&
+         !xllm::util::get_bool_env("XLLM_MINIMAX_EP_MOE_REFERENCE", false);
+}
+
+bool should_keep_minimax_decode_input_params_on_host(
+    const ModelArgs& args,
+    const ForwardInput& input) {
+  return FLAGS_enable_graph && args.model_type() == "minimax_m2" &&
+         input.input_params.batch_forward_type.is_decode();
+}
+
+ForwardInput prepare_minimax_decode_graph_input(const ForwardInput& input,
+                                                const torch::Device& device,
+                                                torch::ScalarType dtype) {
+  ForwardInput processed = input;
+  processed.token_ids = safe_to(input.token_ids, device, true);
+  processed.positions = safe_to(input.positions, device, true);
+  processed.sampling_params = input.sampling_params.to(device, dtype);
+  processed.decoder_sampling_params =
+      input.decoder_sampling_params.to(device, dtype);
+  processed.acc_logprob = safe_to(input.acc_logprob, device, true);
+  return processed;
+}
+#endif
 
 // During TP model initialization, each rank loads weights concurrently.
 // MoE weight assembly (especially stack/cat on large expert tensors) runs on
@@ -465,9 +493,18 @@ void WorkerImpl::prepare_work_before_execute(const ForwardInput& input,
   const bool use_default_stream =
       !enable_schedule_overlap() && options_.backend() == "llm";
   auto prepare_input_on_current_stream = [&]() {
+#if defined(USE_NPU)
+    if (should_keep_minimax_decode_input_params_on_host(
+            context_.get_model_args(), input)) {
+      processed_input =
+          prepare_minimax_decode_graph_input(input, device_, dtype_);
+    } else {
+      processed_input = input.to(device_, dtype_);
+    }
+#else
     processed_input = input.to(device_, dtype_);
+#endif
     auto& input_params = processed_input.input_params;
-
 #if defined(USE_NPU)
     CpPrefillInputs tmp_cp_inputs;
     if (parallel_args_.cp_size() > 1 &&
@@ -881,12 +918,31 @@ bool WorkerImpl::init_model(const std::string& model_weights_path,
   model_weights_path_ = std::move(model_weights_path);
   auto tokenizer = model_loader->tokenizer();
   CHECK(tokenizer != nullptr);
+  tokenizer_vocab_size_ = static_cast<int64_t>(tokenizer->vocab_size());
 
   auto args = model_loader->model_args();
   auto quant_args = model_loader->quant_args();
   torch::ScalarType dtype = util::parse_dtype(args.dtype(), device_);
 
-  const int64_t tokenizer_vocab_size = tokenizer->vocab_size();
+#if defined(USE_NPU)
+  if (args.model_type() == "minimax_m2" && FLAGS_enable_graph) {
+    if (should_keep_minimax_decode_graph_enabled()) {
+      LOG(INFO) << "Keeping ACL graph enabled for MiniMax-M2.5 worker decode: "
+                   "native paged-attention and a graph-safe MiniMax decode MoE "
+                   "path are enabled.";
+    } else {
+      LOG(WARNING) << "Disabling ACL graph for MiniMax-M2.5 worker decode "
+                      "because either XLLM_MINIMAX_NATIVE_DECODE_ATTN=0, "
+                      "or XLLM_MINIMAX_EP_MOE_REFERENCE=1. The eager/reference/"
+                      "compare decode paths must run outside ACL graph "
+                      "capture.";
+      FLAGS_enable_graph = false;
+    }
+  }
+#endif
+
+  const int64_t tokenizer_vocab_size =
+      static_cast<int64_t>(tokenizer->vocab_size());
   int64_t model_vocab_size = args.vocab_size();
   // use tokenizer vocab size if model vocab size is not set
   if (model_vocab_size <= 0) {

--- a/xllm/core/runtime/worker_impl.h
+++ b/xllm/core/runtime/worker_impl.h
@@ -298,6 +298,8 @@ class WorkerImpl {
 
   Status status_ = Status::UNINITIALIZED;
 
+  int64_t tokenizer_vocab_size_ = -1;
+
   torch::Tensor expert_load_data_;
 
   std::string model_weights_path_;

--- a/xllm/core/scheduler/profile/profile_manager.cpp
+++ b/xllm/core/scheduler/profile/profile_manager.cpp
@@ -30,6 +30,7 @@ limitations under the License.
 #include "common/global_flags.h"
 #include "framework/batch/batch_factory.h"
 #include "framework/request/request_state.h"
+#include "util/env_var.h"
 #include "util/rec_model_utils.h"
 
 namespace xllm {
@@ -867,8 +868,15 @@ void ProfileManager::warmup_for_graph() {
 
   // Warmup parameters - align with bucket logic
   // Prefill: align max_tokens_per_batch to bucket
-  int32_t prefill_tokens =
+  int32_t default_prefill_tokens =
       std::min(FLAGS_max_tokens_per_batch, max_context_len);
+  if (model_args.model_type() == "minimax_m2") {
+    default_prefill_tokens = std::min(default_prefill_tokens, 1024);
+  }
+  int64_t configured_prefill_tokens = util::get_int_env(
+      "XLLM_GRAPH_WARMUP_PREFILL_TOKENS", default_prefill_tokens);
+  int32_t prefill_tokens = static_cast<int32_t>(std::clamp<int64_t>(
+      configured_prefill_tokens, 1, default_prefill_tokens));
 
   std::vector<int32_t> decode_seq_lens = {16};
 

--- a/xllm/models/llm/npu/minimax_m2.h
+++ b/xllm/models/llm/npu/minimax_m2.h
@@ -1,0 +1,1718 @@
+/* Copyright 2025 The xLLM Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://github.com/jd-opensource/xllm/blob/main/LICENSE
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#pragma once
+
+#include <absl/strings/match.h>
+#include <absl/strings/str_replace.h>
+#include <glog/logging.h>
+#include <torch_npu/csrc/aten/CustomFunctions.h>
+
+#include <algorithm>
+#include <array>
+#include <cmath>
+#include <limits>
+#include <memory>
+#include <optional>
+#include <string>
+#include <tuple>
+#include <unordered_map>
+#include <unordered_set>
+#include <utility>
+#include <vector>
+
+#include "core/common/global_flags.h"
+#include "core/common/interruption_bus.h"
+#include "core/framework/hf_model_loader.h"
+#include "core/framework/model/model_input_params.h"
+#include "core/framework/model/model_output.h"
+#include "core/framework/model_context.h"
+#include "core/framework/model_loader.h"
+#include "core/framework/parallel_state/parallel_state.h"
+#include "core/kernels/ops_api.h"
+#include "core/layers/common/attention_mask.h"
+#include "core/layers/common/attention_metadata_builder.h"
+#include "core/layers/common/dense_mlp.h"
+#include "core/layers/common/linear.h"
+#include "core/layers/common/lm_head.h"
+#include "core/layers/common/rms_norm.h"
+#include "core/layers/common/rotary_embedding_util.h"
+#include "core/layers/common/word_embedding.h"
+#include "core/layers/npu_torch/attention.h"
+#include "core/layers/npu_torch/fused_moe.h"
+#include "core/util/env_var.h"
+#include "core/util/tensor_helper.h"
+
+namespace xllm {
+
+using torch::indexing::None;
+using ISlice = torch::indexing::Slice;
+
+template <typename DecoderLayerType>
+class MiniMaxM2ModelImplBase : public torch::nn::Module {
+ public:
+  explicit MiniMaxM2ModelImplBase(const ModelArgs& args) {
+    InterruptionBus::get_instance().subscribe(
+        [this](bool interrupted) { layer_forward_interrupted_ = interrupted; });
+    mrope_section_ = args.rope_scaling_mrope_section();
+  }
+
+  torch::Tensor get_input_embeddings(torch::Tensor input_ids) {
+    return embed_tokens_(input_ids);
+  }
+
+  virtual layer::WordEmbedding get_word_embedding() { return embed_tokens_; }
+
+  virtual void set_word_embedding(layer::WordEmbedding& word_embedding) {
+    embed_tokens_ = word_embedding;
+  }
+
+ protected:
+  int32_t max_seq_len_ = 0;
+  std::vector<int64_t> mrope_section_;
+  layer::WordEmbedding embed_tokens_{nullptr};
+  layer::RMSNorm norm_{nullptr};
+  std::vector<DecoderLayerType> layers_;
+  bool layer_forward_interrupted_ = false;
+};
+
+template <typename LlmModelType>
+class MiniMaxM2ForCausalLMImplBase : public torch::nn::Module {
+ public:
+  explicit MiniMaxM2ForCausalLMImplBase(const ModelContext& context) {
+    tie_word_embeddings_ = context.get_model_args().tie_word_embeddings();
+    model_ = register_module("model", LlmModelType(context));
+    lm_head_ = register_module("lm_head", layer::LmHead(context));
+  }
+
+  ModelOutput forward(const torch::Tensor& tokens,
+                      const torch::Tensor& positions,
+                      std::vector<KVCache>& kv_caches,
+                      const ModelInputParams& input_params) {
+    return model_(tokens, positions, kv_caches, input_params);
+  }
+
+  torch::Tensor logits(const torch::Tensor& hidden_states,
+                       const torch::Tensor& selected_idxes) {
+    auto h = hidden_states;
+    if (selected_idxes.defined()) {
+      h = h.index_select(/*dim=*/0, selected_idxes);
+    }
+    return lm_head_(h);
+  }
+
+  torch::Tensor pooler(const torch::Tensor& hidden_states,
+                       const torch::Tensor& selected_idxes) {
+    if (selected_idxes.defined()) {
+      return hidden_states.index_select(/*dim=*/0, selected_idxes);
+    }
+    return hidden_states;
+  }
+
+  void load_model(std::unique_ptr<ModelLoader> loader,
+                  std::string prefix = "model.") {
+    if (auto* hf_loader = dynamic_cast<HFModelLoader*>(loader.get())) {
+      hf_loader->for_each_state_dict([&](const StateDict& state_dict) {
+        model_->load_state_dict(state_dict.get_dict_with_prefix(prefix));
+        if (tie_word_embeddings_) {
+          lm_head_->load_state_dict(
+              state_dict.get_dict_with_prefix(prefix + "embed_tokens."));
+        } else {
+          lm_head_->load_state_dict(
+              state_dict.get_dict_with_prefix("lm_head."));
+        }
+      });
+      return;
+    }
+
+    for (const auto& state_dict : loader->get_state_dicts()) {
+      model_->load_state_dict(state_dict->get_dict_with_prefix(prefix));
+      if (tie_word_embeddings_) {
+        lm_head_->load_state_dict(
+            state_dict->get_dict_with_prefix(prefix + "embed_tokens."));
+      } else {
+        lm_head_->load_state_dict(state_dict->get_dict_with_prefix("lm_head."));
+      }
+    }
+  }
+
+  void prepare_expert_weight(int32_t layer_id,
+                             const std::vector<int32_t>& expert_ids) {
+    (void)layer_id;
+    (void)expert_ids;
+  }
+
+  void update_expert_weight(int32_t layer_id) { (void)layer_id; }
+
+  layer::LmHead get_lm_head() { return lm_head_; }
+
+  void set_lm_head(layer::LmHead& head) { lm_head_ = head; }
+
+  layer::WordEmbedding get_word_embedding() {
+    return model_->get_word_embedding();
+  }
+
+  void set_word_embedding(layer::WordEmbedding& word_embedding) {
+    model_->set_word_embedding(word_embedding);
+  }
+
+ protected:
+  LlmModelType model_{nullptr};
+  bool tie_word_embeddings_ = false;
+  layer::LmHead lm_head_{nullptr};
+};
+
+namespace minimax_m2_detail {
+
+struct DecodePathConfig {
+  bool native_decode_attention = true;
+  bool native_decode_moe = true;
+  int64_t native_decode_moe_min_batch = 8;
+};
+
+inline const DecodePathConfig& get_decode_path_config() {
+  static const DecodePathConfig config = []() {
+    DecodePathConfig cfg;
+    cfg.native_decode_attention =
+        util::get_bool_env("XLLM_MINIMAX_NATIVE_DECODE_ATTN", true);
+    cfg.native_decode_moe =
+        util::get_bool_env("XLLM_MINIMAX_NATIVE_DECODE_MOE", true);
+    cfg.native_decode_moe_min_batch = std::max<int64_t>(
+        1, util::get_int_env("XLLM_MINIMAX_NATIVE_DECODE_MOE_MIN_BATCH", 8));
+    return cfg;
+  }();
+  return config;
+}
+
+inline bool should_use_native_decode_moe(int64_t num_tokens) {
+  const auto& cfg = get_decode_path_config();
+  return cfg.native_decode_moe && num_tokens >= cfg.native_decode_moe_min_batch;
+}
+
+inline std::string remap_layer_weight_name(const std::string& name) {
+  std::string mapped_name = name;
+  if (absl::StartsWith(mapped_name, "block_sparse_moe.")) {
+    mapped_name =
+        absl::StrReplaceAll(mapped_name, {{"block_sparse_moe.", "mlp."}});
+  }
+  if (mapped_name == "mlp.e_score_correction_bias") {
+    return "mlp.gate.e_score_correction_bias";
+  }
+  mapped_name = absl::StrReplaceAll(mapped_name,
+                                    {{".w1.", ".gate_proj."},
+                                     {".w2.", ".down_proj."},
+                                     {".w3.", ".up_proj."}});
+  return mapped_name;
+}
+
+inline bool is_fp8_dtype(torch::ScalarType dtype) {
+  return dtype == torch::kFloat8_e5m2 || dtype == torch::kFloat8_e4m3fn;
+}
+
+inline QuantArgs make_runtime_quant_args(const QuantArgs& src) {
+  QuantArgs dst = src;
+  if (src.quant_method() == "fp8") {
+    // MiniMax native NPU path dequantizes fp8 checkpoint tensors to bf16
+    // during load_state_dict, so runtime modules should allocate/use the
+    // regular dense weight path instead of an fp8 kernel mode.
+    dst.quant_method("");
+  }
+  return dst;
+}
+
+inline torch::Tensor dequantize_fp8_block_weight(
+    const torch::Tensor& fp8_weight,
+    const torch::Tensor& weight_scale_inv,
+    const std::array<int64_t, 2>& block_size) {
+  CHECK_EQ(fp8_weight.dim(), 2)
+      << "Only 2D fp8 weights are supported, got shape " << fp8_weight.sizes();
+  CHECK_EQ(weight_scale_inv.dim(), 2)
+      << "FP8 weight scale tensor must be 2D, got shape "
+      << weight_scale_inv.sizes();
+
+  const int64_t block_n = block_size[0];
+  const int64_t block_k = block_size[1];
+  const int64_t n = fp8_weight.size(0);
+  const int64_t k = fp8_weight.size(1);
+  const int64_t n_tiles = (n + block_n - 1) / block_n;
+  const int64_t k_tiles = (k + block_k - 1) / block_k;
+
+  CHECK_EQ(weight_scale_inv.size(0), n_tiles)
+      << "Unexpected fp8 scale shape " << weight_scale_inv.sizes()
+      << " for weight shape " << fp8_weight.sizes();
+  CHECK_EQ(weight_scale_inv.size(1), k_tiles)
+      << "Unexpected fp8 scale shape " << weight_scale_inv.sizes()
+      << " for weight shape " << fp8_weight.sizes();
+
+  if (n % block_n == 0 && k % block_k == 0) {
+    // For tile-aligned weights, broadcast the per-block scales in tiled layout
+    // instead of materializing a full [n, k] expanded scale tensor.
+    auto weight_bf16 = fp8_weight.to(torch::kBFloat16)
+                           .reshape({n_tiles, block_n, k_tiles, block_k});
+    auto scale_bf16 =
+        weight_scale_inv.to(torch::kBFloat16).reshape({n_tiles, 1, k_tiles, 1});
+    return (weight_bf16 * scale_bf16).reshape({n, k});
+  }
+
+  auto expanded_scale = weight_scale_inv.repeat_interleave(block_n, 0)
+                            .repeat_interleave(block_k, 1);
+  expanded_scale = expanded_scale.slice(/*dim=*/0, /*start=*/0, /*end=*/n)
+                       .slice(/*dim=*/1, /*start=*/0, /*end=*/k)
+                       .to(torch::kBFloat16);
+  return fp8_weight.to(torch::kBFloat16) * expanded_scale;
+}
+
+inline torch::Tensor rotate_half(const torch::Tensor& x) {
+  auto chunks = x.chunk(/*chunks=*/2, /*dim=*/-1);
+  return torch::cat({-chunks[1], chunks[0]}, /*dim=*/-1);
+}
+
+inline std::tuple<torch::Tensor, torch::Tensor> apply_rotary_pos_emb(
+    const torch::Tensor& q,
+    const torch::Tensor& k,
+    const torch::Tensor& cos_sin) {
+  const auto chunks = cos_sin.chunk(/*chunks=*/2, /*dim=*/-1);
+  const auto& cos = chunks[0];
+  const auto& sin = chunks[1];
+  auto q_embed = (q * cos) + (rotate_half(q) * sin);
+  auto k_embed = (k * cos) + (rotate_half(k) * sin);
+  return std::make_tuple(q_embed, k_embed);
+}
+
+inline torch::Tensor repeat_kv(const torch::Tensor& hidden_states,
+                               int64_t n_rep) {
+  CHECK_EQ(hidden_states.dim(), 4)
+      << "repeat_kv expects [batch, kv_heads, seq, head_dim], got "
+      << hidden_states.sizes();
+  if (n_rep == 1) {
+    return hidden_states;
+  }
+  const auto batch = hidden_states.size(0);
+  const auto num_kv_heads = hidden_states.size(1);
+  const auto seq_len = hidden_states.size(2);
+  const auto head_dim = hidden_states.size(3);
+  return hidden_states.unsqueeze(/*dim=*/2)
+      .expand({batch, num_kv_heads, n_rep, seq_len, head_dim})
+      .reshape({batch, num_kv_heads * n_rep, seq_len, head_dim});
+}
+
+inline torch::Tensor build_attention_mask(int64_t q_len,
+                                          int64_t kv_len,
+                                          int64_t prefix_len,
+                                          int64_t sliding_window,
+                                          const torch::Device& device) {
+  auto pos_options = torch::TensorOptions().dtype(torch::kInt64).device(device);
+  auto q_pos = torch::arange(prefix_len, prefix_len + q_len, pos_options)
+                   .view({q_len, 1});
+  auto k_pos = torch::arange(kv_len, pos_options).view({1, kv_len});
+  auto invalid = k_pos > q_pos;
+  if (sliding_window > 0) {
+    auto min_k_pos = q_pos - (sliding_window - 1);
+    invalid = invalid.logical_or(k_pos < min_k_pos);
+  }
+  auto mask = torch::zeros(
+      {1, 1, q_len, kv_len},
+      torch::TensorOptions().dtype(torch::kFloat32).device(device));
+  mask.masked_fill_(invalid.unsqueeze(/*dim=*/0).unsqueeze(/*dim=*/0),
+                    -9984.0f);
+  return mask;
+}
+
+inline bool should_limit_topk_by_group(int64_t num_total_experts,
+                                       int64_t num_expert_group,
+                                       int64_t topk_group) {
+  return num_expert_group > 1 && topk_group > 0 &&
+         topk_group < num_expert_group &&
+         num_total_experts % num_expert_group == 0;
+}
+
+inline torch::Tensor mask_scores_by_selected_groups(const torch::Tensor& scores,
+                                                    int64_t num_expert_group,
+                                                    int64_t topk_group) {
+  const int64_t experts_per_group = scores.size(-1) / num_expert_group;
+  const int64_t group_score_topk = std::min<int64_t>(2, experts_per_group);
+  auto grouped_scores =
+      scores.view({scores.size(0), num_expert_group, experts_per_group});
+  auto group_topk = std::get<0>(torch::topk(grouped_scores,
+                                            group_score_topk,
+                                            /*dim=*/-1,
+                                            /*largest=*/true,
+                                            /*sorted=*/false));
+  auto group_scores = group_topk.sum(/*dim=*/-1);
+  auto selected_groups = std::get<1>(torch::topk(group_scores,
+                                                 topk_group,
+                                                 /*dim=*/-1,
+                                                 /*largest=*/true,
+                                                 /*sorted=*/false));
+
+  auto selected_mask = torch::zeros(group_scores.sizes(),
+                                    group_scores.options().dtype(torch::kBool));
+  selected_mask.scatter_(
+      /*dim=*/1,
+      selected_groups,
+      torch::ones(selected_groups.sizes(), selected_mask.options()));
+
+  auto expert_mask =
+      selected_mask.unsqueeze(-1)
+          .expand({scores.size(0), num_expert_group, experts_per_group})
+          .reshape_as(scores);
+  return scores.masked_fill(expert_mask.logical_not(), 0.0);
+}
+
+}  // namespace minimax_m2_detail
+
+class MiniMaxTensorParallelRMSNormImpl : public torch::nn::Module {
+ public:
+  MiniMaxTensorParallelRMSNormImpl(int64_t local_dim,
+                                   int64_t global_dim,
+                                   int64_t replica_factor,
+                                   double eps,
+                                   ProcessGroup* process_group,
+                                   const torch::TensorOptions& options)
+      : local_dim_(local_dim),
+        global_dim_(global_dim),
+        replica_factor_(replica_factor),
+        eps_(eps),
+        process_group_(process_group) {
+    CHECK(process_group_ != nullptr)
+        << "MiniMaxTensorParallelRMSNorm requires tp process group";
+    CHECK_GT(replica_factor_, 0);
+    CHECK_EQ(process_group_->world_size() % replica_factor_, 0)
+        << "tp world size " << process_group_->world_size()
+        << " must be divisible by replica factor " << replica_factor_;
+    const int64_t effective_world_size =
+        process_group_->world_size() / replica_factor_;
+    CHECK_GT(effective_world_size, 0);
+    CHECK_EQ(global_dim_ % effective_world_size, 0)
+        << "global_dim " << global_dim_
+        << " must be divisible by effective world size "
+        << effective_world_size;
+    CHECK_EQ(local_dim_, global_dim_ / effective_world_size)
+        << "unexpected local shard size for TP RMSNorm";
+
+    weight_ = register_parameter(
+        "weight", torch::empty({local_dim_}, options), /*requires_grad=*/false);
+  }
+
+  torch::Tensor forward(const torch::Tensor& input) {
+    auto org_shape = input.sizes().vec();
+    auto input_2d = input.reshape({-1, local_dim_});
+    auto input_fp32 = input_2d.to(torch::kFloat32);
+    auto sq_sum = (input_fp32 * input_fp32).sum(/*dim=*/-1, /*keepdim=*/true);
+    if (process_group_->world_size() > 1) {
+      sq_sum = parallel_state::reduce(sq_sum, process_group_);
+    }
+
+    const float inv_global_dim =
+        1.0f / static_cast<float>(global_dim_ * replica_factor_);
+    // Match HF MiniMax q/k RMSNorm: compute the normalization factor and
+    // apply it in fp32, then cast back to the activation dtype before the
+    // learned weight multiply.
+    auto inv_rms = torch::rsqrt(sq_sum * inv_global_dim + eps_);
+    auto normalized = (input_fp32 * inv_rms).to(input_2d.scalar_type());
+    auto output = normalized * weight_.view({1, local_dim_});
+    return output.view(org_shape);
+  }
+
+  const torch::Tensor& weight() const { return weight_; }
+  double eps() const { return eps_; }
+  ProcessGroup* process_group() const { return process_group_; }
+
+  void load_state_dict(const StateDict& state_dict) {
+    if (weight_is_loaded_) {
+      return;
+    }
+
+    const int64_t rank = process_group_->rank() / replica_factor_;
+    const int64_t world_size = process_group_->world_size() / replica_factor_;
+    auto tensor = state_dict.get_sharded_tensor("weight", 0, rank, world_size);
+    if (!tensor.defined()) {
+      return;
+    }
+
+    torch::NoGradGuard no_grad;
+    CHECK_EQ(weight_.sizes(), tensor.sizes())
+        << "weight size mismatch for " << state_dict.prefix() << "weight";
+    weight_.copy_(tensor);
+    weight_is_loaded_ = true;
+  }
+
+ private:
+  DEFINE_WEIGHT(weight);
+  int64_t local_dim_ = 0;
+  int64_t global_dim_ = 0;
+  int64_t replica_factor_ = 1;
+  double eps_ = 1e-6;
+  ProcessGroup* process_group_ = nullptr;
+};
+TORCH_MODULE(MiniMaxTensorParallelRMSNorm);
+
+inline std::tuple<torch::Tensor, torch::Tensor> apply_minimax_tp_qk_rms_norm(
+    const torch::Tensor& query,
+    const torch::Tensor& key,
+    MiniMaxTensorParallelRMSNorm& q_norm,
+    MiniMaxTensorParallelRMSNorm& k_norm) {
+  auto* process_group = q_norm->process_group();
+  if (process_group == nullptr || process_group != k_norm->process_group() ||
+      !query.device().is_privateuseone() || !key.device().is_privateuseone()) {
+    return std::make_tuple(q_norm->forward(query), k_norm->forward(key));
+  }
+
+  const auto q_input = query.is_contiguous() ? query : query.contiguous();
+  const auto k_input = key.is_contiguous() ? key : key.contiguous();
+  auto [q_local, q_inv_rms] = at_npu::native::custom_ops::npu_rms_norm(
+      q_input, q_norm->weight(), q_norm->eps());
+  auto [k_local, k_inv_rms] = at_npu::native::custom_ops::npu_rms_norm(
+      k_input, k_norm->weight(), k_norm->eps());
+
+  auto normalize_inv_rms = [](const torch::Tensor& inv_rms) {
+    auto inv_rms_fp32 = inv_rms.to(torch::kFloat32);
+    if (inv_rms_fp32.dim() > 0 && inv_rms_fp32.size(-1) != 1) {
+      inv_rms_fp32 = inv_rms_fp32.mean(/*dim=*/-1, /*keepdim=*/true);
+    }
+    return inv_rms_fp32;
+  };
+
+  auto q_local_rstd = normalize_inv_rms(q_inv_rms);
+  auto k_local_rstd = normalize_inv_rms(k_inv_rms);
+  auto q_local_var =
+      (q_local_rstd.reciprocal().pow(2) - q_norm->eps()).clamp_min(0.0);
+  auto k_local_var =
+      (k_local_rstd.reciprocal().pow(2) - k_norm->eps()).clamp_min(0.0);
+
+  auto qk_var = torch::cat({q_local_var, k_local_var}, /*dim=*/-1);
+  if (process_group->world_size() > 1) {
+    qk_var = parallel_state::reduce(qk_var, process_group);
+    qk_var = qk_var / static_cast<double>(process_group->world_size());
+  }
+
+  auto q_global_var = qk_var.slice(/*dim=*/-1, /*start=*/0, /*end=*/1);
+  auto k_global_var = qk_var.slice(/*dim=*/-1, /*start=*/1, /*end=*/2);
+  auto q_global_rstd = torch::rsqrt(q_global_var + q_norm->eps());
+  auto k_global_rstd = torch::rsqrt(k_global_var + k_norm->eps());
+
+  q_local = q_local * (q_global_rstd / q_local_rstd).to(q_local.scalar_type());
+  k_local = k_local * (k_global_rstd / k_local_rstd).to(k_local.scalar_type());
+  return std::make_tuple(std::move(q_local), std::move(k_local));
+}
+
+class MiniMaxM2RotaryEmbeddingImpl : public torch::nn::Module {
+ public:
+  MiniMaxM2RotaryEmbeddingImpl(int64_t rotary_dim,
+                               int64_t max_position_embeddings,
+                               int64_t rope_theta,
+                               const std::vector<int64_t>& mrope_section,
+                               const torch::TensorOptions& options)
+      : rotary_dim_(rotary_dim), mrope_section_(mrope_section) {
+    const auto inv_freq =
+        layer::rotary::compute_inv_freq(rotary_dim, rope_theta, options);
+    const auto cos_sin =
+        layer::rotary::compute_cos_sin_cache(rotary_dim,
+                                             max_position_embeddings,
+                                             /*interleaved=*/false,
+                                             inv_freq,
+                                             options);
+    cos_sin_cache_ = register_buffer("cos_sin_cache", cos_sin.to(options));
+  }
+
+  std::tuple<torch::Tensor, torch::Tensor> forward(
+      const torch::Tensor& query,
+      const torch::Tensor& key,
+      const torch::Tensor& positions) const {
+    DCHECK_GE(query.size(-1), rotary_dim_);
+    auto query_rotary = query.index({"...", ISlice(0, rotary_dim_)});
+    auto query_pass = query.index({"...", ISlice(rotary_dim_, None)});
+    auto key_rotary = key.index({"...", ISlice(0, rotary_dim_)});
+    auto key_pass = key.index({"...", ISlice(rotary_dim_, None)});
+
+    namespace F = torch::nn::functional;
+    auto cos_sin = F::embedding(positions, cos_sin_cache_);
+    if (positions.dim() == 2 && !mrope_section_.empty()) {
+      auto chunks = cos_sin.chunk(/*chunks=*/2, /*dim=*/-1);
+      auto apply = [this](torch::Tensor x) {
+        auto sections = mrope_section_;
+        sections.insert(sections.end(), sections.begin(), sections.end());
+        auto vec = x.split(sections, /*dim=*/-1);
+        std::vector<torch::Tensor> selects;
+        selects.reserve(vec.size());
+        for (int64_t i = 0; i < static_cast<int64_t>(vec.size()); ++i) {
+          selects.push_back(vec[i][i % mrope_section_.size()]);
+        }
+        return torch::cat(selects, /*dim=*/-1);
+      };
+
+      auto cos = apply(chunks[0]);
+      auto sin = apply(chunks[1]);
+      cos_sin = torch::cat({cos, sin}, /*dim=*/-1);
+    }
+
+    cos_sin = cos_sin.unsqueeze(/*dim=*/1);
+    std::tie(query_rotary, key_rotary) =
+        minimax_m2_detail::apply_rotary_pos_emb(
+            query_rotary, key_rotary, cos_sin);
+    return std::make_tuple(torch::cat({query_rotary, query_pass}, /*dim=*/-1),
+                           torch::cat({key_rotary, key_pass}, /*dim=*/-1));
+  }
+
+ private:
+  torch::Tensor cos_sin_cache_;
+  int64_t rotary_dim_ = 0;
+  std::vector<int64_t> mrope_section_;
+};
+TORCH_MODULE(MiniMaxM2RotaryEmbedding);
+
+class MiniMaxM2AttentionImpl : public torch::nn::Module {
+ public:
+  explicit MiniMaxM2AttentionImpl(const ModelContext& context) {
+    const auto& args = context.get_model_args();
+    const auto quant_args =
+        minimax_m2_detail::make_runtime_quant_args(context.get_quant_args());
+    const auto& parallel_args = context.get_parallel_args();
+    const auto& options = context.get_tensor_options();
+    const int64_t tp_size = parallel_args.tp_group_->world_size();
+    const int64_t total_num_heads = args.n_heads();
+    const int64_t total_num_kv_heads =
+        args.n_kv_heads().value_or(args.n_heads());
+
+    CHECK(total_num_heads % tp_size == 0);
+    num_heads_ = total_num_heads / tp_size;
+    if (total_num_kv_heads >= tp_size) {
+      CHECK(total_num_kv_heads % tp_size == 0);
+      num_kv_heads_ = total_num_kv_heads / tp_size;
+      num_kv_head_replicas_ = 1;
+    } else {
+      CHECK(tp_size % total_num_kv_heads == 0);
+      num_kv_heads_ = 1;
+      num_kv_head_replicas_ = tp_size / total_num_kv_heads;
+    }
+
+    head_dim_ = args.head_dim();
+    q_size_ = num_heads_ * head_dim_;
+    kv_size_ = num_kv_heads_ * head_dim_;
+    CHECK_EQ(num_heads_ % num_kv_heads_, 0)
+        << "MiniMax local attention heads must be divisible by local kv heads";
+    scaling_ = std::sqrt(1.0f / head_dim_);
+    use_qk_norm_ = args.use_qk_norm();
+    use_per_layer_qk_norm_ = args.qk_norm_type() == "per_layer";
+    sliding_window_ = args.sliding_window();
+
+    qkv_proj_ =
+        register_module("qkv_proj",
+                        layer::QKVParallelLinear(args.hidden_size(),
+                                                 num_heads_,
+                                                 num_kv_heads_,
+                                                 head_dim_,
+                                                 num_kv_head_replicas_,
+                                                 /*bias=*/false,
+                                                 /*gather_output=*/false,
+                                                 parallel_args,
+                                                 options));
+
+    o_proj_ = register_module(
+        "o_proj",
+        layer::RowParallelLinear(total_num_heads * head_dim_,
+                                 args.hidden_size(),
+                                 /*bias=*/false,
+                                 /*input_is_parallelized=*/true,
+                                 /*enable_result_reduction=*/true,
+                                 quant_args,
+                                 parallel_args.tp_group_,
+                                 options));
+
+    if (use_qk_norm_) {
+      if (use_per_layer_qk_norm_) {
+        q_norm_tp_ = register_module(
+            "q_norm",
+            MiniMaxTensorParallelRMSNorm(q_size_,
+                                         total_num_heads * head_dim_,
+                                         /*replica_factor=*/1,
+                                         args.rms_norm_eps(),
+                                         parallel_args.tp_group_,
+                                         options));
+        k_norm_tp_ = register_module(
+            "k_norm",
+            MiniMaxTensorParallelRMSNorm(kv_size_,
+                                         total_num_kv_heads * head_dim_,
+                                         num_kv_head_replicas_,
+                                         args.rms_norm_eps(),
+                                         parallel_args.tp_group_,
+                                         options));
+      } else {
+        q_norm_ = register_module(
+            "q_norm", layer::RMSNorm(head_dim_, args.rms_norm_eps(), options));
+        k_norm_ = register_module(
+            "k_norm", layer::RMSNorm(head_dim_, args.rms_norm_eps(), options));
+      }
+    }
+
+    const int64_t rotary_dim =
+        args.rotary_dim() > 0 ? args.rotary_dim() : args.head_dim();
+    rotary_emb_ = register_module(
+        "rope",
+        MiniMaxM2RotaryEmbedding(rotary_dim,
+                                 args.max_position_embeddings(),
+                                 args.rope_theta(),
+                                 args.rope_scaling_mrope_section(),
+                                 options));
+    attn_ = register_module("attn",
+                            layer::Attention(num_heads_,
+                                             head_dim_,
+                                             scaling_,
+                                             num_kv_heads_,
+                                             args.sliding_window()));
+  }
+
+  torch::Tensor forward(const torch::Tensor& positions,
+                        const torch::Tensor& hidden_states,
+                        const layer::AttentionMetadata& attn_metadata,
+                        KVCache& kv_cache) {
+    if (attn_metadata.is_dummy) {
+      // Empty DP participants still need to walk the model so MoE collectives
+      // stay matched, but they must not enter the native decode-attention
+      // kernels with zero-length decode metadata.
+      return torch::zeros_like(hidden_states);
+    }
+
+    auto qkv = qkv_proj_->forward(hidden_states);
+    auto q = qkv.slice(/*dim=*/-1, 0, q_size_);
+    auto k = qkv.slice(/*dim=*/-1, q_size_, q_size_ + kv_size_);
+    auto v = qkv.slice(/*dim=*/-1, q_size_ + kv_size_, q_size_ + 2 * kv_size_);
+
+    const int64_t num_tokens = q.size(0);
+    if (use_qk_norm_) {
+      if (use_per_layer_qk_norm_) {
+        std::tie(q, k) =
+            apply_minimax_tp_qk_rms_norm(q, k, q_norm_tp_, k_norm_tp_);
+      }
+    }
+
+    auto q_heads = q.view({num_tokens, num_heads_, head_dim_});
+    auto k_heads = k.view({num_tokens, num_kv_heads_, head_dim_});
+    auto v_heads = v.view({num_tokens, num_kv_heads_, head_dim_});
+
+    if (use_qk_norm_ && !use_per_layer_qk_norm_) {
+      q_heads = std::get<0>(q_norm_->forward(q_heads));
+      k_heads = std::get<0>(k_norm_->forward(k_heads));
+    }
+
+    std::tie(q_heads, k_heads) =
+        rotary_emb_->forward(q_heads, k_heads, positions);
+    if (!attn_metadata.is_prefill && !attn_metadata.is_chunked_prefill &&
+        minimax_m2_detail::get_decode_path_config().native_decode_attention) {
+      auto q_flat = q_heads.reshape({num_tokens, q_size_}).contiguous();
+      auto k_flat = k_heads.reshape({num_tokens, kv_size_}).contiguous();
+      auto v_flat = v_heads.reshape({num_tokens, kv_size_}).contiguous();
+      auto out = std::get<0>(
+          attn_->forward(attn_metadata, q_flat, k_flat, v_flat, kv_cache));
+      return o_proj_->forward(out);
+    }
+    auto out_heads = forward_eager_attention(
+        q_heads, k_heads, v_heads, attn_metadata, kv_cache);
+    return o_proj_->forward(out_heads.view({num_tokens, q_size_}));
+  }
+
+  void load_state_dict(const StateDict& state_dict) {
+    qkv_proj_->load_state_dict(state_dict, {"q_proj.", "k_proj.", "v_proj."});
+    o_proj_->load_state_dict(state_dict.get_dict_with_prefix("o_proj."));
+    if (use_qk_norm_) {
+      if (use_per_layer_qk_norm_) {
+        q_norm_tp_->load_state_dict(state_dict.get_dict_with_prefix("q_norm."));
+        k_norm_tp_->load_state_dict(state_dict.get_dict_with_prefix("k_norm."));
+      } else {
+        q_norm_->load_state_dict(state_dict.get_dict_with_prefix("q_norm."));
+        k_norm_->load_state_dict(state_dict.get_dict_with_prefix("k_norm."));
+      }
+    }
+  }
+
+ private:
+  void store_kv_cache(const layer::AttentionMetadata& attn_metadata,
+                      const torch::Tensor& key_states,
+                      const torch::Tensor& value_states,
+                      KVCache& kv_cache) const {
+    if (!attn_metadata.slot_mapping.defined()) {
+      return;
+    }
+
+    // Match the normal paged-cache path: slot_mapping is expected to already
+    // contain only valid cache slots for active tokens. Avoid .item() checks on
+    // device tensors here because MiniMax decode runs under ACL graph capture.
+    auto slot_mapping =
+        attn_metadata.slot_mapping.reshape({-1}).to(torch::kLong);
+    auto k_cache = kv_cache.get_k_cache().view({-1, num_kv_heads_, head_dim_});
+    auto v_cache = kv_cache.get_v_cache().view({-1, num_kv_heads_, head_dim_});
+    k_cache.index_copy_(/*dim=*/0, slot_mapping, key_states.contiguous());
+    v_cache.index_copy_(/*dim=*/0, slot_mapping, value_states.contiguous());
+  }
+
+  std::tuple<torch::Tensor, torch::Tensor> materialize_cached_kv(
+      const layer::AttentionMetadata& attn_metadata,
+      int64_t seq_idx,
+      int64_t kv_len,
+      KVCache& kv_cache) const {
+    CHECK(attn_metadata.block_table.defined())
+        << "MiniMax eager attention needs block_table for cached KV paths";
+
+    auto k_cache = kv_cache.get_k_cache();
+    auto v_cache = kv_cache.get_v_cache();
+    CHECK(v_cache.defined()) << "MiniMax eager attention requires v_cache";
+
+    const int64_t block_size = k_cache.size(1);
+    const int64_t num_blocks = (kv_len + block_size - 1) / block_size;
+    auto block_ids =
+        attn_metadata.block_table.index({seq_idx, ISlice(0, num_blocks)})
+            .to(k_cache.device())
+            .to(torch::kLong);
+    auto k_seq =
+        k_cache.index_select(/*dim=*/0, block_ids)
+            .reshape({num_blocks * block_size, num_kv_heads_, head_dim_})
+            .slice(/*dim=*/0, /*start=*/0, /*end=*/kv_len);
+    auto v_seq =
+        v_cache.index_select(/*dim=*/0, block_ids)
+            .reshape({num_blocks * block_size, num_kv_heads_, head_dim_})
+            .slice(/*dim=*/0, /*start=*/0, /*end=*/kv_len);
+    return std::make_tuple(k_seq.unsqueeze(/*dim=*/0)
+                               .transpose(/*dim0=*/1, /*dim1=*/2)
+                               .contiguous(),
+                           v_seq.unsqueeze(/*dim=*/0)
+                               .transpose(/*dim0=*/1, /*dim1=*/2)
+                               .contiguous());
+  }
+
+  torch::Tensor forward_eager_attention(
+      const torch::Tensor& query_states,
+      const torch::Tensor& key_states,
+      const torch::Tensor& value_states,
+      const layer::AttentionMetadata& attn_metadata,
+      KVCache& kv_cache) const {
+    // Correctness-first MiniMax path: bypass the shared NPU ATB attention
+    // kernels until their MiniMax contract is validated against the checkpoint.
+    if (attn_metadata.is_dummy) {
+      return torch::zeros_like(query_states);
+    }
+
+    store_kv_cache(attn_metadata, key_states, value_states, kv_cache);
+
+    CHECK(attn_metadata.q_seq_lens_host.defined())
+        << "MiniMax eager attention requires q_seq_lens_host";
+    auto output = torch::empty_like(query_states);
+    const int64_t kv_repeat = num_heads_ / num_kv_heads_;
+    torch::Tensor kv_seq_lens_host;
+    if (attn_metadata.kv_seq_lens_host.defined()) {
+      kv_seq_lens_host = attn_metadata.kv_seq_lens_host.contiguous();
+    }
+
+    const auto q_seq_lens_host = attn_metadata.q_seq_lens_host.contiguous();
+    const int64_t num_sequences = q_seq_lens_host.numel();
+    int64_t q_start = 0;
+    for (int64_t seq_idx = 0; seq_idx < num_sequences; ++seq_idx) {
+      const int64_t q_len = q_seq_lens_host[seq_idx].item<int64_t>();
+      const int64_t q_end = q_start + q_len;
+      if (q_len == 0) {
+        q_start = q_end;
+        continue;
+      }
+
+      auto q_seq = query_states.slice(/*dim=*/0, q_start, q_end)
+                       .unsqueeze(/*dim=*/0)
+                       .transpose(/*dim0=*/1, /*dim1=*/2)
+                       .contiguous();
+
+      torch::Tensor k_seq;
+      torch::Tensor v_seq;
+      torch::Tensor attn_mask;
+      if (attn_metadata.is_prefill && !attn_metadata.is_chunked_prefill) {
+        k_seq = key_states.slice(/*dim=*/0, q_start, q_end)
+                    .unsqueeze(/*dim=*/0)
+                    .transpose(/*dim0=*/1, /*dim1=*/2)
+                    .contiguous();
+        v_seq = value_states.slice(/*dim=*/0, q_start, q_end)
+                    .unsqueeze(/*dim=*/0)
+                    .transpose(/*dim0=*/1, /*dim1=*/2)
+                    .contiguous();
+        attn_mask = minimax_m2_detail::build_attention_mask(
+            q_len, q_len, /*prefix_len=*/0, sliding_window_, q_seq.device());
+      } else {
+        CHECK(kv_seq_lens_host.defined())
+            << "MiniMax eager attention requires kv_seq_lens for cached paths";
+        const int64_t kv_len = kv_seq_lens_host[seq_idx].item<int64_t>();
+        const int64_t prefix_len = std::max<int64_t>(0, kv_len - q_len);
+        std::tie(k_seq, v_seq) =
+            materialize_cached_kv(attn_metadata, seq_idx, kv_len, kv_cache);
+        attn_mask = minimax_m2_detail::build_attention_mask(
+            q_len, kv_len, prefix_len, sliding_window_, q_seq.device());
+      }
+
+      auto k_full = minimax_m2_detail::repeat_kv(k_seq, kv_repeat);
+      auto v_full = minimax_m2_detail::repeat_kv(v_seq, kv_repeat);
+      auto q_attn = q_seq.to(torch::kFloat32);
+      auto k_attn = k_full.to(torch::kFloat32);
+      auto v_attn = v_full.to(torch::kFloat32);
+      auto attn_weights =
+          torch::matmul(q_attn, k_attn.transpose(/*dim0=*/-2, /*dim1=*/-1)) *
+          scaling_;
+      attn_weights = attn_weights + attn_mask;
+      attn_weights = torch::softmax(attn_weights, /*dim=*/-1, torch::kFloat32);
+      auto attn_output =
+          torch::matmul(attn_weights, v_attn).to(query_states.scalar_type());
+      output.slice(/*dim=*/0, q_start, q_end)
+          .copy_(attn_output.squeeze(/*dim=*/0).transpose(/*dim0=*/0,
+                                                          /*dim1=*/1));
+      q_start = q_end;
+    }
+
+    return output;
+  }
+
+  int64_t num_heads_ = 0;
+  int64_t num_kv_heads_ = 0;
+  int64_t num_kv_head_replicas_ = 0;
+  int64_t head_dim_ = 0;
+  int64_t q_size_ = 0;
+  int64_t kv_size_ = 0;
+  int64_t sliding_window_ = -1;
+  float scaling_ = 1.0f;
+  bool use_qk_norm_ = false;
+  bool use_per_layer_qk_norm_ = false;
+
+  layer::QKVParallelLinear qkv_proj_{nullptr};
+  layer::RowParallelLinear o_proj_{nullptr};
+  layer::RMSNorm q_norm_{nullptr};
+  layer::RMSNorm k_norm_{nullptr};
+  MiniMaxTensorParallelRMSNorm q_norm_tp_{nullptr};
+  MiniMaxTensorParallelRMSNorm k_norm_tp_{nullptr};
+  MiniMaxM2RotaryEmbedding rotary_emb_{nullptr};
+  layer::Attention attn_{nullptr};
+};
+TORCH_MODULE(MiniMaxM2Attention);
+
+class MiniMaxM2SparseMoEImpl : public torch::nn::Module {
+ public:
+  explicit MiniMaxM2SparseMoEImpl(const ModelContext& context,
+                                  int64_t layer_id) {
+    const auto& args = context.get_model_args();
+    const auto& parallel_args = context.get_parallel_args();
+    const auto& options = context.get_tensor_options();
+    const auto quant_args =
+        minimax_m2_detail::make_runtime_quant_args(context.get_quant_args());
+
+    if (parallel_args.ep_size() > 1) {
+      layer::FusedMoEArgs moe_args;
+      ep_moe_ = register_module(
+          "ep_moe",
+          layer::FusedMoE(args, moe_args, quant_args, parallel_args, options));
+      return;
+    }
+
+    CHECK(parallel_args.tp_group_ != nullptr)
+        << "MiniMax sparse MoE requires tp_group";
+    CHECK_GT(args.n_routed_experts(), 0);
+    CHECK_EQ(args.n_shared_experts(), 0)
+        << "MiniMax native correctness-first MoE fallback does not support "
+           "shared experts yet";
+    CHECK(args.hidden_act() == "silu")
+        << "MiniMax native correctness-first MoE fallback only supports "
+           "silu activation, got "
+        << args.hidden_act();
+
+    tp_group_ = parallel_args.tp_group_;
+    rank_ = tp_group_->rank();
+    world_size_ = tp_group_->world_size();
+
+    hidden_size_ = args.hidden_size();
+    num_experts_ = args.n_routed_experts();
+    topk_ = args.num_experts_per_tok();
+    num_expert_group_ = std::max<int64_t>(args.n_group(), 1);
+    topk_group_ = args.topk_group() > 0 ? args.topk_group()
+                                        : std::max<int64_t>(args.n_group(), 1);
+    route_scale_ = args.routed_scaling_factor();
+    renormalize_ = args.norm_topk_prob();
+    hidden_act_ = args.hidden_act();
+    scoring_func_ =
+        args.scoring_func().empty() ? "softmax" : args.scoring_func();
+    local_intermediate_size_ = args.moe_intermediate_size() / world_size_;
+    CHECK_EQ(args.moe_intermediate_size() % world_size_, 0)
+        << "MiniMax MoE intermediate size must be divisible by TP size";
+
+    gate_weight_ =
+        register_parameter("gate_weight",
+                           torch::empty({hidden_size_, num_experts_},
+                                        options.dtype(torch::kFloat32)),
+                           /*requires_grad=*/false);
+    e_score_correction_bias_ = register_parameter(
+        "e_score_correction_bias",
+        torch::zeros({num_experts_}, options.dtype(torch::kFloat32)),
+        /*requires_grad=*/false);
+    // Keep MiniMax MoE weights in a decode-friendly runtime layout so we do
+    // not duplicate the full expert weights just to cache transposed copies.
+    w13_ = register_parameter(
+        "w13",
+        torch::empty({num_experts_, hidden_size_, local_intermediate_size_ * 2},
+                     options),
+        /*requires_grad=*/false);
+    w2_ = register_parameter(
+        "w2",
+        torch::empty({num_experts_, local_intermediate_size_, hidden_size_},
+                     options),
+        /*requires_grad=*/false);
+  }
+
+  torch::Tensor forward(const torch::Tensor& hidden_states,
+                        const ModelInputParams& input_params) {
+    if (ep_moe_) {
+      return ep_moe_->forward(hidden_states, input_params);
+    }
+    if (input_params.batch_forward_type.is_decode()) {
+      if (minimax_m2_detail::should_use_native_decode_moe(
+              hidden_states.size(0))) {
+        return forward_native_decode(hidden_states);
+      }
+      return forward_decode_vectorized_fallback(hidden_states);
+    }
+    return forward_eager_fallback(hidden_states);
+  }
+
+  torch::Tensor forward_eager_fallback(const torch::Tensor& hidden_states) {
+    auto hidden_states_2d =
+        hidden_states.reshape({-1, hidden_states.size(-1)}).contiguous();
+    auto router_logits =
+        torch::matmul(hidden_states_2d.to(torch::kFloat32), gate_weight_);
+
+    torch::Tensor routing_scores;
+    if (scoring_func_ == "sigmoid") {
+      routing_scores = torch::sigmoid(router_logits.to(torch::kFloat32));
+    } else if (scoring_func_ == "softmax") {
+      routing_scores =
+          torch::softmax(router_logits.to(torch::kFloat32), /*dim=*/-1);
+    } else {
+      LOG(FATAL) << "Unsupported MiniMax scoring_func " << scoring_func_;
+    }
+
+    auto choice_scores = routing_scores;
+    if (e_score_correction_bias_.defined()) {
+      choice_scores = choice_scores + e_score_correction_bias_;
+    }
+    if (minimax_m2_detail::should_limit_topk_by_group(
+            num_experts_, num_expert_group_, topk_group_)) {
+      choice_scores = minimax_m2_detail::mask_scores_by_selected_groups(
+          choice_scores, num_expert_group_, topk_group_);
+    }
+
+    auto topk_result = torch::topk(choice_scores,
+                                   topk_,
+                                   /*dim=*/-1,
+                                   /*largest=*/true,
+                                   /*sorted=*/false);
+    auto topk_ids = std::get<1>(topk_result).to(torch::kLong).contiguous();
+    auto topk_weights = routing_scores.gather(/*dim=*/1, topk_ids).contiguous();
+    if (renormalize_) {
+      topk_weights = topk_weights / (topk_weights.sum(-1, true) + 1e-6);
+    }
+    if (route_scale_ != 1.0) {
+      topk_weights = topk_weights * route_scale_;
+    }
+
+    auto output = torch::zeros_like(hidden_states_2d);
+    for (int64_t expert_idx = 0; expert_idx < num_experts_; ++expert_idx) {
+      auto expert_matches = (topk_ids == expert_idx).nonzero();
+      if (expert_matches.numel() == 0) {
+        continue;
+      }
+
+      auto token_idx = expert_matches.index({ISlice(), 0}).to(torch::kLong);
+      auto topk_slot = expert_matches.index({ISlice(), 1}).to(torch::kLong);
+      auto current_states = hidden_states_2d.index_select(/*dim=*/0, token_idx);
+      auto current_w13 = w13_.index({expert_idx});
+      auto current_w2 = w2_.index({expert_idx});
+
+      auto gate_up = torch::matmul(current_states, current_w13);
+      auto gate_proj = gate_up.slice(/*dim=*/-1,
+                                     /*start=*/0,
+                                     /*end=*/local_intermediate_size_);
+      auto up_proj = gate_up.slice(/*dim=*/-1,
+                                   /*start=*/local_intermediate_size_,
+                                   /*end=*/local_intermediate_size_ * 2);
+      auto activated = torch::silu(gate_proj) * up_proj;
+      auto expert_out = torch::matmul(activated, current_w2);
+      auto combine_weight = topk_weights.index({token_idx, topk_slot})
+                                .to(expert_out.scalar_type())
+                                .unsqueeze(/*dim=*/-1);
+      output.index_add_(/*dim=*/0, token_idx, expert_out * combine_weight);
+    }
+
+    if (world_size_ > 1) {
+      output = parallel_state::reduce(output, tp_group_);
+    }
+    return output.reshape(hidden_states.sizes());
+  }
+
+  torch::Tensor forward_native_decode(const torch::Tensor& hidden_states) {
+    return forward_native_decode_impl(prepare_decode_routing(hidden_states),
+                                      /*trace=*/nullptr,
+                                      hidden_states.sizes());
+  }
+
+  torch::Tensor forward_decode_vectorized_fallback(
+      const torch::Tensor& hidden_states) {
+    return forward_decode_vectorized_fallback_impl(
+        prepare_decode_routing(hidden_states),
+        /*trace=*/nullptr,
+        hidden_states.sizes());
+  }
+
+  void load_state_dict(const StateDict& state_dict) {
+    if (state_dict.size() == 0) {
+      return;
+    }
+    if (ep_moe_) {
+      ep_moe_->load_state_dict(state_dict);
+      return;
+    }
+
+    auto gate_weight = state_dict.get_tensor("gate.weight");
+    if (gate_weight.defined() && !gate_weight_is_loaded_) {
+      torch::NoGradGuard no_grad;
+      auto gate_weight_t = gate_weight.to(gate_weight_.dtype())
+                               .transpose(/*dim0=*/0, /*dim1=*/1);
+      CHECK_EQ(gate_weight_.sizes(), gate_weight_t.sizes())
+          << "MiniMax sparse MoE gate.weight size mismatch";
+      gate_weight_.copy_(gate_weight_t);
+      gate_weight_is_loaded_ = true;
+    }
+    auto bias = state_dict.get_tensor("gate.e_score_correction_bias");
+    if (bias.defined() && !e_score_correction_bias_is_loaded_) {
+      torch::NoGradGuard no_grad;
+      CHECK_EQ(e_score_correction_bias_.sizes(), bias.sizes())
+          << "MiniMax e_score_correction_bias size mismatch";
+      e_score_correction_bias_.copy_(bias.to(e_score_correction_bias_.dtype()));
+      e_score_correction_bias_is_loaded_ = true;
+    }
+
+    torch::NoGradGuard no_grad;
+    for (int64_t expert_idx = 0; expert_idx < num_experts_; ++expert_idx) {
+      const std::string expert_prefix =
+          "experts." + std::to_string(expert_idx) + ".";
+      auto expert_state = state_dict.get_dict_with_prefix(expert_prefix);
+      auto w1 = expert_state.get_sharded_tensor(
+          "gate_proj.weight", /*dim=*/0, rank_, world_size_);
+      auto w3 = expert_state.get_sharded_tensor(
+          "up_proj.weight", /*dim=*/0, rank_, world_size_);
+      auto w2 = expert_state.get_sharded_tensor(
+          "down_proj.weight", /*dim=*/1, rank_, world_size_);
+      auto current_w13 = w13_.index({expert_idx});
+      auto current_w2 = w2_.index({expert_idx});
+      if (w1.defined()) {
+        auto current_w1 = current_w13.slice(/*dim=*/1,
+                                            /*start=*/0,
+                                            /*end=*/local_intermediate_size_);
+        auto w1_t = w1.transpose(/*dim0=*/0, /*dim1=*/1);
+        CHECK_EQ(current_w1.sizes(), w1_t.sizes())
+            << "MiniMax sparse MoE gate_proj weight size mismatch for expert "
+            << expert_idx;
+        current_w1.copy_(w1_t);
+        w13_is_loaded_ = true;
+      }
+      if (w3.defined()) {
+        auto current_w3 = current_w13.slice(
+            /*dim=*/1,
+            /*start=*/local_intermediate_size_,
+            /*end=*/local_intermediate_size_ * 2);
+        auto w3_t = w3.transpose(/*dim0=*/0, /*dim1=*/1);
+        CHECK_EQ(current_w3.sizes(), w3_t.sizes())
+            << "MiniMax sparse MoE up_proj weight size mismatch for expert "
+            << expert_idx;
+        current_w3.copy_(w3_t);
+        w13_is_loaded_ = true;
+      }
+      if (w2.defined()) {
+        auto w2_t = w2.transpose(/*dim0=*/0, /*dim1=*/1);
+        CHECK_EQ(current_w2.sizes(), w2_t.sizes())
+            << "MiniMax sparse MoE down_proj weight size mismatch for expert "
+            << expert_idx;
+        current_w2.copy_(w2_t);
+        w2_is_loaded_ = true;
+      }
+    }
+  }
+
+ private:
+  struct DecodeRoutingResult {
+    torch::Tensor hidden_states_2d;
+    torch::Tensor topk_ids_i32;
+    torch::Tensor topk_weights;
+  };
+
+  struct NativeDecodeTrace {
+    torch::Tensor expand_hidden_states;
+    torch::Tensor expand_row_ids;
+    torch::Tensor group_list;
+    torch::Tensor gemm1_out;
+    torch::Tensor act_out;
+    torch::Tensor gemm2_out;
+  };
+
+  struct FallbackDecodeTrace {
+    torch::Tensor expert_idx;
+    torch::Tensor expanded_hidden_states;
+    torch::Tensor gate_up;
+    torch::Tensor act_out;
+    torch::Tensor expert_out;
+  };
+
+  DecodeRoutingResult prepare_decode_routing(
+      const torch::Tensor& hidden_states) const {
+    auto hidden_states_2d =
+        hidden_states.reshape({-1, hidden_states.size(-1)}).contiguous();
+    auto router_logits =
+        torch::matmul(hidden_states_2d.to(torch::kFloat32), gate_weight_);
+
+    torch::Tensor routing_scores;
+    if (scoring_func_ == "sigmoid") {
+      routing_scores = torch::sigmoid(router_logits.to(torch::kFloat32));
+    } else if (scoring_func_ == "softmax") {
+      routing_scores =
+          torch::softmax(router_logits.to(torch::kFloat32), /*dim=*/-1);
+    } else {
+      LOG(FATAL) << "Unsupported MiniMax scoring_func " << scoring_func_;
+    }
+
+    auto choice_scores = routing_scores;
+    if (e_score_correction_bias_.defined()) {
+      choice_scores = choice_scores + e_score_correction_bias_;
+    }
+    if (minimax_m2_detail::should_limit_topk_by_group(
+            num_experts_, num_expert_group_, topk_group_)) {
+      choice_scores = minimax_m2_detail::mask_scores_by_selected_groups(
+          choice_scores, num_expert_group_, topk_group_);
+    }
+
+    auto topk_result = torch::topk(choice_scores,
+                                   topk_,
+                                   /*dim=*/-1,
+                                   /*largest=*/true,
+                                   /*sorted=*/false);
+    auto topk_ids_i32 = std::get<1>(topk_result).to(torch::kInt32).contiguous();
+    auto topk_weights = routing_scores.gather(
+        /*dim=*/1, topk_ids_i32.to(torch::kLong).contiguous());
+    if (renormalize_) {
+      topk_weights = topk_weights / (topk_weights.sum(-1, true) + 1e-6);
+    }
+    if (route_scale_ != 1.0) {
+      topk_weights = topk_weights * route_scale_;
+    }
+    topk_weights = topk_weights.contiguous();
+
+    return {hidden_states_2d, topk_ids_i32, topk_weights};
+  }
+
+  torch::Tensor forward_native_decode_impl(const DecodeRoutingResult& routing,
+                                           NativeDecodeTrace* trace,
+                                           torch::IntArrayRef output_shape) {
+    xllm::kernel::MoeInitRoutingV2Params moe_init_routing_params;
+    moe_init_routing_params.x = routing.hidden_states_2d;
+    moe_init_routing_params.expert_idx = routing.topk_ids_i32;
+    moe_init_routing_params.scale = std::nullopt;
+    moe_init_routing_params.offset = std::nullopt;
+    moe_init_routing_params.active_num =
+        routing.hidden_states_2d.size(0) * topk_;
+    moe_init_routing_params.expert_capacity = 0;
+    moe_init_routing_params.expert_num = num_experts_;
+    moe_init_routing_params.drop_pad_mode = 0;
+    moe_init_routing_params.expert_tokens_num_type = 1;
+    moe_init_routing_params.expert_tokens_num_flag = true;
+    moe_init_routing_params.row_idx_type = 0;
+    std::array<int64_t, 2> active_expert_range = {0, num_experts_};
+    moe_init_routing_params.active_expert_range = torch::IntArrayRef(
+        active_expert_range.data(), active_expert_range.size());
+    moe_init_routing_params.quant_mode = -1;
+    auto [expand_hidden_states, expand_row_ids, group_list, dynamic_scale] =
+        xllm::kernel::moe_init_routing_v2(moe_init_routing_params);
+    (void)dynamic_scale;
+
+    auto run_group_gemm = [&](const torch::Tensor& input,
+                              const torch::Tensor& weight) -> torch::Tensor {
+      xllm::kernel::GroupGemmParams params;
+      params.a = input;
+      params.b = weight;
+      params.group_list = group_list;
+      params.split_item = 2;
+      params.group_type = 0;
+      params.group_list_type = 1;
+      return xllm::kernel::group_gemm(params);
+    };
+
+    auto w1_gemm =
+        w13_.slice(/*dim=*/2, /*start=*/0, /*end=*/local_intermediate_size_);
+    auto gate_proj = run_group_gemm(expand_hidden_states, w1_gemm);
+
+    auto w3_gemm = w13_.slice(/*dim=*/2,
+                              /*start=*/local_intermediate_size_,
+                              /*end=*/local_intermediate_size_ * 2);
+    auto up_proj = run_group_gemm(expand_hidden_states, w3_gemm);
+
+    auto gemm1_out = torch::cat({gate_proj, up_proj}, /*dim=*/1);
+    auto act_out = torch::silu(gate_proj) * up_proj;
+
+    xllm::kernel::GroupGemmParams group_gemm2_params;
+    group_gemm2_params.a = act_out;
+    group_gemm2_params.b = w2_;
+    group_gemm2_params.group_list = group_list;
+    group_gemm2_params.split_item = 2;
+    group_gemm2_params.group_type = 0;
+    group_gemm2_params.group_list_type = 1;
+    auto gemm2_out = xllm::kernel::group_gemm(group_gemm2_params);
+
+    xllm::kernel::MoeCombineResultParams moe_combine_params;
+    moe_combine_params.input = gemm2_out;
+    moe_combine_params.reduce_weight = routing.topk_weights;
+    moe_combine_params.gather_ids = expand_row_ids;
+    auto output = xllm::kernel::moe_combine_result(moe_combine_params);
+    if (world_size_ > 1) {
+      output = parallel_state::reduce(output, tp_group_);
+    }
+    if (trace != nullptr) {
+      trace->expand_hidden_states = expand_hidden_states;
+      trace->expand_row_ids = expand_row_ids;
+      trace->group_list = group_list;
+      trace->gemm1_out = gemm1_out;
+      trace->act_out = act_out;
+      trace->gemm2_out = gemm2_out;
+    }
+    return output.reshape(output_shape);
+  }
+
+  torch::Tensor forward_decode_vectorized_fallback_impl(
+      const DecodeRoutingResult& routing,
+      FallbackDecodeTrace* trace,
+      torch::IntArrayRef output_shape) {
+    auto topk_ids = routing.topk_ids_i32.to(torch::kLong).contiguous();
+    const int64_t num_tokens = routing.hidden_states_2d.size(0);
+    auto token_idx =
+        torch::arange(num_tokens,
+                      routing.hidden_states_2d.options().dtype(torch::kLong))
+            .unsqueeze(/*dim=*/1)
+            .expand({num_tokens, topk_})
+            .reshape({-1})
+            .contiguous();
+    auto expert_idx = topk_ids.reshape({-1}).contiguous();
+    auto combine_weight = routing.topk_weights.reshape({-1})
+                              .to(routing.hidden_states_2d.scalar_type())
+                              .unsqueeze(/*dim=*/-1)
+                              .contiguous();
+
+    auto expanded_hidden_states = routing.hidden_states_2d.unsqueeze(/*dim=*/1)
+                                      .expand({num_tokens, topk_, hidden_size_})
+                                      .reshape({-1, hidden_size_})
+                                      .contiguous();
+    auto selected_w13 = w13_.index_select(/*dim=*/0, expert_idx);
+    auto gate_up =
+        torch::bmm(expanded_hidden_states.unsqueeze(/*dim=*/1), selected_w13)
+            .squeeze(/*dim=*/1);
+    auto gate_proj = gate_up.slice(/*dim=*/-1,
+                                   /*start=*/0,
+                                   /*end=*/local_intermediate_size_);
+    auto up_proj = gate_up.slice(/*dim=*/-1,
+                                 /*start=*/local_intermediate_size_,
+                                 /*end=*/local_intermediate_size_ * 2);
+    auto activated = torch::silu(gate_proj) * up_proj;
+
+    auto selected_w2 = w2_.index_select(/*dim=*/0, expert_idx);
+    auto expert_out = torch::bmm(activated.unsqueeze(/*dim=*/1), selected_w2)
+                          .squeeze(/*dim=*/1);
+
+    auto output = torch::zeros_like(routing.hidden_states_2d);
+    output.index_add_(/*dim=*/0, token_idx, expert_out * combine_weight);
+    if (world_size_ > 1) {
+      output = parallel_state::reduce(output, tp_group_);
+    }
+    if (trace != nullptr) {
+      trace->expert_idx = expert_idx;
+      trace->expanded_hidden_states = expanded_hidden_states;
+      trace->gate_up = gate_up;
+      trace->act_out = activated;
+      trace->expert_out = expert_out;
+    }
+    return output.reshape(output_shape);
+  }
+
+  DEFINE_WEIGHT(gate_weight);
+  DEFINE_WEIGHT(e_score_correction_bias);
+  DEFINE_WEIGHT(w13);
+  DEFINE_WEIGHT(w2);
+
+  int64_t rank_ = 0;
+  int64_t world_size_ = 1;
+  int64_t hidden_size_ = 0;
+  int64_t num_experts_ = 0;
+  int64_t topk_ = 0;
+  int64_t num_expert_group_ = 1;
+  int64_t topk_group_ = 1;
+  int64_t local_intermediate_size_ = 0;
+  double route_scale_ = 1.0;
+  bool renormalize_ = true;
+  std::string hidden_act_;
+  std::string scoring_func_;
+  ProcessGroup* tp_group_ = nullptr;
+  layer::FusedMoE ep_moe_{nullptr};
+};
+TORCH_MODULE(MiniMaxM2SparseMoE);
+
+class MiniMaxM2DecoderLayerImpl : public torch::nn::Module {
+ public:
+  MiniMaxM2DecoderLayerImpl(const ModelContext& context, int32_t layer_id) {
+    const auto& model_args = context.get_model_args();
+    const auto quant_args =
+        minimax_m2_detail::make_runtime_quant_args(context.get_quant_args());
+    const auto& parallel_args = context.get_parallel_args();
+    const auto& options = context.get_tensor_options();
+
+    attention_ = register_module("self_attn", MiniMaxM2Attention(context));
+    input_norm_ = register_module(
+        "input_layernorm",
+        layer::RMSNorm(
+            model_args.hidden_size(), model_args.rms_norm_eps(), options));
+    post_norm_ = register_module(
+        "post_attention_layernorm",
+        layer::RMSNorm(
+            model_args.hidden_size(), model_args.rms_norm_eps(), options));
+
+    if (model_args.n_routed_experts() > 0) {
+      moe_mlp_ = register_module("mlp", MiniMaxM2SparseMoE(context, layer_id));
+    } else {
+      dense_mlp_ =
+          register_module("mlp",
+                          layer::DenseMLP(model_args.hidden_size(),
+                                          model_args.intermediate_size(),
+                                          /*is_gated=*/true,
+                                          /*has_bias=*/false,
+                                          model_args.hidden_act(),
+                                          /*enable_result_reduction=*/true,
+                                          quant_args,
+                                          parallel_args.tp_group_,
+                                          options));
+    }
+  }
+
+  torch::Tensor forward(torch::Tensor& x,
+                        std::optional<torch::Tensor>& residual,
+                        torch::Tensor& positions,
+                        const layer::AttentionMetadata& attn_metadata,
+                        KVCache& kv_cache,
+                        const ModelInputParams& input_params) {
+    if (x.numel() == 0) {
+      // Keep the empty-hidden-state fast path trivial.
+      if (moe_mlp_) {
+        return moe_mlp_->forward(x, input_params);
+      }
+      return x;
+    }
+
+    if (!residual.has_value()) {
+      residual = x;
+      x = std::get<0>(input_norm_->forward(x));
+    } else {
+      std::tie(x, residual) = input_norm_->forward(x, residual);
+    }
+
+    x = attention_->forward(positions, x, attn_metadata, kv_cache);
+    std::tie(x, residual) = post_norm_->forward(x, residual);
+    if (moe_mlp_) {
+      x = moe_mlp_->forward(x, input_params);
+    } else {
+      x = dense_mlp_->forward(x);
+    }
+    return x;
+  }
+
+  void load_state_dict(const StateDict& state_dict) {
+    attention_->load_state_dict(state_dict.get_dict_with_prefix("self_attn."));
+    input_norm_->load_state_dict(
+        state_dict.get_dict_with_prefix("input_layernorm."));
+    post_norm_->load_state_dict(
+        state_dict.get_dict_with_prefix("post_attention_layernorm."));
+    if (moe_mlp_) {
+      moe_mlp_->load_state_dict(state_dict.get_dict_with_prefix("mlp."));
+    } else {
+      dense_mlp_->load_state_dict(state_dict.get_dict_with_prefix("mlp."));
+    }
+  }
+
+ private:
+  MiniMaxM2Attention attention_{nullptr};
+  layer::DenseMLP dense_mlp_{nullptr};
+  MiniMaxM2SparseMoE moe_mlp_{nullptr};
+  layer::RMSNorm input_norm_{nullptr};
+  layer::RMSNorm post_norm_{nullptr};
+};
+TORCH_MODULE(MiniMaxM2DecoderLayer);
+
+class MiniMaxM2ModelImpl
+    : public MiniMaxM2ModelImplBase<MiniMaxM2DecoderLayer> {
+ public:
+  explicit MiniMaxM2ModelImpl(const ModelContext& context)
+      : MiniMaxM2ModelImplBase<MiniMaxM2DecoderLayer>(
+            context.get_model_args()) {
+    const auto& options = context.get_tensor_options();
+    const auto& model_args = context.get_model_args();
+    const auto& quant_args = context.get_quant_args();
+    const auto& parallel_args = context.get_parallel_args();
+
+    if (quant_args.quant_method() == "fp8") {
+      enable_fp8_dynamic_dequant_ = true;
+      if (quant_args.weight_block_size().size() == 2 &&
+          quant_args.weight_block_size()[0] > 0 &&
+          quant_args.weight_block_size()[1] > 0) {
+        fp8_weight_block_size_ = {quant_args.weight_block_size()[0],
+                                  quant_args.weight_block_size()[1]};
+      }
+    }
+
+    layers_.reserve(model_args.n_layers());
+    hidden_size_ = model_args.hidden_size();
+    enable_mla_ = model_args.enable_mla();
+    embed_tokens_ =
+        register_module("embed_tokens",
+                        layer::WordEmbedding(model_args.vocab_size(),
+                                             model_args.hidden_size(),
+                                             parallel_args,
+                                             options));
+    norm_ = register_module("norm", layer::RMSNorm(context));
+    int32_t mask_value = FLAGS_enable_chunked_prefill ? -9984 : 1;
+    attn_mask_ = layer::AttentionMask(
+        options.device(), options.dtype().toScalarType(), mask_value);
+
+    for (int32_t i = 0; i < model_args.n_layers(); ++i) {
+      layers_.push_back(MiniMaxM2DecoderLayer(context, i));
+    }
+  }
+
+  ModelOutput forward(torch::Tensor tokens,
+                      torch::Tensor positions,
+                      std::vector<KVCache>& kv_caches,
+                      const ModelInputParams& input_params) {
+    ModelInputParams modified_input_params = input_params;
+    torch::Tensor h;
+    if (input_params.input_embedding.defined()) {
+      h = input_params.input_embedding;
+    } else if (tokens.numel() == 0) {
+      h = torch::empty({0, hidden_size_}, embed_tokens_->weight().options());
+    } else {
+      h = embed_tokens_(tokens);
+    }
+
+    if (!modified_input_params.attn_metadata) {
+      modified_input_params.attn_metadata =
+          std::make_shared<layer::AttentionMetadata>(
+              get_attention_metadata(modified_input_params, h));
+    }
+
+    auto& attn_metadata = *(modified_input_params.attn_metadata);
+    std::optional<torch::Tensor> residual;
+    for (size_t i = 0; i < layers_.size(); ++i) {
+#if defined(USE_CUDA) || defined(USE_MUSA)
+      attn_metadata.plan_info->layer_id = i;
+#endif
+      h = layers_[i](h,
+                     residual,
+                     positions,
+                     attn_metadata,
+                     kv_caches[i],
+                     modified_input_params);
+    }
+
+    if (h.numel() == 0) {
+      return ModelOutput(h);
+    }
+
+    auto [hidden_states, residual_out] = norm_(h, residual);
+    return ModelOutput(hidden_states, residual_out);
+  }
+
+  void load_state_dict(const StateDict& state_dict) {
+    embed_tokens_->load_state_dict(
+        state_dict.get_dict_with_prefix("embed_tokens."));
+
+    for (size_t i = 0; i < layers_.size(); ++i) {
+      const auto layer_state_dict =
+          state_dict.get_dict_with_prefix("layers." + std::to_string(i) + ".");
+      std::unordered_map<std::string, torch::Tensor> remapped_layer_state_dict;
+      remapped_layer_state_dict.reserve(layer_state_dict.size());
+      std::unordered_map<std::string, torch::Tensor> pending_fp8_weights;
+      std::unordered_map<std::string, torch::Tensor> pending_fp8_scales;
+
+      for (const auto& [name, tensor] : layer_state_dict) {
+        std::string mapped_name =
+            minimax_m2_detail::remap_layer_weight_name(name);
+        if (enable_fp8_dynamic_dequant_) {
+          if (absl::EndsWith(mapped_name, ".weight_scale_inv")) {
+            const std::string paired_weight_name =
+                mapped_name.substr(0, mapped_name.size() - 10);
+            auto pending_weight = pending_fp8_weights.find(paired_weight_name);
+            if (pending_weight != pending_fp8_weights.end()) {
+              remapped_layer_state_dict.emplace(
+                  paired_weight_name,
+                  minimax_m2_detail::dequantize_fp8_block_weight(
+                      pending_weight->second, tensor, fp8_weight_block_size_));
+              pending_fp8_weights.erase(pending_weight);
+            } else {
+              pending_fp8_scales.emplace(mapped_name, tensor);
+            }
+            continue;
+          }
+
+          if (absl::EndsWith(mapped_name, ".weight") &&
+              minimax_m2_detail::is_fp8_dtype(tensor.scalar_type())) {
+            const std::string scale_name = mapped_name + "_scale_inv";
+            auto pending_scale = pending_fp8_scales.find(scale_name);
+            if (pending_scale != pending_fp8_scales.end()) {
+              remapped_layer_state_dict.emplace(
+                  mapped_name,
+                  minimax_m2_detail::dequantize_fp8_block_weight(
+                      tensor, pending_scale->second, fp8_weight_block_size_));
+              pending_fp8_scales.erase(pending_scale);
+            } else {
+              pending_fp8_weights.emplace(mapped_name, tensor);
+            }
+            continue;
+          }
+        }
+
+        remapped_layer_state_dict.emplace(mapped_name, tensor);
+      }
+
+      if (enable_fp8_dynamic_dequant_) {
+        CHECK(pending_fp8_weights.empty() && pending_fp8_scales.empty())
+            << "Unpaired fp8 MiniMax-M2 weight/scale tensors detected: "
+            << "pending_weights=" << pending_fp8_weights.size()
+            << ", pending_scales=" << pending_fp8_scales.size();
+      }
+
+      layers_[i]->load_state_dict(
+          StateDict(std::move(remapped_layer_state_dict)));
+    }
+
+    norm_->load_state_dict(state_dict.get_dict_with_prefix("norm."));
+  }
+
+ private:
+  layer::AttentionMetadata get_attention_metadata(
+      const ModelInputParams& params,
+      const torch::Tensor& h) {
+    if (params.q_max_seq_len == 0) {
+      return layer::AttentionMetadataBuilder::build(params, enable_mla_);
+    }
+
+    max_seq_len_ = std::max(params.kv_max_seq_len, max_seq_len_);
+    torch::Tensor attn_mask;
+    if (FLAGS_enable_chunked_prefill) {
+      const int32_t max_kv_seq = params.kv_max_seq_len;
+      const int32_t num_sequences = params.num_sequences;
+      if (num_sequences > 0) {
+        std::vector<torch::Tensor> req_mask_vec;
+        req_mask_vec.reserve(num_sequences);
+        for (int32_t j = 0; j < num_sequences; ++j) {
+          req_mask_vec.emplace_back(
+              attn_mask_.gen_append_mask(params.q_seq_lens_vec[j],
+                                         params.kv_seq_lens_vec[j],
+                                         max_kv_seq,
+                                         h.dtype().toScalarType(),
+                                         h.device()));
+        }
+        attn_mask = torch::cat(req_mask_vec, 0);
+      } else {
+        attn_mask = attn_mask_.get_attn_mask(
+            max_seq_len_, h.dtype().toScalarType(), h.device());
+      }
+    } else {
+      attn_mask = attn_mask_.get_attn_mask(
+          max_seq_len_, h.dtype().toScalarType(), h.device());
+    }
+    return layer::AttentionMetadataBuilder::build(
+        params, enable_mla_, attn_mask);
+  }
+
+  int64_t hidden_size_ = 0;
+  layer::AttentionMask attn_mask_;
+  bool enable_mla_ = false;
+  bool enable_fp8_dynamic_dequant_ = false;
+  std::array<int64_t, 2> fp8_weight_block_size_ = {128, 128};
+};
+TORCH_MODULE(MiniMaxM2Model);
+
+class MiniMaxM2ForCausalLMImpl
+    : public MiniMaxM2ForCausalLMImplBase<MiniMaxM2Model> {
+ public:
+  explicit MiniMaxM2ForCausalLMImpl(const ModelContext& context)
+      : MiniMaxM2ForCausalLMImplBase<MiniMaxM2Model>(context) {}
+};
+TORCH_MODULE(MiniMaxM2ForCausalLM);
+
+REGISTER_CAUSAL_MODEL(minimax_m2, MiniMaxM2ForCausalLM);
+
+REGISTER_MODEL_ARGS(minimax_m2, [&] {
+  LOAD_ARG_OR(model_type, "model_type", "minimax_m2");
+  LOAD_ARG_OR(dtype, "torch_dtype", "bfloat16");
+  LOAD_ARG_OR(attention_bias, "attention_bias", false);
+  LOAD_ARG_OR(attention_dropout, "attention_dropout", 0.0f);
+  LOAD_ARG_OR(bos_token_id, "bos_token_id", 200019);
+  LOAD_ARG_OR(eos_token_id, "eos_token_id", 200020);
+  LOAD_ARG_OR(head_dim, "head_dim", 128);
+  LOAD_ARG_OR(rotary_dim, "rotary_dim", 64);
+  LOAD_ARG_OR(hidden_act, "hidden_act", "silu");
+  LOAD_ARG_OR(hidden_size, "hidden_size", 3072);
+  LOAD_ARG_OR(intermediate_size, "intermediate_size", 1536);
+  LOAD_ARG_OR(max_position_embeddings, "max_position_embeddings", 196608);
+  LOAD_ARG_OR(max_window_layers, "max_window_layers", 62);
+  LOAD_ARG_OR(moe_intermediate_size, "intermediate_size", 1536);
+  SET_ARG(n_shared_experts, 0);
+  LOAD_ARG_OR(norm_topk_prob, "norm_topk_prob", true);
+  LOAD_ARG_OR(n_heads, "num_attention_heads", 48);
+  LOAD_ARG_OR(num_experts, "num_local_experts", 256);
+  LOAD_ARG_OR(n_routed_experts, "num_local_experts", 256);
+  LOAD_ARG_OR(num_experts_per_tok, "num_experts_per_tok", 8);
+  LOAD_ARG_OR(n_group, "n_group", 1);
+  LOAD_ARG_OR(n_layers, "num_hidden_layers", 62);
+  if (json.contains("attn_type_list")) {
+    const auto attn_type_list =
+        json.value_or<std::vector<int>>("attn_type_list", std::vector<int>());
+    if (!attn_type_list.empty() &&
+        args->n_layers() != static_cast<int32_t>(attn_type_list.size())) {
+      LOG(WARNING) << "MiniMax config mismatch: num_hidden_layers="
+                   << args->n_layers()
+                   << ", attn_type_list size=" << attn_type_list.size()
+                   << ". Using attn_type_list size.";
+      args->n_layers() = static_cast<int32_t>(attn_type_list.size());
+    }
+  }
+  LOAD_ARG_OR(n_kv_heads, "num_key_value_heads", 8);
+  LOAD_ARG_OR(output_router_logits, "output_router_logits", false);
+  LOAD_ARG_OR(qk_norm_type, "qk_norm_type", "");
+  LOAD_ARG_OR(use_qk_norm, "use_qk_norm", true);
+  LOAD_ARG_OR(rms_norm_eps, "rms_norm_eps", 1e-6);
+  LOAD_ARG_OR(rope_theta, "rope_theta", 5000000.0f);
+  LOAD_ARG_OR(scoring_func, "scoring_func", "sigmoid");
+  LOAD_ARG_OR(topk_group, "topk_group", 1);
+  LOAD_ARG_OR(routed_scaling_factor, "routed_scaling_factor", 1.0f);
+  LOAD_ARG_OR(router_aux_loss_coef, "router_aux_loss_coef", 0.0f);
+  LOAD_ARG_OR(use_sliding_window, "use_sliding_window", false);
+  LOAD_ARG_OR(tie_word_embeddings, "tie_word_embeddings", false);
+  LOAD_ARG_OR(vocab_size, "vocab_size", 200064);
+  LOAD_ARG_OR(mlp_only_layers, "mlp_only_layers", std::vector<int>());
+
+  SET_ARG(stop_token_ids, std::unordered_set<int32_t>({args->eos_token_id()}));
+  SET_ARG(topk_method, "noaux_tc");
+});
+
+}  // namespace xllm

--- a/xllm/models/models.h
+++ b/xllm/models/models.h
@@ -35,6 +35,7 @@ limitations under the License.
 #include "llm/npu/kimi_k2.h"                  // IWYU pragma: keep
 #include "llm/npu/llama.h"                    // IWYU pragma: keep
 #include "llm/npu/llama3.h"                   // IWYU pragma: keep
+#include "llm/npu/minimax_m2.h"               // IWYU pragma: keep
 #include "llm/npu/oxygen.h"                   // IWYU pragma: keep
 #include "llm/npu/qwen2.h"                    // IWYU pragma: keep
 #include "llm/npu/qwen3.h"                    // IWYU pragma: keep

--- a/xllm/pybind/CMakeLists.txt
+++ b/xllm/pybind/CMakeLists.txt
@@ -25,6 +25,5 @@ pybind_extension(
     c10
 )
 target_link_options(xllm_export PRIVATE -Wl,-Bsymbolic)
-target_link_libraries(common PRIVATE leveldb::leveldb OpenSSL::SSL OpenSSL::Crypto protobuf::libprotobuf)
-add_dependencies(common brpc-static)
-
+target_link_libraries(xllm_export PRIVATE leveldb::leveldb OpenSSL::SSL OpenSSL::Crypto protobuf::libprotobuf)
+add_dependencies(xllm_export brpc-static)


### PR DESCRIPTION
## Summary
- add MiniMax M2-series support on xLLM NPU path, covering MiniMax-M2/M2.1/M2.5/M2.7
- introduce MiniMax-specific model registration, decoder loader, attention, router, and decode MoE path
- add the CANN 8.5 baseline needed to bring the model up on xLLM
- add an offline `fp8 -> bf16` conversion tool for faster and simpler bf16 baseline validation

## Verified Baseline
- environment: CANN 8.5 + torch-npu 2.7.1
- stable baseline: bf16 checkpoint, pure TP=16, ACL graph enabled
- server can load weights, finish warmup, and serve OpenAI-compatible requests

## Current Limitations
- EP is not the current stable baseline yet
- direct fp8 runtime still needs separate re-validation on the new stack
- performance optimization is not the focus of this PR
