### PR TITLE
bugfix: avoid rebuilding xllm_ops repeatedly when marker is missing.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -41,11 +41,16 @@ if(USE_NPU)
   message(STATUS "Using xllm_atb_layers source at: ${XLLM_ATB_LAYERS_SOURCE_DIR}")
 
   execute_process(
-    COMMAND git -C "${CMAKE_SOURCE_DIR}/third_party/xllm_ops" rev-parse HEAD
+    COMMAND git -c "safe.directory=${CMAKE_SOURCE_DIR}/third_party/xllm_ops" -C "${CMAKE_SOURCE_DIR}/third_party/xllm_ops" rev-parse HEAD
     OUTPUT_VARIABLE XLLM_OPS_GIT_HEAD
     OUTPUT_STRIP_TRAILING_WHITESPACE
     ERROR_QUIET
   )
+  if(DEFINED ENV{ASCEND_HOME_PATH} AND NOT "$ENV{ASCEND_HOME_PATH}" STREQUAL "")
+    set(XLLM_OPS_MARKER_PATH "$ENV{ASCEND_HOME_PATH}/opp/vendors/xllm/.xllm_ops_git_head")
+  else()
+    set(XLLM_OPS_MARKER_PATH "/usr/local/Ascend/ascend-toolkit/latest/opp/vendors/xllm/.xllm_ops_git_head")
+  endif()
 
   if(NOT DEFINED XLLM_OPS_GIT_HEAD_CACHED OR NOT XLLM_OPS_GIT_HEAD STREQUAL XLLM_OPS_GIT_HEAD_CACHED)
     message(STATUS "xllm_ops git HEAD changed; running precompile via execute_process")
@@ -58,6 +63,9 @@ if(USE_NPU)
       message(FATAL_ERROR "Failed to precompile xllm ops, error code: ${XLLM_OPS_RESULT}")
     endif()
     set(XLLM_OPS_GIT_HEAD_CACHED "${XLLM_OPS_GIT_HEAD}" CACHE INTERNAL "" FORCE)
+    get_filename_component(XLLM_OPS_MARKER_DIR "${XLLM_OPS_MARKER_PATH}" DIRECTORY)
+    file(MAKE_DIRECTORY "${XLLM_OPS_MARKER_DIR}")
+    file(WRITE "${XLLM_OPS_MARKER_PATH}" "${XLLM_OPS_GIT_HEAD}\n")
     message(STATUS "xllm ops precompiled and HEAD cache updated")
   else()
     message(STATUS "xllm_ops git HEAD unchanged; skipping precompile")

--- a/utils.py
+++ b/utils.py
@@ -333,8 +333,50 @@ def _ensure_prebuild_dependencies_installed(script_path: str) -> None:
     _export_cmake_prefix_paths(["/usr/local/yalantinglibs"])
 
 
+def _get_cmake_cache_path() -> str:
+    plat_name = sysconfig.get_platform()
+    dir_name = f"cmake.{plat_name}-{sys.implementation.name}-{get_python_version()}"
+    return os.path.join(get_base_dir(), "build", dir_name, "CMakeCache.txt")
+
+
+def _get_xllm_ops_marker_path() -> str:
+    ascend_home = os.getenv("ASCEND_HOME_PATH", "/usr/local/Ascend/ascend-toolkit/latest")
+    opp_root = os.path.join(ascend_home, "opp")
+    return os.path.join(opp_root, "vendors", "xllm", ".xllm_ops_git_head")
+
+
+def _clear_xllm_ops_cache_git_head(cache_path: str) -> bool:
+    if not os.path.isfile(cache_path):
+        return False
+
+    cache_prefix = "XLLM_OPS_GIT_HEAD_CACHED:"
+    with open(cache_path, "r", encoding="utf-8") as cache_file:
+        old_lines = cache_file.readlines()
+
+    new_lines = [line for line in old_lines if not line.startswith(cache_prefix)]
+    if new_lines == old_lines:
+        return False
+
+    temp_file_path = f"{cache_path}.tmp"
+    with open(temp_file_path, "w", encoding="utf-8") as cache_file:
+        cache_file.writelines(new_lines)
+    os.replace(temp_file_path, cache_path)
+    return True
+
+
+def _ensure_xllm_ops_rebuild_on_missing_marker() -> None:
+    marker_path = _get_xllm_ops_marker_path()
+    if os.path.isfile(marker_path):
+        return
+
+    cmake_cache_path = _get_cmake_cache_path()
+    if _clear_xllm_ops_cache_git_head(cmake_cache_path):
+        print("✅ Cleared XLLM_OPS_GIT_HEAD_CACHED from CMake cache to trigger xllm_ops rebuild.")
+        return
+
 def pre_build() -> None:
     script_path = os.path.dirname(os.path.abspath(__file__))
 
     _validate_submodules_or_exit(script_path)
     _ensure_prebuild_dependencies_installed(script_path)
+    _ensure_xllm_ops_rebuild_on_missing_marker()


### PR DESCRIPTION
During development, switching to a new container could leave /usr/local without the installed xllm_ops shared library, which required developers to rebuild xllm_ops manually. This change fixes that by detecting the missing install marker and triggering the rebuild automatically.