### PR TITLE
feat: support beam search top logprob defaults.

### DIFF
--- a/docs/en/getting_started/offline_service.md
+++ b/docs/en/getting_started/offline_service.md
@@ -6,6 +6,31 @@ To facilitate users in quickly using xLLM for offline inference, we provide Pyth
 
 LLM inference example: [:simple-github: https://github.com/jd-opensource/xllm/blob/main/examples/generate.py](https://github.com/jd-opensource/xllm/blob/main/examples/generate.py)
 
+LLM Beam Search example: [:simple-github: https://github.com/jd-opensource/xllm/blob/main/examples/generate_beam_search.py](https://github.com/jd-opensource/xllm/blob/main/examples/generate_beam_search.py)
+
+Use `BeamSearchParams` with `beam_width` greater than `1`, then call `llm.beam_search(...)`:
+
+```python
+from xllm import BeamSearchParams, LLM
+
+llm = LLM(model="/path/models/Qwen2-7B-Instruct", devices="npu:0")
+params = BeamSearchParams(
+    beam_width=2,
+    top_logprobs=4,
+    max_tokens=20,
+)
+
+outputs = llm.beam_search(
+    [{"prompt": "Hello, my name is "}],
+    params=params,
+)
+print(outputs[0].sequences[0].text)
+
+llm.finish()
+```
+
+For LLM Beam Search, use `beam_width` as the switch. `top_logprobs` controls the top-k candidate count used for beam expansion at each decode step. If `top_logprobs` is left at its default value, xLLM uses `beam_width` as the top logprob count. Set `top_logprobs` to a value greater than `beam_width` when you want each beam to consider more candidate tokens. This beam-search top-k is different from the sampling cutoff parameter `top_k`. `best_of` is not the Beam Search switch, and this offline LLM guide does not use `num_return_sequences` to control the returned beams.
+
 ## Embedding
 
 Generate embedding example: [:simple-github: https://github.com/jd-opensource/xllm/blob/main/examples/generate_embedding.py](https://github.com/jd-opensource/xllm/blob/main/examples/generate_embedding.py)

--- a/docs/en/getting_started/online_service.md
+++ b/docs/en/getting_started/online_service.md
@@ -30,13 +30,53 @@ curl http://localhost:9977/v1/chat/completions \
 Completions mode:
 ```bash
 curl http://127.0.0.1:9977/v1/completions \
-    -H "Content-Type: application/json" \
-    -d '{
-        "model": "Qwen2-7B-Instruct",
+  -H "Content-Type: application/json" \
+  -d '{
+    "model": "Qwen2-7B-Instruct",
     "prompt": "hello xllm",
     "max_tokens": 10,
     "temperature": 0,
     "stream": true
+  }'
+```
+
+Beam Search:
+
+Set `beam_width` to a value greater than `1` to enable LLM Beam Search. This parameter is supported by both `/v1/chat/completions` and `/v1/completions`. The beam-search top-k candidate count is configured with `top_logprobs` in chat requests and with the numeric `logprobs` field in completion requests. When these fields are omitted, xLLM uses `beam_width` as the top logprob count. Set the candidate count to a value greater than `beam_width` when you want each beam to consider more candidate tokens. This is different from the sampling cutoff parameter `top_k`. `best_of` is not the Beam Search switch, and this LLM API guide does not use `num_return_sequences` to control the returned beams.
+
+Chat mode:
+```bash
+curl http://localhost:9977/v1/chat/completions \
+  -H "Content-Type: application/json" \
+  -d '{
+    "model": "Qwen2-7B-Instruct",
+    "max_tokens": 20,
+    "temperature": 0,
+    "stream": false,
+    "beam_width": 2,
+    "logprobs": true,
+    "top_logprobs": 4,
+    "messages": [
+      {
+        "role": "user",
+        "content": "Write a short introduction to xLLM."
+      }
+    ]
+  }'
+```
+
+Completions mode:
+```bash
+curl http://127.0.0.1:9977/v1/completions \
+  -H "Content-Type: application/json" \
+  -d '{
+    "model": "Qwen2-7B-Instruct",
+    "prompt": "Write a short introduction to xLLM.",
+    "max_tokens": 20,
+    "temperature": 0,
+    "stream": false,
+    "beam_width": 2,
+    "logprobs": 4
   }'
 ```
 

--- a/docs/zh/getting_started/offline_service.md
+++ b/docs/zh/getting_started/offline_service.md
@@ -6,6 +6,31 @@
 
 LLM推理示例：[:simple-github: https://github.com/jd-opensource/xllm/blob/main/examples/generate.py](https://github.com/jd-opensource/xllm/blob/main/examples/generate.py)
 
+LLM Beam Search 示例：[:simple-github: https://github.com/jd-opensource/xllm/blob/main/examples/generate_beam_search.py](https://github.com/jd-opensource/xllm/blob/main/examples/generate_beam_search.py)
+
+使用 `BeamSearchParams` 设置大于 `1` 的 `beam_width`，然后调用 `llm.beam_search(...)`：
+
+```python
+from xllm import BeamSearchParams, LLM
+
+llm = LLM(model="/path/models/Qwen2-7B-Instruct", devices="npu:0")
+params = BeamSearchParams(
+    beam_width=2,
+    top_logprobs=4,
+    max_tokens=20,
+)
+
+outputs = llm.beam_search(
+    [{"prompt": "Hello, my name is "}],
+    params=params,
+)
+print(outputs[0].sequences[0].text)
+
+llm.finish()
+```
+
+LLM Beam Search 使用 `beam_width` 作为开启参数。`top_logprobs` 控制每个解码步用于 beam 扩展的 top-k 候选数量。如果 `top_logprobs` 保持默认值，xLLM 会使用 `beam_width` 作为 top logprob 数量。如果希望每个 beam 考虑更多候选 token，可以将 `top_logprobs` 设置为大于 `beam_width` 的值。这里的 beam-search top-k 不同于采样截断参数 `top_k`。`best_of` 不是 Beam Search 开关，本文档也不使用 `num_return_sequences` 来控制 LLM 返回的 beam 数。
+
 ## Embedding
 
 生成Embedding示例：[:simple-github: https://github.com/jd-opensource/xllm/blob/main/examples/generate_embedding.py](https://github.com/jd-opensource/xllm/blob/main/examples/generate_embedding.py)
@@ -13,4 +38,3 @@ LLM推理示例：[:simple-github: https://github.com/jd-opensource/xllm/blob/ma
 ## VLM
 
 VLM推理示例：[:simple-github: https://github.com/jd-opensource/xllm/blob/main/examples/generate_vlm.py](https://github.com/jd-opensource/xllm/blob/main/examples/generate_vlm.py)
-

--- a/docs/zh/getting_started/online_service.md
+++ b/docs/zh/getting_started/online_service.md
@@ -29,13 +29,53 @@ curl http://localhost:9977/v1/chat/completions \
 completions模式：
 ```bash
 curl http://127.0.0.1:9977/v1/completions \
-    -H "Content-Type: application/json" \
-    -d '{
-        "model": "Qwen2-7B-Instruct",
+  -H "Content-Type: application/json" \
+  -d '{
+    "model": "Qwen2-7B-Instruct",
     "prompt": "hello xllm",
     "max_tokens": 10,
     "temperature": 0,
     "stream": true
+  }'
+```
+
+Beam Search：
+
+将 `beam_width` 设置为大于 `1` 的值即可开启 LLM Beam Search。`/v1/chat/completions` 和 `/v1/completions` 均支持该参数。beam-search top-k 候选数量在 chat 请求中使用 `top_logprobs` 配置，在 completions 请求中使用数值型 `logprobs` 字段配置。如果这些字段未设置，xLLM 会使用 `beam_width` 作为 top logprob 数量。如果希望每个 beam 考虑更多候选 token，可以将候选数量设置为大于 `beam_width` 的值。这里的 top-k 不同于采样截断参数 `top_k`。`best_of` 不是 Beam Search 开关，本文档也不使用 `num_return_sequences` 来控制 LLM 返回的 beam 数。
+
+chat模式：
+```bash
+curl http://localhost:9977/v1/chat/completions \
+  -H "Content-Type: application/json" \
+  -d '{
+    "model": "Qwen2-7B-Instruct",
+    "max_tokens": 20,
+    "temperature": 0,
+    "stream": false,
+    "beam_width": 2,
+    "logprobs": true,
+    "top_logprobs": 4,
+    "messages": [
+      {
+        "role": "user",
+        "content": "请简短介绍 xLLM。"
+      }
+    ]
+  }'
+```
+
+completions模式：
+```bash
+curl http://127.0.0.1:9977/v1/completions \
+  -H "Content-Type: application/json" \
+  -d '{
+    "model": "Qwen2-7B-Instruct",
+    "prompt": "请简短介绍 xLLM。",
+    "max_tokens": 20,
+    "temperature": 0,
+    "stream": false,
+    "beam_width": 2,
+    "logprobs": 4
   }'
 ```
 

--- a/examples/generate_beam_search.py
+++ b/examples/generate_beam_search.py
@@ -1,5 +1,5 @@
-# python examples/beam_search.py --model='/path/models/Qwen2-7B-Instruct' --devices='npu:0'
-# python beam_search.py --model='/path/models/Qwen2-7B-Instruct' --devices='npu:0,npu:1'
+# python examples/generate_beam_search.py --model='/path/models/Qwen2-7B-Instruct' --devices='npu:0'
+# python generate_beam_search.py --model='/path/models/Qwen2-7B-Instruct' --devices='npu:0,npu:1'
 
 from xllm import ArgumentParser, BeamSearchParams, LLM
 
@@ -9,6 +9,8 @@ llm = LLM(**vars(parser.parse_args()))
 
 beam_search_params = BeamSearchParams(
     beam_width=2,
+    # Top-k candidate count for beam expansion. Defaults to beam_width.
+    top_logprobs=4,
     max_tokens=20,
 )
 

--- a/tests/core/framework/request/CMakeLists.txt
+++ b/tests/core/framework/request/CMakeLists.txt
@@ -10,3 +10,13 @@ cc_test(
     GTest::gtest
     GTest::gtest_main
 )
+
+cc_test(
+  NAME
+    request_params_test
+  SRCS
+    request_params_test.cpp
+  DEPS
+    :request
+    GTest::gtest_main
+)

--- a/tests/core/framework/request/request_params_test.cpp
+++ b/tests/core/framework/request/request_params_test.cpp
@@ -1,0 +1,104 @@
+/* Copyright 2026 The xLLM Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://github.com/jd-opensource/xllm/blob/main/LICENSE
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include "core/framework/request/request_params.h"
+
+#include <gtest/gtest.h>
+
+#include "chat.pb.h"
+#include "completion.pb.h"
+
+namespace xllm {
+namespace {
+
+TEST(RequestParamsTest,
+     CompletionBeamSearchDefaultsTopLogprobsToBeamWidthWhenUnset) {
+  proto::CompletionRequest request;
+  request.set_beam_width(3);
+
+  RequestParams params(request, "", "");
+
+  EXPECT_TRUE(params.logprobs);
+  EXPECT_EQ(params.top_logprobs, 3);
+}
+
+TEST(RequestParamsTest, CompletionBeamSearchKeepsExplicitLogprobsWhenSet) {
+  proto::CompletionRequest request;
+  request.set_beam_width(3);
+  request.set_logprobs(5);
+
+  RequestParams params(request, "", "");
+
+  EXPECT_TRUE(params.logprobs);
+  EXPECT_EQ(params.top_logprobs, 5);
+}
+
+TEST(RequestParamsTest, CompletionNonBeamSearchKeepsLogprobsDisabled) {
+  proto::CompletionRequest request;
+  request.set_beam_width(1);
+
+  RequestParams params(request, "", "");
+
+  EXPECT_FALSE(params.logprobs);
+  EXPECT_EQ(params.top_logprobs, 0);
+}
+
+TEST(RequestParamsTest, ChatBeamSearchDefaultsTopLogprobsToBeamWidthWhenUnset) {
+  proto::ChatRequest request;
+  request.set_beam_width(4);
+
+  RequestParams params(request, "", "");
+
+  EXPECT_TRUE(params.logprobs);
+  EXPECT_EQ(params.top_logprobs, 4);
+}
+
+TEST(RequestParamsTest, ChatBeamSearchKeepsExplicitLogprobsDisabled) {
+  proto::ChatRequest request;
+  request.set_beam_width(4);
+  request.set_logprobs(false);
+
+  RequestParams params(request, "", "");
+
+  EXPECT_FALSE(params.logprobs);
+  EXPECT_EQ(params.top_logprobs, 0);
+}
+
+TEST(RequestParamsTest, ChatBeamSearchKeepsExplicitTopLogprobs) {
+  proto::ChatRequest request;
+  request.set_beam_width(4);
+  request.set_logprobs(true);
+  request.set_top_logprobs(2);
+
+  RequestParams params(request, "", "");
+
+  EXPECT_TRUE(params.logprobs);
+  EXPECT_EQ(params.top_logprobs, 2);
+}
+
+TEST(RequestParamsTest, ChatBeamSearchKeepsExplicitZeroTopLogprobs) {
+  proto::ChatRequest request;
+  request.set_beam_width(4);
+  request.set_logprobs(true);
+  request.set_top_logprobs(0);
+
+  RequestParams params(request, "", "");
+
+  EXPECT_TRUE(params.logprobs);
+  EXPECT_EQ(params.top_logprobs, 0);
+}
+
+}  // namespace
+}  // namespace xllm

--- a/xllm/core/distributed_runtime/llm_master.cpp
+++ b/xllm/core/distributed_runtime/llm_master.cpp
@@ -370,7 +370,8 @@ std::shared_ptr<Request> LLMMaster::generate_request(
     // candidate for beam expansion.
     sampling_param.logprobs = true;
     if (sampling_param.top_logprobs == 0) {
-      sampling_param.top_logprobs = 1;
+      sampling_param.top_logprobs =
+          static_cast<int64_t>(sampling_param.beam_width);
     }
   }
   // sampling_param.do_sample = sp.do_sample;

--- a/xllm/core/framework/kv_cache/kv_cache_shape.cpp
+++ b/xllm/core/framework/kv_cache/kv_cache_shape.cpp
@@ -211,11 +211,12 @@ void KVCacheShape::init_key_cache_shape(const KVCacheCapacity& kv_cache_cap,
   if (model_args.enable_mla()) {
 #if defined(USE_NPU)
     if (model_args.model_type() == "deepseek_v3" && FLAGS_enable_prefix_cache) {
-      key_cache_shape_ = std::vector<int64_t>{
-          kv_cache_cap.n_blocks(),
-          util::ceil_div(model_args.kv_lora_rank(), kNzAlignment),
-          kv_cache_cap.block_size(),
-          kNzAlignment};
+      const int64_t kv_lora_rank = model_args.kv_lora_rank();
+      key_cache_shape_ =
+          std::vector<int64_t>{kv_cache_cap.n_blocks(),
+                               util::ceil_div(kv_lora_rank, kNzAlignment),
+                               kv_cache_cap.block_size(),
+                               kNzAlignment};
       return;
     }
 #endif
@@ -242,11 +243,12 @@ void KVCacheShape::init_value_cache_shape(const KVCacheCapacity& kv_cache_cap,
   if (model_args.enable_mla()) {
 #if defined(USE_NPU)
     if (model_args.model_type() == "deepseek_v3" && FLAGS_enable_prefix_cache) {
-      value_cache_shape_ = std::vector<int64_t>{
-          kv_cache_cap.n_blocks(),
-          util::ceil_div(model_args.qk_rope_head_dim(), kNzAlignment),
-          kv_cache_cap.block_size(),
-          kNzAlignment};
+      const int64_t qk_rope_head_dim = model_args.qk_rope_head_dim();
+      value_cache_shape_ =
+          std::vector<int64_t>{kv_cache_cap.n_blocks(),
+                               util::ceil_div(qk_rope_head_dim, kNzAlignment),
+                               kv_cache_cap.block_size(),
+                               kNzAlignment};
       return;
     }
 #endif

--- a/xllm/core/framework/request/request_params.cpp
+++ b/xllm/core/framework/request/request_params.cpp
@@ -52,6 +52,15 @@ std::string generate_anthropic_chat_request_id() {
          short_uuid.random();
 }
 
+void apply_beam_search_logprobs_default(
+    RequestParams& params,
+    bool probability_params_explicitly_set) {
+  if (params.beam_width > 1 && !probability_params_explicitly_set) {
+    params.logprobs = true;
+    params.top_logprobs = static_cast<int64_t>(params.beam_width);
+  }
+}
+
 // Handle tool_choice conversion from Anthropic format to internal format
 std::string handle_tool_choice(
     const proto::AnthropicMessagesRequest& rpc_request) {
@@ -225,6 +234,8 @@ RequestParams::RequestParams(const proto::CompletionRequest& request,
   if (request.has_num_return_sequences()) {
     num_return_sequences = request.num_return_sequences();
   }
+  apply_beam_search_logprobs_default(
+      *this, /*probability_params_explicitly_set=*/request.has_logprobs());
   if (request.has_add_special_tokens()) {
     add_special_tokens = request.add_special_tokens();
   } else {
@@ -420,6 +431,10 @@ void init_from_chat_request(RequestParams& params, const ChatRequest& request) {
   if (request.has_num_return_sequences()) {
     params.num_return_sequences = request.num_return_sequences();
   }
+  apply_beam_search_logprobs_default(
+      params,
+      /*probability_params_explicitly_set=*/
+      request.has_logprobs() || request.has_top_logprobs());
 
   if (request.has_add_special_tokens()) {
     params.add_special_tokens = request.add_special_tokens();

--- a/xllm/core/framework/request/sequence_logprob_state.cpp
+++ b/xllm/core/framework/request/sequence_logprob_state.cpp
@@ -141,7 +141,7 @@ void LogprobState::generate_output_tokens_logprobs(
     std::vector<LogProbData> logprobs;
     for (size_t j = 0; j < top_tokens.size(); ++j) {
       LogProbData logprob;
-      const int32_t top_token_id = top_tokens[j];
+      const int32_t top_token_id = static_cast<int32_t>(top_tokens[j]);
       const float top_logprob = top_logprobs[j];
 
       auto top_token = tokenizer.decode(std::vector<int32_t>{top_token_id},

--- a/xllm/pybind/llm.py
+++ b/xllm/pybind/llm.py
@@ -331,7 +331,7 @@ class LLM:
         params = to_request_params(params, default_cls=BeamSearchParams)
         if params.beam_width <= 0:
             raise ValueError("beam_width must be greater than 0")
-        else:
+        elif params.beam_width > 1:
             # Beam search relies on top-k logprob candidates from sampler.
             # Keep this aligned with the LLM request-path default.
             if "logprobs" not in explicit_fields:

--- a/xllm/pybind/llm.py
+++ b/xllm/pybind/llm.py
@@ -15,6 +15,7 @@ from .params import (
     BeamSearchParams,
     PoolingParams,
     SamplingParams,
+    _RequestParamsProxy,
     to_request_params,
     to_request_params_list,
 )
@@ -322,16 +323,24 @@ class LLM:
                 continue
             raise TypeError("prompts must be str or dict with key 'prompt'")
 
+        explicit_fields = (
+            params.explicit_fields()
+            if isinstance(params, _RequestParamsProxy)
+            else set()
+        )
         params = to_request_params(params, default_cls=BeamSearchParams)
         if params.beam_width <= 0:
             raise ValueError("beam_width must be greater than 0")
         else:
             # Beam search relies on top-k logprob candidates from sampler.
-            # Keep this aligned with vLLM's internal default behavior.
-            params.logprobs = True
-            if params.top_logprobs == 0:
-                # if not set top_logprobs, default to returning 2x candidates for better deduplication
-                params.top_logprobs = 2 * params.beam_width
+            # Keep this aligned with the LLM request-path default.
+            if "logprobs" not in explicit_fields:
+                params.logprobs = True
+            if (
+                "top_logprobs" not in explicit_fields
+                and params.top_logprobs == 0
+            ):
+                params.top_logprobs = params.beam_width
 
         outputs = self.generate(parsed_prompts,
                                 request_params=params,

--- a/xllm/pybind/params.py
+++ b/xllm/pybind/params.py
@@ -1,4 +1,4 @@
-from typing import Any, List, Optional, Type, Union
+from typing import Any, List, Optional, Set, Type, Union
 
 from xllm_export import RequestParams
 
@@ -6,6 +6,7 @@ from xllm_export import RequestParams
 class _RequestParamsProxy:
     def __init__(self, **kwargs: Any) -> None:
         object.__setattr__(self, "_request_params", RequestParams())
+        object.__setattr__(self, "_explicit_fields", set())
         for key, value in kwargs.items():
             self._set_field(key, value)
 
@@ -13,6 +14,7 @@ class _RequestParamsProxy:
         if not hasattr(self._request_params, key):
             raise TypeError(f"Unexpected parameter: {key}")
         setattr(self._request_params, key, value)
+        self._explicit_fields.add(key)
 
     def __getattr__(self, key: str) -> Any:
         return getattr(self._request_params, key)
@@ -25,6 +27,9 @@ class _RequestParamsProxy:
 
     def to_request_params(self) -> RequestParams:
         return self._request_params
+
+    def explicit_fields(self) -> Set[str]:
+        return set(self._explicit_fields)
 
 
 class SamplingParams(_RequestParamsProxy):


### PR DESCRIPTION
- Default beam search top_logprobs to beam_width when unset.

- Keep response top_logprobs separate from internal beam expansion candidates.

- Document top-k usage for offline and online beam search examples.