### PR TITLE
feat: add mlu mooncake pd push support.

### DIFF
--- a/xllm/core/distributed_runtime/llm_engine.cpp
+++ b/xllm/core/distributed_runtime/llm_engine.cpp
@@ -553,7 +553,7 @@ bool LLMEngine::allocate_kv_cache(const Engine::KVCacheCapacity& kv_cache_cap) {
 
   CHECK_GT(kv_cache_cap.n_blocks, 0) << "no memory for kv cache";
   const int32_t block_size = options_.block_size();
-  bool enable_lighting_indexer = args_.index_n_heads() > 1;
+  bool enable_lighting_indexer = args_.index_n_heads() > 0;
   bool enable_gdn_attention = has_linear_attention_layers(args_);
 
   // init kv cache for each worker

--- a/xllm/core/framework/kv_cache/CMakeLists.txt
+++ b/xllm/core/framework/kv_cache/CMakeLists.txt
@@ -15,8 +15,8 @@ cc_library(
     $<$<BOOL:${USE_NPU}>:spec_kv_cache_transfer.h>
     kv_cache_store.h
     hierarchy_kv_cache_transfer.h
-    $<$<BOOL:${USE_NPU}>:mooncake_transfer_engine.h>
-    $<$<BOOL:${USE_NPU}>:mooncake_kv_cache_transfer.h>
+    $<$<OR:$<BOOL:${USE_NPU}>,$<BOOL:${USE_MLU}>>:mooncake_transfer_engine.h>
+    $<$<OR:$<BOOL:${USE_NPU}>,$<BOOL:${USE_MLU}>>:mooncake_kv_cache_transfer.h>
     $<$<BOOL:${USE_NPU}>:mooncake_weight_transfer.h>
   SRCS
     embedding_cache.cpp 
@@ -26,8 +26,8 @@ cc_library(
     $<$<BOOL:${USE_NPU}>:spec_kv_cache_transfer.cpp>
     kv_cache_store.cpp
     hierarchy_kv_cache_transfer.cpp
-    $<$<BOOL:${USE_NPU}>:mooncake_transfer_engine.cpp>
-    $<$<BOOL:${USE_NPU}>:mooncake_kv_cache_transfer.cpp>
+    $<$<OR:$<BOOL:${USE_NPU}>,$<BOOL:${USE_MLU}>>:mooncake_transfer_engine.cpp>
+    $<$<OR:$<BOOL:${USE_NPU}>,$<BOOL:${USE_MLU}>>:mooncake_kv_cache_transfer.cpp>
     $<$<BOOL:${USE_NPU}>:mooncake_weight_transfer.cpp>
   DEPS
     :common
@@ -59,3 +59,15 @@ target_link_libraries(embedding_cache_test
                       $<$<BOOL:${USE_NPU}>:hccl>
                       $<$<BOOL:${USE_NPU}>:c_sec>
                       $<$<BOOL:${USE_NPU}>:nnopbase>)
+
+if(USE_NPU OR USE_MLU)
+cc_test(
+  NAME
+    mooncake_transfer_engine_test
+  SRCS
+    mooncake_transfer_engine_test.cpp
+  DEPS
+    :kv_cache
+    GTest::gtest_main
+)
+endif()

--- a/xllm/core/framework/kv_cache/kv_cache_transfer.cpp
+++ b/xllm/core/framework/kv_cache/kv_cache_transfer.cpp
@@ -21,8 +21,13 @@ limitations under the License.
 
 #if defined(USE_NPU)
 #include <torch_npu/csrc/core/npu/NPUFormat.h>
+#endif
 
+#if defined(USE_NPU)
 #include "llm_data_dist_transfer.h"
+#endif
+
+#if defined(USE_NPU) || defined(USE_MLU)
 #include "mooncake_kv_cache_transfer.h"
 #endif
 
@@ -56,11 +61,11 @@ folly::SemiFuture<bool> KVCacheTransfer::pull_kv_blocks_async(
   return future;
 }
 
-#if defined(USE_NPU)
+#if defined(USE_NPU) || defined(USE_MLU)
 folly::SemiFuture<bool> KVCacheTransfer::push_kv_blocks_async(
     const std::vector<TransferKVInfo>& transfer_kv_infos,
     const ParallelArgs& parallel_args,
-    std::shared_ptr<NPULayerSynchronizerImpl> layer_synchronizer,
+    std::shared_ptr<KVPushSynchronizerImpl> layer_synchronizer,
     bool is_spec_draft) {
   folly::Promise<bool> promise;
   auto future = promise.getSemiFuture();
@@ -245,10 +250,11 @@ std::shared_ptr<KVCacheTransfer> KVCacheTransferFactory::create(
 
   int32_t device_id = device.index();
 
-#if defined(USE_NPU)
+#if defined(USE_NPU) || defined(USE_MLU)
   LOG(INFO) << "Create KVCacheTransfer for " << transfer_type << "flag"
             << FLAGS_kv_cache_transfer_type;
   if (transfer_type == "LlmDataDist") {
+#if defined(USE_NPU)
     transfer = std::make_shared<LlmDataDistTransfer>(device_ip,
                                                      transfer_listen_port,
                                                      instance_role,
@@ -259,8 +265,12 @@ std::shared_ptr<KVCacheTransfer> KVCacheTransferFactory::create(
 
     transfer->initialize(device_id);
     transfer->allocate_kv_cache(kv_caches, num_layers, kv_cache_shape, dtype);
+#else
+    LOG(FATAL) << "LlmDataDist is not supported on MLU backend.";
+#endif
   } else if (transfer_type == "Mooncake") {
     std::shared_ptr<MooncakeKVCacheTransferBase> mooncake_transfer;
+#if defined(USE_NPU)
     if (FLAGS_enable_xtensor) {
       auto xtensor_transfer = std::make_shared<MooncakeKVCacheTransferXTensor>(
           device_id, transfer_listen_port, device);
@@ -275,6 +285,10 @@ std::shared_ptr<KVCacheTransfer> KVCacheTransferFactory::create(
       mooncake_transfer = std::make_shared<MooncakeKVCacheTransferDefault>(
           device_id, transfer_listen_port, device, model_type);
     }
+#else
+    mooncake_transfer = std::make_shared<MooncakeKVCacheTransferDefault>(
+        device_id, transfer_listen_port, device, model_type);
+#endif
 
     mooncake_transfer->initialize(device_id);
     mooncake_transfer->allocate_kv_cache(

--- a/xllm/core/framework/kv_cache/kv_cache_transfer.h
+++ b/xllm/core/framework/kv_cache/kv_cache_transfer.h
@@ -22,11 +22,21 @@ limitations under the License.
 #if defined(USE_NPU)
 #include "platform/npu/npu_layer_synchronizer.h"
 #endif
+#if defined(USE_MLU)
+#include "platform/mlu/mlu_layer_synchronizer.h"
+#endif
 #include "framework/parallel_state/parallel_args.h"
 #include "platform/device.h"
 #include "util/threadpool.h"
 
 namespace xllm {
+
+#if defined(USE_NPU)
+using KVPushSynchronizerImpl = NPULayerSynchronizerImpl;
+#elif defined(USE_MLU)
+using KVPushSynchronizerImpl = MLULayerSynchronizerImpl;
+#endif
+
 class KVCacheTransfer {
  public:
   struct KVCacheInfo {
@@ -101,11 +111,11 @@ class KVCacheTransfer {
       const std::vector<uint64_t>& src_blocks,
       const std::vector<uint64_t>& dst_blocks);
 
-#if defined(USE_NPU)
+#if defined(USE_NPU) || defined(USE_MLU)
   virtual folly::SemiFuture<bool> push_kv_blocks_async(
       const std::vector<TransferKVInfo>& transfer_kv_infos,
       const ParallelArgs& parallel_args,
-      std::shared_ptr<NPULayerSynchronizerImpl> layer_synchronizer,
+      std::shared_ptr<KVPushSynchronizerImpl> layer_synchronizer,
       bool is_spec_draft);
 #endif
 
@@ -114,10 +124,10 @@ class KVCacheTransfer {
       const std::vector<TransferKVInfo>& transfer_kv_infos,
       const ParallelArgs& parallel_args);
 
-#if defined(USE_NPU)
+#if defined(USE_NPU) || defined(USE_MLU)
   virtual bool push_kv_blocks(
       std::unordered_map<std::string, KVCacheInfo>& merged_kv_infos,
-      std::shared_ptr<NPULayerSynchronizerImpl>& layer_synchronizer,
+      std::shared_ptr<KVPushSynchronizerImpl>& layer_synchronizer,
       bool is_spec_draft) = 0;
 #endif
 

--- a/xllm/core/framework/kv_cache/mooncake_kv_cache_transfer.cpp
+++ b/xllm/core/framework/kv_cache/mooncake_kv_cache_transfer.cpp
@@ -422,8 +422,9 @@ void MooncakeKVCacheTransferXTensor::register_kv_cache_impl() {
 
   std::vector<void*> addrs = {global_xtensor.base_vaddr()};
   std::vector<size_t> lens = {global_xtensor.total_size()};
+  std::vector<uint64_t> buf_bytes = {static_cast<uint64_t>(size_per_block_)};
 
-  if (!mooncake_te_->register_memory(addrs, lens, size_per_block_)) {
+  if (!mooncake_te_->register_memory(addrs, lens, buf_bytes)) {
     LOG(ERROR) << "register GlobalXTensor failed";
     return;
   }

--- a/xllm/core/framework/kv_cache/mooncake_kv_cache_transfer.cpp
+++ b/xllm/core/framework/kv_cache/mooncake_kv_cache_transfer.cpp
@@ -17,6 +17,8 @@ limitations under the License.
 
 #include <glog/logging.h>
 
+#include <numeric>
+
 #if defined(USE_NPU)
 #ifdef TORCH_HIGHER_THAN_PTA6
 #include <torch_npu/csrc/core/npu/NPUFormat.h>
@@ -44,6 +46,7 @@ MooncakeKVCacheTransferBase::MooncakeKVCacheTransferBase(
     const torch::Device& device,
     std::unique_ptr<MooncakeTransferEngine> engine)
     : device_id_(device_id),
+      device_(device),
       listen_port_(listen_port),
       mooncake_te_(std::move(engine)) {
   std::string instance_ip = net::get_local_ip_addr();
@@ -119,10 +122,18 @@ void MooncakeKVCacheTransferDefault::register_kv_cache(
     const std::vector<std::vector<int64_t>>& kv_cache_shape,
     torch::ScalarType dtype) {
   num_layers_ = kv_caches.size();
+  if (!kv_caches.empty()) {
+    torch::Tensor value_cache = kv_caches[0].get_v_cache();
+    torch::Tensor index_cache = kv_caches[0].get_index_cache();
+    has_v_cache_ = value_cache.defined() && value_cache.numel() > 0;
+    has_index_cache_ = index_cache.defined() && index_cache.numel() > 0;
+  }
+  buf_cnt_per_layer_ = 1 + static_cast<int64_t>(has_v_cache_) +
+                       static_cast<int64_t>(has_index_cache_);
 
   int64_t data_size = torch::scalarTypeToTypeMeta(dtype).itemsize();
   int64_t count_per_block = 1;
-  for (int32_t i = 1; i < kv_cache_shape[0].size(); ++i) {
+  for (size_t i = 1; i < kv_cache_shape[0].size(); ++i) {
     count_per_block *= kv_cache_shape[0][i];
   }
   size_per_block_ = count_per_block * data_size;
@@ -135,6 +146,26 @@ void MooncakeKVCacheTransferDefault::allocate_kv_cache_impl(
     int64_t num_layers,
     const std::vector<std::vector<int64_t>>& kv_cache_shape,
     torch::ScalarType dtype) {
+#if defined(USE_MLU)
+  torch::TensorOptions options =
+      torch::TensorOptions().dtype(dtype).device(device_);
+  for (int64_t i = 0; i < num_layers; ++i) {
+    torch::Tensor key_cache = torch::zeros(kv_cache_shape[0], options);
+    torch::Tensor value_cache;
+    torch::Tensor index_cache;
+    if (kv_cache_shape.size() > 1 && !kv_cache_shape[1].empty()) {
+      value_cache = torch::zeros(kv_cache_shape[1], options);
+    }
+    if (kv_cache_shape.size() > 2 && !kv_cache_shape[2].empty()) {
+      index_cache = torch::zeros(kv_cache_shape[2], options);
+    }
+    if (index_cache.defined()) {
+      kv_caches.emplace_back(key_cache, value_cache, index_cache);
+    } else {
+      kv_caches.emplace_back(key_cache, value_cache);
+    }
+  }
+#else
   // Original mode: allocate device memory using aclrtMalloc
   // calculate the size of kv cache for each layer
   auto data_size = torch::elementSize(dtype);
@@ -190,36 +221,78 @@ void MooncakeKVCacheTransferDefault::allocate_kv_cache_impl(
     value_cache = v_torch_tensors[i];
     kv_caches.emplace_back(key_cache, value_cache);
   }
+#endif
+}
+
+void MooncakeKVCacheTransferDefault::add_buf(
+    const torch::Tensor& tensor,
+    std::vector<void*>& addrs,
+    std::vector<size_t>& lens,
+    std::vector<uint64_t>& buf_bytes) const {
+  if (!tensor.defined() || tensor.numel() == 0) {
+    return;
+  }
+
+  CHECK_GT(tensor.dim(), 0) << "cache tensor dim must be positive";
+  int64_t block_cnt = tensor.size(0);
+  CHECK_GT(block_cnt, 0) << "cache tensor block dim must be positive";
+
+  addrs.emplace_back(tensor.data_ptr());
+  lens.emplace_back(static_cast<size_t>(tensor.nbytes()));
+  buf_bytes.emplace_back(static_cast<uint64_t>(tensor.nbytes() / block_cnt));
+}
+
+std::vector<int64_t> MooncakeKVCacheTransferDefault::get_buf_ids(
+    const std::vector<int64_t>& layer_ids) const {
+  std::vector<int64_t> active_layer_ids;
+  if (layer_ids.empty()) {
+    active_layer_ids.resize(static_cast<size_t>(num_layers_));
+    std::iota(active_layer_ids.begin(), active_layer_ids.end(), 0);
+  } else {
+    active_layer_ids = layer_ids;
+  }
+
+  std::vector<int64_t> buf_ids;
+  buf_ids.reserve(active_layer_ids.size() *
+                  static_cast<size_t>(buf_cnt_per_layer_));
+  for (int64_t layer_id : active_layer_ids) {
+    CHECK_GE(layer_id, 0) << "layer_id must be non-negative";
+    CHECK_LT(layer_id, num_layers_) << "layer_id out of range";
+
+    int64_t buf_id = layer_id * buf_cnt_per_layer_;
+    buf_ids.emplace_back(buf_id++);
+    if (has_v_cache_) {
+      buf_ids.emplace_back(buf_id++);
+    }
+    if (has_index_cache_) {
+      buf_ids.emplace_back(buf_id);
+    }
+  }
+  return buf_ids;
 }
 
 void MooncakeKVCacheTransferDefault::register_kv_cache_impl(
     std::vector<xllm::KVCache>& kv_caches) {
-  // Default mode registers each layer's K/V cache tensor buffers directly.
-  int64_t num_cache = num_layers_ * 2;
+  std::vector<void*> addrs;
+  std::vector<size_t> lens;
+  std::vector<uint64_t> buf_bytes;
+  addrs.reserve(static_cast<size_t>(num_layers_) * 3);
+  lens.reserve(static_cast<size_t>(num_layers_) * 3);
+  buf_bytes.reserve(static_cast<size_t>(num_layers_) * 3);
 
-  std::vector<void*> cache_addrs;
-  std::vector<size_t> cache_lens;
-  cache_addrs.reserve(num_cache);
-  cache_lens.reserve(num_cache);
-
-  for (int32_t i = 0; i < num_layers_; ++i) {
-    cache_addrs.emplace_back(kv_caches[i].get_k_cache().data_ptr());
-    cache_lens.emplace_back(kv_caches[i].get_k_cache().nbytes());
+  for (int64_t i = 0; i < num_layers_; ++i) {
+    add_buf(kv_caches[i].get_k_cache(), addrs, lens, buf_bytes);
+    add_buf(kv_caches[i].get_v_cache(), addrs, lens, buf_bytes);
+    add_buf(kv_caches[i].get_index_cache(), addrs, lens, buf_bytes);
   }
 
-  for (int32_t i = 0; i < num_layers_; ++i) {
-    cache_addrs.emplace_back(kv_caches[i].get_v_cache().data_ptr());
-    cache_lens.emplace_back(kv_caches[i].get_v_cache().nbytes());
-  }
-
-  if (!mooncake_te_->register_memory(
-          cache_addrs, cache_lens, size_per_block_)) {
+  if (!mooncake_te_->register_memory(addrs, lens, buf_bytes)) {
     LOG(ERROR) << "register_kv_cache_impl failed";
     return;
   }
 
   LOG(INFO) << "register_kv_cache_impl success, num_layers=" << num_layers_
-            << ", size_per_block=" << size_per_block_;
+            << ", buffers=" << buf_bytes.size();
 }
 
 bool MooncakeKVCacheTransferDefault::pull_kv_blocks(
@@ -233,8 +306,9 @@ bool MooncakeKVCacheTransferDefault::pull_kv_blocks(
   (void)src_k_cache_id;
   (void)src_v_cache_id;
   std::vector<int64_t> layer_ids;
+  std::vector<int64_t> buf_ids = get_buf_ids(layer_ids);
   auto ret = mooncake_te_->pull_memory_blocks(
-      src_addr, src_blocks, dst_blocks, layer_ids);
+      src_addr, src_blocks, dst_blocks, buf_ids);
   if (!ret) {
     LOG(ERROR) << "Pull kv cache blocks failed, ret = " << ret;
     return false;
@@ -244,16 +318,17 @@ bool MooncakeKVCacheTransferDefault::pull_kv_blocks(
 
 bool MooncakeKVCacheTransferDefault::push_kv_blocks(
     std::unordered_map<std::string, KVCacheInfo>& merged_kv_infos,
-    std::shared_ptr<NPULayerSynchronizerImpl>& layer_synchronizer,
+    std::shared_ptr<KVPushSynchronizerImpl>& layer_synchronizer,
     bool is_spec_draft) {
   (void)is_spec_draft;
   for (int64_t layer_index = 0; layer_index < num_layers_; ++layer_index) {
     layer_synchronizer->synchronize_layer(layer_index);
     for (const auto& pair : merged_kv_infos) {
       std::vector<int64_t> layer_ids = {layer_index};
+      std::vector<int64_t> buf_ids = get_buf_ids(layer_ids);
       const KVCacheInfo& kv_info = pair.second;
       auto ret = mooncake_te_->push_memory_blocks(
-          kv_info.dst_addr, kv_info.src_blocks, kv_info.dst_blocks, layer_ids);
+          kv_info.dst_addr, kv_info.src_blocks, kv_info.dst_blocks, buf_ids);
       if (!ret) {
         LOG(ERROR) << "Push kv blocks failed, layer = " << layer_index
                    << ", ret = " << ret;
@@ -375,7 +450,7 @@ bool MooncakeKVCacheTransferXTensor::pull_kv_blocks(
 
 bool MooncakeKVCacheTransferXTensor::push_kv_blocks(
     std::unordered_map<std::string, KVCacheInfo>& merged_kv_infos,
-    std::shared_ptr<NPULayerSynchronizerImpl>& layer_synchronizer,
+    std::shared_ptr<KVPushSynchronizerImpl>& layer_synchronizer,
     bool is_spec_draft) {
   (void)is_spec_draft;
   return push_kv_blocks_impl(merged_kv_infos, layer_synchronizer);
@@ -446,7 +521,7 @@ bool MooncakeKVCacheTransferXTensor::pull_kv_blocks_impl(
 
 bool MooncakeKVCacheTransferXTensor::push_kv_blocks_impl(
     std::unordered_map<std::string, KVCacheInfo>& merged_kv_infos,
-    std::shared_ptr<NPULayerSynchronizerImpl>& layer_synchronizer) {
+    std::shared_ptr<KVPushSynchronizerImpl>& layer_synchronizer) {
   if (model_id_.empty()) {
     LOG(ERROR) << "model_id not set for XTensor mode push";
     return false;

--- a/xllm/core/framework/kv_cache/mooncake_kv_cache_transfer.h
+++ b/xllm/core/framework/kv_cache/mooncake_kv_cache_transfer.h
@@ -53,6 +53,7 @@ class MooncakeKVCacheTransferBase : public KVCacheTransfer {
   uint64_t cluster_id_;
   int16_t listen_port_;
   int32_t device_id_;
+  torch::Device device_;
   int64_t num_layers_ = 0;
   int64_t size_per_block_ = 0;
 
@@ -87,7 +88,7 @@ class MooncakeKVCacheTransferDefault final
 
   bool push_kv_blocks(
       std::unordered_map<std::string, KVCacheInfo>& merged_kv_infos,
-      std::shared_ptr<NPULayerSynchronizerImpl>& layer_synchronizer,
+      std::shared_ptr<KVPushSynchronizerImpl>& layer_synchronizer,
       bool is_spec_draft) override;
 
  private:
@@ -97,9 +98,18 @@ class MooncakeKVCacheTransferDefault final
       const std::vector<std::vector<int64_t>>& kv_cache_shape,
       torch::ScalarType dtype);
 
+  void add_buf(const torch::Tensor& tensor,
+               std::vector<void*>& addrs,
+               std::vector<size_t>& lens,
+               std::vector<uint64_t>& buf_bytes) const;
+  std::vector<int64_t> get_buf_ids(const std::vector<int64_t>& layer_ids) const;
+
   // Register per-layer K/V tensor memory.
   void register_kv_cache_impl(std::vector<xllm::KVCache>& kv_caches);
 
+  bool has_v_cache_ = true;
+  bool has_index_cache_ = false;
+  int64_t buf_cnt_per_layer_ = 2;
   std::string model_type_;
 };
 
@@ -132,7 +142,7 @@ class MooncakeKVCacheTransferXTensor final
 
   bool push_kv_blocks(
       std::unordered_map<std::string, KVCacheInfo>& merged_kv_infos,
-      std::shared_ptr<NPULayerSynchronizerImpl>& layer_synchronizer,
+      std::shared_ptr<KVPushSynchronizerImpl>& layer_synchronizer,
       bool is_spec_draft) override;
 
  private:
@@ -151,7 +161,7 @@ class MooncakeKVCacheTransferXTensor final
 
   bool push_kv_blocks_impl(
       std::unordered_map<std::string, KVCacheInfo>& merged_kv_infos,
-      std::shared_ptr<NPULayerSynchronizerImpl>& layer_synchronizer);
+      std::shared_ptr<KVPushSynchronizerImpl>& layer_synchronizer);
 
   std::string model_id_;
 };

--- a/xllm/core/framework/kv_cache/mooncake_transfer_engine.cpp
+++ b/xllm/core/framework/kv_cache/mooncake_transfer_engine.cpp
@@ -303,15 +303,6 @@ std::string MooncakeTransferEngine::initialize() {
 
 bool MooncakeTransferEngine::register_memory(std::vector<void*> addrs,
                                              std::vector<size_t> lens,
-                                             int64_t size_per_block) {
-  std::vector<uint64_t> buf_bytes(addrs.size(),
-                                  static_cast<uint64_t>(size_per_block));
-  return register_memory(
-      std::move(addrs), std::move(lens), std::move(buf_bytes));
-}
-
-bool MooncakeTransferEngine::register_memory(std::vector<void*> addrs,
-                                             std::vector<size_t> lens,
                                              std::vector<uint64_t> buf_bytes) {
   if (addrs.size() != lens.size() || addrs.size() != buf_bytes.size()) {
     LOG(ERROR) << "register_memory input size mismatch, addrs=" << addrs.size()

--- a/xllm/core/framework/kv_cache/mooncake_transfer_engine.cpp
+++ b/xllm/core/framework/kv_cache/mooncake_transfer_engine.cpp
@@ -158,7 +158,6 @@ bool MooncakeTransferEngineCore::open_session(const uint64_t cluster_id,
     return true;
   }
 
-  bool remote_opened = false;
   if (cluster_id != 0) {
     proto::MooncakeTransferEngineService_Stub* stub =
         get_or_create_stub_locked(cluster_id);
@@ -167,27 +166,24 @@ bool MooncakeTransferEngineCore::open_session(const uint64_t cluster_id,
       return false;
     }
 
-    proto::SessionInfo session_info;
-    session_info.set_addr(addr_);
+    proto::SessionInfo request;
+    request.set_addr(addr_);
     proto::Status response;
     brpc::Controller cntl;
-    stub->OpenSession(&cntl, &session_info, &response, nullptr);
+    stub->OpenSession(&cntl, &request, &response, nullptr);
     if (cntl.Failed() || !response.ok()) {
       LOG(ERROR) << "OpenSession failed, " << cntl.ErrorText();
       return false;
     }
-    remote_opened = true;
 
     LOG(INFO) << "OpenSession RPC to " << remote_addr
               << ", local_addr=" << addr_;
+    return true;
   }
 
   Transport::SegmentHandle handle = engine_->openSegment(remote_addr);
   if (handle == static_cast<Transport::SegmentHandle>(-1)) {
     LOG(ERROR) << "Fail to connect to " << remote_addr;
-    if (remote_opened) {
-      close_remote_session(this, cluster_id);
-    }
     return false;
   }
 
@@ -209,6 +205,18 @@ bool MooncakeTransferEngineCore::close_session(const uint64_t cluster_id,
             << ", remote_addr=" << remote_addr;
 
   auto it = handles_.find(remote_addr);
+  if (cluster_id != 0) {
+    if (it != handles_.end()) {
+      it->second.ref_count--;
+      LOG(INFO) << "Decremented ref_count for " << remote_addr
+                << ", ref_count=" << it->second.ref_count;
+      if (it->second.ref_count > 0) {
+        return true;
+      }
+    }
+    return close_remote_session(this, cluster_id);
+  }
+
   if (it == handles_.end()) {
     return true;
   }
@@ -217,14 +225,8 @@ bool MooncakeTransferEngineCore::close_session(const uint64_t cluster_id,
   LOG(INFO) << "Decremented ref_count for " << remote_addr
             << ", ref_count=" << it->second.ref_count;
 
-  // Keep the shared session alive while other users still reference it.
   if (it->second.ref_count > 0) {
     return true;
-  }
-
-  bool ret = true;
-  if (cluster_id != 0) {
-    ret = close_remote_session(this, cluster_id);
   }
 
   SegmentHandle handle = it->second.handle;
@@ -235,7 +237,7 @@ bool MooncakeTransferEngineCore::close_session(const uint64_t cluster_id,
 
   LOG(INFO) << "Closed session for " << remote_addr;
 
-  return ret;
+  return true;
 }
 
 SegmentHandle MooncakeTransferEngineCore::get_handle(

--- a/xllm/core/framework/kv_cache/mooncake_transfer_engine.cpp
+++ b/xllm/core/framework/kv_cache/mooncake_transfer_engine.cpp
@@ -15,25 +15,72 @@ limitations under the License.
 
 #include "mooncake_transfer_engine.h"
 
-#include <acl/acl.h>
-#include <gflags/gflags.h>
 #include <glog/logging.h>
 
+#include <algorithm>
 #include <numeric>
 
-#include "common/global_flags.h"
 #include "util/net.h"
 
 namespace xllm {
+
+namespace {
+
+bool close_remote_session(MooncakeTransferEngineCore* core,
+                          uint64_t cluster_id) {
+  proto::MooncakeTransferEngineService_Stub* stub =
+      core->get_or_create_stub(cluster_id);
+  if (stub == nullptr) {
+    LOG(ERROR) << "create_rpc_channel failed for cluster_id=" << cluster_id;
+    return false;
+  }
+
+  proto::SessionInfo session_info;
+  session_info.set_addr(core->addr());
+  proto::Status response;
+  brpc::Controller cntl;
+  stub->CloseSession(&cntl, &session_info, &response, nullptr);
+  if (cntl.Failed() || !response.ok()) {
+    LOG(ERROR) << "CloseSession failed, " << cntl.ErrorText();
+    return false;
+  }
+  return true;
+}
+
+bool check_buf_range(uint64_t buf_len,
+                     uint64_t buf_bytes,
+                     uint64_t block_id,
+                     uint64_t block_len,
+                     int64_t buf_id) {
+  if (buf_bytes == 0) {
+    LOG(ERROR) << "buf bytes is zero, buf_id=" << buf_id;
+    return false;
+  }
+  if (buf_len % buf_bytes != 0) {
+    LOG(ERROR) << "buf len is not aligned with block bytes, buf_id=" << buf_id
+               << ", buf_len=" << buf_len << ", buf_bytes=" << buf_bytes;
+    return false;
+  }
+
+  uint64_t block_cnt = buf_len / buf_bytes;
+  if (block_id > block_cnt || block_len > block_cnt - block_id) {
+    LOG(ERROR) << "block range out of bounds, buf_id=" << buf_id
+               << ", block_cnt=" << block_cnt << ", block_id=" << block_id
+               << ", block_len=" << block_len;
+    return false;
+  }
+  return true;
+}
+
+}  // namespace
 
 // ============================================================================
 // MooncakeTransferEngineCore (Singleton)
 // ============================================================================
 
 MooncakeTransferEngineCore::~MooncakeTransferEngineCore() {
-  // free stub
   for (auto& pair : stub_map_) {
-    if (pair.second) {
+    if (pair.second != nullptr) {
       delete pair.second->channel();
       delete pair.second;
     }
@@ -58,7 +105,6 @@ bool MooncakeTransferEngineCore::initialize(int16_t listen_port,
   listen_port_ = listen_port;
   host_ip_ = net::get_local_ip_addr();
 
-  // Create TransferEngine
   engine_ = std::make_unique<TransferEngine>(true);
 
   Device dev(device);
@@ -74,7 +120,6 @@ bool MooncakeTransferEngineCore::initialize(int16_t listen_port,
 
   LOG(INFO) << "TransferEngine init success, hostname=" << hostname;
 
-  // Create brpc service and server
   service_ = std::make_shared<MooncakeTransferEngineService>();
   if (server_.AddService(service_.get(), brpc::SERVER_DOESNT_OWN_SERVICE) !=
       0) {
@@ -106,40 +151,43 @@ bool MooncakeTransferEngineCore::open_session(const uint64_t cluster_id,
 
   auto it = handles_.find(remote_addr);
   if (it != handles_.end()) {
-    // Session exists, just increment ref count
+    // Reuse the existing session until the last caller releases it.
     it->second.ref_count++;
     LOG(INFO) << "Reusing existing session for " << remote_addr
               << ", ref_count=" << it->second.ref_count;
     return true;
   }
 
+  bool remote_opened = false;
   if (cluster_id != 0) {
     proto::MooncakeTransferEngineService_Stub* stub =
-        get_or_create_stub(cluster_id);
-    if (!stub) {
+        get_or_create_stub_locked(cluster_id);
+    if (stub == nullptr) {
       LOG(ERROR) << "create_rpc_channel failed";
       return false;
     }
 
-    proto::SessionInfo proto_session_info;
-    proto_session_info.set_addr(addr_);
-    proto::Status status;
+    proto::SessionInfo session_info;
+    session_info.set_addr(addr_);
+    proto::Status response;
     brpc::Controller cntl;
-    stub->OpenSession(&cntl, &proto_session_info, &status, nullptr);
-    if (cntl.Failed() || !status.ok()) {
+    stub->OpenSession(&cntl, &session_info, &response, nullptr);
+    if (cntl.Failed() || !response.ok()) {
       LOG(ERROR) << "OpenSession failed, " << cntl.ErrorText();
       return false;
     }
+    remote_opened = true;
 
     LOG(INFO) << "OpenSession RPC to " << remote_addr
               << ", local_addr=" << addr_;
-    return true;
   }
 
-  Transport::SegmentHandle handle;
-  handle = engine_->openSegment(remote_addr);
-  if (handle == (Transport::SegmentHandle)-1) {
+  Transport::SegmentHandle handle = engine_->openSegment(remote_addr);
+  if (handle == static_cast<Transport::SegmentHandle>(-1)) {
     LOG(ERROR) << "Fail to connect to " << remote_addr;
+    if (remote_opened) {
+      close_remote_session(this, cluster_id);
+    }
     return false;
   }
 
@@ -165,43 +213,29 @@ bool MooncakeTransferEngineCore::close_session(const uint64_t cluster_id,
     return true;
   }
 
-  // Decrement ref count
   it->second.ref_count--;
   LOG(INFO) << "Decremented ref_count for " << remote_addr
             << ", ref_count=" << it->second.ref_count;
 
-  // Only close when ref_count reaches 0
+  // Keep the shared session alive while other users still reference it.
   if (it->second.ref_count > 0) {
     return true;
   }
 
+  bool ret = true;
   if (cluster_id != 0) {
-    proto::MooncakeTransferEngineService_Stub* stub =
-        get_or_create_stub(cluster_id);
-    if (!stub) {
-      LOG(ERROR) << "create_rpc_channel failed";
-      return false;
-    }
-
-    proto::SessionInfo proto_session_info;
-    proto_session_info.set_addr(addr_);
-
-    proto::Status status;
-    brpc::Controller cntl;
-    stub->CloseSession(&cntl, &proto_session_info, &status, nullptr);
-    if (cntl.Failed() || !status.ok()) {
-      LOG(ERROR) << "CloseSession failed, " << cntl.ErrorText();
-      return false;
-    }
-    return true;
+    ret = close_remote_session(this, cluster_id);
   }
 
-  engine_->closeSegment(it->second.handle);
-  handles_.erase(remote_addr);
+  SegmentHandle handle = it->second.handle;
+  if (handle != static_cast<SegmentHandle>(-1)) {
+    engine_->closeSegment(handle);
+  }
+  handles_.erase(it);
 
   LOG(INFO) << "Closed session for " << remote_addr;
 
-  return true;
+  return ret;
 }
 
 SegmentHandle MooncakeTransferEngineCore::get_handle(
@@ -209,14 +243,19 @@ SegmentHandle MooncakeTransferEngineCore::get_handle(
   std::lock_guard<std::mutex> lock(mutex_);
   auto it = handles_.find(remote_addr);
   if (it == handles_.end()) {
-    return (SegmentHandle)-1;
+    return static_cast<SegmentHandle>(-1);
   }
   return it->second.handle;
 }
 
 proto::MooncakeTransferEngineService_Stub*
 MooncakeTransferEngineCore::get_or_create_stub(uint64_t cluster_id) {
-  // Note: caller should hold mutex_ if needed
+  std::lock_guard<std::mutex> lock(mutex_);
+  return get_or_create_stub_locked(cluster_id);
+}
+
+proto::MooncakeTransferEngineService_Stub*
+MooncakeTransferEngineCore::get_or_create_stub_locked(uint64_t cluster_id) {
   auto it = stub_map_.find(cluster_id);
   if (it == stub_map_.end()) {
     auto [remote_ip, remote_port] = net::convert_uint64_to_ip_port(cluster_id);
@@ -263,25 +302,36 @@ std::string MooncakeTransferEngine::initialize() {
 bool MooncakeTransferEngine::register_memory(std::vector<void*> addrs,
                                              std::vector<size_t> lens,
                                              int64_t size_per_block) {
-  int64_t num = addrs.size();
-  num_layers_ = num / 2;
+  std::vector<uint64_t> buf_bytes(addrs.size(),
+                                  static_cast<uint64_t>(size_per_block));
+  return register_memory(
+      std::move(addrs), std::move(lens), std::move(buf_bytes));
+}
 
-  std::vector<BufferEntry> buffers;
-  buffers.reserve(num);
-  for (size_t i = 0; i < num; i++) {
-    buffers.push_back(BufferEntry{(void*)addrs[i], lens[i]});
-  }
-
-  int ret =
-      core_.engine()->registerLocalMemoryBatch(buffers, kWildcardLocation);
-  if (ret) {
-    LOG(ERROR) << "registerLocalMemoryBatch failed, ret=" << ret;
+bool MooncakeTransferEngine::register_memory(std::vector<void*> addrs,
+                                             std::vector<size_t> lens,
+                                             std::vector<uint64_t> buf_bytes) {
+  if (addrs.size() != lens.size() || addrs.size() != buf_bytes.size()) {
+    LOG(ERROR) << "register_memory input size mismatch, addrs=" << addrs.size()
+               << ", lens=" << lens.size()
+               << ", buf_bytes=" << buf_bytes.size();
     return false;
   }
 
-  size_per_block_ = size_per_block;
+  TransferEngine* engine = core_.engine();
+  for (size_t i = 0; i < addrs.size(); ++i) {
+    int32_t ret = engine->registerLocalMemory(
+        addrs[i], lens[i], kWildcardLocation, true, true);
+    if (ret != 0) {
+      LOG(ERROR) << "registerLocalMemory failed, buf_id=" << i
+                 << ", addr=" << addrs[i] << ", len=" << lens[i]
+                 << ", ret=" << ret;
+      return false;
+    }
+  }
 
-  LOG(INFO) << "register_memory success, size_per_block_=" << size_per_block_;
+  buf_bytes_ = std::move(buf_bytes);
+  LOG(INFO) << "register_memory success, buf_num=" << buf_bytes_.size();
 
   return true;
 }
@@ -308,11 +358,11 @@ void merge_block_ids(const std::vector<uint64_t>& src_blocks,
                      std::vector<uint64_t>& merged_src_blocks,
                      std::vector<uint64_t>& merged_dst_blocks,
                      std::vector<uint64_t>& block_lengths) {
-  // Create an index array and sort it based on the values of src blocks.
   size_t block_num = src_blocks.size();
   if (block_num == 0) {
     return;
   }
+
   std::vector<uint64_t> indices(block_num);
   std::iota(indices.begin(), indices.end(), 0);
   std::sort(
@@ -320,17 +370,15 @@ void merge_block_ids(const std::vector<uint64_t>& src_blocks,
         return src_blocks[i] < src_blocks[j];
       });
 
-  // Generate sorted src blocks and dst blocks.
   std::vector<uint64_t> sorted_src_blocks;
   std::vector<uint64_t> sorted_dst_blocks;
   sorted_src_blocks.reserve(block_num);
   sorted_dst_blocks.reserve(block_num);
-  for (auto id : indices) {
+  for (uint64_t id : indices) {
     sorted_src_blocks.emplace_back(src_blocks[id]);
     sorted_dst_blocks.emplace_back(dst_blocks[id]);
   }
 
-  // Obtain continuous blocks.
   uint64_t current_src_id = sorted_src_blocks[0];
   uint64_t current_dst_id = sorted_dst_blocks[0];
   uint64_t current_length = 1;
@@ -359,32 +407,48 @@ bool MooncakeTransferEngine::move_memory_blocks(
     const std::string& remote_addr,
     const std::vector<uint64_t>& src_blocks,
     const std::vector<uint64_t>& dst_blocks,
-    const std::vector<int64_t>& layer_ids,
+    const std::vector<int64_t>& buf_ids,
     MoveOpcode move_opcode) {
-  auto remote_handle = core_.get_handle(remote_addr);
-  if (remote_handle == (SegmentHandle)-1) {
+  if (src_blocks.size() != dst_blocks.size()) {
+    LOG(ERROR) << "src_blocks size must equal dst_blocks size, src="
+               << src_blocks.size() << ", dst=" << dst_blocks.size();
+    return false;
+  }
+
+  SegmentHandle remote_handle = core_.get_handle(remote_addr);
+  if (remote_handle == static_cast<SegmentHandle>(-1)) {
     LOG(ERROR) << "remote addr does not exist: " << remote_addr;
     return false;
   }
 
-  auto* engine = core_.engine();
-  std::shared_ptr<TransferMetadata::SegmentDesc> remote_segment_desc;
-  remote_segment_desc =
+  TransferEngine* engine = core_.engine();
+  std::shared_ptr<TransferMetadata::SegmentDesc> remote_segment_desc =
       engine->getMetadata()->getSegmentDescByID(remote_handle);
   if (!remote_segment_desc) {
     LOG(ERROR) << "remote_segment_desc is null";
     return false;
   }
 
-  std::shared_ptr<TransferMetadata::SegmentDesc> local_segment_desc;
-  local_segment_desc =
+  std::shared_ptr<TransferMetadata::SegmentDesc> local_segment_desc =
       engine->getMetadata()->getSegmentDescByID(LOCAL_SEGMENT_ID);
   if (!local_segment_desc) {
     LOG(ERROR) << "local_segment_desc is null";
     return false;
   }
 
-  // Merge consecutive block ids to improve transmission efficiency.
+  size_t local_buf_cnt = local_segment_desc->buffers.size();
+  size_t remote_buf_cnt = remote_segment_desc->buffers.size();
+  if (local_buf_cnt != remote_buf_cnt) {
+    LOG(ERROR) << "buffer count mismatch, local=" << local_buf_cnt
+               << ", remote=" << remote_buf_cnt;
+    return false;
+  }
+  if (local_buf_cnt != buf_bytes_.size()) {
+    LOG(ERROR) << "registered buffer count mismatch, local=" << local_buf_cnt
+               << ", block_bytes=" << buf_bytes_.size();
+    return false;
+  }
+
   std::vector<uint64_t> merged_src_blocks;
   std::vector<uint64_t> merged_dst_blocks;
   std::vector<uint64_t> block_lengths;
@@ -394,60 +458,66 @@ bool MooncakeTransferEngine::move_memory_blocks(
                   merged_dst_blocks,
                   block_lengths);
 
-  std::vector<int64_t> addr_ids;
-  if (layer_ids.size() == 0) {
-    addr_ids.resize(num_layers_);
-    std::iota(addr_ids.begin(), addr_ids.end(), 0);
+  std::vector<int64_t> active_buf_ids;
+  if (buf_ids.empty()) {
+    active_buf_ids.resize(buf_bytes_.size());
+    std::iota(active_buf_ids.begin(), active_buf_ids.end(), 0);
   } else {
-    addr_ids = layer_ids;
+    active_buf_ids = buf_ids;
   }
 
-  TransferRequest::OpCode opcode;
+  TransferRequest::OpCode opcode = TransferRequest::READ;
   if (move_opcode == MoveOpcode::WRITE) {
     opcode = TransferRequest::WRITE;
-  } else {
-    opcode = TransferRequest::READ;
   }
 
   std::vector<TransferRequest> entries;
-  entries.reserve(addr_ids.size() * merged_src_blocks.size() * 2);
-  for (auto addr_id : addr_ids) {
-    char* k_local_base = (char*)(local_segment_desc->buffers[addr_id].addr);
-    char* k_remote_base = (char*)(remote_segment_desc->buffers[addr_id].addr);
+  for (int64_t buf_id : active_buf_ids) {
+    if (buf_id < 0 || static_cast<size_t>(buf_id) >= local_buf_cnt) {
+      LOG(ERROR) << "buf_id out of range, buf_id=" << buf_id
+                 << ", buf_cnt=" << local_buf_cnt;
+      return false;
+    }
 
-    int64_t v_addr_id = addr_id + num_layers_;
-    char* v_local_base = (char*)(local_segment_desc->buffers[v_addr_id].addr);
-    char* v_remote_base = (char*)(remote_segment_desc->buffers[v_addr_id].addr);
+    size_t local_buf_id = static_cast<size_t>(buf_id);
+    uint64_t buf_bytes = buf_bytes_[local_buf_id];
+    uint64_t local_buf_len = local_segment_desc->buffers[local_buf_id].length;
+    uint64_t remote_buf_len = remote_segment_desc->buffers[local_buf_id].length;
 
+    char* local_base =
+        reinterpret_cast<char*>(local_segment_desc->buffers[local_buf_id].addr);
+    uint64_t remote_base = remote_segment_desc->buffers[local_buf_id].addr;
     for (size_t i = 0; i < merged_src_blocks.size(); ++i) {
       uint64_t src_block_id = merged_src_blocks[i];
       uint64_t dst_block_id = merged_dst_blocks[i];
       uint64_t block_length = block_lengths[i];
-      uint64_t src_bias = src_block_id * size_per_block_;
-      uint64_t dst_bias = dst_block_id * size_per_block_;
-      uint64_t len = block_length * size_per_block_;
+      if (!check_buf_range(
+              local_buf_len, buf_bytes, src_block_id, block_length, buf_id) ||
+          !check_buf_range(
+              remote_buf_len, buf_bytes, dst_block_id, block_length, buf_id)) {
+        return false;
+      }
 
-      TransferRequest k_entry;
-      k_entry.opcode = opcode;
-      k_entry.length = len;
-      k_entry.source = (void*)(k_local_base + src_bias);
-      k_entry.target_id = remote_handle;
-      k_entry.target_offset = (uint64_t)(k_remote_base + dst_bias);
-      k_entry.advise_retry_cnt = 0;
-      entries.push_back(k_entry);
+      uint64_t src_bias = src_block_id * buf_bytes;
+      uint64_t dst_bias = dst_block_id * buf_bytes;
+      uint64_t len = block_length * buf_bytes;
 
-      TransferRequest v_entry;
-      v_entry.opcode = opcode;
-      v_entry.length = len;
-      v_entry.source = (void*)(v_local_base + src_bias);
-      v_entry.target_id = remote_handle;
-      v_entry.target_offset = (uint64_t)(v_remote_base + dst_bias);
-      v_entry.advise_retry_cnt = 0;
-      entries.push_back(v_entry);
+      TransferRequest entry;
+      entry.opcode = opcode;
+      entry.length = len;
+      entry.source = reinterpret_cast<void*>(local_base + src_bias);
+      entry.target_id = remote_handle;
+      entry.target_offset = remote_base + dst_bias;
+      entry.advise_retry_cnt = 0;
+      entries.push_back(entry);
     }
   }
 
-  auto batch_size = entries.size();
+  if (entries.empty()) {
+    return true;
+  }
+
+  size_t batch_size = entries.size();
   auto batch_id = engine->allocateBatchID(batch_size);
   mooncake::Status s = engine->submitTransfer(batch_id, entries);
   if (!s.ok()) {
@@ -491,44 +561,41 @@ bool MooncakeTransferEngine::move_memory_by_global_offsets(
     const std::vector<uint64_t>& dst_offsets,
     size_t transfer_size,
     MoveOpcode move_opcode) {
-  auto remote_handle = core_.get_handle(remote_addr);
-  if (remote_handle == (SegmentHandle)-1) {
+  SegmentHandle remote_handle = core_.get_handle(remote_addr);
+  if (remote_handle == static_cast<SegmentHandle>(-1)) {
     LOG(ERROR) << "remote addr does not exist: " << remote_addr;
     return false;
   }
 
-  auto* engine = core_.engine();
-  std::shared_ptr<TransferMetadata::SegmentDesc> remote_segment_desc;
-  remote_segment_desc =
+  TransferEngine* engine = core_.engine();
+  std::shared_ptr<TransferMetadata::SegmentDesc> remote_segment_desc =
       engine->getMetadata()->getSegmentDescByID(remote_handle);
   if (!remote_segment_desc) {
     LOG(ERROR) << "remote_segment_desc is null";
     return false;
   }
 
-  std::shared_ptr<TransferMetadata::SegmentDesc> local_segment_desc;
-  local_segment_desc =
+  std::shared_ptr<TransferMetadata::SegmentDesc> local_segment_desc =
       engine->getMetadata()->getSegmentDescByID(LOCAL_SEGMENT_ID);
   if (!local_segment_desc) {
     LOG(ERROR) << "local_segment_desc is null";
     return false;
   }
 
-  // XTensor mode: use buffer[0] which is the GlobalXTensor
   if (local_segment_desc->buffers.empty() ||
       remote_segment_desc->buffers.empty()) {
     LOG(ERROR) << "No buffers registered for XTensor mode";
     return false;
   }
 
-  char* local_base = (char*)(local_segment_desc->buffers[0].addr);
-  char* remote_base = (char*)(remote_segment_desc->buffers[0].addr);
+  char* local_base =
+      reinterpret_cast<char*>(local_segment_desc->buffers[0].addr);
+  char* remote_base =
+      reinterpret_cast<char*>(remote_segment_desc->buffers[0].addr);
 
-  TransferRequest::OpCode opcode;
+  TransferRequest::OpCode opcode = TransferRequest::READ;
   if (move_opcode == MoveOpcode::WRITE) {
     opcode = TransferRequest::WRITE;
-  } else {
-    opcode = TransferRequest::READ;
   }
 
   std::vector<TransferRequest> entries;
@@ -538,14 +605,15 @@ bool MooncakeTransferEngine::move_memory_by_global_offsets(
     TransferRequest entry;
     entry.opcode = opcode;
     entry.length = transfer_size;
-    entry.source = (void*)(local_base + src_offsets[i]);
+    entry.source = reinterpret_cast<void*>(local_base + src_offsets[i]);
     entry.target_id = remote_handle;
-    entry.target_offset = (uint64_t)(remote_base + dst_offsets[i]);
+    entry.target_offset =
+        reinterpret_cast<uint64_t>(remote_base + dst_offsets[i]);
     entry.advise_retry_cnt = 0;
     entries.push_back(entry);
   }
 
-  auto batch_size = entries.size();
+  size_t batch_size = entries.size();
   auto batch_id = engine->allocateBatchID(batch_size);
   mooncake::Status s = engine->submitTransfer(batch_id, entries);
   if (!s.ok()) {
@@ -587,9 +655,9 @@ bool MooncakeTransferEngine::pull_memory_blocks(
     const std::string& remote_addr,
     const std::vector<uint64_t>& src_blocks,
     const std::vector<uint64_t>& dst_blocks,
-    const std::vector<int64_t>& layer_ids) {
-  auto ret = move_memory_blocks(
-      remote_addr, src_blocks, dst_blocks, layer_ids, MoveOpcode::READ);
+    const std::vector<int64_t>& buf_ids) {
+  bool ret = move_memory_blocks(
+      remote_addr, src_blocks, dst_blocks, buf_ids, MoveOpcode::READ);
   if (!ret) {
     LOG(ERROR) << "Pull memory blocks failed, ret = " << ret;
     return false;
@@ -602,9 +670,9 @@ bool MooncakeTransferEngine::push_memory_blocks(
     const std::string& remote_addr,
     const std::vector<uint64_t>& src_blocks,
     const std::vector<uint64_t>& dst_blocks,
-    const std::vector<int64_t>& layer_ids) {
-  auto ret = move_memory_blocks(
-      remote_addr, src_blocks, dst_blocks, layer_ids, MoveOpcode::WRITE);
+    const std::vector<int64_t>& buf_ids) {
+  bool ret = move_memory_blocks(
+      remote_addr, src_blocks, dst_blocks, buf_ids, MoveOpcode::WRITE);
   if (!ret) {
     LOG(ERROR) << "Push memory blocks failed, ret = " << ret;
     return false;
@@ -623,8 +691,14 @@ void MooncakeTransferEngineService::OpenSession(
     proto::Status* response,
     ::google::protobuf::Closure* done) {
   brpc::ClosureGuard done_guard(done);
-  if (!request || !response || !controller) {
+  if (request == nullptr || response == nullptr || controller == nullptr) {
     LOG(ERROR) << "brpc request | response | controller is null";
+    return;
+  }
+
+  if (request->addr().empty()) {
+    LOG(ERROR) << "OpenSession request missing addr";
+    response->set_ok(false);
     return;
   }
 
@@ -641,8 +715,14 @@ void MooncakeTransferEngineService::CloseSession(
     proto::Status* response,
     ::google::protobuf::Closure* done) {
   brpc::ClosureGuard done_guard(done);
-  if (!request || !response || !controller) {
+  if (request == nullptr || response == nullptr || controller == nullptr) {
     LOG(ERROR) << "brpc request | response | controller is null";
+    return;
+  }
+
+  if (request->addr().empty()) {
+    LOG(ERROR) << "CloseSession request missing addr";
+    response->set_ok(false);
     return;
   }
 

--- a/xllm/core/framework/kv_cache/mooncake_transfer_engine.h
+++ b/xllm/core/framework/kv_cache/mooncake_transfer_engine.h
@@ -106,9 +106,6 @@ class MooncakeTransferEngine final {
 
   bool register_memory(std::vector<void*> addrs,
                        std::vector<size_t> lens,
-                       int64_t size_per_block);
-  bool register_memory(std::vector<void*> addrs,
-                       std::vector<size_t> lens,
                        std::vector<uint64_t> buf_bytes);
 
   bool move_memory_blocks(const std::string& remote_addr,

--- a/xllm/core/framework/kv_cache/mooncake_transfer_engine.h
+++ b/xllm/core/framework/kv_cache/mooncake_transfer_engine.h
@@ -19,8 +19,11 @@ limitations under the License.
 #include <brpc/channel.h>
 #include <brpc/server.h>
 
+#include <cstdint>
 #include <mutex>
 #include <thread>
+#include <unordered_map>
+#include <vector>
 
 #include "mooncake_transfer_engine.pb.h"
 #include "platform/device.h"
@@ -31,38 +34,38 @@ using namespace mooncake;
 
 class MooncakeTransferEngineService;
 
-// Singleton core that holds the actual TransferEngine and brpc Server
-// Multiple MooncakeTransferEngine instances share this core
+// Singleton core that holds the actual TransferEngine and brpc Server.
+// Multiple MooncakeTransferEngine instances share this core.
 class MooncakeTransferEngineCore {
  public:
-  // Get the global singleton instance
   static MooncakeTransferEngineCore& get_instance() {
     static MooncakeTransferEngineCore instance;
     return instance;
   }
 
-  // Initialize the core (only first call takes effect)
+  // Initialize the shared core. Only the first call takes effect.
   bool initialize(int16_t listen_port, const torch::Device& device);
 
-  // Get the underlying TransferEngine
   TransferEngine* engine() { return engine_.get(); }
 
-  // Get the RPC address
   const std::string& addr() const { return addr_; }
   const std::string& host_ip() const { return host_ip_; }
 
-  // Session management (shared across all MooncakeTransferEngine instances)
+  // Session state is shared across all MooncakeTransferEngine instances.
   bool open_session(const uint64_t cluster_id, const std::string& remote_addr);
   bool close_session(const uint64_t cluster_id, const std::string& remote_addr);
   SegmentHandle get_handle(const std::string& remote_addr);
 
-  // RPC channel management
+  // Lazily create and cache the RPC stub for a remote cluster.
   proto::MooncakeTransferEngineService_Stub* get_or_create_stub(
       uint64_t cluster_id);
 
   bool is_initialized() const { return initialized_; }
 
  private:
+  proto::MooncakeTransferEngineService_Stub* get_or_create_stub_locked(
+      uint64_t cluster_id);
+
   MooncakeTransferEngineCore() = default;
   ~MooncakeTransferEngineCore();
   MooncakeTransferEngineCore(const MooncakeTransferEngineCore&) = delete;
@@ -81,11 +84,10 @@ class MooncakeTransferEngineCore {
   brpc::Server server_;
   std::shared_ptr<MooncakeTransferEngineService> service_;
 
-  // Session handle with reference count for isolation between kv cache and
-  // weight transfer
+  // Keep a shared session handle so kv cache and weight transfer can reuse it.
   struct SessionInfo {
-    SegmentHandle handle;
-    int ref_count = 0;
+    SegmentHandle handle = static_cast<SegmentHandle>(-1);
+    int32_t ref_count = 0;
   };
   std::unordered_map<std::string, SessionInfo> handles_;
   std::unordered_map<uint64_t, proto::MooncakeTransferEngineService_Stub*>
@@ -105,27 +107,27 @@ class MooncakeTransferEngine final {
   bool register_memory(std::vector<void*> addrs,
                        std::vector<size_t> lens,
                        int64_t size_per_block);
+  bool register_memory(std::vector<void*> addrs,
+                       std::vector<size_t> lens,
+                       std::vector<uint64_t> buf_bytes);
 
   bool move_memory_blocks(const std::string& remote_addr,
                           const std::vector<uint64_t>& src_blocks,
                           const std::vector<uint64_t>& dst_blocks,
-                          const std::vector<int64_t>& layer_ids,
+                          const std::vector<int64_t>& buf_ids,
                           MoveOpcode move_opcode);
 
   bool pull_memory_blocks(const std::string& remote_addr,
                           const std::vector<uint64_t>& src_blocks,
                           const std::vector<uint64_t>& dst_blocks,
-                          const std::vector<int64_t>& layer_ids);
+                          const std::vector<int64_t>& buf_ids);
 
   bool push_memory_blocks(const std::string& remote_addr,
                           const std::vector<uint64_t>& src_blocks,
                           const std::vector<uint64_t>& dst_blocks,
-                          const std::vector<int64_t>& layer_ids);
+                          const std::vector<int64_t>& buf_ids);
 
-  // === XTensor mode: transfer by GlobalXTensor offsets ===
-  // Instead of using block_id and per-layer buffers, this method uses
-  // raw offsets into the GlobalXTensor memory region (buffer[0]).
-  // src_offsets and dst_offsets are absolute offsets within GlobalXTensor.
+  // XTensor mode uses raw offsets in the GlobalXTensor region in buffer[0].
   bool move_memory_by_global_offsets(const std::string& remote_addr,
                                      const std::vector<uint64_t>& src_offsets,
                                      const std::vector<uint64_t>& dst_offsets,
@@ -141,8 +143,7 @@ class MooncakeTransferEngine final {
 
  private:
   int16_t listen_port_;
-  int64_t size_per_block_ = 0;
-  int64_t num_layers_ = 0;
+  std::vector<uint64_t> buf_bytes_;
   Device device_;
   MooncakeTransferEngineCore& core_;
 };

--- a/xllm/core/framework/kv_cache/mooncake_transfer_engine_test.cpp
+++ b/xllm/core/framework/kv_cache/mooncake_transfer_engine_test.cpp
@@ -1,0 +1,57 @@
+/* Copyright 2026 The xLLM Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://github.com/jd-opensource/xllm/blob/main/LICENSE
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include "framework/kv_cache/mooncake_transfer_engine.h"
+
+#include <brpc/controller.h>
+#include <gtest/gtest.h>
+
+namespace xllm {
+
+TEST(MooncakeTransferEngineServiceTest, OpenSessionRejectsMissingAddr) {
+  MooncakeTransferEngineService service;
+  proto::SessionInfo request;
+  proto::Status response;
+  brpc::Controller cntl;
+
+  service.OpenSession(&cntl, &request, &response, nullptr);
+
+  EXPECT_FALSE(response.ok());
+}
+
+TEST(MooncakeTransferEngineServiceTest, CloseSessionRejectsMissingAddr) {
+  MooncakeTransferEngineService service;
+  proto::SessionInfo request;
+  proto::Status response;
+  brpc::Controller cntl;
+
+  service.CloseSession(&cntl, &request, &response, nullptr);
+
+  EXPECT_FALSE(response.ok());
+}
+
+TEST(MooncakeTransferEngineServiceTest, CloseSessionWithoutHandleReturnsTrue) {
+  MooncakeTransferEngineService service;
+  proto::SessionInfo request;
+  request.set_addr("127.0.0.1:5001");
+  proto::Status response;
+  brpc::Controller cntl;
+
+  service.CloseSession(&cntl, &request, &response, nullptr);
+
+  EXPECT_TRUE(response.ok());
+}
+
+}  // namespace xllm

--- a/xllm/core/framework/kv_cache/mooncake_weight_transfer.cpp
+++ b/xllm/core/framework/kv_cache/mooncake_weight_transfer.cpp
@@ -53,8 +53,9 @@ bool MooncakeWeightTransfer::register_global_xtensor() {
 
   std::vector<void*> addrs = {global_xtensor.base_vaddr()};
   std::vector<size_t> lens = {global_xtensor.total_size()};
-  if (!mooncake_te_->register_memory(
-          addrs, lens, static_cast<int64_t>(global_xtensor.page_size()))) {
+  std::vector<uint64_t> buf_bytes = {
+      static_cast<uint64_t>(global_xtensor.page_size())};
+  if (!mooncake_te_->register_memory(addrs, lens, buf_bytes)) {
     LOG(ERROR) << "register GlobalXTensor failed";
     return false;
   }

--- a/xllm/core/framework/model/model_input_params.h
+++ b/xllm/core/framework/model/model_input_params.h
@@ -26,6 +26,9 @@ limitations under the License.
 #if defined(USE_NPU)
 #include "platform/npu/npu_layer_synchronizer.h"
 #endif
+#if defined(USE_MLU)
+#include "platform/mlu/mlu_layer_synchronizer.h"
+#endif
 #include "framework/batch/batch_forward_type.h"
 #include "framework/request/mm_batch_data.h"
 #include "npu_cp_ep_padding.h"
@@ -385,7 +388,7 @@ struct ModelInputParams {
     params.ring_cur_seqlen_host = ring_cur_seqlen_host;
     params.ring_cache_seqlen = safe_to(ring_cache_seqlen, device);
     params.ring_cache_seqlen_host = ring_cache_seqlen_host;
-#if defined(USE_NPU)
+#if defined(USE_NPU) || defined(USE_MLU)
     params.layer_synchronizer = layer_synchronizer;
 #endif
     params.expert_load_data = expert_load_data;
@@ -475,6 +478,20 @@ struct ModelInputParams {
         return false;
       }
     }
+#else
+    (void)layer_idx;
+#endif
+    return true;
+  }
+
+  bool record_layer(uint32_t layer_idx, const torch::Device& device) const {
+#if defined(USE_MLU)
+    if (layer_synchronizer != nullptr) {
+      return layer_synchronizer->record_current(layer_idx, device.index());
+    }
+#else
+    (void)layer_idx;
+    (void)device;
 #endif
     return true;
   }
@@ -563,7 +580,9 @@ struct ModelInputParams {
   // visual pos mask for Qwen3-VL
   mutable torch::Tensor visual_pos_masks;
 
-#if defined(USE_NPU)
+#if defined(USE_MLU)
+  std::shared_ptr<MLULayerSynchronizerImpl> layer_synchronizer = nullptr;
+#elif defined(USE_NPU)
   std::shared_ptr<NPULayerSynchronizerImpl> layer_synchronizer = nullptr;
   uint32_t layers_per_bacth_copy = std::numeric_limits<uint32_t>::max();
   std::shared_ptr<NPULayerSynchronizerImpl> layer_wise_load_synchronizer =

--- a/xllm/core/platform/CMakeLists.txt
+++ b/xllm/core/platform/CMakeLists.txt
@@ -14,6 +14,7 @@ cc_library(
     vmm_api.h
     shared_vmm_allocator.h
     vmm_torch_allocator.h
+    $<$<BOOL:${USE_MLU}>:mlu/mlu_layer_synchronizer.h>
     $<$<BOOL:${USE_CUDA}>:cuda/cuda_utils.h>
     $<$<BOOL:${USE_CUDA}>:numa_utils.h>
   SRCS
@@ -21,6 +22,7 @@ cc_library(
     device.cpp
     vmm_api.cpp
     shared_vmm_allocator.cpp
+    $<$<BOOL:${USE_MLU}>:mlu/mlu_layer_synchronizer.cpp>
     $<$<BOOL:${USE_CUDA}>:numa_utils.cpp>
   DEPS
     torch
@@ -51,4 +53,3 @@ cc_test(
     glog::glog
 )
 endif()
-

--- a/xllm/core/platform/mlu/mlu_layer_synchronizer.cpp
+++ b/xllm/core/platform/mlu/mlu_layer_synchronizer.cpp
@@ -1,0 +1,49 @@
+/* Copyright 2026 The xLLM Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://github.com/jd-opensource/xllm/blob/main/LICENSE
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include "platform/mlu/mlu_layer_synchronizer.h"
+
+#include <framework/core/MLUStream.h>
+
+#include <thread>
+
+namespace xllm {
+
+MLULayerSynchronizerImpl::MLULayerSynchronizerImpl(int64_t num_layers)
+    : events_(), event_record_flags_(static_cast<size_t>(num_layers)) {
+  events_.reserve(static_cast<size_t>(num_layers));
+  for (int64_t i = 0; i < num_layers; ++i) {
+    events_.emplace_back(c10::DeviceType::PrivateUse1);
+  }
+}
+
+bool MLULayerSynchronizerImpl::synchronize_layer(int64_t layer_index) {
+  while (!event_record_flags_[layer_index].load(std::memory_order_acquire)) {
+    std::this_thread::yield();
+  }
+  events_[layer_index].synchronize();
+  return true;
+}
+
+bool MLULayerSynchronizerImpl::record_current(int64_t layer_index,
+                                              int32_t device_index) {
+  c10::Stream current_stream =
+      torch_mlu::getCurrentMLUStream(device_index).unwrap();
+  events_[layer_index].record(current_stream);
+  event_record_flags_[layer_index].store(true, std::memory_order_release);
+  return true;
+}
+
+}  // namespace xllm

--- a/xllm/core/platform/mlu/mlu_layer_synchronizer.h
+++ b/xllm/core/platform/mlu/mlu_layer_synchronizer.h
@@ -1,0 +1,40 @@
+/* Copyright 2026 The xLLM Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://github.com/jd-opensource/xllm/blob/main/LICENSE
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#pragma once
+
+#include <c10/core/Event.h>
+
+#include <atomic>
+#include <cstdint>
+#include <vector>
+
+namespace xllm {
+
+class MLULayerSynchronizerImpl final {
+ public:
+  explicit MLULayerSynchronizerImpl(int64_t num_layers);
+  ~MLULayerSynchronizerImpl() = default;
+
+  bool synchronize_layer(int64_t layer_index);
+  bool record_current(int64_t layer_index, int32_t device_index);
+  uint32_t get_event_size() const { return events_.size(); }
+
+ private:
+  std::vector<c10::Event> events_;
+  std::vector<std::atomic<bool>> event_record_flags_;
+};
+
+}  // namespace xllm

--- a/xllm/core/runtime/llm_worker_impl.cpp
+++ b/xllm/core/runtime/llm_worker_impl.cpp
@@ -101,6 +101,12 @@ std::optional<ForwardOutput> LLMWorkerImpl::step_internal(
     std::shared_ptr<NPULayerSynchronizerImpl> layer_synchronizer =
         std::make_shared<NPULayerSynchronizerImpl>(
             context_.get_model_args().n_layers());
+#elif defined(USE_MLU)
+    std::shared_ptr<MLULayerSynchronizerImpl> layer_synchronizer =
+        std::make_shared<MLULayerSynchronizerImpl>(
+            context_.get_model_args().n_layers());
+#endif
+#if defined(USE_NPU) || defined(USE_MLU)
     const_cast<ModelInputParams*>(&(input.input_params))->layer_synchronizer =
         layer_synchronizer;
 

--- a/xllm/core/runtime/rec_worker_impl.cpp
+++ b/xllm/core/runtime/rec_worker_impl.cpp
@@ -143,6 +143,12 @@ std::optional<ForwardOutput> RecWorkerImpl::RecWorkPipeline::step(
     std::shared_ptr<NPULayerSynchronizerImpl> layer_synchronizer =
         std::make_shared<NPULayerSynchronizerImpl>(
             runtime_.context->get_model_args().n_layers());
+#elif defined(USE_MLU)
+    std::shared_ptr<MLULayerSynchronizerImpl> layer_synchronizer =
+        std::make_shared<MLULayerSynchronizerImpl>(
+            runtime_.context->get_model_args().n_layers());
+#endif
+#if defined(USE_NPU) || defined(USE_MLU)
     const_cast<ModelInputParams*>(&(input.input_params))->layer_synchronizer =
         layer_synchronizer;
 

--- a/xllm/core/runtime/worker_impl.cpp
+++ b/xllm/core/runtime/worker_impl.cpp
@@ -436,7 +436,7 @@ void WorkerImpl::get_cache_info(uint64_t& cluster_id,
                                 std::string& addr,
                                 int64_t& k_cache_id,
                                 int64_t& v_cache_id) {
-#if defined(USE_NPU)
+#if defined(USE_NPU) || defined(USE_MLU)
   kv_cache_transfer_->get_cache_info(cluster_id, addr, k_cache_id, v_cache_id);
 #endif
 }
@@ -445,7 +445,7 @@ bool WorkerImpl::link_cluster(const std::vector<uint64_t>& cluster_ids,
                               const std::vector<std::string>& addrs,
                               const std::vector<std::string>& device_ips,
                               const std::vector<uint16_t>& ports) {
-#if defined(USE_NPU)
+#if defined(USE_NPU) || defined(USE_MLU)
   for (int32_t i = 0; i < cluster_ids.size(); ++i) {
     if (!kv_cache_transfer_->link_cluster(
             cluster_ids[i], addrs[i], device_ips[i], ports[i])) {
@@ -460,7 +460,7 @@ bool WorkerImpl::unlink_cluster(const std::vector<uint64_t>& cluster_ids,
                                 const std::vector<std::string>& addrs,
                                 const std::vector<std::string>& device_ips,
                                 const std::vector<uint16_t>& ports) {
-#if defined(USE_NPU)
+#if defined(USE_NPU) || defined(USE_MLU)
   for (int32_t i = 0; i < cluster_ids.size(); ++i) {
     if (!kv_cache_transfer_->unlink_cluster(
             cluster_ids[i], addrs[i], device_ips[i], ports[i])) {
@@ -1210,6 +1210,14 @@ folly::SemiFuture<bool> WorkerImpl::pull_kv_blocks_async(
                                                   src_v_cache_id,
                                                   src_blocks,
                                                   dst_blocks);
+#elif defined(USE_MLU)
+  (void)src_cluster_id;
+  (void)src_addr;
+  (void)src_k_cache_id;
+  (void)src_v_cache_id;
+  (void)src_blocks;
+  (void)dst_blocks;
+  LOG(FATAL) << "MLU backend does not support PULL kv cache transfer.";
 #endif
   return false;
 }

--- a/xllm/models/llm/deepseek_v2.h
+++ b/xllm/models/llm/deepseek_v2.h
@@ -103,6 +103,10 @@ class DeepseekV2ModelImpl : public torch::nn::Module {
                             attn_metadata,
                             kv_caches[i],
                             modified_input_params);
+      if (!modified_input_params.record_layer(static_cast<uint32_t>(i),
+                                              hidden_states.device())) {
+        return ModelOutput();
+      }
     }
     auto [h, res] = norm_(hidden_states, residual);
     return ModelOutput(h, res);

--- a/xllm/models/llm/llm_model_base.h
+++ b/xllm/models/llm/llm_model_base.h
@@ -121,6 +121,10 @@ class LlmModelImplBase : public torch::nn::Module {
                 attn_metadata,
                 kv_caches[i],
                 modified_input_params);
+      if (!modified_input_params.record_layer(static_cast<uint32_t>(i),
+                                              h.device())) {
+        return ModelOutput();
+      }
     }
     auto [hidden_states, residual_out] = norm_(h, residual);
     return ModelOutput(hidden_states, residual_out);

--- a/xllm/models/llm/mtp_model_base.h
+++ b/xllm/models/llm/mtp_model_base.h
@@ -196,6 +196,10 @@ class MtpModelImplBase : public torch::nn::Module {
                             attn_metadata,
                             kv_caches[i],
                             modified_input_params);
+      if (!modified_input_params.record_layer(static_cast<uint32_t>(i),
+                                              hidden_states.device())) {
+        return ModelOutput();
+      }
     }
     auto [h_out, r_out] = norm_(hidden_states, residual);
     return ModelOutput(h_out, r_out);

--- a/xllm/models/llm/oxygen.h
+++ b/xllm/models/llm/oxygen.h
@@ -81,6 +81,10 @@ class OxygenModelImpl : public QWen3ModelImpl {
                 attn_metadata,
                 kv_caches[i],
                 input_params_new);
+      if (!input_params_new.record_layer(static_cast<uint32_t>(i),
+                                         h.device())) {
+        return ModelOutput();
+      }
 
       if (use_deepstack) {
         if (deep_stacks.size() > 0 && i < deep_stacks.size()) {

--- a/xllm/models/llm/qwen3.h
+++ b/xllm/models/llm/qwen3.h
@@ -172,6 +172,10 @@ class QWen3ModelImpl : public LlmModelImplBase<layer::Qwen3DecoderLayer> {
                 attn_metadata,
                 kv_caches[i],
                 input_params_new);
+      if (!input_params_new.record_layer(static_cast<uint32_t>(i),
+                                         h.device())) {
+        return ModelOutput();
+      }
 
       if (use_deepstack) {
         if (deep_stacks.size() > 0 && i < deep_stacks.size()) {

--- a/xllm/models/llm/qwen3_moe.h
+++ b/xllm/models/llm/qwen3_moe.h
@@ -164,6 +164,10 @@ class Qwen3MoeModelImpl : public LlmModelImplBase<layer::Qwen3MoeDecoderLayer> {
                 attn_metadata,
                 kv_caches[i],
                 modified_input_params);
+      if (!modified_input_params.record_layer(static_cast<uint32_t>(i),
+                                              h.device())) {
+        return ModelOutput();
+      }
 
       if (deep_stack_size && i < deep_stack_size) {
         h = deepstack_process(h, input_params.visual_pos_masks, deep_stacks[i]);

--- a/xllm/xllm.cpp
+++ b/xllm/xllm.cpp
@@ -50,6 +50,45 @@ static const std::unordered_set<std::string> prefill_sp_supported_model_set = {
     "deepseek_v32",
     "glm_moe_dsa"};
 
+namespace {
+
+void fix_mlu_disagg_pd_flags() {
+  if (FLAGS_kv_cache_transfer_type != "Mooncake") {
+    LOG(WARNING) << "MLU disaggregated PD requires "
+                 << "kv_cache_transfer_type=Mooncake; forcing from "
+                 << FLAGS_kv_cache_transfer_type << " to Mooncake.";
+    FLAGS_kv_cache_transfer_type = "Mooncake";
+  }
+  if (FLAGS_kv_cache_transfer_mode != "PUSH") {
+    LOG(WARNING) << "MLU disaggregated PD requires "
+                 << "kv_cache_transfer_mode=PUSH; forcing from "
+                 << FLAGS_kv_cache_transfer_mode << " to PUSH.";
+    FLAGS_kv_cache_transfer_mode = "PUSH";
+  }
+  if (FLAGS_kv_cache_dtype != "auto") {
+    LOG(WARNING) << "MLU disaggregated PD requires kv_cache_dtype=auto; "
+                 << "forcing from " << FLAGS_kv_cache_dtype << " to auto.";
+    FLAGS_kv_cache_dtype = "auto";
+  }
+  if (FLAGS_enable_prefix_cache) {
+    LOG(WARNING) << "MLU disaggregated PD does not support prefix cache; "
+                 << "forcing enable_prefix_cache=false.";
+    FLAGS_enable_prefix_cache = false;
+  }
+  if (FLAGS_enable_chunked_prefill) {
+    LOG(WARNING) << "MLU disaggregated PD does not support chunked prefill; "
+                 << "forcing enable_chunked_prefill=false.";
+    FLAGS_enable_chunked_prefill = false;
+  }
+  if (FLAGS_enable_pd_ooc) {
+    LOG(WARNING) << "MLU disaggregated PD does not support pd_ooc; "
+                 << "forcing enable_pd_ooc=false.";
+    FLAGS_enable_pd_ooc = false;
+  }
+}
+
+}  // namespace
+
 void shutdown_handler(int signal) {
   // TODO: gracefully shutdown the server
   LOG(WARNING) << "Received signal " << signal << ", stopping server...";
@@ -79,6 +118,12 @@ void validate_flags(const std::string& model_type) {
       FLAGS_backend != "dit") {
     LOG(FATAL) << "Currently, block_size must be 16 for MLU backend, we will "
                   "support other block sizes in the future.";
+  }
+  if (FLAGS_enable_disagg_pd) {
+    if (FLAGS_backend != "llm") {
+      LOG(FATAL) << "MLU disaggregated PD only supports backend=llm.";
+    }
+    fix_mlu_disagg_pd_flags();
   }
 #endif
 


### PR DESCRIPTION
- add backend-agnostic layer synchronizer wiring for layer-wise push overlap
- enable mooncake push on mlu with descriptor-based memory registration
- enforce mlu pd push flag validation and reject unsupported pull mode