### PR TITLE
refactor: use constexpr whenever possible.

### DIFF
--- a/xllm/core/framework/batch/batch_forward_type.h
+++ b/xllm/core/framework/batch/batch_forward_type.h
@@ -46,23 +46,27 @@ class BatchForwardType {
     return *this;
   }
 
-  int32_t value() const { return value_; }
+  constexpr int32_t value() const { return value_; }
 
-  bool is_prefill() const { return (value_ == PREFILL); }
+  constexpr bool is_prefill() const { return (value_ == PREFILL); }
 
-  bool is_chunked_prefill() const { return (value_ == CHUNKED_PREFILL); }
+  constexpr bool is_chunked_prefill() const {
+    return (value_ == CHUNKED_PREFILL);
+  }
 
-  bool no_decode() const {
+  constexpr bool no_decode() const {
     return (value_ == PREFILL || value_ == CHUNKED_PREFILL);
   }
 
-  bool has_decode() const { return (value_ == DECODE || value_ == MIXED); }
+  constexpr bool has_decode() const {
+    return (value_ == DECODE || value_ == MIXED);
+  }
 
-  bool is_decode() const { return (value_ == DECODE); }
+  constexpr bool is_decode() const { return (value_ == DECODE); }
 
-  bool is_mixed() const { return (value_ == MIXED); }
+  constexpr bool is_mixed() const { return (value_ == MIXED); }
 
-  bool is_empty() const { return (value_ == EMPTY); }
+  constexpr bool is_empty() const { return (value_ == EMPTY); }
 
   std::string to_string() const {
     switch (value_) {

--- a/xllm/core/framework/block/block.h
+++ b/xllm/core/framework/block/block.h
@@ -43,10 +43,10 @@ class Block final {
   Block& operator=(Block&& other) noexcept;
 
   // get the block id
-  int32_t id() const { return id_; }
+  constexpr int32_t id() const { return id_; }
 
   // get the block size
-  uint32_t size() const { return size_; }
+  constexpr uint32_t size() const { return size_; }
 
   // get the reference count, 0 if the block is invalid after move
   uint32_t ref_count() const { return ref_count_ == nullptr ? 0 : *ref_count_; }
@@ -67,7 +67,9 @@ class Block final {
     memcpy(hash_value_, hash_value, XXH3_128BITS_HASH_VALUE_LEN);
   }
 
-  uint32_t get_hash_value_len() const { return XXH3_128BITS_HASH_VALUE_LEN; }
+  constexpr uint32_t get_hash_value_len() const {
+    return XXH3_128BITS_HASH_VALUE_LEN;
+  }
 
  private:
   // increase reference count
@@ -92,7 +94,7 @@ class Block final {
 };
 
 // equeal operator, mainly used for testing
-inline bool operator==(const Block& lhs, const Block& rhs) {
+inline constexpr bool operator==(const Block& lhs, const Block& rhs) {
   return lhs.id() == rhs.id();
 }
 

--- a/xllm/core/framework/request/mm_type.h
+++ b/xllm/core/framework/request/mm_type.h
@@ -34,15 +34,15 @@ class MMType {
   };
 
   MMType() = default;
-  MMType(Value v) : value_(v) {}
-  operator Value() const { return value_; }
+  constexpr MMType(Value v) : value_(v) {}
+  constexpr operator Value() const { return value_; }
   explicit operator bool() const = delete;
 
-  bool operator==(MMType rhs) const { return value_ == rhs.value_; }
-  bool operator!=(MMType rhs) const { return value_ != rhs.value_; }
+  constexpr bool operator==(MMType rhs) const { return value_ == rhs.value_; }
+  constexpr bool operator!=(MMType rhs) const { return value_ != rhs.value_; }
 
-  bool operator==(Value v) const { return value_ == v; }
-  bool operator!=(Value v) const { return value_ != v; }
+  constexpr bool operator==(Value v) const { return value_ == v; }
+  constexpr bool operator!=(Value v) const { return value_ != v; }
 
   std::optional<std::string> to_string();
 

--- a/xllm/core/framework/request/stopping_checker.h
+++ b/xllm/core/framework/request/stopping_checker.h
@@ -42,21 +42,23 @@ class StoppingChecker {
     max_generated_tokens_ = tokens;
   }
 
-  inline size_t get_max_generated_tokens() const {
+  inline constexpr size_t get_max_generated_tokens() const {
     return max_generated_tokens_;
   }
 
   inline void set_max_context_len(size_t len) { max_context_len_ = len; }
 
-  inline size_t get_max_context_len() const { return max_context_len_; }
+  inline constexpr size_t get_max_context_len() const {
+    return max_context_len_;
+  }
 
   inline void set_eos_token(int32_t eos_token) { eos_token_ = eos_token; }
 
-  inline int32_t get_eos_token() const { return eos_token_; }
+  inline constexpr int32_t get_eos_token() const { return eos_token_; }
 
   inline void set_ignore_eos(bool ignore_eos) { ignore_eos_ = ignore_eos; }
 
-  inline bool get_ignore_eos() const { return ignore_eos_; }
+  inline constexpr bool get_ignore_eos() const { return ignore_eos_; }
 
   inline void set_stop_tokens(const std::unordered_set<int32_t>& tokens) {
     stop_tokens_ = std::move(tokens);

--- a/xllm/core/util/int32_map.h
+++ b/xllm/core/util/int32_map.h
@@ -248,11 +248,11 @@ class Int32Map {
   uint32_t tombstones_ = 0;  // number of TOMBSTONE
 
   // ----- Helpers -----
-  static bool is_filled_(int32_t k) noexcept {
+  static constexpr bool is_filled_(int32_t k) noexcept {
     return k != KEY_EMPTY && k != KEY_TOMBSTONE;
   }
 
-  static uint32_t mix_hash_(int32_t key) noexcept {
+  static constexpr uint32_t mix_hash_(int32_t key) noexcept {
     // 32-bit mix (Murmur-inspired)
     uint32_t x = static_cast<uint32_t>(key);
     x ^= x >> 16;


### PR DESCRIPTION
Use constexpr whenever possible following "Effective Modern C++" Item 15 guidelines.

> Item 15: Use constexpr whenever possible.