### PR TITLE
bugfix: fix llm default stream execution without overlap.

### DIFF
--- a/xllm/core/distributed_runtime/worker_service.cpp
+++ b/xllm/core/distributed_runtime/worker_service.cpp
@@ -79,6 +79,8 @@ void WorkerService::step(ForwardInput& fwd_input,
                          torch::Tensor& src_seq_idxes,
                          torch::Tensor& out_tokens,
                          torch::Tensor& out_logprobs) {
+  const bool use_default_stream =
+      !options_.enable_schedule_overlap() && options_.backend() == "llm";
   // execute model
   auto future = worker_->step_async(fwd_input);
   if (!options_.enable_schedule_overlap()) {
@@ -96,58 +98,71 @@ void WorkerService::step(ForwardInput& fwd_input,
       prepared_layer_id = forward_outputs.value().prepared_layer_id;
 
       {
-        c10::StreamGuard streamGuard = stream_->set_stream_guard();
-        // only driver worker (rank=0) need to fill this
-        // [num_seq, ..., embed_dim] FloatTensor
-        embeddings = safe_to(sample_output.embeddings,
-                             torch::dtype(torch::kFloat32).device(torch::kCPU),
-                             true);
-
-        mm_embeddings.clear();
-        mm_embeddings.reserve(sample_output.mm_embeddings.size());
-        for (auto mm_embedding : sample_output.mm_embeddings) {
-          mm_embeddings.emplace_back(safe_to(mm_embedding, torch::kCPU, true));
-        }
-
-        dit_images.clear();
-        dit_images.reserve(dit_forward_output.tensors.size());
-        for (auto dit_image : dit_forward_output.tensors) {
-          dit_images.emplace_back(safe_to(dit_image, torch::kCPU, true));
-        }
-
-        // [num_seq]
-        next_tokens = safe_to(sample_output.next_tokens, torch::kCPU, true);
-        if (next_tokens.defined()) {
-          // [num_seq]
-          logprobs = safe_to(sample_output.logprobs, torch::kCPU, true);
-
-          if (!beam_search_output.src_seq_idxes.defined()) {
-            // beam search kernel will provide final tokens/logprobs in beam
-            // search output, so keep top_tokens/top_logprobs undefined to
-            // avoid returning them.
-            // [num_seq, topk]
-            top_tokens = safe_to(sample_output.top_tokens, torch::kCPU, true);
-            // [num_seq, topk]
-            top_logprobs =
-                safe_to(sample_output.top_logprobs, torch::kCPU, true);
-          }
-        }
-
-        // beam search output
-        // [num_seq]
-        src_seq_idxes =
-            safe_to(beam_search_output.src_seq_idxes, torch::kCPU, true);
-        if (src_seq_idxes.defined()) {
-          // [num_seq]
-          out_tokens =
-              safe_to(beam_search_output.out_tokens, torch::kCPU, true);
-          // [num_seq]
-          out_logprobs =
-              safe_to(beam_search_output.out_logprobs,
+        auto copy_output_to_host = [&]() {
+          // only driver worker (rank=0) need to fill this
+          // [num_seq, ..., embed_dim] FloatTensor
+          embeddings =
+              safe_to(sample_output.embeddings,
                       torch::dtype(torch::kFloat32).device(torch::kCPU),
                       true);
+
+          mm_embeddings.clear();
+          mm_embeddings.reserve(sample_output.mm_embeddings.size());
+          for (auto mm_embedding : sample_output.mm_embeddings) {
+            mm_embeddings.emplace_back(
+                safe_to(mm_embedding, torch::kCPU, true));
+          }
+
+          dit_images.clear();
+          dit_images.reserve(dit_forward_output.tensors.size());
+          for (auto dit_image : dit_forward_output.tensors) {
+            dit_images.emplace_back(safe_to(dit_image, torch::kCPU, true));
+          }
+
+          // [num_seq]
+          next_tokens = safe_to(sample_output.next_tokens, torch::kCPU, true);
+          if (next_tokens.defined()) {
+            // [num_seq]
+            logprobs = safe_to(sample_output.logprobs, torch::kCPU, true);
+
+            if (!beam_search_output.src_seq_idxes.defined()) {
+              // beam search kernel will provide final tokens/logprobs in beam
+              // search output, so keep top_tokens/top_logprobs undefined to
+              // avoid returning them.
+              // [num_seq, topk]
+              top_tokens = safe_to(sample_output.top_tokens, torch::kCPU, true);
+              // [num_seq, topk]
+              top_logprobs =
+                  safe_to(sample_output.top_logprobs, torch::kCPU, true);
+            }
+          }
+
+          // beam search output
+          // [num_seq]
+          src_seq_idxes =
+              safe_to(beam_search_output.src_seq_idxes, torch::kCPU, true);
+          if (src_seq_idxes.defined()) {
+            // [num_seq]
+            out_tokens =
+                safe_to(beam_search_output.out_tokens, torch::kCPU, true);
+            // [num_seq]
+            out_logprobs =
+                safe_to(beam_search_output.out_logprobs,
+                        torch::dtype(torch::kFloat32).device(torch::kCPU),
+                        true);
+          }
+        };
+        if (use_default_stream) {
+          copy_output_to_host();
+        } else {
+          c10::StreamGuard stream_guard = stream_->set_stream_guard();
+          copy_output_to_host();
         }
-        auto ret = stream_->synchronize();
+        if (use_default_stream) {
+          device_.synchronize_default_stream();
+        } else {
+          stream_->synchronize();
+        }
       }
     }
   } else {
@@ -692,6 +707,8 @@ void WorkerService::GetLastStepResult(
   threadpool_->schedule(
       [this, controller, req, pb_forward_output, done]() mutable {
         brpc::ClosureGuard done_guard(done);
+        const bool use_default_stream =
+            !options_.enable_schedule_overlap() && options_.backend() == "llm";
 
         auto future = worker_->get_last_step_result_async();
         auto forward_outputs = std::move(future).get();
@@ -702,46 +719,64 @@ void WorkerService::GetLastStepResult(
           int32_t prepared_layer_id = forward_outputs.value().prepared_layer_id;
           const auto& beam_search_output =
               forward_outputs.value().beam_search_output;
-          c10::StreamGuard streamGuard = stream_->set_stream_guard();
-          // [num_seq, ..., embed_dim]
-          auto embeddings =
-              safe_to(sample_output.embeddings, torch::kCPU, true);
-          embeddings = safe_to(embeddings, torch::kFloat32, true);
-
+          torch::Tensor embeddings;
+          torch::Tensor next_tokens;
+          torch::Tensor logprobs;
+          torch::Tensor top_tokens;
+          torch::Tensor top_logprobs;
+          torch::Tensor src_seq_idxes;
+          torch::Tensor out_tokens;
+          torch::Tensor out_logprobs;
           std::vector<torch::Tensor> dit_images;
-          dit_images.reserve(
-              forward_outputs.value().dit_forward_output.tensors.size());
-          for (auto image :
-               forward_outputs.value().dit_forward_output.tensors) {
-            dit_images.emplace_back(image);
+          auto copy_output_to_host = [&]() {
+            // [num_seq, ..., embed_dim]
+            embeddings = safe_to(sample_output.embeddings, torch::kCPU, true);
+            embeddings = safe_to(embeddings, torch::kFloat32, true);
+
+            dit_images.reserve(
+                forward_outputs.value().dit_forward_output.tensors.size());
+            for (auto image :
+                 forward_outputs.value().dit_forward_output.tensors) {
+              dit_images.emplace_back(image);
+            }
+
+            // [num_seq]
+            next_tokens = safe_to(sample_output.next_tokens, torch::kCPU, true);
+            if (next_tokens.defined() || FLAGS_enable_eplb) {
+              // [num_seq] FloatTensor
+              logprobs = safe_to(sample_output.logprobs, torch::kCPU, true);
+              // [num_seq, topk]
+              top_tokens = safe_to(sample_output.top_tokens, torch::kCPU, true);
+              // [num_seq, topk]
+              top_logprobs =
+                  safe_to(sample_output.top_logprobs, torch::kCPU, true);
+              // [num_seq]
+              src_seq_idxes =
+                  safe_to(beam_search_output.src_seq_idxes, torch::kCPU, true);
+              // [num_seq]
+              out_tokens =
+                  safe_to(beam_search_output.out_tokens, torch::kCPU, true);
+              // [num_seq]
+              out_logprobs =
+                  safe_to(beam_search_output.out_logprobs,
+                          torch::dtype(torch::kFloat32).device(torch::kCPU),
+                          true);
+            }
+          };
+
+          if (use_default_stream) {
+            copy_output_to_host();
+          } else {
+            c10::StreamGuard stream_guard = stream_->set_stream_guard();
+            copy_output_to_host();
+          }
+          if (use_default_stream) {
+            device_.synchronize_default_stream();
+          } else {
+            stream_->synchronize();
           }
 
-          // [num_seq]
-          const auto& next_tokens =
-              safe_to(sample_output.next_tokens, torch::kCPU, true);
           if (next_tokens.defined() || FLAGS_enable_eplb) {
-            // [num_seq] FloatTensor
-            const auto& logprobs =
-                safe_to(sample_output.logprobs, torch::kCPU, true);
-            // [num_seq, topk]
-            const auto& top_tokens =
-                safe_to(sample_output.top_tokens, torch::kCPU, true);
-            // [num_seq, topk]
-            const auto& top_logprobs =
-                safe_to(sample_output.top_logprobs, torch::kCPU, true);
-            // [num_seq]
-            const auto& src_seq_idxes =
-                safe_to(beam_search_output.src_seq_idxes, torch::kCPU, true);
-            // [num_seq]
-            const auto& out_tokens =
-                safe_to(beam_search_output.out_tokens, torch::kCPU, true);
-            // [num_seq]
-            const auto& out_logprobs =
-                safe_to(beam_search_output.out_logprobs,
-                        torch::dtype(torch::kFloat32).device(torch::kCPU),
-                        true);
-            auto ret = stream_->synchronize();
-
             forward_output_to_proto(next_tokens,
                                     logprobs,
                                     top_tokens,

--- a/xllm/core/framework/model/model_input_params.h
+++ b/xllm/core/framework/model/model_input_params.h
@@ -346,7 +346,9 @@ struct ModelInputParams {
 
     params.kv_seq_lens = safe_to(kv_seq_lens, device, true);
     params.q_seq_lens = safe_to(q_seq_lens, device, true);
+#if !defined(USE_CUDA)
     params.q_cu_seq_lens = safe_to(q_cu_seq_lens, device, true);
+#endif
 
     params.new_cache_slots = safe_to(new_cache_slots, device, true);
     params.block_tables = safe_to(block_tables, device, true);

--- a/xllm/core/layers/common/attention_metadata_builder.cpp
+++ b/xllm/core/layers/common/attention_metadata_builder.cpp
@@ -101,7 +101,7 @@ AttentionMetadata build_attention_metadata(
   attn_metadata.is_prefill = params.batch_forward_type.is_prefill();
   if (!attn_metadata.is_prefill || enable_mla) {
     attn_metadata.block_table = params.block_tables;
-#if !defined(USE_NPU)
+#if !defined(USE_NPU) && !defined(USE_CUDA)
     attn_metadata.kv_seq_lens = torch::diff(params.kv_seq_lens);  // kv seqlens
     attn_metadata.q_seq_lens = torch::diff(params.q_seq_lens);    // q seqlens
 #endif

--- a/xllm/core/runtime/forward_shared_memory_manager.cpp
+++ b/xllm/core/runtime/forward_shared_memory_manager.cpp
@@ -1978,6 +1978,7 @@ inline void deserialize_raw_forward_input(const char*& buffer,
   read_data(context, input_params.batch_id);
   read_tensor_and_vector(
       context, input_params.q_seq_lens, input_params.q_seq_lens_vec, stream);
+#if !defined(USE_CUDA)
   if (!input_params.q_seq_lens_vec.empty()) {
     std::vector<int32_t> cu_lens(input_params.q_seq_lens_vec.size());
     std::partial_sum(input_params.q_seq_lens_vec.begin(),
@@ -1989,6 +1990,7 @@ inline void deserialize_raw_forward_input(const char*& buffer,
                                                    .device(torch::kCPU)
                                                    .pinned_memory(true));
   }
+#endif
   read_tensor_and_vector(
       context, input_params.kv_seq_lens, input_params.kv_seq_lens_vec, stream);
   read_tensor(context, input_params.paged_kv_indptr, stream);

--- a/xllm/core/runtime/llm_worker_impl.cpp
+++ b/xllm/core/runtime/llm_worker_impl.cpp
@@ -79,7 +79,15 @@ bool LLMWorkerImpl::init_model(ModelContext& context) {
 std::optional<ForwardOutput> LLMWorkerImpl::step(const ForwardInput& input) {
   if (FLAGS_enable_manual_loader) {
 #if defined(USE_NPU)
-    SET_ATB_EXECUTE_STREAM(compute_stream_, device_, context_);
+    if (!enable_schedule_overlap() && options_.backend() == "llm") {
+      aclrtStream current_stream =
+          c10_npu::getCurrentNPUStream(device_.index()).stream();
+      atb::Context* atb_context =
+          const_cast<atb::Context*>(context_.get_atb_context());
+      atb_context->SetExecuteStream(current_stream);
+    } else {
+      SET_ATB_EXECUTE_STREAM(compute_stream_, device_, context_);
+    }
 #endif
     return step_internal(input);
   }

--- a/xllm/core/runtime/worker_impl.cpp
+++ b/xllm/core/runtime/worker_impl.cpp
@@ -598,65 +598,78 @@ void WorkerImpl::prepare_work_before_execute(const ForwardInput& input,
     lock_guard.emplace(capture_lock);
   }
 #endif
-  c10::StreamGuard streamGuard = prepare_stream_->set_stream_guard();
-  processed_input = input.to(device_, dtype_);
-  auto& input_params = processed_input.input_params;
+  const bool use_default_stream =
+      !enable_schedule_overlap() && options_.backend() == "llm";
+  auto prepare_input_on_current_stream = [&]() {
+    processed_input = input.to(device_, dtype_);
+    auto& input_params = processed_input.input_params;
 
 #if defined(USE_NPU)
-  CpPrefillInputs tmp_cp_inputs;
-  if (parallel_args_.cp_size() > 1 &&
-      input.input_params.batch_forward_type.is_prefill()) {
-    tmp_cp_inputs = prepare_cp_prefill_inputs(parallel_args_.cp_size(),
-                                              input.token_ids,
-                                              input.positions,
-                                              input.input_params.q_seq_lens);
-    processed_input.input_params.cp_prefill_inputs = tmp_cp_inputs.to(device_);
-    CpEpPadding cp_ep_padding(
-        input.token_ids,
-        context_.get_model_args().num_experts_per_tok(),
-        context_.get_parallel_args().mapping_data(),
-        /*device=*/device_,
-        dtype_,
-        /*is_prefill=*/input.input_params.batch_forward_type.is_prefill());
-    processed_input.input_params.cp_ep_padding_data = cp_ep_padding.build();
-  }
-#endif
-
-  apply_kv_block_swaps(input_params);
-
-#if defined(USE_NPU)
-  if (context_.get_model_args().enable_mla() &&
-      input_params.batch_forward_type.is_chunked_prefill()) {
-    prepare_mla_prefixcache_inputs(input_params);
-  }
-
-  if (!context_.get_parallel_args().mapping_data().empty() &&
-      !(context_.get_parallel_args().cp_size() > 1) &&
-      (context_.get_parallel_args().dp_size() > 1 ||
-       context_.get_parallel_args().ep_size() > 1)) {
-    torch::Tensor token_size_per_dp_group =
-        torch::tensor(processed_input.input_params.dp_global_token_nums,
-                      torch::TensorOptions()
-                          .device(torch::kCPU)
-                          .dtype(torch::kInt32)
-                          .pinned_memory(true));
-    bool is_prefill =
-        processed_input.input_params.batch_forward_type.is_prefill();
-    DpEpPadding dp_ep_padding(token_size_per_dp_group,
-                              context_.get_model_args().num_experts_per_tok(),
-                              context_.get_parallel_args().mapping_data(),
-                              device_,
-                              dtype_,
-                              is_prefill);
-    processed_input.input_params.dp_ep_padding_data = dp_ep_padding.build();
-    if (FLAGS_enable_eplb) {
-      // expert_load_data_.fill_(0);
-      processed_input.input_params.expert_load_data = expert_load_data_;
+    CpPrefillInputs tmp_cp_inputs;
+    if (parallel_args_.cp_size() > 1 &&
+        input.input_params.batch_forward_type.is_prefill()) {
+      tmp_cp_inputs = prepare_cp_prefill_inputs(parallel_args_.cp_size(),
+                                                input.token_ids,
+                                                input.positions,
+                                                input.input_params.q_seq_lens);
+      processed_input.input_params.cp_prefill_inputs =
+          tmp_cp_inputs.to(device_);
+      CpEpPadding cp_ep_padding(
+          input.token_ids,
+          context_.get_model_args().num_experts_per_tok(),
+          context_.get_parallel_args().mapping_data(),
+          /*device=*/device_,
+          dtype_,
+          /*is_prefill=*/input.input_params.batch_forward_type.is_prefill());
+      processed_input.input_params.cp_ep_padding_data = cp_ep_padding.build();
     }
-  }
 #endif
 
-  auto ret = prepare_stream_->synchronize();
+    apply_kv_block_swaps(input_params);
+
+#if defined(USE_NPU)
+    if (context_.get_model_args().enable_mla() &&
+        input_params.batch_forward_type.is_chunked_prefill()) {
+      prepare_mla_prefixcache_inputs(input_params);
+    }
+
+    if (!context_.get_parallel_args().mapping_data().empty() &&
+        !(context_.get_parallel_args().cp_size() > 1) &&
+        (context_.get_parallel_args().dp_size() > 1 ||
+         context_.get_parallel_args().ep_size() > 1)) {
+      torch::Tensor token_size_per_dp_group =
+          torch::tensor(processed_input.input_params.dp_global_token_nums,
+                        torch::TensorOptions()
+                            .device(torch::kCPU)
+                            .dtype(torch::kInt32)
+                            .pinned_memory(true));
+      bool is_prefill =
+          processed_input.input_params.batch_forward_type.is_prefill();
+      DpEpPadding dp_ep_padding(token_size_per_dp_group,
+                                context_.get_model_args().num_experts_per_tok(),
+                                context_.get_parallel_args().mapping_data(),
+                                device_,
+                                dtype_,
+                                is_prefill);
+      processed_input.input_params.dp_ep_padding_data = dp_ep_padding.build();
+      if (FLAGS_enable_eplb) {
+        // expert_load_data_.fill_(0);
+        processed_input.input_params.expert_load_data = expert_load_data_;
+      }
+    }
+#endif
+  };
+
+  if (use_default_stream) {
+    prepare_input_on_current_stream();
+  } else {
+    c10::StreamGuard stream_guard = prepare_stream_->set_stream_guard();
+    prepare_input_on_current_stream();
+  }
+
+  if (!use_default_stream) {
+    prepare_stream_->synchronize();
+  }
 }
 
 void WorkerImpl::apply_kv_block_swaps(const ModelInputParams& input_params) {

--- a/xllm/core/scheduler/continuous_scheduler.cpp
+++ b/xllm/core/scheduler/continuous_scheduler.cpp
@@ -1044,7 +1044,7 @@ std::vector<Batch> ContinuousScheduler::schedule_request(
       break;
     }
     // wait for new requests to arrive
-    constexpr uint64_t kStepSleepTimeMs = 10;
+    constexpr uint64_t kStepSleepTimeMs = 1;
     const auto time_to_sleep =
         std::min(absl::Milliseconds(kStepSleepTimeMs), deadline - now);
     absl::SleepFor(time_to_sleep);
@@ -1119,7 +1119,7 @@ void ContinuousScheduler::generate() {
   while (num_pending_requests() > 0 || !batch_empty ||
          request_queue_.size() > 0) {
     // build a batch of requests/sequences
-    const auto timeout = absl::Milliseconds(500);
+    const auto timeout = absl::Milliseconds(50);
     std::vector<Batch> batch = schedule_request(timeout);
     batch_empty = true;
     for (auto& b : batch) {


### PR DESCRIPTION
- route worker prepare, execute, and host-copy paths through the default stream when schedule overlap is disabled for the llm backend
- keep q_cu_seq_lens materialization off the cuda path and preserve the shared-memory deserialization guard
- reduce scheduler sleep and polling time to improve wake-up latency