### PR TITLE
refactor: prefer const_iterators to iterators.

### DIFF
--- a/xllm/core/common/interruption_bus.h
+++ b/xllm/core/common/interruption_bus.h
@@ -26,8 +26,8 @@ class InterruptionBus {
   void subscribe(std::function<void(bool)> func) { observers_.push_back(func); }
 
   void publish(bool interruption) {
-    for (auto it = observers_.begin(); it != observers_.end(); ++it) {
-      auto& observer = *it;
+    for (auto it = observers_.cbegin(); it != observers_.cend(); ++it) {
+      const auto& observer = *it;
       observer(interruption);
     }
   }

--- a/xllm/core/framework/batch/batch_input_builder.cpp
+++ b/xllm/core/framework/batch/batch_input_builder.cpp
@@ -425,8 +425,8 @@ void BatchInputBuilder::setup_kv_cache_info(
 
   // calculate the block ids that need to be written
   int32_t kv_cache_block_idx = n_kv_cache_tokens / block_size;
-  for (auto iter = block_ids.begin() + kv_cache_block_idx;
-       iter != block_ids.end();
+  for (auto iter = block_ids.cbegin() + kv_cache_block_idx;
+       iter != block_ids.cend();
        ++iter) {
     write_block_ids.insert(*iter);
   }

--- a/xllm/core/framework/request/mm_input.h
+++ b/xllm/core/framework/request/mm_input.h
@@ -108,6 +108,14 @@ class MMInput {
 
   std::vector<MMInputItem>::const_iterator end() const { return items_.end(); }
 
+  std::vector<MMInputItem>::const_iterator cbegin() const {
+    return items_.cbegin();
+  }
+
+  std::vector<MMInputItem>::const_iterator cend() const {
+    return items_.cend();
+  }
+
   void insert(const std::vector<MMInputItem>& inputs) {
     items_.insert(items_.end(), inputs.begin(), inputs.end());
   }
@@ -129,7 +137,7 @@ class MMInput {
   std::vector<VideoMetadata> get_video_metadata() const {
     std::vector<VideoMetadata> metas;
     metas.reserve(items_.size());
-    for (auto& item : items_) {
+    for (const auto& item : items_) {
       if (item.has_type(MMType::VIDEO)) {
         metas.push_back(item.video_meta);
       }

--- a/xllm/core/layers/npu/loader/deepseek_v2_decoder_loader.cpp
+++ b/xllm/core/layers/npu/loader/deepseek_v2_decoder_loader.cpp
@@ -376,10 +376,10 @@ void DeekseekV2DecoderLoader::process_expert_weights(
   const int safe_end =
       std::min(end_idx, static_cast<int>(device_expert_list_.size()));
 
-  auto it = std::find(device_expert_list_.begin() + start_idx,
-                      device_expert_list_.begin() + safe_end,
+  auto it = std::find(device_expert_list_.cbegin() + start_idx,
+                      device_expert_list_.cbegin() + safe_end,
                       expert_index);
-  const bool in_partition = it != device_expert_list_.begin() + safe_end;
+  const bool in_partition = it != device_expert_list_.cbegin() + safe_end;
 
   // Early return if neither EPLB nor partition needs this expert
   if (!needs_eplb && !in_partition) {
@@ -420,11 +420,11 @@ void DeekseekV2DecoderLoader::process_expert_weights(
   // Step 5: Handle partition case
   if (in_partition) {
     std::vector<size_t> matches_pos;
-    for (auto iter = it; iter != device_expert_list_.begin() + safe_end;
+    for (auto iter = it; iter != device_expert_list_.cbegin() + safe_end;
          ++iter) {
       if (*iter == expert_index) {
         matches_pos.emplace_back(
-            std::distance(device_expert_list_.begin(), iter) - start_idx);
+            std::distance(device_expert_list_.cbegin(), iter) - start_idx);
       }
     }
 

--- a/xllm/core/layers/npu/loader/deepseek_v32_decoder_loader.cpp
+++ b/xllm/core/layers/npu/loader/deepseek_v32_decoder_loader.cpp
@@ -422,10 +422,10 @@ void DeekseekV32DecoderLoader::process_expert_weights(
   const int safe_end =
       std::min(end_idx, static_cast<int>(device_expert_list_.size()));
 
-  auto it = std::find(device_expert_list_.begin() + start_idx,
-                      device_expert_list_.begin() + safe_end,
+  auto it = std::find(device_expert_list_.cbegin() + start_idx,
+                      device_expert_list_.cbegin() + safe_end,
                       expert_index);
-  const bool in_partition = it != device_expert_list_.begin() + safe_end;
+  const bool in_partition = it != device_expert_list_.cbegin() + safe_end;
 
   // Early return if neither EPLB nor partition needs this expert
   if (!needs_eplb && !in_partition) {
@@ -466,11 +466,11 @@ void DeekseekV32DecoderLoader::process_expert_weights(
   // Step 5: Handle partition case
   if (in_partition) {
     std::vector<size_t> matches_pos;
-    for (auto iter = it; iter != device_expert_list_.begin() + safe_end;
+    for (auto iter = it; iter != device_expert_list_.cbegin() + safe_end;
          ++iter) {
       if (*iter == expert_index) {
         matches_pos.emplace_back(
-            std::distance(device_expert_list_.begin(), iter) - start_idx);
+            std::distance(device_expert_list_.cbegin(), iter) - start_idx);
       }
     }
 

--- a/xllm/core/runtime/params_utils.cpp
+++ b/xllm/core/runtime/params_utils.cpp
@@ -636,13 +636,13 @@ void forward_output_to_proto(const torch::Tensor& next_tokens,
           pb_token.set_empty(true);
         }
         pb_token.mutable_top_tokens()->Reserve(token.top_tokens.size());
-        for (auto it = token.top_tokens.begin(); it != token.top_tokens.end();
+        for (auto it = token.top_tokens.cbegin(); it != token.top_tokens.cend();
              ++it) {
           pb_token.add_top_tokens(*it);
         }
         pb_token.mutable_top_logprobs()->Reserve(token.top_logprobs.size());
-        for (auto it = token.top_logprobs.begin();
-             it != token.top_logprobs.end();
+        for (auto it = token.top_logprobs.cbegin();
+             it != token.top_logprobs.cend();
              ++it) {
           pb_token.add_top_logprobs(*it);
         }
@@ -674,13 +674,13 @@ void forward_output_to_proto(const torch::Tensor& next_tokens,
           pb_token.set_empty(true);
         }
         pb_token.mutable_top_tokens()->Reserve(token.top_tokens.size());
-        for (auto it = token.top_tokens.begin(); it != token.top_tokens.end();
+        for (auto it = token.top_tokens.cbegin(); it != token.top_tokens.cend();
              ++it) {
           pb_token.add_top_tokens(*it);
         }
         pb_token.mutable_top_logprobs()->Reserve(token.top_logprobs.size());
-        for (auto it = token.top_logprobs.begin();
-             it != token.top_logprobs.end();
+        for (auto it = token.top_logprobs.cbegin();
+             it != token.top_logprobs.cend();
              ++it) {
           pb_token.add_top_logprobs(*it);
         }

--- a/xllm/core/scheduler/continuous_scheduler.cpp
+++ b/xllm/core/scheduler/continuous_scheduler.cpp
@@ -825,7 +825,7 @@ std::vector<Batch> ContinuousScheduler::prepare_batch() {
       // new prefill has high priority, but these requests has lower priority
       // then existed requests in running_queue_ in decoding stage.
       // so we need to push them to the back of running_queue_.
-      for (auto it = running_requests_.begin(); it != running_requests_.end();
+      for (auto it = running_requests_.cbegin(); it != running_requests_.cend();
            ++it) {
         // finished request is set to nullptr
         if (*it == nullptr) {
@@ -849,7 +849,8 @@ std::vector<Batch> ContinuousScheduler::prepare_batch() {
       // remaining requests. Therefore, the `push_front`
       // method needs to be used.
       //
-      for (auto it = running_requests_.rbegin(); it != running_requests_.rend();
+      for (auto it = running_requests_.crbegin();
+           it != running_requests_.crend();
            ++it) {
         // finished request is set to nullptr
         if (*it == nullptr) {
@@ -864,7 +865,7 @@ std::vector<Batch> ContinuousScheduler::prepare_batch() {
       }
     }
   } else {
-    for (auto it = running_requests_.begin(); it != running_requests_.end();
+    for (auto it = running_requests_.cbegin(); it != running_requests_.cend();
          ++it) {
       if (*it == nullptr) {
         continue;

--- a/xllm/core/scheduler/mix_scheduler.cpp
+++ b/xllm/core/scheduler/mix_scheduler.cpp
@@ -55,9 +55,9 @@ void MixScheduler::get_latency_budget_and_request_order(
 
   int32_t min_remaining_time = std::numeric_limits<int32_t>::max();
   int32_t min_tpot = std::numeric_limits<int32_t>::max();
-  for (auto it = running_queue.begin(); it != running_queue.end(); it++) {
-    auto request = *it;
-    auto& sequence = request->sequences()[0];
+  for (auto it = running_queue.cbegin(); it != running_queue.cend(); it++) {
+    const auto request = *it;
+    const auto& sequence = request->sequences()[0];
     auto remaining_time = request->get_remaining_time();
     total_exec_time += sequence->estimated_latency();
     if (request->tpot_slo_ms() < min_tpot) {

--- a/xllm/core/scheduler/pd_ooc_scheduler.cpp
+++ b/xllm/core/scheduler/pd_ooc_scheduler.cpp
@@ -240,7 +240,7 @@ std::vector<Batch> PDOOCScheduler::prepare_batch() {
       // new prefill has high priority, but these requests has lower priority
       // then existed requests in running_queue_ in decoding stage.
       // so we need to push them to the back of running_queue_.
-      for (auto it = running_requests_.begin(); it != running_requests_.end();
+      for (auto it = running_requests_.cbegin(); it != running_requests_.cend();
            ++it) {
         // finished request is set to nullptr
         if (*it == nullptr) {
@@ -264,7 +264,8 @@ std::vector<Batch> PDOOCScheduler::prepare_batch() {
       // remaining requests. Therefore, the `push_front`
       // method needs to be used.
       //
-      for (auto it = running_requests_.rbegin(); it != running_requests_.rend();
+      for (auto it = running_requests_.crbegin();
+           it != running_requests_.crend();
            ++it) {
         // finished request is set to nullptr
         if (*it == nullptr) {
@@ -279,7 +280,7 @@ std::vector<Batch> PDOOCScheduler::prepare_batch() {
       }
     }
   } else {
-    for (auto it = running_requests_.begin(); it != running_requests_.end();
+    for (auto it = running_requests_.cbegin(); it != running_requests_.cend();
          ++it) {
       if (*it == nullptr) {
         continue;

--- a/xllm/core/scheduler/prefill_only_scheduler.cpp
+++ b/xllm/core/scheduler/prefill_only_scheduler.cpp
@@ -485,7 +485,7 @@ std::vector<Batch> PrefillOnlyScheduler::prepare_batch() {
       // new prefill has high priority, but these requests has lower priority
       // then existed requests in running_queue_ in decoding stage.
       // so we need to push them to the back of running_queue_.
-      for (auto it = running_requests_.begin(); it != running_requests_.end();
+      for (auto it = running_requests_.cbegin(); it != running_requests_.cend();
            ++it) {
         // finished request is set to nullptr
         if (*it == nullptr) {
@@ -513,7 +513,8 @@ std::vector<Batch> PrefillOnlyScheduler::prepare_batch() {
       // remaining requests. Therefore, the `push_front`
       // method needs to be used.
       //
-      for (auto it = running_requests_.rbegin(); it != running_requests_.rend();
+      for (auto it = running_requests_.crbegin();
+           it != running_requests_.crend();
            ++it) {
         // finished request is set to nullptr
         if (*it == nullptr) {
@@ -529,7 +530,7 @@ std::vector<Batch> PrefillOnlyScheduler::prepare_batch() {
     }
   } else {
     // directly push running requests to the priority queue
-    for (auto it = running_requests_.begin(); it != running_requests_.end();
+    for (auto it = running_requests_.cbegin(); it != running_requests_.cend();
          ++it) {
       if (*it == nullptr) {
         continue;

--- a/xllm/core/util/slice.h
+++ b/xllm/core/util/slice.h
@@ -40,6 +40,8 @@ class Slice final {
   // iterator for the slice
   const T* begin() const { return data_; }
   const T* end() const { return data_ + size_; }
+  const T* cbegin() const { return data_; }
+  const T* cend() const { return data_ + size_; }
 
   // get the size of the slice
   size_t size() const { return size_; }

--- a/xllm/core/util/suffix_decoding_cache.cpp
+++ b/xllm/core/util/suffix_decoding_cache.cpp
@@ -231,7 +231,7 @@ void SuffixDecodingCache::maybe_evict_requests(int32_t new_seq_id) {
   while (static_cast<int32_t>(req_to_seq_id_.size()) > max_cached_requests_) {
     bool evicted = false;
 
-    for (auto it = cache_order_.begin(); it != cache_order_.end(); ++it) {
+    for (auto it = cache_order_.cbegin(); it != cache_order_.cend(); ++it) {
       const std::string& req_id = *it;
       auto req_it = req_to_seq_id_.find(req_id);
       if (req_it == req_to_seq_id_.end()) {


### PR DESCRIPTION
Replace iterators with const_iterators following "Effective Modern C++" Item 13 guidelines.

> Item 13: Prefer const_iterators to iterators.