### PR TITLE
bugfix: fix high concurrency linear state overflow.

### DIFF
--- a/xllm/core/distributed_runtime/llm_engine.cpp
+++ b/xllm/core/distributed_runtime/llm_engine.cpp
@@ -528,7 +528,7 @@ KVCacheCapacity LLMEngine::estimate_kv_cache_capacity() {
   }
 #endif
 
-  kv_cache_cap.num_linear_state_blocks() = FLAGS_max_seqs_per_batch + 2;
+  kv_cache_cap.num_linear_state_blocks() = FLAGS_max_concurrent_requests + 2;
   for (int64_t layer_id = 0; layer_id < kv_cache_cap.n_layers(); ++layer_id) {
     if (is_full_attention_layer(args_, layer_id)) {
       ++kv_cache_cap.num_full_attention_layers();
@@ -551,8 +551,8 @@ KVCacheCapacity LLMEngine::estimate_kv_cache_capacity() {
     CHECK_GT(kv_cache_cap.cache_size_in_bytes(),
              kv_cache_cap.linear_cache_size_in_bytes())
         << "failed to reserve linear state cache for linear-attention layers: "
-        << "max_seqs_per_batch (" << FLAGS_max_seqs_per_batch
-        << ") is too large. Please reduce max_seqs_per_batch to less than "
+        << "max_concurrent_requests (" << FLAGS_max_concurrent_requests
+        << ") is too large. Please reduce max_concurrent_requests to less than "
         << kv_cache_cap.cache_size_in_bytes() /
                    (kv_cache_cap.num_linear_attention_layers() *
                     kv_cache_cap.linear_slot_size()) -

--- a/xllm/core/distributed_runtime/vlm_engine.cpp
+++ b/xllm/core/distributed_runtime/vlm_engine.cpp
@@ -275,7 +275,7 @@ KVCacheCapacity VLMEngine::estimate_kv_cache_capacity() {
   kv_cache_cap.n_layers() = args_.n_layers();
   kv_cache_cap.block_size() = options_.block_size();
 
-  kv_cache_cap.num_linear_state_blocks() = options_.max_seqs_per_batch() + 2;
+  kv_cache_cap.num_linear_state_blocks() = FLAGS_max_concurrent_requests + 2;
   for (int64_t layer_id = 0; layer_id < kv_cache_cap.n_layers(); ++layer_id) {
     if (is_full_attention_layer(args_, layer_id)) {
       ++kv_cache_cap.num_full_attention_layers();
@@ -297,7 +297,7 @@ KVCacheCapacity VLMEngine::estimate_kv_cache_capacity() {
     CHECK_GT(kv_cache_cap.cache_size_in_bytes(),
              kv_cache_cap.linear_cache_size_in_bytes())
         << "failed to reserve linear state cache for VLM linear-attention "
-        << "layers: max_seqs_per_batch (" << options_.max_seqs_per_batch()
+        << "layers: max_concurrent_requests (" << FLAGS_max_concurrent_requests
         << ") is too large.";
   }
   CHECK_GT(available_full_cache_size_in_bytes, 0)


### PR DESCRIPTION

## Summary

Fixes a crash in `aclnnCausalConv1d` operator when concurrent requests exceed `max_seqs_per_batch`.

## Problem

When running high concurrency tests (e.g., 19 concurrent requests with default `max_seqs_per_batch=16`), the service crashes with an internal error in the `aclnnCausalConv1d` operator:

```
Check failed: workspace_status == 0
call aclnnCausalConv1d failed, detail:EH9999: Inner Error!
CausalConv1d do tiling failed, ret is -1.
```

## Root Cause

There is a mismatch between the capacity of `conv_cache` and the block IDs allocated by `SingleBlockManager`:

- **`SingleBlockManager`** allocates block IDs based on `FLAGS_max_concurrent_requests + 2` (default: 202).
- **`conv_cache`** (linear state blocks) is allocated based on `FLAGS_max_seqs_per_batch + 2` (default: 18).

When concurrency exceeds `max_seqs_per_batch`, the `linear_state_indices` passed to `causal_conv1d` contains values larger than the `conv_cache` size, causing an out-of-bounds access and operator failure.

## Fix

Update `num_linear_state_blocks` calculation in `llm_engine.cpp` and `vlm_engine.cpp` to use `FLAGS_max_concurrent_requests + 2`, aligning it with `SingleBlockManager`'s allocation logic.

## Changes

- `xllm/core/distributed_runtime/llm_engine.cpp`: Use `FLAGS_max_concurrent_requests` for capacity calculation.
- `xllm/core/distributed_runtime/vlm_engine.cpp`: Same fix for VLM engine.
- Updated error messages to reference the correct configuration parameter.

## Testing

- Verified 19 concurrent requests pass without crashes (previously failed at 19).
- Verified 18 concurrent requests still work correctly.

---
