### PR TITLE
bugfix: forward REC tokenizer methods through proxy.

### DIFF
--- a/xllm/core/framework/tokenizer/tokenizer_proxy.cpp
+++ b/xllm/core/framework/tokenizer/tokenizer_proxy.cpp
@@ -36,9 +36,20 @@ bool TokenizerProxy::encode(const std::string_view& text,
   return get_tls_tokenizer()->encode(text, ids, add_special_tokens);
 }
 
+bool TokenizerProxy::encode(int64_t item_id,
+                            std::vector<int32_t>* token_ids) const {
+  return get_tls_tokenizer()->encode(item_id, token_ids);
+}
+
 std::string TokenizerProxy::decode(const Slice<int32_t>& ids,
                                    bool skip_special_tokens) const {
   return get_tls_tokenizer()->decode(ids, skip_special_tokens);
+}
+
+bool TokenizerProxy::decode(const Slice<int32_t>& token_ids,
+                            bool skip_special_tokens,
+                            std::vector<int64_t>* item_ids) const {
+  return get_tls_tokenizer()->decode(token_ids, skip_special_tokens, item_ids);
 }
 
 std::optional<int32_t> TokenizerProxy::token_to_id(

--- a/xllm/core/framework/tokenizer/tokenizer_proxy.h
+++ b/xllm/core/framework/tokenizer/tokenizer_proxy.h
@@ -29,8 +29,14 @@ class TokenizerProxy : public Tokenizer {
               std::vector<int32_t>* ids,
               bool add_special_tokens = true) const override;
 
+  bool encode(int64_t item_id, std::vector<int32_t>* token_ids) const override;
+
   std::string decode(const Slice<int32_t>& ids,
                      bool skip_special_tokens) const override;
+
+  bool decode(const Slice<int32_t>& token_ids,
+              bool skip_special_tokens,
+              std::vector<int64_t>* item_ids) const override;
 
   std::optional<int32_t> token_to_id(
       const std::string_view& token) const override;


### PR DESCRIPTION
## Summary
- forward REC-specific `encode` and `decode` methods through `TokenizerProxy`
- fix proxied OneRec item decoding so the request output path can resolve item ids correctly

## Validation
- manually verified on the real OneRec request path
- no extra test-only changes are included in this PR
