### PR TITLE
bugfix: init ssm_cache by config ssm_cache_type and fix dimension order of g & beta for qwen3.5.

### DIFF
--- a/xllm/core/distributed_runtime/llm_engine.cpp
+++ b/xllm/core/distributed_runtime/llm_engine.cpp
@@ -43,6 +43,7 @@ limitations under the License.
 #include "server/xllm_server_registry.h"
 #include "util/env_var.h"
 #include "util/pretty_print.h"
+#include "util/tensor_helper.h"
 #include "util/utils.h"
 
 namespace {
@@ -497,8 +498,13 @@ Engine::KVCacheCapacity LLMEngine::estimate_kv_cache_capacity() {
   if (args_.linear_num_value_heads() > 0) {
     int64_t head_k_dim = args_.linear_key_head_dim();
     int64_t head_v_dim = args_.linear_value_head_dim();
+
+    // Parse mamba_ssm_dtype if specified
+    int64_t ssm_dtype_size =
+        resolve_ssm_dtype_size(args_.mamba_ssm_dtype(), dtype_size);
+
     int64_t linear_ssm_slot_size =
-        dtype_size * n_local_linear_v_heads_ * head_k_dim * head_v_dim;
+        ssm_dtype_size * n_local_linear_v_heads_ * head_k_dim * head_v_dim;
     int64_t linear_conv_slot_size = dtype_size *
                                     (head_k_dim * n_local_linear_k_heads_ * 2 +
                                      head_v_dim * n_local_linear_v_heads_) *

--- a/xllm/core/framework/model/model_args.h
+++ b/xllm/core/framework/model/model_args.h
@@ -181,6 +181,7 @@ struct ModelArgs {
   PROPERTY(int32_t, linear_value_head_dim) = 0;
   PROPERTY(int64_t, linear_num_key_heads) = 0;
   PROPERTY(int32_t, linear_num_value_heads) = 0;
+  PROPERTY(std::string, mamba_ssm_dtype);
   PROPERTY(int32_t, shared_expert_intermediate_size) = 0;
   PROPERTY(float, partial_rotary_factor) = 0.0f;
   PROPERTY(std::vector<std::string>, layer_types) = {};

--- a/xllm/core/layers/npu_torch/qwen3_gated_delta_net_base.cpp
+++ b/xllm/core/layers/npu_torch/qwen3_gated_delta_net_base.cpp
@@ -411,6 +411,8 @@ torch::Tensor Qwen3GatedDeltaNetBaseImpl::forward(
     gdn_params.beta = 1.0f;
     gdn_params.threshold = 20.0f;
     std::tie(g, beta) = xllm::kernel::fused_gdn_gating(gdn_params);
+    g = g.permute({1, 0, 2}).contiguous();
+    beta = beta.permute({1, 0, 2}).contiguous();
   }
   auto [processed_q, processed_k, processed_v] = process_mixed_qkv(mixed_qkv);
   int64_t repeat_times = num_v_heads_ / num_k_heads_;

--- a/xllm/core/runtime/worker_impl.cpp
+++ b/xllm/core/runtime/worker_impl.cpp
@@ -250,6 +250,10 @@ bool WorkerImpl::allocate_kv_cache(
 
       if (is_linear_layer) {
         // Linear attention layer: only allocate conv_cache and ssm_cache
+        // Parse mamba_ssm_dtype if specified
+        torch::ScalarType ssm_dtype =
+            resolve_ssm_dtype(args.mamba_ssm_dtype(), dtype_);
+
 #if defined(USE_NPU)
         aclFormat npu_format_type = ACL_FORMAT_ND;
         if (enable_linear_attention) {
@@ -267,14 +271,14 @@ bool WorkerImpl::allocate_kv_cache(
           conv_cache = torch::zeros(kv_cache_shape[2],
                                     torch::dtype(dtype_).device(device_));
           ssm_cache = torch::zeros(kv_cache_shape[3],
-                                   torch::dtype(dtype_).device(device_));
+                                   torch::dtype(ssm_dtype).device(device_));
         }
 #else
         if (enable_linear_attention) {
           conv_cache = torch::empty(kv_cache_shape[2],
                                     torch::dtype(dtype_).device(device_));
           ssm_cache = torch::empty(kv_cache_shape[3],
-                                   torch::dtype(dtype_).device(device_));
+                                   torch::dtype(ssm_dtype).device(device_));
         }
 #endif
         // Create empty KVCache with only conv and ssm

--- a/xllm/core/util/tensor_helper.h
+++ b/xllm/core/util/tensor_helper.h
@@ -360,4 +360,33 @@ inline int32_t get_dtype_size(torch::ScalarType dtype) {
   return static_cast<int32_t>(torch::elementSize(dtype));
 }
 
+inline torch::ScalarType resolve_ssm_dtype(
+    const std::string& mamba_ssm_dtype_str,
+    torch::ScalarType default_dtype) {
+  if (mamba_ssm_dtype_str.empty()) {
+    return default_dtype;
+  }
+  auto parsed = try_get_scalar_type_from_string(mamba_ssm_dtype_str);
+  if (parsed) {
+    return parsed.value();
+  }
+  LOG(WARNING) << "Failed to parse mamba_ssm_dtype='" << mamba_ssm_dtype_str
+               << "', falling back to default_dtype: " << default_dtype;
+  return default_dtype;
+}
+
+inline int64_t resolve_ssm_dtype_size(const std::string& mamba_ssm_dtype_str,
+                                      int64_t default_dtype_size) {
+  if (mamba_ssm_dtype_str.empty()) {
+    return default_dtype_size;
+  }
+  auto parsed = try_get_scalar_type_from_string(mamba_ssm_dtype_str);
+  if (parsed) {
+    return get_dtype_size(parsed.value());
+  }
+  LOG(WARNING) << "Failed to parse mamba_ssm_dtype='" << mamba_ssm_dtype_str
+               << "', falling back to default dtype size";
+  return default_dtype_size;
+}
+
 }  // namespace xllm

--- a/xllm/models/llm/qwen3_5.h
+++ b/xllm/models/llm/qwen3_5.h
@@ -144,7 +144,9 @@ TORCH_MODULE(Qwen3_5ForCausalLM);
   SET_ARG(n_group, -1);                                                        \
   SET_ARG(topk_group, 0);                                                      \
   SET_ARG(routed_scaling_factor, 1.0f);                                        \
-  SET_ARG(stop_token_ids, std::unordered_set<int32_t>({args->eos_token_id()}))
+  SET_ARG(stop_token_ids,                                                      \
+          std::unordered_set<int32_t>({args->eos_token_id()}));                \
+  LOAD_ARG_TEXT_OR_ROOT(mamba_ssm_dtype, "mamba_ssm_dtype", "float32")
 
 #define LOAD_QWEN3_5_TYPE_AND_DTYPE(default_model_type)         \
   LOAD_ARG_OR(model_type, "model_type", default_model_type);    \


### PR DESCRIPTION
This PR makes the following changes to the xLLM inference engine:

Add mamba_ssm_dtype config field — A new mamba_ssm_dtype string property is added to ModelArgs , allowing the SSM (State Space Model) cache dtype to be specified independently from the model's primary dtype.
Use mamba_ssm_dtype for KV cache capacity estimation — In llm_engine.cpp , the estimate_kv_cache_capacity() function now uses the mamba_ssm_dtype -derived byte size for calculating the SSM slot size, instead of always using the model dtype size.
Fix g/beta tensor layout in GDN gating — In qwen3_gated_delta_net_base.cpp , after calling fused_gdn_gating() , the g and beta tensors are permuted from [seq_len, batch, heads] to [batch, seq_len, heads] layout via .permute({1, 0, 2}).contiguous() .
Load mamba_ssm_dtype from model config — The qwen3_5.h model registration macro now loads mamba_ssm_dtype from the JSON config (with text_config.mamba_ssm_dtype fallback) using LOAD_ARG_TEXT_OR_ROOT .