### PR TITLE
bugfix: stabilize ACL graph dp/cp ep padding capture addresses.

### DIFF
--- a/xllm/core/runtime/acl_graph_executor_impl.cpp
+++ b/xllm/core/runtime/acl_graph_executor_impl.cpp
@@ -578,7 +578,7 @@ std::optional<ModelInputParams> GraphPersistentParam::update(
     auto slice_like = [](const torch::Tensor& persistent,
                          const torch::Tensor& src) -> torch::Tensor {
       if (!src.defined() || src.numel() == 0 || !persistent.defined()) {
-        return src;
+        return persistent;
       }
       return persistent.slice(/*dim=*/0, /*start=*/0, /*end=*/src.size(0));
     };


### PR DESCRIPTION
stabilize ACL graph dp/cp ep padding capture addresses on empty src.