### PR TITLE
bugfix: remove spurious backslash breaking output redirection in launch scripts.

### DIFF
--- a/docs/en/getting_started/launch_xllm.md
+++ b/docs/en/getting_started/launch_xllm.md
@@ -43,7 +43,7 @@ do
     --enable_chunked_prefill=true \
     --enable_schedule_overlap=true \
     --enable_shm=true \
-    --node_rank=$i \ > $LOG_FILE 2>&1 &
+    --node_rank=$i > $LOG_FILE 2>&1 &
 done
 ```
 
@@ -84,7 +84,7 @@ do
     --enable_prefix_cache=false \
     --enable_chunked_prefill=false \
     --enable_schedule_overlap=true \
-    --node_rank=$i \ > $LOG_FILE 2>&1 &
+    --node_rank=$i > $LOG_FILE 2>&1 &
 done
 ```
 
@@ -120,6 +120,6 @@ do
     --nnodes=$NNODES \
     --master_node_addr=$MASTER_NODE_ADDR \
     --block_size=16 \
-    --node_rank=$i \ > $LOG_FILE 2>&1 &
+    --node_rank=$i > $LOG_FILE 2>&1 &
 done
 ```


### PR DESCRIPTION
Closes #1247

## Problem

In `docs/en/getting_started/launch_xllm.md`, all three platform launch scripts (NPU, NVIDIA GPU, MLU) contain a shell syntax error on the final argument line:

```bash
--node_rank=$i \ > $LOG_FILE 2>&1 &
```

The `\ >` sequence causes the shell to interpret `>` as a literal escaped character rather than a **redirection operator**. As a result:
- The log file is **never created**
- All xllm stdout/stderr prints to the terminal instead of being captured
- Users running the launch script lose all logs

## Fix

Remove the spurious `\` before `>` in all three script blocks (lines 46, 87, 123):

```bash
# Before (broken):
    --node_rank=$i \ > $LOG_FILE 2>&1 &

# After (correct):
    --node_rank=$i > $LOG_FILE 2>&1 &
```

## Testing

```bash
# Demonstrate the bug (no file created):
echo hello \ > /tmp/test_broken.log
cat /tmp/test_broken.log  # file empty or missing

# Correct form:
echo hello > /tmp/test_fixed.log
cat /tmp/test_fixed.log   # prints: hello
```