### PR TITLE
feat: support MiniMax-M2.7 on npu device. 

### DIFF
--- a/tools/dequant_minimax_fp8.py
+++ b/tools/dequant_minimax_fp8.py
@@ -1,0 +1,264 @@
+#!/usr/bin/env python3
+"""Offline dequantize a MiniMax-M2.5 FP8 checkpoint into BF16 safetensors.
+
+The current xLLM MiniMax path dequantizes FP8 block weights during
+`load_state_dict`. This tool moves that work offline so repeated server
+restarts can reuse a dequantized checkpoint directory.
+
+Usage:
+    python tools/dequant_minimax_fp8.py \
+        --input-dir /models/MiniMax-M2.5 \
+        --output-dir /models/MiniMax-M2.5-bf16
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import shutil
+from pathlib import Path
+
+import torch
+from safetensors import safe_open
+from safetensors.torch import save_file
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Offline dequantize MiniMax-M2.5 FP8 safetensors to BF16."
+    )
+    parser.add_argument(
+        "--input-dir",
+        type=Path,
+        required=True,
+        help="Input MiniMax checkpoint directory.",
+    )
+    parser.add_argument(
+        "--output-dir",
+        type=Path,
+        required=True,
+        help="Output directory for the dequantized checkpoint.",
+    )
+    return parser.parse_args()
+
+
+def load_json(path: Path) -> dict:
+    with path.open("r", encoding="utf-8") as f:
+        return json.load(f)
+
+
+def save_json(path: Path, data: dict) -> None:
+    with path.open("w", encoding="utf-8") as f:
+        json.dump(data, f, indent=2, ensure_ascii=False, sort_keys=True)
+        f.write("\n")
+
+
+def is_fp8_dtype(dtype: torch.dtype) -> bool:
+    return dtype in {
+        torch.float8_e4m3fn,
+        torch.float8_e4m3fnuz,
+        torch.float8_e5m2,
+        torch.float8_e5m2fnuz,
+    }
+
+
+def dequantize_fp8_block_weight(
+    fp8_weight: torch.Tensor,
+    weight_scale_inv: torch.Tensor,
+    block_size: tuple[int, int],
+) -> torch.Tensor:
+    if fp8_weight.dim() != 2:
+        raise ValueError(
+            f"Only 2D fp8 weights are supported, got shape {tuple(fp8_weight.shape)}"
+        )
+    if weight_scale_inv.dim() != 2:
+        raise ValueError(
+            "FP8 weight scale tensor must be 2D, "
+            f"got shape {tuple(weight_scale_inv.shape)}"
+        )
+
+    block_n, block_k = block_size
+    n, k = fp8_weight.shape
+    n_tiles = (n + block_n - 1) // block_n
+    k_tiles = (k + block_k - 1) // block_k
+
+    if tuple(weight_scale_inv.shape) != (n_tiles, k_tiles):
+        raise ValueError(
+            "Unexpected fp8 scale shape "
+            f"{tuple(weight_scale_inv.shape)} for weight shape {tuple(fp8_weight.shape)}"
+        )
+
+    if n % block_n == 0 and k % block_k == 0:
+        weight_bf16 = fp8_weight.to(torch.bfloat16).reshape(
+            n_tiles, block_n, k_tiles, block_k
+        )
+        scale_bf16 = weight_scale_inv.to(torch.bfloat16).reshape(
+            n_tiles, 1, k_tiles, 1
+        )
+        return (weight_bf16 * scale_bf16).reshape(n, k)
+
+    expanded_scale = weight_scale_inv.repeat_interleave(block_n, 0).repeat_interleave(
+        block_k, 1
+    )
+    expanded_scale = expanded_scale[:n, :k].to(torch.bfloat16)
+    return fp8_weight.to(torch.bfloat16) * expanded_scale
+
+
+def discover_safetensor_files(input_dir: Path) -> tuple[list[str], dict[str, str]]:
+    index_path = input_dir / "model.safetensors.index.json"
+    if index_path.exists():
+        index_data = load_json(index_path)
+        weight_map = index_data["weight_map"]
+        files = sorted(set(weight_map.values()))
+        return files, weight_map
+
+    shard_paths = sorted(p.name for p in input_dir.glob("*.safetensors"))
+    if len(shard_paths) != 1:
+        raise ValueError(
+            "Expected model.safetensors.index.json or a single .safetensors shard "
+            f"under {input_dir}"
+        )
+    return shard_paths, {}
+
+
+def prepare_output_dir(output_dir: Path) -> None:
+    if output_dir.exists():
+        if any(output_dir.iterdir()):
+            raise ValueError(
+                f"Output directory {output_dir} already exists and is not empty"
+            )
+    else:
+        output_dir.mkdir(parents=True, exist_ok=True)
+
+
+def copy_non_safetensors_files(input_dir: Path, output_dir: Path) -> None:
+    for path in input_dir.iterdir():
+        if path.is_file() and path.suffix != ".safetensors":
+            if path.name in {"config.json", "model.safetensors.index.json"}:
+                continue
+            shutil.copy2(path, output_dir / path.name)
+
+
+def update_config(input_dir: Path, output_dir: Path) -> tuple[int, int]:
+    config_path = input_dir / "config.json"
+    if not config_path.exists():
+        raise ValueError(f"Missing config.json under {input_dir}")
+
+    config = load_json(config_path)
+    quant_config = config.get("quantization_config", {})
+    if quant_config.get("quant_method") != "fp8":
+        raise ValueError(
+            "This converter expects quantization_config.quant_method == 'fp8'"
+        )
+
+    block_size = quant_config.get("weight_block_size")
+    if not isinstance(block_size, list) or len(block_size) != 2:
+        raise ValueError(
+            "This converter expects quantization_config.weight_block_size to be a "
+            "2-element list"
+        )
+
+    config["torch_dtype"] = "bfloat16"
+    config.pop("quantization_config", None)
+    save_json(output_dir / "config.json", config)
+    return int(block_size[0]), int(block_size[1])
+
+
+def tensor_nbytes(tensor: torch.Tensor) -> int:
+    return tensor.numel() * tensor.element_size()
+
+
+def convert_shard(
+    input_path: Path, output_path: Path, block_size: tuple[int, int]
+) -> tuple[dict[str, str], int, int]:
+    converted: dict[str, torch.Tensor] = {}
+    shard_weight_map: dict[str, str] = {}
+    converted_fp8_tensors = 0
+    total_bytes = 0
+
+    with safe_open(input_path, framework="pt") as f:
+        keys = list(f.keys())
+        key_set = set(keys)
+        skipped = set()
+
+        for name in keys:
+            if name in skipped:
+                continue
+
+            if name.endswith(".weight_scale_inv"):
+                paired_weight_name = name[: -len("_scale_inv")]
+                if paired_weight_name in key_set:
+                    paired_weight = f.get_tensor(paired_weight_name)
+                    if is_fp8_dtype(paired_weight.dtype):
+                        skipped.add(name)
+                        continue
+
+            tensor = f.get_tensor(name)
+            if is_fp8_dtype(tensor.dtype):
+                scale_name = f"{name}_scale_inv"
+                if scale_name not in key_set:
+                    raise ValueError(
+                        f"Missing paired scale tensor {scale_name} for FP8 weight {name}"
+                    )
+                scale = f.get_tensor(scale_name)
+                tensor = dequantize_fp8_block_weight(tensor, scale, block_size)
+                skipped.add(scale_name)
+                converted_fp8_tensors += 1
+
+            converted[name] = tensor
+            shard_weight_map[name] = output_path.name
+            total_bytes += tensor_nbytes(tensor)
+
+    save_file(converted, str(output_path), metadata={"format": "pt"})
+    return shard_weight_map, converted_fp8_tensors, total_bytes
+
+
+def main() -> None:
+    args = parse_args()
+    input_dir = args.input_dir.resolve()
+    output_dir = args.output_dir.resolve()
+
+    if input_dir == output_dir:
+        raise ValueError("--input-dir and --output-dir must differ")
+
+    prepare_output_dir(output_dir)
+    copy_non_safetensors_files(input_dir, output_dir)
+    block_size = update_config(input_dir, output_dir)
+
+    shard_names, _ = discover_safetensor_files(input_dir)
+
+    total_weight_map: dict[str, str] = {}
+    total_size = 0
+    total_fp8_tensors = 0
+    total_shards = len(shard_names)
+
+    print(
+        f"Dequantizing MiniMax FP8 checkpoint from {input_dir} to {output_dir} "
+        f"with block_size={list(block_size)}"
+    )
+    for i, shard_name in enumerate(shard_names, start=1):
+        input_path = input_dir / shard_name
+        output_path = output_dir / shard_name
+        print(f"[{i}/{total_shards}] Processing {shard_name}")
+        shard_weight_map, converted_fp8_tensors, shard_bytes = convert_shard(
+            input_path, output_path, block_size
+        )
+        total_weight_map.update(shard_weight_map)
+        total_fp8_tensors += converted_fp8_tensors
+        total_size += shard_bytes
+
+    index_data = {
+        "metadata": {"total_size": total_size},
+        "weight_map": total_weight_map,
+    }
+    save_json(output_dir / "model.safetensors.index.json", index_data)
+    print(
+        "Done. Converted "
+        f"{total_fp8_tensors} fp8 tensors. "
+        f"Point MODEL_PATH to {output_dir} to use the bf16 checkpoint cache."
+    )
+
+
+if __name__ == "__main__":
+    main()
+

--- a/xllm/core/layers/npu/CMakeLists.txt
+++ b/xllm/core/layers/npu/CMakeLists.txt
@@ -35,6 +35,7 @@ cc_library(
     npu_glm4_decoder_layer_impl.h
     npu_rms_norm_impl.h
     npu_siglip_encoder_layer_impl.h
+    rotary_embedding.h
     ../common/rotary_embedding_util.h
     loader/qwen3_decoder_loader.h
     loader/qwen2_decoder_loader.h
@@ -86,6 +87,7 @@ cc_library(
     npu_glm4_decoder_layer_impl.cpp
     npu_rms_norm_impl.cpp
     npu_siglip_encoder_layer_impl.cpp
+    rotary_embedding.cpp
     ../common/rotary_embedding_util.cpp
     loader/qwen3_decoder_loader.cpp
     loader/qwen2_decoder_loader.cpp

--- a/xllm/core/layers/npu_torch/CMakeLists.txt
+++ b/xllm/core/layers/npu_torch/CMakeLists.txt
@@ -6,6 +6,9 @@ cc_library(
   HDRS
     fused_moe.h
     attention.h
+    minimax_m2_decode_layer.h
+    minimax_rms_norm.h
+    minimax_m2_attention.h
     qwen3_gated_delta_net_base.h
     qwen3_next_attention.h
     qwen3_next_gated_delta_net.h
@@ -16,6 +19,9 @@ cc_library(
   SRCS
     fused_moe.cpp
     attention.cpp
+    minimax_m2_decode_layer.cpp
+    minimax_rms_norm.cpp
+    minimax_m2_attention.cpp
     qwen3_gated_delta_net_base.cpp
     qwen3_next_attention.cpp
     qwen3_next_gated_delta_net.cpp
@@ -25,4 +31,5 @@ cc_library(
     qwen3_5_decoder_layer_impl.cpp
   DEPS
     :common_layers
+    :npu_layers
 )

--- a/xllm/core/layers/npu_torch/fused_moe.cpp
+++ b/xllm/core/layers/npu_torch/fused_moe.cpp
@@ -278,7 +278,9 @@ FusedMoEImpl::FusedMoEImpl(const ModelArgs& model_args,
       skip_gate_load_(moe_args.skip_gate_load),
       renormalize_(model_args.norm_topk_prob() ? 1 : 0),
       hidden_act_(model_args.hidden_act()),
-      scoring_func_(model_args.scoring_func()),
+      scoring_func_(model_args.scoring_func().empty()
+                        ? std::string("softmax")
+                        : model_args.scoring_func()),
       is_smoothquant_(quant_args.quant_method() == "smoothquant"),
       quant_args_(quant_args),
       parallel_args_(parallel_args),
@@ -618,20 +620,45 @@ torch::Tensor FusedMoEImpl::select_experts(
         << hidden_states_2d.size(0) << ", got " << topk_ids.size(0);
     topk_weights = topk_weights.to(hidden_states_2d.dtype());
   } else {
-    // prepare the parameters for select_experts
-    xllm::kernel::MoeFusedTopkParams moe_active_topk_params;
-    moe_active_topk_params.input = router_logits_2d;
-    moe_active_topk_params.topk = topk_;
-    // moe_active_topk_params.num_expert_group = num_expert_group_;
-    // moe_active_topk_params.topk_group = topk_group_;
-    moe_active_topk_params.normalize = static_cast<bool>(renormalize_);
-    // moe_active_topk_params.normed_by = "topk_logit";
-    moe_active_topk_params.scoring_func = scoring_func_;
-    // moe_active_topk_params.route_scale = route_scale_;
-    // moe_active_topk_params.e_score_correction_bias = e_score_correction_bias;
-    std::tie(topk_weights, topk_ids) =
-        xllm::kernel::moe_active_topk(moe_active_topk_params);
-    topk_ids = topk_ids.to(torch::kInt32);
+    // Use NPU fused kernel for simple softmax routing without bias.
+    if (scoring_func_ == "softmax" && !e_score_correction_bias_.defined()) {
+      xllm::kernel::MoeFusedTopkParams moe_active_topk_params;
+      moe_active_topk_params.input = router_logits_2d;
+      moe_active_topk_params.topk = topk_;
+      moe_active_topk_params.normalize = static_cast<bool>(renormalize_);
+      moe_active_topk_params.scoring_func = scoring_func_;
+      std::tie(topk_weights, topk_ids) =
+          xllm::kernel::moe_active_topk(moe_active_topk_params);
+      topk_ids = topk_ids.to(torch::kInt32);
+    } else {
+      // PyTorch-based routing for sigmoid scoring, routing bias, etc.
+      auto logits_f32 = router_logits_2d.to(torch::kFloat32);
+      torch::Tensor routing_scores;
+      if (scoring_func_ == "sigmoid") {
+        routing_scores = torch::sigmoid(logits_f32);
+      } else {
+        routing_scores = torch::softmax(logits_f32, /*dim=*/-1);
+      }
+
+      auto choice_scores = routing_scores;
+      if (e_score_correction_bias_.defined()) {
+        choice_scores = choice_scores + e_score_correction_bias_;
+      }
+
+      auto topk_result = torch::topk(choice_scores,
+                                     topk_,
+                                     /*dim=*/-1,
+                                     /*largest=*/true,
+                                     /*sorted=*/false);
+      topk_ids = std::get<1>(topk_result).to(torch::kInt32).contiguous();
+      topk_weights = routing_scores.gather(
+          /*dim=*/1, topk_ids.to(torch::kLong).contiguous());
+
+      if (renormalize_) {
+        topk_weights = topk_weights / (topk_weights.sum(-1, true) + 1e-6);
+      }
+      topk_weights = topk_weights.contiguous();
+    }
   }
 
   xllm::kernel::MoeInitRoutingV2Params moe_init_routing_params;

--- a/xllm/core/layers/npu_torch/minimax_m2_attention.cpp
+++ b/xllm/core/layers/npu_torch/minimax_m2_attention.cpp
@@ -1,0 +1,153 @@
+/* Copyright 2026 The xLLM Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://github.com/jd-opensource/xllm/blob/main/LICENSE
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include "minimax_m2_attention.h"
+
+#include "core/layers/common/rotary_embedding_util.h"
+
+namespace xllm {
+namespace layer {
+
+MiniMaxM2AttentionImpl::MiniMaxM2AttentionImpl(const ModelContext& context) {
+  const auto& args = context.get_model_args();
+  auto quant_args = context.get_quant_args();
+  if (quant_args.quant_method() == "fp8") {
+    quant_args.quant_method("");
+  }
+  const auto& parallel_args = context.get_parallel_args();
+  const auto& options = context.get_tensor_options();
+  const int64_t tp_size = parallel_args.tp_group_->world_size();
+  const int64_t total_num_heads = args.n_heads();
+  const int64_t total_num_kv_heads = args.n_kv_heads().value_or(args.n_heads());
+
+  CHECK(total_num_heads % tp_size == 0);
+  num_heads_ = total_num_heads / tp_size;
+  if (total_num_kv_heads >= tp_size) {
+    CHECK(total_num_kv_heads % tp_size == 0);
+    num_kv_heads_ = total_num_kv_heads / tp_size;
+    num_kv_head_replicas_ = 1;
+  } else {
+    CHECK(tp_size % total_num_kv_heads == 0);
+    num_kv_heads_ = 1;
+    num_kv_head_replicas_ = tp_size / total_num_kv_heads;
+  }
+
+  head_dim_ = args.head_dim();
+  q_size_ = num_heads_ * head_dim_;
+  kv_size_ = num_kv_heads_ * head_dim_;
+  CHECK_EQ(num_heads_ % num_kv_heads_, 0)
+      << "MiniMax local attention heads must be divisible by local kv heads";
+  scaling_ = std::sqrt(1.0f / head_dim_);
+  sliding_window_ = args.sliding_window();
+
+  qkv_proj_ = register_module("qkv_proj",
+                              layer::QKVParallelLinear(args.hidden_size(),
+                                                       num_heads_,
+                                                       num_kv_heads_,
+                                                       head_dim_,
+                                                       num_kv_head_replicas_,
+                                                       /*bias=*/false,
+                                                       /*gather_output=*/false,
+                                                       parallel_args,
+                                                       options));
+
+  o_proj_ =
+      register_module("o_proj",
+                      layer::RowParallelLinear(total_num_heads * head_dim_,
+                                               args.hidden_size(),
+                                               /*bias=*/false,
+                                               /*input_is_parallelized=*/true,
+                                               /*enable_result_reduction=*/true,
+                                               quant_args,
+                                               parallel_args.tp_group_,
+                                               options));
+
+  q_norm_tp_ =
+      register_module("q_norm",
+                      MiniMaxTensorParallelRMSNorm(q_size_,
+                                                   total_num_heads * head_dim_,
+                                                   /*replica_factor=*/1,
+                                                   args.rms_norm_eps(),
+                                                   parallel_args.tp_group_,
+                                                   options));
+  k_norm_tp_ = register_module(
+      "k_norm",
+      MiniMaxTensorParallelRMSNorm(kv_size_,
+                                   total_num_kv_heads * head_dim_,
+                                   num_kv_head_replicas_,
+                                   args.rms_norm_eps(),
+                                   parallel_args.tp_group_,
+                                   options));
+
+  const int64_t rotary_dim =
+      args.rotary_dim() > 0 ? args.rotary_dim() : args.head_dim();
+  const auto inv_freq =
+      layer::rotary::compute_inv_freq(rotary_dim, args.rope_theta(), options);
+  rotary_emb_ = register_module(
+      "rope",
+      std::make_shared<RotaryEmbeddingGeneric>(rotary_dim,
+                                               args.max_position_embeddings(),
+                                               inv_freq,
+                                               /*interleaved=*/false,
+                                               options));
+  attn_ = register_module("attn",
+                          layer::Attention(num_heads_,
+                                           head_dim_,
+                                           scaling_,
+                                           num_kv_heads_,
+                                           args.sliding_window()));
+}
+
+torch::Tensor MiniMaxM2AttentionImpl::forward(
+    const torch::Tensor& positions,
+    const torch::Tensor& hidden_states,
+    const layer::AttentionMetadata& attn_metadata,
+    KVCache& kv_cache) {
+  if (attn_metadata.is_dummy) {
+    return torch::zeros_like(hidden_states);
+  }
+
+  auto qkv = qkv_proj_->forward(hidden_states);
+  auto q = qkv.slice(/*dim=*/-1, 0, q_size_);
+  auto k = qkv.slice(/*dim=*/-1, q_size_, q_size_ + kv_size_);
+  auto v = qkv.slice(/*dim=*/-1, q_size_ + kv_size_, q_size_ + 2 * kv_size_);
+
+  const int64_t num_tokens = q.size(0);
+  std::tie(q, k) = forward_qk_rms_norm(q_norm_tp_, k_norm_tp_, q, k);
+
+  auto q_heads = q.view({num_tokens, num_heads_, head_dim_});
+  auto k_heads = k.view({num_tokens, num_kv_heads_, head_dim_});
+  auto v_heads = v.view({num_tokens, num_kv_heads_, head_dim_});
+
+  std::tie(q_heads, k_heads) =
+      rotary_emb_->forward(q_heads, k_heads, positions);
+
+  auto q_flat = q_heads.reshape({num_tokens, q_size_}).contiguous();
+  auto k_flat = k_heads.reshape({num_tokens, kv_size_}).contiguous();
+  auto v_flat = v_heads.reshape({num_tokens, kv_size_}).contiguous();
+  auto out = std::get<0>(
+      attn_->forward(attn_metadata, q_flat, k_flat, v_flat, kv_cache));
+  return o_proj_->forward(out);
+}
+
+void MiniMaxM2AttentionImpl::load_state_dict(const StateDict& state_dict) {
+  qkv_proj_->load_state_dict(state_dict, {"q_proj.", "k_proj.", "v_proj."});
+  o_proj_->load_state_dict(state_dict.get_dict_with_prefix("o_proj."));
+  q_norm_tp_->load_state_dict(state_dict.get_dict_with_prefix("q_norm."));
+  k_norm_tp_->load_state_dict(state_dict.get_dict_with_prefix("k_norm."));
+}
+
+}  // namespace layer
+}  // namespace xllm

--- a/xllm/core/layers/npu_torch/minimax_m2_attention.h
+++ b/xllm/core/layers/npu_torch/minimax_m2_attention.h
@@ -1,0 +1,61 @@
+/* Copyright 2026 The xLLM Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://github.com/jd-opensource/xllm/blob/main/LICENSE
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#pragma once
+
+#include <string>
+#include <vector>
+
+#include "core/framework/model_context.h"
+#include "core/layers/common/attention_metadata_builder.h"
+#include "core/layers/common/linear.h"
+#include "core/layers/npu/rotary_embedding.h"
+#include "core/layers/npu_torch/attention.h"
+#include "core/layers/npu_torch/minimax_rms_norm.h"
+
+namespace xllm {
+namespace layer {
+
+class MiniMaxM2AttentionImpl : public torch::nn::Module {
+ public:
+  explicit MiniMaxM2AttentionImpl(const ModelContext& context);
+
+  torch::Tensor forward(const torch::Tensor& positions,
+                        const torch::Tensor& hidden_states,
+                        const layer::AttentionMetadata& attn_metadata,
+                        KVCache& kv_cache);
+
+  void load_state_dict(const StateDict& state_dict);
+
+ private:
+  int64_t num_heads_ = 0;
+  int64_t num_kv_heads_ = 0;
+  int64_t num_kv_head_replicas_ = 0;
+  int64_t head_dim_ = 0;
+  int64_t q_size_ = 0;
+  int64_t kv_size_ = 0;
+  int64_t sliding_window_ = -1;
+  float scaling_ = 1.0f;
+  layer::QKVParallelLinear qkv_proj_{nullptr};
+  layer::RowParallelLinear o_proj_{nullptr};
+  MiniMaxTensorParallelRMSNorm q_norm_tp_{nullptr};
+  MiniMaxTensorParallelRMSNorm k_norm_tp_{nullptr};
+  std::shared_ptr<NpuRotaryEmbedding> rotary_emb_;
+  layer::Attention attn_{nullptr};
+};
+TORCH_MODULE(MiniMaxM2Attention);
+
+}  // namespace layer
+}  // namespace xllm

--- a/xllm/core/layers/npu_torch/minimax_m2_decode_layer.cpp
+++ b/xllm/core/layers/npu_torch/minimax_m2_decode_layer.cpp
@@ -1,0 +1,83 @@
+/* Copyright 2026 The xLLM Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://github.com/jd-opensource/xllm/blob/main/LICENSE
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include "minimax_m2_decode_layer.h"
+
+namespace xllm {
+namespace layer {
+
+MiniMaxM2DecoderLayerImpl::MiniMaxM2DecoderLayerImpl(
+    const ModelContext& context,
+    int32_t layer_id) {
+  const auto& model_args = context.get_model_args();
+  auto quant_args = context.get_quant_args();
+  if (quant_args.quant_method() == "fp8") {
+    quant_args.quant_method("");
+  }
+  const auto& parallel_args = context.get_parallel_args();
+  const auto& options = context.get_tensor_options();
+
+  attention_ = register_module("self_attn", MiniMaxM2Attention(context));
+  input_norm_ = register_module(
+      "input_layernorm",
+      layer::RMSNorm(
+          model_args.hidden_size(), model_args.rms_norm_eps(), options));
+  post_norm_ = register_module(
+      "post_attention_layernorm",
+      layer::RMSNorm(
+          model_args.hidden_size(), model_args.rms_norm_eps(), options));
+
+  layer::FusedMoEArgs moe_args;
+  moe_ = register_module(
+      "mlp",
+      layer::FusedMoE(
+          model_args, moe_args, quant_args, parallel_args, options));
+}
+
+torch::Tensor MiniMaxM2DecoderLayerImpl::forward(
+    torch::Tensor& x,
+    std::optional<torch::Tensor>& residual,
+    torch::Tensor& positions,
+    const layer::AttentionMetadata& attn_metadata,
+    KVCache& kv_cache,
+    const ModelInputParams& input_params) {
+  if (x.numel() == 0) {
+    return moe_->forward(x, input_params);
+  }
+
+  if (!residual.has_value()) {
+    residual = x;
+    x = std::get<0>(input_norm_->forward(x));
+  } else {
+    std::tie(x, residual) = input_norm_->forward(x, residual);
+  }
+
+  x = attention_->forward(positions, x, attn_metadata, kv_cache);
+  std::tie(x, residual) = post_norm_->forward(x, residual);
+  x = moe_->forward(x, input_params);
+  return x;
+}
+
+void MiniMaxM2DecoderLayerImpl::load_state_dict(const StateDict& state_dict) {
+  attention_->load_state_dict(state_dict.get_dict_with_prefix("self_attn."));
+  input_norm_->load_state_dict(
+      state_dict.get_dict_with_prefix("input_layernorm."));
+  post_norm_->load_state_dict(
+      state_dict.get_dict_with_prefix("post_attention_layernorm."));
+  moe_->load_state_dict(state_dict.get_dict_with_prefix("mlp."));
+}
+
+}  // namespace layer
+}  // namespace xllm

--- a/xllm/core/layers/npu_torch/minimax_m2_decode_layer.h
+++ b/xllm/core/layers/npu_torch/minimax_m2_decode_layer.h
@@ -1,0 +1,50 @@
+/* Copyright 2026 The xLLM Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://github.com/jd-opensource/xllm/blob/main/LICENSE
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#pragma once
+
+#include <string>
+
+#include "core/framework/model_context.h"
+#include "core/layers/common/rms_norm.h"
+#include "core/layers/npu_torch/fused_moe.h"
+#include "minimax_m2_attention.h"
+
+namespace xllm {
+namespace layer {
+
+class MiniMaxM2DecoderLayerImpl : public torch::nn::Module {
+ public:
+  MiniMaxM2DecoderLayerImpl(const ModelContext& context, int32_t layer_id);
+
+  torch::Tensor forward(torch::Tensor& x,
+                        std::optional<torch::Tensor>& residual,
+                        torch::Tensor& positions,
+                        const layer::AttentionMetadata& attn_metadata,
+                        KVCache& kv_cache,
+                        const ModelInputParams& input_params);
+
+  void load_state_dict(const StateDict& state_dict);
+
+ private:
+  MiniMaxM2Attention attention_{nullptr};
+  layer::FusedMoE moe_{nullptr};
+  layer::RMSNorm input_norm_{nullptr};
+  layer::RMSNorm post_norm_{nullptr};
+};
+TORCH_MODULE(MiniMaxM2DecoderLayer);
+
+}  // namespace layer
+}  // namespace xllm

--- a/xllm/core/layers/npu_torch/minimax_rms_norm.cpp
+++ b/xllm/core/layers/npu_torch/minimax_rms_norm.cpp
@@ -1,0 +1,133 @@
+/* Copyright 2026 The xLLM Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://github.com/jd-opensource/xllm/blob/main/LICENSE
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include "minimax_rms_norm.h"
+
+namespace xllm {
+namespace layer {
+
+MiniMaxTensorParallelRMSNormImpl::MiniMaxTensorParallelRMSNormImpl(
+    int64_t local_dim,
+    int64_t global_dim,
+    int64_t replica_factor,
+    double eps,
+    ProcessGroup* process_group,
+    const torch::TensorOptions& options)
+    : local_dim_(local_dim),
+      global_dim_(global_dim),
+      replica_factor_(replica_factor),
+      eps_(eps),
+      process_group_(process_group) {
+  CHECK(process_group_ != nullptr)
+      << "MiniMaxTensorParallelRMSNorm requires tp process group";
+  CHECK_GT(replica_factor_, 0);
+  CHECK_EQ(process_group_->world_size() % replica_factor_, 0)
+      << "tp world size " << process_group_->world_size()
+      << " must be divisible by replica factor " << replica_factor_;
+  const int64_t effective_world_size =
+      process_group_->world_size() / replica_factor_;
+  CHECK_GT(effective_world_size, 0);
+  CHECK_EQ(global_dim_ % effective_world_size, 0)
+      << "global_dim " << global_dim_
+      << " must be divisible by effective world size " << effective_world_size;
+  CHECK_EQ(local_dim_, global_dim_ / effective_world_size)
+      << "unexpected local shard size for TP RMSNorm";
+
+  weight_ = register_parameter(
+      "weight", torch::empty({local_dim_}, options), /*requires_grad=*/false);
+}
+
+torch::Tensor MiniMaxTensorParallelRMSNormImpl::forward(
+    const torch::Tensor& input) {
+  auto org_shape = input.sizes().vec();
+  auto input_2d = input.reshape({-1, local_dim_});
+  auto input_fp32 = input_2d.to(torch::kFloat32);
+  auto sq_sum = (input_fp32 * input_fp32).sum(/*dim=*/-1, /*keepdim=*/true);
+  if (process_group_->world_size() > 1) {
+    sq_sum = parallel_state::reduce(sq_sum, process_group_);
+  }
+
+  const float inv_global_dim =
+      1.0f / static_cast<float>(global_dim_ * replica_factor_);
+  auto inv_rms = torch::rsqrt(sq_sum * inv_global_dim + eps_);
+  auto normalized = (input_fp32 * inv_rms).to(input_2d.scalar_type());
+  auto output = normalized * weight_.view({1, local_dim_});
+  return output.view(org_shape);
+}
+
+void MiniMaxTensorParallelRMSNormImpl::load_state_dict(
+    const StateDict& state_dict) {
+  if (weight_is_loaded_) {
+    return;
+  }
+
+  const int64_t rank = process_group_->rank() / replica_factor_;
+  const int64_t world_size = process_group_->world_size() / replica_factor_;
+  auto tensor = state_dict.get_sharded_tensor("weight", 0, rank, world_size);
+  if (!tensor.defined()) {
+    return;
+  }
+
+  CHECK_EQ(weight_.sizes(), tensor.sizes())
+      << "weight size mismatch for " << state_dict.prefix() << "weight";
+  weight_.copy_(tensor);
+  weight_is_loaded_ = true;
+}
+
+std::tuple<torch::Tensor, torch::Tensor> forward_qk_rms_norm(
+    MiniMaxTensorParallelRMSNorm& q_norm,
+    MiniMaxTensorParallelRMSNorm& k_norm,
+    const torch::Tensor& query,
+    const torch::Tensor& key) {
+  CHECK(q_norm->process_group() != nullptr &&
+        q_norm->process_group() == k_norm->process_group())
+      << "forward_qk requires q_norm and k_norm to share the same process "
+         "group";
+
+  auto q_org_shape = query.sizes().vec();
+  auto k_org_shape = key.sizes().vec();
+  const auto q_2d =
+      query.reshape({-1, q_norm->local_dim()}).to(torch::kFloat32);
+  const auto k_2d = key.reshape({-1, k_norm->local_dim()}).to(torch::kFloat32);
+
+  auto q_var = (q_2d * q_2d).mean(/*dim=*/-1, /*keepdim=*/true);
+  auto k_var = (k_2d * k_2d).mean(/*dim=*/-1, /*keepdim=*/true);
+
+  if (q_norm->process_group()->world_size() > 1) {
+    auto qk_var = torch::cat({q_var, k_var}, /*dim=*/-1);
+    qk_var = parallel_state::reduce(qk_var, q_norm->process_group());
+    auto chunks = qk_var.chunk(2, /*dim=*/-1);
+    q_var = chunks[0];
+    k_var = chunks[1];
+  }
+
+  const int64_t q_effective_ws =
+      q_norm->process_group()->world_size() / q_norm->replica_factor();
+  const int64_t k_effective_ws =
+      k_norm->process_group()->world_size() / k_norm->replica_factor();
+  q_var = q_var / static_cast<double>(q_effective_ws);
+  k_var = k_var / static_cast<double>(k_effective_ws);
+
+  auto q_out =
+      (q_2d * torch::rsqrt(q_var + q_norm->eps())).to(query.scalar_type());
+  auto k_out =
+      (k_2d * torch::rsqrt(k_var + k_norm->eps())).to(key.scalar_type());
+  q_out = (q_out * q_norm->weight()).view(q_org_shape);
+  k_out = (k_out * k_norm->weight()).view(k_org_shape);
+  return std::make_tuple(std::move(q_out), std::move(k_out));
+}
+
+}  // namespace layer
+}  // namespace xllm

--- a/xllm/core/layers/npu_torch/minimax_rms_norm.h
+++ b/xllm/core/layers/npu_torch/minimax_rms_norm.h
@@ -1,0 +1,65 @@
+/* Copyright 2026 The xLLM Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://github.com/jd-opensource/xllm/blob/main/LICENSE
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#pragma once
+
+#include <torch/torch.h>
+
+#include <tuple>
+
+#include "core/framework/parallel_state/parallel_state.h"
+#include "framework/state_dict/state_dict.h"
+#include "framework/state_dict/utils.h"
+
+namespace xllm {
+namespace layer {
+
+class MiniMaxTensorParallelRMSNormImpl : public torch::nn::Module {
+ public:
+  MiniMaxTensorParallelRMSNormImpl(int64_t local_dim,
+                                   int64_t global_dim,
+                                   int64_t replica_factor,
+                                   double eps,
+                                   ProcessGroup* process_group,
+                                   const torch::TensorOptions& options);
+
+  torch::Tensor forward(const torch::Tensor& input);
+
+  const torch::Tensor& weight() const { return weight_; }
+  double eps() const { return eps_; }
+  ProcessGroup* process_group() const { return process_group_; }
+  int64_t local_dim() const { return local_dim_; }
+  int64_t replica_factor() const { return replica_factor_; }
+
+  void load_state_dict(const StateDict& state_dict);
+
+ private:
+  DEFINE_WEIGHT(weight);
+  int64_t local_dim_ = 0;
+  int64_t global_dim_ = 0;
+  int64_t replica_factor_ = 1;
+  double eps_ = 1e-6;
+  ProcessGroup* process_group_ = nullptr;
+};
+TORCH_MODULE(MiniMaxTensorParallelRMSNorm);
+
+std::tuple<torch::Tensor, torch::Tensor> forward_qk_rms_norm(
+    MiniMaxTensorParallelRMSNorm& q_norm,
+    MiniMaxTensorParallelRMSNorm& k_norm,
+    const torch::Tensor& query,
+    const torch::Tensor& key);
+
+}  // namespace layer
+}  // namespace xllm

--- a/xllm/models/llm/npu/minimax_m2.h
+++ b/xllm/models/llm/npu/minimax_m2.h
@@ -1,0 +1,462 @@
+/* Copyright 2025 The xLLM Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://github.com/jd-opensource/xllm/blob/main/LICENSE
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#pragma once
+
+#include <absl/strings/match.h>
+#include <absl/strings/str_replace.h>
+#include <glog/logging.h>
+
+#include <array>
+#include <memory>
+#include <string>
+#include <unordered_map>
+#include <unordered_set>
+#include <vector>
+
+#include "core/common/global_flags.h"
+#include "core/common/interruption_bus.h"
+#include "core/framework/hf_model_loader.h"
+#include "core/framework/model/model_input_params.h"
+#include "core/framework/model/model_output.h"
+#include "core/framework/model_context.h"
+#include "core/framework/model_loader.h"
+#include "core/layers/common/attention_mask.h"
+#include "core/layers/common/attention_metadata_builder.h"
+#include "core/layers/common/lm_head.h"
+#include "core/layers/common/word_embedding.h"
+#include "core/layers/npu_torch/minimax_m2_decode_layer.h"
+
+namespace xllm::npu::model {
+
+class MiniMaxM2MoeDecoderLayerImpl : public torch::nn::Module {
+ public:
+  MiniMaxM2MoeDecoderLayerImpl(const ModelContext& context, int32_t layer_id) {
+    const auto& quant_args = context.get_quant_args();
+
+    if (quant_args.quant_method() == "fp8") {
+      enable_fp8_dynamic_dequant_ = true;
+      if (quant_args.weight_block_size().size() == 2 &&
+          quant_args.weight_block_size()[0] > 0 &&
+          quant_args.weight_block_size()[1] > 0) {
+        fp8_weight_block_size_ = {quant_args.weight_block_size()[0],
+                                  quant_args.weight_block_size()[1]};
+      }
+    }
+
+    layer_ = register_module("layer",
+                             layer::MiniMaxM2DecoderLayer(context, layer_id));
+  }
+
+  torch::Tensor forward(torch::Tensor& x,
+                        std::optional<torch::Tensor>& residual,
+                        torch::Tensor& positions,
+                        const layer::AttentionMetadata& attn_metadata,
+                        KVCache& kv_cache,
+                        const ModelInputParams& input_params) {
+    return layer_->forward(
+        x, residual, positions, attn_metadata, kv_cache, input_params);
+  }
+
+  void load_state_dict(const StateDict& state_dict) {
+    std::unordered_map<std::string, torch::Tensor> remapped;
+    remapped.reserve(state_dict.size());
+    std::unordered_map<std::string, torch::Tensor> pending_fp8_weights;
+    std::unordered_map<std::string, torch::Tensor> pending_fp8_scales;
+
+    for (const auto& [name, tensor] : state_dict) {
+      std::string mapped_name = remap_layer_weight_name(name);
+      if (enable_fp8_dynamic_dequant_) {
+        if (absl::EndsWith(mapped_name, ".weight_scale_inv")) {
+          const std::string paired_weight_name =
+              mapped_name.substr(0, mapped_name.size() - 10);
+          auto pending_weight = pending_fp8_weights.find(paired_weight_name);
+          if (pending_weight != pending_fp8_weights.end()) {
+            remapped.emplace(
+                paired_weight_name,
+                dequantize_fp8_block_weight(
+                    pending_weight->second, tensor, fp8_weight_block_size_));
+            pending_fp8_weights.erase(pending_weight);
+          } else {
+            pending_fp8_scales.emplace(mapped_name, tensor);
+          }
+          continue;
+        }
+
+        if (absl::EndsWith(mapped_name, ".weight") &&
+            is_fp8_dtype(tensor.scalar_type())) {
+          const std::string scale_name = mapped_name + "_scale_inv";
+          auto pending_scale = pending_fp8_scales.find(scale_name);
+          if (pending_scale != pending_fp8_scales.end()) {
+            remapped.emplace(
+                mapped_name,
+                dequantize_fp8_block_weight(
+                    tensor, pending_scale->second, fp8_weight_block_size_));
+            pending_fp8_scales.erase(pending_scale);
+          } else {
+            pending_fp8_weights.emplace(mapped_name, tensor);
+          }
+          continue;
+        }
+      }
+
+      remapped.emplace(mapped_name, tensor);
+    }
+
+    if (enable_fp8_dynamic_dequant_) {
+      CHECK(pending_fp8_weights.empty() && pending_fp8_scales.empty())
+          << "Unpaired fp8 MiniMax-M2 weight/scale tensors detected: "
+          << "pending_weights=" << pending_fp8_weights.size()
+          << ", pending_scales=" << pending_fp8_scales.size();
+    }
+
+    layer_->load_state_dict(StateDict(std::move(remapped)));
+  }
+
+ private:
+  static std::string remap_layer_weight_name(const std::string& name) {
+    std::string mapped_name = name;
+    if (absl::StartsWith(mapped_name, "block_sparse_moe.")) {
+      mapped_name =
+          absl::StrReplaceAll(mapped_name, {{"block_sparse_moe.", "mlp."}});
+    }
+    if (mapped_name == "mlp.e_score_correction_bias") {
+      return "mlp.gate.e_score_correction_bias";
+    }
+    mapped_name = absl::StrReplaceAll(mapped_name,
+                                      {{".w1.", ".gate_proj."},
+                                       {".w2.", ".down_proj."},
+                                       {".w3.", ".up_proj."}});
+    return mapped_name;
+  }
+
+  static bool is_fp8_dtype(torch::ScalarType dtype) {
+    return dtype == torch::kFloat8_e5m2 || dtype == torch::kFloat8_e4m3fn;
+  }
+
+  static torch::Tensor dequantize_fp8_block_weight(
+      const torch::Tensor& fp8_weight,
+      const torch::Tensor& weight_scale_inv,
+      const std::array<int64_t, 2>& block_size) {
+    CHECK_EQ(fp8_weight.dim(), 2)
+        << "Only 2D fp8 weights are supported, got shape "
+        << fp8_weight.sizes();
+    CHECK_EQ(weight_scale_inv.dim(), 2)
+        << "FP8 weight scale tensor must be 2D, got shape "
+        << weight_scale_inv.sizes();
+
+    const int64_t block_n = block_size[0];
+    const int64_t block_k = block_size[1];
+    const int64_t n = fp8_weight.size(0);
+    const int64_t k = fp8_weight.size(1);
+    const int64_t n_tiles = (n + block_n - 1) / block_n;
+    const int64_t k_tiles = (k + block_k - 1) / block_k;
+
+    CHECK_EQ(weight_scale_inv.size(0), n_tiles)
+        << "Unexpected fp8 scale shape " << weight_scale_inv.sizes()
+        << " for weight shape " << fp8_weight.sizes();
+    CHECK_EQ(weight_scale_inv.size(1), k_tiles)
+        << "Unexpected fp8 scale shape " << weight_scale_inv.sizes()
+        << " for weight shape " << fp8_weight.sizes();
+
+    if (n % block_n == 0 && k % block_k == 0) {
+      auto weight_bf16 = fp8_weight.to(torch::kBFloat16)
+                             .reshape({n_tiles, block_n, k_tiles, block_k});
+      auto scale_bf16 = weight_scale_inv.to(torch::kBFloat16)
+                            .reshape({n_tiles, 1, k_tiles, 1});
+      return (weight_bf16 * scale_bf16).reshape({n, k});
+    }
+
+    auto expanded_scale = weight_scale_inv.repeat_interleave(block_n, 0)
+                              .repeat_interleave(block_k, 1);
+    expanded_scale = expanded_scale.slice(/*dim=*/0, /*start=*/0, /*end=*/n)
+                         .slice(/*dim=*/1, /*start=*/0, /*end=*/k)
+                         .to(torch::kBFloat16);
+    return fp8_weight.to(torch::kBFloat16) * expanded_scale;
+  }
+
+  layer::MiniMaxM2DecoderLayer layer_{nullptr};
+  bool enable_fp8_dynamic_dequant_ = false;
+  std::array<int64_t, 2> fp8_weight_block_size_ = {128, 128};
+};
+TORCH_MODULE(MiniMaxM2MoeDecoderLayer);
+
+class MiniMaxM2ModelImpl : public torch::nn::Module {
+ public:
+  explicit MiniMaxM2ModelImpl(const ModelContext& context) {
+    InterruptionBus::get_instance().subscribe(
+        [this](bool interrupted) { layer_forward_interrupted_ = interrupted; });
+
+    const auto& options = context.get_tensor_options();
+    const auto& model_args = context.get_model_args();
+    const auto& parallel_args = context.get_parallel_args();
+
+    enable_mla_ = model_args.enable_mla();
+
+    embed_tokens_ =
+        register_module("embed_tokens",
+                        layer::WordEmbedding(model_args.vocab_size(),
+                                             model_args.hidden_size(),
+                                             parallel_args,
+                                             options));
+    norm_ = register_module("norm", layer::RMSNorm(context));
+
+    int32_t mask_value = FLAGS_enable_chunked_prefill ? -9984 : 1;
+    attn_mask_ = layer::AttentionMask(
+        options.device(), options.dtype().toScalarType(), mask_value);
+
+    layers_.reserve(model_args.n_layers());
+    for (int32_t i = 0; i < model_args.n_layers(); ++i) {
+      layers_.push_back(register_module(std::to_string(i),
+                                        MiniMaxM2MoeDecoderLayer(context, i)));
+    }
+  }
+
+  ModelOutput forward(torch::Tensor tokens,
+                      torch::Tensor positions,
+                      std::vector<KVCache>& kv_caches,
+                      const ModelInputParams& input_params) {
+    ModelInputParams modified_input_params = input_params;
+    torch::Tensor h;
+    if (input_params.input_embedding.defined()) {
+      h = input_params.input_embedding;
+    } else if (tokens.numel() == 0) {
+      h = torch::empty({0, hidden_size_}, embed_tokens_->weight().options());
+    } else {
+      h = embed_tokens_(tokens);
+    }
+
+    if (!modified_input_params.attn_metadata) {
+      modified_input_params.attn_metadata =
+          std::make_shared<layer::AttentionMetadata>(
+              get_attention_metadata(modified_input_params, h));
+    }
+
+    auto& attn_metadata = *(modified_input_params.attn_metadata);
+    std::optional<torch::Tensor> residual;
+    for (size_t i = 0; i < layers_.size(); ++i) {
+      h = layers_[i]->forward(h,
+                              residual,
+                              positions,
+                              attn_metadata,
+                              kv_caches[i],
+                              modified_input_params);
+    }
+
+    if (h.numel() == 0) {
+      return ModelOutput(h);
+    }
+
+    auto [hidden_states, residual_out] = norm_(h, residual);
+    return ModelOutput(hidden_states, residual_out);
+  }
+
+  void load_state_dict(const StateDict& state_dict) {
+    embed_tokens_->load_state_dict(
+        state_dict.get_dict_with_prefix("embed_tokens."));
+
+    for (size_t i = 0; i < layers_.size(); ++i) {
+      layers_[i]->load_state_dict(
+          state_dict.get_dict_with_prefix("layers." + std::to_string(i) + "."));
+    }
+
+    norm_->load_state_dict(state_dict.get_dict_with_prefix("norm."));
+  }
+
+  torch::Tensor get_input_embeddings(torch::Tensor input_ids) {
+    return embed_tokens_(input_ids);
+  }
+
+  layer::WordEmbedding get_word_embedding() { return embed_tokens_; }
+
+  void set_word_embedding(layer::WordEmbedding& word_embedding) {
+    embed_tokens_ = word_embedding;
+  }
+
+ private:
+  layer::AttentionMetadata get_attention_metadata(
+      const ModelInputParams& params,
+      const torch::Tensor& h) {
+    if (params.q_max_seq_len == 0) {
+      return layer::AttentionMetadataBuilder::build(params, enable_mla_);
+    }
+
+    max_seq_len_ = std::max(params.kv_max_seq_len, max_seq_len_);
+    torch::Tensor attn_mask;
+    if (FLAGS_enable_chunked_prefill) {
+      const int32_t max_kv_seq = params.kv_max_seq_len;
+      const int32_t num_sequences = params.num_sequences;
+      if (num_sequences > 0) {
+        std::vector<torch::Tensor> req_mask_vec;
+        req_mask_vec.reserve(num_sequences);
+        for (int32_t j = 0; j < num_sequences; ++j) {
+          req_mask_vec.emplace_back(
+              attn_mask_.gen_append_mask(params.q_seq_lens_vec[j],
+                                         params.kv_seq_lens_vec[j],
+                                         max_kv_seq,
+                                         h.dtype().toScalarType(),
+                                         h.device()));
+        }
+        attn_mask = torch::cat(req_mask_vec, 0);
+      } else {
+        attn_mask = attn_mask_.get_attn_mask(
+            max_seq_len_, h.dtype().toScalarType(), h.device());
+      }
+    } else {
+      attn_mask = attn_mask_.get_attn_mask(
+          max_seq_len_, h.dtype().toScalarType(), h.device());
+    }
+    return layer::AttentionMetadataBuilder::build(
+        params, enable_mla_, attn_mask);
+  }
+
+  std::vector<MiniMaxM2MoeDecoderLayer> layers_;
+  layer::WordEmbedding embed_tokens_{nullptr};
+  layer::RMSNorm norm_{nullptr};
+  layer::AttentionMask attn_mask_;
+  int64_t hidden_size_ = 0;
+  int32_t max_seq_len_ = 0;
+  bool enable_mla_ = false;
+  bool layer_forward_interrupted_ = false;
+};
+TORCH_MODULE(MiniMaxM2Model);
+
+class MiniMaxM2ForCausalLMImpl : public torch::nn::Module {
+ public:
+  explicit MiniMaxM2ForCausalLMImpl(const ModelContext& context) {
+    tie_word_embeddings_ = context.get_model_args().tie_word_embeddings();
+    model_ = register_module("model", MiniMaxM2Model(context));
+    lm_head_ = register_module("lm_head", layer::LmHead(context));
+  }
+
+  ModelOutput forward(const torch::Tensor& tokens,
+                      const torch::Tensor& positions,
+                      std::vector<KVCache>& kv_caches,
+                      const ModelInputParams& input_params) {
+    return model_(tokens, positions, kv_caches, input_params);
+  }
+
+  torch::Tensor logits(const torch::Tensor& hidden_states,
+                       const torch::Tensor& selected_idxes) {
+    auto h = hidden_states;
+    if (selected_idxes.defined()) {
+      h = h.index_select(/*dim=*/0, selected_idxes);
+    }
+    return lm_head_(h);
+  }
+
+  torch::Tensor pooler(const torch::Tensor& hidden_states,
+                       const torch::Tensor& selected_idxes) {
+    if (selected_idxes.defined()) {
+      return hidden_states.index_select(/*dim=*/0, selected_idxes);
+    }
+    return hidden_states;
+  }
+
+  void load_model(std::unique_ptr<ModelLoader> loader,
+                  std::string prefix = "model.") {
+    for (const auto& state_dict : loader->get_state_dicts()) {
+      model_->load_state_dict(state_dict->get_dict_with_prefix(prefix));
+      if (tie_word_embeddings_) {
+        lm_head_->load_state_dict(
+            state_dict->get_dict_with_prefix(prefix + "embed_tokens."));
+      } else {
+        lm_head_->load_state_dict(state_dict->get_dict_with_prefix("lm_head."));
+      }
+    }
+  }
+
+  void prepare_expert_weight(int32_t layer_id,
+                             const std::vector<int32_t>& expert_ids) {
+    (void)layer_id;
+    (void)expert_ids;
+  }
+
+  void update_expert_weight(int32_t layer_id) { (void)layer_id; }
+
+  layer::LmHead get_lm_head() { return lm_head_; }
+
+  void set_lm_head(layer::LmHead& head) { lm_head_ = head; }
+
+  layer::WordEmbedding get_word_embedding() {
+    return model_->get_word_embedding();
+  }
+
+  void set_word_embedding(layer::WordEmbedding& word_embedding) {
+    model_->set_word_embedding(word_embedding);
+  }
+
+ private:
+  MiniMaxM2Model model_{nullptr};
+  bool tie_word_embeddings_ = false;
+  layer::LmHead lm_head_{nullptr};
+};
+TORCH_MODULE(MiniMaxM2ForCausalLM);
+
+REGISTER_CAUSAL_MODEL(minimax_m2, MiniMaxM2ForCausalLM);
+
+REGISTER_MODEL_ARGS(minimax_m2, [&] {
+  LOAD_ARG_OR(model_type, "model_type", "minimax_m2");
+  LOAD_ARG_OR(dtype, "torch_dtype", "bfloat16");
+  LOAD_ARG_OR(attention_bias, "attention_bias", false);
+  LOAD_ARG_OR(attention_dropout, "attention_dropout", 0.0f);
+  LOAD_ARG_OR(bos_token_id, "bos_token_id", 200019);
+  LOAD_ARG_OR(eos_token_id, "eos_token_id", 200020);
+  LOAD_ARG_OR(head_dim, "head_dim", 128);
+  LOAD_ARG_OR(rotary_dim, "rotary_dim", 64);
+  LOAD_ARG_OR(hidden_act, "hidden_act", "silu");
+  LOAD_ARG_OR(hidden_size, "hidden_size", 3072);
+  LOAD_ARG_OR(intermediate_size, "intermediate_size", 1536);
+  LOAD_ARG_OR(max_position_embeddings, "max_position_embeddings", 196608);
+  LOAD_ARG_OR(max_window_layers, "max_window_layers", 62);
+  LOAD_ARG_OR(moe_intermediate_size, "intermediate_size", 1536);
+  SET_ARG(n_shared_experts, 0);
+  LOAD_ARG_OR(norm_topk_prob, "norm_topk_prob", true);
+  LOAD_ARG_OR(n_heads, "num_attention_heads", 48);
+  LOAD_ARG_OR(num_experts, "num_local_experts", 256);
+  LOAD_ARG_OR(n_routed_experts, "num_local_experts", 256);
+  LOAD_ARG_OR(num_experts_per_tok, "num_experts_per_tok", 8);
+  LOAD_ARG_OR(n_group, "n_group", 1);
+  LOAD_ARG_OR(n_layers, "num_hidden_layers", 62);
+  if (json.contains("attn_type_list")) {
+    const auto attn_type_list =
+        json.value_or<std::vector<int>>("attn_type_list", std::vector<int>());
+    if (!attn_type_list.empty() &&
+        args->n_layers() != static_cast<int32_t>(attn_type_list.size())) {
+      LOG(WARNING) << "MiniMax config mismatch: num_hidden_layers="
+                   << args->n_layers()
+                   << ", attn_type_list size=" << attn_type_list.size()
+                   << ". Using attn_type_list size.";
+      args->n_layers() = static_cast<int32_t>(attn_type_list.size());
+    }
+  }
+  LOAD_ARG_OR(n_kv_heads, "num_key_value_heads", 8);
+  LOAD_ARG_OR(output_router_logits, "output_router_logits", false);
+  LOAD_ARG_OR(rms_norm_eps, "rms_norm_eps", 1e-6);
+  LOAD_ARG_OR(rope_theta, "rope_theta", 5000000.0f);
+  LOAD_ARG_OR(scoring_func, "scoring_func", "sigmoid");
+  LOAD_ARG_OR(topk_group, "topk_group", 1);
+  LOAD_ARG_OR(routed_scaling_factor, "routed_scaling_factor", 1.0f);
+  LOAD_ARG_OR(router_aux_loss_coef, "router_aux_loss_coef", 0.0f);
+  LOAD_ARG_OR(use_sliding_window, "use_sliding_window", false);
+  LOAD_ARG_OR(tie_word_embeddings, "tie_word_embeddings", false);
+  LOAD_ARG_OR(vocab_size, "vocab_size", 200064);
+  LOAD_ARG_OR(mlp_only_layers, "mlp_only_layers", std::vector<int>());
+
+  SET_ARG(stop_token_ids, std::unordered_set<int32_t>({args->eos_token_id()}));
+  SET_ARG(topk_method, "noaux_tc");
+});
+
+}  // namespace xllm::npu::model

--- a/xllm/models/model_registry.cpp
+++ b/xllm/models/model_registry.cpp
@@ -73,7 +73,8 @@ bool is_torch_only_model_type(const std::string& model_type) {
       "qwen3_5_moe_text",
       "qwen3_5_mtp",
       "qwen3_5_moe_mtp",
-      "qwen3_next"};
+      "qwen3_next",
+      "minimax_m2"};
   return kTorchOnlyModelTypes.count(model_type) != 0;
 }
 #endif

--- a/xllm/models/models.h
+++ b/xllm/models/models.h
@@ -35,6 +35,7 @@ limitations under the License.
 #include "llm/npu/kimi_k2.h"                  // IWYU pragma: keep
 #include "llm/npu/llama.h"                    // IWYU pragma: keep
 #include "llm/npu/llama3.h"                   // IWYU pragma: keep
+#include "llm/npu/minimax_m2.h"               // IWYU pragma: keep
 #include "llm/npu/oxygen.h"                   // IWYU pragma: keep
 #include "llm/npu/qwen2.h"                    // IWYU pragma: keep
 #include "llm/npu/qwen3.h"                    // IWYU pragma: keep


### PR DESCRIPTION
Complete MiniMax-M2.7 model adaptation for xllm on Ascend NPU:
- Full eager mode support with TP=16 tensor parallelism
- FP8 dynamic block dequantization at layer level