### PR TITLE
feat: add tilelang fast path for acl graph decode metadata update.

### DIFF
--- a/xllm/compiler/tilelang/targets/ascend/kernels/model_input_buffer_updater.py
+++ b/xllm/compiler/tilelang/targets/ascend/kernels/model_input_buffer_updater.py
@@ -1,0 +1,1058 @@
+#!/usr/bin/env python3
+
+"""
+Unified Python-side TileLang design for ACL graph input-buffer update.
+
+This file intentionally keeps only one kernel design. The old split between a
+"default" runtime-wired ABI and a separate "v2" prototype has been removed.
+The current file is the Python-side source of truth; C++ wrapper/runtime can be
+rewritten later against this ABI.
+
+What this operator updates
+==========================
+1. token-length group
+   - tokens
+   - positions
+   - new_cache_slots
+
+2. batch-length group
+   - q_seq_lens
+   - kv_seq_lens
+   - optional q_cu_seq_lens
+   - optional linear_state_indices
+
+3. 2D row-strided group
+   - block_tables
+
+4. optional embedding group
+   - input_embedding
+
+How input_embedding works
+=========================
+- with_input_embedding = 0:
+  the embedding group is compiled out and the wrapper can pass null pointers
+
+- with_input_embedding = 1:
+  input_embedding is treated as a flat storage buffer plus three runtime
+  scalars:
+  - src_input_embedding_stride
+  - dst_input_embedding_stride
+  - actual_hidden_size
+
+  This keeps hidden size out of the specialization space while still matching
+  the real row stride of runtime 2D tensors.
+
+How positions work
+==================
+- with_mrope = 0:
+  positions are treated as a 1D prefix of length actual_num_tokens
+
+- with_mrope = 1:
+  positions are treated as a flattened [3, actual_num_tokens] buffer, i.e.
+  length = 3 * actual_num_tokens
+
+Zero-fill semantics
+===================
+For token-length tensors there are three logical regions:
+
+- [0, actual_num_tokens)
+  valid data copied from src to dst
+
+- [actual_num_tokens, padded_num_tokens)
+  padding region; only dst_tokens and dst_new_cache_slots are zero-filled
+  because:
+  - tokens padded tail must be zeroed to avoid invalid token ids being
+    consumed by embedding lookup / index_select
+  - new_cache_slots padded tail must be zeroed to avoid reshape_and_cache
+    writing to illegal cache addresses
+
+- [padded_num_tokens, +inf)
+  untouched
+
+Implementation style
+====================
+This kernel is currently intended for ACL decode-only metadata update where
+num_tokens is usually small, so the implementation favors simple runtime-length
+scalar logic.
+
+The current design assumes decode semantics:
+- actual_num_tokens == actual_batch_size
+- the padded logical row extent is padded_num_tokens
+
+The outer work-sharing loop therefore uses continuous row-range partitioning on
+the padded decode batch rather than separate token / position / batch loops.
+Tensors that do not require zero-fill naturally do nothing once they leave
+their valid range.
+"""
+
+import argparse
+from itertools import product
+from pathlib import Path
+
+import tilelang
+import tilelang.language as T
+
+from compiler.tilelang.common.spec import (
+    DispatchField,
+    TilelangKernel,
+    register_kernel,
+)
+
+from .utils import DEFAULT_ASCEND_PASS_CONFIGS, detect_vec_core_num
+
+DEFAULT_DTYPE = "int32"
+DEFAULT_EMBEDDING_DTYPE = "bfloat16"
+NO_INPUT_EMBEDDING_DTYPE = "float32"
+VEC_NUM = 2
+COMPILE_MAX_TOKENS = 16384
+COMPILE_MAX_BATCH = 1024
+COMPILE_MAX_BLOCK_TABLE_LEN = 8192
+COMPILE_MAX_HIDDEN_SIZE = 16384
+MROPE_COMPONENTS = 3
+BLOCK_TABLE_BULK_SIZE = 32
+
+# Python-side ref-checks do not need to use the full compile limits.
+REF_CHECK_COMPILE_MAX_TOKENS = min(COMPILE_MAX_TOKENS, 512)
+REF_CHECK_COMPILE_MAX_BATCH = min(COMPILE_MAX_BATCH, 128)
+REF_CHECK_COMPILE_MAX_BLOCK_TABLE_LEN = min(COMPILE_MAX_BLOCK_TABLE_LEN, 512)
+REF_CHECK_COMPILE_MAX_HIDDEN_SIZE = min(COMPILE_MAX_HIDDEN_SIZE, 256)
+
+
+def _validate_flag(name: str, value: int) -> bool:
+    if value not in (0, 1):
+        raise ValueError(f"{name} must be 0 or 1, got {value}")
+    return bool(value)
+
+
+def _validate_embedding_dtype(dtype: str) -> None:
+    if dtype not in ("float16", "bfloat16", "float32"):
+        raise ValueError(
+            "embedding_dtype must be one of: float16, bfloat16, float32; "
+            f"got {dtype}"
+        )
+
+
+def build_model_input_buffer_updater_kernel(
+    *,
+    compile_max_tokens: int,
+    compile_max_batch: int,
+    compile_max_block_table_len: int,
+    compile_hidden_size: int,
+    vec_core_num: int,
+    embedding_dtype: str = DEFAULT_EMBEDDING_DTYPE,
+    with_mrope: int = 0,
+    with_input_embedding: int = 0,
+    with_linear_state_indices: int = 0,
+    with_q_cu_seq_lens: int = 0,
+):
+    if compile_max_tokens <= 0:
+        raise ValueError(
+            f"compile_max_tokens({compile_max_tokens}) must be > 0"
+        )
+    if compile_max_batch <= 0:
+        raise ValueError(f"compile_max_batch({compile_max_batch}) must be > 0")
+    if compile_max_block_table_len <= 0:
+        raise ValueError(
+            "compile_max_block_table_len"
+            f"({compile_max_block_table_len}) must be > 0"
+        )
+    if compile_hidden_size <= 0:
+        raise ValueError(
+            f"compile_hidden_size({compile_hidden_size}) must be > 0"
+        )
+    compile_input_embedding_elems = compile_max_tokens * compile_hidden_size
+    if vec_core_num <= 0:
+        raise ValueError(f"vec_core_num({vec_core_num}) must be > 0")
+    if vec_core_num % VEC_NUM != 0:
+        raise ValueError(
+            f"vec_core_num({vec_core_num}) must be divisible by VEC_NUM({VEC_NUM})"
+        )
+    _validate_embedding_dtype(embedding_dtype)
+
+    use_mrope = _validate_flag("with_mrope", with_mrope)
+    use_input_embedding = _validate_flag(
+        "with_input_embedding", with_input_embedding
+    )
+    use_linear_state_indices = _validate_flag(
+        "with_linear_state_indices", with_linear_state_indices
+    )
+    use_q_cu_seq_lens = _validate_flag(
+        "with_q_cu_seq_lens", with_q_cu_seq_lens
+    )
+
+    task_num = vec_core_num
+    m_num = vec_core_num // VEC_NUM
+    compile_position_elems = compile_max_tokens * MROPE_COMPONENTS
+    compile_block_table_elems = compile_max_batch * compile_max_block_table_len
+
+    @T.prim_func
+    def model_input_buffer_updater_kernel(
+        src_tokens: T.Tensor((compile_max_tokens,), DEFAULT_DTYPE),
+        src_positions: T.Tensor((compile_position_elems,), DEFAULT_DTYPE),
+        src_new_cache_slots: T.Tensor((compile_max_tokens,), DEFAULT_DTYPE),
+        src_q_seq_lens: T.Tensor((compile_max_batch,), DEFAULT_DTYPE),
+        src_kv_seq_lens: T.Tensor((compile_max_batch,), DEFAULT_DTYPE),
+        src_q_cu_seq_lens: T.Tensor((compile_max_batch,), DEFAULT_DTYPE),
+        src_linear_state_indices: T.Tensor((compile_max_batch,), DEFAULT_DTYPE),
+        src_block_tables: T.Tensor(
+            (compile_block_table_elems,), DEFAULT_DTYPE
+        ),
+        src_input_embedding: T.Tensor(
+            (compile_input_embedding_elems,), embedding_dtype
+        ),
+        dst_tokens: T.Tensor((compile_max_tokens,), DEFAULT_DTYPE),
+        dst_positions: T.Tensor((compile_position_elems,), DEFAULT_DTYPE),
+        dst_new_cache_slots: T.Tensor((compile_max_tokens,), DEFAULT_DTYPE),
+        dst_q_seq_lens: T.Tensor((compile_max_batch,), DEFAULT_DTYPE),
+        dst_kv_seq_lens: T.Tensor((compile_max_batch,), DEFAULT_DTYPE),
+        dst_q_cu_seq_lens: T.Tensor((compile_max_batch,), DEFAULT_DTYPE),
+        dst_linear_state_indices: T.Tensor((compile_max_batch,), DEFAULT_DTYPE),
+        dst_block_tables: T.Tensor(
+            (compile_block_table_elems,), DEFAULT_DTYPE
+        ),
+        dst_input_embedding: T.Tensor(
+            (compile_input_embedding_elems,), embedding_dtype
+        ),
+        actual_num_tokens: T.int32,
+        padded_num_tokens: T.int32,
+        actual_batch_size: T.int32,
+        src_block_table_stride: T.int32,
+        dst_block_table_stride: T.int32,
+        actual_block_table_len: T.int32,
+        src_positions_stride: T.int32,
+        dst_positions_stride: T.int32,
+        src_input_embedding_stride: T.int32,
+        dst_input_embedding_stride: T.int32,
+        actual_hidden_size: T.int32,
+    ):
+        with T.Kernel(m_num, is_npu=True) as (cid, vid):
+            task_id = cid * VEC_NUM + vid
+            block_m = (padded_num_tokens + task_num - 1) // task_num
+            row_start = task_id * block_m
+            rows_left = T.if_then_else(
+                padded_num_tokens > row_start,
+                padded_num_tokens - row_start,
+                0,
+            )
+            num_rows_per_vec = T.if_then_else(
+                rows_left < block_m,
+                rows_left,
+                block_m,
+            )
+
+            with T.Scope("V"):
+                i32_scalar_ub = T.alloc_ub((1,), DEFAULT_DTYPE)
+                i32_zero_ub = T.alloc_ub((1,), DEFAULT_DTYPE)
+                i32_block_table_bulk_ub = T.alloc_shared(
+                    (BLOCK_TABLE_BULK_SIZE,), DEFAULT_DTYPE
+                )
+                emb_scalar_ub = T.alloc_ub((1,), embedding_dtype)
+                i32_zero_ub[0] = 0
+                for row_local in T.serial(num_rows_per_vec):
+                    row = row_start + row_local
+
+                    # Group 1: tokens / positions / new_cache_slots
+                    with T.If(row < actual_num_tokens):
+                        with T.Then():
+                            T.copy(src_tokens[row : row + 1], i32_scalar_ub[0:1])
+                            T.copy(i32_scalar_ub[0:1], dst_tokens[row : row + 1])
+                            T.copy(
+                                src_new_cache_slots[row : row + 1],
+                                i32_scalar_ub[0:1],
+                            )
+                            T.copy(
+                                i32_scalar_ub[0:1],
+                                dst_new_cache_slots[row : row + 1],
+                            )
+                            if use_mrope:
+                                for axis in T.serial(MROPE_COMPONENTS):
+                                    src_pos_idx = axis * src_positions_stride + row
+                                    dst_pos_idx = axis * dst_positions_stride + row
+                                    T.copy(
+                                        src_positions[src_pos_idx : src_pos_idx + 1],
+                                        i32_scalar_ub[0:1],
+                                    )
+                                    T.copy(
+                                        i32_scalar_ub[0:1],
+                                        dst_positions[dst_pos_idx : dst_pos_idx + 1],
+                                    )
+                            else:
+                                T.copy(
+                                    src_positions[row : row + 1],
+                                    i32_scalar_ub[0:1],
+                                )
+                                T.copy(
+                                    i32_scalar_ub[0:1],
+                                    dst_positions[row : row + 1],
+                                )
+                        with T.Else():
+                            T.copy(i32_zero_ub[0:1], dst_tokens[row : row + 1])
+                            T.copy(
+                                i32_zero_ub[0:1],
+                                dst_new_cache_slots[row : row + 1],
+                            )
+
+                    # Group 2: batch metadata + block tables
+                    with T.If(row < actual_batch_size):
+                        with T.Then():
+                            T.copy(
+                                src_q_seq_lens[row : row + 1],
+                                i32_scalar_ub[0:1],
+                            )
+                            T.copy(
+                                i32_scalar_ub[0:1],
+                                dst_q_seq_lens[row : row + 1],
+                            )
+                            T.copy(
+                                src_kv_seq_lens[row : row + 1],
+                                i32_scalar_ub[0:1],
+                            )
+                            T.copy(
+                                i32_scalar_ub[0:1],
+                                dst_kv_seq_lens[row : row + 1],
+                            )
+                            if use_q_cu_seq_lens:
+                                T.copy(
+                                    src_q_cu_seq_lens[row : row + 1],
+                                    i32_scalar_ub[0:1],
+                                )
+                                T.copy(
+                                    i32_scalar_ub[0:1],
+                                    dst_q_cu_seq_lens[row : row + 1],
+                                )
+                            if use_linear_state_indices:
+                                T.copy(
+                                    src_linear_state_indices[row : row + 1],
+                                    i32_scalar_ub[0:1],
+                                )
+                                T.copy(
+                                    i32_scalar_ub[0:1],
+                                    dst_linear_state_indices[row : row + 1],
+                                )
+
+                            src_row_offset = row * src_block_table_stride
+                            dst_row_offset = row * dst_block_table_stride
+                            block_table_bulk_chunks = (
+                                actual_block_table_len
+                                + BLOCK_TABLE_BULK_SIZE
+                                - 1
+                            ) // BLOCK_TABLE_BULK_SIZE
+                            for chunk_idx in T.serial(block_table_bulk_chunks):
+                                col_start = chunk_idx * BLOCK_TABLE_BULK_SIZE
+                                col_end = col_start + BLOCK_TABLE_BULK_SIZE
+                                with T.If(col_end <= actual_block_table_len):
+                                    with T.Then():
+                                        T.copy(
+                                            src_block_tables[
+                                                src_row_offset
+                                                + col_start : src_row_offset
+                                                + col_end
+                                            ],
+                                            i32_block_table_bulk_ub[
+                                                0:BLOCK_TABLE_BULK_SIZE
+                                            ],
+                                        )
+                                        T.copy(
+                                            i32_block_table_bulk_ub[
+                                                0:BLOCK_TABLE_BULK_SIZE
+                                            ],
+                                            dst_block_tables[
+                                                dst_row_offset
+                                                + col_start : dst_row_offset
+                                                + col_end
+                                            ],
+                                        )
+                                    with T.Else():
+                                        with T.If(col_start < actual_block_table_len):
+                                            with T.Then():
+                                                for elem in T.serial(
+                                                    BLOCK_TABLE_BULK_SIZE
+                                                ):
+                                                    col = col_start + elem
+                                                    with T.If(
+                                                        col < actual_block_table_len
+                                                    ):
+                                                        with T.Then():
+                                                            T.copy(
+                                                                src_block_tables[
+                                                                    src_row_offset
+                                                                    + col : src_row_offset
+                                                                    + col
+                                                                    + 1
+                                                                ],
+                                                                i32_scalar_ub[0:1],
+                                                            )
+                                                            T.copy(
+                                                                i32_scalar_ub[0:1],
+                                                                dst_block_tables[
+                                                                    dst_row_offset
+                                                                    + col : dst_row_offset
+                                                                    + col
+                                                                    + 1
+                                                                ],
+                                                            )
+
+                    # Group 3: input embedding
+                    if use_input_embedding:
+                        with T.If(row < actual_num_tokens):
+                            with T.Then():
+                                src_emb_row_offset = row * src_input_embedding_stride
+                                dst_emb_row_offset = row * dst_input_embedding_stride
+                                for col in T.serial(actual_hidden_size):
+                                    T.copy(
+                                        src_input_embedding[
+                                            src_emb_row_offset
+                                            + col : src_emb_row_offset
+                                            + col
+                                            + 1
+                                        ],
+                                        emb_scalar_ub[0:1],
+                                    )
+                                    T.copy(
+                                        emb_scalar_ub[0:1],
+                                        dst_input_embedding[
+                                            dst_emb_row_offset
+                                            + col : dst_emb_row_offset
+                                            + col
+                                            + 1
+                                        ],
+                                    )
+
+    return model_input_buffer_updater_kernel
+
+
+@tilelang.jit(pass_configs=DEFAULT_ASCEND_PASS_CONFIGS)
+def model_input_buffer_updater_kernel_jit(
+    compile_max_tokens: int,
+    compile_max_batch: int,
+    compile_max_block_table_len: int,
+    compile_hidden_size: int,
+    vec_core_num: int,
+    embedding_dtype: str,
+    with_mrope: int,
+    with_input_embedding: int,
+    with_linear_state_indices: int,
+    with_q_cu_seq_lens: int,
+):
+    return build_model_input_buffer_updater_kernel(
+        compile_max_tokens=compile_max_tokens,
+        compile_max_batch=compile_max_batch,
+        compile_max_block_table_len=compile_max_block_table_len,
+        compile_hidden_size=compile_hidden_size,
+        vec_core_num=vec_core_num,
+        embedding_dtype=embedding_dtype,
+        with_mrope=with_mrope,
+        with_input_embedding=with_input_embedding,
+        with_linear_state_indices=with_linear_state_indices,
+        with_q_cu_seq_lens=with_q_cu_seq_lens,
+    )
+
+
+def generate_source(
+    *,
+    compile_hidden_size: int,
+    embedding_dtype: str,
+    with_mrope: int,
+    with_input_embedding: int,
+    with_linear_state_indices: int,
+    with_q_cu_seq_lens: int,
+) -> str:
+    tilelang.disable_cache()
+    tilelang_kernel = build_model_input_buffer_updater_kernel(
+        compile_max_tokens=COMPILE_MAX_TOKENS,
+        compile_max_batch=COMPILE_MAX_BATCH,
+        compile_max_block_table_len=COMPILE_MAX_BLOCK_TABLE_LEN,
+        compile_hidden_size=compile_hidden_size,
+        vec_core_num=detect_vec_core_num(),
+        embedding_dtype=embedding_dtype,
+        with_mrope=with_mrope,
+        with_input_embedding=with_input_embedding,
+        with_linear_state_indices=with_linear_state_indices,
+        with_q_cu_seq_lens=with_q_cu_seq_lens,
+    )
+    with tilelang.tvm.transform.PassContext(
+        opt_level=3, config=DEFAULT_ASCEND_PASS_CONFIGS
+    ):
+        kernel = tilelang.engine.lower(tilelang_kernel)
+    return kernel.kernel_source
+
+
+def _assert_tensor_equal(actual, expected, name: str) -> None:
+    import torch
+
+    if not torch.equal(actual.cpu(), expected.cpu()):
+        raise AssertionError(
+            f"{name} mismatch:\nactual={actual.cpu()}\nexpected={expected.cpu()}"
+        )
+
+
+def _apply_block_table_ref_update(
+    *,
+    src_block_tables,
+    dst_block_tables,
+    actual_batch_size: int,
+    src_block_table_stride: int,
+    dst_block_table_stride: int,
+    actual_block_table_len: int,
+) -> None:
+    for row in range(actual_batch_size):
+        src_row_offset = row * src_block_table_stride
+        dst_row_offset = row * dst_block_table_stride
+        dst_block_tables[
+            dst_row_offset : dst_row_offset + actual_block_table_len
+        ].copy_(
+            src_block_tables[
+                src_row_offset : src_row_offset + actual_block_table_len
+            ],
+            non_blocking=True,
+        )
+
+
+def _make_ref_case(
+    *,
+    device,
+    compile_max_tokens: int,
+    compile_max_batch: int,
+    compile_max_block_table_len: int,
+    actual_num_tokens: int,
+    padded_num_tokens: int,
+    actual_batch_size: int,
+    actual_block_table_len: int,
+    dst_block_table_stride: int,
+    compile_hidden_size: int,
+    actual_hidden_size: int,
+    embedding_dtype: str,
+    with_mrope: int,
+    with_input_embedding: int,
+    with_q_cu_seq_lens: int,
+    with_linear_state_indices: int,
+    seed: int,
+):
+    import torch
+
+    torch.manual_seed(seed)
+    int_kwargs = {"device": device, "dtype": torch.int32}
+    emb_dtype = {
+        "float16": torch.float16,
+        "bfloat16": torch.bfloat16,
+        "float32": torch.float32,
+    }[embedding_dtype]
+    emb_kwargs = {"device": device, "dtype": emb_dtype}
+
+    src_block_table_stride = actual_block_table_len
+    compile_position_elems = compile_max_tokens * MROPE_COMPONENTS
+    compile_block_table_elems = compile_max_batch * compile_max_block_table_len
+    compile_input_embedding_elems = compile_max_tokens * compile_hidden_size
+    src_positions_stride = actual_num_tokens if with_mrope else 0
+    dst_positions_stride = compile_max_tokens if with_mrope else 0
+
+    src_tokens = torch.randint(0, 32000, (compile_max_tokens,), **int_kwargs)
+    src_positions = torch.randint(
+        0, 32000, (compile_position_elems,), **int_kwargs
+    )
+    src_new_cache_slots = torch.randint(
+        0, 2048, (compile_max_tokens,), **int_kwargs
+    )
+    src_q_seq_lens = torch.randint(1, 3, (compile_max_batch,), **int_kwargs)
+    src_kv_seq_lens = torch.randint(1, 4096, (compile_max_batch,), **int_kwargs)
+    src_q_cu_seq_lens = torch.randint(
+        1, 4096, (compile_max_batch,), **int_kwargs
+    )
+    src_linear_state_indices = torch.randint(
+        0, 4096, (compile_max_batch,), **int_kwargs
+    )
+    src_block_tables = torch.randint(
+        0, 4096, (compile_block_table_elems,), **int_kwargs
+    )
+    src_input_embedding = torch.full(
+        (compile_input_embedding_elems,), -1, **emb_kwargs
+    )
+    src_input_embedding_stride = actual_hidden_size if with_input_embedding else 0
+    dst_input_embedding_stride = actual_hidden_size if with_input_embedding else 0
+    if with_input_embedding:
+        src_input_embedding[
+            : compile_max_tokens * actual_hidden_size
+        ] = torch.randn(
+            (compile_max_tokens * actual_hidden_size,), **emb_kwargs
+        )
+
+    dst_tokens = torch.full((compile_max_tokens,), -1, **int_kwargs)
+    dst_positions = torch.full((compile_position_elems,), -1, **int_kwargs)
+    dst_new_cache_slots = torch.full((compile_max_tokens,), -1, **int_kwargs)
+    dst_q_seq_lens = torch.full((compile_max_batch,), -1, **int_kwargs)
+    dst_kv_seq_lens = torch.full((compile_max_batch,), -1, **int_kwargs)
+    dst_q_cu_seq_lens = torch.full((compile_max_batch,), -1, **int_kwargs)
+    dst_linear_state_indices = torch.full(
+        (compile_max_batch,), -1, **int_kwargs
+    )
+    dst_block_tables = torch.full(
+        (compile_block_table_elems,), -1, **int_kwargs
+    )
+    dst_input_embedding = torch.full(
+        (compile_input_embedding_elems,), -1, **emb_kwargs
+    )
+
+    ref = {
+        "dst_tokens": dst_tokens.clone(),
+        "dst_positions": dst_positions.clone(),
+        "dst_new_cache_slots": dst_new_cache_slots.clone(),
+        "dst_q_seq_lens": dst_q_seq_lens.clone(),
+        "dst_kv_seq_lens": dst_kv_seq_lens.clone(),
+        "dst_q_cu_seq_lens": dst_q_cu_seq_lens.clone(),
+        "dst_linear_state_indices": dst_linear_state_indices.clone(),
+        "dst_block_tables": dst_block_tables.clone(),
+        "dst_input_embedding": dst_input_embedding.clone(),
+    }
+
+    ref["dst_tokens"][:actual_num_tokens].copy_(
+        src_tokens[:actual_num_tokens], non_blocking=True
+    )
+    ref["dst_new_cache_slots"][:actual_num_tokens].copy_(
+        src_new_cache_slots[:actual_num_tokens], non_blocking=True
+    )
+
+    if with_mrope:
+        for axis in range(MROPE_COMPONENTS):
+            src_start = axis * src_positions_stride
+            dst_start = axis * dst_positions_stride
+            ref["dst_positions"][dst_start : dst_start + actual_num_tokens].copy_(
+                src_positions[src_start : src_start + actual_num_tokens],
+                non_blocking=True,
+            )
+    else:
+        ref["dst_positions"][:actual_num_tokens].copy_(
+            src_positions[:actual_num_tokens], non_blocking=True
+        )
+
+    ref["dst_q_seq_lens"][:actual_batch_size].copy_(
+        src_q_seq_lens[:actual_batch_size], non_blocking=True
+    )
+    ref["dst_kv_seq_lens"][:actual_batch_size].copy_(
+        src_kv_seq_lens[:actual_batch_size], non_blocking=True
+    )
+    if with_q_cu_seq_lens:
+        ref["dst_q_cu_seq_lens"][:actual_batch_size].copy_(
+            src_q_cu_seq_lens[:actual_batch_size], non_blocking=True
+        )
+    if with_linear_state_indices:
+        ref["dst_linear_state_indices"][:actual_batch_size].copy_(
+            src_linear_state_indices[:actual_batch_size], non_blocking=True
+        )
+
+    if padded_num_tokens > actual_num_tokens:
+        ref["dst_tokens"][actual_num_tokens:padded_num_tokens].fill_(0)
+        ref["dst_new_cache_slots"][actual_num_tokens:padded_num_tokens].fill_(0)
+
+    _apply_block_table_ref_update(
+        src_block_tables=src_block_tables,
+        dst_block_tables=ref["dst_block_tables"],
+        actual_batch_size=actual_batch_size,
+        src_block_table_stride=src_block_table_stride,
+        dst_block_table_stride=dst_block_table_stride,
+        actual_block_table_len=actual_block_table_len,
+    )
+
+    if with_input_embedding:
+        ref["dst_input_embedding"][
+            : actual_num_tokens * actual_hidden_size
+        ].view(actual_num_tokens, actual_hidden_size).copy_(
+            src_input_embedding[: actual_num_tokens * actual_hidden_size].view(
+                actual_num_tokens, actual_hidden_size
+            ),
+            non_blocking=True,
+        )
+
+    return {
+        "src_tokens": src_tokens,
+        "src_positions": src_positions,
+        "src_new_cache_slots": src_new_cache_slots,
+        "src_q_seq_lens": src_q_seq_lens,
+        "src_kv_seq_lens": src_kv_seq_lens,
+        "src_q_cu_seq_lens": src_q_cu_seq_lens,
+        "src_linear_state_indices": src_linear_state_indices,
+        "src_block_tables": src_block_tables,
+        "src_input_embedding": src_input_embedding,
+        "dst_tokens": dst_tokens,
+        "dst_positions": dst_positions,
+        "dst_new_cache_slots": dst_new_cache_slots,
+        "dst_q_seq_lens": dst_q_seq_lens,
+        "dst_kv_seq_lens": dst_kv_seq_lens,
+        "dst_q_cu_seq_lens": dst_q_cu_seq_lens,
+        "dst_linear_state_indices": dst_linear_state_indices,
+        "dst_block_tables": dst_block_tables,
+        "dst_input_embedding": dst_input_embedding,
+        "ref": ref,
+        "src_block_table_stride": src_block_table_stride,
+        "dst_block_table_stride": dst_block_table_stride,
+        "actual_num_tokens": actual_num_tokens,
+        "padded_num_tokens": padded_num_tokens,
+        "actual_batch_size": actual_batch_size,
+        "actual_block_table_len": actual_block_table_len,
+        "src_positions_stride": src_positions_stride,
+        "dst_positions_stride": dst_positions_stride,
+        "src_input_embedding_stride": src_input_embedding_stride,
+        "dst_input_embedding_stride": dst_input_embedding_stride,
+        "actual_hidden_size": actual_hidden_size,
+    }
+
+
+def _run_ref_check(
+    *,
+    device_index: int,
+    compile_hidden_size: int,
+    embedding_dtype: str,
+) -> None:
+    import torch
+
+    if not hasattr(torch, "npu") or not torch.npu.is_available():
+        raise RuntimeError("torch.npu is not available")
+    torch.npu.set_device(device_index)
+    device = torch.device(f"npu:{device_index}")
+    vec_core_num = detect_vec_core_num()
+    compile_max_tokens = REF_CHECK_COMPILE_MAX_TOKENS
+    compile_max_batch = REF_CHECK_COMPILE_MAX_BATCH
+    compile_max_block_table_len = REF_CHECK_COMPILE_MAX_BLOCK_TABLE_LEN
+    compile_hidden_size = max(
+        min(compile_hidden_size, REF_CHECK_COMPILE_MAX_HIDDEN_SIZE), 128
+    )
+
+    cases = [
+        {
+            "name": "plain",
+            "actual_num_tokens": 4,
+            "padded_num_tokens": 8,
+            "actual_batch_size": 3,
+            "actual_block_table_len": 5,
+            "dst_block_table_stride": 16,
+            "with_mrope": 0,
+            "with_input_embedding": 0,
+            "with_q_cu_seq_lens": 0,
+            "with_linear_state_indices": 0,
+            "actual_hidden_size": 0,
+            "seed": 11,
+        },
+        {
+            "name": "mrope",
+            "actual_num_tokens": 5,
+            "padded_num_tokens": 8,
+            "actual_batch_size": 4,
+            "actual_block_table_len": 7,
+            "dst_block_table_stride": 16,
+            "with_mrope": 1,
+            "with_input_embedding": 0,
+            "with_q_cu_seq_lens": 1,
+            "with_linear_state_indices": 0,
+            "actual_hidden_size": 0,
+            "seed": 12,
+        },
+        {
+            "name": "embedding",
+            "actual_num_tokens": 6,
+            "padded_num_tokens": 8,
+            "actual_batch_size": 5,
+            "actual_block_table_len": 9,
+            "dst_block_table_stride": 16,
+            "with_mrope": 0,
+            "with_input_embedding": 1,
+            "with_q_cu_seq_lens": 0,
+            "with_linear_state_indices": 1,
+            "actual_hidden_size": 96,
+            "seed": 13,
+        },
+        {
+            "name": "all",
+            "actual_num_tokens": 9,
+            "padded_num_tokens": 16,
+            "actual_batch_size": 8,
+            "actual_block_table_len": 13,
+            "dst_block_table_stride": 32,
+            "with_mrope": 1,
+            "with_input_embedding": 1,
+            "with_q_cu_seq_lens": 1,
+            "with_linear_state_indices": 1,
+            "actual_hidden_size": 128,
+            "seed": 14,
+        },
+    ]
+
+    for case in cases:
+        case_args = {k: v for k, v in case.items() if k != "name"}
+        kernel = model_input_buffer_updater_kernel_jit(
+            compile_max_tokens=compile_max_tokens,
+            compile_max_batch=compile_max_batch,
+            compile_max_block_table_len=compile_max_block_table_len,
+            compile_hidden_size=compile_hidden_size,
+            vec_core_num=vec_core_num,
+            embedding_dtype=embedding_dtype,
+            with_mrope=case["with_mrope"],
+            with_input_embedding=case["with_input_embedding"],
+            with_linear_state_indices=case["with_linear_state_indices"],
+            with_q_cu_seq_lens=case["with_q_cu_seq_lens"],
+        )
+        tensors = _make_ref_case(
+            device=device,
+            compile_max_tokens=compile_max_tokens,
+            compile_max_batch=compile_max_batch,
+            compile_max_block_table_len=compile_max_block_table_len,
+            compile_hidden_size=compile_hidden_size,
+            embedding_dtype=embedding_dtype,
+            **case_args,
+        )
+        kernel(
+            tensors["src_tokens"],
+            tensors["src_positions"],
+            tensors["src_new_cache_slots"],
+            tensors["src_q_seq_lens"],
+            tensors["src_kv_seq_lens"],
+            tensors["src_q_cu_seq_lens"],
+            tensors["src_linear_state_indices"],
+            tensors["src_block_tables"],
+            tensors["src_input_embedding"],
+            tensors["dst_tokens"],
+            tensors["dst_positions"],
+            tensors["dst_new_cache_slots"],
+            tensors["dst_q_seq_lens"],
+            tensors["dst_kv_seq_lens"],
+            tensors["dst_q_cu_seq_lens"],
+            tensors["dst_linear_state_indices"],
+            tensors["dst_block_tables"],
+            tensors["dst_input_embedding"],
+            tensors["actual_num_tokens"],
+            tensors["padded_num_tokens"],
+            tensors["actual_batch_size"],
+            tensors["src_block_table_stride"],
+            tensors["dst_block_table_stride"],
+            tensors["actual_block_table_len"],
+            tensors["src_positions_stride"],
+            tensors["dst_positions_stride"],
+            tensors["src_input_embedding_stride"],
+            tensors["dst_input_embedding_stride"],
+            tensors["actual_hidden_size"],
+        )
+        torch.npu.synchronize()
+
+        _assert_tensor_equal(
+            tensors["dst_tokens"],
+            tensors["ref"]["dst_tokens"],
+            case["name"] + ":tokens",
+        )
+        _assert_tensor_equal(
+            tensors["dst_positions"],
+            tensors["ref"]["dst_positions"],
+            case["name"] + ":positions",
+        )
+        _assert_tensor_equal(
+            tensors["dst_new_cache_slots"],
+            tensors["ref"]["dst_new_cache_slots"],
+            case["name"] + ":new_cache_slots",
+        )
+        _assert_tensor_equal(
+            tensors["dst_q_seq_lens"],
+            tensors["ref"]["dst_q_seq_lens"],
+            case["name"] + ":q_seq_lens",
+        )
+        _assert_tensor_equal(
+            tensors["dst_kv_seq_lens"],
+            tensors["ref"]["dst_kv_seq_lens"],
+            case["name"] + ":kv_seq_lens",
+        )
+        if case["with_q_cu_seq_lens"]:
+            _assert_tensor_equal(
+                tensors["dst_q_cu_seq_lens"],
+                tensors["ref"]["dst_q_cu_seq_lens"],
+                case["name"] + ":q_cu_seq_lens",
+            )
+        if case["with_linear_state_indices"]:
+            _assert_tensor_equal(
+                tensors["dst_linear_state_indices"],
+                tensors["ref"]["dst_linear_state_indices"],
+                case["name"] + ":linear_state_indices",
+            )
+        _assert_tensor_equal(
+            tensors["dst_block_tables"],
+            tensors["ref"]["dst_block_tables"],
+            case["name"] + ":block_tables",
+        )
+        if case["with_input_embedding"]:
+            _assert_tensor_equal(
+                tensors["dst_input_embedding"],
+                tensors["ref"]["dst_input_embedding"],
+                case["name"] + ":input_embedding",
+            )
+
+    print("[INFO] model_input_buffer_updater ref-check passed")
+
+
+def _embedding_dtype_variant_token(embedding_dtype: str) -> str:
+    return {
+        "float16": "fp16",
+        "bfloat16": "bf16",
+        "float32": "fp32",
+    }[embedding_dtype]
+
+
+def _registered_specializations() -> list[dict[str, object]]:
+    specializations: list[dict[str, object]] = []
+    for with_input_embedding in (0, 1):
+        embedding_dtypes = (
+            (NO_INPUT_EMBEDDING_DTYPE,)
+            if with_input_embedding == 0
+            else ("float16", "bfloat16", "float32")
+        )
+        for (
+            embedding_dtype,
+            with_mrope,
+            with_linear_state_indices,
+            with_q_cu_seq_lens,
+        ) in product(
+            embedding_dtypes,
+            (0, 1),
+            (0, 1),
+            (0, 1),
+        ):
+            variant_key = (
+                "emb"
+                f"{_embedding_dtype_variant_token(embedding_dtype)}"
+                f"_mrope{with_mrope}"
+                f"_iemb{with_input_embedding}"
+                f"_lsi{with_linear_state_indices}"
+                f"_qcu{with_q_cu_seq_lens}"
+            )
+            specializations.append(
+                {
+                    "variant_key": variant_key,
+                    "embedding_dtype": embedding_dtype,
+                    "with_mrope": with_mrope,
+                    "with_input_embedding": with_input_embedding,
+                    "with_linear_state_indices": with_linear_state_indices,
+                    "with_q_cu_seq_lens": with_q_cu_seq_lens,
+                }
+            )
+    return specializations
+
+
+@register_kernel
+class ModelInputBufferUpdater(TilelangKernel):
+    KERNEL_NAME = "model_input_buffer_updater"
+    DISPATCH_SCHEMA = [
+        DispatchField("embedding_dtype", "dtype"),
+        DispatchField("with_mrope", "int32"),
+        DispatchField("with_input_embedding", "int32"),
+        DispatchField("with_linear_state_indices", "int32"),
+        DispatchField("with_q_cu_seq_lens", "int32"),
+    ]
+    SPECIALIZATIONS = _registered_specializations()
+
+    @staticmethod
+    def generate_source(
+        *,
+        embedding_dtype: str,
+        with_mrope: int,
+        with_input_embedding: int,
+        with_linear_state_indices: int,
+        with_q_cu_seq_lens: int,
+    ) -> str:
+        return generate_source(
+            compile_hidden_size=COMPILE_MAX_HIDDEN_SIZE,
+            embedding_dtype=embedding_dtype,
+            with_mrope=with_mrope,
+            with_input_embedding=with_input_embedding,
+            with_linear_state_indices=with_linear_state_indices,
+            with_q_cu_seq_lens=with_q_cu_seq_lens,
+        )
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Generate TileLang AscendC source for model_input_buffer_updater."
+        )
+    )
+    parser.add_argument(
+        "--output",
+        default=None,
+        help="Output AscendC .cpp file. Required unless --run-ref-check is set.",
+    )
+    parser.add_argument(
+        "--run-ref-check",
+        action="store_true",
+        help="Run Python-side torch reference checks instead of generating source.",
+    )
+    parser.add_argument(
+        "--device-index",
+        type=int,
+        default=0,
+        help="NPU device index used by --run-ref-check.",
+    )
+    parser.add_argument(
+        "--compile-hidden-size",
+        type=int,
+        default=4096,
+        help="Compile-time hidden size used by input_embedding group.",
+    )
+    parser.add_argument(
+        "--embedding-dtype",
+        default=DEFAULT_EMBEDDING_DTYPE,
+        choices=["float16", "bfloat16", "float32"],
+        help="Embedding dtype used by input_embedding group.",
+    )
+    parser.add_argument(
+        "--with-mrope",
+        type=int,
+        default=0,
+        choices=[0, 1],
+        help="Enable mRoPE positions group.",
+    )
+    parser.add_argument(
+        "--with-input-embedding",
+        type=int,
+        default=0,
+        choices=[0, 1],
+        help="Enable input_embedding group.",
+    )
+    parser.add_argument(
+        "--with-linear-state-indices",
+        type=int,
+        default=0,
+        choices=[0, 1],
+        help="Enable linear_state_indices group.",
+    )
+    parser.add_argument(
+        "--with-q-cu-seq-lens",
+        type=int,
+        default=0,
+        choices=[0, 1],
+        help="Enable q_cu_seq_lens group.",
+    )
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+    if args.run_ref_check:
+        if args.device_index < 0:
+            raise ValueError("--device-index must be >= 0")
+        _run_ref_check(
+            device_index=args.device_index,
+            compile_hidden_size=args.compile_hidden_size,
+            embedding_dtype=args.embedding_dtype,
+        )
+        return
+
+    if not args.output:
+        raise ValueError("--output is required unless --run-ref-check is set")
+    output = Path(args.output).resolve()
+    output.parent.mkdir(parents=True, exist_ok=True)
+    source = generate_source(
+        compile_hidden_size=args.compile_hidden_size,
+        embedding_dtype=args.embedding_dtype,
+        with_mrope=args.with_mrope,
+        with_input_embedding=args.with_input_embedding,
+        with_linear_state_indices=args.with_linear_state_indices,
+        with_q_cu_seq_lens=args.with_q_cu_seq_lens,
+    )
+    output.write_text(source, encoding="utf-8")
+
+
+if __name__ == "__main__":
+    main()

--- a/xllm/compiler/tilelang/targets/ascend/kernels/utils.py
+++ b/xllm/compiler/tilelang/targets/ascend/kernels/utils.py
@@ -52,6 +52,7 @@ def _dispatch_field_suffix(name: str) -> str:
 def _dtype_enum_suffix(dtype_name: str) -> str:
     common_suffixes = {
         "bf16": "BF16",
+        "bfloat16": "BF16",
         "fp16": "Float16",
         "fp32": "Float32",
         "float16": "Float16",

--- a/xllm/core/kernels/npu/tilelang/CMakeLists.txt
+++ b/xllm/core/kernels/npu/tilelang/CMakeLists.txt
@@ -138,6 +138,11 @@ tilelang_register_runtime_kernel(
   WRAPPER_SRCS split_qkv_rmsnorm_mrope_wrapper.cpp
 )
 
+tilelang_register_runtime_kernel(
+  NAME model_input_buffer_updater
+  WRAPPER_SRCS model_input_buffer_updater_wrapper.cpp
+)
+
 cc_library(
   NAME
     tilelang_kernels
@@ -199,6 +204,18 @@ cc_test(
     split_qkv_rmsnorm_mrope_wrapper_test
   SRCS
     split_qkv_rmsnorm_mrope_wrapper_test.cpp
+  DEPS
+    :tilelang_kernels
+    torch
+    GTest::gtest_main
+    glog::glog
+)
+
+cc_test(
+  NAME
+    model_input_buffer_updater_wrapper_test
+  SRCS
+    model_input_buffer_updater_wrapper_test.cpp
   DEPS
     :tilelang_kernels
     torch

--- a/xllm/core/kernels/npu/tilelang/model_input_buffer_updater_wrapper.cpp
+++ b/xllm/core/kernels/npu/tilelang/model_input_buffer_updater_wrapper.cpp
@@ -1,0 +1,473 @@
+/* Copyright 2026 The xLLM Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://github.com/jd-opensource/xllm/blob/main/LICENSE
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include <c10/core/DeviceType.h>
+#include <glog/logging.h>
+#include <torch_npu/csrc/core/npu/NPUStream.h>
+#include <torch_npu/torch_npu.h>
+
+#include <cstdint>
+#include <limits>
+
+#include "acl/acl.h"
+#include "core/kernels/npu/tilelang/dispatch_registry.h"
+#include "core/kernels/npu/tilelang/tilelang_ops_api.h"
+
+#ifndef XLLM_TL_MODEL_INPUT_BUFFER_UPDATER_REGISTRY_INC
+#error "XLLM_TL_MODEL_INPUT_BUFFER_UPDATER_REGISTRY_INC is not defined"
+#endif
+
+namespace xllm::kernel::npu::tilelang {
+namespace {
+
+constexpr int32_t kCompileMaxTokens = 16384;
+constexpr int32_t kCompileMaxBatch = 1024;
+constexpr int32_t kCompileMaxBlockTableLen = 8192;
+constexpr int32_t kCompileMaxHiddenSize = 16384;
+constexpr int32_t kMropeComponents = 3;
+
+#include XLLM_TL_MODEL_INPUT_BUFFER_UPDATER_REGISTRY_INC
+
+int32_t checked_int32(int64_t value, const char* name) {
+  CHECK_GE(value, 0) << "TileLang model_input_buffer_updater: " << name
+                     << " must be >= 0";
+  CHECK_LE(value, static_cast<int64_t>(std::numeric_limits<int32_t>::max()))
+      << "TileLang model_input_buffer_updater: " << name
+      << " exceeds int32 range";
+  return static_cast<int32_t>(value);
+}
+
+bool is_supported_embedding_dtype(c10::ScalarType dtype) {
+  return dtype == c10::ScalarType::Half || dtype == c10::ScalarType::BFloat16 ||
+         dtype == c10::ScalarType::Float;
+}
+
+void check_defined_npu_int32_vector(const torch::Tensor& tensor,
+                                    const char* name) {
+  CHECK(tensor.defined()) << "TileLang model_input_buffer_updater: " << name
+                          << " must be defined";
+  CHECK(tensor.device().type() == c10::DeviceType::PrivateUse1)
+      << "TileLang model_input_buffer_updater: " << name << " must be on NPU";
+  CHECK_EQ(tensor.dtype(), torch::kInt32)
+      << "TileLang model_input_buffer_updater: " << name << " must be int32";
+  CHECK_EQ(tensor.dim(), 1)
+      << "TileLang model_input_buffer_updater: " << name << " must be 1D";
+  CHECK_EQ(tensor.stride(0), 1)
+      << "TileLang model_input_buffer_updater: " << name
+      << " must be contiguous";
+}
+
+void check_defined_npu_int32_matrix(const torch::Tensor& tensor,
+                                    const char* name) {
+  CHECK(tensor.defined()) << "TileLang model_input_buffer_updater: " << name
+                          << " must be defined";
+  CHECK(tensor.device().type() == c10::DeviceType::PrivateUse1)
+      << "TileLang model_input_buffer_updater: " << name << " must be on NPU";
+  CHECK_EQ(tensor.dtype(), torch::kInt32)
+      << "TileLang model_input_buffer_updater: " << name << " must be int32";
+  CHECK_EQ(tensor.dim(), 2)
+      << "TileLang model_input_buffer_updater: " << name << " must be 2D";
+  CHECK_EQ(tensor.stride(1), 1)
+      << "TileLang model_input_buffer_updater: " << name
+      << " last-dim stride must be 1";
+  CHECK_GT(tensor.stride(0), 0)
+      << "TileLang model_input_buffer_updater: " << name
+      << " row stride must be > 0";
+}
+
+void check_defined_npu_embedding_matrix(const torch::Tensor& tensor,
+                                        const char* name) {
+  CHECK(tensor.defined()) << "TileLang model_input_buffer_updater: " << name
+                          << " must be defined";
+  CHECK(tensor.device().type() == c10::DeviceType::PrivateUse1)
+      << "TileLang model_input_buffer_updater: " << name << " must be on NPU";
+  CHECK(is_supported_embedding_dtype(tensor.scalar_type()))
+      << "TileLang model_input_buffer_updater: unsupported embedding dtype for "
+      << name;
+  CHECK_EQ(tensor.dim(), 2)
+      << "TileLang model_input_buffer_updater: " << name << " must be 2D";
+  CHECK_EQ(tensor.stride(1), 1)
+      << "TileLang model_input_buffer_updater: " << name
+      << " last-dim stride must be 1";
+  CHECK_GT(tensor.stride(0), 0)
+      << "TileLang model_input_buffer_updater: " << name
+      << " row stride must be > 0";
+}
+
+void check_same_device(const torch::Tensor& reference,
+                       const torch::Tensor& tensor,
+                       const char* name) {
+  if (!tensor.defined()) {
+    return;
+  }
+  CHECK_EQ(tensor.device(), reference.device())
+      << "TileLang model_input_buffer_updater: " << name
+      << " must be on the same device as src_tokens";
+}
+
+uint8_t* tensor_data_ptr_or_null(const torch::Tensor& tensor) {
+  if (!tensor.defined()) {
+    return nullptr;
+  }
+  return reinterpret_cast<uint8_t*>(const_cast<void*>(tensor.data_ptr()));
+}
+
+ModelInputBufferUpdaterSpecialization build_runtime_specialization(
+    c10::ScalarType embedding_dtype,
+    bool with_mrope,
+    bool with_input_embedding,
+    bool with_linear_state_indices,
+    bool with_q_cu_seq_lens) {
+  const TilelangDType tilelang_embedding_dtype =
+      with_input_embedding ? to_tilelang_dtype(embedding_dtype)
+                           : TilelangDType::kFloat32;
+  return make_model_input_buffer_updater_specialization(
+      ModelInputBufferUpdaterEmbeddingDType{tilelang_embedding_dtype},
+      ModelInputBufferUpdaterWithMrope{with_mrope ? 1 : 0},
+      ModelInputBufferUpdaterWithInputEmbedding{with_input_embedding ? 1 : 0},
+      ModelInputBufferUpdaterWithLinearStateIndices{
+          with_linear_state_indices ? 1 : 0},
+      ModelInputBufferUpdaterWithQCuSeqLens{with_q_cu_seq_lens ? 1 : 0});
+}
+
+}  // namespace
+
+bool has_model_input_buffer_updater_specialization(
+    c10::ScalarType embedding_dtype,
+    bool with_mrope,
+    bool with_input_embedding,
+    bool with_linear_state_indices,
+    bool with_q_cu_seq_lens) {
+  if (with_input_embedding && !is_supported_embedding_dtype(embedding_dtype)) {
+    return false;
+  }
+  const auto specialization =
+      build_runtime_specialization(embedding_dtype,
+                                   with_mrope,
+                                   with_input_embedding,
+                                   with_linear_state_indices,
+                                   with_q_cu_seq_lens);
+  return find_model_input_buffer_updater_kernel_entry(specialization) !=
+         nullptr;
+}
+
+void model_input_buffer_updater(ModelInputBufferUpdaterParams& params) {
+  check_defined_npu_int32_vector(params.src_tokens, "src_tokens");
+  check_defined_npu_int32_vector(params.src_new_cache_slots,
+                                 "src_new_cache_slots");
+  check_defined_npu_int32_vector(params.src_q_seq_lens, "src_q_seq_lens");
+  check_defined_npu_int32_vector(params.src_kv_seq_lens, "src_kv_seq_lens");
+  check_defined_npu_int32_matrix(params.src_block_tables, "src_block_tables");
+
+  check_defined_npu_int32_vector(params.dst_tokens, "dst_tokens");
+  check_defined_npu_int32_vector(params.dst_new_cache_slots,
+                                 "dst_new_cache_slots");
+  check_defined_npu_int32_vector(params.dst_q_seq_lens, "dst_q_seq_lens");
+  check_defined_npu_int32_vector(params.dst_kv_seq_lens, "dst_kv_seq_lens");
+  check_defined_npu_int32_matrix(params.dst_block_tables, "dst_block_tables");
+
+  const bool with_q_cu_seq_lens =
+      params.src_q_cu_seq_lens.defined() || params.dst_q_cu_seq_lens.defined();
+  const bool with_linear_state_indices =
+      params.src_linear_state_indices.defined() ||
+      params.dst_linear_state_indices.defined();
+  const bool with_input_embedding = params.src_input_embedding.defined() ||
+                                    params.dst_input_embedding.defined();
+
+  CHECK_EQ(params.src_q_cu_seq_lens.defined(),
+           params.dst_q_cu_seq_lens.defined())
+      << "TileLang model_input_buffer_updater: q_cu_seq_lens src/dst must both "
+         "be defined or both be undefined";
+  CHECK_EQ(params.src_linear_state_indices.defined(),
+           params.dst_linear_state_indices.defined())
+      << "TileLang model_input_buffer_updater: linear_state_indices src/dst "
+         "must both be defined or both be undefined";
+  CHECK_EQ(params.src_input_embedding.defined(),
+           params.dst_input_embedding.defined())
+      << "TileLang model_input_buffer_updater: input_embedding src/dst must "
+         "both be defined or both be undefined";
+
+  const bool with_mrope = params.src_positions.dim() == 2;
+  if (with_mrope) {
+    check_defined_npu_int32_matrix(params.src_positions, "src_positions");
+    check_defined_npu_int32_matrix(params.dst_positions, "dst_positions");
+    CHECK_EQ(params.src_positions.size(0), kMropeComponents)
+        << "TileLang model_input_buffer_updater: src_positions mRoPE axis dim "
+           "must be 3";
+    CHECK_EQ(params.dst_positions.size(0), kMropeComponents)
+        << "TileLang model_input_buffer_updater: dst_positions mRoPE axis dim "
+           "must be 3";
+  } else {
+    check_defined_npu_int32_vector(params.src_positions, "src_positions");
+    check_defined_npu_int32_vector(params.dst_positions, "dst_positions");
+  }
+
+  if (with_q_cu_seq_lens) {
+    check_defined_npu_int32_vector(params.src_q_cu_seq_lens,
+                                   "src_q_cu_seq_lens");
+    check_defined_npu_int32_vector(params.dst_q_cu_seq_lens,
+                                   "dst_q_cu_seq_lens");
+  }
+  if (with_linear_state_indices) {
+    check_defined_npu_int32_vector(params.src_linear_state_indices,
+                                   "src_linear_state_indices");
+    check_defined_npu_int32_vector(params.dst_linear_state_indices,
+                                   "dst_linear_state_indices");
+  }
+  if (with_input_embedding) {
+    check_defined_npu_embedding_matrix(params.src_input_embedding,
+                                       "src_input_embedding");
+    check_defined_npu_embedding_matrix(params.dst_input_embedding,
+                                       "dst_input_embedding");
+    CHECK_EQ(params.src_input_embedding.scalar_type(),
+             params.dst_input_embedding.scalar_type())
+        << "TileLang model_input_buffer_updater: input_embedding dtype "
+           "mismatch";
+  }
+
+  check_same_device(params.src_tokens, params.src_positions, "src_positions");
+  check_same_device(
+      params.src_tokens, params.src_new_cache_slots, "src_new_cache_slots");
+  check_same_device(params.src_tokens, params.src_q_seq_lens, "src_q_seq_lens");
+  check_same_device(
+      params.src_tokens, params.src_kv_seq_lens, "src_kv_seq_lens");
+  check_same_device(
+      params.src_tokens, params.src_q_cu_seq_lens, "src_q_cu_seq_lens");
+  check_same_device(params.src_tokens,
+                    params.src_linear_state_indices,
+                    "src_linear_state_indices");
+  check_same_device(
+      params.src_tokens, params.src_block_tables, "src_block_tables");
+  check_same_device(
+      params.src_tokens, params.src_input_embedding, "src_input_embedding");
+  check_same_device(params.src_tokens, params.dst_tokens, "dst_tokens");
+  check_same_device(params.src_tokens, params.dst_positions, "dst_positions");
+  check_same_device(
+      params.src_tokens, params.dst_new_cache_slots, "dst_new_cache_slots");
+  check_same_device(params.src_tokens, params.dst_q_seq_lens, "dst_q_seq_lens");
+  check_same_device(
+      params.src_tokens, params.dst_kv_seq_lens, "dst_kv_seq_lens");
+  check_same_device(
+      params.src_tokens, params.dst_q_cu_seq_lens, "dst_q_cu_seq_lens");
+  check_same_device(params.src_tokens,
+                    params.dst_linear_state_indices,
+                    "dst_linear_state_indices");
+  check_same_device(
+      params.src_tokens, params.dst_block_tables, "dst_block_tables");
+  check_same_device(
+      params.src_tokens, params.dst_input_embedding, "dst_input_embedding");
+
+  const int32_t actual_num_tokens =
+      checked_int32(params.src_tokens.size(0), "actual_num_tokens");
+  const int32_t padded_num_tokens =
+      checked_int32(params.padded_num_tokens, "padded_num_tokens");
+  const int32_t actual_batch_size =
+      checked_int32(params.src_q_seq_lens.size(0), "actual_batch_size");
+  const int32_t actual_block_table_len =
+      checked_int32(params.src_block_tables.size(1), "actual_block_table_len");
+  const int32_t src_block_table_stride = checked_int32(
+      params.src_block_tables.stride(0), "src_block_table_stride");
+  const int32_t dst_block_table_stride = checked_int32(
+      params.dst_block_tables.stride(0), "dst_block_table_stride");
+  const int32_t src_positions_stride =
+      with_mrope
+          ? checked_int32(params.src_positions.size(1), "src_positions_stride")
+          : 0;
+  const int32_t dst_positions_stride =
+      with_mrope
+          ? checked_int32(params.dst_positions.size(1), "dst_positions_stride")
+          : 0;
+  const int32_t actual_hidden_size =
+      with_input_embedding ? checked_int32(params.src_input_embedding.size(1),
+                                           "actual_hidden_size")
+                           : 0;
+  const int32_t src_input_embedding_stride =
+      with_input_embedding ? checked_int32(params.src_input_embedding.stride(0),
+                                           "src_input_embedding_stride")
+                           : 0;
+  const int32_t dst_input_embedding_stride =
+      with_input_embedding ? checked_int32(params.dst_input_embedding.stride(0),
+                                           "dst_input_embedding_stride")
+                           : 0;
+
+  CHECK_LE(padded_num_tokens, kCompileMaxTokens)
+      << "TileLang model_input_buffer_updater: padded_num_tokens exceeds "
+         "compiled limit "
+      << kCompileMaxTokens;
+  CHECK_LE(actual_batch_size, kCompileMaxBatch)
+      << "TileLang model_input_buffer_updater: actual_batch_size exceeds "
+         "compiled limit "
+      << kCompileMaxBatch;
+  CHECK_LE(actual_block_table_len, kCompileMaxBlockTableLen)
+      << "TileLang model_input_buffer_updater: actual_block_table_len exceeds "
+         "compiled limit "
+      << kCompileMaxBlockTableLen;
+  CHECK_LE(src_block_table_stride, kCompileMaxBlockTableLen)
+      << "TileLang model_input_buffer_updater: src_block_table_stride exceeds "
+         "compiled limit "
+      << kCompileMaxBlockTableLen;
+  CHECK_LE(dst_block_table_stride, kCompileMaxBlockTableLen)
+      << "TileLang model_input_buffer_updater: dst_block_table_stride exceeds "
+         "compiled limit "
+      << kCompileMaxBlockTableLen;
+  if (with_mrope) {
+    CHECK_LE(src_positions_stride, kCompileMaxTokens)
+        << "TileLang model_input_buffer_updater: src_positions_stride exceeds "
+           "compiled limit "
+        << kCompileMaxTokens;
+    CHECK_LE(dst_positions_stride, kCompileMaxTokens)
+        << "TileLang model_input_buffer_updater: dst_positions_stride exceeds "
+           "compiled limit "
+        << kCompileMaxTokens;
+  }
+  if (with_input_embedding) {
+    CHECK_LE(actual_hidden_size, kCompileMaxHiddenSize)
+        << "TileLang model_input_buffer_updater: actual_hidden_size exceeds "
+           "compiled limit "
+        << kCompileMaxHiddenSize;
+    CHECK_LE(src_input_embedding_stride, kCompileMaxHiddenSize)
+        << "TileLang model_input_buffer_updater: src_input_embedding_stride "
+           "exceeds compiled limit "
+        << kCompileMaxHiddenSize;
+    CHECK_LE(dst_input_embedding_stride, kCompileMaxHiddenSize)
+        << "TileLang model_input_buffer_updater: dst_input_embedding_stride "
+           "exceeds compiled limit "
+        << kCompileMaxHiddenSize;
+  }
+
+  CHECK_LE(actual_num_tokens, padded_num_tokens)
+      << "TileLang model_input_buffer_updater: actual_num_tokens must be <= "
+         "padded_num_tokens";
+  CHECK_EQ(params.src_new_cache_slots.size(0), actual_num_tokens)
+      << "TileLang model_input_buffer_updater: src_new_cache_slots size "
+         "mismatch";
+  CHECK_GE(params.dst_tokens.size(0), padded_num_tokens)
+      << "TileLang model_input_buffer_updater: dst_tokens capacity mismatch";
+  CHECK_GE(params.dst_new_cache_slots.size(0), padded_num_tokens)
+      << "TileLang model_input_buffer_updater: dst_new_cache_slots capacity "
+         "mismatch";
+  CHECK_EQ(params.src_kv_seq_lens.size(0), actual_batch_size)
+      << "TileLang model_input_buffer_updater: src_kv_seq_lens size mismatch";
+  CHECK_EQ(params.src_block_tables.size(0), actual_batch_size)
+      << "TileLang model_input_buffer_updater: src_block_tables batch mismatch";
+  CHECK_GE(params.dst_q_seq_lens.size(0), actual_batch_size)
+      << "TileLang model_input_buffer_updater: dst_q_seq_lens capacity "
+         "mismatch";
+  CHECK_GE(params.dst_kv_seq_lens.size(0), actual_batch_size)
+      << "TileLang model_input_buffer_updater: dst_kv_seq_lens capacity "
+         "mismatch";
+  CHECK_GE(params.dst_block_tables.size(0), actual_batch_size)
+      << "TileLang model_input_buffer_updater: dst_block_tables batch capacity "
+         "mismatch";
+  CHECK_GE(params.dst_block_tables.size(1), actual_block_table_len)
+      << "TileLang model_input_buffer_updater: dst_block_tables width capacity "
+         "mismatch";
+
+  if (with_mrope) {
+    CHECK_EQ(params.src_positions.size(1), actual_num_tokens)
+        << "TileLang model_input_buffer_updater: src_positions token dim "
+           "mismatch";
+    CHECK_GE(params.dst_positions.size(1), padded_num_tokens)
+        << "TileLang model_input_buffer_updater: dst_positions token capacity "
+           "mismatch";
+  } else {
+    CHECK_EQ(params.src_positions.size(0), actual_num_tokens)
+        << "TileLang model_input_buffer_updater: src_positions size mismatch";
+    CHECK_GE(params.dst_positions.size(0), padded_num_tokens)
+        << "TileLang model_input_buffer_updater: dst_positions capacity "
+           "mismatch";
+  }
+
+  if (with_q_cu_seq_lens) {
+    CHECK_EQ(params.src_q_cu_seq_lens.size(0), actual_batch_size)
+        << "TileLang model_input_buffer_updater: src_q_cu_seq_lens size "
+           "mismatch";
+    CHECK_GE(params.dst_q_cu_seq_lens.size(0), actual_batch_size)
+        << "TileLang model_input_buffer_updater: dst_q_cu_seq_lens capacity "
+           "mismatch";
+  }
+  if (with_linear_state_indices) {
+    CHECK_EQ(params.src_linear_state_indices.size(0), actual_batch_size)
+        << "TileLang model_input_buffer_updater: src_linear_state_indices size "
+           "mismatch";
+    CHECK_GE(params.dst_linear_state_indices.size(0), actual_batch_size)
+        << "TileLang model_input_buffer_updater: dst_linear_state_indices "
+           "capacity mismatch";
+  }
+  if (with_input_embedding) {
+    CHECK_EQ(params.src_input_embedding.size(0), actual_num_tokens)
+        << "TileLang model_input_buffer_updater: src_input_embedding row "
+           "mismatch";
+    CHECK_EQ(params.dst_input_embedding.size(1), actual_hidden_size)
+        << "TileLang model_input_buffer_updater: dst_input_embedding hidden "
+           "size mismatch";
+    CHECK_GE(params.dst_input_embedding.size(0), padded_num_tokens)
+        << "TileLang model_input_buffer_updater: dst_input_embedding capacity "
+           "mismatch";
+  }
+
+  const auto specialization = build_runtime_specialization(
+      with_input_embedding ? params.src_input_embedding.scalar_type()
+                           : c10::ScalarType::Float,
+      with_mrope,
+      with_input_embedding,
+      with_linear_state_indices,
+      with_q_cu_seq_lens);
+  const auto* entry =
+      find_model_input_buffer_updater_kernel_entry(specialization);
+  CHECK(entry != nullptr)
+      << "TileLang model_input_buffer_updater: no compiled variant. Available "
+         "variants: "
+      << available_model_input_buffer_updater_variant_keys();
+
+  if (padded_num_tokens == 0 && actual_batch_size == 0) {
+    return;
+  }
+
+  const int32_t device_id = params.src_tokens.device().index();
+  aclrtStream stream = c10_npu::getCurrentNPUStream(device_id).stream();
+  entry->fn(tensor_data_ptr_or_null(params.src_tokens),
+            tensor_data_ptr_or_null(params.src_positions),
+            tensor_data_ptr_or_null(params.src_new_cache_slots),
+            tensor_data_ptr_or_null(params.src_q_seq_lens),
+            tensor_data_ptr_or_null(params.src_kv_seq_lens),
+            tensor_data_ptr_or_null(params.src_q_cu_seq_lens),
+            tensor_data_ptr_or_null(params.src_linear_state_indices),
+            tensor_data_ptr_or_null(params.src_block_tables),
+            tensor_data_ptr_or_null(params.src_input_embedding),
+            tensor_data_ptr_or_null(params.dst_tokens),
+            tensor_data_ptr_or_null(params.dst_positions),
+            tensor_data_ptr_or_null(params.dst_new_cache_slots),
+            tensor_data_ptr_or_null(params.dst_q_seq_lens),
+            tensor_data_ptr_or_null(params.dst_kv_seq_lens),
+            tensor_data_ptr_or_null(params.dst_q_cu_seq_lens),
+            tensor_data_ptr_or_null(params.dst_linear_state_indices),
+            tensor_data_ptr_or_null(params.dst_block_tables),
+            tensor_data_ptr_or_null(params.dst_input_embedding),
+            actual_num_tokens,
+            padded_num_tokens,
+            actual_batch_size,
+            src_block_table_stride,
+            dst_block_table_stride,
+            actual_block_table_len,
+            src_positions_stride,
+            dst_positions_stride,
+            src_input_embedding_stride,
+            dst_input_embedding_stride,
+            actual_hidden_size,
+            stream);
+}
+
+}  // namespace xllm::kernel::npu::tilelang

--- a/xllm/core/kernels/npu/tilelang/model_input_buffer_updater_wrapper_test.cpp
+++ b/xllm/core/kernels/npu/tilelang/model_input_buffer_updater_wrapper_test.cpp
@@ -1,0 +1,324 @@
+/* Copyright 2026 The xLLM Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://github.com/jd-opensource/xllm/blob/main/LICENSE
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include <gtest/gtest.h>
+#include <torch/torch.h>
+#include <torch_npu/torch_npu.h>
+
+#include <string>
+#include <vector>
+
+#include "core/kernels/npu/tilelang/tilelang_ops_api.h"
+
+namespace xllm::kernel::npu::tilelang {
+namespace {
+
+class TileLangModelInputBufferUpdaterWrapperTest : public ::testing::Test {
+ protected:
+  static void SetUpTestSuite() { torch_npu::init_npu("npu:0"); }
+
+  static void TearDownTestSuite() { torch_npu::finalize_npu(); }
+};
+
+struct UpdaterTestCase {
+  std::string name;
+  int64_t actual_num_tokens;
+  int64_t padded_num_tokens;
+  int64_t actual_batch_size;
+  int64_t actual_block_table_len;
+  int64_t dst_block_table_stride;
+  bool with_mrope;
+  bool with_input_embedding;
+  bool with_q_cu_seq_lens;
+  bool with_linear_state_indices;
+  c10::ScalarType embedding_dtype;
+  int64_t hidden_size;
+  int64_t seed;
+};
+
+struct UpdaterTestBuffers {
+  ModelInputBufferUpdaterParams params;
+  torch::Tensor ref_dst_tokens;
+  torch::Tensor ref_dst_positions;
+  torch::Tensor ref_dst_new_cache_slots;
+  torch::Tensor ref_dst_q_seq_lens;
+  torch::Tensor ref_dst_kv_seq_lens;
+  torch::Tensor ref_dst_q_cu_seq_lens;
+  torch::Tensor ref_dst_linear_state_indices;
+  torch::Tensor ref_dst_block_tables;
+  torch::Tensor ref_dst_input_embedding;
+};
+
+void expect_tensor_equal(const torch::Tensor& actual,
+                         const torch::Tensor& expected,
+                         const std::string& name) {
+  ASSERT_TRUE(torch::equal(actual.cpu(), expected.cpu()))
+      << name << " mismatch\nactual=" << actual.cpu()
+      << "\nexpected=" << expected.cpu();
+}
+
+UpdaterTestBuffers make_case(const UpdaterTestCase& test_case) {
+  const torch::Device device("npu:0");
+  const auto int_opts =
+      torch::TensorOptions().dtype(torch::kInt32).device(device);
+  const auto emb_opts =
+      torch::TensorOptions().dtype(test_case.embedding_dtype).device(device);
+
+  torch::manual_seed(test_case.seed);
+
+  const int64_t token_capacity =
+      std::max<int64_t>(32, test_case.padded_num_tokens + 7);
+  const int64_t batch_capacity =
+      std::max<int64_t>(16, test_case.actual_batch_size + 5);
+
+  UpdaterTestBuffers buffers;
+  buffers.params.padded_num_tokens = test_case.padded_num_tokens;
+
+  buffers.params.src_tokens =
+      torch::randint(0, 32000, {test_case.actual_num_tokens}, int_opts);
+  buffers.params.src_new_cache_slots =
+      torch::randint(0, 4096, {test_case.actual_num_tokens}, int_opts);
+  buffers.params.src_q_seq_lens =
+      torch::randint(1, 3, {test_case.actual_batch_size}, int_opts);
+  buffers.params.src_kv_seq_lens =
+      torch::randint(1, 4096, {test_case.actual_batch_size}, int_opts);
+  buffers.params.src_block_tables = torch::randint(
+      0,
+      4096,
+      {test_case.actual_batch_size, test_case.actual_block_table_len},
+      int_opts);
+
+  if (test_case.with_mrope) {
+    buffers.params.src_positions =
+        torch::randint(0, 32000, {3, test_case.actual_num_tokens}, int_opts);
+    buffers.params.dst_positions =
+        torch::full({3, token_capacity}, -1, int_opts);
+  } else {
+    buffers.params.src_positions =
+        torch::randint(0, 32000, {test_case.actual_num_tokens}, int_opts);
+    buffers.params.dst_positions = torch::full({token_capacity}, -1, int_opts);
+  }
+
+  buffers.params.dst_tokens = torch::full({token_capacity}, -1, int_opts);
+  buffers.params.dst_new_cache_slots =
+      torch::full({token_capacity}, -1, int_opts);
+  buffers.params.dst_q_seq_lens = torch::full({batch_capacity}, -1, int_opts);
+  buffers.params.dst_kv_seq_lens = torch::full({batch_capacity}, -1, int_opts);
+  buffers.params.dst_block_tables = torch::full(
+      {batch_capacity, test_case.dst_block_table_stride}, -1, int_opts);
+
+  if (test_case.with_q_cu_seq_lens) {
+    buffers.params.src_q_cu_seq_lens =
+        torch::randint(1, 4096, {test_case.actual_batch_size}, int_opts);
+    buffers.params.dst_q_cu_seq_lens =
+        torch::full({batch_capacity}, -1, int_opts);
+  }
+
+  if (test_case.with_linear_state_indices) {
+    buffers.params.src_linear_state_indices =
+        torch::randint(0, 4096, {test_case.actual_batch_size}, int_opts);
+    buffers.params.dst_linear_state_indices =
+        torch::full({batch_capacity}, -1, int_opts);
+  }
+
+  if (test_case.with_input_embedding) {
+    buffers.params.src_input_embedding = torch::randn(
+        {test_case.actual_num_tokens, test_case.hidden_size}, emb_opts);
+    buffers.params.dst_input_embedding =
+        torch::full({token_capacity, test_case.hidden_size}, -1, emb_opts);
+  }
+
+  buffers.ref_dst_tokens = buffers.params.dst_tokens.clone();
+  buffers.ref_dst_positions = buffers.params.dst_positions.clone();
+  buffers.ref_dst_new_cache_slots = buffers.params.dst_new_cache_slots.clone();
+  buffers.ref_dst_q_seq_lens = buffers.params.dst_q_seq_lens.clone();
+  buffers.ref_dst_kv_seq_lens = buffers.params.dst_kv_seq_lens.clone();
+  buffers.ref_dst_q_cu_seq_lens = buffers.params.dst_q_cu_seq_lens.defined()
+                                      ? buffers.params.dst_q_cu_seq_lens.clone()
+                                      : torch::Tensor();
+  buffers.ref_dst_linear_state_indices =
+      buffers.params.dst_linear_state_indices.defined()
+          ? buffers.params.dst_linear_state_indices.clone()
+          : torch::Tensor();
+  buffers.ref_dst_block_tables = buffers.params.dst_block_tables.clone();
+  buffers.ref_dst_input_embedding =
+      buffers.params.dst_input_embedding.defined()
+          ? buffers.params.dst_input_embedding.clone()
+          : torch::Tensor();
+
+  buffers.ref_dst_tokens.slice(0, 0, test_case.actual_num_tokens)
+      .copy_(buffers.params.src_tokens, /*non_blocking=*/true);
+  buffers.ref_dst_new_cache_slots.slice(0, 0, test_case.actual_num_tokens)
+      .copy_(buffers.params.src_new_cache_slots, /*non_blocking=*/true);
+  if (test_case.padded_num_tokens > test_case.actual_num_tokens) {
+    buffers.ref_dst_tokens
+        .slice(0, test_case.actual_num_tokens, test_case.padded_num_tokens)
+        .fill_(0);
+    buffers.ref_dst_new_cache_slots
+        .slice(0, test_case.actual_num_tokens, test_case.padded_num_tokens)
+        .fill_(0);
+  }
+
+  if (test_case.with_mrope) {
+    buffers.ref_dst_positions.slice(1, 0, test_case.actual_num_tokens)
+        .copy_(buffers.params.src_positions, /*non_blocking=*/true);
+  } else {
+    buffers.ref_dst_positions.slice(0, 0, test_case.actual_num_tokens)
+        .copy_(buffers.params.src_positions, /*non_blocking=*/true);
+  }
+
+  buffers.ref_dst_q_seq_lens.slice(0, 0, test_case.actual_batch_size)
+      .copy_(buffers.params.src_q_seq_lens, /*non_blocking=*/true);
+  buffers.ref_dst_kv_seq_lens.slice(0, 0, test_case.actual_batch_size)
+      .copy_(buffers.params.src_kv_seq_lens, /*non_blocking=*/true);
+  buffers.ref_dst_block_tables.slice(0, 0, test_case.actual_batch_size)
+      .slice(1, 0, test_case.actual_block_table_len)
+      .copy_(buffers.params.src_block_tables, /*non_blocking=*/true);
+
+  if (test_case.with_q_cu_seq_lens) {
+    buffers.ref_dst_q_cu_seq_lens.slice(0, 0, test_case.actual_batch_size)
+        .copy_(buffers.params.src_q_cu_seq_lens, /*non_blocking=*/true);
+  }
+  if (test_case.with_linear_state_indices) {
+    buffers.ref_dst_linear_state_indices
+        .slice(0, 0, test_case.actual_batch_size)
+        .copy_(buffers.params.src_linear_state_indices, /*non_blocking=*/true);
+  }
+  if (test_case.with_input_embedding) {
+    buffers.ref_dst_input_embedding.slice(0, 0, test_case.actual_num_tokens)
+        .copy_(buffers.params.src_input_embedding, /*non_blocking=*/true);
+  }
+
+  return buffers;
+}
+
+void run_case(const UpdaterTestCase& test_case) {
+  ASSERT_TRUE(has_model_input_buffer_updater_specialization(
+      test_case.embedding_dtype,
+      test_case.with_mrope,
+      test_case.with_input_embedding,
+      test_case.with_linear_state_indices,
+      test_case.with_q_cu_seq_lens));
+
+  auto buffers = make_case(test_case);
+  model_input_buffer_updater(buffers.params);
+  torch::npu::synchronize();
+
+  expect_tensor_equal(buffers.params.dst_tokens,
+                      buffers.ref_dst_tokens,
+                      test_case.name + ":dst_tokens");
+  expect_tensor_equal(buffers.params.dst_positions,
+                      buffers.ref_dst_positions,
+                      test_case.name + ":dst_positions");
+  expect_tensor_equal(buffers.params.dst_new_cache_slots,
+                      buffers.ref_dst_new_cache_slots,
+                      test_case.name + ":dst_new_cache_slots");
+  expect_tensor_equal(buffers.params.dst_q_seq_lens,
+                      buffers.ref_dst_q_seq_lens,
+                      test_case.name + ":dst_q_seq_lens");
+  expect_tensor_equal(buffers.params.dst_kv_seq_lens,
+                      buffers.ref_dst_kv_seq_lens,
+                      test_case.name + ":dst_kv_seq_lens");
+  expect_tensor_equal(buffers.params.dst_block_tables,
+                      buffers.ref_dst_block_tables,
+                      test_case.name + ":dst_block_tables");
+  if (test_case.with_q_cu_seq_lens) {
+    expect_tensor_equal(buffers.params.dst_q_cu_seq_lens,
+                        buffers.ref_dst_q_cu_seq_lens,
+                        test_case.name + ":dst_q_cu_seq_lens");
+  }
+  if (test_case.with_linear_state_indices) {
+    expect_tensor_equal(buffers.params.dst_linear_state_indices,
+                        buffers.ref_dst_linear_state_indices,
+                        test_case.name + ":dst_linear_state_indices");
+  }
+  if (test_case.with_input_embedding) {
+    expect_tensor_equal(buffers.params.dst_input_embedding,
+                        buffers.ref_dst_input_embedding,
+                        test_case.name + ":dst_input_embedding");
+  }
+}
+
+TEST_F(TileLangModelInputBufferUpdaterWrapperTest, RefCasesMatch) {
+  const std::vector<UpdaterTestCase> cases = {
+      {
+          "plain",
+          4,
+          8,
+          3,
+          5,
+          16,
+          false,
+          false,
+          false,
+          false,
+          torch::kFloat32,
+          0,
+          11,
+      },
+      {
+          "mrope_qcu",
+          5,
+          8,
+          4,
+          7,
+          16,
+          true,
+          false,
+          true,
+          false,
+          torch::kFloat32,
+          0,
+          12,
+      },
+      {
+          "embedding_lsi_fp32",
+          6,
+          8,
+          5,
+          9,
+          16,
+          false,
+          true,
+          false,
+          true,
+          torch::kFloat32,
+          96,
+          13,
+      },
+      {
+          "all_bf16",
+          9,
+          16,
+          8,
+          13,
+          32,
+          true,
+          true,
+          true,
+          true,
+          torch::kBFloat16,
+          128,
+          14,
+      },
+  };
+
+  for (const auto& test_case : cases) {
+    run_case(test_case);
+  }
+}
+
+}  // namespace
+}  // namespace xllm::kernel::npu::tilelang

--- a/xllm/core/kernels/npu/tilelang/tilelang_ops_api.h
+++ b/xllm/core/kernels/npu/tilelang/tilelang_ops_api.h
@@ -42,6 +42,58 @@ std::pair<torch::Tensor, torch::Tensor> fused_gdn_gating(
     float softplus_beta,
     float softplus_threshold);
 
+// Fused ACL-graph metadata updater for decode-side persistent buffers.
+//
+// All mandatory metadata tensors are int32 NPU tensors. Optional groups are
+// enabled by defining both src and dst tensors:
+// - q_cu_seq_lens
+// - linear_state_indices
+// - input_embedding
+//
+// positions:
+// - non-mRoPE: 1D [actual_num_tokens]
+// - mRoPE: 2D [3, actual_num_tokens] for src and [3, capacity] for dst
+//
+// block_tables:
+// - src: 2D [actual_batch_size, actual_block_table_len]
+// - dst: 2D [capacity, dst_block_table_stride]
+//
+// input_embedding:
+// - src: 2D [actual_num_tokens, hidden_size]
+// - dst: 2D [capacity, hidden_size]
+struct ModelInputBufferUpdaterParams {
+  torch::Tensor src_tokens;
+  torch::Tensor src_positions;
+  torch::Tensor src_new_cache_slots;
+  torch::Tensor src_q_seq_lens;
+  torch::Tensor src_kv_seq_lens;
+  torch::Tensor src_q_cu_seq_lens;
+  torch::Tensor src_linear_state_indices;
+  torch::Tensor src_block_tables;
+  torch::Tensor src_input_embedding;
+
+  torch::Tensor dst_tokens;
+  torch::Tensor dst_positions;
+  torch::Tensor dst_new_cache_slots;
+  torch::Tensor dst_q_seq_lens;
+  torch::Tensor dst_kv_seq_lens;
+  torch::Tensor dst_q_cu_seq_lens;
+  torch::Tensor dst_linear_state_indices;
+  torch::Tensor dst_block_tables;
+  torch::Tensor dst_input_embedding;
+
+  int64_t padded_num_tokens = 0;
+};
+
+void model_input_buffer_updater(ModelInputBufferUpdaterParams& params);
+
+bool has_model_input_buffer_updater_specialization(
+    c10::ScalarType embedding_dtype,
+    bool with_mrope,
+    bool with_input_embedding,
+    bool with_linear_state_indices,
+    bool with_q_cu_seq_lens);
+
 // Build merged mRoPE gather offsets for split_qkv_rmsnorm_mrope.
 torch::Tensor build_split_qkv_rmsnorm_mrope_gather_pattern(
     int64_t rope_dim,

--- a/xllm/core/runtime/CMakeLists.txt
+++ b/xllm/core/runtime/CMakeLists.txt
@@ -94,6 +94,7 @@ cc_library(
     absl::flat_hash_map
     proto::xllm_proto
     $<$<BOOL:${USE_MLU}>:torch_mlu>
+    $<$<BOOL:${USE_NPU}>:tilelang_kernels>
 )
 
 if(USE_NPU)

--- a/xllm/core/runtime/acl_graph_executor_impl.cpp
+++ b/xllm/core/runtime/acl_graph_executor_impl.cpp
@@ -33,6 +33,7 @@ limitations under the License.
 #endif
 #include "core/common/global_flags.h"
 #include "core/common/metrics.h"
+#include "core/kernels/npu/tilelang/tilelang_ops_api.h"
 #include "core/util/utils.h"
 #include "platform/npu/device_capture_lock.h"
 
@@ -68,6 +69,29 @@ int64_t get_decode_graph_capacity(const runtime::Options& options) {
     return options.max_seqs_per_batch();
   }
   return options.max_seqs_per_batch() * options.num_decoding_tokens();
+}
+
+bool is_npu_int32_vector_contiguous(const torch::Tensor& tensor) {
+  return tensor.defined() &&
+         tensor.device().type() == c10::DeviceType::PrivateUse1 &&
+         tensor.dtype() == torch::kInt32 && tensor.dim() == 1 &&
+         tensor.stride(0) == 1;
+}
+
+bool is_npu_int32_matrix_lastdim_contiguous(const torch::Tensor& tensor) {
+  return tensor.defined() &&
+         tensor.device().type() == c10::DeviceType::PrivateUse1 &&
+         tensor.dtype() == torch::kInt32 && tensor.dim() == 2 &&
+         tensor.stride(1) == 1 && tensor.stride(0) > 0;
+}
+
+bool is_npu_supported_embedding_matrix(const torch::Tensor& tensor) {
+  return tensor.defined() &&
+         tensor.device().type() == c10::DeviceType::PrivateUse1 &&
+         tensor.dim() == 2 && tensor.stride(1) == 1 && tensor.stride(0) > 0 &&
+         (tensor.scalar_type() == c10::ScalarType::Half ||
+          tensor.scalar_type() == c10::ScalarType::BFloat16 ||
+          tensor.scalar_type() == c10::ScalarType::Float);
 }
 }  // namespace
 
@@ -209,82 +233,145 @@ std::optional<ModelInputParams> GraphPersistentParam::update(
       << "padded_num_tokens must be > 0 when return_capture_params is true";
   const uint32_t actual_num_tokens = tokens.size(0);
   const int64_t actual_batch_size = params.num_sequences;
+  const int64_t actual_block_table_len = params.block_tables.size(1);
 
-  // Copy data from input parameters to persistent graph tensors
-  persistent_tokens_.slice(/*dim=*/0, /*start=*/0, /*end=*/actual_num_tokens)
-      .copy_(tokens, /*non_blocking=*/true);
-  // mRoPE positions have shape [3, num_tokens], slice on dim 1
-  if (use_mrope_) {
-    persistent_positions_
-        .slice(/*dim=*/1, /*start=*/0, /*end=*/actual_num_tokens)
-        .copy_(positions, /*non_blocking=*/true);
-  } else {
-    persistent_positions_
-        .slice(/*dim=*/0, /*start=*/0, /*end=*/actual_num_tokens)
-        .copy_(positions, /*non_blocking=*/true);
+  const auto& embedding = params.input_embedding;
+  if (embedding.defined() && persistent_embedding_.numel() == 0) {
+    const int64_t max_tokens_per_batch = FLAGS_max_tokens_per_batch;
+    const int64_t embedding_dim = embedding.size(1);
+    torch::Dtype dtype = util::parse_dtype(args_.dtype(), device_);
+    persistent_embedding_ = torch::zeros({max_tokens_per_batch, embedding_dim},
+                                         torch::dtype(dtype).device(device_));
   }
-  q_seq_lens_.slice(/*dim=*/0, /*start=*/0, /*end=*/actual_batch_size)
-      .copy_(params.q_seq_lens, /*non_blocking=*/true);
-  kv_seq_lens_.slice(/*dim=*/0, /*start=*/0, /*end=*/actual_batch_size)
-      .copy_(params.kv_seq_lens, /*non_blocking=*/true);
 
-  persistent_new_cache_slots_
-      .slice(/*dim=*/0, /*start=*/0, /*end=*/actual_num_tokens)
-      .copy_(params.new_cache_slots, /*non_blocking=*/true);
+  if (params.q_cu_seq_lens.defined() && q_cu_seq_lens_.numel() == 0) {
+    const int64_t max_seqs_per_batch = get_decode_graph_capacity(options_);
+    q_cu_seq_lens_ = torch::zeros({max_seqs_per_batch + 1},
+                                  torch::dtype(torch::kInt).device(device_));
+  }
+
+  torch::Tensor src_linear_state_indices;
   if (!params.linear_state_ids.empty()) {
     if (params.linear_state_indices.defined()) {
-      persistent_linear_state_indices_
-          .slice(/*dim=*/0, /*start=*/0, /*end=*/actual_batch_size)
-          .copy_(params.linear_state_indices, /*non_blocking=*/true);
+      src_linear_state_indices = params.linear_state_indices;
     } else {
+      src_linear_state_indices =
+          torch::tensor(params.linear_state_ids, torch::kInt).to(device_);
+    }
+  }
+
+  const bool with_q_cu_seq_lens = params.q_cu_seq_lens.defined();
+  const bool with_linear_state_indices = src_linear_state_indices.defined();
+  const bool with_input_embedding = embedding.defined();
+  const bool positions_supported =
+      use_mrope_
+          ? (is_npu_int32_matrix_lastdim_contiguous(positions) &&
+             positions.size(0) == 3 && positions.size(1) == actual_num_tokens)
+          : (is_npu_int32_vector_contiguous(positions) &&
+             positions.size(0) == actual_num_tokens);
+  const bool persistent_positions_supported =
+      use_mrope_
+          ? (is_npu_int32_matrix_lastdim_contiguous(persistent_positions_) &&
+             persistent_positions_.size(0) == 3)
+          : is_npu_int32_vector_contiguous(persistent_positions_);
+  const bool use_fast_path =
+      params.batch_forward_type.is_decode() &&
+      actual_num_tokens == static_cast<uint32_t>(actual_batch_size) &&
+      is_npu_int32_vector_contiguous(tokens) && positions_supported &&
+      persistent_positions_supported &&
+      is_npu_int32_vector_contiguous(params.new_cache_slots) &&
+      is_npu_int32_vector_contiguous(params.q_seq_lens) &&
+      is_npu_int32_vector_contiguous(params.kv_seq_lens) &&
+      is_npu_int32_matrix_lastdim_contiguous(params.block_tables) &&
+      (!with_q_cu_seq_lens ||
+       is_npu_int32_vector_contiguous(params.q_cu_seq_lens)) &&
+      (!with_linear_state_indices ||
+       is_npu_int32_vector_contiguous(src_linear_state_indices)) &&
+      (!with_input_embedding ||
+       (is_npu_supported_embedding_matrix(embedding) &&
+        is_npu_supported_embedding_matrix(persistent_embedding_) &&
+        persistent_embedding_.scalar_type() == embedding.scalar_type())) &&
+      xllm::kernel::npu::tilelang::
+          has_model_input_buffer_updater_specialization(
+              with_input_embedding ? embedding.scalar_type()
+                                   : c10::ScalarType::Float,
+              use_mrope_,
+              with_input_embedding,
+              with_linear_state_indices,
+              with_q_cu_seq_lens);
+
+  if (use_fast_path) {
+    xllm::kernel::npu::tilelang::ModelInputBufferUpdaterParams updater_params;
+    updater_params.src_tokens = tokens;
+    updater_params.src_positions = positions;
+    updater_params.src_new_cache_slots = params.new_cache_slots;
+    updater_params.src_q_seq_lens = params.q_seq_lens;
+    updater_params.src_kv_seq_lens = params.kv_seq_lens;
+    updater_params.src_block_tables = params.block_tables;
+    updater_params.dst_tokens = persistent_tokens_;
+    updater_params.dst_positions = persistent_positions_;
+    updater_params.dst_new_cache_slots = persistent_new_cache_slots_;
+    updater_params.dst_q_seq_lens = q_seq_lens_;
+    updater_params.dst_kv_seq_lens = kv_seq_lens_;
+    updater_params.dst_block_tables = persistent_block_tables_;
+    updater_params.padded_num_tokens = padded_num_tokens;
+    if (with_q_cu_seq_lens) {
+      updater_params.src_q_cu_seq_lens = params.q_cu_seq_lens;
+      updater_params.dst_q_cu_seq_lens = q_cu_seq_lens_;
+    }
+    if (with_linear_state_indices) {
+      updater_params.src_linear_state_indices = src_linear_state_indices;
+      updater_params.dst_linear_state_indices =
+          persistent_linear_state_indices_;
+    }
+    if (with_input_embedding) {
+      updater_params.src_input_embedding = embedding;
+      updater_params.dst_input_embedding = persistent_embedding_;
+    }
+    xllm::kernel::npu::tilelang::model_input_buffer_updater(updater_params);
+  } else {
+    persistent_tokens_.slice(/*dim=*/0, /*start=*/0, /*end=*/actual_num_tokens)
+        .copy_(tokens, /*non_blocking=*/true);
+    if (use_mrope_) {
+      persistent_positions_
+          .slice(/*dim=*/1, /*start=*/0, /*end=*/actual_num_tokens)
+          .copy_(positions, /*non_blocking=*/true);
+    } else {
+      persistent_positions_
+          .slice(/*dim=*/0, /*start=*/0, /*end=*/actual_num_tokens)
+          .copy_(positions, /*non_blocking=*/true);
+    }
+    q_seq_lens_.slice(/*dim=*/0, /*start=*/0, /*end=*/actual_batch_size)
+        .copy_(params.q_seq_lens, /*non_blocking=*/true);
+    kv_seq_lens_.slice(/*dim=*/0, /*start=*/0, /*end=*/actual_batch_size)
+        .copy_(params.kv_seq_lens, /*non_blocking=*/true);
+    persistent_new_cache_slots_
+        .slice(/*dim=*/0, /*start=*/0, /*end=*/actual_num_tokens)
+        .copy_(params.new_cache_slots, /*non_blocking=*/true);
+
+    if (with_linear_state_indices) {
       persistent_linear_state_indices_
           .slice(/*dim=*/0, /*start=*/0, /*end=*/actual_batch_size)
-          .copy_(
-              torch::tensor(params.linear_state_ids, torch::kInt).to(device_),
-              /*non_blocking=*/true);
-    }
-  }
-
-  // Copy block table data
-  const int64_t actual_block_table_len = params.block_tables.size(1);
-  auto slice_persistent_block_tables =
-      persistent_block_tables_
-          .slice(/*dim=*/0, /*start=*/0, /*end=*/actual_batch_size)
-          .slice(/*dim=*/1, /*start=*/0, /*end=*/actual_block_table_len);
-  slice_persistent_block_tables.copy_(params.block_tables,
-                                      /*non_blocking=*/true);
-
-  // Update persistent embedding from input_embedding if available
-  const auto& embedding = params.input_embedding;
-  if (embedding.defined()) {
-    const int64_t embedding_tokens = embedding.size(0);
-
-    // Initialize persistent_embedding_ if needed and not already initialized
-    if (persistent_embedding_.numel() == 0) {
-      const int64_t max_tokens_per_batch = FLAGS_max_tokens_per_batch;
-      const int64_t embedding_dim = embedding.size(1);
-      torch::Dtype dtype = util::parse_dtype(args_.dtype(), device_);
-      persistent_embedding_ =
-          torch::zeros({max_tokens_per_batch, embedding_dim},
-                       torch::dtype(dtype).device(device_));
+          .copy_(src_linear_state_indices, /*non_blocking=*/true);
     }
 
-    // Copy embedding data to persistent buffer
-    persistent_embedding_
-        .slice(/*dim=*/0, /*start=*/0, /*end=*/embedding_tokens)
-        .copy_(embedding, /*non_blocking=*/true);
-  }
-  // Update q_cu_seq_lens only if params.q_cu_seq_lens is defined
-  if (params.q_cu_seq_lens.defined()) {
-    // Lazy initialization: if q_cu_seq_lens_ is not initialized, initialize it
-    if (q_cu_seq_lens_.numel() == 0) {
-      const int64_t max_seqs_per_batch = get_decode_graph_capacity(options_);
-      q_cu_seq_lens_ = torch::zeros({max_seqs_per_batch + 1},
-                                    torch::dtype(torch::kInt).device(device_));
+    auto slice_persistent_block_tables =
+        persistent_block_tables_
+            .slice(/*dim=*/0, /*start=*/0, /*end=*/actual_batch_size)
+            .slice(/*dim=*/1, /*start=*/0, /*end=*/actual_block_table_len);
+    slice_persistent_block_tables.copy_(params.block_tables,
+                                        /*non_blocking=*/true);
+
+    if (embedding.defined()) {
+      const int64_t embedding_tokens = embedding.size(0);
+      persistent_embedding_
+          .slice(/*dim=*/0, /*start=*/0, /*end=*/embedding_tokens)
+          .copy_(embedding, /*non_blocking=*/true);
     }
-    // Copy data
-    q_cu_seq_lens_.slice(/*dim=*/0, /*start=*/0, /*end=*/actual_batch_size)
-        .copy_(params.q_cu_seq_lens, /*non_blocking=*/true);
+    if (params.q_cu_seq_lens.defined()) {
+      q_cu_seq_lens_.slice(/*dim=*/0, /*start=*/0, /*end=*/actual_batch_size)
+          .copy_(params.q_cu_seq_lens, /*non_blocking=*/true);
+    }
   }
 
   // Update attention mask only if needed


### PR DESCRIPTION
## Summary

This PR adds a TileLang-based fused input buffer updater for ACL graph decode metadata update, and integrates it into `acl_graph_executor`.

The new path fuses decode-side metadata updates into a single TileLang kernel launch, while preserving the original fallback behavior for unsupported layouts or non-decode cases.

## Main Changes

- register `model_input_buffer_updater` as a formal TileLang Ascend kernel family
- add C++ TileLang API and wrapper for `model_input_buffer_updater`
- integrate decode-only fast path into `GraphPersistentParam::update()`
- keep legacy `slice().copy_()` path as fallback
- add wrapper precision/reference test coverage
- update design doc with finalized ABI, specialization, fast-path boundary, and implementation notes

## Supported Update Groups

The fused updater now covers:

- `tokens`
- `positions`
- `new_cache_slots`
- `q_seq_lens`
- `kv_seq_lens`
- `block_tables`
- optional `input_embedding`
- optional `linear_state_indices`
- optional `q_cu_seq_lens`

Compile-time specialization dimensions:

- `with_mrope`
- `with_input_embedding`
- `with_linear_state_indices`
- `with_q_cu_seq_lens`
- `embedding_dtype`

Runtime layout parameters added for correctness:

- `src_positions_stride`
- `dst_positions_stride`
- `src_input_embedding_stride`
- `dst_input_embedding_stride`
- `actual_hidden_size`

## Fast Path Boundary

The fast path is currently enabled only for decode-only cases.

Key assumptions/guards:

- `params.batch_forward_type.is_decode()`
- `actual_num_tokens == actual_batch_size`
- required tensors must satisfy the expected NPU layout checks
- unsupported cases automatically fall back to the original update logic
