### PR TITLE
bugfix: skip host tensor creation in graph mode to fix TPOT regression

### DIFF
--- a/xllm/core/layers/common/attention_metadata_builder.cpp
+++ b/xllm/core/layers/common/attention_metadata_builder.cpp
@@ -109,14 +109,17 @@ AttentionMetadata build_attention_metadata(
   }
   // Provide capture-time host seq_lens for NPU kernels. ACL graph replay must
   // rely on fixed-address device inputs such as tiling_data, not mutable host
-  // tensors.
-  if (!params.q_seq_lens_vec.empty()) {
-    attn_metadata.q_seq_lens_host =
-        torch::tensor(params.q_seq_lens_vec, torch::kInt);
-  }
-  if (!params.kv_seq_lens_vec.empty()) {
-    attn_metadata.kv_seq_lens_host =
-        torch::tensor(params.kv_seq_lens_vec, torch::kInt);
+  // tensors. Skip host tensor creation in graph mode to avoid unnecessary
+  // CPU memory allocation and copy overhead on every decode step.
+  if (!use_acl_graph) {
+    if (!params.q_seq_lens_vec.empty()) {
+      attn_metadata.q_seq_lens_host =
+          torch::tensor(params.q_seq_lens_vec, torch::kInt);
+    }
+    if (!params.kv_seq_lens_vec.empty()) {
+      attn_metadata.kv_seq_lens_host =
+          torch::tensor(params.kv_seq_lens_vec, torch::kInt);
+    }
   }
 #endif
   attn_metadata.is_chunked_prefill =


### PR DESCRIPTION
MTP commit (0b294d0e) introduced unnecessary host tensor creation (q_seq_lens_host, kv_seq_lens_host) on every decode step, even when ACL graph mode is enabled. These host tensors are not used in graph mode since replay relies on device-side tiling_data.

This change wraps the host tensor creation in a !use_acl_graph check, avoiding CPU memory allocation and copy overhead on every decode step.

Performance impact:
- TPOT improved from ~10.3ms to ~8.36ms (~19% improvement)
- Throughput improved from ~100 to ~125 tokens/sec (~25% improvement)

Fixes performance regression introduced in commit 0b294d0e.