### PR TITLE
refactor: isolate RecCausalLM abstractions into dedicated header.

### DIFF
--- a/xllm/core/framework/hf_model_loader_test.cpp
+++ b/xllm/core/framework/hf_model_loader_test.cpp
@@ -17,12 +17,71 @@ limitations under the License.
 
 #include <gtest/gtest.h>
 
+#include <string>
+#include <type_traits>
+
+#include "core/framework/model/rec_causal_lm.h"
 #include "core/platform/device.h"
-#if defined(USE_NPU)
 #include "models/model_registry.h"
-#endif
 
 namespace xllm {
+
+namespace {
+
+using ExpectedRecModelFactory =
+    std::function<std::unique_ptr<RecCausalLM>(const ModelContext& context)>;
+
+static_assert(std::is_same_v<RecModelFactory, ExpectedRecModelFactory>,
+              "RecModelFactory must return std::unique_ptr<RecCausalLM>.");
+static_assert(std::is_base_of_v<CausalLM, RecCausalLM>,
+              "RecCausalLM must derive from CausalLM.");
+
+class DummyRecCausalLM final : public RecCausalLM {
+ public:
+  explicit DummyRecCausalLM(const torch::TensorOptions& options)
+      : options_(options) {}
+
+  ModelOutput forward(const torch::Tensor& tokens,
+                      const torch::Tensor& positions,
+                      std::vector<KVCache>& kv_caches,
+                      const ModelInputParams& parameters) override {
+    UNUSED_PARAMETER(tokens);
+    UNUSED_PARAMETER(positions);
+    UNUSED_PARAMETER(kv_caches);
+    UNUSED_PARAMETER(parameters);
+    return ModelOutput();
+  }
+
+  torch::Tensor logits(const torch::Tensor& hidden_states,
+                       const torch::Tensor& seleted_idxes) override {
+    UNUSED_PARAMETER(hidden_states);
+    UNUSED_PARAMETER(seleted_idxes);
+    return torch::Tensor();
+  }
+
+  void load_model(std::unique_ptr<ModelLoader> loader) override {
+    UNUSED_PARAMETER(loader);
+  }
+
+  torch::Device device() const override { return options_.device(); }
+
+  void prepare_expert_weight(int32_t layer_id,
+                             const std::vector<int32_t>& expert_ids) override {
+    UNUSED_PARAMETER(layer_id);
+    UNUSED_PARAMETER(expert_ids);
+  }
+
+  void update_expert_weight(int32_t layer_id) override {
+    UNUSED_PARAMETER(layer_id);
+  }
+
+  const torch::TensorOptions& options() const override { return options_; }
+
+ private:
+  torch::TensorOptions options_;
+};
+
+}  // namespace
 
 TEST(HFModelLoaderTest, LoadCompressedTensorsFp8StaticConfig) {
   JsonReader reader;
@@ -79,6 +138,46 @@ TEST(HFModelLoaderTest, KeepLegacyFp8ConfigUnchanged) {
   ASSERT_TRUE(load_quant_cfg(reader, quant_args));
   EXPECT_EQ(quant_args.quant_method(), kQuantMethodFp8);
   EXPECT_FALSE(quant_args.activation_dynamic());
+}
+
+TEST(HFModelLoaderTest, RegisterRecFactoryAcceptsRecCausalLmReturnType) {
+  const std::string factory_name = "rec_causallm_factory_contract_test";
+  RecModelFactory unregistered_factory =
+      ModelRegistry::get_rec_model_factory(factory_name);
+  EXPECT_FALSE(static_cast<bool>(unregistered_factory));
+
+  ModelRegistry::register_rec_model_factory(
+      factory_name,
+      [](const ModelContext& context) -> std::unique_ptr<RecCausalLM> {
+        UNUSED_PARAMETER(context);
+        return nullptr;
+      });
+
+  RecModelFactory factory = ModelRegistry::get_rec_model_factory(factory_name);
+  EXPECT_TRUE(static_cast<bool>(factory));
+}
+
+TEST(HFModelLoaderTest, RecFactoryCreatesRecCausalLmInstance) {
+  const std::string kFactoryName = "rec_causallm_instance_contract_test";
+  ModelRegistry::register_rec_model_factory(
+      kFactoryName,
+      [](const ModelContext& context) -> std::unique_ptr<RecCausalLM> {
+        UNUSED_PARAMETER(context);
+        const torch::TensorOptions options =
+            torch::TensorOptions().dtype(torch::kFloat32).device(torch::kCPU);
+        return std::make_unique<DummyRecCausalLM>(options);
+      });
+
+  RecModelFactory factory = ModelRegistry::get_rec_model_factory(kFactoryName);
+  ASSERT_TRUE(static_cast<bool>(factory));
+
+  ModelContext context;
+  std::unique_ptr<RecCausalLM> rec_model = factory(context);
+  ASSERT_NE(rec_model, nullptr);
+
+  CausalLM* causal_model = dynamic_cast<CausalLM*>(rec_model.get());
+  EXPECT_NE(causal_model, nullptr);
+  EXPECT_EQ(rec_model->device(), torch::Device(torch::kCPU));
 }
 
 #if defined(USE_NPU)

--- a/xllm/core/framework/model/CMakeLists.txt
+++ b/xllm/core/framework/model/CMakeLists.txt
@@ -6,6 +6,7 @@ cc_library(
     model
   HDRS
     causal_lm.h
+    rec_causal_lm.h
     causal_vlm.h
     dit_model.h
     mm_embedding_vlm.h

--- a/xllm/core/framework/model/rec_causal_lm.h
+++ b/xllm/core/framework/model/rec_causal_lm.h
@@ -1,0 +1,189 @@
+/* Copyright 2026 The xLLM Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://github.com/jd-opensource/xllm/blob/main/LICENSE
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#pragma once
+
+#include "core/framework/model/causal_lm.h"
+
+namespace xllm {
+
+class RecCausalLM : public CausalLM {
+ public:
+  ~RecCausalLM() override = default;
+};
+
+template <typename Model>
+class RecCausalLMImpl : public RecCausalLM {
+ public:
+  RecCausalLMImpl(Model model, const torch::TensorOptions& options)
+      : model_(std::move(model)), options_(options) {}
+
+  ModelOutput forward(const torch::Tensor& tokens,
+                      const torch::Tensor& positions,
+                      std::vector<KVCache>& kv_caches,
+                      const ModelInputParams& parameters) override {
+    return model_->forward(tokens, positions, kv_caches, parameters);
+  }
+
+  torch::Tensor pooler(const torch::Tensor& hidden_states,
+                       const torch::Tensor& seleted_idxes) override {
+    return model_->pooler(hidden_states, seleted_idxes);
+  }
+
+  torch::Tensor logits(const torch::Tensor& hidden_states,
+                       const torch::Tensor& seleted_idxes) override {
+    return model_->logits(hidden_states, seleted_idxes);
+  }
+
+  void load_model(std::unique_ptr<ModelLoader> loader) override {
+    model_->load_model(std::move(loader));
+  }
+
+  void lazy_load_model(std::unique_ptr<ModelLoader> loader) override {
+    if constexpr (detail::has_lazy_load_model<Model>::value) {
+      model_->lazy_load_model(std::move(loader));
+    } else {
+      RecCausalLM::lazy_load_model(std::move(loader));
+    }
+  }
+
+  void free_model_weights() override {
+    if constexpr (detail::has_free_model_weights<Model>::value) {
+      model_->free_model_weights();
+    } else {
+      RecCausalLM::free_model_weights();
+    }
+  }
+
+  void reload_model_weights() override {
+    if constexpr (detail::has_reload_model_weights<Model>::value) {
+      model_->reload_model_weights();
+    } else {
+      RecCausalLM::reload_model_weights();
+    }
+  }
+
+  void reload_model_weights_from_device() override {
+    if constexpr (detail::has_reload_model_weights_from_device<Model>::value) {
+      model_->reload_model_weights_from_device();
+    } else {
+      RecCausalLM::reload_model_weights_from_device();
+    }
+  }
+
+  void prepare_expert_weight(int32_t layer_id,
+                             const std::vector<int32_t>& expert_ids) override {
+    return model_->prepare_expert_weight(layer_id, expert_ids);
+  }
+
+  void update_expert_weight(int32_t layer_id) override {
+    return model_->update_expert_weight(layer_id);
+  }
+
+#if defined(USE_NPU)
+  layer::NpuLmHead get_npu_lm_head() override {
+    if constexpr (detail::has_get_npu_lm_head<Model>::value) {
+      return model_->get_npu_lm_head();
+    } else {
+      return RecCausalLM::get_npu_lm_head();
+    }
+  }
+
+  void set_npu_lm_head(layer::NpuLmHead& head) override {
+    if constexpr (detail::has_set_npu_lm_head<Model>::value) {
+      model_->set_npu_lm_head(head);
+    } else {
+      RecCausalLM::set_npu_lm_head(head);
+    }
+  }
+
+  layer::NpuWordEmbedding get_npu_word_embedding() override {
+    if constexpr (detail::has_get_npu_word_embedding<Model>::value) {
+      return model_->get_npu_word_embedding();
+    } else {
+      return RecCausalLM::get_npu_word_embedding();
+    }
+  }
+
+  void set_npu_word_embedding(layer::NpuWordEmbedding& embedding) override {
+    if constexpr (detail::has_set_npu_word_embedding<Model>::value) {
+      model_->set_npu_word_embedding(embedding);
+    } else {
+      RecCausalLM::set_npu_word_embedding(embedding);
+    }
+  }
+
+  bool init_or_refresh_rolling_runtime(Stream* load_stream,
+                                       Stream* compute_stream,
+                                       int32_t num_cached_slots,
+                                       int32_t requested_rolling_slots,
+                                       const std::string& model_id) override {
+    if constexpr (detail::has_init_or_refresh_rolling_runtime<Model>::value) {
+      return model_->init_or_refresh_rolling_runtime(load_stream,
+                                                     compute_stream,
+                                                     num_cached_slots,
+                                                     requested_rolling_slots,
+                                                     model_id);
+    }
+    return RecCausalLM::init_or_refresh_rolling_runtime(load_stream,
+                                                        compute_stream,
+                                                        num_cached_slots,
+                                                        requested_rolling_slots,
+                                                        model_id);
+  }
+#endif
+
+  layer::LmHead get_lm_head() override {
+    if constexpr (detail::has_get_lm_head<Model>::value) {
+      return model_->get_lm_head();
+    } else {
+      return RecCausalLM::get_lm_head();
+    }
+  }
+
+  void set_lm_head(layer::LmHead& head) override {
+    if constexpr (detail::has_set_lm_head<Model>::value) {
+      model_->set_lm_head(head);
+    } else {
+      RecCausalLM::set_lm_head(head);
+    }
+  }
+
+  layer::WordEmbedding get_word_embedding() override {
+    if constexpr (detail::has_get_word_embedding<Model>::value) {
+      return model_->get_word_embedding();
+    } else {
+      return RecCausalLM::get_word_embedding();
+    }
+  }
+
+  void set_word_embedding(layer::WordEmbedding& embedding) override {
+    if constexpr (detail::has_set_word_embedding<Model>::value) {
+      model_->set_word_embedding(embedding);
+    } else {
+      RecCausalLM::set_word_embedding(embedding);
+    }
+  }
+
+  torch::Device device() const override { return options_.device(); }
+
+  const torch::TensorOptions& options() const override { return options_; }
+
+ private:
+  Model model_;
+  torch::TensorOptions options_;
+};
+
+}  // namespace xllm

--- a/xllm/models/model_registry.h
+++ b/xllm/models/model_registry.h
@@ -25,6 +25,7 @@ limitations under the License.
 #include "core/framework/model/causal_vlm.h"
 #include "core/framework/model/dit_model.h"
 #include "core/framework/model/mm_embedding_vlm.h"
+#include "core/framework/model/rec_causal_lm.h"
 #include "core/framework/model_context.h"
 #include "core/framework/tokenizer/tokenizer_args.h"
 #include "core/util/json_reader.h"
@@ -38,7 +39,7 @@ using CausalLMFactory =
     std::function<std::unique_ptr<CausalLM>(const ModelContext& context)>;
 
 using RecModelFactory =
-    std::function<std::unique_ptr<CausalLM>(const ModelContext& context)>;
+    std::function<std::unique_ptr<RecCausalLM>(const ModelContext& context)>;
 
 using CausalVLMFactory =
     std::function<std::unique_ptr<CausalVLM>(const ModelContext& context)>;
@@ -188,7 +189,7 @@ std::unique_ptr<DiTModel> create_dit_model(const DiTModelContext& context);
         #ModelType, [](const ModelContext& context) {                   \
           ModelClass model(context);                                    \
           model->eval();                                                \
-          return std::make_unique<xllm::CausalLMImpl<ModelClass>>(      \
+          return std::make_unique<xllm::RecCausalLMImpl<ModelClass>>(   \
               std::move(model), context.get_tensor_options());          \
         });                                                             \
     return true;                                                        \

--- a/xllm/models/rec/npu/onerec.h
+++ b/xllm/models/rec/npu/onerec.h
@@ -18,22 +18,14 @@ limitations under the License.
 #include <glog/logging.h>
 #include <torch/torch.h>
 
-#include <algorithm>
-#include <cmath>
 #include <mutex>
-#include <optional>
+#include <string>
 #include <type_traits>
 #include <unordered_set>
 #include <utility>
 #include <vector>
 
-#include "core/framework/kv_cache/kv_cache.h"
-#include "core/framework/model/model_input_params.h"
-#include "core/framework/model/model_output.h"
-#include "core/framework/model_context.h"
-#include "core/framework/model_loader.h"
-#include "core/layers/common/lm_head.h"
-#include "core/layers/common/word_embedding.h"
+#include "core/framework/model/rec_causal_lm.h"
 #include "models/model_registry.h"
 #include "models/rec/npu/onerec_npu_impl.h"
 #include "models/rec/rec_model_base.h"
@@ -310,9 +302,9 @@ class OneRecForConditionalGenerationImpl final
 };
 TORCH_MODULE(OneRecForConditionalGeneration);
 
-using OneRecCausalLM = CausalLMImpl<OneRecForConditionalGeneration>;
-static_assert(std::is_base_of_v<CausalLM, OneRecCausalLM>,
-              "OneRec must satisfy CausalLM contract.");
+using OneRecCausalLM = RecCausalLMImpl<OneRecForConditionalGeneration>;
+static_assert(std::is_base_of_v<RecCausalLM, OneRecCausalLM>,
+              "OneRec must satisfy RecCausalLM contract.");
 
 REGISTER_REC_MODEL(onerec, OneRecForConditionalGeneration);
 

--- a/xllm/models/rec/onerec.h
+++ b/xllm/models/rec/onerec.h
@@ -18,20 +18,13 @@ limitations under the License.
 #include <glog/logging.h>
 #include <torch/torch.h>
 
-#include <algorithm>
-#include <optional>
+#include <string>
 #include <type_traits>
 #include <unordered_set>
 #include <utility>
 #include <vector>
 
-#include "core/framework/kv_cache/kv_cache.h"
-#include "core/framework/model/model_input_params.h"
-#include "core/framework/model/model_output.h"
-#include "core/framework/model_context.h"
-#include "core/framework/model_loader.h"
-#include "core/layers/common/lm_head.h"
-#include "core/layers/common/word_embedding.h"
+#include "core/framework/model/rec_causal_lm.h"
 #include "models/model_registry.h"
 #include "models/rec/rec_model_base.h"
 
@@ -221,9 +214,9 @@ class OneRecForConditionalGenerationImpl
 };
 TORCH_MODULE(OneRecForConditionalGeneration);
 
-using OneRecCausalLM = CausalLMImpl<OneRecForConditionalGeneration>;
-static_assert(std::is_base_of_v<CausalLM, OneRecCausalLM>,
-              "OneRec must satisfy CausalLM contract.");
+using OneRecCausalLM = RecCausalLMImpl<OneRecForConditionalGeneration>;
+static_assert(std::is_base_of_v<RecCausalLM, OneRecCausalLM>,
+              "OneRec must satisfy RecCausalLM contract.");
 
 REGISTER_REC_MODEL(onerec, OneRecForConditionalGeneration);
 


### PR DESCRIPTION
Separate RecCausalLM/RecCausalLMImpl into rec_causal_lm.h and update rec model registration and OneRec headers to use explicit Rec interfaces, then add focused tests for RecModelFactory type contracts.