### PR TITLE
refactor: add model input param groups and factory.

### DIFF
--- a/xllm/core/framework/model/CMakeLists.txt
+++ b/xllm/core/framework/model/CMakeLists.txt
@@ -10,11 +10,17 @@ cc_library(
     dit_model.h
     embedding_vlm.h
     mm_embedding_vlm.h
+    model_input.h
+    model_input_factory.h
+    model_input_param_groups.h
     model_args.h
     npu_cp_ep_padding.h
     npu_dp_ep_padding.h
     model_input_params.h
   SRCS
+    model_input.cpp
+    model_input_factory.cpp
+    model_input_param_groups.cpp
     npu_cp_ep_padding.cpp
     npu_dp_ep_padding.cpp
   DEPS
@@ -27,6 +33,16 @@ cc_library(
     torch
     torch_python
     $<$<BOOL:${USE_NPU}>:platform_npu>
+)
+
+cc_test(
+  NAME
+    model_input_factory_test
+  SRCS
+    model_input_factory_test.cpp
+  DEPS
+    model
+    GTest::gtest_main
 )
 
 if(USE_NPU)

--- a/xllm/core/framework/model/causal_lm.h
+++ b/xllm/core/framework/model/causal_lm.h
@@ -39,6 +39,7 @@ limitations under the License.
 #include "core/framework/quant_args.h"
 #include "core/framework/state_dict/state_dict.h"
 #include "model_args.h"
+#include "model_input.h"
 #include "model_input_params.h"
 #include "model_output.h"
 #include "model_traits.h"
@@ -84,6 +85,18 @@ class CausalLM : public torch::nn::Module {
   virtual void update_expert_weight(int32_t layer_id) = 0;
 
   virtual const torch::TensorOptions& options() const = 0;
+
+  virtual model_input::ModelInput create_model_input(
+      const ModelInputParams& parameters) const {
+    model_input::ModelInput input;
+    model_input::ModelInputParamBundle bundle =
+        model_input::ModelInputParamBundle::from_legacy(parameters);
+    input.llm = bundle.llm;
+    if (!std::holds_alternative<std::monostate>(parameters.rec_params)) {
+      input.rec = bundle.rec;
+    }
+    return input;
+  }
 
   // MTP-specific interface.
 #if defined(USE_NPU)

--- a/xllm/core/framework/model/causal_vlm.h
+++ b/xllm/core/framework/model/causal_vlm.h
@@ -36,6 +36,16 @@ class CausalVLM : public CausalLM {
   virtual torch::Tensor get_input_embeddings(
       const torch::Tensor& input_ids,
       const ModelInputParams& input_params) = 0;
+
+  model_input::ModelInput create_model_input(
+      const ModelInputParams& parameters) const override {
+    model_input::ModelInput input;
+    model_input::ModelInputParamBundle bundle =
+        model_input::ModelInputParamBundle::from_legacy(parameters);
+    input.llm = bundle.llm;
+    input.vlm = bundle.vlm;
+    return input;
+  }
 };
 
 template <typename Model>

--- a/xllm/core/framework/model/dit_model.h
+++ b/xllm/core/framework/model/dit_model.h
@@ -22,6 +22,7 @@ limitations under the License.
 #include <vector>
 
 #include "core/framework/dit_model_loader.h"
+#include "core/framework/model/model_input.h"
 #include "core/runtime/dit_forward_params.h"
 namespace xllm {
 
@@ -33,6 +34,15 @@ class DiTModel : public torch::nn::Module {
   virtual torch::Device device() const = 0;
   virtual const torch::TensorOptions& options() const = 0;
   virtual void load_model(std::unique_ptr<DiTModelLoader> loader) = 0;
+
+  virtual model_input::ModelInput create_model_input(
+      const ModelInputParams& parameters) const {
+    model_input::ModelInput input;
+    model_input::ModelInputParamBundle bundle =
+        model_input::ModelInputParamBundle::from_legacy(parameters);
+    input.dit = bundle.dit;
+    return input;
+  }
 };
 
 template <typename Model>

--- a/xllm/core/framework/model/model_input.cpp
+++ b/xllm/core/framework/model/model_input.cpp
@@ -1,0 +1,42 @@
+/* Copyright 2026 The xLLM Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://github.com/jd-opensource/xllm/blob/main/LICENSE
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include "model_input.h"
+
+namespace xllm {
+namespace model_input {
+
+ModelInput ModelInput::from_legacy(const xllm::ModelInputParams& params) {
+  ModelInput model_input;
+  const ModelInputParamBundle bundle =
+      ModelInputParamBundle::from_legacy(params);
+  model_input.llm = bundle.llm;
+  model_input.vlm = bundle.vlm;
+  model_input.dit = bundle.dit;
+  model_input.rec = bundle.rec;
+  return model_input;
+}
+
+void ModelInput::apply_to_legacy(xllm::ModelInputParams* params) const {
+  ModelInputParamBundle bundle;
+  bundle.llm = llm;
+  bundle.vlm = vlm;
+  bundle.dit = dit;
+  bundle.rec = rec;
+  bundle.apply_to_legacy(params);
+}
+
+}  // namespace model_input
+}  // namespace xllm

--- a/xllm/core/framework/model/model_input.h
+++ b/xllm/core/framework/model/model_input.h
@@ -1,0 +1,42 @@
+/* Copyright 2026 The xLLM Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://github.com/jd-opensource/xllm/blob/main/LICENSE
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#pragma once
+
+#include <memory>
+
+#include "model_input_param_groups.h"
+#include "model_input_params.h"
+
+namespace xllm {
+namespace model_input {
+
+struct ModelInput {
+  std::shared_ptr<LLMModelInputParams> llm;
+  std::shared_ptr<VLMModelInputParams> vlm;
+  std::shared_ptr<DitModelInputParams> dit;
+  std::shared_ptr<RecModelInputParams> rec;
+
+  static ModelInput from_legacy(const xllm::ModelInputParams& params);
+  void apply_to_legacy(xllm::ModelInputParams* params) const;
+
+  bool has_llm() const { return llm != nullptr; }
+  bool has_vlm() const { return vlm != nullptr; }
+  bool has_dit() const { return dit != nullptr; }
+  bool has_rec() const { return rec != nullptr; }
+};
+
+}  // namespace model_input
+}  // namespace xllm

--- a/xllm/core/framework/model/model_input_factory.cpp
+++ b/xllm/core/framework/model/model_input_factory.cpp
@@ -1,0 +1,86 @@
+/* Copyright 2026 The xLLM Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://github.com/jd-opensource/xllm/blob/main/LICENSE
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include "model_input_factory.h"
+
+#include "causal_lm.h"
+#include "causal_vlm.h"
+#include "dit_model.h"
+
+namespace xllm {
+namespace model_input {
+
+namespace {
+bool has_rec_payload(const xllm::ModelInputParams& params) {
+  return !std::holds_alternative<std::monostate>(params.rec_params);
+}
+}  // namespace
+
+ModelInput ModelInputFactory::create_all(const xllm::ModelInputParams& params) {
+  return ModelInput::from_legacy(params);
+}
+
+ModelInput ModelInputFactory::create_for_llm(
+    const CausalLM& model,
+    const xllm::ModelInputParams& params) {
+  (void)model;
+  ModelInputParamBundle bundle = ModelInputParamBundle::from_legacy(params);
+  ModelInput input;
+  input.llm = bundle.llm;
+  if (has_rec_payload(params)) {
+    input.rec = bundle.rec;
+  }
+  return input;
+}
+
+ModelInput ModelInputFactory::create_for_vlm(
+    const CausalVLM& model,
+    const xllm::ModelInputParams& params) {
+  (void)model;
+  ModelInputParamBundle bundle = ModelInputParamBundle::from_legacy(params);
+  ModelInput input;
+  input.llm = bundle.llm;
+  input.vlm = bundle.vlm;
+  return input;
+}
+
+ModelInput ModelInputFactory::create_for_dit(
+    const DiTModel& model,
+    const xllm::ModelInputParams& params) {
+  (void)model;
+  ModelInputParamBundle bundle = ModelInputParamBundle::from_legacy(params);
+  ModelInput input;
+  input.dit = bundle.dit;
+  return input;
+}
+
+ModelInput ModelInputFactory::create_for_rec(
+    const CausalLM& model,
+    const xllm::ModelInputParams& params) {
+  (void)model;
+  ModelInputParamBundle bundle = ModelInputParamBundle::from_legacy(params);
+  ModelInput input;
+  input.llm = bundle.llm;
+  input.rec = bundle.rec;
+  return input;
+}
+
+void ModelInputFactory::apply_to_legacy(const ModelInput& input,
+                                        xllm::ModelInputParams* params) {
+  input.apply_to_legacy(params);
+}
+
+}  // namespace model_input
+}  // namespace xllm

--- a/xllm/core/framework/model/model_input_factory.h
+++ b/xllm/core/framework/model/model_input_factory.h
@@ -1,0 +1,48 @@
+/* Copyright 2026 The xLLM Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://github.com/jd-opensource/xllm/blob/main/LICENSE
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#pragma once
+
+#include "model_input.h"
+
+namespace xllm {
+
+class CausalLM;
+class CausalVLM;
+class DiTModel;
+
+namespace model_input {
+
+class ModelInputFactory {
+ public:
+  // Generic conversion that keeps all available partitions.
+  static ModelInput create_all(const xllm::ModelInputParams& params);
+
+  // Build input payloads by model family.
+  static ModelInput create_for_llm(const CausalLM& model,
+                                   const xllm::ModelInputParams& params);
+  static ModelInput create_for_vlm(const CausalVLM& model,
+                                   const xllm::ModelInputParams& params);
+  static ModelInput create_for_dit(const DiTModel& model,
+                                   const xllm::ModelInputParams& params);
+  static ModelInput create_for_rec(const CausalLM& model,
+                                   const xllm::ModelInputParams& params);
+
+  static void apply_to_legacy(const ModelInput& input,
+                              xllm::ModelInputParams* params);
+};
+
+}  // namespace model_input
+}  // namespace xllm

--- a/xllm/core/framework/model/model_input_factory_test.cpp
+++ b/xllm/core/framework/model/model_input_factory_test.cpp
@@ -133,6 +133,35 @@ TEST(ModelInputFactoryTest, CreateForRecIncludesRecPartitionWhenPresent) {
   EXPECT_TRUE(input.has_rec());
 }
 
+TEST(ModelInputFactoryTest, CausalLmCreatesLlmInputDirectly) {
+  FakeCausalLM model;
+  ModelInputParams params;
+  const ModelInput input = model.create_model_input(params);
+  EXPECT_TRUE(input.has_llm());
+  EXPECT_FALSE(input.has_vlm());
+  EXPECT_FALSE(input.has_dit());
+}
+
+TEST(ModelInputFactoryTest, CausalVlmCreatesVlmInputDirectly) {
+  FakeCausalVLM model;
+  ModelInputParams params;
+  params.deep_stacks.push_back(torch::zeros({1, 1}));
+  const ModelInput input = model.create_model_input(params);
+  EXPECT_TRUE(input.has_llm());
+  EXPECT_TRUE(input.has_vlm());
+  EXPECT_FALSE(input.has_dit());
+}
+
+TEST(ModelInputFactoryTest, DitModelCreatesDitInputDirectly) {
+  FakeDiTModel model;
+  ModelInputParams params;
+  params.dit_forward_input.prompts.push_back("dit prompt");
+  const ModelInput input = model.create_model_input(params);
+  EXPECT_FALSE(input.has_llm());
+  EXPECT_FALSE(input.has_vlm());
+  EXPECT_TRUE(input.has_dit());
+}
+
 }  // namespace
 }  // namespace model_input
 }  // namespace xllm

--- a/xllm/core/framework/model/model_input_factory_test.cpp
+++ b/xllm/core/framework/model/model_input_factory_test.cpp
@@ -1,0 +1,138 @@
+/* Copyright 2026 The xLLM Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://github.com/jd-opensource/xllm/blob/main/LICENSE
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include "model_input_factory.h"
+
+#include <gtest/gtest.h>
+
+#include <memory>
+#include <vector>
+
+#include "causal_lm.h"
+#include "causal_vlm.h"
+#include "dit_model.h"
+
+namespace xllm {
+namespace model_input {
+namespace {
+
+class FakeCausalLM final : public CausalLM {
+ public:
+  ModelOutput forward(const torch::Tensor&,
+                      const torch::Tensor&,
+                      std::vector<KVCache>&,
+                      const ModelInputParams&) override {
+    return ModelOutput();
+  }
+  torch::Tensor logits(const torch::Tensor&, const torch::Tensor&) override {
+    return torch::Tensor();
+  }
+  void load_model(std::unique_ptr<ModelLoader>) override {}
+  torch::Device device() const override { return torch::Device(torch::kCPU); }
+  void prepare_expert_weight(int32_t, const std::vector<int32_t>&) override {}
+  void update_expert_weight(int32_t) override {}
+  const torch::TensorOptions& options() const override { return options_; }
+
+ private:
+  torch::TensorOptions options_{torch::TensorOptions().device(torch::kCPU)};
+};
+
+class FakeCausalVLM final : public CausalVLM {
+ public:
+  MMDict encode(const ModelInputParams&) override { return MMDict(); }
+  torch::Tensor get_input_embeddings(const torch::Tensor&,
+                                     const ModelInputParams&) override {
+    return torch::Tensor();
+  }
+  ModelOutput forward(const torch::Tensor&,
+                      const torch::Tensor&,
+                      std::vector<KVCache>&,
+                      const ModelInputParams&) override {
+    return ModelOutput();
+  }
+  torch::Tensor logits(const torch::Tensor&, const torch::Tensor&) override {
+    return torch::Tensor();
+  }
+  void load_model(std::unique_ptr<ModelLoader>) override {}
+  torch::Device device() const override { return torch::Device(torch::kCPU); }
+  void prepare_expert_weight(int32_t, const std::vector<int32_t>&) override {}
+  void update_expert_weight(int32_t) override {}
+  const torch::TensorOptions& options() const override { return options_; }
+
+ private:
+  torch::TensorOptions options_{torch::TensorOptions().device(torch::kCPU)};
+};
+
+class FakeDiTModel final : public DiTModel {
+ public:
+  DiTForwardOutput forward(const DiTForwardInput&) override {
+    return DiTForwardOutput();
+  }
+  torch::Device device() const override { return torch::Device(torch::kCPU); }
+  const torch::TensorOptions& options() const override { return options_; }
+  void load_model(std::unique_ptr<DiTModelLoader>) override {}
+
+ private:
+  torch::TensorOptions options_{torch::TensorOptions().device(torch::kCPU)};
+};
+
+TEST(ModelInputFactoryTest, CreateForLlmIncludesOnlyLlmByDefault) {
+  FakeCausalLM model;
+  ModelInputParams params;
+
+  const ModelInput input = ModelInputFactory::create_for_llm(model, params);
+  EXPECT_TRUE(input.has_llm());
+  EXPECT_FALSE(input.has_vlm());
+  EXPECT_FALSE(input.has_dit());
+  EXPECT_FALSE(input.has_rec());
+}
+
+TEST(ModelInputFactoryTest, CreateForVlmIncludesVlmPartition) {
+  FakeCausalVLM model;
+  ModelInputParams params;
+  params.deep_stacks.push_back(torch::zeros({1, 1}));
+
+  const ModelInput input = ModelInputFactory::create_for_vlm(model, params);
+  EXPECT_TRUE(input.has_llm());
+  EXPECT_TRUE(input.has_vlm());
+  EXPECT_FALSE(input.has_dit());
+}
+
+TEST(ModelInputFactoryTest, CreateForDitIncludesDitPartition) {
+  FakeDiTModel model;
+  ModelInputParams params;
+  params.dit_forward_input.prompts.push_back("dit prompt");
+
+  const ModelInput input = ModelInputFactory::create_for_dit(model, params);
+  EXPECT_FALSE(input.has_llm());
+  EXPECT_FALSE(input.has_vlm());
+  EXPECT_TRUE(input.has_dit());
+  EXPECT_FALSE(input.has_rec());
+}
+
+TEST(ModelInputFactoryTest, CreateForRecIncludesRecPartitionWhenPresent) {
+  FakeCausalLM model;
+  ModelInputParams params;
+  auto& onerec = params.mutable_onerec_params();
+  onerec.bs = 2;
+
+  const ModelInput input = ModelInputFactory::create_for_rec(model, params);
+  EXPECT_TRUE(input.has_llm());
+  EXPECT_TRUE(input.has_rec());
+}
+
+}  // namespace
+}  // namespace model_input
+}  // namespace xllm

--- a/xllm/core/framework/model/model_input_param_groups.cpp
+++ b/xllm/core/framework/model/model_input_param_groups.cpp
@@ -1,0 +1,206 @@
+/* Copyright 2026 The xLLM Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://github.com/jd-opensource/xllm/blob/main/LICENSE
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include "model_input_param_groups.h"
+
+#include <variant>
+
+namespace xllm {
+namespace model_input {
+
+LLMModelInputParams LLMModelInputParams::from_legacy(
+    const xllm::ModelInputParams& src) {
+  LLMModelInputParams dst;
+  dst.enable_mla = src.enable_mla;
+  dst.batch_forward_type = src.batch_forward_type;
+  dst.num_sequences = src.num_sequences;
+  dst.kv_max_seq_len = src.kv_max_seq_len;
+  dst.q_max_seq_len = src.q_max_seq_len;
+  dst.batch_id = src.batch_id;
+  dst.q_seq_lens = src.q_seq_lens;
+  dst.kv_seq_lens = src.kv_seq_lens;
+  dst.q_cu_seq_lens = src.q_cu_seq_lens;
+  dst.kv_seq_lens_vec = src.kv_seq_lens_vec;
+  dst.q_seq_lens_vec = src.q_seq_lens_vec;
+  dst.new_cache_slots = src.new_cache_slots;
+  dst.block_tables = src.block_tables;
+  dst.paged_kv_indptr = src.paged_kv_indptr;
+  dst.paged_kv_indices = src.paged_kv_indices;
+  dst.paged_kv_last_page_len = src.paged_kv_last_page_len;
+  dst.new_cache_slot_offsets = src.new_cache_slot_offsets;
+  dst.kv_cache_start_offsets = src.kv_cache_start_offsets;
+  dst.input_embedding = src.input_embedding;
+  dst.dp_global_token_nums = src.dp_global_token_nums;
+  dst.dp_is_decode = src.dp_is_decode;
+  dst.embedding_ids = src.embedding_ids;
+  dst.request_ids = src.request_ids;
+  dst.extra_token_ids = src.extra_token_ids;
+  dst.swap_blocks = src.swap_blocks;
+  dst.src_block_indices = src.src_block_indices;
+  dst.dst_block_indices = src.dst_block_indices;
+  dst.cum_sum = src.cum_sum;
+#if defined(USE_NPU)
+  dst.layer_synchronizer = src.layer_synchronizer;
+  dst.layers_per_bacth_copy = src.layers_per_bacth_copy;
+  dst.layer_wise_load_synchronizer = src.layer_wise_load_synchronizer;
+#endif
+  dst.dp_ep_padding_data = src.dp_ep_padding_data;
+  dst.cp_ep_padding_data = src.cp_ep_padding_data;
+  dst.cp_prefill_inputs = src.cp_prefill_inputs;
+  dst.expert_load_data = src.expert_load_data;
+  dst.expert_array = src.expert_array;
+  dst.kv_cache_tokens_nums = src.kv_cache_tokens_nums;
+  dst.kv_cache_tokens_nums_host = src.kv_cache_tokens_nums_host;
+  dst.history_compressed_kv = src.history_compressed_kv;
+  dst.history_k_rope = src.history_k_rope;
+  dst.ring_cur_seqlen = src.ring_cur_seqlen;
+  dst.ring_cur_seqlen_host = src.ring_cur_seqlen_host;
+  dst.ring_cache_seqlen = src.ring_cache_seqlen;
+  dst.ring_cache_seqlen_host = src.ring_cache_seqlen_host;
+  dst.graph_attn_mask = src.graph_buffer.attn_mask;
+  dst.graph_tiling_data = src.graph_buffer.tiling_data;
+  dst.attn_metadata = src.attn_metadata;
+  dst.enable_cuda_graph = src.enable_cuda_graph;
+  return dst;
+}
+
+void LLMModelInputParams::apply_to_legacy(xllm::ModelInputParams* dst) const {
+  dst->enable_mla = enable_mla;
+  dst->batch_forward_type = batch_forward_type;
+  dst->num_sequences = num_sequences;
+  dst->kv_max_seq_len = kv_max_seq_len;
+  dst->q_max_seq_len = q_max_seq_len;
+  dst->batch_id = batch_id;
+  dst->q_seq_lens = q_seq_lens;
+  dst->kv_seq_lens = kv_seq_lens;
+  dst->q_cu_seq_lens = q_cu_seq_lens;
+  dst->kv_seq_lens_vec = kv_seq_lens_vec;
+  dst->q_seq_lens_vec = q_seq_lens_vec;
+  dst->new_cache_slots = new_cache_slots;
+  dst->block_tables = block_tables;
+  dst->paged_kv_indptr = paged_kv_indptr;
+  dst->paged_kv_indices = paged_kv_indices;
+  dst->paged_kv_last_page_len = paged_kv_last_page_len;
+  dst->new_cache_slot_offsets = new_cache_slot_offsets;
+  dst->kv_cache_start_offsets = kv_cache_start_offsets;
+  dst->input_embedding = input_embedding;
+  dst->dp_global_token_nums = dp_global_token_nums;
+  dst->dp_is_decode = dp_is_decode;
+  dst->embedding_ids = embedding_ids;
+  dst->request_ids = request_ids;
+  dst->extra_token_ids = extra_token_ids;
+  dst->swap_blocks = swap_blocks;
+  dst->src_block_indices = src_block_indices;
+  dst->dst_block_indices = dst_block_indices;
+  dst->cum_sum = cum_sum;
+#if defined(USE_NPU)
+  dst->layer_synchronizer = layer_synchronizer;
+  dst->layers_per_bacth_copy = layers_per_bacth_copy;
+  dst->layer_wise_load_synchronizer = layer_wise_load_synchronizer;
+#endif
+  dst->dp_ep_padding_data = dp_ep_padding_data;
+  dst->cp_ep_padding_data = cp_ep_padding_data;
+  dst->cp_prefill_inputs = cp_prefill_inputs;
+  dst->expert_load_data = expert_load_data;
+  dst->expert_array = expert_array;
+  dst->kv_cache_tokens_nums = kv_cache_tokens_nums;
+  dst->kv_cache_tokens_nums_host = kv_cache_tokens_nums_host;
+  dst->history_compressed_kv = history_compressed_kv;
+  dst->history_k_rope = history_k_rope;
+  dst->ring_cur_seqlen = ring_cur_seqlen;
+  dst->ring_cur_seqlen_host = ring_cur_seqlen_host;
+  dst->ring_cache_seqlen = ring_cache_seqlen;
+  dst->ring_cache_seqlen_host = ring_cache_seqlen_host;
+  dst->graph_buffer.attn_mask = graph_attn_mask;
+  dst->graph_buffer.tiling_data = graph_tiling_data;
+  dst->attn_metadata = attn_metadata;
+  dst->enable_cuda_graph = enable_cuda_graph;
+}
+
+VLMModelInputParams VLMModelInputParams::from_legacy(
+    const xllm::ModelInputParams& src) {
+  VLMModelInputParams dst;
+  dst.mm_data = src.mm_data;
+  dst.deep_stacks = src.deep_stacks;
+  dst.visual_pos_masks = src.visual_pos_masks;
+  return dst;
+}
+
+void VLMModelInputParams::apply_to_legacy(xllm::ModelInputParams* dst) const {
+  dst->mm_data = mm_data;
+  dst->deep_stacks = deep_stacks;
+  dst->visual_pos_masks = visual_pos_masks;
+}
+
+DitModelInputParams DitModelInputParams::from_legacy(
+    const xllm::ModelInputParams& src) {
+  DitModelInputParams dst;
+  dst.dit_forward_input = src.dit_forward_input;
+  return dst;
+}
+
+void DitModelInputParams::apply_to_legacy(xllm::ModelInputParams* dst) const {
+  dst->dit_forward_input = dit_forward_input;
+}
+
+RecModelInputParams RecModelInputParams::from_legacy(
+    const xllm::ModelInputParams& src) {
+  RecModelInputParams dst;
+  dst.rec_params = src.rec_params;
+  return dst;
+}
+
+void RecModelInputParams::apply_to_legacy(xllm::ModelInputParams* dst) const {
+  dst->rec_params = rec_params;
+}
+
+ModelInputParamBundle ModelInputParamBundle::from_legacy(
+    const xllm::ModelInputParams& src) {
+  ModelInputParamBundle bundle;
+  bundle.llm = std::make_shared<LLMModelInputParams>(
+      LLMModelInputParams::from_legacy(src));
+  if (src.mm_data.valid() || !src.deep_stacks.empty() ||
+      src.visual_pos_masks.defined()) {
+    bundle.vlm = std::make_shared<VLMModelInputParams>(
+        VLMModelInputParams::from_legacy(src));
+  }
+  if (src.dit_forward_input.valid()) {
+    bundle.dit = std::make_shared<DitModelInputParams>(
+        DitModelInputParams::from_legacy(src));
+  }
+  if (!std::holds_alternative<std::monostate>(src.rec_params)) {
+    bundle.rec = std::make_shared<RecModelInputParams>(
+        RecModelInputParams::from_legacy(src));
+  }
+  return bundle;
+}
+
+void ModelInputParamBundle::apply_to_legacy(xllm::ModelInputParams* dst) const {
+  if (llm != nullptr) {
+    llm->apply_to_legacy(dst);
+  }
+  if (vlm != nullptr) {
+    vlm->apply_to_legacy(dst);
+  }
+  if (dit != nullptr) {
+    dit->apply_to_legacy(dst);
+  }
+  if (rec != nullptr) {
+    rec->apply_to_legacy(dst);
+  }
+}
+
+}  // namespace model_input
+}  // namespace xllm

--- a/xllm/core/framework/model/model_input_param_groups.h
+++ b/xllm/core/framework/model/model_input_param_groups.h
@@ -1,0 +1,125 @@
+/* Copyright 2026 The xLLM Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://github.com/jd-opensource/xllm/blob/main/LICENSE
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#pragma once
+
+#include <limits>
+#include <memory>
+#include <string>
+#include <vector>
+
+#include "model_input_params.h"
+
+namespace xllm {
+namespace model_input {
+
+struct LLMModelInputParams {
+  bool enable_mla = false;
+  BatchForwardType batch_forward_type;
+  int32_t num_sequences = 0;
+  int32_t kv_max_seq_len = 0;
+  int32_t q_max_seq_len = 0;
+  uint64_t batch_id = 0;
+
+  torch::Tensor q_seq_lens;
+  torch::Tensor kv_seq_lens;
+  torch::Tensor q_cu_seq_lens;
+  std::vector<int> kv_seq_lens_vec;
+  std::vector<int> q_seq_lens_vec;
+
+  torch::Tensor new_cache_slots;
+  torch::Tensor block_tables;
+  torch::Tensor paged_kv_indptr;
+  torch::Tensor paged_kv_indices;
+  torch::Tensor paged_kv_last_page_len;
+  torch::Tensor new_cache_slot_offsets;
+  torch::Tensor kv_cache_start_offsets;
+  torch::Tensor input_embedding;
+
+  std::vector<int32_t> dp_global_token_nums;
+  std::vector<int32_t> dp_is_decode;
+  std::vector<int32_t> embedding_ids;
+  std::vector<std::string> request_ids;
+  std::vector<int32_t> extra_token_ids;
+  std::vector<BlockTransferInfo> swap_blocks;
+
+  torch::Tensor src_block_indices;
+  torch::Tensor dst_block_indices;
+  torch::Tensor cum_sum;
+
+#if defined(USE_NPU)
+  std::shared_ptr<NPULayerSynchronizerImpl> layer_synchronizer = nullptr;
+  uint32_t layers_per_bacth_copy = std::numeric_limits<uint32_t>::max();
+  std::shared_ptr<NPULayerSynchronizerImpl> layer_wise_load_synchronizer =
+      nullptr;
+#endif
+  DpEpPaddingData dp_ep_padding_data;
+  CpEpPaddingData cp_ep_padding_data;
+  CpPrefillInputs cp_prefill_inputs;
+
+  torch::Tensor expert_load_data;
+  torch::Tensor expert_array;
+  torch::Tensor kv_cache_tokens_nums;
+  std::vector<int32_t> kv_cache_tokens_nums_host;
+  torch::Tensor history_compressed_kv;
+  torch::Tensor history_k_rope;
+  torch::Tensor ring_cur_seqlen;
+  std::vector<int32_t> ring_cur_seqlen_host;
+  torch::Tensor ring_cache_seqlen;
+  std::vector<int32_t> ring_cache_seqlen_host;
+  torch::Tensor graph_attn_mask;
+  torch::Tensor graph_tiling_data;
+  std::shared_ptr<layer::AttentionMetadata> attn_metadata;
+  bool enable_cuda_graph = false;
+
+  static LLMModelInputParams from_legacy(const xllm::ModelInputParams& src);
+  void apply_to_legacy(xllm::ModelInputParams* dst) const;
+};
+
+struct VLMModelInputParams {
+  MMBatchData mm_data;
+  std::vector<torch::Tensor> deep_stacks;
+  torch::Tensor visual_pos_masks;
+
+  static VLMModelInputParams from_legacy(const xllm::ModelInputParams& src);
+  void apply_to_legacy(xllm::ModelInputParams* dst) const;
+};
+
+struct DitModelInputParams {
+  DiTForwardInput dit_forward_input;
+
+  static DitModelInputParams from_legacy(const xllm::ModelInputParams& src);
+  void apply_to_legacy(xllm::ModelInputParams* dst) const;
+};
+
+struct RecModelInputParams {
+  xllm::RecModelInputParams rec_params;
+
+  static RecModelInputParams from_legacy(const xllm::ModelInputParams& src);
+  void apply_to_legacy(xllm::ModelInputParams* dst) const;
+};
+
+struct ModelInputParamBundle {
+  std::shared_ptr<LLMModelInputParams> llm;
+  std::shared_ptr<VLMModelInputParams> vlm;
+  std::shared_ptr<DitModelInputParams> dit;
+  std::shared_ptr<RecModelInputParams> rec;
+
+  static ModelInputParamBundle from_legacy(const xllm::ModelInputParams& src);
+  void apply_to_legacy(xllm::ModelInputParams* dst) const;
+};
+
+}  // namespace model_input
+}  // namespace xllm


### PR DESCRIPTION
Introduce LLM/VLM/DIT/REC model-input param group types plus a ModelInput wrapper and ModelInputFactory to build model-specific payload partitions from legacy ModelInputParams without modifying the legacy struct.