### PR TITLE
feat: add TileLang chunk_gated_delta_rule_fwd_h kernel.

### DIFF
--- a/xllm/compiler/tilelang/patches/tilelang_ascend/0001-install-ascend.patch
+++ b/xllm/compiler/tilelang/patches/tilelang_ascend/0001-install-ascend.patch
@@ -1,4 +1,18 @@
+diff --git a/install_ascend.sh b/install_ascend.sh
+index 48785a9..ed9187c 100644
+--- a/install_ascend.sh
++++ b/install_ascend.sh
+@@ -162,7 +162,7 @@ MAKE_JOBS=$(( CORES * 50 / 100 ))
+ if [ $MAKE_JOBS -lt 1 ]; then
+     MAKE_JOBS=1
+ fi
+-make -j${MAKE_JOBS}
++make -j
+ 
+ if [ $? -ne 0 ]; then
+     echo "Error: TileLang build failed."
 diff --git a/requirements-build.txt b/requirements-build.txt
+index 784cb60..4c2318f 100644
 --- a/requirements-build.txt
 +++ b/requirements-build.txt
 @@ -1,6 +1,5 @@
@@ -8,16 +22,3 @@ diff --git a/requirements-build.txt b/requirements-build.txt
  packaging
  setuptools>=61
  torch
-diff --git a/install_ascend.sh b/install_ascend.sh
---- a/install_ascend.sh
-+++ b/install_ascend.sh
-@@ -140,8 +140,8 @@ echo "Building TileLang with make..."
- # Other wise, make will use all available cores
- # and it may cause the system to be unresponsive
- CORES=$(nproc)
- MAKE_JOBS=$(( CORES * 50 / 100 ))
--make -j${MAKE_JOBS}
-+make -j
- 
- if [ $? -ne 0 ]; then
-     echo "Error: TileLang build failed."

--- a/xllm/compiler/tilelang/targets/ascend/kernels/chunk_gated_delta_rule_fwd_h.py
+++ b/xllm/compiler/tilelang/targets/ascend/kernels/chunk_gated_delta_rule_fwd_h.py
@@ -1,0 +1,817 @@
+import argparse
+from pathlib import Path
+
+import tilelang
+from tilelang import language as T
+import torch
+
+from ....common.spec import DispatchField, TilelangKernel, register_kernel
+
+tilelang.cache.clear_cache()
+
+CHUNK_SIZE = 64
+INPUT_SCALE = 0.01
+GATE_SCALE = 0.002
+
+COMPILE_BT = 64
+DEFAULT_DTYPE = "bf16"
+DEFAULT_ACCUM_DTYPE = "float32"
+
+N_SPECIALIZATION_MIN = 1
+N_SPECIALIZATION_MAX = 32
+N_SPECIALIZATION_STEP = 1
+N_SPECIALIZATIONS = tuple(
+    range(N_SPECIALIZATION_MIN, N_SPECIALIZATION_MAX + 1, N_SPECIALIZATION_STEP)
+)
+
+_AOT_PASS_CONFIGS = {
+    "tl.ascend_auto_sync": False,
+    "tl.ascend_auto_cv_combine": False,
+    "tl.ascend_auto_cross_core_sync": False,
+    "tl.ascend_memory_planning": False,
+}
+
+pass_configs = {
+    tilelang.PassConfigKey.TL_ASCEND_AUTO_SYNC: False,
+    tilelang.PassConfigKey.TL_ASCEND_AUTO_CV_COMBINE: False,
+    tilelang.PassConfigKey.TL_ASCEND_AUTO_CV_SYNC: False,
+    tilelang.PassConfigKey.TL_ASCEND_MEMORY_PLANNING: False,
+}
+
+
+# ==========================================
+# 1. Helper Functions
+# ==========================================
+def _prepare_lens(cu_seqlens: torch.LongTensor) -> torch.LongTensor:
+    return cu_seqlens[1:] - cu_seqlens[:-1]
+
+
+def _prepare_chunk_offsets(
+    cu_seqlens: torch.LongTensor, chunk_size: int
+) -> torch.LongTensor:
+    lens = _prepare_lens(cu_seqlens)
+    nt_per_seq = (lens + chunk_size - 1) // chunk_size
+    return torch.cat(
+        [
+            torch.zeros(1, dtype=torch.int64, device=cu_seqlens.device),
+            nt_per_seq,
+        ]
+    ).cumsum(-1)
+
+
+# ==========================================
+# 2. AOT Build Function
+# ==========================================
+def _build_chunk_gated_delta_rule_fwd_h_kernel(
+    N: int,
+    H: int,
+    Hg: int,
+    K: int,
+    V: int,
+    dtype: str = DEFAULT_DTYPE,
+    accum_dtype: str = DEFAULT_ACCUM_DTYPE,
+    bt: int = COMPILE_BT,
+    use_g: bool = True,
+    store_final_state: bool = True,
+    save_new_value: bool = True,
+):
+    V_half = V // 2
+    input_dtype = "bfloat16"
+
+    NT_sym = T.symbolic("nt")
+    T_total_sym = T.symbolic("total_t")
+
+    SEM_WH_C2V = 0
+    SEM_VNEW_V2C = 2
+    SEM_HUPD_C2V = 4
+    SEM_H_V2C = 6
+
+    @T.prim_func
+    def main(
+        h: T.Tensor([N, NT_sym, H, K, V], input_dtype),
+        k: T.Tensor([T_total_sym, Hg, K], input_dtype),
+        v: T.Tensor([T_total_sym, H, V], input_dtype),
+        w: T.Tensor([T_total_sym, H, K], input_dtype),
+        g: T.Tensor([T_total_sym, H], accum_dtype),
+        v_new: T.Tensor([T_total_sym, H, V], input_dtype),
+        h0: T.Tensor([N, H, K, V], input_dtype),
+        ht: T.Tensor([N, H, K, V], accum_dtype),
+        cu_seqlens: T.Tensor([N + 1], "int32"),
+        ws_wh: T.Tensor([N, H, 2, bt, V_half], accum_dtype),
+        ws_vnew: T.Tensor([N, H, 2, bt, V_half], input_dtype),
+        ws_hupd: T.Tensor([N, H, 2, K, V_half], accum_dtype),
+        ws_h: T.Tensor([N, H, 2, K, V_half], input_dtype),
+    ):
+        with T.Kernel(N * H, is_npu=True) as (cid, vid):
+            i_n = cid // H
+            i_h = cid % H
+
+            hg_ratio = H // Hg
+            k_head = i_h // hg_ratio
+
+            h_state_ub = T.alloc_ub([2, K // 2, V_half], input_dtype)
+            h_state_ub_float = T.alloc_ub([2, K // 2, V_half], accum_dtype)
+            hupd_ub_float = T.alloc_ub([2, K // 2, V_half], accum_dtype)
+            wh_ub_float = T.alloc_ub([2, bt // 2, V_half], accum_dtype)
+
+            v_chunk_ub = T.alloc_ub([2, 2, bt // 2, V_half], input_dtype)
+            v_chunk_ub_float = T.alloc_ub([2, bt // 2, V_half], accum_dtype)
+
+            g_chunk_ub = T.alloc_ub([2, bt // 2], accum_dtype)
+            g_last_scalar = T.alloc_ub([1], accum_dtype)
+            g_exp_ub = T.alloc_ub([bt // 2], accum_dtype)
+            g_exp_ub_broc = T.alloc_ub([bt // 2, V_half], accum_dtype)
+
+            k_chunk_l1 = T.alloc_L1([2, bt, K], input_dtype)
+            w_chunk_l1 = T.alloc_L1([2, bt, K], input_dtype)
+            h_state_l1 = T.alloc_L1([2, K, V_half], input_dtype)
+            wh_frag = T.alloc_L0C([2, bt, V_half], accum_dtype)
+            v_new_l1 = T.alloc_L1([2, bt, V_half], input_dtype)
+            hupd_frag = T.alloc_L0C([2, K, V_half], accum_dtype)
+
+            with T.Scope("C"):
+                bos = cu_seqlens[i_n]
+                eos = cu_seqlens[i_n + 1]
+                T_len = eos - bos
+                NT_i = T.ceildiv(T_len, bt)
+
+                actual_len = T.if_then_else(T_len < bt, T_len, bt)
+                T.copy(w[bos : bos + actual_len, i_h, :], w_chunk_l1[0, :, :])
+                T.copy(k[bos : bos + actual_len, k_head, :], k_chunk_l1[0, :, :])
+                T.set_flag("mte2", "m", 0)
+
+                for i in T.serial(NT_i):
+                    pid = i % 2
+                    next_pid = (i + 1) % 2
+                    chunk_start_next = bos + (i + 1) * bt
+
+                    chunk_len = T.if_then_else(i * bt + bt > T_len, T_len - i * bt, bt)
+
+                    if i + 1 < NT_i:
+                        next_len = T.if_then_else(
+                            (i + 1) * bt + bt > T_len, T_len - (i + 1) * bt, bt
+                        )
+                        T.copy(
+                            w[chunk_start_next : chunk_start_next + next_len, i_h, :],
+                            w_chunk_l1[next_pid, :, :],
+                        )
+                        T.copy(
+                            k[
+                                chunk_start_next : chunk_start_next + next_len,
+                                k_head,
+                                :,
+                            ],
+                            k_chunk_l1[next_pid, :, :],
+                        )
+                        T.set_flag("mte2", "m", next_pid)
+
+                    # w @ h
+                    T.wait_flag("mte2", "m", pid)
+                    for j in T.serial(2):
+                        T.wait_cross_flag(SEM_H_V2C + j)
+                        T.copy(ws_h[i_n, i_h, j, :, :], h_state_l1[j, :, :])
+                        T.set_flag("mte2", "m", 2)
+                        T.wait_flag("mte2", "m", 2)
+                        T.gemm_v0(
+                            w_chunk_l1[pid, :, :],
+                            h_state_l1[j, :, :],
+                            wh_frag[j, :, :],
+                            init=True,
+                        )
+                        T.set_flag("m", "fix", 3)
+                        T.wait_flag("m", "fix", 3)
+                        T.copy(wh_frag[j, :, :], ws_wh[i_n, i_h, j, :, :])
+                        T.set_cross_flag("FIX", SEM_WH_C2V + j)
+
+                    # k @ v_new
+                    for j in T.serial(2):
+                        T.wait_cross_flag(SEM_VNEW_V2C + j)
+                        T.copy(ws_vnew[i_n, i_h, j, :chunk_len, :], v_new_l1[j, :, :])
+                        T.set_flag("mte2", "m", 4)
+                        T.wait_flag("mte2", "m", 4)
+                        T.gemm_v0(
+                            k_chunk_l1[pid, :, :],
+                            v_new_l1[j, :, :],
+                            hupd_frag[j, :, :],
+                            transpose_A=True,
+                            init=True,
+                        )
+                        T.set_flag("m", "fix", 5)
+                        T.wait_flag("m", "fix", 5)
+                        T.copy(hupd_frag[j, :, :], ws_hupd[i_n, i_h, j, :, :])
+                        T.set_cross_flag("FIX", SEM_HUPD_C2V + j)
+
+            with T.Scope("V"):
+                bos = cu_seqlens[i_n]
+                eos = cu_seqlens[i_n + 1]
+                T_len = eos - bos
+                NT_i = T.ceildiv(T_len, bt)
+
+                for j in T.serial(2):
+                    T.copy(
+                        h0[
+                            i_n,
+                            i_h,
+                            K // 2 * vid : K // 2 * vid + K // 2,
+                            j * V_half : (j + 1) * V_half,
+                        ],
+                        h_state_ub[j, :, :],
+                    )
+                    T.set_flag("mte2", "v", 12)
+                    T.wait_flag("mte2", "v", 12)
+                    T.copy(h_state_ub[j, :, :], h_state_ub_float[j, :, :])
+
+                chunk_len = T.if_then_else(T_len < bt, T_len, bt)
+                vec_chunk_len = T.if_then_else(
+                    vid == 0, T.min(bt // 2, chunk_len), T.max(chunk_len - bt // 2, 0)
+                )
+                vec_start_in_chunk = T.if_then_else(vid == 0, 0, bt // 2)
+                vec_global_start = bos + vec_start_in_chunk
+
+                for j in T.serial(2):
+                    T.copy(
+                        v[
+                            vec_global_start : vec_global_start + vec_chunk_len,
+                            i_h,
+                            j * V_half : (j + 1) * V_half,
+                        ],
+                        v_chunk_ub[0, j, :, :],
+                    )
+                if use_g:
+                    T.copy(
+                        g[vec_global_start : vec_global_start + vec_chunk_len, i_h],
+                        g_chunk_ub[0, :],
+                    )
+                T.set_flag("mte2", "v", 2)
+
+                for i in T.serial(NT_i):
+                    pid = i % 2
+                    next_pid = (i + 1) % 2
+                    v_flag_pid = pid + 2
+                    v_flag_next = next_pid + 2
+                    g_start = bos + i * bt
+                    g_start_next = bos + (i + 1) * bt
+
+                    chunk_len = T.if_then_else(i * bt + bt > T_len, T_len - i * bt, bt)
+                    vec_chunk_len = T.if_then_else(
+                        vid == 0,
+                        T.min(bt // 2, chunk_len),
+                        T.max(chunk_len - bt // 2, 0),
+                    )
+                    vec_start_in_chunk = T.if_then_else(vid == 0, 0, bt // 2)
+
+                    # v[t+1], g[t+1]
+                    if i + 1 < NT_i:
+                        next_chunk_len = T.if_then_else(
+                            (i + 1) * bt + bt > T_len, T_len - (i + 1) * bt, bt
+                        )
+                        next_vec_start_in_chunk = T.if_then_else(vid == 0, 0, bt // 2)
+                        next_vec_chunk_len = T.if_then_else(
+                            vid == 0,
+                            T.min(bt // 2, next_chunk_len),
+                            T.max(next_chunk_len - bt // 2, 0),
+                        )
+                        next_vec_global_start = g_start_next + next_vec_start_in_chunk
+
+                        for j in T.serial(2):
+                            T.copy(
+                                v[
+                                    next_vec_global_start : next_vec_global_start
+                                    + next_vec_chunk_len,
+                                    i_h,
+                                    j * V_half : (j + 1) * V_half,
+                                ],
+                                v_chunk_ub[next_pid, j, :, :],
+                            )
+                        if use_g:
+                            T.copy(
+                                g[
+                                    next_vec_global_start : next_vec_global_start
+                                    + next_vec_chunk_len,
+                                    i_h,
+                                ],
+                                g_chunk_ub[next_pid, :],
+                            )
+                        T.set_flag("mte2", "v", v_flag_next)
+
+                    # h to cube
+                    for j in T.serial(2):
+                        T.copy(h_state_ub_float[j, :, :], h_state_ub[j, :, :])
+                        T.set_flag("v", "mte3", 11)
+                        T.wait_flag("v", "mte3", 11)
+                        T.copy(
+                            h_state_ub[j, :, :],
+                            ws_h[i_n, i_h, j, K // 2 * vid : K // 2 * vid + K // 2, :],
+                        )
+                        T.set_cross_flag("MTE3", SEM_H_V2C + j)
+                        # save h[t]
+                        T.copy(
+                            h_state_ub[j, :, :],
+                            h[
+                                i_n,
+                                i,
+                                i_h,
+                                K // 2 * vid : K // 2 * vid + K // 2,
+                                j * V_half : (j + 1) * V_half,
+                            ],
+                        )
+
+                    T.wait_flag("mte2", "v", v_flag_pid)
+                    # prepare gating
+                    if use_g:
+                        g_last = T.if_then_else(
+                            i * bt + bt <= T_len,
+                            g[g_start + bt - 1, i_h],
+                            g[g_start + T_len - i * bt - 1, i_h],
+                        )
+
+                        T.tile.fill(g_exp_ub, g_last)
+                        T.set_flag("mte2", "v", 4)
+                        T.wait_flag("mte2", "v", 4)
+                        T.tile.sub(g_exp_ub, g_exp_ub, g_chunk_ub[pid, :])
+                        T.tile.exp(g_exp_ub, g_exp_ub)
+                        T.tile.broadcast(g_exp_ub_broc, g_exp_ub, axis=1)
+
+                        T.tile.fill(g_last_scalar, g_last)
+                        T.tile.exp(g_last_scalar, g_last_scalar)
+
+                    for j in T.serial(2):
+                        T.copy(v_chunk_ub[pid, j, :, :], v_chunk_ub_float[j, :, :])
+
+                        # v_new = v - w @ h
+                        T.wait_cross_flag(SEM_WH_C2V + j)
+                        T.copy(
+                            ws_wh[
+                                i_n,
+                                i_h,
+                                j,
+                                vec_start_in_chunk : vec_start_in_chunk + bt // 2,
+                                :,
+                            ],
+                            wh_ub_float[j, :, :],
+                        )
+                        T.set_flag("mte2", "v", 5)
+                        T.wait_flag("mte2", "v", 5)
+                        T.tile.sub(
+                            v_chunk_ub_float[j, :, :],
+                            v_chunk_ub_float[j, :, :],
+                            wh_ub_float[j, :, :],
+                        )
+
+                        if save_new_value:
+                            T.copy(v_chunk_ub_float[j, :, :], v_chunk_ub[pid, j, :, :])
+                            T.set_flag("v", "mte3", 6)
+                            T.wait_flag("v", "mte3", 6)
+                            T.copy(
+                                v_chunk_ub[pid, j, :vec_chunk_len, :],
+                                v_new[
+                                    g_start + vec_start_in_chunk : g_start
+                                    + vec_start_in_chunk
+                                    + vec_chunk_len,
+                                    i_h,
+                                    j * V_half : j * V_half + V_half,
+                                ],
+                            )
+
+                        if use_g:
+                            # v_new *= exp(g_last - g)
+                            T.tile.mul(
+                                v_chunk_ub_float[j, :, :],
+                                v_chunk_ub_float[j, :, :],
+                                g_exp_ub_broc,
+                            )
+                            # h *= exp(g_last)
+                            T.tile.mul(
+                                h_state_ub_float[j, :, :],
+                                h_state_ub_float[j, :, :],
+                                g_last_scalar[0],
+                            )
+
+                        T.set_flag("mte3", "v", 7)
+                        T.wait_flag("mte3", "v", 7)
+                        T.copy(v_chunk_ub_float[j, :, :], v_chunk_ub[pid, j, :, :])
+                        T.set_flag("v", "mte3", 8)
+                        T.wait_flag("v", "mte3", 8)
+                        T.copy(
+                            v_chunk_ub[pid, j, :, :],
+                            ws_vnew[
+                                i_n,
+                                i_h,
+                                j,
+                                vec_start_in_chunk : vec_start_in_chunk + bt // 2,
+                                :,
+                            ],
+                        )
+                        T.set_cross_flag("MTE3", SEM_VNEW_V2C + j)
+
+                    for j in T.serial(2):
+                        # h += k @ v_new
+                        T.wait_cross_flag(SEM_HUPD_C2V + j)
+                        T.copy(
+                            ws_hupd[
+                                i_n, i_h, j, K // 2 * vid : K // 2 * vid + K // 2, :
+                            ],
+                            hupd_ub_float[j, :, :],
+                        )
+                        T.set_flag("mte2", "v", 9)
+                        T.wait_flag("mte2", "v", 9)
+                        T.tile.add(
+                            h_state_ub_float[j, :, :],
+                            h_state_ub_float[j, :, :],
+                            hupd_ub_float[j, :, :],
+                        )
+
+                    T.set_flag("v", "mte3", 10)
+                    T.wait_flag("v", "mte3", 10)
+
+                if store_final_state:
+                    for j in T.serial(2):
+                        T.copy(
+                            h_state_ub_float[j, :, :],
+                            ht[
+                                i_n,
+                                i_h,
+                                K // 2 * vid : K // 2 * vid + K // 2,
+                                j * V_half : (j + 1) * V_half,
+                            ],
+                        )
+
+    return main
+
+
+@register_kernel
+class ChunkGatedDeltaRuleFwdHKernel(TilelangKernel):
+    KERNEL_NAME = "chunk_gated_delta_rule_fwd_h"
+    DISPATCH_SCHEMA = [
+        DispatchField("N", "int32"),
+        DispatchField("H", "int32"),
+        DispatchField("Hg", "int32"),
+        DispatchField("K", "int32"),
+        DispatchField("V", "int32"),
+        DispatchField("dtype", "dtype"),
+    ]
+    SPECIALIZATIONS = [
+        {
+            "variant_key": f"n{n}_h{hv}_hg{hg}_k{k}_v{v}_bf16",
+            "N": n,
+            "H": hv,
+            "Hg": hg,
+            "K": k,
+            "V": v,
+            "dtype": DEFAULT_DTYPE,
+        }
+        for n in N_SPECIALIZATIONS
+        for hv, hg, k, v in [
+            (16, 1, 128, 128),
+            (8, 1, 128, 128),
+            (32, 16, 128, 128),
+        ]
+    ]
+
+    @staticmethod
+    def generate_source(N: int, H: int, Hg: int, K: int, V: int, dtype: str) -> str:
+        if dtype != DEFAULT_DTYPE:
+            raise ValueError(
+                f"chunk_gated_delta_rule_fwd_h only supports dtype={DEFAULT_DTYPE}, got {dtype}"
+            )
+        tilelang.disable_cache()
+        tilelang_kernel = _build_chunk_gated_delta_rule_fwd_h_kernel(
+            N=N,
+            H=H,
+            Hg=Hg,
+            K=K,
+            V=V,
+            dtype=dtype,
+            bt=COMPILE_BT,
+        )
+        with tilelang.tvm.transform.PassContext(opt_level=3, config=_AOT_PASS_CONFIGS):
+            kernel = tilelang.engine.lower(tilelang_kernel)
+        return kernel.kernel_source
+
+
+@tilelang.jit(workspace_idx=[9, 10, 11, 12], pass_configs=pass_configs)
+def chunk_gated_delta_rule_fwd_kernel_jit(
+    N: int,
+    H: int,
+    T_total: int,
+    Hg: int,
+    K: int,
+    V: int,
+    NT_max: int,
+    BT: int = 64,
+    USE_G: bool = True,
+    STORE_FINAL_STATE: bool = True,
+    SAVE_NEW_VALUE: bool = True,
+    dtype: str = "float16",
+    accum_dtype: str = "float32",
+):
+    return _build_chunk_gated_delta_rule_fwd_h_kernel(
+        N=N,
+        H=H,
+        Hg=Hg,
+        K=K,
+        V=V,
+        dtype=dtype,
+        accum_dtype=accum_dtype,
+        bt=BT,
+        use_g=USE_G,
+        store_final_state=STORE_FINAL_STATE,
+        save_new_value=SAVE_NEW_VALUE,
+    )
+
+
+# ==========================================
+# 4. Python Wrapper Layer (JIT)
+# ==========================================
+def chunk_gated_delta_rule_fwd_h(
+    k: torch.Tensor,
+    w: torch.Tensor,
+    u: torch.Tensor,
+    g: torch.Tensor | None = None,
+    initial_state: torch.Tensor | None = None,
+    output_final_state: bool = False,
+    chunk_size: int = 64,
+    save_new_value: bool = True,
+    cu_seqlens: torch.LongTensor | None = None,
+    chunk_offsets: torch.Tensor | None = None,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor | None]:
+    BT = chunk_size
+    USE_G = g is not None
+    IS_VARLEN = cu_seqlens is None
+
+    # --- 1. Derive cu_seqlens, flatten inputs, extract shapes ---
+    if IS_VARLEN:
+        B, T, Hg, K = k.shape
+        H = u.shape[-2]
+        V = u.shape[-1]
+        N = B
+        cu_seqlens = torch.tensor(
+            [i * T for i in range(B + 1)], dtype=torch.int32, device=k.device
+        )
+        k_flat = k.reshape(B * T, Hg, K)
+        w_flat = w.reshape(B * T, H, K)
+        u_flat = u.reshape(B * T, H, V)
+        g_flat = g.reshape(B * T, H) if USE_G else None
+        T_total = B * T
+        NT_max = (T + BT - 1) // BT
+    else:
+        k_flat = k.squeeze(0)
+        w_flat = w.squeeze(0)
+        u_flat = u.squeeze(0)
+        g_flat = g.squeeze(0) if USE_G else None
+        T_total, Hg, K = k_flat.shape
+        _, H, V = u_flat.shape
+        N = len(cu_seqlens) - 1
+        if chunk_offsets is None:
+            chunk_offsets = _prepare_chunk_offsets(cu_seqlens, BT)
+        NT_per_seq = chunk_offsets[1:] - chunk_offsets[:-1]
+        NT_max = int(NT_per_seq.max().item())
+
+    # --- 2. Common allocations ---
+    g_c_t = (
+        g_flat.float().contiguous()
+        if USE_G
+        else torch.empty((T_total, H), dtype=torch.float32, device=k.device)
+    )
+    v_new_flat = torch.empty((T_total, H, V), dtype=k.dtype, device=k.device)
+    h_out = torch.empty((N, NT_max, H, K, V), dtype=k.dtype, device=k.device)
+    h0 = torch.zeros((N, H, K, V), dtype=k.dtype, device=k.device)
+    if initial_state is not None:
+        h0.copy_(initial_state if IS_VARLEN else initial_state.squeeze(0))
+    ht = torch.zeros((N, H, K, V), dtype=torch.float32, device=k.device)
+
+    # --- 3. Kernel invocation ---
+    ker = chunk_gated_delta_rule_fwd_kernel_jit(
+        N,
+        H,
+        T_total,
+        Hg,
+        K,
+        V,
+        NT_max,
+        BT=BT,
+        USE_G=USE_G,
+        STORE_FINAL_STATE=output_final_state,
+        SAVE_NEW_VALUE=save_new_value,
+        dtype=str(k.dtype).split(".")[-1],
+    )
+    ker(
+        h_out,
+        k_flat,
+        u_flat,
+        w_flat,
+        g_c_t,
+        v_new_flat,
+        h0,
+        ht,
+        cu_seqlens.to(torch.int32),
+    )
+
+    # --- 4. Format outputs ---
+    ht_ret = ht if output_final_state else None
+    if IS_VARLEN:
+        return h_out, v_new_flat.reshape(B, T, H, V), ht_ret
+
+    chunk_offsets_cpu = chunk_offsets.cpu().numpy()
+    slices = [
+        h_out[i, : int(chunk_offsets_cpu[i + 1] - chunk_offsets_cpu[i])]
+        for i in range(N)
+    ]
+    h_ret = torch.cat(slices, dim=0).unsqueeze(0)
+    return h_ret, v_new_flat.unsqueeze(0), ht_ret
+
+
+# ==========================================
+# 5. Golden Reference
+# ==========================================
+def _ref_chunk_gated_delta_rule_fwd_h(
+    k: torch.Tensor,
+    w: torch.Tensor,
+    u: torch.Tensor,
+    g: torch.Tensor | None,
+    initial_state: torch.Tensor | None,
+    output_final_state: bool,
+    chunk_size: int = CHUNK_SIZE,
+    use_exp2: bool = False,
+):
+    B, T = k.shape[0], k.shape[1]
+    Hg = k.shape[2]
+    K = k.shape[3]
+    H = w.shape[2]
+    V = u.shape[3]
+    NT = (T + chunk_size - 1) // chunk_size
+    hg_ratio = H // Hg
+
+    k_f = k.float()
+    w_f = w.float()
+    u_f = u.float()
+    g_f = g.float() if g is not None else None
+
+    h = torch.empty((B, NT, H, K, V), dtype=k.dtype)
+    v_new = torch.empty_like(u)
+    final_state = (
+        torch.empty((B, H, K, V), dtype=torch.float32) if output_final_state else None
+    )
+
+    for b in range(B):
+        for head in range(H):
+            k_head = head // hg_ratio
+            if initial_state is None:
+                state = torch.zeros((K, V), dtype=torch.float32)
+            else:
+                state = initial_state[b, head].float().clone()
+
+            for chunk_id, start in enumerate(range(0, T, chunk_size)):
+                end = min(start + chunk_size, T)
+                h[b, chunk_id, head] = state.to(k.dtype)
+
+                residual = u_f[b, start:end, head] - w_f[b, start:end, head] @ state
+                if g_f is not None:
+                    g_chunk = g_f[b, start:end, head]
+                    last_g = g_chunk[-1]
+                    if use_exp2:
+                        v_chunk = residual
+                        state_v = residual * torch.exp2(last_g - g_chunk)[:, None]
+                        state = state * torch.exp2(last_g)
+                    else:
+                        v_chunk = residual
+                        state_v = residual * (last_g - g_chunk).exp()[:, None]
+                        state = state * last_g.exp()
+                else:
+                    v_chunk = residual
+                    state_v = residual
+
+                v_new[b, start:end, head] = v_chunk.to(u.dtype)
+                state = state + k_f[b, start:end, k_head].transpose(-1, -2) @ state_v
+
+            if output_final_state:
+                final_state[b, head] = state
+
+    return h, v_new, final_state
+
+
+# ==========================================
+# 6. Test Functions
+# ==========================================
+def _chunk_local_cumsum_cpu(g: torch.Tensor, chunk_size: int) -> torch.Tensor:
+    out = torch.empty_like(g, dtype=torch.float32)
+    for start in range(0, g.shape[1], chunk_size):
+        end = min(start + chunk_size, g.shape[1])
+        out[:, start:end] = g[:, start:end].float().cumsum(dim=1)
+    return out
+
+
+def test_chunk_gated_delta_rule_batch(
+    B: int,
+    T: int,
+    H: int,
+    Hg: int,
+    K: int,
+    V: int,
+    use_g: bool = True,
+    use_initial_state: bool = True,
+    dtype: torch.dtype = torch.bfloat16,
+) -> None:
+    print(
+        f"Testing Batch B={B}, T={T}, H={H}, Hg={Hg}, K={K}, V={V}, use_g={use_g}, use_initial_state={use_initial_state}"
+    )
+    torch.manual_seed(41)
+
+    k = torch.randn(B, T, Hg, K, dtype=dtype).npu() * INPUT_SCALE
+    w = torch.randn(B, T, H, K, dtype=dtype).npu() * INPUT_SCALE
+    u = torch.randn(B, T, H, V, dtype=dtype).npu() * INPUT_SCALE
+    g = (
+        _chunk_local_cumsum_cpu(
+            torch.randn((B, T, H), dtype=torch.float32) * GATE_SCALE, CHUNK_SIZE
+        ).npu()
+        if use_g
+        else None
+    )
+    initial_state = (
+        torch.randn(B, H, K, V, dtype=dtype).npu() * INPUT_SCALE
+        if use_initial_state
+        else None
+    )
+
+    h, v_new, ht = chunk_gated_delta_rule_fwd_h(
+        k, w, u, g, initial_state=initial_state, output_final_state=True
+    )
+    torch.npu.synchronize()
+
+    ref_h, ref_v_new, ref_ht = _ref_chunk_gated_delta_rule_fwd_h(
+        k.cpu(),
+        w.cpu(),
+        u.cpu(),
+        g.cpu() if g is not None else None,
+        initial_state=initial_state.cpu() if initial_state is not None else None,
+        output_final_state=True,
+    )
+    torch.npu.synchronize()
+
+    torch.testing.assert_close(h.cpu(), ref_h.cpu(), rtol=5e-4, atol=1e-2)
+    torch.testing.assert_close(v_new.cpu(), ref_v_new.cpu(), rtol=5e-4, atol=1e-2)
+    torch.testing.assert_close(ht.cpu(), ref_ht.cpu(), rtol=5e-4, atol=1e-2)
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(
+        description="Test chunk gated delta rule (supports batch and varlen modes)"
+    )
+    parser.add_argument(
+        "--aot", action="store_true", help="Run AOT source generation mode"
+    )
+    parser.add_argument(
+        "--use_g",
+        type=lambda x: x.lower() == "true",
+        default=True,
+        help="Whether to use gating (True/False)",
+    )
+    parser.add_argument(
+        "--use_initial_state",
+        type=lambda x: x.lower() == "true",
+        default=True,
+        help="Whether to use initial state (True/False)",
+    )
+    parser.add_argument("--B", type=int, default=1, help="Batch size for batch mode")
+    parser.add_argument(
+        "--T", type=int, default=2048, help="Sequence length for batch mode"
+    )
+    parser.add_argument("--H", type=int, default=8, help="Number of heads")
+    parser.add_argument(
+        "--Hg", type=int, default=8, help="Number of grouped heads (must be <= H)"
+    )
+    parser.add_argument("--K", type=int, default=128, help="Key dimension")
+    parser.add_argument("--V", type=int, default=128, help="Value dimension")
+    parser.add_argument("--output", help="Output AscendC .cpp file (for --aot mode)")
+    args = parser.parse_args()
+
+    if args.aot:
+        output = Path(args.output).resolve() if args.output else None
+        if output is None:
+            print("Error: --output is required for AOT mode")
+            exit(1)
+        output.parent.mkdir(parents=True, exist_ok=True)
+        output.write_text(
+            ChunkGatedDeltaRuleFwdHKernel.generate_source(
+                N=args.B,
+                H=args.H,
+                Hg=args.Hg,
+                K=args.K,
+                V=args.V,
+                dtype=DEFAULT_DTYPE,
+            ),
+            encoding="utf-8",
+        )
+    else:
+        print("=" * 60)
+        test_chunk_gated_delta_rule_batch(
+            B=args.B,
+            T=args.T,
+            H=args.H,
+            Hg=args.Hg,
+            K=args.K,
+            V=args.V,
+            use_g=args.use_g,
+            use_initial_state=args.use_initial_state,
+        )
+        print("Kernel Output Match!")

--- a/xllm/compiler/tilelang/targets/ascend/kernels/fused_gdn_gating.py
+++ b/xllm/compiler/tilelang/targets/ascend/kernels/fused_gdn_gating.py
@@ -213,9 +213,6 @@ def build_fused_gdn_gating_kernel(
                 beta_fp32_ub = T.alloc_shared(
                     (rows_per_iter, ub_tensor_dim), acc_dtype
                 )
-                sigmoid_tmp_ub = T.alloc_ub(
-                    (rows_per_iter, ub_tensor_dim), mask_dtype
-                )
                 softplus_cmp_mask_ub = T.alloc_ub(
                     (rows_per_iter, compare_select_mask_bytes), mask_dtype
                 )
@@ -309,7 +306,7 @@ def build_fused_gdn_gating_kernel(
                             x_ub, b_half_ub, "CAST_NONE", multi_count
                         )
                         T.tile.sigmoid(
-                            beta_fp32_ub, x_ub, sigmoid_tmp_ub
+                            beta_fp32_ub, x_ub
                         )
                         T.tile.mul(x_ub, neg_exp_A_ub, beta_x_ub)
                         T.tile.cast(
@@ -406,7 +403,7 @@ def build_fused_gdn_gating_kernel(
                             x_ub, b_half_ub, "CAST_NONE", multi_count
                         )
                         T.tile.sigmoid(
-                            beta_fp32_ub, x_ub, sigmoid_tmp_ub
+                            beta_fp32_ub, x_ub
                         )
                         T.tile.mul(x_ub, neg_exp_A_ub, beta_x_ub)
                         T.tile.cast(

--- a/xllm/compiler/tilelang/targets/ascend/kernels/split_qkv_rmsnorm_mrope.py
+++ b/xllm/compiler/tilelang/targets/ascend/kernels/split_qkv_rmsnorm_mrope.py
@@ -210,7 +210,6 @@ def build_split_qkv_rmsnorm_mrope_kernel(
 
     acc_dtype = "float32"
     input_dtype = "bfloat16"
-    reduce_tmp_dtype = "uint8"
     task_num = _select_task_num(
         max_num_tokens=max_num_tokens, vec_core_num=vec_core_num
     )
@@ -225,19 +224,17 @@ def build_split_qkv_rmsnorm_mrope_kernel(
         square_ub,
         rms_vec_ub,
         rms_vec_2d_ub,
-        bcast_tmp_ub,
-        reduce_tmp_ub,
         weight_2d_fp32_ub,
         num_heads,
         eps,
     ):
         T.tile.cast(heads_fp32_ub, heads_half_ub, "CAST_NONE", num_heads * head_size)
         T.tile.mul(square_ub, heads_fp32_ub, heads_fp32_ub)
-        T.reduce_sum(square_ub, rms_vec_ub, reduce_tmp_ub, dim=-1)
+        T.reduce_sum(square_ub, rms_vec_ub, dim=-1)
         T.tile.mul(rms_vec_ub, rms_vec_ub, 1.0 / head_size)
         T.tile.add(rms_vec_ub, rms_vec_ub, eps)
         T.tile.rsqrt(rms_vec_ub, rms_vec_ub)
-        T.tile.broadcast(rms_vec_2d_ub, rms_vec_ub, bcast_tmp_ub)
+        T.tile.broadcast(rms_vec_2d_ub, rms_vec_ub)
         T.tile.mul(heads_fp32_ub, heads_fp32_ub, rms_vec_2d_ub)
         T.tile.mul(heads_fp32_ub, heads_fp32_ub, weight_2d_fp32_ub)
 
@@ -282,10 +279,9 @@ def build_split_qkv_rmsnorm_mrope_kernel(
         rope_swapped_ub,
         rope_cos_2d_ub,
         rope_sin_2d_ub,
-        bcast_tmp_ub,
     ):
-        T.tile.broadcast(rope_cos_2d_ub, cos_full_ub, bcast_tmp_ub)
-        T.tile.broadcast(rope_sin_2d_ub, sin_signed_ub, bcast_tmp_ub)
+        T.tile.broadcast(rope_cos_2d_ub, cos_full_ub)
+        T.tile.broadcast(rope_sin_2d_ub, sin_signed_ub)
         for head_idx in T.serial(num_heads):
             T.copy(heads_fp32_ub[head_idx, 0], rope_orig_ub[head_idx, :])
             T.copy(
@@ -345,18 +341,12 @@ def build_split_qkv_rmsnorm_mrope_kernel(
                 q_square_ub = T.alloc_shared((num_q_heads, head_size), acc_dtype)
                 q_rms_vec_ub = T.alloc_shared((num_q_heads, 1), acc_dtype)
                 q_rms_vec_2d_ub = T.alloc_shared((num_q_heads, head_size), acc_dtype)
-                q_reduce_tmp_ub = T.alloc_shared(
-                    num_q_heads * head_size, reduce_tmp_dtype
-                )
 
                 k_heads_half_ub = T.alloc_shared((num_kv_heads, head_size), input_dtype)
                 k_heads_fp32_ub = T.alloc_shared((num_kv_heads, head_size), acc_dtype)
                 k_square_ub = T.alloc_shared((num_kv_heads, head_size), acc_dtype)
                 k_rms_vec_ub = T.alloc_shared((num_kv_heads, 1), acc_dtype)
                 k_rms_vec_2d_ub = T.alloc_shared((num_kv_heads, head_size), acc_dtype)
-                k_reduce_tmp_ub = T.alloc_shared(
-                    num_kv_heads * head_size, reduce_tmp_dtype
-                )
 
                 # Separate passthrough buffers for gate and V. Keeping these
                 # independent from q/k_heads_half_ub lets MTE2 issue their
@@ -368,12 +358,6 @@ def build_split_qkv_rmsnorm_mrope_kernel(
                 )
                 v_heads_half_ub = T.alloc_shared(
                     (num_kv_heads, head_size), input_dtype
-                )
-
-                # Shared uint8 tmp buffer for T.tile.broadcast operations.
-                # Sized to the largest broadcast target (Q RMSNorm 2D buffer).
-                bcast_tmp_ub = T.alloc_shared(
-                    num_q_heads * head_size, reduce_tmp_dtype
                 )
 
                 # Gather buffers for merged cos+sin assembly.
@@ -403,8 +387,8 @@ def build_split_qkv_rmsnorm_mrope_kernel(
                 v_wait_mte2(E.INIT_WEIGHTS)
                 T.tile.cast(q_weight_fp32_ub, q_weight_half_ub, "CAST_NONE", head_size)
                 T.tile.cast(k_weight_fp32_ub, k_weight_half_ub, "CAST_NONE", head_size)
-                T.tile.broadcast(q_weight_2d_fp32_ub, q_weight_fp32_ub, bcast_tmp_ub)
-                T.tile.broadcast(k_weight_2d_fp32_ub, k_weight_fp32_ub, bcast_tmp_ub)
+                T.tile.broadcast(q_weight_2d_fp32_ub, q_weight_fp32_ub)
+                T.tile.broadcast(k_weight_2d_fp32_ub, k_weight_fp32_ub)
 
                 for row_local in T.serial(num_rows_per_vec):
                     row = row_start + row_local
@@ -493,8 +477,6 @@ def build_split_qkv_rmsnorm_mrope_kernel(
                         q_square_ub,
                         q_rms_vec_ub,
                         q_rms_vec_2d_ub,
-                        bcast_tmp_ub,
-                        q_reduce_tmp_ub,
                         q_weight_2d_fp32_ub,
                         num_q_heads,
                         eps,
@@ -508,7 +490,6 @@ def build_split_qkv_rmsnorm_mrope_kernel(
                         q_rope_swapped_ub,
                         q_rope_cos_2d_ub,
                         q_rope_sin_2d_ub,
-                        bcast_tmp_ub,
                     )
                     T.tile.cast(q_heads_half_ub, q_heads_fp32_ub, "CAST_RINT", q_size)
                     v_notify_mte3(E.Q_CAST)
@@ -521,8 +502,6 @@ def build_split_qkv_rmsnorm_mrope_kernel(
                         k_square_ub,
                         k_rms_vec_ub,
                         k_rms_vec_2d_ub,
-                        bcast_tmp_ub,
-                        k_reduce_tmp_ub,
                         k_weight_2d_fp32_ub,
                         num_kv_heads,
                         eps,
@@ -536,7 +515,6 @@ def build_split_qkv_rmsnorm_mrope_kernel(
                         k_rope_swapped_ub,
                         k_rope_cos_2d_ub,
                         k_rope_sin_2d_ub,
-                        bcast_tmp_ub,
                     )
                     T.tile.cast(k_heads_half_ub, k_heads_fp32_ub, "CAST_RINT", kv_size)
                     v_notify_mte3(E.K_CAST)

--- a/xllm/core/kernels/npu/tilelang/CMakeLists.txt
+++ b/xllm/core/kernels/npu/tilelang/CMakeLists.txt
@@ -138,6 +138,11 @@ tilelang_register_runtime_kernel(
   WRAPPER_SRCS split_qkv_rmsnorm_mrope_wrapper.cpp
 )
 
+tilelang_register_runtime_kernel(
+  NAME chunk_gated_delta_rule_fwd_h
+  WRAPPER_SRCS chunk_gated_delta_rule_fwd_h_wrapper.cpp
+)
+
 cc_library(
   NAME
     tilelang_kernels
@@ -199,6 +204,18 @@ cc_test(
     split_qkv_rmsnorm_mrope_wrapper_test
   SRCS
     split_qkv_rmsnorm_mrope_wrapper_test.cpp
+  DEPS
+    :tilelang_kernels
+    torch
+    GTest::gtest_main
+    glog::glog
+)
+
+cc_test(
+  NAME
+    chunk_gated_delta_rule_fwd_h_wrapper_test
+  SRCS
+    chunk_gated_delta_rule_fwd_h_wrapper_test.cpp
   DEPS
     :tilelang_kernels
     torch

--- a/xllm/core/kernels/npu/tilelang/chunk_gated_delta_rule_fwd_h_wrapper.cpp
+++ b/xllm/core/kernels/npu/tilelang/chunk_gated_delta_rule_fwd_h_wrapper.cpp
@@ -1,0 +1,319 @@
+/* Copyright 2026 The xLLM Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://github.com/jd-opensource/xllm/blob/main/LICENSE
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include <c10/core/DeviceType.h>
+#include <glog/logging.h>
+#include <torch_npu/csrc/core/npu/NPUStream.h>
+#include <torch_npu/torch_npu.h>
+
+#include <algorithm>
+#include <cstdint>
+#include <tuple>
+#include <utility>
+
+#include "acl/acl.h"
+#include "core/kernels/npu/tilelang/dispatch_registry.h"
+#include "core/kernels/npu/tilelang/tilelang_ops_api.h"
+
+#ifndef XLLM_TL_CHUNK_GATED_DELTA_RULE_FWD_H_REGISTRY_INC
+#error "XLLM_TL_CHUNK_GATED_DELTA_RULE_FWD_H_REGISTRY_INC is not defined"
+#endif
+
+namespace xllm::kernel::npu::tilelang {
+namespace {
+
+constexpr int32_t kCompileBT = 64;
+constexpr int32_t kNSpecializationMin = 1;
+constexpr int32_t kNSpecializationStep = 1;
+
+bool is_supported_initial_state_dtype(torch::ScalarType dtype) {
+  return dtype == torch::kBFloat16 || dtype == torch::kFloat32;
+}
+
+#include XLLM_TL_CHUNK_GATED_DELTA_RULE_FWD_H_REGISTRY_INC
+
+int32_t max_compiled_n(int32_t H,
+                       int32_t Hg,
+                       int32_t K,
+                       int32_t V,
+                       TilelangDType dtype) {
+  int32_t max_n = 0;
+  for (const auto& entry : kChunkGatedDeltaRuleFwdHRegistry) {
+    const auto& spec = entry.spec;
+    if (spec.H == H && spec.Hg == Hg && spec.K == K && spec.V == V &&
+        spec.dtype == dtype) {
+      max_n = std::max(max_n, spec.N);
+    }
+  }
+  return max_n;
+}
+
+int32_t select_launch_n(int64_t actual_n,
+                        int32_t H,
+                        int32_t Hg,
+                        int32_t K,
+                        int32_t V,
+                        TilelangDType dtype) {
+  CHECK_GT(actual_n, 0)
+      << "TileLang chunk_gated_delta_rule_fwd_h: actual_n must be > 0";
+  const int32_t max_n = max_compiled_n(H, Hg, K, V, dtype);
+  CHECK_GT(max_n, 0)
+      << "TileLang chunk_gated_delta_rule_fwd_h: no compiled N variant for "
+      << "H=" << H << ", Hg=" << Hg << ", K=" << K << ", V=" << V
+      << ", dtype=" << static_cast<int>(dtype);
+  CHECK_GE(max_n, kNSpecializationMin)
+      << "TileLang chunk_gated_delta_rule_fwd_h: compiled N variants must "
+      << "be >= " << kNSpecializationMin;
+
+  const int64_t capped = std::min<int64_t>(actual_n, max_n);
+  int64_t rounded_up =
+      ((capped + kNSpecializationStep - 1) / kNSpecializationStep) *
+      kNSpecializationStep;
+  rounded_up = std::max<int64_t>(rounded_up, kNSpecializationMin);
+  rounded_up = std::min<int64_t>(rounded_up, max_n);
+  return static_cast<int32_t>(rounded_up);
+}
+
+void check_supported(const torch::Tensor& k,
+                     const torch::Tensor& w,
+                     const torch::Tensor& u,
+                     const std::optional<torch::Tensor>& g,
+                     const std::optional<torch::Tensor>& initial_state,
+                     int64_t chunk_size,
+                     const std::optional<torch::Tensor>& cu_seqlens) {
+  CHECK(k.defined())
+      << "TileLang chunk_gated_delta_rule_fwd_h: k must be defined";
+  CHECK(w.defined())
+      << "TileLang chunk_gated_delta_rule_fwd_h: w must be defined";
+  CHECK(u.defined())
+      << "TileLang chunk_gated_delta_rule_fwd_h: u must be defined";
+  CHECK(g.has_value())
+      << "TileLang chunk_gated_delta_rule_fwd_h: g must be defined";
+
+  CHECK(k.device().type() == c10::DeviceType::PrivateUse1 &&
+        w.device().type() == c10::DeviceType::PrivateUse1 &&
+        u.device().type() == c10::DeviceType::PrivateUse1 &&
+        g.value().device().type() == c10::DeviceType::PrivateUse1)
+      << "TileLang chunk_gated_delta_rule_fwd_h: all tensors must be on NPU";
+
+  CHECK_EQ(k.dim(), 3)
+      << "TileLang chunk_gated_delta_rule_fwd_h: k must be 3D [T, Hg, K]";
+  CHECK_EQ(w.dim(), 3)
+      << "TileLang chunk_gated_delta_rule_fwd_h: w must be 3D [T, H, K]";
+  CHECK_EQ(u.dim(), 3)
+      << "TileLang chunk_gated_delta_rule_fwd_h: u must be 3D [T, H, V]";
+
+  CHECK_EQ(k.size(0), w.size(0))
+      << "TileLang chunk_gated_delta_rule_fwd_h: k/w token dim mismatch";
+  CHECK_EQ(k.size(0), u.size(0))
+      << "TileLang chunk_gated_delta_rule_fwd_h: k/u token dim mismatch";
+  CHECK_EQ(w.size(1), u.size(1))
+      << "TileLang chunk_gated_delta_rule_fwd_h: w/u head dim mismatch";
+
+  CHECK_EQ(k.dtype(), torch::kBFloat16)
+      << "TileLang chunk_gated_delta_rule_fwd_h: only bf16 inputs are "
+         "supported";
+  CHECK_EQ(k.dtype(), w.dtype())
+      << "TileLang chunk_gated_delta_rule_fwd_h: k/w dtype mismatch";
+  CHECK_EQ(k.dtype(), u.dtype())
+      << "TileLang chunk_gated_delta_rule_fwd_h: k/u dtype mismatch";
+
+  if (initial_state.has_value()) {
+    CHECK(is_supported_initial_state_dtype(initial_state.value().scalar_type()))
+        << "TileLang chunk_gated_delta_rule_fwd_h: initial_state must be "
+        << "bfloat16 or float32, got " << initial_state.value().scalar_type();
+  }
+
+  CHECK_EQ(chunk_size, kCompileBT)
+      << "TileLang chunk_gated_delta_rule_fwd_h: only chunk_size=" << kCompileBT
+      << " is supported, got " << chunk_size;
+
+  CHECK(cu_seqlens.has_value())
+      << "TileLang chunk_gated_delta_rule_fwd_h: cu_seqlens must be defined";
+
+  const int64_t N = cu_seqlens.value().size(0) - 1;
+  CHECK_GT(N, 0) << "TileLang chunk_gated_delta_rule_fwd_h: N must be > 0";
+}
+
+ChunkGatedDeltaRuleFwdHSpecialization build_runtime_specialization(
+    int32_t compiled_n,
+    const torch::Tensor& k,
+    const torch::Tensor& u) {
+  CHECK_EQ(k.dim(), 3);
+  CHECK_EQ(u.dim(), 3);
+  const int32_t H = static_cast<int32_t>(u.size(1));
+  const int32_t Hg = static_cast<int32_t>(k.size(1));
+  const int32_t K = static_cast<int32_t>(k.size(2));
+  const int32_t V = static_cast<int32_t>(u.size(2));
+  const TilelangDType dtype = to_tilelang_dtype(k.scalar_type());
+
+  return make_chunk_gated_delta_rule_fwd_h_specialization(
+      ChunkGatedDeltaRuleFwdHN{compiled_n},
+      ChunkGatedDeltaRuleFwdHH{H},
+      ChunkGatedDeltaRuleFwdHHg{Hg},
+      ChunkGatedDeltaRuleFwdHK{K},
+      ChunkGatedDeltaRuleFwdHV{V},
+      ChunkGatedDeltaRuleFwdHDType{dtype});
+}
+
+const auto* find_entry_with_fallback(
+    ChunkGatedDeltaRuleFwdHSpecialization specialization) {
+  const auto* entry =
+      find_chunk_gated_delta_rule_fwd_h_kernel_entry(specialization);
+  if (entry != nullptr) {
+    return entry;
+  }
+  int32_t fallback_n = specialization.N - kNSpecializationStep;
+  while (fallback_n >= kNSpecializationMin && entry == nullptr) {
+    specialization = make_chunk_gated_delta_rule_fwd_h_specialization(
+        ChunkGatedDeltaRuleFwdHN{fallback_n},
+        ChunkGatedDeltaRuleFwdHH{specialization.H},
+        ChunkGatedDeltaRuleFwdHHg{specialization.Hg},
+        ChunkGatedDeltaRuleFwdHK{specialization.K},
+        ChunkGatedDeltaRuleFwdHV{specialization.V},
+        ChunkGatedDeltaRuleFwdHDType{specialization.dtype});
+    entry = find_chunk_gated_delta_rule_fwd_h_kernel_entry(specialization);
+    fallback_n -= kNSpecializationStep;
+  }
+  return entry;
+}
+
+std::tuple<torch::Tensor, torch::Tensor, torch::Tensor>
+run_tilelang_chunk_gated_delta_rule_fwd_h(
+    const torch::Tensor& k,
+    const torch::Tensor& w,
+    const torch::Tensor& u,
+    const torch::Tensor& g,
+    const std::optional<torch::Tensor>& initial_state,
+    bool output_final_state,
+    const torch::Tensor& cu_seqlens) {
+  const int64_t actual_n = cu_seqlens.size(0) - 1;
+  const int64_t t_total = k.size(0);
+  const int64_t H = u.size(1);
+  const int64_t Hg = k.size(1);
+  const int64_t K = k.size(2);
+  const int64_t V = u.size(2);
+  const TilelangDType dtype = to_tilelang_dtype(k.scalar_type());
+
+  const int32_t compiled_n = select_launch_n(actual_n,
+                                             static_cast<int32_t>(H),
+                                             static_cast<int32_t>(Hg),
+                                             static_cast<int32_t>(K),
+                                             static_cast<int32_t>(V),
+                                             dtype);
+
+  int32_t actual_nt_max = 0;
+  {
+    auto cu_cpu = cu_seqlens.cpu().contiguous();
+    auto cu_ptr = cu_cpu.data_ptr<int32_t>();
+    for (int64_t i = 0; i < actual_n; ++i) {
+      const int32_t seq_len = cu_ptr[i + 1] - cu_ptr[i];
+      const int32_t nt_i = (seq_len + kCompileBT - 1) / kCompileBT;
+      actual_nt_max = std::max(actual_nt_max, nt_i);
+    }
+  }
+  CHECK_GT(actual_nt_max, 0)
+      << "TileLang chunk_gated_delta_rule_fwd_h: actual_nt_max must be > 0";
+
+  const auto options_bf16 = k.options();
+  const auto options_fp32 = k.options().dtype(torch::kFloat32);
+
+  const int32_t V_half = static_cast<int32_t>(V) / 2;
+  const int64_t t_total_i64 = static_cast<int64_t>(t_total);
+  const int64_t actual_nt_i64 = static_cast<int64_t>(actual_nt_max);
+
+  auto h_out = torch::empty({compiled_n, actual_nt_i64, H, K, V}, options_bf16);
+  auto v_new_out = torch::empty({t_total_i64, H, V}, options_bf16);
+  auto h0 = torch::zeros({compiled_n, H, K, V}, options_bf16);
+  if (initial_state.has_value()) {
+    h0.narrow(0, 0, actual_n).copy_(initial_state.value().to(torch::kBFloat16));
+  }
+  auto ht = torch::zeros({compiled_n, H, K, V}, options_fp32);
+
+  auto ws_wh =
+      torch::empty({compiled_n, H, 2, kCompileBT, V_half}, options_fp32);
+  auto ws_vnew =
+      torch::empty({compiled_n, H, 2, kCompileBT, V_half}, options_bf16);
+  auto ws_hupd = torch::empty({compiled_n, H, 2, K, V_half}, options_fp32);
+  auto ws_h = torch::empty({compiled_n, H, 2, K, V_half}, options_bf16);
+
+  auto cu_prepared = cu_seqlens.to(torch::kInt32).contiguous();
+  if (static_cast<int64_t>(compiled_n) > actual_n) {
+    auto cu_padded = torch::empty({compiled_n + 1}, cu_prepared.options());
+    cu_padded.narrow(0, 0, actual_n + 1).copy_(cu_prepared);
+    cu_padded.narrow(0, actual_n + 1, compiled_n - actual_n)
+        .fill_(static_cast<int32_t>(t_total));
+    cu_prepared = cu_padded;
+  }
+
+  auto specialization = build_runtime_specialization(compiled_n, k, u);
+  const auto* entry = find_entry_with_fallback(specialization);
+  CHECK(entry != nullptr)
+      << "TileLang chunk_gated_delta_rule_fwd_h: no compiled variant. "
+      << "Available variants: "
+      << available_chunk_gated_delta_rule_fwd_h_variant_keys();
+
+  const int32_t device_id = k.device().index();
+  aclrtStream stream = c10_npu::getCurrentNPUStream(device_id).stream();
+  entry->fn(static_cast<uint8_t*>(h_out.data_ptr()),
+            static_cast<uint8_t*>(k.data_ptr()),
+            static_cast<uint8_t*>(u.data_ptr()),
+            static_cast<uint8_t*>(w.data_ptr()),
+            static_cast<uint8_t*>(g.data_ptr()),
+            static_cast<uint8_t*>(v_new_out.data_ptr()),
+            static_cast<uint8_t*>(h0.data_ptr()),
+            static_cast<uint8_t*>(ht.data_ptr()),
+            static_cast<uint8_t*>(cu_prepared.data_ptr()),
+            static_cast<uint8_t*>(ws_wh.data_ptr()),
+            static_cast<uint8_t*>(ws_vnew.data_ptr()),
+            static_cast<uint8_t*>(ws_hupd.data_ptr()),
+            static_cast<uint8_t*>(ws_h.data_ptr()),
+            static_cast<int64_t>(actual_nt_max),
+            static_cast<int64_t>(t_total),
+            stream);
+
+  auto h_sliced = h_out.narrow(0, 0, actual_n);
+  auto ht_sliced =
+      output_final_state ? ht.narrow(0, 0, actual_n) : torch::Tensor();
+
+  return {h_sliced, v_new_out, ht_sliced};
+}
+
+}  // namespace
+
+std::tuple<torch::Tensor, torch::Tensor, torch::Tensor>
+chunk_gated_delta_rule_fwd_h(
+    const torch::Tensor& k,
+    const torch::Tensor& w,
+    const torch::Tensor& u,
+    const std::optional<torch::Tensor>& g,
+    const std::optional<torch::Tensor>& initial_state,
+    bool output_final_state,
+    int64_t chunk_size,
+    bool save_new_value,
+    const std::optional<torch::Tensor>& cu_seqlens,
+    const std::optional<torch::Tensor>& chunk_offsets) {
+  (void)save_new_value;
+  (void)chunk_offsets;
+  check_supported(k, w, u, g, initial_state, chunk_size, cu_seqlens);
+
+  auto g_c_t = g.value().to(torch::kFloat32).contiguous();
+  auto cu_valid = cu_seqlens.value().contiguous();
+
+  return run_tilelang_chunk_gated_delta_rule_fwd_h(
+      k, w, u, g_c_t, initial_state, output_final_state, cu_valid);
+}
+
+}  // namespace xllm::kernel::npu::tilelang

--- a/xllm/core/kernels/npu/tilelang/chunk_gated_delta_rule_fwd_h_wrapper_test.cpp
+++ b/xllm/core/kernels/npu/tilelang/chunk_gated_delta_rule_fwd_h_wrapper_test.cpp
@@ -1,0 +1,378 @@
+/* Copyright 2026 The xLLM Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://github.com/jd-opensource/xllm/blob/main/LICENSE
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include <gtest/gtest.h>
+#include <torch/torch.h>
+#include <torch_npu/csrc/core/npu/NPUStream.h>
+#include <torch_npu/torch_npu.h>
+
+#include <cmath>
+#include <cstdint>
+#include <iostream>
+#include <tuple>
+#include <vector>
+
+#include "acl/acl.h"
+#include "core/kernels/npu/tilelang/tilelang_ops_api.h"
+
+namespace xllm::kernel::npu::tilelang {
+namespace {
+
+class TileLangChunkGatedDeltaRuleFwdHTest : public ::testing::Test {
+ protected:
+  static void SetUpTestSuite() { torch_npu::init_npu("npu:0"); }
+
+  static void TearDownTestSuite() { torch_npu::finalize_npu(); }
+};
+
+struct ChunkGdrTestCase {
+  std::string name;
+  int64_t batch_size;
+  int64_t seq_len;
+  int64_t H;
+  int64_t Hg;
+  int64_t K;
+  int64_t V;
+  int64_t chunk_size;
+  int64_t seed;
+};
+
+torch::Tensor make_chunk_local_cumsum(int64_t N,
+                                      int64_t T,
+                                      int64_t H,
+                                      int64_t chunk_size,
+                                      int64_t seed) {
+  auto cpu_opts =
+      torch::TensorOptions().dtype(torch::kFloat32).device(torch::kCPU);
+  torch::manual_seed(seed);
+  auto g_cumsum = torch::empty({N * T, H}, cpu_opts);
+  constexpr float kGateScale = 0.002F;
+
+  for (int64_t b = 0; b < N; ++b) {
+    int64_t seq_start = b * T;
+    int64_t seq_end = seq_start + T;
+    for (int64_t head = 0; head < H; ++head) {
+      for (int64_t chunk_start = seq_start; chunk_start < seq_end;
+           chunk_start += chunk_size) {
+        int64_t chunk_end = std::min(chunk_start + chunk_size, seq_end);
+        int64_t chunk_len = chunk_end - chunk_start;
+        auto gate = torch::randn({chunk_len}, cpu_opts) * kGateScale;
+        auto chunk_cumsum = torch::cumsum(gate, /*dim=*/0);
+        g_cumsum.slice(0, chunk_start, chunk_end)
+            .select(1, head)
+            .copy_(chunk_cumsum);
+      }
+    }
+  }
+  return g_cumsum;
+}
+
+std::tuple<torch::Tensor, torch::Tensor, torch::Tensor>
+ref_chunk_gated_delta_rule(const torch::Tensor& k,
+                           const torch::Tensor& w,
+                           const torch::Tensor& u,
+                           const torch::Tensor& g,
+                           const torch::Tensor& initial_state,
+                           const torch::Tensor& cu_seqlens,
+                           int64_t chunk_size) {
+  const int64_t N = initial_state.size(0);
+  const int64_t H = u.size(1);
+  const int64_t Hg = k.size(1);
+  const int64_t K = k.size(2);
+  const int64_t V = u.size(2);
+  const int64_t hg_ratio = H / Hg;
+
+  auto k_f = k.to(torch::kFloat32);
+  auto w_f = w.to(torch::kFloat32);
+  auto u_f = u.to(torch::kFloat32);
+  auto g_f = g.to(torch::kFloat32);
+  auto h0_f = initial_state.to(torch::kFloat32);
+
+  auto cu_cpu = cu_seqlens.cpu().contiguous();
+  auto cu_ptr = cu_cpu.data_ptr<int32_t>();
+
+  int64_t nt_max = 0;
+  for (int64_t i = 0; i < N; ++i) {
+    int64_t seq_len = cu_ptr[i + 1] - cu_ptr[i];
+    int64_t nt_i = (seq_len + chunk_size - 1) / chunk_size;
+    nt_max = std::max(nt_max, nt_i);
+  }
+
+  auto h_out = torch::empty({N, nt_max, H, K, V}, k.options());
+  auto v_new = torch::empty_like(u);
+  auto ht = torch::empty({N, H, K, V}, torch::kFloat32);
+
+  for (int64_t n = 0; n < N; ++n) {
+    int64_t bos = static_cast<int64_t>(cu_ptr[n]);
+    int64_t eos = static_cast<int64_t>(cu_ptr[n + 1]);
+    for (int64_t head = 0; head < H; ++head) {
+      auto state = h0_f[n][head].clone();
+      int64_t k_head_idx = head / hg_ratio;
+
+      int64_t chunk_id = 0;
+      for (int64_t start = bos; start < eos; start += chunk_size) {
+        int64_t end = std::min(start + chunk_size, eos);
+
+        // h[t] ← state (before this chunk's update)
+        h_out[n][chunk_id][head].copy_(state.to(k.dtype()));
+
+        // residual = u - w @ h
+        auto u_chunk = u_f.slice(0, start, end).select(1, head);  // [L, V]
+        auto w_chunk = w_f.slice(0, start, end).select(1, head);  // [L, K]
+        auto residual = u_chunk - torch::matmul(w_chunk, state);  // [L, V]
+
+        // Gating: state_v = residual * exp(last_g - g_chunk)
+        //          state   = state   * exp(last_g)
+        auto g_chunk = g_f.slice(0, start, end).select(1, head);  // [L]
+        auto last_g = g_chunk[-1].clone();
+        auto state_v =
+            residual * (last_g - g_chunk).exp().unsqueeze(/*dim=*/-1);
+        state = state * std::exp(last_g.item<float>());
+
+        // v_new[t] ← residual (before gating)
+        v_new.slice(0, start, end)
+            .select(1, head)
+            .copy_(residual.to(k.dtype()));
+
+        // h += k^T @ v_new
+        auto k_chunk =
+            k_f.slice(0, start, end).select(1, k_head_idx);  // [L, K]
+        state = state + torch::matmul(k_chunk.t(), state_v);
+
+        ++chunk_id;
+      }
+      ht[n][head].copy_(state);
+    }
+  }
+
+  return {h_out, v_new, ht};
+}
+
+void run_chunk_gated_delta_rule_fwd_h_case(const ChunkGdrTestCase& test_case) {
+  ASSERT_GT(test_case.batch_size, 0);
+  ASSERT_GT(test_case.seq_len, 0);
+  ASSERT_GT(test_case.H, 0);
+  ASSERT_GT(test_case.Hg, 0);
+  ASSERT_GE(test_case.H, test_case.Hg);
+  ASSERT_GT(test_case.K, 0);
+  ASSERT_GT(test_case.V, 0);
+  ASSERT_EQ(test_case.chunk_size, 64);
+
+  const auto npu_device = torch::Device("npu:0");
+  const auto bf16_opts =
+      torch::TensorOptions().dtype(torch::kBFloat16).device(npu_device);
+
+  torch::manual_seed(test_case.seed);
+
+  const int64_t N = test_case.batch_size;
+  const int64_t T = test_case.seq_len;
+  const int64_t H = test_case.H;
+  const int64_t Hg = test_case.Hg;
+  const int64_t K = test_case.K;
+  const int64_t V = test_case.V;
+
+  auto k = torch::randn({N * T, Hg, K}, bf16_opts) * 0.01F;
+  auto w = torch::randn({N * T, H, K}, bf16_opts) * 0.01F;
+  auto u = torch::randn({N * T, H, V}, bf16_opts) * 0.01F;
+  auto initial_state = torch::randn({N, H, K, V}, bf16_opts) * 0.01F;
+
+  auto g = make_chunk_local_cumsum(N,
+                                   T,
+                                   H,
+                                   /*chunk_size=*/64,
+                                   test_case.seed)
+               .to(npu_device);
+
+  std::vector<int32_t> cu_seqlens_vec(N + 1);
+  for (int64_t i = 0; i <= N; ++i) {
+    cu_seqlens_vec[i] = static_cast<int32_t>(i * T);
+  }
+  auto cu_seqlens =
+      torch::from_blob(
+          cu_seqlens_vec.data(), {N + 1}, torch::dtype(torch::kInt32))
+          .to(npu_device);
+
+  auto [h, v_new, ht] =
+      chunk_gated_delta_rule_fwd_h(k,
+                                   w,
+                                   u,
+                                   g,
+                                   initial_state,
+                                   /*output_final_state=*/true,
+                                   /*chunk_size=*/64,
+                                   /*save_new_value=*/true,
+                                   cu_seqlens,
+                                   /*chunk_offsets=*/std::nullopt);
+
+  std::cout << "[chunk_gated_delta_rule_fwd_h_test] case=" << test_case.name
+            << ", h_shape=" << h.sizes() << ", v_new_shape=" << v_new.sizes()
+            << ", ht_shape=" << ht.sizes() << std::endl;
+
+  EXPECT_EQ(h.dim(), 5);
+  EXPECT_EQ(h.size(0), N);
+  EXPECT_EQ(h.size(2), H);
+  EXPECT_EQ(h.size(3), K);
+  EXPECT_EQ(h.size(4), V);
+  EXPECT_EQ(v_new.size(0), N * T);
+  EXPECT_EQ(v_new.size(1), H);
+  EXPECT_EQ(v_new.size(2), V);
+  EXPECT_EQ(ht.size(0), N);
+  EXPECT_EQ(ht.size(1), H);
+  EXPECT_EQ(ht.size(2), K);
+  EXPECT_EQ(ht.size(3), V);
+}
+
+void run_chunk_gated_delta_rule_fwd_h_accuracy_case(
+    const ChunkGdrTestCase& test_case) {
+  ASSERT_GT(test_case.batch_size, 0);
+  ASSERT_GT(test_case.seq_len, 0);
+  ASSERT_GT(test_case.H, 0);
+  ASSERT_GT(test_case.Hg, 0);
+  ASSERT_GE(test_case.H, test_case.Hg);
+  ASSERT_GT(test_case.K, 0);
+  ASSERT_GT(test_case.V, 0);
+  ASSERT_EQ(test_case.chunk_size, 64);
+
+  const auto npu_device = torch::Device("npu:0");
+  const auto bf16_opts =
+      torch::TensorOptions().dtype(torch::kBFloat16).device(npu_device);
+
+  torch::manual_seed(test_case.seed);
+
+  const int64_t N = test_case.batch_size;
+  const int64_t T = test_case.seq_len;
+  const int64_t H = test_case.H;
+  const int64_t Hg = test_case.Hg;
+  const int64_t K = test_case.K;
+  const int64_t V = test_case.V;
+
+  auto k_npu = torch::randn({N * T, Hg, K}, bf16_opts) * 0.01F;
+  auto w_npu = torch::randn({N * T, H, K}, bf16_opts) * 0.01F;
+  auto u_npu = torch::randn({N * T, H, V}, bf16_opts) * 0.01F;
+  auto h0_npu = torch::randn({N, H, K, V}, bf16_opts) * 0.01F;
+
+  auto g_cpu =
+      make_chunk_local_cumsum(N, T, H, /*chunk_size=*/64, test_case.seed);
+  auto g_npu = g_cpu.to(npu_device);
+
+  auto k_cpu = k_npu.cpu();
+  auto w_cpu = w_npu.cpu();
+  auto u_cpu = u_npu.cpu();
+  auto h0_cpu = h0_npu.cpu();
+
+  std::vector<int32_t> cu_seqlens_vec(N + 1);
+  for (int64_t i = 0; i <= N; ++i) {
+    cu_seqlens_vec[i] = static_cast<int32_t>(i * T);
+  }
+  auto cu_cpu = torch::from_blob(
+                    cu_seqlens_vec.data(), {N + 1}, torch::dtype(torch::kInt32))
+                    .clone();
+  auto cu_npu = cu_cpu.to(npu_device);
+
+  auto [h_ref, v_new_ref, ht_ref] = ref_chunk_gated_delta_rule(
+      k_cpu, w_cpu, u_cpu, g_cpu, h0_cpu, cu_cpu, /*chunk_size=*/64);
+
+  auto [h_npu, v_new_npu, ht_npu] =
+      chunk_gated_delta_rule_fwd_h(k_npu,
+                                   w_npu,
+                                   u_npu,
+                                   g_npu,
+                                   h0_npu,
+                                   /*output_final_state=*/true,
+                                   /*chunk_size=*/64,
+                                   /*save_new_value=*/true,
+                                   cu_npu,
+                                   /*chunk_offsets=*/std::nullopt);
+
+  constexpr float kRtol = 5e-2F;
+  constexpr float kAtol = 5e-1F;
+
+  EXPECT_TRUE(torch::allclose(h_npu.cpu(), h_ref, kRtol, kAtol))
+      << "h_out mismatch for case " << test_case.name;
+  EXPECT_TRUE(torch::allclose(v_new_npu.cpu(), v_new_ref, kRtol, kAtol))
+      << "v_new mismatch for case " << test_case.name;
+  EXPECT_TRUE(torch::allclose(ht_npu.cpu(), ht_ref, kRtol, kAtol))
+      << "ht mismatch for case " << test_case.name;
+}
+
+TEST_F(TileLangChunkGatedDeltaRuleFwdHTest,
+       ChunkGatedDeltaRuleFwdHMatchesExpectedShapes) {
+  const std::vector<ChunkGdrTestCase> cases = {
+      {.name = "small_n1_t64_h16_hg1_k128_v128",
+       .batch_size = 1,
+       .seq_len = 64,
+       .H = 16,
+       .Hg = 1,
+       .K = 128,
+       .V = 128,
+       .chunk_size = 64,
+       .seed = 20260511},
+      {.name = "medium_n2_t128_h8_hg1_k128_v128",
+       .batch_size = 2,
+       .seq_len = 128,
+       .H = 8,
+       .Hg = 1,
+       .K = 128,
+       .V = 128,
+       .chunk_size = 64,
+       .seed = 20260512},
+      {.name = "large_n1_t128_h32_hg16_k128_v128",
+       .batch_size = 1,
+       .seq_len = 128,
+       .H = 32,
+       .Hg = 16,
+       .K = 128,
+       .V = 128,
+       .chunk_size = 64,
+       .seed = 20260512},
+  };
+
+  for (const auto& test_case : cases) {
+    SCOPED_TRACE(::testing::Message() << "case=" << test_case.name);
+    run_chunk_gated_delta_rule_fwd_h_case(test_case);
+  }
+}
+
+TEST_F(TileLangChunkGatedDeltaRuleFwdHTest,
+       ChunkGatedDeltaRuleFwdHMatchesReference) {
+  const std::vector<ChunkGdrTestCase> accuracy_cases = {
+      {.name = "accuracy_n1_t64_h16_hg1_k128_v128",
+       .batch_size = 1,
+       .seq_len = 64,
+       .H = 16,
+       .Hg = 1,
+       .K = 128,
+       .V = 128,
+       .chunk_size = 64,
+       .seed = 20260513},
+      {.name = "accuracy_n1_t128_h32_hg16_k128_v128",
+       .batch_size = 1,
+       .seq_len = 128,
+       .H = 32,
+       .Hg = 16,
+       .K = 128,
+       .V = 128,
+       .chunk_size = 64,
+       .seed = 20260514},
+  };
+
+  for (const auto& test_case : accuracy_cases) {
+    SCOPED_TRACE(::testing::Message() << "case=" << test_case.name);
+    run_chunk_gated_delta_rule_fwd_h_accuracy_case(test_case);
+  }
+}
+
+}  // namespace
+}  // namespace xllm::kernel::npu::tilelang

--- a/xllm/core/kernels/npu/tilelang/tilelang_ops_api.h
+++ b/xllm/core/kernels/npu/tilelang/tilelang_ops_api.h
@@ -17,6 +17,7 @@ limitations under the License.
 
 #include <torch/torch.h>
 
+#include <optional>
 #include <tuple>
 #include <utility>
 #include <vector>
@@ -71,5 +72,22 @@ split_qkv_rmsnorm_mrope(const torch::Tensor& qkvg,
 bool has_split_qkv_rmsnorm_mrope_specialization(int64_t num_q_heads,
                                                 int64_t num_kv_heads,
                                                 int64_t head_size);
+
+// Compute chunk_gated_delta_rule forward pass for hidden state on NPU.
+// Returns (h, v_new, final_state).
+//   h: [N, NT_max, H, K, V] (flattened per-sequence chunks)
+//   v_new: [T_total, H, V] (updated values)
+//   final_state: [N, H, K, V] (optional, empty tensor if !output_final_state)
+std::tuple<torch::Tensor, torch::Tensor, torch::Tensor>
+chunk_gated_delta_rule_fwd_h(const torch::Tensor& k,
+                             const torch::Tensor& w,
+                             const torch::Tensor& u,
+                             const std::optional<torch::Tensor>& g,
+                             const std::optional<torch::Tensor>& initial_state,
+                             bool output_final_state,
+                             int64_t chunk_size,
+                             bool save_new_value,
+                             const std::optional<torch::Tensor>& cu_seqlens,
+                             const std::optional<torch::Tensor>& chunk_offsets);
 
 }  // namespace xllm::kernel::npu::tilelang

--- a/xllm/core/kernels/ops_api.cpp
+++ b/xllm/core/kernels/ops_api.cpp
@@ -38,6 +38,14 @@ limitations under the License.
 
 namespace xllm::kernel {
 
+namespace {
+#if defined(USE_NPU)
+bool is_supported_initial_state_dtype(torch::ScalarType dtype) {
+  return dtype == torch::kBFloat16 || dtype == torch::kFloat32;
+}
+#endif
+}  // namespace
+
 void apply_rotary(RotaryParams& params) {
 #if defined(USE_MLU)
   mlu::apply_rotary(params.q,
@@ -1068,17 +1076,92 @@ torch::Tensor build_split_qkv_rmsnorm_mrope_gather_pattern(
 std::pair<torch::Tensor, torch::Tensor> chunk_gated_delta_rule(
     ChunkGatedDeltaRuleParams& params) {
 #if defined(USE_NPU)
-  return npu::npu_chunk_gated_delta_rule(params.q,
-                                         params.k,
-                                         params.v,
-                                         params.g,
-                                         params.beta,
-                                         params.scale,
-                                         params.initial_state,
-                                         params.output_final_state,
-                                         params.cu_seqlens,
-                                         params.head_first,
-                                         params.use_qk_l2norm_in_kernel);
+  CHECK(!params.head_first)
+      << "chunk_gated_delta_rule only supports head_first=false.";
+  CHECK(params.q.scalar_type() == torch::kBFloat16 &&
+        params.k.scalar_type() == torch::kBFloat16 &&
+        params.v.scalar_type() == torch::kBFloat16)
+      << "chunk_gated_delta_rule expects q/k/v to be bfloat16.";
+  if (params.initial_state.has_value()) {
+    CHECK(is_supported_initial_state_dtype(
+        params.initial_state.value().scalar_type()))
+        << "chunk_gated_delta_rule expects initial_state to be bfloat16 or "
+           "float32, got "
+        << params.initial_state.value().scalar_type();
+  }
+
+  const torch::ScalarType input_dtype = params.q.scalar_type();
+  const int64_t batch_size = params.q.size(0);
+  const int64_t seq_len = params.q.size(1);
+  const int64_t num_heads_qk = params.q.size(2);
+  CHECK(params.q.sizes() == params.k.sizes())
+      << "q and k must have the same shape.";
+  CHECK(params.v.dim() == 4 && params.v.size(0) == batch_size &&
+        params.v.size(1) == seq_len)
+      << "v must have shape [B, T, Hv, V].";
+  const int64_t num_heads_v = params.v.size(2);
+  const int64_t head_dim = params.q.size(3);
+  const int64_t chunk_size = params.chunk_size;
+  CHECK(num_heads_v % num_heads_qk == 0)
+      << "chunk_gated_delta_rule expects num_heads_v to be "
+         "divisible by num_heads_qk, got "
+      << num_heads_v << " and " << num_heads_qk;
+  CHECK(params.beta.dim() == 3 && params.beta.size(0) == batch_size &&
+        params.beta.size(1) == seq_len && params.beta.size(2) == num_heads_v)
+      << "beta must have shape [B, T, H].";
+  CHECK(params.g.dim() == 3 && params.g.size(0) == batch_size &&
+        params.g.size(1) == seq_len && params.g.size(2) == num_heads_v)
+      << "g must have shape [B, T, H].";
+
+  auto q_prepared = params.use_qk_l2norm_in_kernel
+                        ? npu::npu_l2norm_last_dim(params.q)
+                        : params.q;
+  auto k_prepared = params.use_qk_l2norm_in_kernel
+                        ? npu::npu_l2norm_last_dim(params.k)
+                        : params.k;
+  auto cu_prepared =
+      params.cu_seqlens.has_value()
+          ? std::optional<torch::Tensor>(
+                params.cu_seqlens.value().to(torch::kInt32).contiguous())
+          : std::nullopt;
+  auto g_cumsum =
+      npu::npu_chunk_local_cumsum(params.g, chunk_size, cu_prepared);
+  const float scale_value = params.scale.has_value()
+                                ? params.scale.value()
+                                : std::pow(static_cast<float>(head_dim), -0.5f);
+  auto matrix_a = npu::npu_chunk_scaled_dot_kkt_fwd(
+      k_prepared, params.beta, g_cumsum, chunk_size, cu_prepared);
+  auto matrix_a_inv = npu::npu_solve_tril(
+      matrix_a, chunk_size, cu_prepared, params.k.scalar_type());
+  auto [w, u] = npu::npu_recompute_w_u_fwd(
+      k_prepared, params.v, params.beta, g_cumsum, matrix_a_inv, cu_prepared);
+  auto init_state_prepared =
+      params.initial_state.has_value()
+          ? std::optional<torch::Tensor>(
+                params.initial_state.value().to(torch::kFloat32).contiguous())
+          : std::nullopt;
+  auto [h, v_new, final_state] =
+      npu::npu_chunk_gated_delta_rule_fwd_h(k_prepared,
+                                            w,
+                                            u,
+                                            g_cumsum,
+                                            init_state_prepared,
+                                            params.output_final_state,
+                                            chunk_size,
+                                            /*save_new_value=*/true,
+                                            cu_prepared,
+                                            /*chunk_offsets=*/std::nullopt);
+  auto out = npu::npu_chunk_fwd_o(q_prepared,
+                                  k_prepared,
+                                  v_new,
+                                  h,
+                                  g_cumsum,
+                                  scale_value,
+                                  chunk_size,
+                                  cu_prepared);
+
+  return {out.to(input_dtype),
+          params.output_final_state ? final_state : torch::Tensor()};
 #else
   NOT_IMPLEMENTED();
 #endif

--- a/xllm/core/kernels/ops_api.cpp
+++ b/xllm/core/kernels/ops_api.cpp
@@ -1138,23 +1138,23 @@ std::pair<torch::Tensor, torch::Tensor> chunk_gated_delta_rule(
   auto init_state_prepared =
       params.initial_state.has_value()
           ? std::optional<torch::Tensor>(
-                params.initial_state.value().to(torch::kFloat32).contiguous())
+                params.initial_state.value().to(torch::kBFloat16).contiguous())
           : std::nullopt;
-  auto [h, v_new, final_state] =
-      npu::npu_chunk_gated_delta_rule_fwd_h(k_prepared,
-                                            w,
-                                            u,
-                                            g_cumsum,
-                                            init_state_prepared,
-                                            params.output_final_state,
-                                            chunk_size,
-                                            /*save_new_value=*/true,
-                                            cu_prepared,
-                                            /*chunk_offsets=*/std::nullopt);
+  auto [h, v_new, final_state] = npu::tilelang::chunk_gated_delta_rule_fwd_h(
+      k_prepared.squeeze(0),
+      w.squeeze(0),
+      u.squeeze(0),
+      g_cumsum.squeeze(0),
+      init_state_prepared,
+      params.output_final_state,
+      chunk_size,
+      /*save_new_value=*/true,
+      cu_prepared,
+      /*chunk_offsets=*/std::nullopt);
   auto out = npu::npu_chunk_fwd_o(q_prepared,
                                   k_prepared,
-                                  v_new,
-                                  h,
+                                  v_new.unsqueeze(0),
+                                  h.unsqueeze(0),
                                   g_cumsum,
                                   scale_value,
                                   chunk_size,


### PR DESCRIPTION
## Summary

Add TileLang `chunk_gated_delta_rule_fwd_h` kernel for Ascend NPU and replace the NPU native dispatch in `chunk_gated_delta_rule`.

## Background

In the chunk-wise gated delta rule pipeline, the `chunk_gated_delta_rule_fwd_h` step computes hidden states across chunks with gating. Previously this was handled by a monolithic NPU native operator. This PR refactors the pipeline into explicit steps in `ops_api.cpp` and implements the `fwd_h` step as a TileLang kernel with AOT dispatch, enabling better maintainability and future optimization.

## Changes

### 1. Refactor pipeline (`ops_api.cpp`)

Move `chunk_gated_delta_rule` logic from `torch_npu_ops` into `ops_api.cpp`, decomposing into explicit operator calls:

```
chunk_local_cumsum → scaled_dot_kkt_fwd → solve_tril → recompute_w_u_fwd → fwd_h → chunk_fwd_o
```

### 2. New TileLang kernel (`chunk_gated_delta_rule_fwd_h.py`)

- Kernel definition supporting batch & varlen modes, GQA head mapping, optional gating, and final state output
- JIT path via `@tilelang.jit` for development and AOT path via `@register_kernel` for production dispatch
- 96 specialization variants covering common (N, H, Hg, K, V) configs

### 3. C++ AOT wrapper (`chunk_gated_delta_rule_fwd_h_wrapper.cpp`)

- Input validation, specialization selection with N-fallback, workspace allocation
- Integrated into `tilelang_kernels` CMake build

### 4. Tests (`chunk_gated_delta_rule_fwd_h_wrapper_test.cpp`)

- Shape-correctness tests for multiple (N, T, H, Hg) combos
- Accuracy tests against CPU float32 reference with GQA head mapping

### 5. Cleanup

Remove unused temporary buffers in `fused_gdn_gating.py` and `split_qkv_rmsnorm_mrope.py`.

## Files Changed

| File | Change |
|------|--------|
| `xllm/compiler/tilelang/.../chunk_gated_delta_rule_fwd_h.py` | +623 new |
| `xllm/core/kernels/npu/tilelang/chunk_gated_delta_rule_fwd_h_wrapper.cpp` | +329 new |
| `xllm/core/kernels/npu/tilelang/chunk_gated_delta_rule_fwd_h_wrapper_test.cpp` | +376 new |
| `xllm/core/kernels/ops_api.cpp` | +94/-11 refactor |
| `xllm/core/kernels/npu/tilelang/CMakeLists.txt` | +17 |
| `xllm/core/kernels/npu/tilelang/tilelang_ops_api.h` | +19 |
| `xllm/compiler/tilelang/.../fused_gdn_gating.py` | -3 cleanup |
| `xllm/compiler/tilelang/.../split_qkv_rmsnorm_mrope.py` | -34 cleanup |
| `third_party/tilelang-ascend` + patch | submodule bump |

## Verification

- C++ unit tests: shape-correctness and accuracy-against-reference for multiple configs
- Python JIT tests: batch mode validation against CPU reference
- All tests pass with `rtol=5e-4, atol=1e-2` (Python) and `rtol=5e-2, atol=5e-1` (C++ bf16 vs fp32 reference)
## Performance

### Environment

| Item       | Value            |
|-----------|------------------|
| Hardware  | Ascend 910B (A3) |
| Model     | Qwen3.5-9B       |
| Precision | BF16             |

### Kernel Profiler (MS Profiler)

Config: `WARMUP_BATCHES=8`, `INPUT_TOKENS=16384`

| Metric               | TileLang        | Triton          | Speedup |
|---------------------|-----------------|-----------------|---------|
| Total op time       | 2,569,377.50 us | 2,619,642.52 us | 1.02x   |
| `fwd_h` op time     | 65,050.62 us    | 112,864.36 us   | **1.73x** |
| `fwd_h` avg per call| 2,710.44 us     | 4,702.68 us     | **1.73x** |

### TTFT (ais_bench)

Config: `batch_size=1`, `max_out_len=512`, `requests_per_round=10`, BF16, random input ~Uniform(1,200), random output ~Gaussian(μ=100, σ²=200, [1,100])

| Round | TileLang Avg | TileLang P99 | Triton Avg  | Triton P99  | Speedup Avg | Speedup P99 |
|-------|-------------|-------------|------------|------------|------------|------------|
| 1     | 83.721 ms   | 88.924 ms   | 82.923 ms  | 90.149 ms  | 0.99x      | 1.01x      |
| 2     | 81.760 ms   | 84.648 ms   | 86.864 ms  | 95.160 ms  | 1.06x      | 1.12x      |
| 3     | 85.378 ms   | 92.813 ms   | 88.900 ms  | 99.998 ms  | 1.04x      | 1.08x      |
| 4     | 82.837 ms   | 86.564 ms   | 84.759 ms  | 92.103 ms  | 1.02x      | 1.06x      |
| **Avg** | **83.424 ms** | **88.237 ms** | **85.862 ms** | **94.352 ms** | **1.03x** | **1.07x** |

TileLang P99 consistently lower; overall avg TTFT speedup ~1.03x, P99 speedup ~1.07x.
