### PR TITLE
feat: support DeepSeek-V4 NPU MoE EP2 dispatch.

### DIFF
--- a/xllm/core/framework/parallel_state/npu_process_group.cpp
+++ b/xllm/core/framework/parallel_state/npu_process_group.cpp
@@ -176,4 +176,17 @@ ProcessGroupImpl::ProcessGroupImpl(int rank,
       comm_(comm),
       comm_stream_(c10_npu::getNPUStreamFromPool(device.index())) {}
 
+std::string ProcessGroupImpl::hccl_comm_name(bool init_comm) {
+  CHECK(pg_ != nullptr) << "HCCL comm name requires a torch NPU process group.";
+#if defined(USE_NPU) &&         \
+    (TORCH_VERSION_MAJOR < 2 || \
+     (TORCH_VERSION_MAJOR == 2 && TORCH_VERSION_MINOR < 7))
+  return pg_->getHcclCommName(pg_->getRank(), init_comm);
+#else
+  auto* hccl_pg = dynamic_cast<c10d_npu::ProcessGroupHCCL*>(pg_.get());
+  CHECK(hccl_pg != nullptr) << "Process group is not NPU HCCL.";
+  return hccl_pg->getHcclCommName(pg_->getRank(), init_comm);
+#endif
+}
+
 }  // namespace xllm

--- a/xllm/core/framework/parallel_state/npu_process_group.h
+++ b/xllm/core/framework/parallel_state/npu_process_group.h
@@ -55,6 +55,8 @@ class ProcessGroupImpl : public ProcessGroup {
   // Destructor.
   ~ProcessGroupImpl() override;
 
+  std::string hccl_comm_name(bool init_comm = true) override;
+
  private:
   HcclComm comm_ = nullptr;
   c10_npu::NPUStream comm_stream_;

--- a/xllm/core/framework/parallel_state/process_group.cpp
+++ b/xllm/core/framework/parallel_state/process_group.cpp
@@ -185,6 +185,12 @@ void ProcessGroup::all_to_all_single(
   }
 }
 
+std::string ProcessGroup::hccl_comm_name(bool init_comm) {
+  (void)init_comm;
+  CHECK(false) << "hccl_comm_name is only supported on NPU HCCL process group.";
+  return "";
+}
+
 std::unique_ptr<ProcessGroup> create_process_group(
     int32_t rank,
     int32_t world_size,

--- a/xllm/core/framework/parallel_state/process_group.h
+++ b/xllm/core/framework/parallel_state/process_group.h
@@ -17,6 +17,7 @@ limitations under the License.
 
 #include <torch/torch.h>
 
+#include <string>
 #include <torch/csrc/distributed/c10d/Backend.hpp>
 #include <torch/csrc/distributed/c10d/TCPStore.hpp>
 
@@ -95,6 +96,8 @@ class ProcessGroup {
       std::vector<int64_t> input_split_sizes = {},
       bool async_op = false,
       c10::intrusive_ptr<c10d::Work>* async_work = nullptr);
+
+  virtual std::string hccl_comm_name(bool init_comm = true);
 
  private:
   // rank of current process.

--- a/xllm/core/kernels/npu/CMakeLists.txt
+++ b/xllm/core/kernels/npu/CMakeLists.txt
@@ -14,10 +14,13 @@ cc_library(
     matmul.cpp
     npu_grouped_matmul.cpp
     npu_moe_gating_topk_softmax.cpp
+    npu_moe_distribute_combine_v2.cpp
+    npu_moe_distribute_dispatch_v2.cpp
     npu_moe_init_routing_v2.cpp
     npu_moe_token_unpermute.cpp
     rope.cpp
     w4a8_dynamic_moe_preprocess.cpp
   DEPS
     :torch_npu_kernels
+    opapi
 )

--- a/xllm/core/kernels/npu/npu_moe_distribute_combine_v2.cpp
+++ b/xllm/core/kernels/npu/npu_moe_distribute_combine_v2.cpp
@@ -1,0 +1,148 @@
+/* Copyright 2026 The xLLM Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://github.com/jd-opensource/xllm/blob/main/LICENSE
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include <optional>
+#include <string>
+
+#include "pytorch_npu_helper.h"
+
+namespace xllm::kernel::npu {
+namespace {
+
+constexpr int64_t kOutDtypeDefault = 0;
+constexpr int64_t kGroupListTypeDefault = 0;
+
+bool has_combine_v2() {
+  static const bool is_available =
+      GetOpApiFuncAddr("aclnnMoeDistributeCombineV2GetWorkspaceSize") !=
+          nullptr &&
+      GetOpApiFuncAddr("aclnnMoeDistributeCombineV2") != nullptr;
+  return is_available;
+}
+
+}  // namespace
+
+torch::Tensor apply_npu_moe_distribute_combine_v2(
+    const torch::Tensor& expand_x,
+    const torch::Tensor& expert_ids,
+    const torch::Tensor& assist_info_for_combine,
+    const torch::Tensor& ep_send_counts,
+    const torch::Tensor& expert_scales,
+    const std::optional<torch::Tensor>& tp_send_counts,
+    const std::optional<torch::Tensor>& x_active_mask,
+    const std::optional<torch::Tensor>& expand_scales,
+    const std::optional<torch::Tensor>& shared_expert_x,
+    const std::string& group_ep,
+    int64_t ep_world_size,
+    int64_t ep_rank_id,
+    int64_t moe_expert_num,
+    const std::string& group_tp,
+    int64_t tp_world_size,
+    int64_t tp_rank_id,
+    int64_t expert_shard_type,
+    int64_t shared_expert_num,
+    int64_t shared_expert_rank_num,
+    int64_t global_bs,
+    int64_t comm_quant_mode,
+    const std::string& comm_alg) {
+  TORCH_CHECK(has_combine_v2(),
+              "aclnnMoeDistributeCombineV2 is not available in libopapi.");
+  TORCH_CHECK(expand_x.dim() == 2,
+              "MoeDistributeCombineV2 expects 2D expand_x.");
+  TORCH_CHECK(expert_ids.dim() == 2,
+              "MoeDistributeCombineV2 expects 2D expert_ids.");
+  TORCH_CHECK(expert_ids.scalar_type() == at::kInt,
+              "MoeDistributeCombineV2 expects int32 expert_ids, got ",
+              c10::toString(expert_ids.scalar_type()));
+  TORCH_CHECK(expert_scales.defined(),
+              "MoeDistributeCombineV2 requires expert_scales.");
+  TORCH_CHECK(expert_scales.scalar_type() == at::kFloat,
+              "MoeDistributeCombineV2 expects float32 expert_scales, got ",
+              c10::toString(expert_scales.scalar_type()));
+  TORCH_CHECK(!group_ep.empty(),
+              "MoeDistributeCombineV2 requires non-empty EP group name.");
+  TORCH_CHECK(ep_world_size > 1,
+              "MoeDistributeCombineV2 requires ep_world_size > 1.");
+  TORCH_CHECK(ep_rank_id >= 0 && ep_rank_id < ep_world_size,
+              "invalid EP rank ",
+              ep_rank_id,
+              " for ep_world_size ",
+              ep_world_size);
+
+  auto output =
+      at::empty({expert_ids.size(0), expand_x.size(1)}, expand_x.options());
+
+  auto tp_send_counts_optional =
+      tp_world_size > 1 && tp_send_counts.has_value() &&
+              tp_send_counts->defined()
+          ? c10::optional<at::Tensor>(tp_send_counts.value())
+          : c10::nullopt;
+  auto x_active_mask_optional =
+      x_active_mask.has_value() && x_active_mask->defined()
+          ? c10::optional<at::Tensor>(x_active_mask.value())
+          : c10::nullopt;
+  auto expand_scales_optional =
+      expand_scales.has_value() && expand_scales->defined()
+          ? c10::optional<at::Tensor>(expand_scales.value())
+          : c10::nullopt;
+  auto shared_expert_x_optional =
+      shared_expert_x.has_value() && shared_expert_x->defined()
+          ? c10::optional<at::Tensor>(shared_expert_x.value())
+          : c10::nullopt;
+  c10::optional<at::Tensor> activation_scale_optional = c10::nullopt;
+  c10::optional<at::Tensor> weight_scale_optional = c10::nullopt;
+  c10::optional<at::Tensor> group_list_optional = c10::nullopt;
+
+  std::string group_ep_copy = group_ep;
+  char* group_ep_ptr = group_ep_copy.data();
+  std::string group_tp_copy = group_tp;
+  char* group_tp_ptr = group_tp_copy.data();
+  std::string comm_alg_copy = comm_alg;
+  char* comm_alg_ptr = comm_alg_copy.data();
+
+  EXEC_NPU_CMD(aclnnMoeDistributeCombineV2,
+               expand_x,
+               expert_ids,
+               assist_info_for_combine,
+               ep_send_counts,
+               expert_scales,
+               tp_send_counts_optional,
+               x_active_mask_optional,
+               activation_scale_optional,
+               weight_scale_optional,
+               group_list_optional,
+               expand_scales_optional,
+               shared_expert_x_optional,
+               group_ep_ptr,
+               ep_world_size,
+               ep_rank_id,
+               moe_expert_num,
+               group_tp_ptr,
+               tp_world_size,
+               tp_rank_id,
+               expert_shard_type,
+               shared_expert_num,
+               shared_expert_rank_num,
+               global_bs,
+               kOutDtypeDefault,
+               comm_quant_mode,
+               kGroupListTypeDefault,
+               comm_alg_ptr,
+               output);
+
+  return output;
+}
+
+}  // namespace xllm::kernel::npu

--- a/xllm/core/kernels/npu/npu_moe_distribute_dispatch_v2.cpp
+++ b/xllm/core/kernels/npu/npu_moe_distribute_dispatch_v2.cpp
@@ -1,0 +1,224 @@
+/* Copyright 2026 The xLLM Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://github.com/jd-opensource/xllm/blob/main/LICENSE
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include <algorithm>
+#include <optional>
+#include <string>
+#include <tuple>
+
+#include "pytorch_npu_helper.h"
+
+namespace xllm::kernel::npu {
+namespace {
+
+constexpr int64_t kNoQuantMode = 0;
+
+int64_t resolve_local_expert_num(int64_t ep_world_size,
+                                 int64_t moe_expert_num,
+                                 int64_t shared_expert_rank_num) {
+  const int64_t routed_ep_size = ep_world_size - shared_expert_rank_num;
+  TORCH_CHECK(routed_ep_size > 0,
+              "invalid shared_expert_rank_num=",
+              shared_expert_rank_num,
+              " for ep_world_size=",
+              ep_world_size);
+  TORCH_CHECK(moe_expert_num % routed_ep_size == 0,
+              "moe_expert_num must be divisible by routed EP size, got ",
+              moe_expert_num,
+              " / ",
+              routed_ep_size);
+  return moe_expert_num / routed_ep_size;
+}
+
+int64_t resolve_dispatch_capacity(int64_t local_bs,
+                                  int64_t topk,
+                                  int64_t local_expert_num,
+                                  int64_t ep_world_size,
+                                  int64_t global_bs) {
+  const int64_t global_bs_real =
+      global_bs == 0 ? local_bs * ep_world_size : global_bs;
+  return global_bs_real * std::min(local_expert_num, topk);
+}
+
+bool has_dispatch_v2() {
+  static const bool is_available =
+      GetOpApiFuncAddr("aclnnMoeDistributeDispatchV2GetWorkspaceSize") !=
+          nullptr &&
+      GetOpApiFuncAddr("aclnnMoeDistributeDispatchV2") != nullptr;
+  return is_available;
+}
+
+}  // namespace
+
+std::tuple<torch::Tensor,
+           torch::Tensor,
+           torch::Tensor,
+           torch::Tensor,
+           torch::Tensor,
+           torch::Tensor,
+           torch::Tensor>
+apply_npu_moe_distribute_dispatch_v2(
+    const torch::Tensor& x,
+    const torch::Tensor& expert_ids,
+    const std::optional<torch::Tensor>& expert_scales,
+    const std::optional<torch::Tensor>& x_active_mask,
+    const std::optional<torch::Tensor>& scales,
+    const std::string& group_ep,
+    int64_t ep_world_size,
+    int64_t ep_rank_id,
+    int64_t moe_expert_num,
+    const std::string& group_tp,
+    int64_t tp_world_size,
+    int64_t tp_rank_id,
+    int64_t expert_shard_type,
+    int64_t shared_expert_num,
+    int64_t shared_expert_rank_num,
+    int64_t quant_mode,
+    int64_t global_bs,
+    int64_t expert_token_nums_type,
+    const std::string& comm_alg) {
+  TORCH_CHECK(has_dispatch_v2(),
+              "aclnnMoeDistributeDispatchV2 is not available in libopapi.");
+  TORCH_CHECK(x.dim() == 2, "MoeDistributeDispatchV2 expects 2D x.");
+  TORCH_CHECK(x.scalar_type() == at::kHalf || x.scalar_type() == at::kBFloat16,
+              "MoeDistributeDispatchV2 only supports FP16/BF16 x, got ",
+              c10::toString(x.scalar_type()));
+  TORCH_CHECK(expert_ids.dim() == 2,
+              "MoeDistributeDispatchV2 expects 2D expert_ids.");
+  TORCH_CHECK(expert_ids.scalar_type() == at::kInt,
+              "MoeDistributeDispatchV2 expects int32 expert_ids, got ",
+              c10::toString(expert_ids.scalar_type()));
+  TORCH_CHECK(!group_ep.empty(),
+              "MoeDistributeDispatchV2 requires non-empty EP group name.");
+  TORCH_CHECK(ep_world_size > 1,
+              "MoeDistributeDispatchV2 requires ep_world_size > 1.");
+  TORCH_CHECK(ep_rank_id >= 0 && ep_rank_id < ep_world_size,
+              "invalid EP rank ",
+              ep_rank_id,
+              " for ep_world_size ",
+              ep_world_size);
+  TORCH_CHECK(tp_world_size == 0 || tp_world_size == 1 || tp_world_size == 2,
+              "tp_world_size must be 0, 1, or 2, got ",
+              tp_world_size);
+  TORCH_CHECK(quant_mode == kNoQuantMode,
+              "xLLM currently uses MoeDistributeDispatchV2 only in "
+              "non-quantized communication mode.");
+
+  const int64_t local_bs = x.size(0);
+  const int64_t hidden = x.size(1);
+  const int64_t topk = expert_ids.size(1);
+  TORCH_CHECK(topk > 0, "MoeDistributeDispatchV2 requires topk > 0.");
+  const int64_t local_expert_num = resolve_local_expert_num(
+      ep_world_size, moe_expert_num, shared_expert_rank_num);
+  const int64_t capacity = resolve_dispatch_capacity(
+      local_bs, topk, local_expert_num, ep_world_size, global_bs);
+  const int64_t tp_factor = std::max<int64_t>(tp_world_size, 1);
+  int64_t ep_recv_count_num =
+      tp_world_size == 2 ? ep_world_size * local_expert_num * tp_world_size
+                         : ep_world_size * local_expert_num;
+  int64_t assist_info_num = std::max(local_bs * topk, capacity * 128);
+  const bool has_expert_scales =
+      expert_scales.has_value() && expert_scales->defined();
+  if (has_expert_scales) {
+    TORCH_CHECK(expert_scales->dim() == 2,
+                "MoeDistributeDispatchV2 expects 2D expert_scales.");
+    TORCH_CHECK(expert_scales->scalar_type() == at::kFloat,
+                "MoeDistributeDispatchV2 expects float32 expert_scales, got ",
+                c10::toString(expert_scales->scalar_type()));
+    const int64_t global_bs_real =
+        global_bs == 0 ? local_bs * ep_world_size : global_bs;
+    const int64_t scale_info_num =
+        global_bs_real * 2 * topk * (ep_world_size / 8);
+    ep_recv_count_num += scale_info_num;
+    assist_info_num = std::max(assist_info_num, scale_info_num);
+  }
+
+  auto expand_x = at::empty({capacity * tp_factor, hidden}, x.options());
+  auto dynamic_scales = at::empty({0}, x.options().dtype(at::kFloat));
+  auto assist_info_for_combine =
+      at::empty({assist_info_num}, x.options().dtype(at::kInt));
+  auto expert_token_nums =
+      at::empty({local_expert_num}, x.options().dtype(at::kLong));
+  auto ep_recv_counts =
+      at::empty({ep_recv_count_num}, x.options().dtype(at::kInt));
+  auto tp_recv_counts = at::empty({tp_world_size}, x.options().dtype(at::kInt));
+  auto expand_scales =
+      has_expert_scales ? at::empty({capacity}, x.options().dtype(at::kFloat))
+                        : at::empty({0}, x.options().dtype(at::kFloat));
+
+  auto scales_optional = scales.has_value() && scales->defined()
+                             ? c10::optional<at::Tensor>(scales.value())
+                             : c10::nullopt;
+  auto x_active_mask_optional =
+      x_active_mask.has_value() && x_active_mask->defined()
+          ? c10::optional<at::Tensor>(x_active_mask.value())
+          : c10::nullopt;
+  auto expert_scales_optional =
+      expert_scales.has_value() && expert_scales->defined()
+          ? c10::optional<at::Tensor>(expert_scales.value())
+          : c10::nullopt;
+
+  std::string group_ep_copy = group_ep;
+  char* group_ep_ptr = group_ep_copy.data();
+  std::string group_tp_copy = group_tp;
+  char* group_tp_ptr = group_tp_copy.data();
+  std::string comm_alg_copy = comm_alg;
+  char* comm_alg_ptr = comm_alg_copy.data();
+
+  EXEC_NPU_CMD(aclnnMoeDistributeDispatchV2,
+               x,
+               expert_ids,
+               scales_optional,
+               x_active_mask_optional,
+               expert_scales_optional,
+               group_ep_ptr,
+               ep_world_size,
+               ep_rank_id,
+               moe_expert_num,
+               group_tp_ptr,
+               tp_world_size,
+               tp_rank_id,
+               expert_shard_type,
+               shared_expert_num,
+               shared_expert_rank_num,
+               quant_mode,
+               global_bs,
+               expert_token_nums_type,
+               comm_alg_ptr,
+               expand_x,
+               dynamic_scales,
+               assist_info_for_combine,
+               expert_token_nums,
+               ep_recv_counts,
+               tp_recv_counts,
+               expand_scales);
+
+  return std::make_tuple(expand_x,
+                         dynamic_scales,
+                         assist_info_for_combine,
+                         expert_token_nums,
+                         ep_recv_counts,
+                         tp_recv_counts,
+                         expand_scales);
+}
+
+bool has_moe_distribute_dispatch_combine_v2() {
+  return has_dispatch_v2() &&
+         GetOpApiFuncAddr("aclnnMoeDistributeCombineV2GetWorkspaceSize") !=
+             nullptr &&
+         GetOpApiFuncAddr("aclnnMoeDistributeCombineV2") != nullptr;
+}
+
+}  // namespace xllm::kernel::npu

--- a/xllm/core/kernels/npu/npu_moe_init_routing_v2.cpp
+++ b/xllm/core/kernels/npu/npu_moe_init_routing_v2.cpp
@@ -47,7 +47,7 @@ apply_npu_moe_init_routing_v2(const torch::Tensor& x,
       expert_tokens_num_flag,
       quant_mode,
       active_expert_range,
-      0);
+      row_idx_type);
 }
 
 }  // namespace xllm::kernel::npu

--- a/xllm/core/kernels/npu/npu_ops_api.h
+++ b/xllm/core/kernels/npu/npu_ops_api.h
@@ -126,6 +126,60 @@ apply_npu_moe_init_routing_v2(const torch::Tensor& x,
                               torch::IntArrayRef active_expert_range,
                               int row_idx_type);
 
+std::tuple<torch::Tensor,
+           torch::Tensor,
+           torch::Tensor,
+           torch::Tensor,
+           torch::Tensor,
+           torch::Tensor,
+           torch::Tensor>
+apply_npu_moe_distribute_dispatch_v2(
+    const torch::Tensor& x,
+    const torch::Tensor& expert_ids,
+    const std::optional<torch::Tensor>& expert_scales,
+    const std::optional<torch::Tensor>& x_active_mask,
+    const std::optional<torch::Tensor>& scales,
+    const std::string& group_ep,
+    int64_t ep_world_size,
+    int64_t ep_rank_id,
+    int64_t moe_expert_num,
+    const std::string& group_tp,
+    int64_t tp_world_size,
+    int64_t tp_rank_id,
+    int64_t expert_shard_type,
+    int64_t shared_expert_num,
+    int64_t shared_expert_rank_num,
+    int64_t quant_mode,
+    int64_t global_bs,
+    int64_t expert_token_nums_type,
+    const std::string& comm_alg);
+
+torch::Tensor apply_npu_moe_distribute_combine_v2(
+    const torch::Tensor& expand_x,
+    const torch::Tensor& expert_ids,
+    const torch::Tensor& assist_info_for_combine,
+    const torch::Tensor& ep_send_counts,
+    const torch::Tensor& expert_scales,
+    const std::optional<torch::Tensor>& tp_send_counts,
+    const std::optional<torch::Tensor>& x_active_mask,
+    const std::optional<torch::Tensor>& expand_scales,
+    const std::optional<torch::Tensor>& shared_expert_x,
+    const std::string& group_ep,
+    int64_t ep_world_size,
+    int64_t ep_rank_id,
+    int64_t moe_expert_num,
+    const std::string& group_tp,
+    int64_t tp_world_size,
+    int64_t tp_rank_id,
+    int64_t expert_shard_type,
+    int64_t shared_expert_num,
+    int64_t shared_expert_rank_num,
+    int64_t global_bs,
+    int64_t comm_quant_mode,
+    const std::string& comm_alg);
+
+bool has_moe_distribute_dispatch_combine_v2();
+
 std::pair<torch::Tensor, torch::Tensor> apply_npu_partial_rotary_embedding(
     const torch::Tensor& positions,
     torch::Tensor& query,

--- a/xllm/core/kernels/npu/xllm_ops/xllm_ops_api.h
+++ b/xllm/core/kernels/npu/xllm_ops/xllm_ops_api.h
@@ -25,6 +25,7 @@ limitations under the License.
 #include <torch_npu/csrc/framework/utils/OpPreparation.h>
 #endif
 
+#include <string>
 #include <tuple>
 #include <vector>
 

--- a/xllm/core/kernels/ops_api.cpp
+++ b/xllm/core/kernels/ops_api.cpp
@@ -863,6 +863,78 @@ moe_init_routing_v2(MoeInitRoutingV2Params& params) {
 #endif
 }
 
+std::tuple<torch::Tensor,
+           torch::Tensor,
+           torch::Tensor,
+           torch::Tensor,
+           torch::Tensor,
+           torch::Tensor,
+           torch::Tensor>
+moe_distribute_dispatch_v2(MoeDistributeDispatchV2Params& params) {
+#if defined(USE_NPU)
+  return npu::apply_npu_moe_distribute_dispatch_v2(
+      params.x,
+      params.expert_ids,
+      params.expert_scales,
+      params.x_active_mask,
+      params.scales,
+      params.group_ep,
+      params.ep_world_size,
+      params.ep_rank_id,
+      params.moe_expert_num,
+      params.group_tp,
+      params.tp_world_size,
+      params.tp_rank_id,
+      params.expert_shard_type,
+      params.shared_expert_num,
+      params.shared_expert_rank_num,
+      params.quant_mode,
+      params.global_bs,
+      params.expert_token_nums_type,
+      params.comm_alg);
+#else
+  NOT_IMPLEMENTED();
+#endif
+}
+
+torch::Tensor moe_distribute_combine_v2(MoeDistributeCombineV2Params& params) {
+#if defined(USE_NPU)
+  return npu::apply_npu_moe_distribute_combine_v2(
+      params.expand_x,
+      params.expert_ids,
+      params.assist_info_for_combine,
+      params.ep_send_counts,
+      params.expert_scales,
+      params.tp_send_counts,
+      params.x_active_mask,
+      params.expand_scales,
+      params.shared_expert_x,
+      params.group_ep,
+      params.ep_world_size,
+      params.ep_rank_id,
+      params.moe_expert_num,
+      params.group_tp,
+      params.tp_world_size,
+      params.tp_rank_id,
+      params.expert_shard_type,
+      params.shared_expert_num,
+      params.shared_expert_rank_num,
+      params.global_bs,
+      params.comm_quant_mode,
+      params.comm_alg);
+#else
+  NOT_IMPLEMENTED();
+#endif
+}
+
+bool has_moe_distribute_dispatch_combine_v2() {
+#if defined(USE_NPU)
+  return npu::has_moe_distribute_dispatch_combine_v2();
+#else
+  return false;
+#endif
+}
+
 torch::Tensor hc_post(HcPostParams& params) {
 #if defined(USE_NPU)
   return npu::hc_post(params.x, params.residual, params.post, params.comb);

--- a/xllm/core/kernels/ops_api.h
+++ b/xllm/core/kernels/ops_api.h
@@ -46,8 +46,7 @@ torch::Tensor matmul(MatmulParams& params);
 
 torch::Tensor quant_matmul(QuantMatmulParams& params);
 
-torch::Tensor quantize(
-    NpuQuantizeParams& params);
+torch::Tensor quantize(NpuQuantizeParams& params);
 
 std::tuple<torch::Tensor, std::optional<torch::Tensor>> dynamic_quant(
     NpuQuantizeParams& params);
@@ -117,6 +116,19 @@ void fused_indexer_k(FusedIndexerKParams& params);
 // (and token_count/cusum outputs) on other backends.
 std::tuple<torch::Tensor, torch::Tensor, torch::Tensor, torch::Tensor>
 moe_init_routing_v2(MoeInitRoutingV2Params& params);
+
+std::tuple<torch::Tensor,
+           torch::Tensor,
+           torch::Tensor,
+           torch::Tensor,
+           torch::Tensor,
+           torch::Tensor,
+           torch::Tensor>
+moe_distribute_dispatch_v2(MoeDistributeDispatchV2Params& params);
+
+torch::Tensor moe_distribute_combine_v2(MoeDistributeCombineV2Params& params);
+
+bool has_moe_distribute_dispatch_combine_v2();
 
 // FP8 scaled quantize: quantizes input tensor to FP8 e4m3 format
 // Returns: (quantized_output, scale)

--- a/xllm/core/kernels/param.h
+++ b/xllm/core/kernels/param.h
@@ -1314,6 +1314,53 @@ struct MoeInitRoutingV2Params {
   int row_idx_type;
 };
 
+struct MoeDistributeDispatchV2Params {
+  torch::Tensor x;
+  torch::Tensor expert_ids;
+  std::optional<torch::Tensor> expert_scales = std::nullopt;
+  std::optional<torch::Tensor> x_active_mask = std::nullopt;
+  std::optional<torch::Tensor> scales = std::nullopt;
+  std::string group_ep;
+  int64_t ep_world_size = 1;
+  int64_t ep_rank_id = 0;
+  int64_t moe_expert_num = 1;
+  std::string group_tp;
+  int64_t tp_world_size = 0;
+  int64_t tp_rank_id = 0;
+  int64_t expert_shard_type = 0;
+  int64_t shared_expert_num = 1;
+  int64_t shared_expert_rank_num = 0;
+  int64_t quant_mode = 0;
+  int64_t global_bs = 0;
+  int64_t expert_token_nums_type = 1;
+  std::string comm_alg;
+};
+
+struct MoeDistributeCombineV2Params {
+  torch::Tensor expand_x;
+  torch::Tensor expert_ids;
+  torch::Tensor assist_info_for_combine;
+  torch::Tensor ep_send_counts;
+  torch::Tensor expert_scales;
+  std::optional<torch::Tensor> tp_send_counts = std::nullopt;
+  std::optional<torch::Tensor> x_active_mask = std::nullopt;
+  std::optional<torch::Tensor> expand_scales = std::nullopt;
+  std::optional<torch::Tensor> shared_expert_x = std::nullopt;
+  std::string group_ep;
+  int64_t ep_world_size = 1;
+  int64_t ep_rank_id = 0;
+  int64_t moe_expert_num = 1;
+  std::string group_tp;
+  int64_t tp_world_size = 0;
+  int64_t tp_rank_id = 0;
+  int64_t expert_shard_type = 0;
+  int64_t shared_expert_num = 1;
+  int64_t shared_expert_rank_num = 0;
+  int64_t global_bs = 0;
+  int64_t comm_quant_mode = 0;
+  std::string comm_alg;
+};
+
 // FP8 scaled quantize parameters
 // Quantizes input tensor to FP8 e4m3 format with scale
 struct Fp8ScaledQuantizeParams {

--- a/xllm/core/layers/npu_torch/fused_moe.cpp
+++ b/xllm/core/layers/npu_torch/fused_moe.cpp
@@ -19,13 +19,16 @@ limitations under the License.
 
 #include <algorithm>
 #include <cctype>
+#include <cstdint>
 #include <numeric>
 #include <sstream>
 #include <string>
 #include <vector>
 
+#include "common/global_flags.h"
 #include "framework/parallel_state/parallel_state.h"
 #include "kernels/ops_api.h"
+#include "layers/common/dp_utils.h"
 
 namespace xllm {
 namespace layer {
@@ -298,6 +301,12 @@ FusedMoEImpl::FusedMoEImpl(const ModelArgs& model_args,
   // calculate the number of experts per rank
   num_experts_per_rank_ = num_experts / ep_size;
   start_expert_id_ = ep_rank * num_experts_per_rank_;
+  enable_ep2_dispatch_combine_ =
+      is_deepseek_v4_ && FLAGS_expert_parallel_degree == 2 && ep_size > 1;
+  if (enable_ep2_dispatch_combine_) {
+    CHECK(parallel_args_.moe_ep_group_ != nullptr)
+        << "DeepSeek-V4 NPU EP2 dispatch/combine requires moe_ep_group.";
+  }
 
   if (topk_method == "noaux_tc") {
     e_score_correction_bias_ = register_parameter(
@@ -574,6 +583,37 @@ void FusedMoEImpl::resolve_quant_method_from_state_dict(
   }
 }
 
+void FusedMoEImpl::ensure_group_gemm_weight_layout(torch::Tensor& weight,
+                                                   bool& prepared,
+                                                   int64_t input_dim,
+                                                   int64_t output_dim,
+                                                   const char* name) {
+  CHECK(weight.defined()) << name << " must be defined.";
+  CHECK_EQ(weight.dim(), 3)
+      << name << " must be 3D [expert, *, *], got " << weight.sizes();
+
+  if (!prepared) {
+    if (weight.size(1) == output_dim && weight.size(2) == input_dim) {
+      weight = weight.transpose(1, 2);
+    } else if (weight.size(1) == input_dim && weight.size(2) == output_dim) {
+      // Already in grouped-matmul [expert, input, output] layout.
+    } else {
+      LOG(FATAL) << name << " shape " << weight.sizes()
+                 << " is incompatible with grouped matmul input_dim="
+                 << input_dim << " output_dim=" << output_dim;
+    }
+    prepared = true;
+  }
+
+  CHECK_EQ(weight.size(1), input_dim)
+      << name << " grouped matmul input dim mismatch after layout prepare, got "
+      << weight.sizes() << ", expected dim1=" << input_dim;
+  CHECK_EQ(weight.size(2), output_dim)
+      << name
+      << " grouped matmul output dim mismatch after layout prepare, got "
+      << weight.sizes() << ", expected dim2=" << output_dim;
+}
+
 torch::Tensor FusedMoEImpl::select_experts(
     const torch::Tensor& hidden_states_2d,
     const torch::Tensor& router_logits_2d,
@@ -692,9 +732,11 @@ torch::Tensor FusedMoEImpl::forward_expert(
         << "dynamic_quant must return per-token scale for W8A8 fused MoE.";
 
     // Step 5: first grouped matmul (int32 output expected for dequant+swiglu).
-    if (w13_.size(1) != quantized_expand_hidden_states.size(1)) {
-      w13_ = w13_.transpose(1, 2);
-    }
+    ensure_group_gemm_weight_layout(w13_,
+                                    w13_group_gemm_layout_prepared_,
+                                    quantized_expand_hidden_states.size(1),
+                                    local_intermediate_size_ * 2,
+                                    "w13");
 
     {
       std::vector<torch::Tensor> x_list = {quantized_expand_hidden_states};
@@ -726,9 +768,11 @@ torch::Tensor FusedMoEImpl::forward_expert(
     }
 
     // Step 7: second grouped matmul (dequant to hidden dtype).
-    if (w2_.size(1) != act_quantized.size(1)) {
-      w2_ = w2_.transpose(1, 2);
-    }
+    ensure_group_gemm_weight_layout(w2_,
+                                    w2_group_gemm_layout_prepared_,
+                                    act_quantized.size(1),
+                                    hidden_size_,
+                                    "w2");
     {
       std::vector<torch::Tensor> x_list = {act_quantized};
       std::vector<torch::Tensor> weight_list = {w2_};
@@ -845,9 +889,11 @@ torch::Tensor FusedMoEImpl::forward_expert(
     {
       xllm::kernel::GroupGemmParams group_gemm_params;
       group_gemm_params.a = expand_hidden_states;
-      if (w13_.size(1) != expand_hidden_states.size(1)) {
-        w13_ = w13_.transpose(1, 2);
-      }
+      ensure_group_gemm_weight_layout(w13_,
+                                      w13_group_gemm_layout_prepared_,
+                                      expand_hidden_states.size(1),
+                                      local_intermediate_size_ * 2,
+                                      "w13");
       group_gemm_params.b = w13_;
       group_gemm_params.group_list = selected_expert_info.token_count_slice;
       group_gemm_params.split_item = 2;
@@ -871,9 +917,11 @@ torch::Tensor FusedMoEImpl::forward_expert(
     {
       xllm::kernel::GroupGemmParams group_gemm_params;
       group_gemm_params.a = act_out;
-      if (w2_.size(1) != act_out.size(1)) {
-        w2_ = w2_.transpose(1, 2);
-      }
+      ensure_group_gemm_weight_layout(w2_,
+                                      w2_group_gemm_layout_prepared_,
+                                      act_out.size(1),
+                                      hidden_size_,
+                                      "w2");
       group_gemm_params.b = w2_;
       group_gemm_params.group_list = selected_expert_info.token_count_slice;
       group_gemm_params.split_item = 2;
@@ -883,13 +931,13 @@ torch::Tensor FusedMoEImpl::forward_expert(
     }
   }
 
-  // Step 8: combine the intermediate results and get the final hidden states
-  torch::Tensor final_hidden_states;
+  // Step 8: combine the intermediate results and get the final hidden states.
   xllm::kernel::MoeCombineResultParams moe_combine_params;
   moe_combine_params.input = gemm2_out;
   moe_combine_params.reduce_weight = selected_expert_info.reduce_weight;
   moe_combine_params.gather_ids = selected_expert_info.combine_idx;
-  final_hidden_states = xllm::kernel::moe_combine_result(moe_combine_params);
+  torch::Tensor final_hidden_states =
+      xllm::kernel::moe_combine_result(moe_combine_params);
   if (is_deepseek_v4_) {
     final_hidden_states = final_hidden_states * route_scale_;
   }
@@ -952,6 +1000,238 @@ torch::Tensor FusedMoEImpl::forward(const torch::Tensor& hidden_states,
   return output;
 }
 
+bool FusedMoEImpl::can_use_ep2_dispatch_combine(
+    const ModelInputParams& input_params,
+    const torch::Tensor& hidden_states) const {
+  if (!enable_ep2_dispatch_combine_) {
+    return false;
+  }
+  if (!all_dp_ranks_are_decode(input_params)) {
+    return false;
+  }
+  if (parallel_args_.dp_size() != 1) {
+    return false;
+  }
+  if (hidden_states.scalar_type() != torch::kHalf &&
+      hidden_states.scalar_type() != torch::kBFloat16) {
+    return false;
+  }
+  if (!parallel_args_.moe_ep_group_ ||
+      parallel_args_.moe_ep_group_->world_size() <= 1) {
+    return false;
+  }
+  if (!tp_pg_ || tp_pg_->world_size() != 1) {
+    return false;
+  }
+  if (is_w4a8_dynamic_quant_method(resolved_moe_quant_method_)) {
+    return false;
+  }
+  return xllm::kernel::has_moe_distribute_dispatch_combine_v2();
+}
+
+const std::string& FusedMoEImpl::get_moe_ep_group_name() {
+  if (moe_ep_group_name_.empty()) {
+    CHECK(parallel_args_.moe_ep_group_ != nullptr)
+        << "DeepSeek-V4 NPU EP2 dispatch/combine requires moe_ep_group.";
+    moe_ep_group_name_ = parallel_args_.moe_ep_group_->hccl_comm_name();
+  }
+  return moe_ep_group_name_;
+}
+
+torch::Tensor FusedMoEImpl::forward_with_selected_experts_ep2(
+    const torch::Tensor& hidden_states,
+    const torch::Tensor& topk_weights,
+    const torch::Tensor& topk_ids,
+    const ModelInputParams& input_params) {
+  (void)input_params;
+  const auto hidden_states_shape = hidden_states.sizes();
+  auto input_2d =
+      hidden_states.reshape({-1, hidden_states.size(-1)}).contiguous();
+  auto weights_2d =
+      topk_weights.reshape({-1, topk_}).to(torch::kFloat32).contiguous();
+  auto ids_2d = topk_ids.reshape({-1, topk_}).to(torch::kInt32).contiguous();
+  CHECK_EQ(weights_2d.size(0), input_2d.size(0))
+      << "topk_weights token count mismatch, expected " << input_2d.size(0)
+      << ", got " << weights_2d.size(0);
+  CHECK_EQ(ids_2d.size(0), input_2d.size(0))
+      << "topk_ids token count mismatch, expected " << input_2d.size(0)
+      << ", got " << ids_2d.size(0);
+
+  const auto ep_world_size = parallel_args_.moe_ep_group_->world_size();
+  const auto ep_rank_id = parallel_args_.moe_ep_group_->rank();
+  const auto global_bs = input_2d.size(0) * ep_world_size;
+
+  xllm::kernel::MoeDistributeDispatchV2Params dispatch_params;
+  dispatch_params.x = input_2d;
+  dispatch_params.expert_ids = ids_2d;
+  dispatch_params.expert_scales = weights_2d;
+  dispatch_params.group_ep = get_moe_ep_group_name();
+  dispatch_params.ep_world_size = ep_world_size;
+  dispatch_params.ep_rank_id = ep_rank_id;
+  dispatch_params.moe_expert_num = num_total_experts_;
+  dispatch_params.tp_world_size = 0;
+  dispatch_params.tp_rank_id = 0;
+  dispatch_params.expert_shard_type = 0;
+  dispatch_params.shared_expert_num = 1;
+  dispatch_params.shared_expert_rank_num = 0;
+  dispatch_params.quant_mode = 0;
+  dispatch_params.global_bs = global_bs;
+  dispatch_params.expert_token_nums_type = 1;
+
+  auto [expand_hidden_states,
+        dynamic_scale,
+        assist_info_for_combine,
+        group_list,
+        ep_send_counts,
+        tp_send_counts,
+        expand_scales] =
+      xllm::kernel::moe_distribute_dispatch_v2(dispatch_params);
+  (void)dynamic_scale;
+
+  torch::Tensor gemm1_out;
+  torch::Tensor gemm2_out;
+  const auto hidden_states_dtype = hidden_states.dtype().toScalarType();
+  if (is_w8a8_dynamic_quant_method(resolved_moe_quant_method_)) {
+    CHECK(w13_scale_is_loaded_ && w13_scale_.defined())
+        << "w13_scale is required for W8A8 EP2 dispatch/combine.";
+    CHECK(w2_scale_is_loaded_ && w2_scale_.defined())
+        << "w2_scale is required for W8A8 EP2 dispatch/combine.";
+
+    xllm::kernel::NpuQuantizeParams quant_params;
+    quant_params.input = expand_hidden_states;
+    torch::Tensor quantized_expand_hidden_states;
+    std::optional<torch::Tensor> pertoken_scale;
+    std::tie(quantized_expand_hidden_states, pertoken_scale) =
+        xllm::kernel::dynamic_quant(quant_params);
+    CHECK(pertoken_scale.has_value() && pertoken_scale->defined())
+        << "dynamic_quant must return per-token scale for W8A8 EP2 MoE.";
+
+    ensure_group_gemm_weight_layout(w13_,
+                                    w13_group_gemm_layout_prepared_,
+                                    quantized_expand_hidden_states.size(1),
+                                    local_intermediate_size_ * 2,
+                                    "w13");
+    {
+      std::vector<torch::Tensor> x_list = {quantized_expand_hidden_states};
+      std::vector<torch::Tensor> weight_list = {w13_};
+      xllm::kernel::GroupGemmParams group_gemm_params;
+      group_gemm_params.x_list = torch::TensorList(x_list);
+      group_gemm_params.weight_list = torch::TensorList(weight_list);
+      group_gemm_params.group_list = group_list.to(torch::kInt64);
+      group_gemm_params.split_item = 2;
+      group_gemm_params.group_type = 0;
+      group_gemm_params.group_list_type = 1;
+      group_gemm_params.output_dtype = torch::kInt32;
+      gemm1_out = xllm::kernel::group_gemm(group_gemm_params);
+    }
+
+    torch::Tensor act_quantized;
+    torch::Tensor act_scale;
+    {
+      xllm::kernel::DequantSwigluQuantParams params;
+      params.x = gemm1_out;
+      params.weight_scale = w13_scale_;
+      params.activation_scale = pertoken_scale.value();
+      params.group_index = group_list.to(torch::kInt64);
+      params.activate_left = true;
+      params.quant_mode = 1;
+      std::tie(act_quantized, act_scale) =
+          xllm::kernel::dequant_swiglu_quant(params);
+    }
+
+    ensure_group_gemm_weight_layout(w2_,
+                                    w2_group_gemm_layout_prepared_,
+                                    act_quantized.size(1),
+                                    hidden_size_,
+                                    "w2");
+    {
+      std::vector<torch::Tensor> x_list = {act_quantized};
+      std::vector<torch::Tensor> weight_list = {w2_};
+      std::vector<torch::Tensor> scale_list = {w2_scale_};
+      std::vector<torch::Tensor> per_token_scale_list = {act_scale};
+      xllm::kernel::GroupGemmParams group_gemm_params;
+      group_gemm_params.x_list = torch::TensorList(x_list);
+      group_gemm_params.weight_list = torch::TensorList(weight_list);
+      group_gemm_params.scale_list = torch::TensorList(scale_list);
+      group_gemm_params.per_token_scale_list =
+          torch::TensorList(per_token_scale_list);
+      group_gemm_params.group_list = group_list.to(torch::kInt64);
+      group_gemm_params.split_item = 2;
+      group_gemm_params.group_type = 0;
+      group_gemm_params.group_list_type = 1;
+      group_gemm_params.output_dtype = hidden_states_dtype;
+      gemm2_out = xllm::kernel::group_gemm(group_gemm_params);
+    }
+  } else {
+    {
+      xllm::kernel::GroupGemmParams group_gemm_params;
+      group_gemm_params.a = expand_hidden_states;
+      ensure_group_gemm_weight_layout(w13_,
+                                      w13_group_gemm_layout_prepared_,
+                                      expand_hidden_states.size(1),
+                                      local_intermediate_size_ * 2,
+                                      "w13");
+      group_gemm_params.b = w13_;
+      group_gemm_params.group_list = group_list.to(torch::kInt64);
+      group_gemm_params.split_item = 2;
+      group_gemm_params.group_type = 0;
+      group_gemm_params.group_list_type = 1;
+      gemm1_out = xllm::kernel::group_gemm(group_gemm_params);
+    }
+
+    torch::Tensor act_out;
+    xllm::kernel::ActivationParams activation_params;
+    activation_params.input = gemm1_out;
+    activation_params.output = act_out;
+    activation_params.act_mode = hidden_act_;
+    activation_params.is_gated = is_gated_;
+    xllm::kernel::active(activation_params);
+    act_out = activation_params.output;
+
+    {
+      xllm::kernel::GroupGemmParams group_gemm_params;
+      group_gemm_params.a = act_out;
+      ensure_group_gemm_weight_layout(w2_,
+                                      w2_group_gemm_layout_prepared_,
+                                      act_out.size(1),
+                                      hidden_size_,
+                                      "w2");
+      group_gemm_params.b = w2_;
+      group_gemm_params.group_list = group_list.to(torch::kInt64);
+      group_gemm_params.split_item = 2;
+      group_gemm_params.group_type = 0;
+      group_gemm_params.group_list_type = 1;
+      gemm2_out = xllm::kernel::group_gemm(group_gemm_params);
+    }
+  }
+
+  xllm::kernel::MoeDistributeCombineV2Params combine_params;
+  combine_params.expand_x = gemm2_out;
+  combine_params.expert_ids = ids_2d;
+  combine_params.assist_info_for_combine = assist_info_for_combine;
+  combine_params.ep_send_counts = ep_send_counts;
+  combine_params.expert_scales = weights_2d;
+  combine_params.tp_send_counts = tp_send_counts;
+  combine_params.expand_scales = expand_scales;
+  combine_params.group_ep = get_moe_ep_group_name();
+  combine_params.ep_world_size = ep_world_size;
+  combine_params.ep_rank_id = ep_rank_id;
+  combine_params.moe_expert_num = num_total_experts_;
+  combine_params.tp_world_size = 0;
+  combine_params.tp_rank_id = 0;
+  combine_params.expert_shard_type = 0;
+  combine_params.shared_expert_num = 1;
+  combine_params.shared_expert_rank_num = 0;
+  combine_params.global_bs = global_bs;
+  auto final_hidden_states_2d =
+      xllm::kernel::moe_distribute_combine_v2(combine_params);
+  if (is_deepseek_v4_) {
+    final_hidden_states_2d = final_hidden_states_2d * route_scale_;
+  }
+
+  return final_hidden_states_2d.reshape(hidden_states_shape);
+}
+
 torch::Tensor FusedMoEImpl::forward_with_selected_experts(
     const torch::Tensor& hidden_states,
     const torch::Tensor& topk_weights,
@@ -974,6 +1254,28 @@ torch::Tensor FusedMoEImpl::forward_with_selected_experts(
                                parallel_args_.dp_local_process_group_,
                                input_params.dp_global_token_nums);
     need_slice = true;
+  }
+
+  if (!need_slice && can_use_ep2_dispatch_combine(input_params, input)) {
+    std::optional<torch::Tensor> shared_output = std::nullopt;
+    if (n_shared_experts_ > 0) {
+      shared_output = shared_experts_(input);
+      if (should_apply_shared_expert_gate(shared_expert_gate_,
+                                          is_deepseek_v4_,
+                                          shared_expert_gate_is_loaded_)) {
+        auto gate = torch::sigmoid(shared_expert_gate_->forward(input));
+        if (shared_output.has_value()) {
+          torch::Tensor res = gate * shared_output.value();
+          shared_output = res;
+        }
+      }
+    }
+    auto output = forward_with_selected_experts_ep2(
+        input, selected_topk_weights, selected_topk_ids, input_params);
+    if (shared_output.has_value()) {
+      output = output + shared_output.value();
+    }
+    return output;
   }
 
   auto hidden_rows = input.reshape({-1, input.size(-1)}).size(0);

--- a/xllm/core/layers/npu_torch/fused_moe.h
+++ b/xllm/core/layers/npu_torch/fused_moe.h
@@ -18,6 +18,7 @@ limitations under the License.
 #include <torch/torch.h>
 
 #include <optional>
+#include <string>
 #include <utility>
 
 #include "framework/model/model_args.h"
@@ -95,6 +96,8 @@ class FusedMoEImpl : public torch::nn::Module {
   int64_t start_expert_id_;
   int64_t local_intermediate_size_;
   bool w4a8_dynamic_preprocessed_ = false;
+  bool w13_group_gemm_layout_prepared_ = false;
+  bool w2_group_gemm_layout_prepared_ = false;
 
   ReplicatedLinear gate_{nullptr};
   DenseMLP shared_experts_{nullptr};
@@ -129,7 +132,23 @@ class FusedMoEImpl : public torch::nn::Module {
   void resolve_quant_method_from_state_dict(const StateDict& state_dict);
   void validate_resolved_quant_method() const;
   void ensure_quant_weight_layout();
+  void ensure_group_gemm_weight_layout(torch::Tensor& weight,
+                                       bool& prepared,
+                                       int64_t input_dim,
+                                       int64_t output_dim,
+                                       const char* name);
   void preprocess_w4a8_dynamic_weights();
+  bool can_use_ep2_dispatch_combine(const ModelInputParams& input_params,
+                                    const torch::Tensor& hidden_states) const;
+  torch::Tensor forward_with_selected_experts_ep2(
+      const torch::Tensor& hidden_states,
+      const torch::Tensor& topk_weights,
+      const torch::Tensor& topk_ids,
+      const ModelInputParams& input_params);
+  const std::string& get_moe_ep_group_name();
+
+  bool enable_ep2_dispatch_combine_ = false;
+  std::string moe_ep_group_name_;
 };
 TORCH_MODULE(FusedMoE);
 


### PR DESCRIPTION
Add HCCL process-group comm name access and wrap MoeDistributeDispatchV2/CombineV2 for NPU.

Route DeepSeek-V4 decode MoE through dispatch/combine when expert_parallel_degree=2, and keep grouped GEMM weights in the expected layout.

Pass row_idx_type through MoeInitRoutingV2 for correct expert routing metadata.