### PR TITLE
bugfix: fix hybrid kv cache layer detection.

### DIFF
--- a/xllm/core/framework/model/model_args.h
+++ b/xllm/core/framework/model/model_args.h
@@ -456,8 +456,8 @@ inline bool is_full_attention_layer(const ModelArgs& args, int64_t layer_id) {
   }
 
   int32_t attention_interval = args.full_attention_interval();
-  if (attention_interval <= 0) {
-    attention_interval = 4;
+  if (attention_interval <= 1) {
+    return true;
   }
   return (layer_id + 1) % attention_interval == 0;
 }

--- a/xllm/core/runtime/worker_impl.cpp
+++ b/xllm/core/runtime/worker_impl.cpp
@@ -238,12 +238,10 @@ bool WorkerImpl::allocate_kv_cache(
     torch::ScalarType cache_dtype =
         enable_kv_cache_quant ? torch::kInt8 : dtype_;
 
-    // Helper function to check if a layer is linear attention
+    // Helper function to check if a layer is linear attention.
+    // Keep this consistent with KV cache capacity estimation.
     auto is_linear_attention_layer = [&](int64_t layer_idx) {
-      if (args.full_attention_interval() > 1) {
-        return (layer_idx + 1) % args.full_attention_interval() != 0;
-      }
-      return false;
+      return !is_full_attention_layer(args, layer_idx);
     };
 
     for (int64_t i = 0; i < num_layers; ++i) {


### PR DESCRIPTION
- treat models without hybrid config as full-attention by default
- align worker kv-cache allocation with the shared layer classification helper
- avoid kv-cache over-allocation for non-hybrid models