### PR TITLE
feat: add chunk_gated_delta_rule_fwd_h tilelang kernel for npu device.

### DIFF
--- a/xllm/compiler/tilelang/targets/ascend/kernels/chunk_gated_delta_rule_fwd_h.py
+++ b/xllm/compiler/tilelang/targets/ascend/kernels/chunk_gated_delta_rule_fwd_h.py
@@ -1,0 +1,664 @@
+#!/usr/bin/env python3
+
+import argparse
+from pathlib import Path
+from typing import Any
+
+import tilelang
+import tilelang.language as T
+
+import torch
+
+from .utils import (
+    DEFAULT_ASCEND_PASS_CONFIGS,
+    detect_vec_core_num,
+)
+from ....common.spec import DispatchField, TilelangKernel, register_kernel
+
+DEFAULT_H = 8
+DEFAULT_HG = 4
+DEFAULT_K = 128
+DEFAULT_V = 128
+DEFAULT_BT = 64
+DEFAULT_USE_G = 1
+DEFAULT_DTYPE = "float16"
+DEFAULT_ACCUM_DTYPE = "float32"
+
+SECONDARY_H = 4
+SECONDARY_HG = 2
+SECONDARY_K = 64
+SECONDARY_V = 64
+SECONDARY_BT = 32
+
+VEC_NUM = 2
+
+MIN_COMPILE_N = 16
+MIN_COMPILE_NT_MAX = 64
+MIN_COMPILE_T_TOTAL = 4096
+
+PASS_CONFIGS_NO_AUTO_SYNC = {
+    tilelang.PassConfigKey.TL_ASCEND_AUTO_SYNC: False,
+    tilelang.PassConfigKey.TL_ASCEND_AUTO_CV_COMBINE: False,
+    tilelang.PassConfigKey.TL_ASCEND_AUTO_CV_SYNC: False,
+    tilelang.PassConfigKey.TL_ASCEND_MEMORY_PLANNING: False,
+}
+
+
+def _prepare_chunk_offsets(cu_seqlens: torch.Tensor, chunk_size: int) -> torch.Tensor:
+    chunk_offsets = []
+    offset = 0
+    cu_seqlens_np = cu_seqlens.cpu().numpy()
+    for i in range(len(cu_seqlens_np) - 1):
+        T_len = int(cu_seqlens_np[i + 1] - cu_seqlens_np[i])
+        NT = (T_len + chunk_size - 1) // chunk_size
+        chunk_offsets.append(offset)
+        offset += NT
+    return torch.tensor(chunk_offsets, dtype=torch.int32, device=cu_seqlens.device)
+
+
+def build_chunk_gated_delta_rule_fwd_h_kernel(
+    H: int,
+    Hg: int,
+    K: int,
+    V: int,
+    BT: int,
+    USE_G: int,
+    dtype: str,
+    accum_dtype: str,
+    compile_N: int,
+    compile_T_total: int,
+    compile_NT_max: int,
+):
+    V_half = V // 2
+    USE_G_BOOL = bool(USE_G)
+
+    SEM_WH_C2V = 0
+    SEM_VNEW_V2C = 2
+    SEM_HUPD_C2V = 4
+    SEM_H_V2C = 6
+
+    @T.prim_func
+    def chunk_gated_delta_rule_fwd_h_kernel(
+        h: T.Tensor([compile_N, compile_NT_max, H, K, V], dtype),
+        k: T.Tensor([compile_T_total, Hg, K], dtype),
+        v: T.Tensor([compile_T_total, H, V], dtype),
+        w: T.Tensor([compile_T_total, H, K], dtype),
+        g: T.Tensor([H, compile_T_total], accum_dtype),
+        v_new: T.Tensor([compile_T_total, H, V], dtype),
+        h0: T.Tensor([compile_N, H, K, V], dtype),
+        ht: T.Tensor([compile_N, H, K, V], dtype),
+        cu_seqlens: T.Tensor([compile_N + 1], "int32"),
+        ws_wh: T.Tensor([compile_N, H, 2, BT, V_half], accum_dtype),
+        ws_vnew: T.Tensor([compile_N, H, 2, BT, V_half], dtype),
+        ws_hupd: T.Tensor([compile_N, H, 2, K, V_half], accum_dtype),
+        ws_h: T.Tensor([compile_N, H, 2, K, V_half], dtype),
+        N: T.int32,
+        T_total: T.int32,
+        NT_max: T.int32,
+        STORE_FINAL_STATE: T.int32,
+        SAVE_NEW_VALUE: T.int32,
+    ):
+        with T.Kernel(compile_N * H, is_npu=True) as (cid, vid):
+            i_n = cid // H
+            i_h = cid % H
+
+            hg_ratio = H // Hg
+            k_head = i_h // hg_ratio
+
+            h_state_ub = T.alloc_ub([2, K // 2, V_half], dtype)
+            h_state_ub_float = T.alloc_ub([2, K // 2, V_half], accum_dtype)
+            hupd_ub_float = T.alloc_ub([2, K // 2, V_half], accum_dtype)
+            wh_ub_float = T.alloc_ub([2, BT // 2, V_half], accum_dtype)
+
+            v_chunk_ub = T.alloc_ub([2, 2, BT // 2, V_half], dtype)
+            v_chunk_ub_float = T.alloc_ub([2, BT // 2, V_half], accum_dtype)
+
+            g_chunk_ub = T.alloc_ub([2, BT // 2], accum_dtype)
+            g_last_scalar = T.alloc_ub([1], accum_dtype)
+            g_exp_ub = T.alloc_ub([BT // 2], accum_dtype)
+            g_exp_ub_broc = T.alloc_ub([BT // 2, V_half], accum_dtype)
+
+            k_chunk_l1 = T.alloc_L1([2, BT, K], dtype)
+            w_chunk_l1 = T.alloc_L1([2, BT, K], dtype)
+            h_state_l1 = T.alloc_L1([2, K, V_half], dtype)
+            wh_frag = T.alloc_L0C([2, BT, V_half], accum_dtype)
+            v_new_l1 = T.alloc_L1([2, BT, V_half], dtype)
+            hupd_frag = T.alloc_L0C([2, K, V_half], accum_dtype)
+
+            with T.Scope("C"):
+                bos = cu_seqlens[i_n]
+                eos = cu_seqlens[i_n + 1]
+                T_len = eos - bos
+                NT_i = T.ceildiv(T_len, BT)
+
+                actual_len = T.if_then_else(T_len < BT, T_len, BT)
+                T.copy(w[bos : bos + actual_len, i_h, :], w_chunk_l1[0, :, :])
+                T.copy(k[bos : bos + actual_len, k_head, :], k_chunk_l1[0, :, :])
+                T.set_flag("mte2", "m", 0)
+
+                for i in T.serial(NT_i):
+                    pid = i % 2
+                    next_pid = (i + 1) % 2
+                    chunk_start_next = bos + (i + 1) * BT
+
+                    chunk_len = T.if_then_else(i * BT + BT > T_len, T_len - i * BT, BT)
+
+                    if i + 1 < NT_i:
+                        next_len = T.if_then_else((i + 1) * BT + BT > T_len, T_len - (i + 1) * BT, BT)
+                        T.copy(w[chunk_start_next : chunk_start_next + next_len, i_h, :], w_chunk_l1[next_pid, :, :])
+                        T.copy(k[chunk_start_next : chunk_start_next + next_len, k_head, :], k_chunk_l1[next_pid, :, :])
+                        T.set_flag("mte2", "m", next_pid)
+
+                    T.wait_flag("mte2", "m", pid)
+                    for j in T.serial(2):
+                        T.wait_cross_flag(SEM_H_V2C + j)
+                        T.copy(ws_h[i_n, i_h, j, :, :], h_state_l1[j, :, :])
+                        T.set_flag("mte2", "m", 2)
+                        T.wait_flag("mte2", "m", 2)
+                        T.gemm_v0(w_chunk_l1[pid, :, :], h_state_l1[j, :, :], wh_frag[j, :, :], init=True)
+                        T.set_flag("m", "fix", 3)
+                        T.wait_flag("m", "fix", 3)
+                        T.copy(wh_frag[j, :, :], ws_wh[i_n, i_h, j, :, :])
+                        T.set_cross_flag("FIX", SEM_WH_C2V + j)
+
+                    for j in T.serial(2):
+                        T.wait_cross_flag(SEM_VNEW_V2C + j)
+                        T.copy(ws_vnew[i_n, i_h, j, :chunk_len, :], v_new_l1[j, :, :])
+                        T.set_flag("mte2", "m", 4)
+                        T.wait_flag("mte2", "m", 4)
+                        T.gemm_v0(k_chunk_l1[pid, :, :], v_new_l1[j, :, :], hupd_frag[j, :, :], transpose_A=True, init=True)
+                        T.set_flag("m", "fix", 5)
+                        T.wait_flag("m", "fix", 5)
+                        T.copy(hupd_frag[j, :, :], ws_hupd[i_n, i_h, j, :, :])
+                        T.set_cross_flag("FIX", SEM_HUPD_C2V + j)
+
+            with T.Scope("V"):
+                bos = cu_seqlens[i_n]
+                eos = cu_seqlens[i_n + 1]
+                T_len = eos - bos
+                NT_i = T.ceildiv(T_len, BT)
+
+                for j in T.serial(2):
+                    T.copy(h0[i_n, i_h, K // 2 * vid : K // 2 * vid + K // 2, j * V_half : (j + 1) * V_half], h_state_ub[j, :, :])
+
+                chunk_len = T.if_then_else(T_len < BT, T_len, BT)
+                vec_chunk_len = T.if_then_else(vid == 0, T.min(BT // 2, chunk_len), T.max(chunk_len - BT // 2, 0))
+                vec_start_in_chunk = T.if_then_else(vid == 0, 0, BT // 2)
+                vec_global_start = bos + vec_start_in_chunk
+
+                for j in T.serial(2):
+                    T.copy(
+                        v[vec_global_start : vec_global_start + vec_chunk_len, i_h, j * V_half : (j + 1) * V_half],
+                        v_chunk_ub[0, j, :, :],
+                    )
+                if USE_G_BOOL:
+                    T.copy(g[i_h, vec_global_start : vec_global_start + vec_chunk_len], g_chunk_ub[0, :])
+                T.set_flag("mte2", "v", 2)
+
+                for i in T.serial(NT_i):
+                    pid = i % 2
+                    next_pid = (i + 1) % 2
+                    v_flag_pid = pid + 2
+                    v_flag_next = next_pid + 2
+                    g_start = bos + i * BT
+                    g_start_next = bos + (i + 1) * BT
+
+                    chunk_len = T.if_then_else(i * BT + BT > T_len, T_len - i * BT, BT)
+                    vec_chunk_len = T.if_then_else(vid == 0, T.min(BT // 2, chunk_len), T.max(chunk_len - BT // 2, 0))
+                    vec_start_in_chunk = T.if_then_else(vid == 0, 0, BT // 2)
+
+                    if i + 1 < NT_i:
+                        next_chunk_len = T.if_then_else((i + 1) * BT + BT > T_len, T_len - (i + 1) * BT, BT)
+                        next_vec_start_in_chunk = T.if_then_else(vid == 0, 0, BT // 2)
+                        next_vec_chunk_len = T.if_then_else(vid == 0, T.min(BT // 2, next_chunk_len), T.max(next_chunk_len - BT // 2, 0))
+                        next_vec_global_start = g_start_next + next_vec_start_in_chunk
+
+                        for j in T.serial(2):
+                            T.copy(
+                                v[next_vec_global_start : next_vec_global_start + next_vec_chunk_len, i_h, j * V_half : (j + 1) * V_half],
+                                v_chunk_ub[next_pid, j, :, :],
+                            )
+                        if USE_G_BOOL:
+                            T.copy(g[i_h, next_vec_global_start : next_vec_global_start + next_vec_chunk_len], g_chunk_ub[next_pid, :])
+                        T.set_flag("mte2", "v", v_flag_next)
+
+                    for j in T.serial(2):
+                        T.copy(h_state_ub[j, :, :], ws_h[i_n, i_h, j, K // 2 * vid : K // 2 * vid + K // 2, :])
+                        T.set_cross_flag("MTE3", SEM_H_V2C + j)
+
+                    for j in T.serial(2):
+                        T.copy(h_state_ub[j, :, :], h[i_n, i, i_h, K // 2 * vid : K // 2 * vid + K // 2, j * V_half : (j + 1) * V_half])
+
+                    T.wait_flag("mte2", "v", v_flag_pid)
+                    if USE_G_BOOL:
+                        g_last = T.if_then_else(i * BT + BT <= T_len, g[i_h, g_start + BT - 1], g[i_h, g_start + T_len - i * BT - 1])
+
+                        T.tile.fill(g_exp_ub, g_last)
+                        T.set_flag("mte2", "v", 4)
+                        T.wait_flag("mte2", "v", 4)
+                        T.tile.sub(g_exp_ub, g_exp_ub, g_chunk_ub[pid, :])
+                        T.tile.exp(g_exp_ub, g_exp_ub)
+                        T.tile.broadcast(g_exp_ub_broc, g_exp_ub, axis=1)
+
+                        T.tile.fill(g_last_scalar, g_last)
+                        T.tile.exp(g_last_scalar, g_last_scalar)
+
+                    for j in T.serial(2):
+                        T.copy(v_chunk_ub[pid, j, :, :], v_chunk_ub_float[j, :, :])
+
+                        T.wait_cross_flag(SEM_WH_C2V + j)
+                        T.copy(ws_wh[i_n, i_h, j, vec_start_in_chunk : vec_start_in_chunk + BT // 2, :], wh_ub_float[j, :, :])
+                        T.set_flag("mte2", "v", 5)
+                        T.wait_flag("mte2", "v", 5)
+                        T.tile.sub(v_chunk_ub_float[j, :, :], v_chunk_ub_float[j, :, :], wh_ub_float[j, :, :])
+
+                        if SAVE_NEW_VALUE:
+                            T.copy(v_chunk_ub_float[j, :, :], v_chunk_ub[pid, j, :, :])
+                            T.set_flag("v", "mte3", 6)
+                            T.wait_flag("v", "mte3", 6)
+                            T.copy(
+                                v_chunk_ub[pid, j, :vec_chunk_len, :],
+                                v_new[
+                                    g_start + vec_start_in_chunk : g_start + vec_start_in_chunk + vec_chunk_len,
+                                    i_h,
+                                    j * V_half : j * V_half + V_half,
+                                ],
+                            )
+
+                        if USE_G_BOOL:
+                            T.tile.mul(v_chunk_ub_float[j, :, :], v_chunk_ub_float[j, :, :], g_exp_ub_broc)
+                            T.copy(h_state_ub[j, :, :], h_state_ub_float[j, :, :])
+                            T.tile.mul(h_state_ub_float[j, :, :], h_state_ub_float[j, :, :], g_last_scalar[0])
+                        else:
+                            T.copy(h_state_ub[j, :, :], h_state_ub_float[j, :, :])
+
+                        T.set_flag("mte3", "v", 7)
+                        T.wait_flag("mte3", "v", 7)
+                        T.copy(v_chunk_ub_float[j, :, :], v_chunk_ub[pid, j, :, :])
+                        T.set_flag("v", "mte3", 8)
+                        T.wait_flag("v", "mte3", 8)
+                        T.copy(v_chunk_ub[pid, j, :, :], ws_vnew[i_n, i_h, j, vec_start_in_chunk : vec_start_in_chunk + BT // 2, :])
+                        T.set_cross_flag("MTE3", SEM_VNEW_V2C + j)
+
+                    for j in T.serial(2):
+                        T.wait_cross_flag(SEM_HUPD_C2V + j)
+                        T.copy(ws_hupd[i_n, i_h, j, K // 2 * vid : K // 2 * vid + K // 2, :], hupd_ub_float[j, :, :])
+                        T.set_flag("mte2", "v", 9)
+                        T.wait_flag("mte2", "v", 9)
+                        T.tile.add(h_state_ub_float[j, :, :], h_state_ub_float[j, :, :], hupd_ub_float[j, :, :])
+                        T.copy(h_state_ub_float[j, :, :], h_state_ub[j, :, :])
+
+                    T.set_flag("v", "mte3", 10)
+                    T.wait_flag("v", "mte3", 10)
+
+                if STORE_FINAL_STATE:
+                    for j in T.serial(2):
+                        T.copy(h_state_ub[j, :, :], ht[i_n, i_h, K // 2 * vid : K // 2 * vid + K // 2, j * V_half : (j + 1) * V_half])
+
+    return chunk_gated_delta_rule_fwd_h_kernel
+
+
+@register_kernel
+class ChunkGatedDeltaRuleFwdHKernel(TilelangKernel):
+    DISPATCH_SCHEMA = [
+        DispatchField("H", "int32"),
+        DispatchField("Hg", "int32"),
+        DispatchField("K", "int32"),
+        DispatchField("V", "int32"),
+        DispatchField("BT", "int32"),
+        DispatchField("USE_G", "int32"),
+        DispatchField("dtype", "dtype"),
+    ]
+    SPECIALIZATIONS = [
+        {
+            "variant_key": "h8_hg4_k128_v128_bt64_useg1_fp16",
+            "H": DEFAULT_H,
+            "Hg": DEFAULT_HG,
+            "K": DEFAULT_K,
+            "V": DEFAULT_V,
+            "BT": DEFAULT_BT,
+            "USE_G": DEFAULT_USE_G,
+            "dtype": DEFAULT_DTYPE,
+        },
+        {
+            "variant_key": "h4_hg2_k64_v64_bt32_useg1_fp16",
+            "H": SECONDARY_H,
+            "Hg": SECONDARY_HG,
+            "K": SECONDARY_K,
+            "V": SECONDARY_V,
+            "BT": SECONDARY_BT,
+            "USE_G": DEFAULT_USE_G,
+            "dtype": DEFAULT_DTYPE,
+        },
+        {
+            "variant_key": "h8_hg4_k128_v128_bt64_useg0_fp16",
+            "H": DEFAULT_H,
+            "Hg": DEFAULT_HG,
+            "K": DEFAULT_K,
+            "V": DEFAULT_V,
+            "BT": DEFAULT_BT,
+            "USE_G": 0,
+            "dtype": DEFAULT_DTYPE,
+        },
+    ]
+
+    @staticmethod
+    def generate_source(
+        H: int,
+        Hg: int,
+        K: int,
+        V: int,
+        BT: int,
+        USE_G: int,
+        dtype: str,
+    ) -> str:
+        tilelang.disable_cache()
+        compile_N = MIN_COMPILE_N
+        compile_T_total = MIN_COMPILE_T_TOTAL
+        compile_NT_max = MIN_COMPILE_NT_MAX
+        tilelang_kernel = build_chunk_gated_delta_rule_fwd_h_kernel(
+            H=H,
+            Hg=Hg,
+            K=K,
+            V=V,
+            BT=BT,
+            USE_G=USE_G,
+            dtype=dtype,
+            accum_dtype=DEFAULT_ACCUM_DTYPE,
+            compile_N=compile_N,
+            compile_T_total=compile_T_total,
+            compile_NT_max=compile_NT_max,
+        )
+        with tilelang.tvm.transform.PassContext(
+            opt_level=3, config=PASS_CONFIGS_NO_AUTO_SYNC
+        ):
+            kernel = tilelang.engine.lower(tilelang_kernel)
+        return kernel.kernel_source
+
+
+def ref_chunk_gated_delta_rule(
+    k: torch.Tensor,
+    w: torch.Tensor,
+    u: torch.Tensor,
+    g: torch.Tensor | None = None,
+    initial_state: torch.Tensor | None = None,
+    output_final_state: bool = False,
+    chunk_size: int = 64,
+    cu_seqlens: torch.LongTensor | None = None,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor | None]:
+    BT = chunk_size
+
+    k = k.float().squeeze(0)
+    w = w.float().squeeze(0)
+    u = u.float().squeeze(0)
+    g = g.float().squeeze(0) if g is not None else None
+    initial_state = initial_state.float().squeeze(0) if initial_state is not None else None
+
+    T_total, Hg, K = k.shape
+    _, H, V = u.shape
+    N = len(cu_seqlens) - 1
+
+    NT_total = sum([(int(cu_seqlens[i + 1]) - int(cu_seqlens[i]) + BT - 1) // BT for i in range(N)])
+
+    h = torch.zeros(NT_total, H, K, V, dtype=torch.float32, device=k.device)
+    v_new = torch.zeros(T_total, H, V, dtype=torch.float32, device=k.device)
+    final_state = torch.zeros(N, H, K, V, dtype=torch.float32, device=k.device) if output_final_state else None
+
+    chunk_offset = 0
+    for i_n in range(N):
+        bos, eos = int(cu_seqlens[i_n]), int(cu_seqlens[i_n + 1])
+        T_len = eos - bos
+        NT = (T_len + BT - 1) // BT
+
+        for i_h in range(H):
+            h_state = (
+                initial_state[i_n, i_h].clone() if initial_state is not None else torch.zeros(K, V, dtype=torch.float32, device=k.device)
+            )
+            k_head = i_h // (H // Hg)
+
+            for i_t in range(NT):
+                t_start = i_t * BT
+                t_end = min((i_t + 1) * BT, T_len)
+
+                h[chunk_offset + i_t, i_h] = h_state
+                k_chunk, w_chunk, v_chunk = (
+                    k[bos + t_start : bos + t_end, k_head, :],
+                    w[bos + t_start : bos + t_end, i_h, :],
+                    u[bos + t_start : bos + t_end, i_h, :],
+                )
+
+                v_n = v_chunk - torch.matmul(w_chunk, h_state)
+                v_new[bos + t_start : bos + t_end, i_h, :] = v_n
+
+                if g is not None:
+                    g_chunk = g[bos + t_start : bos + t_end, i_h]
+                    g_last = g_chunk[-1].item()
+                    v_n = v_n * torch.exp(g_last - g_chunk)[:, None]
+                    h_state = h_state * torch.exp(torch.tensor(g_last, device=k.device))
+
+                h_state = h_state + torch.matmul(k_chunk.transpose(-1, -2), v_n)
+
+            if output_final_state:
+                final_state[i_n, i_h] = h_state
+        chunk_offset += NT
+
+    return h.half().unsqueeze(0), v_new.half().unsqueeze(0), final_state.half() if final_state is not None else None
+
+
+def chunk_gated_delta_rule_fwd_h(
+    k: torch.Tensor,
+    w: torch.Tensor,
+    u: torch.Tensor,
+    g: torch.Tensor | None = None,
+    initial_state: torch.Tensor | None = None,
+    output_final_state: bool = False,
+    chunk_size: int = 64,
+    save_new_value: bool = True,
+    cu_seqlens: torch.LongTensor | None = None,
+    chunk_offsets: torch.Tensor | None = None,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor | None]:
+    BT = chunk_size
+    USE_G = g is not None
+
+    k_flat = k.squeeze(0)
+    w_flat = w.squeeze(0)
+    u_flat = u.squeeze(0)
+    g_flat = g.squeeze(0) if g is not None else None
+
+    T_total, Hg, K = k_flat.shape
+    _, H, V = u_flat.shape
+    N = len(cu_seqlens) - 1
+
+    if chunk_offsets is None:
+        chunk_offsets = _prepare_chunk_offsets(cu_seqlens, BT)
+
+    cu_seqlens_np = cu_seqlens.cpu().numpy()
+    NT_max = 0
+    NT_total = 0
+    for i in range(N):
+        T_len = int(cu_seqlens_np[i + 1] - cu_seqlens_np[i])
+        NT = (T_len + BT - 1) // BT
+        NT_max = max(NT_max, NT)
+        NT_total += NT
+
+    if USE_G:
+        g_c_t = g_flat.float().transpose(0, 1).contiguous()
+    else:
+        g_c_t = torch.empty((H, T_total), dtype=torch.float32, device=k.device)
+
+    v_new_flat = torch.empty((T_total, H, V), dtype=torch.float16, device=k.device)
+
+    h_out = torch.zeros((N, NT_max, H, K, V), dtype=torch.float16, device=k.device)
+    h0 = torch.zeros((N, H, K, V), dtype=torch.float16, device=k.device)
+    if initial_state is not None:
+        h0.copy_(initial_state.squeeze(0))
+
+    ht = torch.zeros((N, H, K, V), dtype=torch.float16, device=k.device)
+
+    V_half = V // 2
+    ws_wh = torch.zeros((N, H, 2, BT, V_half), dtype=torch.float32, device=k.device)
+    ws_vnew = torch.zeros((N, H, 2, BT, V_half), dtype=torch.float16, device=k.device)
+    ws_hupd = torch.zeros((N, H, 2, K, V_half), dtype=torch.float32, device=k.device)
+    ws_h = torch.zeros((N, H, 2, K, V_half), dtype=torch.float16, device=k.device)
+
+    @tilelang.jit(
+    # Kernel parameters 0-8 are input/output tensors, 9-12 are workspace tensors
+    # that TileLang manages internally for double buffering and cross-core sync
+    workspace_idx=[9, 10, 11, 12],
+    pass_configs=PASS_CONFIGS_NO_AUTO_SYNC
+)
+    def jit_kernel(
+        N,
+        H,
+        T_total,
+        Hg,
+        K,
+        V,
+        NT_max,
+        BT,
+        USE_G,
+        dtype,
+        accum_dtype,
+    ):
+        return build_chunk_gated_delta_rule_fwd_h_kernel(
+            H=H,
+            Hg=Hg,
+            K=K,
+            V=V,
+            BT=BT,
+            USE_G=USE_G,
+            dtype=dtype,
+            accum_dtype=accum_dtype,
+            compile_N=max(N, MIN_COMPILE_N),
+            compile_T_total=max(T_total, MIN_COMPILE_T_TOTAL),
+            compile_NT_max=max(NT_max, MIN_COMPILE_NT_MAX),
+        )
+
+    ker = jit_kernel(
+        N,
+        H,
+        T_total,
+        Hg,
+        K,
+        V,
+        NT_max,
+        BT=BT,
+        USE_G=1 if USE_G else 0,
+        dtype="float16",
+        accum_dtype="float32",
+    )
+    ker(
+        h_out,
+        k_flat,
+        u_flat,
+        w_flat,
+        g_c_t,
+        v_new_flat,
+        h0,
+        ht,
+        cu_seqlens.to(torch.int32),
+        ws_wh,
+        ws_vnew,
+        ws_hupd,
+        ws_h,
+        N,
+        T_total,
+        NT_max,
+        1 if output_final_state else 0,
+        1 if save_new_value else 0,
+    )
+
+    v_new_ret = v_new_flat.unsqueeze(0)
+
+    h_ret = torch.zeros((NT_total, H, K, V), dtype=torch.float16, device=k.device)
+    for i in range(N):
+        NT_i = (int(cu_seqlens_np[i + 1]) - int(cu_seqlens_np[i]) + BT - 1) // BT
+        offset = int(chunk_offsets[i].item())
+        h_ret[offset : offset + NT_i] = h_out[i, :NT_i]
+    h_ret = h_ret.unsqueeze(0)
+
+    ht_ret = ht if output_final_state else None
+
+    return h_ret, v_new_ret, ht_ret
+
+
+def test_chunk_gated_delta_rule(seqlens, H, Hg, K, V, use_g=True, use_initial_state=True):
+    print(f"Testing Varlen seqlens={seqlens}, H={H}, Hg={Hg}, K={K}, V={V}, use_g={use_g}, use_initial_state={use_initial_state}")
+    torch.manual_seed(41)
+
+    T_total = sum(seqlens)
+    N = len(seqlens)
+    cu_seqlens = torch.tensor([0] + [sum(seqlens[: i + 1]) for i in range(len(seqlens))], dtype=torch.int32).npu()
+
+    torch.manual_seed(41)
+    k = torch.rand(1, T_total, Hg, K, dtype=torch.float16).npu() * 0.01
+    w = torch.rand(1, T_total, H, K, dtype=torch.float16).npu() * 0.01
+    u = torch.rand(1, T_total, H, V, dtype=torch.float16).npu() * 0.01
+    g = torch.rand(1, T_total, H, dtype=torch.float32).npu() * -1.0 if use_g else None
+    initial_state = torch.rand(1, N, H, K, V, dtype=torch.float16).npu() * 0.01 if use_initial_state else None
+
+    torch.npu.synchronize()
+
+    h, v_new, ht = chunk_gated_delta_rule_fwd_h(k, w, u, g, initial_state=initial_state, output_final_state=True, cu_seqlens=cu_seqlens)
+    torch.npu.synchronize()
+    ref_h, ref_v_new, ref_ht = ref_chunk_gated_delta_rule(
+        k.cpu(),
+        w.cpu(),
+        u.cpu(),
+        g.cpu() if g is not None else None,
+        initial_state=initial_state.cpu() if initial_state is not None else None,
+        output_final_state=True,
+        cu_seqlens=cu_seqlens.cpu(),
+    )
+    torch.npu.synchronize()
+
+    torch.testing.assert_close(h.cpu(), ref_h.cpu(), rtol=1e-5, atol=1e-5)
+    torch.testing.assert_close(v_new.cpu(), ref_v_new.cpu(), rtol=1e-5, atol=1e-5)
+    torch.testing.assert_close(ht.cpu(), ref_ht.cpu(), rtol=1e-5, atol=1e-5)
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Generate TileLang AscendC source for chunk_gated_delta_rule_fwd_h AOT kernel.")
+    parser.add_argument("--output", required=True, help="Output AscendC .cpp file")
+    parser.add_argument("--H", type=int, default=DEFAULT_H)
+    parser.add_argument("--Hg", type=int, default=DEFAULT_HG)
+    parser.add_argument("--K", type=int, default=DEFAULT_K)
+    parser.add_argument("--V", type=int, default=DEFAULT_V)
+    parser.add_argument("--BT", type=int, default=DEFAULT_BT)
+    parser.add_argument("--use-g", type=int, default=DEFAULT_USE_G, choices=[0, 1])
+    parser.add_argument("--dtype", default=DEFAULT_DTYPE)
+    parser.add_argument("--skip-ref-check", action="store_true", help="Skip runtime torch-reference check.")
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+    output = Path(args.output).resolve()
+    output.parent.mkdir(parents=True, exist_ok=True)
+    output.write_text(
+        ChunkGatedDeltaRuleFwdHKernel.generate_source(
+            H=args.H,
+            Hg=args.Hg,
+            K=args.K,
+            V=args.V,
+            BT=args.BT,
+            USE_G=args.use_g,
+            dtype=args.dtype,
+        ),
+        encoding="utf-8",
+    )
+
+    if not args.skip_ref_check:
+        test_chunk_gated_delta_rule(
+            seqlens=[2048],
+            H=args.H,
+            Hg=args.Hg,
+            K=args.K,
+            V=args.V,
+            use_g=bool(args.use_g),
+            use_initial_state=True,
+        )
+
+
+if __name__ == "__main__":
+    main()

--- a/xllm/core/kernels/npu/tilelang/CMakeLists.txt
+++ b/xllm/core/kernels/npu/tilelang/CMakeLists.txt
@@ -138,6 +138,11 @@ tilelang_register_runtime_kernel(
   WRAPPER_SRCS split_qkv_rmsnorm_mrope_wrapper.cpp
 )
 
+tilelang_register_runtime_kernel(
+  NAME chunk_gated_delta_rule_fwd_h
+  WRAPPER_SRCS chunk_gated_delta_rule_fwd_h_wrapper.cpp
+)
+
 cc_library(
   NAME
     tilelang_kernels
@@ -199,6 +204,18 @@ cc_test(
     split_qkv_rmsnorm_mrope_wrapper_test
   SRCS
     split_qkv_rmsnorm_mrope_wrapper_test.cpp
+  DEPS
+    :tilelang_kernels
+    torch
+    GTest::gtest_main
+    glog::glog
+)
+
+cc_test(
+  NAME
+    chunk_gated_delta_rule_fwd_h_wrapper_test
+  SRCS
+    chunk_gated_delta_rule_fwd_h_wrapper_test.cpp
   DEPS
     :tilelang_kernels
     torch

--- a/xllm/core/kernels/npu/tilelang/chunk_gated_delta_rule_fwd_h_wrapper.cpp
+++ b/xllm/core/kernels/npu/tilelang/chunk_gated_delta_rule_fwd_h_wrapper.cpp
@@ -1,0 +1,282 @@
+/* Copyright 2026 The xLLM Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://github.com/jd-opensource/xllm/blob/main/LICENSE
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include <c10/core/DeviceType.h>
+#include <glog/logging.h>
+#include <torch_npu/csrc/core/npu/NPUStream.h>
+#include <torch_npu/csrc/libs/init_npu.h>
+#include <torch_npu/torch_npu.h>
+
+#include <cstdint>
+#include <limits>
+#include <tuple>
+
+#include "acl/acl.h"
+#include "dispatch_registry.h"
+#include "tilelang_ops_api.h"
+
+#ifndef XLLM_TL_CHUNK_GATED_DELTA_RULE_FWD_H_REGISTRY_INC
+#error "XLLM_TL_CHUNK_GATED_DELTA_RULE_FWD_H_REGISTRY_INC is not defined"
+#endif
+
+namespace xllm::kernel::npu::tilelang {
+namespace {
+
+#include XLLM_TL_CHUNK_GATED_DELTA_RULE_FWD_H_REGISTRY_INC
+
+void check_supported(
+    const torch::Tensor& k,
+    const torch::Tensor& w,
+    const torch::Tensor& v,
+    const torch::Tensor& g,
+    const torch::Tensor& initial_state,
+    const torch::Tensor& cu_seqlens,
+    bool use_g) {
+  CHECK(k.defined()) << "TileLang ChunkGatedDeltaRuleFwdH: k must be defined";
+  CHECK(w.defined()) << "TileLang ChunkGatedDeltaRuleFwdH: w must be defined";
+  CHECK(v.defined()) << "TileLang ChunkGatedDeltaRuleFwdH: v must be defined";
+  CHECK(cu_seqlens.defined()) << "TileLang ChunkGatedDeltaRuleFwdH: cu_seqlens must be defined";
+
+  CHECK(k.device().type() == c10::DeviceType::PrivateUse1 &&
+        w.device().type() == c10::DeviceType::PrivateUse1 &&
+        v.device().type() == c10::DeviceType::PrivateUse1 &&
+        cu_seqlens.device().type() == c10::DeviceType::PrivateUse1)
+      << "TileLang ChunkGatedDeltaRuleFwdH: all tensors must be on NPU";
+
+  if (use_g) {
+    CHECK(g.defined()) << "TileLang ChunkGatedDeltaRuleFwdH: g must be defined when use_g is true";
+    CHECK(g.device().type() == c10::DeviceType::PrivateUse1)
+        << "TileLang ChunkGatedDeltaRuleFwdH: g must be on NPU when use_g is true";
+  }
+
+  if (initial_state.defined()) {
+    CHECK(initial_state.device().type() == c10::DeviceType::PrivateUse1)
+        << "TileLang ChunkGatedDeltaRuleFwdH: initial_state must be on NPU if defined";
+  }
+
+  CHECK_EQ(k.dim(), 4) << "TileLang ChunkGatedDeltaRuleFwdH: k must be 4D [1, T, Hg, K]";
+  CHECK_EQ(w.dim(), 4) << "TileLang ChunkGatedDeltaRuleFwdH: w must be 4D [1, T, H, K]";
+  CHECK_EQ(v.dim(), 4) << "TileLang ChunkGatedDeltaRuleFwdH: v must be 4D [1, T, H, V]";
+  CHECK_EQ(cu_seqlens.dim(), 1) << "TileLang ChunkGatedDeltaRuleFwdH: cu_seqlens must be 1D [N+1]";
+
+  CHECK_EQ(k.size(0), 1) << "TileLang ChunkGatedDeltaRuleFwdH: k batch dim must be 1";
+  CHECK_EQ(w.size(0), 1) << "TileLang ChunkGatedDeltaRuleFwdH: w batch dim must be 1";
+  CHECK_EQ(v.size(0), 1) << "TileLang ChunkGatedDeltaRuleFwdH: v batch dim must be 1";
+
+  CHECK_EQ(k.size(1), w.size(1))
+      << "TileLang ChunkGatedDeltaRuleFwdH: k and w must have same T dim";
+  CHECK_EQ(k.size(1), v.size(1))
+      << "TileLang ChunkGatedDeltaRuleFwdH: k and v must have same T dim";
+
+  CHECK(k.is_contiguous()) << "TileLang ChunkGatedDeltaRuleFwdH: k must be contiguous";
+  CHECK(w.is_contiguous()) << "TileLang ChunkGatedDeltaRuleFwdH: w must be contiguous";
+  CHECK(v.is_contiguous()) << "TileLang ChunkGatedDeltaRuleFwdH: v must be contiguous";
+
+  if (use_g) {
+    CHECK_EQ(g.dim(), 3) << "TileLang ChunkGatedDeltaRuleFwdH: g must be 3D [1, T, H]";
+    CHECK_EQ(g.size(0), 1) << "TileLang ChunkGatedDeltaRuleFwdH: g batch dim must be 1";
+    CHECK_EQ(g.size(1), k.size(1))
+        << "TileLang ChunkGatedDeltaRuleFwdH: g and k must have same T dim";
+    CHECK_EQ(g.size(2), w.size(2))
+        << "TileLang ChunkGatedDeltaRuleFwdH: g and w must have same H dim";
+    CHECK(g.is_contiguous()) << "TileLang ChunkGatedDeltaRuleFwdH: g must be contiguous";
+  }
+
+  if (initial_state.defined()) {
+    CHECK_EQ(initial_state.dim(), 5)
+        << "TileLang ChunkGatedDeltaRuleFwdH: initial_state must be 5D [1, N, H, K, V]";
+    CHECK_EQ(initial_state.size(0), 1)
+        << "TileLang ChunkGatedDeltaRuleFwdH: initial_state batch dim must be 1";
+    CHECK_EQ(initial_state.size(2), w.size(2))
+        << "TileLang ChunkGatedDeltaRuleFwdH: initial_state and w must have same H dim";
+    CHECK_EQ(initial_state.size(3), k.size(3))
+        << "TileLang ChunkGatedDeltaRuleFwdH: initial_state and k must have same K dim";
+    CHECK_EQ(initial_state.size(4), v.size(3))
+        << "TileLang ChunkGatedDeltaRuleFwdH: initial_state and v must have same V dim";
+  }
+
+  CHECK_GT(cu_seqlens.size(0), 1)
+      << "TileLang ChunkGatedDeltaRuleFwdH: cu_seqlens must have at least 2 elements";
+  CHECK_EQ(cu_seqlens[cu_seqlens.size(0) - 1].item<int64_t>(), k.size(1))
+      << "TileLang ChunkGatedDeltaRuleFwdH: cu_seqlens last element must match input T_total";
+
+  CHECK_EQ(w.size(2) % k.size(2), 0)
+      << "TileLang ChunkGatedDeltaRuleFwdH: H must be divisible by Hg for GQA";
+  CHECK_EQ(k.size(3) % 2, 0)
+      << "TileLang ChunkGatedDeltaRuleFwdH: K must be even";
+  CHECK_EQ(v.size(3) % 2, 0)
+      << "TileLang ChunkGatedDeltaRuleFwdH: V must be even";
+}
+
+ChunkGatedDeltaRuleFwdHSpecialization build_runtime_specialization(
+    const torch::Tensor& k,
+    const torch::Tensor& w,
+    const torch::Tensor& v,
+    int32_t chunk_size,
+    bool use_g) {
+  CHECK_EQ(k.dim(), 4) << "TileLang ChunkGatedDeltaRuleFwdH: k must be 4D";
+  CHECK_EQ(w.dim(), 4) << "TileLang ChunkGatedDeltaRuleFwdH: w must be 4D";
+  CHECK_EQ(v.dim(), 4) << "TileLang ChunkGatedDeltaRuleFwdH: v must be 4D";
+
+  const int32_t H = static_cast<int32_t>(w.size(2));
+  const int32_t Hg = static_cast<int32_t>(k.size(2));
+  const int32_t K = static_cast<int32_t>(k.size(3));
+  const int32_t V = static_cast<int32_t>(v.size(3));
+  const int32_t BT = chunk_size;
+  const int32_t USE_G = use_g ? 1 : 0;
+
+  return make_chunk_gated_delta_rule_fwd_h_specialization(
+      ChunkGatedDeltaRuleFwdHH{H},
+      ChunkGatedDeltaRuleFwdHHg{Hg},
+      ChunkGatedDeltaRuleFwdHK{K},
+      ChunkGatedDeltaRuleFwdHV{V},
+      ChunkGatedDeltaRuleFwdHBT{BT},
+      ChunkGatedDeltaRuleFwdHUSEG{USE_G},
+      ChunkGatedDeltaRuleFwdHDType{to_tilelang_dtype(k.scalar_type())});
+}
+
+torch::Tensor prepare_chunk_offsets_cpu(const torch::Tensor& cu_seqlens, int32_t chunk_size) {
+  const int64_t N = cu_seqlens.size(0) - 1;
+  torch::Tensor chunk_offsets = torch::zeros({N}, torch::TensorOptions().dtype(torch::kInt32).device(torch::kCPU));
+  int64_t offset = 0;
+  for (int64_t i = 0; i < N; ++i) {
+    chunk_offsets[i] = offset;
+    const int64_t T_len = cu_seqlens[i + 1].item<int64_t>() - cu_seqlens[i].item<int64_t>();
+    const int64_t NT = (T_len + chunk_size - 1) / chunk_size;
+    offset += NT;
+  }
+  return chunk_offsets;
+}
+
+}  // namespace
+
+std::tuple<torch::Tensor, torch::Tensor, torch::Tensor> chunk_gated_delta_rule_fwd_h(
+    const torch::Tensor& k,
+    const torch::Tensor& w,
+    const torch::Tensor& v,
+    const torch::Tensor& g,
+    const torch::Tensor& initial_state,
+    bool output_final_state,
+    int64_t chunk_size,
+    bool save_new_value,
+    const torch::Tensor& cu_seqlens) {
+  const bool use_g = g.defined();
+  check_supported(k, w, v, g, initial_state, cu_seqlens, use_g);
+
+  const int64_t T_total = k.size(1);
+  const int64_t H = w.size(2);
+  const int64_t Hg = k.size(2);
+  const int64_t K = k.size(3);
+  const int64_t V = v.size(3);
+  const int64_t N = cu_seqlens.size(0) - 1;
+
+  CHECK_GT(N, 0) << "TileLang ChunkGatedDeltaRuleFwdH: N must be > 0";
+  CHECK_LE(N, static_cast<int64_t>(std::numeric_limits<int32_t>::max()))
+      << "TileLang ChunkGatedDeltaRuleFwdH: N exceeds int32 range";
+
+  const int32_t BT = static_cast<int32_t>(chunk_size);
+
+  int32_t NT_max = 0;
+  int64_t NT_total = 0;
+  for (int64_t i = 0; i < N; ++i) {
+    const int64_t T_len = cu_seqlens[i + 1].item<int64_t>() - cu_seqlens[i].item<int64_t>();
+    const int64_t NT = (T_len + chunk_size - 1) / chunk_size;
+    NT_max = std::max(NT_max, static_cast<int32_t>(NT));
+    NT_total += NT;
+  }
+
+  const ChunkGatedDeltaRuleFwdHSpecialization specialization =
+      build_runtime_specialization(k, w, v, BT, use_g);
+  const auto* entry = find_chunk_gated_delta_rule_fwd_h_kernel_entry(specialization);
+  CHECK(entry != nullptr)
+      << "TileLang ChunkGatedDeltaRuleFwdH: no compiled variant. Available variants: "
+      << available_chunk_gated_delta_rule_fwd_h_variant_keys();
+
+  const torch::Tensor k_flat = k.squeeze(0);
+  const torch::Tensor w_flat = w.squeeze(0);
+  const torch::Tensor v_flat = v.squeeze(0);
+  torch::Tensor g_flat;
+  if (use_g) {
+    g_flat = g.squeeze(0).to(torch::kFloat32).transpose(0, 1).contiguous();
+  } else {
+    g_flat = torch::empty({H, T_total}, torch::TensorOptions().dtype(torch::kFloat32).device(k.device()));
+  }
+
+  torch::Tensor v_new_flat = torch::zeros({T_total, H, V}, torch::TensorOptions().dtype(k.scalar_type()).device(k.device()));
+  torch::Tensor h_out = torch::zeros({N, NT_max, H, K, V}, torch::TensorOptions().dtype(k.scalar_type()).device(k.device()));
+  torch::Tensor h0 = torch::zeros({N, H, K, V}, torch::TensorOptions().dtype(k.scalar_type()).device(k.device()));
+  if (initial_state.defined()) {
+    h0.copy_(initial_state.squeeze(0));
+  }
+
+  torch::Tensor ht = torch::zeros({N, H, K, V}, torch::TensorOptions().dtype(k.scalar_type()).device(k.device()));
+
+  const int32_t V_half = V / 2;
+  torch::Tensor ws_wh = torch::zeros({N, H, 2, BT, V_half}, torch::TensorOptions().dtype(torch::kFloat32).device(k.device()));
+  torch::Tensor ws_vnew = torch::zeros({N, H, 2, BT, V_half}, torch::TensorOptions().dtype(k.scalar_type()).device(k.device()));
+  torch::Tensor ws_hupd = torch::zeros({N, H, 2, K, V_half}, torch::TensorOptions().dtype(torch::kFloat32).device(k.device()));
+  torch::Tensor ws_h = torch::zeros({N, H, 2, K, V_half}, torch::TensorOptions().dtype(k.scalar_type()).device(k.device()));
+
+  const torch::Tensor cu_seqlens_int32 = cu_seqlens.to(torch::kInt32);
+
+  const int32_t device_id = k.device().index();
+  aclrtStream stream = c10_npu::getCurrentNPUStream(device_id).stream();
+  const int32_t N_int32 = static_cast<int32_t>(N);
+  const int32_t T_total_int32 = static_cast<int32_t>(T_total);
+  const int32_t STORE_FINAL_STATE = output_final_state ? 1 : 0;
+  const int32_t SAVE_NEW_VALUE_INT32 = save_new_value ? 1 : 0;
+
+  entry->fn(
+      /*h=*/reinterpret_cast<uint8_t*>(h_out.data_ptr()),
+      /*k=*/reinterpret_cast<uint8_t*>(const_cast<void*>(k_flat.data_ptr())),
+      /*v=*/reinterpret_cast<uint8_t*>(const_cast<void*>(v_flat.data_ptr())),
+      /*w=*/reinterpret_cast<uint8_t*>(const_cast<void*>(w_flat.data_ptr())),
+      /*g=*/reinterpret_cast<uint8_t*>(const_cast<void*>(g_flat.data_ptr())),
+      /*v_new=*/reinterpret_cast<uint8_t*>(v_new_flat.data_ptr()),
+      /*h0=*/reinterpret_cast<uint8_t*>(const_cast<void*>(h0.data_ptr())),
+      /*ht=*/reinterpret_cast<uint8_t*>(ht.data_ptr()),
+      /*cu_seqlens=*/reinterpret_cast<uint8_t*>(const_cast<void*>(cu_seqlens_int32.data_ptr())),
+      /*ws_wh=*/reinterpret_cast<uint8_t*>(ws_wh.data_ptr()),
+      /*ws_vnew=*/reinterpret_cast<uint8_t*>(ws_vnew.data_ptr()),
+      /*ws_hupd=*/reinterpret_cast<uint8_t*>(ws_hupd.data_ptr()),
+      /*ws_h=*/reinterpret_cast<uint8_t*>(ws_h.data_ptr()),
+      /*N=*/N_int32,
+      /*T_total=*/T_total_int32,
+      /*NT_max=*/NT_max,
+      /*STORE_FINAL_STATE=*/STORE_FINAL_STATE,
+      /*SAVE_NEW_VALUE=*/SAVE_NEW_VALUE_INT32,
+      /*stream=*/stream);
+
+  torch::Tensor v_new = v_new_flat.unsqueeze(0);
+
+  torch::Tensor chunk_offsets = prepare_chunk_offsets_cpu(cu_seqlens, chunk_size).to(k.device());
+  torch::Tensor h = torch::zeros({NT_total, H, K, V}, torch::TensorOptions().dtype(k.scalar_type()).device(k.device()));
+  for (int64_t i = 0; i < N; ++i) {
+    const int64_t T_len = cu_seqlens[i + 1].item<int64_t>() - cu_seqlens[i].item<int64_t>();
+    const int64_t NT_i = (T_len + chunk_size - 1) / chunk_size;
+    const int64_t offset = chunk_offsets[i].item<int64_t>();
+    h.slice(0, offset, offset + NT_i) = h_out.slice(1, 0, NT_i)[i];
+  }
+  h = h.unsqueeze(0);
+
+  torch::Tensor ht_out;
+  if (output_final_state) {
+    ht_out = ht;
+  }
+
+  return std::make_tuple(h, v_new, ht_out);
+}
+
+}  // namespace xllm::kernel::npu::tilelang

--- a/xllm/core/kernels/npu/tilelang/chunk_gated_delta_rule_fwd_h_wrapper_test.cpp
+++ b/xllm/core/kernels/npu/tilelang/chunk_gated_delta_rule_fwd_h_wrapper_test.cpp
@@ -1,0 +1,287 @@
+/* Copyright 2026 The xLLM Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://github.com/jd-opensource/xllm/blob/main/LICENSE
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include <gtest/gtest.h>
+#include <torch/torch.h>
+#include <torch_npu/csrc/core/npu/NPUStream.h>
+#include <torch_npu/torch_npu.h>
+
+#include <functional>
+#include <iostream>
+#include <string>
+#include <tuple>
+#include <vector>
+
+#include "acl/acl.h"
+#include "tilelang_ops_api.h"
+
+namespace xllm::kernel::npu::tilelang {
+namespace {
+
+class TileLangChunkGatedDeltaRuleFwdHWrapperTest : public ::testing::Test {
+ protected:
+  static void SetUpTestSuite() { torch_npu::init_npu("npu:0"); }
+
+  static void TearDownTestSuite() { torch_npu::finalize_npu(); }
+};
+
+struct ChunkGatedDeltaRuleFwdHTestCase {
+  std::string name;
+  std::vector<int64_t> seqlens;
+  int64_t H;
+  int64_t Hg;
+  int64_t K;
+  int64_t V;
+  int64_t chunk_size;
+  bool use_g;
+  bool use_initial_state;
+  int64_t seed;
+};
+
+std::tuple<torch::Tensor, torch::Tensor, torch::Tensor> torch_ref_chunk_gated_delta_rule(
+    const torch::Tensor& k,
+    const torch::Tensor& w,
+    const torch::Tensor& u,
+    const torch::Tensor& g,
+    const torch::Tensor& initial_state,
+    bool output_final_state,
+    int64_t chunk_size,
+    const torch::Tensor& cu_seqlens) {
+  const int64_t BT = chunk_size;
+  const torch::Tensor k_fp32 = k.squeeze(0).to(torch::kFloat32);
+  const torch::Tensor w_fp32 = w.squeeze(0).to(torch::kFloat32);
+  const torch::Tensor u_fp32 = u.squeeze(0).to(torch::kFloat32);
+  torch::Tensor g_fp32;
+  if (g.defined()) {
+    g_fp32 = g.squeeze(0).to(torch::kFloat32);
+  }
+  torch::Tensor h0_fp32;
+  if (initial_state.defined()) {
+    h0_fp32 = initial_state.squeeze(0).to(torch::kFloat32);
+  }
+
+  const int64_t T_total = k_fp32.size(0);
+  const int64_t Hg = k_fp32.size(1);
+  const int64_t K = k_fp32.size(2);
+  const int64_t H = w_fp32.size(1);
+  const int64_t V = u_fp32.size(2);
+  const int64_t N = cu_seqlens.size(0) - 1;
+
+  int64_t NT_total = 0;
+  for (int64_t i = 0; i < N; ++i) {
+    const int64_t T_len = cu_seqlens[i + 1].item<int64_t>() - cu_seqlens[i].item<int64_t>();
+    NT_total += (T_len + BT - 1) / BT;
+  }
+
+  torch::Tensor h = torch::zeros({NT_total, H, K, V}, torch::TensorOptions().dtype(torch::kFloat32).device(k.device()));
+  torch::Tensor v_new = torch::zeros({T_total, H, V}, torch::TensorOptions().dtype(torch::kFloat32).device(k.device()));
+  torch::Tensor final_state;
+  if (output_final_state) {
+    final_state = torch::zeros({N, H, K, V}, torch::TensorOptions().dtype(torch::kFloat32).device(k.device()));
+  }
+
+  int64_t chunk_offset = 0;
+  for (int64_t i_n = 0; i_n < N; ++i_n) {
+    const int64_t bos = cu_seqlens[i_n].item<int64_t>();
+    const int64_t eos = cu_seqlens[i_n + 1].item<int64_t>();
+    const int64_t T_len = eos - bos;
+    const int64_t NT = (T_len + BT - 1) / BT;
+
+    for (int64_t i_h = 0; i_h < H; ++i_h) {
+      torch::Tensor h_state;
+      if (h0_fp32.defined()) {
+        h_state = h0_fp32[i_n][i_h].clone();
+      } else {
+        h_state = torch::zeros({K, V}, torch::TensorOptions().dtype(torch::kFloat32).device(k.device()));
+      }
+      const int64_t k_head = i_h / (H / Hg);
+
+      for (int64_t i_t = 0; i_t < NT; ++i_t) {
+        const int64_t t_start = i_t * BT;
+        const int64_t t_end = std::min((i_t + 1) * BT, T_len);
+
+        h[chunk_offset + i_t][i_h] = h_state;
+        torch::Tensor k_chunk = k_fp32.slice(0, bos + t_start, bos + t_end).slice(1, k_head, k_head + 1).squeeze(1);
+        torch::Tensor w_chunk = w_fp32.slice(0, bos + t_start, bos + t_end).slice(1, i_h, i_h + 1).squeeze(1);
+        torch::Tensor v_chunk = u_fp32.slice(0, bos + t_start, bos + t_end).slice(1, i_h, i_h + 1).squeeze(1);
+
+        torch::Tensor v_n = v_chunk - w_chunk.matmul(h_state);
+        v_new.slice(0, bos + t_start, bos + t_end).slice(1, i_h, i_h + 1).squeeze(1) = v_n;
+
+        if (g_fp32.defined()) {
+          torch::Tensor g_chunk = g_fp32.slice(0, bos + t_start, bos + t_end).slice(1, i_h, i_h + 1).squeeze(1);
+          const float g_last = g_chunk[-1].item<float>();
+          v_n = v_n * torch::exp(g_last - g_chunk).unsqueeze(1);
+          h_state = h_state * torch::exp(torch::tensor(g_last, torch::TensorOptions().dtype(torch::kFloat32).device(k.device())));
+        }
+
+        h_state = h_state + k_chunk.transpose(0, 1).matmul(v_n);
+      }
+
+      if (output_final_state) {
+        final_state[i_n][i_h] = h_state;
+      }
+    }
+    chunk_offset += NT;
+  }
+
+  return std::make_tuple(
+      h.to(torch::kFloat16).unsqueeze(0),
+      v_new.to(torch::kFloat16).unsqueeze(0),
+      final_state.defined() ? final_state.to(torch::kFloat16) : torch::Tensor());
+}
+
+void run_chunk_gated_delta_rule_fwd_h_case(const ChunkGatedDeltaRuleFwdHTestCase& test_case) {
+  ASSERT_GT(test_case.seqlens.size(), 0);
+  ASSERT_GT(test_case.H, 0);
+  ASSERT_GT(test_case.Hg, 0);
+  ASSERT_GT(test_case.K, 0);
+  ASSERT_GT(test_case.V, 0);
+  ASSERT_GT(test_case.chunk_size, 0);
+  ASSERT_LE(test_case.Hg, test_case.H);
+
+  const auto npu_device = torch::Device("npu:0");
+  const auto fp16_opts =
+      torch::TensorOptions().dtype(torch::kFloat16).device(npu_device);
+  const auto fp32_opts =
+      torch::TensorOptions().dtype(torch::kFloat32).device(npu_device);
+
+  torch::manual_seed(test_case.seed);
+
+  const int64_t T_total = 0;
+  for (const auto& seqlen : test_case.seqlens) {
+    T_total += seqlen;
+  }
+  const int64_t N = test_case.seqlens.size();
+
+  torch::Tensor cu_seqlens = torch::zeros({N + 1}, torch::TensorOptions().dtype(torch::kInt64).device(torch::kCPU));
+  for (int64_t i = 0; i < N; ++i) {
+    cu_seqlens[i + 1] = cu_seqlens[i].item<int64_t>() + test_case.seqlens[i];
+  }
+  cu_seqlens = cu_seqlens.to(npu_device);
+
+  torch::Tensor k = torch::randn({1, T_total, test_case.Hg, test_case.K}, fp16_opts) * 0.01;
+  torch::Tensor w = torch::randn({1, T_total, test_case.H, test_case.K}, fp16_opts) * 0.01;
+  torch::Tensor u = torch::randn({1, T_total, test_case.H, test_case.V}, fp16_opts) * 0.01;
+  torch::Tensor g;
+  if (test_case.use_g) {
+    g = torch::randn({1, T_total, test_case.H}, fp32_opts) * -1.0;
+  }
+  torch::Tensor initial_state;
+  if (test_case.use_initial_state) {
+    initial_state = torch::randn({1, N, test_case.H, test_case.K, test_case.V}, fp16_opts) * 0.01;
+  }
+
+  auto [ref_h, ref_v_new, ref_ht] = torch_ref_chunk_gated_delta_rule(
+      k, w, u, g, initial_state, true, test_case.chunk_size, cu_seqlens);
+
+  auto [tilelang_h, tilelang_v_new, tilelang_ht] = chunk_gated_delta_rule_fwd_h(
+      k, w, u, g, initial_state, true, test_case.chunk_size, true, cu_seqlens);
+
+  torch::npu.synchronize();
+
+  EXPECT_TRUE(torch::allclose(tilelang_h, ref_h, /*rtol=*/1e-2, /*atol=*/1e-2))
+      << "h mismatch: tilelang output differs from reference, case=" << test_case.name;
+  EXPECT_TRUE(torch::allclose(tilelang_v_new, ref_v_new, /*rtol=*/1e-2, /*atol=*/1e-2))
+      << "v_new mismatch: tilelang output differs from reference, case=" << test_case.name;
+  EXPECT_TRUE(torch::allclose(tilelang_ht, ref_ht, /*rtol=*/1e-2, /*atol=*/1e-2))
+      << "ht mismatch: tilelang output differs from reference, case=" << test_case.name;
+
+  std::cout << "[chunk_gated_delta_rule_fwd_h_wrapper_test] case=" << test_case.name
+            << " passed" << std::endl;
+}
+
+TEST_F(TileLangChunkGatedDeltaRuleFwdHWrapperTest, BasicSingleSequence) {
+  const std::vector<ChunkGatedDeltaRuleFwdHTestCase> cases = {
+      {.name = "single_2048_h8_hg4_k128_v128_bt64_useg",
+       .seqlens = {2048},
+       .H = 8,
+       .Hg = 4,
+       .K = 128,
+       .V = 128,
+       .chunk_size = 64,
+       .use_g = true,
+       .use_initial_state = true,
+       .seed = 20260507},
+      {.name = "single_1024_h8_hg4_k128_v128_bt64_no_g",
+       .seqlens = {1024},
+       .H = 8,
+       .Hg = 4,
+       .K = 128,
+       .V = 128,
+       .chunk_size = 64,
+       .use_g = false,
+       .use_initial_state = true,
+       .seed = 20260508},
+  };
+
+  for (const auto& test_case : cases) {
+    SCOPED_TRACE(::testing::Message() << "case=" << test_case.name);
+    run_chunk_gated_delta_rule_fwd_h_case(test_case);
+  }
+}
+
+TEST_F(TileLangChunkGatedDeltaRuleFwdHWrapperTest, MultiSequenceVarlen) {
+  const std::vector<ChunkGatedDeltaRuleFwdHTestCase> cases = {
+      {.name = "multi_512_512_h8_hg4_k128_v128_bt64",
+       .seqlens = {512, 512},
+       .H = 8,
+       .Hg = 4,
+       .K = 128,
+       .V = 128,
+       .chunk_size = 64,
+       .use_g = true,
+       .use_initial_state = true,
+       .seed = 20260509},
+      {.name = "multi_128_256_512_h8_hg4_k128_v128_bt64",
+       .seqlens = {128, 256, 512},
+       .H = 8,
+       .Hg = 4,
+       .K = 128,
+       .V = 128,
+       .chunk_size = 64,
+       .use_g = true,
+       .use_initial_state = true,
+       .seed = 20260510},
+  };
+
+  for (const auto& test_case : cases) {
+    SCOPED_TRACE(::testing::Message() << "case=" << test_case.name);
+    run_chunk_gated_delta_rule_fwd_h_case(test_case);
+  }
+}
+
+TEST_F(TileLangChunkGatedDeltaRuleFwdHWrapperTest, SecondarySpecialization) {
+  const std::vector<ChunkGatedDeltaRuleFwdHTestCase> cases = {
+      {.name = "secondary_h4_hg2_k64_v64_bt32",
+       .seqlens = {512},
+       .H = 4,
+       .Hg = 2,
+       .K = 64,
+       .V = 64,
+       .chunk_size = 32,
+       .use_g = true,
+       .use_initial_state = true,
+       .seed = 20260511},
+  };
+
+  for (const auto& test_case : cases) {
+    SCOPED_TRACE(::testing::Message() << "case=" << test_case.name);
+    run_chunk_gated_delta_rule_fwd_h_case(test_case);
+  }
+}
+
+}  // namespace
+}  // namespace xllm::kernel::npu::tilelang

--- a/xllm/core/kernels/npu/tilelang/tilelang_ops_api.h
+++ b/xllm/core/kernels/npu/tilelang/tilelang_ops_api.h
@@ -72,4 +72,21 @@ bool has_split_qkv_rmsnorm_mrope_specialization(int64_t num_q_heads,
                                                 int64_t num_kv_heads,
                                                 int64_t head_size);
 
+// Compute chunked gated delta rule recurrence for varlen sequences.
+// Invalid inputs trigger CHECK failures.
+// Returns tuple of (h, v_new, ht) where:
+// - h: [1, NT_total, H, K, V] hidden states per chunk
+// - v_new: [1, T_total, H, V] new values
+// - ht: [N, H, K, V] final states (empty if output_final_state=false)
+std::tuple<torch::Tensor, torch::Tensor, torch::Tensor> chunk_gated_delta_rule_fwd_h(
+    const torch::Tensor& k,
+    const torch::Tensor& w,
+    const torch::Tensor& v,
+    const torch::Tensor& g,
+    const torch::Tensor& initial_state,
+    bool output_final_state,
+    int64_t chunk_size,
+    bool save_new_value,
+    const torch::Tensor& cu_seqlens);
+
 }  // namespace xllm::kernel::npu::tilelang


### PR DESCRIPTION
Add TileLang Ascend kernel for chunked gated delta rule forward hidden state computation with varlen sequence support:

- Python kernel with DISPATCH_SCHEMA (H/Hg/K/V/BT/USE_G) and 3 specializations (primary, secondary, no_gating)
- C++ wrapper with runtime dispatch, comprehensive input validation (GQA ratio, V/K evenness, cu_seqlens bounds)
- Workspace tensors for double buffering and cross-core sync
- C++ unit tests covering single/multi sequence varlen cases
- Public API declaration in tilelang_ops_api.h
- CMake registration for kernel and wrapper test