### PR TITLE
bugfix: add ILU process group ctor for explicit local rank. (#1240)

### DIFF
--- a/xllm/core/framework/parallel_state/ilu_process_group.h
+++ b/xllm/core/framework/parallel_state/ilu_process_group.h
@@ -70,8 +70,9 @@ class ProcessGroupImpl : public ProcessGroup {
     if (world_size != rank_size) {
       std::vector<uint64_t> uint64_ranks;
       uint64_ranks.reserve(group_ranks.size());
-      for (const auto rank : group_ranks) {
-        uint64_ranks.push_back(static_cast<uint64_t>(rank));
+      for (const int32_t rank : group_ranks) {
+        uint64_ranks.emplace_back(static_cast<uint64_t>(rank));
+      }
       }
       pg_options->global_ranks_in_group = std::move(uint64_ranks);
     }

--- a/xllm/core/framework/parallel_state/ilu_process_group.h
+++ b/xllm/core/framework/parallel_state/ilu_process_group.h
@@ -50,6 +50,36 @@ class ProcessGroupImpl : public ProcessGroup {
     pg_ = std::make_unique<c10d::ProcessGroupNCCL>(
         store, rank, rank_size, pg_options);
   }
+
+  ProcessGroupImpl(int32_t global_rank,
+                   int32_t local_rank,
+                   const std::vector<int32_t>& group_ranks,
+                   int32_t world_size,
+                   int32_t rank_size,
+                   int32_t port,
+                   const std::string& host,
+                   const std::string& group_name,
+                   const torch::Device& device)
+      : ProcessGroup(global_rank, world_size, device) {
+    c10::intrusive_ptr<c10d::ProcessGroupNCCL::Options> pg_options =
+        c10d::ProcessGroupNCCL::Options::create();
+#if TORCH_VERSION_MAJOR > 2 || \
+    (TORCH_VERSION_MAJOR == 2 && TORCH_VERSION_MINOR >= 7)
+    pg_options->group_name = group_name;
+#endif
+    if (world_size != rank_size) {
+      std::vector<uint64_t> uint64_ranks;
+      uint64_ranks.reserve(group_ranks.size());
+      for (const auto rank : group_ranks) {
+        uint64_ranks.push_back(static_cast<uint64_t>(rank));
+      }
+      pg_options->global_ranks_in_group = std::move(uint64_ranks);
+    }
+
+    auto store = create_tcp_store(host, port, local_rank);
+    pg_ = std::make_unique<c10d::ProcessGroupNCCL>(
+        store, local_rank, rank_size, pg_options);
+  }
 };
 
 }  // namespace xllm


### PR DESCRIPTION
Add the ILU ProcessGroup constructor overload that accepts local_rank and explicit group_ranks, so the DiT process-group creation path matches the expected signature and builds successfully.