### PR TITLE
refactor: prefer lambda to bind.

### DIFF
--- a/.agents/skills/code-review/references/custom-code-style.md
+++ b/.agents/skills/code-review/references/custom-code-style.md
@@ -267,6 +267,21 @@ auto layer = DecoderLayer(/*hidden_size=*/4096, /*num_heads=*/32);
 auto layer = DecoderLayer(4096, 32);
 ```
 
+- **Prefer lambdas over `std::bind`**. Lambdas have explicit capture lists and parameter types. When a parameter is unused, annotate it with `/*unused*/`.
+
+```cpp
+// Good
+auto fn = [this](const etcd::Response& response, uint64_t prefix_len) {
+  handle_watch(response, prefix_len);
+};
+[](void* /*unused*/) { request_in_metric(nullptr); }
+
+// Bad
+auto fn = std::bind(&MyClass::handle_watch, this,
+                    std::placeholders::_1, std::placeholders::_2);
+std::bind(request_in_metric, nullptr)
+```
+
 ---
 
 ## 9. STL Best Practices

--- a/xllm/api_service/api_service.cpp
+++ b/xllm/api_service/api_service.cpp
@@ -77,8 +77,10 @@ void process_typed_brpc_request(std::unique_ptr<Service>& service_impl,
                                 const char* service_name) {
   xllm::ClosureGuard done_guard(
       done,
-      std::bind(request_in_metric, nullptr),
-      std::bind(request_out_metric, (void*)controller));
+      [](void* /*unused*/) { request_in_metric(nullptr); },
+      [controller](void* /*unused*/) {
+        request_out_metric(static_cast<void*>(controller));
+      });
   if (!request || !response || !controller) {
     LOG(ERROR) << "brpc request | respose | controller is null";
     return;
@@ -147,8 +149,10 @@ void APIService::Completions(::google::protobuf::RpcController* controller,
                              ::google::protobuf::Closure* done) {
   xllm::ClosureGuard done_guard(
       done,
-      std::bind(request_in_metric, nullptr),
-      std::bind(request_out_metric, (void*)controller));
+      [](void* /*unused*/) { request_in_metric(nullptr); },
+      [controller](void* /*unused*/) {
+        request_out_metric(static_cast<void*>(controller));
+      });
   if (!request || !response || !controller) {
     LOG(ERROR) << "brpc request | respose | controller is null.";
     return;
@@ -175,8 +179,10 @@ void APIService::CompletionsHttp(::google::protobuf::RpcController* controller,
                                  ::google::protobuf::Closure* done) {
   xllm::ClosureGuard done_guard(
       done,
-      std::bind(request_in_metric, nullptr),
-      std::bind(request_out_metric, (void*)controller));
+      [](void* /*unused*/) { request_in_metric(nullptr); },
+      [controller](void* /*unused*/) {
+        request_out_metric(static_cast<void*>(controller));
+      });
   if (!request || !response || !controller) {
     LOG(ERROR) << "brpc request | respose | controller is null";
     return;
@@ -215,8 +221,10 @@ void APIService::Sample(::google::protobuf::RpcController* controller,
                         ::google::protobuf::Closure* done) {
   xllm::ClosureGuard done_guard(
       done,
-      std::bind(request_in_metric, nullptr),
-      std::bind(request_out_metric, (void*)controller));
+      [](void* /*unused*/) { request_in_metric(nullptr); },
+      [controller](void* /*unused*/) {
+        request_out_metric(static_cast<void*>(controller));
+      });
   if (!request || !response || !controller) {
     LOG(ERROR) << "brpc request | respose | controller is null.";
     return;
@@ -241,8 +249,10 @@ void APIService::SampleHttp(::google::protobuf::RpcController* controller,
                             ::google::protobuf::Closure* done) {
   xllm::ClosureGuard done_guard(
       done,
-      std::bind(request_in_metric, nullptr),
-      std::bind(request_out_metric, (void*)controller));
+      [](void* /*unused*/) { request_in_metric(nullptr); },
+      [controller](void* /*unused*/) {
+        request_out_metric(static_cast<void*>(controller));
+      });
   if (!request || !response || !controller) {
     LOG(ERROR) << "brpc request | respose | controller is null";
     return;
@@ -383,8 +393,10 @@ void APIService::ChatCompletions(::google::protobuf::RpcController* controller,
   // TODO with xllm-service
   xllm::ClosureGuard done_guard(
       done,
-      std::bind(request_in_metric, nullptr),
-      std::bind(request_out_metric, (void*)controller));
+      [](void* /*unused*/) { request_in_metric(nullptr); },
+      [controller](void* /*unused*/) {
+        request_out_metric(static_cast<void*>(controller));
+      });
   if (!request || !response || !controller) {
     LOG(ERROR) << "brpc request | respose | controller is null";
     return;
@@ -403,8 +415,10 @@ void APIService::ChatCompletionsHttp(
     ::google::protobuf::Closure* done) {
   xllm::ClosureGuard done_guard(
       done,
-      std::bind(request_in_metric, nullptr),
-      std::bind(request_out_metric, (void*)controller));
+      [](void* /*unused*/) { request_in_metric(nullptr); },
+      [controller](void* /*unused*/) {
+        request_out_metric(static_cast<void*>(controller));
+      });
   if (!request || !response || !controller) {
     LOG(ERROR) << "brpc request | respose | controller is null";
     return;
@@ -425,8 +439,10 @@ void APIService::Embeddings(::google::protobuf::RpcController* controller,
                             ::google::protobuf::Closure* done) {
   xllm::ClosureGuard done_guard(
       done,
-      std::bind(request_in_metric, nullptr),
-      std::bind(request_out_metric, (void*)controller));
+      [](void* /*unused*/) { request_in_metric(nullptr); },
+      [controller](void* /*unused*/) {
+        request_out_metric(static_cast<void*>(controller));
+      });
   if (!request || !response || !controller) {
     LOG(ERROR) << "brpc request | respose | controller is null";
     return;
@@ -464,8 +480,10 @@ void handle_embedding_request(std::unique_ptr<Service>& embedding_service_impl_,
                               ::google::protobuf::Closure* done) {
   xllm::ClosureGuard done_guard(
       done,
-      std::bind(request_in_metric, nullptr),
-      std::bind(request_out_metric, (void*)controller));
+      [](void* /*unused*/) { request_in_metric(nullptr); },
+      [controller](void* /*unused*/) {
+        request_out_metric(static_cast<void*>(controller));
+      });
   if (!request || !response || !controller) {
     LOG(ERROR) << "brpc request | respose | controller is null";
     return;
@@ -534,8 +552,10 @@ void APIService::ImageGenerationHttp(
     ::google::protobuf::Closure* done) {
   xllm::ClosureGuard done_guard(
       done,
-      std::bind(request_in_metric, nullptr),
-      std::bind(request_out_metric, (void*)controller));
+      [](void* /*unused*/) { request_in_metric(nullptr); },
+      [controller](void* /*unused*/) {
+        request_out_metric(static_cast<void*>(controller));
+      });
   if (!request || !response || !controller) {
     LOG(ERROR) << "brpc request | respose | controller is null";
     return;
@@ -586,8 +606,10 @@ void APIService::AudioGenerationHttp(
     ::google::protobuf::Closure* done) {
   xllm::ClosureGuard done_guard(
       done,
-      std::bind(request_in_metric, nullptr),
-      std::bind(request_out_metric, static_cast<void*>(controller)));
+      [](void* /*unused*/) { request_in_metric(nullptr); },
+      [controller](void* /*unused*/) {
+        request_out_metric(static_cast<void*>(controller));
+      });
   if (!request || !response || !controller) {
     LOG(ERROR) << "brpc request | response | controller is null";
     return;
@@ -638,8 +660,10 @@ void APIService::VideoGenerationHttp(
     ::google::protobuf::Closure* done) {
   xllm::ClosureGuard done_guard(
       done,
-      std::bind(request_in_metric, nullptr),
-      std::bind(request_out_metric, (void*)controller));
+      [](void* /*unused*/) { request_in_metric(nullptr); },
+      [controller](void* /*unused*/) {
+        request_out_metric(static_cast<void*>(controller));
+      });
   if (!request || !response || !controller) {
     LOG(ERROR) << "brpc request | respose | controller is null";
     return;
@@ -684,8 +708,10 @@ void APIService::RerankHttp(::google::protobuf::RpcController* controller,
                             ::google::protobuf::Closure* done) {
   xllm::ClosureGuard done_guard(
       done,
-      std::bind(request_in_metric, nullptr),
-      std::bind(request_out_metric, (void*)controller));
+      [](void* /*unused*/) { request_in_metric(nullptr); },
+      [controller](void* /*unused*/) {
+        request_out_metric(static_cast<void*>(controller));
+      });
   if (!request || !response || !controller) {
     LOG(ERROR) << "brpc request | respose | controller is null";
     return;
@@ -842,8 +868,10 @@ void APIService::AnthropicMessagesHttp(
     ::google::protobuf::Closure* done) {
   xllm::ClosureGuard done_guard(
       done,
-      std::bind(request_in_metric, nullptr),
-      std::bind(request_out_metric, (void*)controller));
+      [](void* /*unused*/) { request_in_metric(nullptr); },
+      [controller](void* /*unused*/) {
+        request_out_metric(static_cast<void*>(controller));
+      });
 
   if (!request || !response || !controller) {
     LOG(ERROR) << "brpc request | respose | controller is null";

--- a/xllm/core/common/etcd_client.cpp
+++ b/xllm/core/common/etcd_client.cpp
@@ -80,12 +80,12 @@ void EtcdClient::add_watch(const std::string& key_prefix,
   }
 
   uint64_t prefix_len = etcd_namespace_prefix_.size();
-  auto bound_callback = std::bind(callback, std::placeholders::_1, prefix_len);
-
   auto watcher = std::make_unique<etcd::Watcher>(
       client_,
       namespaced_key(key_prefix),
-      [bound_callback](etcd::Response response) { bound_callback(response); },
+      [callback, prefix_len](const etcd::Response& response) {
+        callback(response, prefix_len);
+      },
       recursive);
 
   watchers_[key_prefix] = {std::move(watcher), callback};

--- a/xllm/core/runtime/xservice_client.cpp
+++ b/xllm/core/runtime/xservice_client.cpp
@@ -151,17 +151,17 @@ bool XServiceClient::init(const std::string& etcd_addr,
       &XServiceClient::reconcile_registration_loop, this);
 
   // watch master xllm_service change
-  auto master_func = std::bind(&XServiceClient::handle_master_service_watch,
-                               this,
-                               std::placeholders::_1,
-                               std::placeholders::_2);
+  auto master_func = [this](const etcd::Response& response,
+                            uint64_t prefix_len) {
+    handle_master_service_watch(response, prefix_len);
+  };
   etcd_client_->add_watch(ETCD_MASTER_SERVICE_KEY, master_func);
 
   // watch all xllm_service changes
-  auto xservices_func = std::bind(&XServiceClient::handle_xservices_watch,
-                                  this,
-                                  std::placeholders::_1,
-                                  std::placeholders::_2);
+  auto xservices_func = [this](const etcd::Response& response,
+                               uint64_t prefix_len) {
+    handle_xservices_watch(response, prefix_len);
+  };
   etcd_client_->add_watch(ETCD_XSERVICES_KEY_PREFIX, xservices_func);
 
   block_manager_pool_ = block_manager_pool;


### PR DESCRIPTION
Replace std::bind with lambdas following "Effective Modern C++" Item 34 guidelines.

> Item 34: Prefer lambdas to std::bind.