### PR TITLE
bugfix: ensure tensor contiguous layout before protobuf serialization.

### DIFF
--- a/xllm/core/util/utils.cpp
+++ b/xllm/core/util/utils.cpp
@@ -518,6 +518,8 @@ bool torch_to_proto(const torch::Tensor& torch_tensor,
     return false;
   }
 
+  // Ensure contiguous (NCHW) layout before serializing raw bytes
+  auto contig_tensor = torch_tensor.contiguous();
   torch::ScalarType torch_dtype = torch_tensor.scalar_type();
   std::string proto_datatype = torch_datatype_to_proto(torch_dtype);
   if (proto_datatype.empty()) {
@@ -568,7 +570,7 @@ bool torch_to_proto(const torch::Tensor& torch_tensor,
       break;
     case torch::kBFloat16: {
       // Need to convert bfloat16 to uint8_t for storage
-      auto bfloat16_ptr = torch_tensor.data_ptr<torch::BFloat16>();
+      auto bfloat16_ptr = contig_tensor.data_ptr<torch::BFloat16>();
       uint8_t* uint8_ptr = reinterpret_cast<uint8_t*>(bfloat16_ptr);
       torch::Tensor uint8_tensor =
           torch::from_blob(uint8_ptr,
@@ -581,7 +583,7 @@ bool torch_to_proto(const torch::Tensor& torch_tensor,
     }
     case torch::kHalf: {
       // Need to convert float16 to uint8_t for storage
-      auto float16_ptr = torch_tensor.data_ptr<torch::Half>();
+      auto float16_ptr = contig_tensor.data_ptr<torch::Half>();
       uint8_t* uint8_ptr = reinterpret_cast<uint8_t*>(float16_ptr);
       torch::Tensor uint8_tensor = torch::from_blob(
           uint8_ptr,

--- a/xllm/core/util/utils.cpp
+++ b/xllm/core/util/utils.cpp
@@ -518,8 +518,6 @@ bool torch_to_proto(const torch::Tensor& torch_tensor,
     return false;
   }
 
-  // Ensure contiguous (NCHW) layout before serializing raw bytes
-  auto contig_tensor = torch_tensor.contiguous();
   torch::ScalarType torch_dtype = torch_tensor.scalar_type();
   std::string proto_datatype = torch_datatype_to_proto(torch_dtype);
   if (proto_datatype.empty()) {
@@ -569,12 +567,15 @@ bool torch_to_proto(const torch::Tensor& torch_tensor,
           proto_contents, torch_tensor, proto_datatype);
       break;
     case torch::kBFloat16: {
-      // Need to convert bfloat16 to uint8_t for storage
+      // Need to convert bfloat16 to uint8_t for storage.
+      // Ensure contiguous layout first — data_ptr() reads raw memory
+      // which would be wrong for NHWC/ChannelsLast tensors.
+      torch::Tensor contig_tensor = torch_tensor.contiguous();
       auto bfloat16_ptr = contig_tensor.data_ptr<torch::BFloat16>();
       uint8_t* uint8_ptr = reinterpret_cast<uint8_t*>(bfloat16_ptr);
       torch::Tensor uint8_tensor =
           torch::from_blob(uint8_ptr,
-                           {static_cast<int64_t>(torch_tensor.numel() *
+                           {static_cast<int64_t>(contig_tensor.numel() *
                                                  sizeof(torch::BFloat16))},
                            torch::dtype(torch::kUInt8));
       data_set_success = set_data_to_contents<uint8_t>(
@@ -582,12 +583,15 @@ bool torch_to_proto(const torch::Tensor& torch_tensor,
       break;
     }
     case torch::kHalf: {
-      // Need to convert float16 to uint8_t for storage
+      // Need to convert float16 to uint8_t for storage.
+      // Ensure contiguous layout first — data_ptr() reads raw memory
+      // which would be wrong for NHWC/ChannelsLast tensors.
+      torch::Tensor contig_tensor = torch_tensor.contiguous();
       auto float16_ptr = contig_tensor.data_ptr<torch::Half>();
       uint8_t* uint8_ptr = reinterpret_cast<uint8_t*>(float16_ptr);
       torch::Tensor uint8_tensor = torch::from_blob(
           uint8_ptr,
-          {static_cast<int64_t>(torch_tensor.numel() * sizeof(torch::Half))},
+          {static_cast<int64_t>(contig_tensor.numel() * sizeof(torch::Half))},
           torch::dtype(torch::kUInt8));
       data_set_success = set_data_to_contents<uint8_t>(
           proto_contents, uint8_tensor, proto_datatype);


### PR DESCRIPTION
NHWC (channels_last) tensors pass raw bytes directly into the proto buffer when serialized via torch_to_proto. On deserialization the reconstructed tensor assumes NCHW (contiguous) layout, which corrupts the channel order for bfloat16 and float16 image data. Force a contiguous copy before reading data_ptr() so the byte stream always matches the expected row-major order.