### PR TITLE
feat: add add_norm fusion operator for qwen3.5/qwen3.5-moe linear-attention layers.

### DIFF
--- a/xllm/core/layers/common/qwen3_next_rms_norm.cpp
+++ b/xllm/core/layers/common/qwen3_next_rms_norm.cpp
@@ -29,13 +29,30 @@ Qwen3NextRMSNormImpl::Qwen3NextRMSNormImpl(int64_t dim,
   weight_ = register_parameter("weight", torch::empty({dim}, options), false);
 }
 
-torch::Tensor Qwen3NextRMSNormImpl::forward(torch::Tensor& input) {
-  xllm::kernel::GemmaRMSNormParams norm_params;
-  norm_params.x = input;
-  norm_params.gamma = weight_;
-  norm_params.epsilon = eps_;
-  xllm::kernel::gemma_rms_norm(norm_params);
-  return norm_params.norm_out;
+std::tuple<torch::Tensor, std::optional<torch::Tensor>>
+Qwen3NextRMSNormImpl::forward(torch::Tensor& input,
+                              std::optional<torch::Tensor> residual) {
+  if (!residual.has_value()) {
+    // No residual: use original gemma_rms_norm
+    xllm::kernel::GemmaRMSNormParams norm_params;
+    norm_params.x = input;
+    norm_params.gamma = weight_;
+    norm_params.epsilon = eps_;
+    xllm::kernel::gemma_rms_norm(norm_params);
+    return std::make_tuple(norm_params.norm_out, std::nullopt);
+  }
+
+  // With residual: use fused_layernorm (which calls npu::add_rms_norm on NPU)
+  xllm::kernel::FusedLayerNormParams fused_params;
+  fused_params.input = input;
+  fused_params.residual = residual;
+  fused_params.output = torch::empty_like(input);
+  fused_params.residual_out = torch::empty_like(residual.value());
+  fused_params.weight = 1.0 + weight_;
+  fused_params.eps = eps_;
+  fused_params.mode = "rmsnorm";
+  xllm::kernel::fused_layernorm(fused_params);
+  return std::make_tuple(fused_params.output, fused_params.residual_out);
 }
 
 void Qwen3NextRMSNormImpl::load_state_dict(const StateDict& state_dict) {

--- a/xllm/core/layers/common/qwen3_next_rms_norm.cpp
+++ b/xllm/core/layers/common/qwen3_next_rms_norm.cpp
@@ -46,8 +46,12 @@ Qwen3NextRMSNormImpl::forward(torch::Tensor& input,
   xllm::kernel::FusedLayerNormParams fused_params;
   fused_params.input = input;
   fused_params.residual = residual;
+#if !defined(USE_NPU)
+  // NPU backend allocates outputs internally in npu::add_rms_norm,
+  // so skip pre-allocation to avoid wasted memory.
   fused_params.output = torch::empty_like(input);
   fused_params.residual_out = torch::empty_like(residual.value());
+#endif
   fused_params.weight = 1.0 + weight_;
   fused_params.eps = eps_;
   fused_params.mode = "rmsnorm";

--- a/xllm/core/layers/common/qwen3_next_rms_norm.h
+++ b/xllm/core/layers/common/qwen3_next_rms_norm.h
@@ -29,7 +29,9 @@ class Qwen3NextRMSNormImpl : public torch::nn::Module {
                        double eps,
                        const torch::TensorOptions& options);
 
-  torch::Tensor forward(torch::Tensor& input);
+  std::tuple<torch::Tensor, std::optional<torch::Tensor>> forward(
+      torch::Tensor& input,
+      std::optional<torch::Tensor> residual = std::nullopt);
   torch::Tensor weight() const { return weight_; }
   double eps() const { return eps_; }
 

--- a/xllm/core/layers/npu_torch/qwen3_next_attention.cpp
+++ b/xllm/core/layers/npu_torch/qwen3_next_attention.cpp
@@ -188,9 +188,9 @@ torch::Tensor Qwen3NextAttentionImpl::forward(
 
   const int64_t T = q.size(0);
   auto q_3d = q.view({T, num_heads_, head_dim_});
-  q = q_norm_->forward(q_3d).view({T, q_size_});
+  q = std::get<0>(q_norm_->forward(q_3d)).view({T, q_size_});
   auto k_3d = k.view({T, num_kv_heads_, head_dim_});
-  k = k_norm_->forward(k_3d).view({T, kv_size_});
+  k = std::get<0>(k_norm_->forward(k_3d)).view({T, kv_size_});
 
   rotary_emb_->forward(positions, q, k);
   auto out = std::get<0>(attn_->forward(attn_metadata, q, k, v, kv_cache));

--- a/xllm/core/layers/npu_torch/qwen3_next_hybrid_decoder_layer_base.cpp
+++ b/xllm/core/layers/npu_torch/qwen3_next_hybrid_decoder_layer_base.cpp
@@ -16,6 +16,8 @@ limitations under the License.
 #include "qwen3_next_hybrid_decoder_layer_base.h"
 
 #include <algorithm>
+#include <optional>
+#include <tuple>
 
 namespace xllm {
 namespace layer {
@@ -106,14 +108,19 @@ void Qwen3HybridDecoderLayerImplBase::verify_loaded_weights(
 
 torch::Tensor Qwen3HybridDecoderLayerImplBase::forward(
     torch::Tensor& x,
+    std::optional<torch::Tensor>& residual,
     torch::Tensor& positions,
     const AttentionMetadata& attn_metadata,
     KVCache& kv_cache,
     const ModelInputParams& input_params,
     const torch::Tensor& mrope_cos_sin) {
   // Pre-attention norm
-  torch::Tensor residual = x;
-  x = input_norm_(x);
+  if (!residual.has_value()) {
+    residual = x;
+    x = std::get<0>(input_norm_->forward(x));
+  } else {
+    std::tie(x, residual) = input_norm_->forward(x, residual);
+  }
 
   // Attention
   if (attention_) {
@@ -123,17 +130,8 @@ torch::Tensor Qwen3HybridDecoderLayerImplBase::forward(
     x = linear_attention_->forward(x, attn_metadata, kv_cache, input_params);
   }
 
-  auto orig_dtype = x.dtype();
-  if (orig_dtype == torch::kBFloat16) {
-    x = x.to(torch::kFloat32);
-    residual = residual.to(torch::kFloat32);
-  }
-  x = x + residual;
-
   // Post-attention norm
-  residual = x;
-  x = x.to(orig_dtype);
-  x = post_norm_(x);
+  std::tie(x, residual) = post_norm_->forward(x, residual);
 
   // MLP forward
   if (moe_mlp_) {
@@ -142,13 +140,6 @@ torch::Tensor Qwen3HybridDecoderLayerImplBase::forward(
     x = mlp_(x);
   }
 
-  orig_dtype = x.dtype();
-  if (orig_dtype == torch::kBFloat16) {
-    x = x.to(torch::kFloat32);
-    residual = residual.to(torch::kFloat32);
-  }
-  x = x + residual;
-  x = x.to(orig_dtype);
   return x;
 }
 

--- a/xllm/core/layers/npu_torch/qwen3_next_hybrid_decoder_layer_base.h
+++ b/xllm/core/layers/npu_torch/qwen3_next_hybrid_decoder_layer_base.h
@@ -38,6 +38,7 @@ class Qwen3HybridDecoderLayerModule : public torch::nn::Module {
   virtual void load_state_dict(const StateDict& state_dict) = 0;
   virtual void verify_loaded_weights(const std::string& prefix) const = 0;
   virtual torch::Tensor forward(torch::Tensor& x,
+                                std::optional<torch::Tensor>& residual,
                                 torch::Tensor& positions,
                                 const AttentionMetadata& attn_metadata,
                                 KVCache& kv_cache,
@@ -64,6 +65,7 @@ class Qwen3HybridDecoderLayerImplBase : public Qwen3HybridDecoderLayerModule {
   void verify_loaded_weights(const std::string& prefix) const override;
 
   torch::Tensor forward(torch::Tensor& x,
+                        std::optional<torch::Tensor>& residual,
                         torch::Tensor& positions,
                         const AttentionMetadata& attn_metadata,
                         KVCache& kv_cache,

--- a/xllm/models/llm/qwen3_5_mtp.h
+++ b/xllm/models/llm/qwen3_5_mtp.h
@@ -122,16 +122,22 @@ class Qwen3_5MtpModelImpl : public Qwen3HybridModelImplBase {
       hidden = embedding;
     }
 
-    embedding = pre_fc_norm_embedding_(embedding);
-    hidden = pre_fc_norm_hidden_(hidden);
+    embedding = std::get<0>(pre_fc_norm_embedding_->forward(embedding));
+    hidden = std::get<0>(pre_fc_norm_hidden_->forward(hidden));
     torch::Tensor mtp_hidden = fc_(torch::cat({embedding, hidden}, -1));
 
     CHECK_EQ(kv_caches.size(), layers_.size());
+    std::optional<torch::Tensor> residual = std::nullopt;
     for (size_t i = 0; i < layers_.size(); ++i) {
-      mtp_hidden = layers_[i]->forward(
-          mtp_hidden, positions, attn_metadata, kv_caches[i], input_params);
+      mtp_hidden = layers_[i]->forward(mtp_hidden,
+                                       residual,
+                                       positions,
+                                       attn_metadata,
+                                       kv_caches[i],
+                                       input_params);
     }
-    mtp_hidden = norm_(mtp_hidden);
+    auto [new_mtp_hidden, new_res] = norm_->forward(mtp_hidden, residual);
+    mtp_hidden = new_mtp_hidden;
     return ModelOutput(mtp_hidden);
   }
 

--- a/xllm/models/llm/qwen3_next_hybrid_base.h
+++ b/xllm/models/llm/qwen3_next_hybrid_base.h
@@ -104,16 +104,19 @@ class Qwen3HybridModelImplBase : public Qwen3HybridModelModule {
       if (mrope_cos_sin.defined()) break;
     }
 
+    std::optional<torch::Tensor> residual = std::nullopt;
     for (size_t i = 0; i < layers_.size(); i++) {
       auto& layer = layers_[i];
       h = layer->forward(h,
+                         residual,
                          positions,
                          attn_metadata,
                          kv_caches[i],
                          input_params,
                          mrope_cos_sin);
     }
-    h = norm_(h);
+    auto [hidden_states, residual_out] = norm_->forward(h, residual);
+    h = hidden_states;
     return ModelOutput(h);
   }
 


### PR DESCRIPTION
replace add and norm with add_norm fusion operator.
修改前：
<img width="271" height="174" alt="image" src="https://github.com/user-attachments/assets/ea45941b-1d82-4b76-8400-f1d93949d19e" />
修改后：
<img width="251" height="232" alt="image" src="https://github.com/user-attachments/assets/1f88351f-eb0b-46cb-8fd2-6353dea314c9" />

