### PR TITLE
feat: update causal convolution 1D operation for Qwen3.5/Qwen3-Next on the NPU.

### DIFF
--- a/xllm/core/framework/model/model_input_params.h
+++ b/xllm/core/framework/model/model_input_params.h
@@ -597,6 +597,10 @@ struct ModelInputParams {
   uint32_t layers_per_bacth_copy = std::numeric_limits<uint32_t>::max();
   std::shared_ptr<NPULayerSynchronizerImpl> layer_wise_load_synchronizer =
       nullptr;
+  // cumulative lengths per query
+  std::vector<int64_t> query_start_loc;
+  // if each sequencce has initial conv state, for conv1d
+  std::vector<int64_t> has_initial_state;
 #endif
 
   DpEpPaddingData dp_ep_padding_data;

--- a/xllm/core/kernels/npu/npu_ops_api.h
+++ b/xllm/core/kernels/npu/npu_ops_api.h
@@ -153,4 +153,16 @@ torch::Tensor npu_recurrent_gated_delta_rule(
     const std::optional<torch::Tensor>& num_accepted_tokens,
     const std::optional<torch::Tensor>& g,
     const std::optional<torch::Tensor>& gk);
+
+torch::Tensor causal_conv1d(const torch::Tensor& x,
+                            const torch::Tensor& weight,
+                            const torch::Tensor& conv_state,
+                            const std::optional<torch::Tensor>& bias_opt,
+                            const torch::IntArrayRef query_start_loc_opt,
+                            const torch::IntArrayRef cache_indices_opt,
+                            const torch::IntArrayRef initial_state_mode_opt,
+                            const torch::IntArrayRef num_accepted_tokens_opt,
+                            int64_t activation_mode,
+                            int64_t pad_slot_id,
+                            int64_t run_mode);
 }  // namespace xllm::kernel::npu

--- a/xllm/core/kernels/npu/xllm_ops/xllm_ops_api.h
+++ b/xllm/core/kernels/npu/xllm_ops/xllm_ops_api.h
@@ -53,16 +53,4 @@ void select_unshared_kv(const torch::Tensor& beam_index,
                         int64_t decode_step,
                         int64_t beam_size,
                         int64_t layer_num);
-
-torch::Tensor causal_conv1d(const torch::Tensor& x,
-                            const torch::Tensor& weight,
-                            const torch::Tensor& conv_state,
-                            const std::optional<torch::Tensor>& bias_opt,
-                            const torch::IntArrayRef query_start_loc_opt,
-                            const torch::IntArrayRef cache_indices_opt,
-                            const torch::IntArrayRef initial_state_mode_opt,
-                            const torch::IntArrayRef num_accepted_tokens_opt,
-                            int64_t activation_mode,
-                            int64_t pad_slot_id,
-                            int64_t run_mode);
 }  // namespace xllm::kernel::npu

--- a/xllm/core/kernels/ops_api.cpp
+++ b/xllm/core/kernels/ops_api.cpp
@@ -1088,4 +1088,32 @@ torch::Tensor recurrent_gated_delta_rule(
   NOT_IMPLEMENTED();
 #endif
 }
+
+torch::Tensor causal_conv1d(const torch::Tensor& x,
+                            const torch::Tensor& weight,
+                            const torch::Tensor& conv_state,
+                            const std::optional<torch::Tensor>& bias_opt,
+                            const torch::IntArrayRef query_start_loc_opt,
+                            const torch::IntArrayRef cache_indices_opt,
+                            const torch::IntArrayRef initial_state_mode_opt,
+                            const torch::IntArrayRef num_accepted_tokens_opt,
+                            int64_t activation_mode,
+                            int64_t pad_slot_id,
+                            int64_t run_mode) {
+#if defined(USE_NPU)
+  return npu::causal_conv1d(x,
+                            weight,
+                            conv_state,
+                            bias_opt,
+                            query_start_loc_opt,
+                            cache_indices_opt,
+                            initial_state_mode_opt,
+                            num_accepted_tokens_opt,
+                            activation_mode,
+                            pad_slot_id,
+                            run_mode);
+#else
+  NOT_IMPLEMENTED();
+#endif
+}
 }  // namespace xllm::kernel

--- a/xllm/core/kernels/ops_api.h
+++ b/xllm/core/kernels/ops_api.h
@@ -174,4 +174,16 @@ torch::Tensor recurrent_gated_delta_rule(
     const std::optional<torch::Tensor>& num_accepted_tokens,
     const std::optional<torch::Tensor>& g,
     const std::optional<torch::Tensor>& gk);
+
+torch::Tensor causal_conv1d(const torch::Tensor& x,
+                            const torch::Tensor& weight,
+                            const torch::Tensor& conv_state,
+                            const std::optional<torch::Tensor>& bias_opt,
+                            const torch::IntArrayRef query_start_loc_opt,
+                            const torch::IntArrayRef cache_indices_opt,
+                            const torch::IntArrayRef initial_state_mode_opt,
+                            const torch::IntArrayRef num_accepted_tokens_opt,
+                            int64_t activation_mode,
+                            int64_t pad_slot_id,
+                            int64_t run_mode);
 }  // namespace xllm::kernel

--- a/xllm/core/layers/npu_torch/qwen3_gated_delta_net_base.cpp
+++ b/xllm/core/layers/npu_torch/qwen3_gated_delta_net_base.cpp
@@ -359,30 +359,25 @@ torch::Tensor Qwen3GatedDeltaNetBaseImpl::forward(
   auto device = mixed_qkv.device();
   auto conv_weight = conv1d_->weight();
   auto linear_state_indices = get_linear_state_indices(input_params, device);
-
   if (attn_metadata.is_prefill) {
-    mixed_qkv = mixed_qkv.transpose(1, 2);
-    torch::Tensor conv_state =
-        (seq_len < conv_kernel_size_ - 1)
-            ? torch::pad(mixed_qkv, {0, conv_kernel_size_ - 1 - seq_len})
-        : (seq_len > conv_kernel_size_ - 1)
-            ? mixed_qkv.narrow(
-                  -1, seq_len - conv_kernel_size_ + 1, conv_kernel_size_ - 1)
-            : mixed_qkv;
-    conv_state = conv_state.transpose(1, 2).contiguous();
-    conv_cache.index_put_({linear_state_indices},
-                          conv_state.to(conv_cache.dtype()));
-    torch::Tensor bias;
-    auto conv_output =
-        torch::conv1d(mixed_qkv,
-                      conv_weight.unsqueeze(1).to(device),
-                      bias,
-                      /*stride=*/std::vector<int64_t>{1},
-                      /*padding=*/std::vector<int64_t>{3},
-                      /*dilation=*/std::vector<int64_t>{1},
-                      /*groups=*/static_cast<int64_t>(mixed_qkv.size(1)));
-    mixed_qkv = torch::silu(conv_output.slice(2, 0, seq_len));
-
+    torch::IntArrayRef num_accepted_tokens_opt;
+    torch::Tensor conv_weight_T = conv_weight.transpose(0, 1).contiguous();
+    std::vector<int64_t> linear_state_indices_vec(
+        input_params.linear_state_ids.begin(),
+        input_params.linear_state_ids.end());
+    mixed_qkv = xllm::kernel::causal_conv1d(
+        mixed_qkv,
+        conv_weight_T,
+        conv_cache,
+        std::optional<torch::Tensor>(),  // bias (no bias for qwen3)
+        torch::IntArrayRef(input_params.query_start_loc),
+        torch::IntArrayRef(linear_state_indices_vec),
+        torch::IntArrayRef(input_params.has_initial_state),
+        num_accepted_tokens_opt,
+        1,   // activation_mode
+        -1,  // pad_slot_id
+        0    // run mode  0:fn, 1:update
+    );
   } else {
     xllm::kernel::CausalConv1dUpdateParams conv1d_params;
     conv1d_params.x = mixed_qkv.reshape({-1, mixed_qkv.size(-1)});
@@ -395,12 +390,11 @@ torch::Tensor Qwen3GatedDeltaNetBaseImpl::forward(
     conv1d_params.query_start_loc = attn_metadata.q_cu_seq_lens;
     conv1d_params.max_query_len = attn_metadata.max_query_len;
     mixed_qkv = xllm::kernel::causal_conv1d_update(conv1d_params);
-    // Reshape back to 3D [batch_size, dim, seq_len]
-    mixed_qkv =
-        mixed_qkv.view({batch_size, -1, mixed_qkv.size(-1)}).contiguous();
-    mixed_qkv = mixed_qkv.transpose(1, 2);
   }
 
+  // Reshape back to 3D [batch_size, dim, seq_len]
+  mixed_qkv = mixed_qkv.view({batch_size, -1, mixed_qkv.size(-1)}).contiguous();
+  mixed_qkv = mixed_qkv.transpose(1, 2);
   // Compute gated delta net decay and beta terms.
   if (attn_metadata.is_prefill) {
     xllm::kernel::FusedGdnGatingParams gdn_params;

--- a/xllm/core/runtime/worker_impl.cpp
+++ b/xllm/core/runtime/worker_impl.cpp
@@ -116,6 +116,25 @@ class ScopedAtenLoadThreads {
   bool active_ = false;
 };
 
+void prepare_input_params_for_linear_attention(ModelInputParams& input_params) {
+  int64_t batch_size = input_params.block_tables.size(0);
+  input_params.query_start_loc.resize(batch_size + 1, 0);
+  int64_t cumsum = 0;
+  for (int64_t i = 0; i < batch_size; ++i) {
+    int64_t seq_len = static_cast<int64_t>(input_params.q_seq_lens_vec[i]);
+    cumsum += seq_len;
+    input_params.query_start_loc[i + 1] = cumsum;
+  }
+
+  torch::Tensor has_initial_state_tensor = input_params.kv_seq_lens > 0;
+  torch::Tensor has_initial_state_int64 =
+      has_initial_state_tensor.contiguous().to(torch::kCPU).to(torch::kInt64);
+  input_params.has_initial_state =
+      std::vector<int64_t>(has_initial_state_int64.data_ptr<int64_t>(),
+                           has_initial_state_int64.data_ptr<int64_t>() +
+                               has_initial_state_int64.size(0));
+}
+
 }  // namespace
 
 WorkerImpl::WorkerImpl(const ParallelArgs& parallel_args,
@@ -520,6 +539,10 @@ void WorkerImpl::prepare_work_before_execute(const ForwardInput& input,
         // expert_load_data_.fill_(0);
         processed_input.input_params.expert_load_data = expert_load_data_;
       }
+    }
+
+    if (has_linear_attention_layers(context_.get_model_args())) {
+      prepare_input_params_for_linear_attention(processed_input.input_params);
     }
 #endif
   };


### PR DESCRIPTION
Added a dedicated causal convolution 1D kernel implementation for the NPU, including:

- Added conv1d-related fields to the model input parameters

- Modified the `worker_impl` preprocessing logic to support conv1d

- Refactored the forward computation of `qwen3_gated_delta_net_base` to use the new kernel