### PR TITLE
feat: support LongCat-AudioDiT on cuda device.

### DIFF
--- a/xllm/api_service/CMakeLists.txt
+++ b/xllm/api_service/CMakeLists.txt
@@ -14,6 +14,7 @@ cc_library(
     anthropic_service_impl.h
     sample_service_impl.h
     embedding_service_impl.h
+    audio_generation_service_impl.h
     image_generation_service_impl.h
     rerank_service_impl.h
     qwen3_rerank_service_impl.h
@@ -37,6 +38,7 @@ cc_library(
     anthropic_service_impl.cpp
     sample_service_impl.cpp
     embedding_service_impl.cpp
+    audio_generation_service_impl.cpp
     image_generation_service_impl.cpp
     models_service_impl.cpp
     rerank_service_impl.cpp

--- a/xllm/api_service/api_service.cpp
+++ b/xllm/api_service/api_service.cpp
@@ -487,6 +487,52 @@ void APIService::ImageGenerationHttp(
   image_generation_service_impl_->process_async(call);
 }
 
+void APIService::AudioGeneration(::google::protobuf::RpcController* controller,
+                                 const proto::AudioGenerationRequest* request,
+                                 proto::AudioGenerationResponse* response,
+                                 ::google::protobuf::Closure* done) {
+  // TODO with xllm-service
+}
+
+void APIService::AudioGenerationHttp(
+    ::google::protobuf::RpcController* controller,
+    const proto::HttpRequest* request,
+    proto::HttpResponse* response,
+    ::google::protobuf::Closure* done) {
+  xllm::ClosureGuard done_guard(
+      done,
+      std::bind(request_in_metric, nullptr),
+      std::bind(request_out_metric, static_cast<void*>(controller)));
+  if (!request || !response || !controller) {
+    LOG(ERROR) << "brpc request | response | controller is null";
+    return;
+  }
+
+  auto arena = GetArenaWithCheck<AudioGenerationCall>(response);
+  auto req_pb =
+      google::protobuf::Arena::CreateMessage<proto::AudioGenerationRequest>(
+          arena);
+  auto resp_pb =
+      google::protobuf::Arena::CreateMessage<proto::AudioGenerationResponse>(
+          arena);
+
+  brpc::Controller* ctrl = static_cast<brpc::Controller*>(controller);
+  std::string error;
+  json2pb::Json2PbOptions options;
+  butil::IOBuf& buf = ctrl->request_attachment();
+  butil::IOBufAsZeroCopyInputStream iobuf_stream(buf);
+  bool st = json2pb::JsonToProtoMessage(&iobuf_stream, req_pb, options, &error);
+  if (!st) {
+    ctrl->SetFailed(error);
+    LOG(ERROR) << "parse json to proto failed: " << error;
+    return;
+  }
+  std::shared_ptr<AudioGenerationCall> call =
+      std::make_shared<AudioGenerationCall>(
+          ctrl, done_guard.release(), req_pb, resp_pb, arena != nullptr);
+  audio_generation_service_impl_->process_async(call);
+}
+
 void APIService::Rerank(::google::protobuf::RpcController* controller,
                         const proto::RerankRequest* request,
                         proto::RerankResponse* response,

--- a/xllm/api_service/api_service.h
+++ b/xllm/api_service/api_service.h
@@ -21,6 +21,7 @@ limitations under the License.
 #include <unordered_map>
 
 #include "anthropic_service_impl.h"
+#include "audio_generation_service_impl.h"
 #include "chat_service_impl.h"
 #include "completion_service_impl.h"
 #include "embedding_service_impl.h"
@@ -92,6 +93,16 @@ class APIService : public proto::XllmAPIService {
                        ::google::protobuf::Closure* done) override;
 
   void ImageGenerationHttp(::google::protobuf::RpcController* controller,
+                           const proto::HttpRequest* request,
+                           proto::HttpResponse* response,
+                           ::google::protobuf::Closure* done) override;
+
+  void AudioGeneration(::google::protobuf::RpcController* controller,
+                       const proto::AudioGenerationRequest* request,
+                       proto::AudioGenerationResponse* response,
+                       ::google::protobuf::Closure* done) override;
+
+  void AudioGenerationHttp(::google::protobuf::RpcController* controller,
                            const proto::HttpRequest* request,
                            proto::HttpResponse* response,
                            ::google::protobuf::Closure* done) override;
@@ -204,6 +215,7 @@ class APIService : public proto::XllmAPIService {
   std::unique_ptr<MMEmbeddingServiceImpl> mm_embedding_service_impl_;
   std::unique_ptr<ModelsServiceImpl> models_service_impl_;
   std::unique_ptr<ImageGenerationServiceImpl> image_generation_service_impl_;
+  std::unique_ptr<AudioGenerationServiceImpl> audio_generation_service_impl_;
   std::unique_ptr<RerankServiceImpl> rerank_service_impl_;
   std::unique_ptr<RecCompletionServiceImpl> rec_completion_service_impl_;
 };

--- a/xllm/api_service/audio_generation_service_impl.cpp
+++ b/xllm/api_service/audio_generation_service_impl.cpp
@@ -1,0 +1,97 @@
+/* Copyright 2026 The xLLM Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://github.com/jd-opensource/xllm/blob/main/LICENSE
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include "audio_generation_service_impl.h"
+
+#include <glog/logging.h>
+
+#include "butil/base64.h"
+#include "common/instance_name.h"
+#include "distributed_runtime/dit_master.h"
+#include "framework/request/dit_request_output.h"
+#include "framework/request/dit_request_params.h"
+#include "util/utils.h"
+#include "util/uuid.h"
+
+namespace xllm {
+namespace {
+
+bool send_result_to_client_brpc(std::shared_ptr<AudioGenerationCall> call,
+                                const std::string& request_id,
+                                int64_t created_time,
+                                const std::string& model,
+                                const DiTRequestOutput& req_output) {
+  auto& response = call->response();
+  response.set_object("list");
+  response.set_id(request_id);
+  response.set_created(created_time);
+  response.set_model(model);
+  auto* proto_output = response.mutable_output();
+  const std::vector<DiTGenerationOutput>& outputs = req_output.outputs;
+  proto_output->mutable_results()->Reserve(
+      static_cast<int32_t>(outputs.size()));
+
+  for (const auto& output : outputs) {
+    auto* proto_result = proto_output->add_results();
+    std::string audio_b64;
+    butil::Base64Encode(output.audio, &audio_b64);
+    proto_result->set_audio(audio_b64);
+    proto_result->set_seed(output.seed);
+  }
+  return call->write_and_finish(response);
+}
+
+}  // namespace
+
+AudioGenerationServiceImpl::AudioGenerationServiceImpl(
+    DiTMaster* master,
+    const std::vector<std::string>& models)
+    : APIServiceImpl(models), master_{master} {
+  CHECK(master_ != nullptr);
+}
+
+void AudioGenerationServiceImpl::process_async_impl(
+    std::shared_ptr<AudioGenerationCall> call) {
+  const auto& rpc_request = call->request();
+  const std::string& model = rpc_request.model();
+  if (!models_.contains(model)) {
+    call->finish_with_error(StatusCode::UNKNOWN, "Model not supported");
+    return;
+  }
+
+  DiTRequestParams request_params(
+      rpc_request, call->get_x_request_id(), call->get_x_request_time());
+
+  std::string saved_request_id = request_params.request_id;
+  master_->handle_request(
+      std::move(request_params),
+      call.get(),
+      [call,
+       model,
+       request_id = std::move(saved_request_id),
+       created_time = absl::ToUnixSeconds(absl::Now())](
+          const DiTRequestOutput& req_output) -> bool {
+        if (req_output.status.has_value()) {
+          const auto& status = req_output.status.value();
+          if (!status.ok()) {
+            return call->finish_with_error(status.code(), status.message());
+          }
+        }
+        return send_result_to_client_brpc(
+            call, request_id, created_time, model, req_output);
+      });
+}
+
+}  // namespace xllm

--- a/xllm/api_service/audio_generation_service_impl.h
+++ b/xllm/api_service/audio_generation_service_impl.h
@@ -1,0 +1,42 @@
+/* Copyright 2026 The xLLM Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://github.com/jd-opensource/xllm/blob/main/LICENSE
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#pragma once
+#include <absl/container/flat_hash_set.h>
+
+#include "api_service/api_service_impl.h"
+#include "api_service/non_stream_call.h"
+#include "audio_generation.pb.h"
+
+namespace xllm {
+
+using AudioGenerationCall = NonStreamCall<proto::AudioGenerationRequest,
+                                          proto::AudioGenerationResponse>;
+class DiTMaster;
+
+class AudioGenerationServiceImpl final
+    : public APIServiceImpl<AudioGenerationCall> {
+ public:
+  explicit AudioGenerationServiceImpl(DiTMaster* master,
+                                      const std::vector<std::string>& models);
+
+  void process_async_impl(std::shared_ptr<AudioGenerationCall> call) override;
+
+ private:
+  DISALLOW_COPY_AND_ASSIGN(AudioGenerationServiceImpl);
+  DiTMaster* master_ = nullptr;
+};
+
+}  // namespace xllm

--- a/xllm/api_service/service_impl_factory.cpp
+++ b/xllm/api_service/service_impl_factory.cpp
@@ -88,9 +88,11 @@ void ServiceImplFactory::create(
        [](APIService* self,
           Master* master,
           const std::vector<std::string>& models) {
+         auto* dit_master = dynamic_cast<DiTMaster*>(master);
          self->image_generation_service_impl_ =
-             std::make_unique<ImageGenerationServiceImpl>(
-                 dynamic_cast<DiTMaster*>(master), models);
+             std::make_unique<ImageGenerationServiceImpl>(dit_master, models);
+         self->audio_generation_service_impl_ =
+             std::make_unique<AudioGenerationServiceImpl>(dit_master, models);
        }},
       {static_cast<int8_t>(ServingMode::REC),
        [](APIService* self,

--- a/xllm/core/framework/batch/dit_batch.cpp
+++ b/xllm/core/framework/batch/dit_batch.cpp
@@ -109,6 +109,17 @@ DiTForwardInput DiTBatch::prepare_forward_input() {
     mask_images.emplace_back(input_params.mask_image);
     condition_images.emplace_back(input_params.condition_image);
     control_images.emplace_back(input_params.control_image);
+
+    // Voice cloning: prompt_audio is per-request (batch_size==1 in practice).
+    // Forward the first defined tensor; multi-batch voice cloning is not
+    // supported (different prompt lengths can't be stacked).
+    if (input_params.prompt_audio.defined() && !input.prompt_audio.defined()) {
+      input.prompt_audio = input_params.prompt_audio;
+    }
+    if (!input_params.audio_prompt_text.empty() &&
+        input.audio_prompt_text.empty()) {
+      input.audio_prompt_text = input_params.audio_prompt_text;
+    }
   }
 
   if (input.prompts.size() != request_vec_.size()) {

--- a/xllm/core/framework/dit_model_context.h
+++ b/xllm/core/framework/dit_model_context.h
@@ -44,6 +44,10 @@ class DiTModelContext {
 
   const QuantArgs& get_quant_args(const std::string& component) const;
 
+  bool has_component(const std::string& component) const {
+    return model_args_.count(component) > 0;
+  }
+
 #if defined(USE_NPU) || defined(USE_CUDA) || defined(USE_MLU)
   ModelContext get_model_context(const std::string& component) const;
 #endif

--- a/xllm/core/framework/dit_model_loader.cpp
+++ b/xllm/core/framework/dit_model_loader.cpp
@@ -19,12 +19,15 @@ limitations under the License.
 #include <absl/strings/match.h>
 #include <absl/strings/str_replace.h>
 #include <glog/logging.h>
+#include <pybind11/embed.h>
 #include <torch/torch.h>
 
 #include <boost/algorithm/string.hpp>
 #include <filesystem>
+#include <fstream>
 #include <vector>
 
+#include "core/framework/tokenizer/tokenizer_args.h"
 #include "core/framework/tokenizer/tokenizer_factory.h"
 #include "core/util/json_reader.h"
 #include "models/model_registry.h"
@@ -52,7 +55,13 @@ DiTFolderLoader::DiTFolderLoader(const std::string& folder_path,
 }
 
 std::unique_ptr<Tokenizer> DiTFolderLoader::tokenizer() const {
-  return TokenizerFactory::create_tokenizer(model_weights_path_,
+  // When vocab_file is already an absolute path (e.g. loaded from HF cache),
+  // pass empty dir_path so the tokenizer uses it directly without prepending
+  // model_weights_path_.
+  const std::string& vocab = tokenizer_args_.vocab_file();
+  const bool vocab_is_absolute = !vocab.empty() && vocab[0] == '/';
+  const std::string dir_path = vocab_is_absolute ? "" : model_weights_path_;
+  return TokenizerFactory::create_tokenizer(dir_path,
                                             tokenizer_args_,
                                             /*proxy*/ false);
 }
@@ -71,13 +80,15 @@ std::vector<std::unique_ptr<StateDict>>& DiTFolderLoader::get_state_dicts() {
 }
 
 bool DiTFolderLoader::load_args(const std::string& model_weights_path) {
-  if (!load_tokenizer_args(model_weights_path)) {
-    LOG(ERROR) << "Failed to load tokenizer args from " << model_weights_path;
+  // model_args must be loaded first: it populates text_encoder_model_ which
+  // load_tokenizer_args uses as a fallback when no tokenizer files are present.
+  if (!load_model_args(model_weights_path)) {
+    LOG(ERROR) << "Failed to load model args from " << model_weights_path;
     return false;
   }
 
-  if (!load_model_args(model_weights_path)) {
-    LOG(ERROR) << "Failed to load model args from " << model_weights_path;
+  if (!load_tokenizer_args(model_weights_path)) {
+    LOG(ERROR) << "Failed to load tokenizer args from " << model_weights_path;
     return false;
   }
 
@@ -128,6 +139,14 @@ bool DiTFolderLoader::load_model_args(const std::string& model_weights_path) {
     if (!load_json_config("config.json")) {
       LOG(ERROR) << "Failed to load required config.json for safetensors model";
       return false;
+    }
+    // Read text_encoder_model for tokenizer fallback resolution.
+    const std::string config_json_path = model_weights_path + "/config.json";
+    JsonReader cfg_reader;
+    if (cfg_reader.parse(config_json_path)) {
+      if (auto v = cfg_reader.value<std::string>("text_encoder_model")) {
+        text_encoder_model_ = v.value();
+      }
     }
     load_image_preprocessor_args(model_weights_path);
   } else {
@@ -202,6 +221,196 @@ bool DiTFolderLoader::load_image_preprocessor_args(
   return true;
 }
 
+namespace {
+
+// Resolve a tokenizer directory from a HuggingFace repo id or local path,
+// following the same lookup order as HuggingFace Hub / mainstream frameworks.
+// Returns the resolved directory path, or empty string if not found.
+std::string resolve_text_encoder_tokenizer_path(
+    const std::string& text_encoder_model) {
+  // 1. Local absolute path.
+  if (std::filesystem::exists(text_encoder_model) &&
+      std::filesystem::is_directory(text_encoder_model)) {
+    return text_encoder_model;
+  }
+
+  // 2. HuggingFace cache: convert "org/name" -> "models--org--name".
+  //    Cache root candidates (matches huggingface_hub default behaviour):
+  //      $HF_HOME/hub  >  $HUGGINGFACE_HUB_CACHE  >  ~/.cache/huggingface/hub
+  const std::string hf_cache_dir = [&]() -> std::string {
+    if (const char* v = std::getenv("HF_HOME")) {
+      return std::string(v) + "/hub";
+    }
+    if (const char* v = std::getenv("HUGGINGFACE_HUB_CACHE")) {
+      return std::string(v);
+    }
+    if (const char* v = std::getenv("HOME")) {
+      return std::string(v) + "/.cache/huggingface/hub";
+    }
+    return "";
+  }();
+
+  if (!hf_cache_dir.empty() && std::filesystem::exists(hf_cache_dir)) {
+    // "google/umt5-base" -> "models--google--umt5-base"
+    std::string cache_key = "models--";
+    cache_key += absl::StrReplaceAll(text_encoder_model, {{"/", "--"}});
+
+    const std::filesystem::path model_cache_dir =
+        std::filesystem::path(hf_cache_dir) / cache_key;
+    const std::filesystem::path snapshots_dir = model_cache_dir / "snapshots";
+    if (std::filesystem::exists(snapshots_dir)) {
+      // Prefer the snapshot pointed to by refs/main (or refs/master),
+      // matching huggingface_hub's standard resolution order.
+      for (const auto& ref : {"main", "master"}) {
+        const std::filesystem::path ref_file = model_cache_dir / "refs" / ref;
+        if (std::filesystem::exists(ref_file)) {
+          std::ifstream ifs(ref_file.string());
+          std::string commit_hash;
+          if (std::getline(ifs, commit_hash) && !commit_hash.empty()) {
+            // Trim trailing whitespace/newline
+            while (!commit_hash.empty() &&
+                   (commit_hash.back() == '\n' || commit_hash.back() == '\r' ||
+                    commit_hash.back() == ' ')) {
+              commit_hash.pop_back();
+            }
+            const std::filesystem::path snapshot = snapshots_dir / commit_hash;
+            if (std::filesystem::exists(snapshot) &&
+                std::filesystem::is_directory(snapshot)) {
+              return snapshot.string();
+            }
+          }
+        }
+      }
+      // Fallback: pick the only snapshot directory if there is exactly one.
+      std::filesystem::path only;
+      int32_t dir_count = 0;
+      for (const auto& entry :
+           std::filesystem::directory_iterator(snapshots_dir)) {
+        if (entry.is_directory()) {
+          only = entry.path();
+          ++dir_count;
+        }
+      }
+      if (dir_count == 1) {
+        return only.string();
+      }
+    }
+  }
+
+  // 3. Not in local cache — download tokenizer files only via huggingface_hub.
+  //    We use snapshot_download with allow_patterns to fetch only tokenizer
+  //    files, avoiding downloading multi-GB model weights.
+  LOG(INFO) << "Tokenizer for '" << text_encoder_model
+            << "' not found in HuggingFace cache, downloading via "
+               "huggingface_hub.snapshot_download ...";
+  try {
+    namespace py = pybind11;
+    // The Python interpreter may not be initialized when this function is
+    // called from a worker thread (e.g. DiTWorkerImpl::init_model).
+    // Initialize it here if needed; it is safe to call Py_InitializeEx(0)
+    // multiple times — subsequent calls are no-ops once already initialized.
+    if (!Py_IsInitialized()) {
+      // init_signal_handlers=0: don't override the process signal handlers
+      // (SIGSEGV etc.) that glog/folly have already registered.
+      Py_InitializeEx(0);
+    }
+    py::gil_scoped_acquire gil;
+    py::module_ hf_hub = py::module_::import("huggingface_hub");
+    py::list allow_patterns;
+    for (const auto& p : {"spiece.model",
+                          "tokenizer.model",
+                          "tokenizer.json",
+                          "tokenizer_config.json",
+                          "special_tokens_map.json"}) {
+      allow_patterns.append(p);
+    }
+    py::object result = hf_hub.attr("snapshot_download")(
+        text_encoder_model, py::arg("allow_patterns") = allow_patterns);
+    return result.cast<std::string>();
+  } catch (const std::exception& e) {
+    LOG(WARNING) << "huggingface_hub.snapshot_download failed for '"
+                 << text_encoder_model << "': " << e.what();
+  }
+  return "";
+}
+
+// Load tokenizer args from an arbitrary directory (used for HF cache fallback).
+// Probes SentencePiece vocab filenames first when tokenizer_config.json
+// indicates a SentencePiece-based tokenizer class (e.g. T5Tokenizer), then
+// falls back to tokenizer.json (fast tokenizer).
+bool load_tokenizer_args_from_dir(const std::string& dir, TokenizerArgs& args) {
+  // Check tokenizer_config.json to determine the correct tokenizer type.
+  // T5Tokenizer and UMT5Tokenizer use SentencePiece (spiece.model), not the
+  // fast tokenizer (tokenizer.json). Prefer SentencePiece in that case.
+  bool prefer_sentencepiece = false;
+  const std::string cfg_path = dir + "/tokenizer_config.json";
+  if (std::filesystem::exists(cfg_path)) {
+    JsonReader r;
+    if (r.parse(cfg_path)) {
+      if (auto v = r.value<std::string>("tokenizer_class")) {
+        const std::string& cls = v.value();
+        if (cls == "T5Tokenizer" || cls == "T5TokenizerFast" ||
+            cls.find("T5") != std::string::npos) {
+          prefer_sentencepiece = true;
+        }
+      }
+    }
+  }
+
+  if (!prefer_sentencepiece) {
+    // fast tokenizer
+    const std::string tokenizer_json = dir + "/tokenizer.json";
+    if (std::filesystem::exists(tokenizer_json)) {
+      args.tokenizer_type() = "fast";
+      args.vocab_file() = tokenizer_json;
+      return true;
+    }
+  }
+
+  // SentencePiece vocab
+  for (const auto& candidate : {"spiece.model", "tokenizer.model"}) {
+    const std::string vocab_path = dir + "/" + candidate;
+    if (std::filesystem::exists(vocab_path)) {
+      args.tokenizer_type() = "sentencepiece";
+      args.vocab_file() = vocab_path;
+      // Also parse tokenizer_config.json for bos/eos/pad tokens if present.
+      if (std::filesystem::exists(cfg_path)) {
+        JsonReader r;
+        if (r.parse(cfg_path)) {
+          if (auto v = r.value<bool>("add_bos_token")) {
+            args.add_bos_token() = v.value();
+          }
+          if (auto v = r.value<bool>("add_eos_token")) {
+            args.add_eos_token() = v.value();
+          }
+          if (auto v = r.value<std::string>("tokenizer_class")) {
+            args.tokenizer_class() = v.value();
+          }
+          if (auto v = r.value<std::string>("bos_token.content")) {
+            args.bos_token() = v.value();
+          } else if (auto v = r.value<std::string>("bos_token")) {
+            args.bos_token() = v.value();
+          }
+          if (auto v = r.value<std::string>("eos_token.content")) {
+            args.eos_token() = v.value();
+          } else if (auto v = r.value<std::string>("eos_token")) {
+            args.eos_token() = v.value();
+          }
+          if (auto v = r.value<std::string>("pad_token.content")) {
+            args.pad_token() = v.value();
+          } else if (auto v = r.value<std::string>("pad_token")) {
+            args.pad_token() = v.value();
+          }
+        }
+      }
+      return true;
+    }
+  }
+  return false;
+}
+
+}  // namespace
+
 bool DiTFolderLoader::load_tokenizer_args(
     const std::string& model_weights_path) {
   // tokenizer args from tokenizer_config.json
@@ -209,15 +418,62 @@ bool DiTFolderLoader::load_tokenizer_args(
   const std::string tokenizer_args_file_path =
       model_weights_path_ + "/tokenizer_config.json";
 
-  // check if tokenizer.json exists, if exists, set the tokenizer type to fast
+  // Check tokenizer.json; but prefer SentencePiece when tokenizer_class is
+  // T5Tokenizer (e.g. UMT5), because the fast tokenizer produces different
+  // token IDs from the SentencePiece tokenizer used during training.
   const std::string tokenizer_json_path =
       model_weights_path + "/tokenizer.json";
   if (std::filesystem::exists(tokenizer_json_path)) {
-    tokenizer_args_.tokenizer_type() = "fast";
-    tokenizer_args_.vocab_file() = tokenizer_json_path;
+    // Peek at tokenizer_config.json to see if this is a T5-family model.
+    bool is_t5 = false;
+    const std::string cfg_peek = model_weights_path_ + "/tokenizer_config.json";
+    if (std::filesystem::exists(cfg_peek)) {
+      JsonReader pr;
+      if (pr.parse(cfg_peek)) {
+        if (auto v = pr.value<std::string>("tokenizer_class")) {
+          const std::string& cls = v.value();
+          if (cls.find("T5") != std::string::npos) {
+            is_t5 = true;
+          }
+        }
+      }
+    }
+    if (!is_t5) {
+      tokenizer_args_.tokenizer_type() = "fast";
+      tokenizer_args_.vocab_file() = tokenizer_json_path;
+    }
   }
 
   if (!std::filesystem::exists(tokenizer_args_file_path)) {
+    // No tokenizer_config.json in this directory.
+    // 1. Probe known vocab filenames in the current directory.
+    for (const auto& candidate : {"spiece.model", "tokenizer.model"}) {
+      const std::string candidate_path = model_weights_path_ + "/" + candidate;
+      if (std::filesystem::exists(candidate_path)) {
+        tokenizer_args_.tokenizer_type() = "sentencepiece";
+        tokenizer_args_.vocab_file() = candidate;
+        return true;
+      }
+    }
+    // 2. Fall back to text_encoder_model path (mirrors what official inference
+    //    code does: AutoTokenizer.from_pretrained(config.text_encoder_model)).
+    if (!text_encoder_model_.empty()) {
+      const std::string resolved =
+          resolve_text_encoder_tokenizer_path(text_encoder_model_);
+      if (!resolved.empty()) {
+        LOG(INFO) << "Tokenizer not found in model directory, loading from "
+                  << "text_encoder_model path: " << resolved;
+        if (load_tokenizer_args_from_dir(resolved, tokenizer_args_)) {
+          return true;
+        }
+      }
+      LOG(WARNING)
+          << "text_encoder_model '" << text_encoder_model_
+          << "' specified in config.json but no tokenizer files found. "
+          << "Please download the tokenizer to the model directory or ensure "
+          << "the HuggingFace cache is populated (e.g. run the official "
+          << "inference script once to cache '" << text_encoder_model_ << "').";
+    }
     return true;
   }
   if (tokenizer_reader.parse(tokenizer_args_file_path)) {
@@ -263,7 +519,27 @@ DiTModelLoader::DiTModelLoader(const std::string& model_root_path)
   std::filesystem::path index_file = root_path / "model_index.json";
   const std::string model_index_file = index_file.string();
   if (!std::filesystem::exists(model_index_file)) {
-    LOG(FATAL) << "Model index file does not exist: " << model_index_file;
+    // Flat layout: no model_index.json. The entire model root is a single
+    // component (e.g. AudioDiT ships one model.safetensors at the root).
+    // Read model_type from config.json and register the root as "model".
+    std::filesystem::path config_json_path = root_path / "config.json";
+    if (!std::filesystem::exists(config_json_path)) {
+      LOG(FATAL) << "DiTModelLoader: neither model_index.json nor config.json "
+                    "found in: "
+                 << model_root_path_;
+    }
+    JsonReader cfg_reader;
+    if (!cfg_reader.parse(config_json_path.string())) {
+      LOG(FATAL) << "DiTModelLoader: failed to parse config.json in: "
+                 << model_root_path_;
+    }
+    auto model_type_opt = cfg_reader.value<std::string>("model_type");
+    const std::string model_type =
+        model_type_opt.has_value() ? model_type_opt.value() : "";
+    set_model_type(model_type);
+    name_to_loader_["model"] = std::make_unique<DiTFolderLoader>(
+        model_root_path_, "model", model_type);
+    return;
   }
 
   JsonReader model_index_reader;

--- a/xllm/core/framework/dit_model_loader.h
+++ b/xllm/core/framework/dit_model_loader.h
@@ -50,6 +50,12 @@ class DiTFolderLoader : public ModelLoader {
 
   std::string component_name_;
 
+  // HuggingFace repo id or local path for the text encoder (e.g.
+  // "google/umt5-base"), read from config.json's "text_encoder_model" field.
+  // Used as a fallback tokenizer source when no tokenizer files exist in the
+  // model directory.
+  std::string text_encoder_model_;
+
   // sorted model weights files
   std::vector<std::string> model_weights_files_;
   // models weights tensors

--- a/xllm/core/framework/request/dit_request.cpp
+++ b/xllm/core/framework/request/dit_request.cpp
@@ -21,6 +21,7 @@ limitations under the License.
 #include <glog/logging.h>
 
 #include <cstdint>
+#include <cstring>
 #include <opencv2/opencv.hpp>
 #include <string>
 #include <vector>
@@ -29,6 +30,68 @@ limitations under the License.
 #include "mm_codec.h"
 
 namespace xllm {
+namespace {
+
+// Write a minimal PCM WAV file into `out`.
+// samples: float32 mono, range [-1, 1], shape (N,) on CPU.
+void encode_wav(const torch::Tensor& samples,
+                int32_t sample_rate,
+                std::string& out) {
+  CHECK(samples.device().is_cpu()) << "encode_wav: tensor must be on CPU";
+  CHECK(samples.is_contiguous()) << "encode_wav: tensor must be contiguous";
+  CHECK_EQ(samples.scalar_type(), torch::kFloat32)
+      << "encode_wav: tensor must be float32";
+  CHECK_GT(samples.numel(), 0) << "encode_wav: tensor must not be empty";
+  const int32_t num_samples = static_cast<int32_t>(samples.numel());
+  const int32_t num_channels = 1;
+  const int32_t bits_per_sample = 16;
+  const int32_t byte_rate = sample_rate * num_channels * bits_per_sample / 8;
+  const int16_t block_align =
+      static_cast<int16_t>(num_channels * bits_per_sample / 8);
+  const int32_t data_size = num_samples * num_channels * bits_per_sample / 8;
+  const int32_t chunk_size = 36 + data_size;
+
+  out.resize(44 + data_size);
+  char* p = out.data();
+
+  auto write4 = [&](const char* s) {
+    std::memcpy(p, s, 4);
+    p += 4;
+  };
+  auto writeI32 = [&](int32_t v) {
+    std::memcpy(p, &v, 4);
+    p += 4;
+  };
+  auto writeI16 = [&](int16_t v) {
+    std::memcpy(p, &v, 2);
+    p += 2;
+  };
+
+  write4("RIFF");
+  writeI32(chunk_size);
+  write4("WAVE");
+  write4("fmt ");
+  writeI32(16);  // PCM subchunk size
+  writeI16(1);   // AudioFormat = PCM
+  writeI16(static_cast<int16_t>(num_channels));
+  writeI32(sample_rate);
+  writeI32(byte_rate);
+  writeI16(block_align);
+  writeI16(static_cast<int16_t>(bits_per_sample));
+  write4("data");
+  writeI32(data_size);
+
+  const float* src = samples.data_ptr<float>();
+  // Convert float32 -> int16 and write samples
+  int16_t* dst = reinterpret_cast<int16_t*>(p);
+  for (int32_t i = 0; i < num_samples; ++i) {
+    float v = std::max(-1.0f, std::min(1.0f, src[i]));
+    dst[i] = static_cast<int16_t>(v * 32767.0f);
+  }
+}
+
+}  // namespace
+
 DiTRequest::DiTRequest(const std::string& request_id,
                        const std::string& x_request_id,
                        const std::string& x_request_time,
@@ -52,7 +115,11 @@ void DiTRequest::log_statistic(double total_latency) {
 }
 
 void DiTRequest::handle_forward_output(torch::Tensor output) {
-  int count = state_.generation_params().num_images_per_prompt;
+  // Pipeline already chunks by batch size along dim 0 before calling here.
+  // For image models, also split by num_images_per_prompt.
+  // For audio models, num_images_per_prompt defaults to 1 so this is a no-op.
+  const int32_t count =
+      static_cast<int32_t>(state_.generation_params().num_images_per_prompt);
   output_.tensors = torch::chunk(output, count);
 }
 
@@ -64,17 +131,30 @@ const DiTRequestOutput DiTRequest::generate_output() {
   output.finished = finished();
   output.cancelled = false;
 
-  DiTGenerationOutput result;
-  result.height = state_.generation_params().height;
-  result.width = state_.generation_params().width;
-  result.seed = state_.generation_params().seed;
+  const bool is_audio =
+      !output_.tensors.empty() && output_.tensors[0].dim() <= 2;
 
-  OpenCVImageEncoder encoder;
-  int count = state_.generation_params().num_images_per_prompt;
+  DiTGenerationOutput result;
+  result.seed = state_.generation_params().seed;
+  if (!is_audio) {
+    result.height = state_.generation_params().height;
+    result.width = state_.generation_params().width;
+  }
+
+  const int32_t count =
+      static_cast<int32_t>(state_.generation_params().num_images_per_prompt);
+  OpenCVImageEncoder image_encoder;
   for (size_t idx = 0; idx < count; ++idx) {
-    torch::Tensor image =
+    torch::Tensor output_tensor =
         output_.tensors[idx].squeeze(0).cpu().to(torch::kFloat32).contiguous();
-    encoder.encode(image, result.image);
+    if (is_audio) {
+      torch::Tensor samples = output_tensor.flatten().contiguous();
+      encode_wav(samples,
+                 state_.generation_params().audio_sampling_rate,
+                 result.audio);
+    } else {
+      image_encoder.encode(output_tensor, result.image);
+    }
     output.outputs.push_back(result);
   }
 

--- a/xllm/core/framework/request/dit_request_output.h
+++ b/xllm/core/framework/request/dit_request_output.h
@@ -34,13 +34,16 @@ struct DiTGenerationOutput {
   // the generated image in torch tensor format.
   std::string image;
 
+  // the generated audio as raw WAV bytes (audio models only).
+  std::string audio;
+
   // the height of the generated image.
   int32_t height;
 
   // the width of the generated image.
   int32_t width;
 
-  // seed used for image generation.
+  // seed used for generation.
   int64_t seed;
 };
 

--- a/xllm/core/framework/request/dit_request_params.cpp
+++ b/xllm/core/framework/request/dit_request_params.cpp
@@ -33,6 +33,42 @@ std::string generate_image_generation_request_id() {
          short_uuid.random();
 }
 
+std::string generate_audio_generation_request_id() {
+  return "audiogen-" + InstanceName::name()->get_name_hash() + "-" +
+         short_uuid.random();
+}
+
+// Decode a base64-encoded WAV/audio blob into a float32 CPU tensor of shape
+// (1, num_samples) at the given sample rate (mono).
+// Returns true on success and writes to `out`; logs ERROR and returns false
+// on any decoding failure.
+bool decode_prompt_audio(const std::string& b64_audio,
+                         int64_t target_sample_rate,
+                         torch::Tensor& out) {
+  std::string raw_bytes;
+  if (!butil::Base64Decode(b64_audio, &raw_bytes)) {
+    LOG(ERROR) << "Base64 prompt_audio decode failed";
+    return false;
+  }
+  FFmpegAudioDecoder audio_decoder;
+  AudioMetadata audio_meta;
+  torch::Tensor audio_tensor;
+  if (!audio_decoder.decode(
+          raw_bytes, audio_tensor, audio_meta, target_sample_rate)) {
+    LOG(ERROR) << "prompt_audio WAV decode failed";
+    return false;
+  }
+  // Ensure shape (1, num_samples): FFmpegAudioDecoder may return
+  // (num_samples,) or (num_channels, num_samples).
+  if (audio_tensor.dim() == 1) {
+    audio_tensor = audio_tensor.unsqueeze(0);
+  } else if (audio_tensor.dim() == 2 && audio_tensor.size(0) > 1) {
+    audio_tensor = audio_tensor.mean(0, /*keepdim=*/true);
+  }
+  out = audio_tensor.to(torch::kFloat32);
+  return true;
+}
+
 }  // namespace
 
 std::pair<int, int> splitResolution(const std::string& s) {
@@ -166,6 +202,57 @@ DiTRequestParams::DiTRequestParams(const proto::ImageGenerationRequest& request,
   }
   if (params.has_cfg_renorm_min()) {
     generation_params.cfg_renorm_min = params.cfg_renorm_min();
+  }
+}
+
+DiTRequestParams::DiTRequestParams(const proto::AudioGenerationRequest& request,
+                                   const std::string& x_rid,
+                                   const std::string& x_rtime) {
+  if (request.has_request_id()) {
+    request_id = request.request_id();
+  } else {
+    request_id = generate_audio_generation_request_id();
+  }
+  x_request_id = x_rid;
+  x_request_time = x_rtime;
+  model = request.model();
+
+  // generation params — must be parsed before input to make audio_sampling_rate
+  // available for prompt audio decoding.
+  const auto& params = request.parameters();
+  if (params.has_seed()) {
+    generation_params.seed = params.seed();
+  }
+  if (params.has_max_sequence_length()) {
+    generation_params.max_sequence_length = params.max_sequence_length();
+  }
+  if (params.has_guidance_scale()) {
+    generation_params.guidance_scale = params.guidance_scale();
+  }
+  if (params.has_audio_duration_frames()) {
+    generation_params.audio_duration_frames = params.audio_duration_frames();
+  }
+  if (params.has_audio_steps()) {
+    generation_params.audio_steps = params.audio_steps();
+  }
+  if (params.has_audio_guidance_method()) {
+    generation_params.audio_guidance_method = params.audio_guidance_method();
+  }
+  if (params.has_sampling_rate()) {
+    generation_params.audio_sampling_rate = params.sampling_rate();
+  }
+
+  // input params — decode prompt audio using the model's sampling rate.
+  const auto& input = request.input();
+  input_params.prompt = input.prompt();
+
+  if (input.has_prompt_audio()) {
+    decode_prompt_audio(input.prompt_audio(),
+                        generation_params.audio_sampling_rate,
+                        input_params.prompt_audio);
+  }
+  if (input.has_prompt_text()) {
+    input_params.audio_prompt_text = input.prompt_text();
   }
 }
 

--- a/xllm/core/framework/request/dit_request_params.h
+++ b/xllm/core/framework/request/dit_request_params.h
@@ -7,6 +7,7 @@
 #include <string>
 #include <vector>
 
+#include "audio_generation.pb.h"
 #include "dit_request_output.h"
 #include "dit_request_state.h"
 #include "image_generation.pb.h"
@@ -17,6 +18,9 @@ namespace xllm {
 struct DiTRequestParams {
   DiTRequestParams() = default;
   DiTRequestParams(const proto::ImageGenerationRequest& request,
+                   const std::string& x_rid,
+                   const std::string& x_rtime);
+  DiTRequestParams(const proto::AudioGenerationRequest& request,
                    const std::string& x_rid,
                    const std::string& x_rtime);
 

--- a/xllm/core/framework/request/dit_request_state.h
+++ b/xllm/core/framework/request/dit_request_state.h
@@ -43,7 +43,11 @@ struct DiTGenerationParams {
            max_sequence_length == other.max_sequence_length &&
            strength == other.strength &&
            enable_cfg_renorm == other.enable_cfg_renorm &&
-           cfg_renorm_min == other.cfg_renorm_min;
+           cfg_renorm_min == other.cfg_renorm_min &&
+           audio_duration_frames == other.audio_duration_frames &&
+           audio_steps == other.audio_steps &&
+           audio_guidance_method == other.audio_guidance_method &&
+           audio_sampling_rate == other.audio_sampling_rate;
   }
 
   bool operator!=(const DiTGenerationParams& other) const {
@@ -71,6 +75,19 @@ struct DiTGenerationParams {
   bool enable_cfg_renorm = true;
 
   float cfg_renorm_min = 0.0f;
+
+  // Audio generation params (for LongCat-AudioDiT)
+  // Target duration in latent frames (prompt + gen). 0 means use max_duration.
+  int32_t audio_duration_frames = 0;
+
+  // Number of ODE Euler steps for audio generation
+  int32_t audio_steps = 16;
+
+  // Guidance method: "cfg" or "apg"
+  std::string audio_guidance_method = "cfg";
+
+  // Audio sample rate in Hz, read from model config.json (sampling_rate).
+  int32_t audio_sampling_rate = 24000;
 };
 
 struct DiTInputParams {
@@ -105,6 +122,13 @@ struct DiTInputParams {
   torch::Tensor mask_image;
 
   torch::Tensor masked_image_latent;
+
+  // Prompt audio for voice cloning (LongCat-AudioDiT).
+  // Float32 PCM, shape (1, num_samples), mono 24 kHz.
+  torch::Tensor prompt_audio;
+
+  // Transcript of the prompt audio (for duration estimation).
+  std::string audio_prompt_text;
 };
 
 struct DiTRequestState {

--- a/xllm/core/framework/request/mm_codec.cpp
+++ b/xllm/core/framework/request/mm_codec.cpp
@@ -392,8 +392,10 @@ class MemoryVideoReader : public MemoryMediaReader {
 
 class MemoryAudioReader : public MemoryMediaReader {
  public:
-  MemoryAudioReader(const uint8_t* data, size_t size)
-      : MemoryMediaReader(data, size) {}
+  MemoryAudioReader(const uint8_t* data, size_t size, int64_t target_sr = 16000)
+      : MemoryMediaReader(data, size) {
+    target_sr_ = target_sr;
+  }
 
   ~MemoryAudioReader() {
     if (swr_ctx_) {
@@ -620,9 +622,11 @@ bool FFmpegVideoDecoder::decode(const std::string& raw_data,
 
 bool FFmpegAudioDecoder::decode(const std::string& raw_data,
                                 torch::Tensor& t,
-                                AudioMetadata& metadata) {
+                                AudioMetadata& metadata,
+                                int64_t target_sr) {
   MemoryAudioReader reader(reinterpret_cast<const uint8_t*>(raw_data.data()),
-                           raw_data.size());
+                           raw_data.size(),
+                           target_sr);
 
   if (!reader.init(metadata) || !reader.read(t, metadata)) {
     LOG(INFO) << "audio decode faild";

--- a/xllm/core/framework/request/mm_codec.h
+++ b/xllm/core/framework/request/mm_codec.h
@@ -60,6 +60,7 @@ class FFmpegAudioDecoder {
 
   bool decode(const std::string& raw_data,
               torch::Tensor& t,
-              AudioMetadata& meta);
+              AudioMetadata& meta,
+              int64_t target_sr = 16000);
 };
 }  // namespace xllm

--- a/xllm/core/runtime/dit_forward_params.h
+++ b/xllm/core/runtime/dit_forward_params.h
@@ -207,6 +207,11 @@ struct DiTForwardInput {
     if (control_image.defined()) {
       input.control_image = control_image.to(device, dtype);
     }
+
+    if (prompt_audio.defined()) {
+      input.prompt_audio = prompt_audio.to(device, torch::kFloat32);
+    }
+
     return input;
   }
 
@@ -243,6 +248,13 @@ struct DiTForwardInput {
   torch::Tensor negative_pooled_prompt_embeds;
 
   torch::Tensor latents;
+
+  // Optional prompt audio for voice cloning (LongCat-AudioDiT)
+  // Shape: (batch, 1, num_samples) at 24kHz
+  torch::Tensor prompt_audio;
+
+  // Transcript of the prompt audio — used for duration estimation only.
+  std::string audio_prompt_text;
 
   // generation params
   DiTGenerationParams generation_params;

--- a/xllm/core/runtime/params_utils.cpp
+++ b/xllm/core/runtime/params_utils.cpp
@@ -337,41 +337,61 @@ bool dit_forward_input_to_proto(const DiTForwardInput& dit_inputs,
   ADD_VECTOR_TO_PROTO(pb_dit_inputs->mutable_negative_prompts_2(),
                       dit_inputs.negative_prompts_2);
 
-  torch_tensor_to_proto_tensor(dit_inputs.images,
-                               pb_dit_inputs->mutable_images());
-
-  torch_tensor_to_proto_tensor(dit_inputs.condition_images,
-                               pb_dit_inputs->mutable_condition_images());
-
-  torch_tensor_to_proto_tensor(dit_inputs.mask_images,
-                               pb_dit_inputs->mutable_mask_images());
-
-  torch_tensor_to_proto_tensor(dit_inputs.control_image,
-                               pb_dit_inputs->mutable_control_image());
-
-  torch_tensor_to_proto_tensor(dit_inputs.masked_image_latents,
-                               pb_dit_inputs->mutable_masked_image_latents());
-
-  torch_tensor_to_proto_tensor(dit_inputs.prompt_embeds,
-                               pb_dit_inputs->mutable_prompt_embeds());
-
-  torch_tensor_to_proto_tensor(dit_inputs.pooled_prompt_embeds,
-                               pb_dit_inputs->mutable_pooled_prompt_embeds());
-
-  torch_tensor_to_proto_tensor(dit_inputs.negative_prompt_embeds,
-                               pb_dit_inputs->mutable_negative_prompt_embeds());
-
-  torch_tensor_to_proto_tensor(
-      dit_inputs.negative_pooled_prompt_embeds,
-      pb_dit_inputs->mutable_negative_pooled_prompt_embeds());
-
-  torch_tensor_to_proto_tensor(dit_inputs.latents,
-                               pb_dit_inputs->mutable_latents());
+  if (dit_inputs.images.defined()) {
+    torch_tensor_to_proto_tensor(dit_inputs.images,
+                                 pb_dit_inputs->mutable_images());
+  }
+  if (dit_inputs.condition_images.defined()) {
+    torch_tensor_to_proto_tensor(dit_inputs.condition_images,
+                                 pb_dit_inputs->mutable_condition_images());
+  }
+  if (dit_inputs.mask_images.defined()) {
+    torch_tensor_to_proto_tensor(dit_inputs.mask_images,
+                                 pb_dit_inputs->mutable_mask_images());
+  }
+  if (dit_inputs.control_image.defined()) {
+    torch_tensor_to_proto_tensor(dit_inputs.control_image,
+                                 pb_dit_inputs->mutable_control_image());
+  }
+  if (dit_inputs.masked_image_latents.defined()) {
+    torch_tensor_to_proto_tensor(dit_inputs.masked_image_latents,
+                                 pb_dit_inputs->mutable_masked_image_latents());
+  }
+  if (dit_inputs.prompt_embeds.defined()) {
+    torch_tensor_to_proto_tensor(dit_inputs.prompt_embeds,
+                                 pb_dit_inputs->mutable_prompt_embeds());
+  }
+  if (dit_inputs.pooled_prompt_embeds.defined()) {
+    torch_tensor_to_proto_tensor(dit_inputs.pooled_prompt_embeds,
+                                 pb_dit_inputs->mutable_pooled_prompt_embeds());
+  }
+  if (dit_inputs.negative_prompt_embeds.defined()) {
+    torch_tensor_to_proto_tensor(
+        dit_inputs.negative_prompt_embeds,
+        pb_dit_inputs->mutable_negative_prompt_embeds());
+  }
+  if (dit_inputs.negative_pooled_prompt_embeds.defined()) {
+    torch_tensor_to_proto_tensor(
+        dit_inputs.negative_pooled_prompt_embeds,
+        pb_dit_inputs->mutable_negative_pooled_prompt_embeds());
+  }
+  if (dit_inputs.latents.defined()) {
+    torch_tensor_to_proto_tensor(dit_inputs.latents,
+                                 pb_dit_inputs->mutable_latents());
+  }
 
   if (!generation_params_to_proto(dit_inputs.generation_params,
                                   pb_dit_inputs->mutable_generation_params())) {
     LOG(ERROR) << "Failed to convert generation_params";
     return false;
+  }
+
+  if (dit_inputs.prompt_audio.defined()) {
+    torch_tensor_to_proto_tensor(dit_inputs.prompt_audio,
+                                 pb_dit_inputs->mutable_prompt_audio());
+  }
+  if (!dit_inputs.audio_prompt_text.empty()) {
+    pb_dit_inputs->set_audio_prompt_text(dit_inputs.audio_prompt_text);
   }
 
   return true;
@@ -474,6 +494,14 @@ bool proto_to_dit_forward_input(const proto::DiTForwardInput& pb_dit_inputs,
                                   dit_inputs.generation_params)) {
     LOG(ERROR) << "Failed to convert generation_params";
     return false;
+  }
+
+  if (pb_dit_inputs.has_prompt_audio()) {
+    dit_inputs.prompt_audio =
+        util::proto_to_torch(pb_dit_inputs.prompt_audio());
+  }
+  if (pb_dit_inputs.has_audio_prompt_text()) {
+    dit_inputs.audio_prompt_text = pb_dit_inputs.audio_prompt_text();
   }
 
   return true;

--- a/xllm/models/dit/pipeline_longcat_audiodit.h
+++ b/xllm/models/dit/pipeline_longcat_audiodit.h
@@ -1,0 +1,619 @@
+/* Copyright 2026 The xLLM Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://github.com/jd-opensource/xllm/blob/main/LICENSE
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+// LongCat-AudioDiT pipeline for xLLM.
+// Ref:
+// https://github.com/meituan-longcat/LongCat-AudioDiT/blob/main/audiodit/modeling_audiodit.py
+// Architecture:
+//   - AudioDiTVae: WAV-VAE encoder/decoder with SnakeBeta activations and
+//     weight_norm convolutions.
+//   - AudioDiTTransformer: DiT backbone (24 blocks) with:
+//       timestep embedding, input/text embedders, ConvNeXtV2 text processing,
+//       rotary position embedding, self-attn + cross-attn + FFN per block,
+//       global AdaLN, long-skip connection.
+//   - UMT5EncoderModel: text encoder (google/umt5-base) from umt5_encoder.h.
+//   - ODE solver: inline Euler method.
+//   - CFG and APG guidance.
+//
+// Usage (registered as "audiodit"):
+//   DiTForwardInput input;
+//   input.prompts = {"a jazz piano piece"};
+//   input.generation_params.audio_duration_frames = 500;
+//   input.generation_params.audio_steps = 16;
+//   input.generation_params.guidance_scale = 4.0f;
+//   auto output = model->forward(input);
+//   // output.tensors[0] = waveform (1, num_samples)
+
+#pragma once
+
+#include "core/runtime/dit_forward_params.h"
+#include "core/util/json_reader.h"
+#include "models/model_registry.h"
+#include "transformer_longcat_audiodit.h"
+
+namespace xllm {
+
+// ============================================================================
+// LongCatAudioDiTPipeline - main pipeline implementation
+// ============================================================================
+
+class LongCatAudioDiTPipelineImpl final : public torch::nn::Module {
+ public:
+  explicit LongCatAudioDiTPipelineImpl(const DiTModelContext& context)
+      : context_(context) {
+    options_ = context.get_tensor_options();
+
+    LOG(INFO) << "Initializing LongCat-AudioDiT pipeline...";
+
+    // Build VAE with default config matching Python AudioDiTVaeConfig
+    AudioDiTVaeConfig vae_cfg;
+    vae_cfg.encoder_cfg.in_channels = 1;
+    vae_cfg.encoder_cfg.channels = 128;
+    vae_cfg.encoder_cfg.c_mults = {1, 2, 4, 8, 16};
+    vae_cfg.encoder_cfg.strides = {2, 4, 4, 8, 8};
+    vae_cfg.encoder_cfg.encoder_latent_dim = 128;  // 2 * latent_dim
+    vae_cfg.encoder_cfg.use_snake = true;
+    vae_cfg.encoder_cfg.use_downsample_shortcut =
+        true;  // config.downsample_shortcut="averaging"
+    vae_cfg.decoder_cfg.in_channels = 1;
+    vae_cfg.decoder_cfg.channels = 128;
+    vae_cfg.decoder_cfg.c_mults = {1, 2, 4, 8, 16};
+    vae_cfg.decoder_cfg.strides = {2, 4, 4, 8, 8};
+    vae_cfg.decoder_cfg.latent_dim = 64;
+    vae_cfg.decoder_cfg.use_snake = true;
+    vae_cfg.decoder_cfg.use_upsample_shortcut =
+        true;  // config.upsample_shortcut="duplicating"
+    vae_cfg.decoder_cfg.use_in_shortcut =
+        true;  // config.in_shortcut="duplicating"
+    vae_cfg.decoder_cfg.final_tanh = false;
+    vae_cfg.scale = 0.71f;
+    vae_cfg.downsampling_ratio = 2048;
+    vae_cfg.latent_dim = 64;
+    vae_ = register_module("vae", AudioDiTVae(vae_cfg));
+
+    // Build Transformer with default config
+    AudioDiTTransformerConfig tr_cfg;
+    tr_cfg.dim = 1536;
+    tr_cfg.depth = 24;
+    tr_cfg.heads = 24;
+    tr_cfg.ff_mult = 4.0f;
+    tr_cfg.latent_dim = 64;
+    tr_cfg.text_dim = 768;
+    tr_cfg.long_skip = true;
+    tr_cfg.text_conv = true;
+    tr_cfg.use_latent_condition = true;
+    tr_cfg.adaln_type = "global";
+    transformer_ = register_module("transformer", AudioDiTTransformer(tr_cfg));
+
+    // UMT5 text encoder.
+    // In the flat layout the context has no per-component args; build ModelArgs
+    // from the known UMT5 config embedded in config.json.
+    torch::TensorOptions t5_opts =
+        context.get_tensor_options().dtype(torch::kFloat32);
+    ModelContext t5_ctx;
+    if (context.has_component("text_encoder")) {
+      t5_ctx = ModelContext(context.get_parallel_args(),
+                            context.get_model_args("text_encoder"),
+                            context.get_quant_args("text_encoder"),
+                            t5_opts);
+    } else {
+      ModelArgs t5_args;
+      t5_args.vocab_size() = 256384;
+      t5_args.d_model() = 768;
+      t5_args.num_layers() = 12;
+      t5_args.n_heads() = 12;
+      t5_args.d_kv() = 64;
+      t5_args.d_ff() = 2048;
+      t5_args.act_fn() = "gelu_new";
+      t5_args.is_gated_act() = true;
+      t5_args.relative_attention_num_buckets() = 32;
+      t5_args.relative_attention_max_distance() = 128;
+      t5_args.layer_norm_eps() = 1e-6f;
+      t5_ctx = ModelContext(
+          context.get_parallel_args(), t5_args, QuantArgs(), t5_opts);
+    }
+    text_encoder_ = register_module("text_encoder", UMT5TextEncoder(t5_ctx));
+  }
+
+  DiTForwardOutput forward(const DiTForwardInput& input) {
+    torch::NoGradGuard no_grad;
+    const auto& gp = input.generation_params;
+
+    // Batch size
+    int64_t batch_size = static_cast<int64_t>(input.prompts.size());
+    if (batch_size == 0) {
+      batch_size = 1;
+    }
+
+    auto device = options_.device();
+    auto dtype = options_.dtype().toScalarType();
+
+    // ── 1. Tokenize and encode text ─────────────────────────────────────────
+    CHECK(tokenizer_ != nullptr) << "Tokenizer not loaded for AudioDiT";
+    int64_t max_seq_len = gp.max_sequence_length;
+
+    // Tokenize prompts
+    std::vector<std::vector<int32_t>> batch_tokens;
+    std::vector<int32_t> attention_mask_flat;
+    batch_tokens.reserve(batch_size);
+
+    for (int64_t i = 0; i < batch_size; ++i) {
+      const std::string& prompt =
+          (i < static_cast<int64_t>(input.prompts.size())) ? input.prompts[i]
+                                                           : "";
+      std::vector<int32_t> tokens;
+      if (!tokenizer_->encode(prompt, &tokens, /*add_bos=*/false)) {
+        tokens.clear();
+      }
+      // HuggingFace AutoTokenizer (used in official Python) appends EOS (id=1)
+      // after encoding. SentencePiece does not, causing a 1-token difference.
+      // Add EOS here to match official tokenization.
+      if (!tokens.empty()) {
+        tokens.push_back(1);  // EOS token id for UMT5 / SentencePiece
+      }
+      if (static_cast<int64_t>(tokens.size()) > max_seq_len) {
+        tokens.resize(max_seq_len);
+      }
+      batch_tokens.push_back(std::move(tokens));
+    }
+
+    // Pad to max_seq_len and build attention mask
+    std::vector<int32_t> input_ids_flat;
+    input_ids_flat.reserve(batch_size * max_seq_len);
+    attention_mask_flat.reserve(batch_size * max_seq_len);
+
+    for (int64_t i = 0; i < batch_size; ++i) {
+      auto& tokens = batch_tokens[i];
+      int64_t real_len = static_cast<int64_t>(tokens.size());
+      int64_t pad_len = max_seq_len - real_len;
+      // pad token id: try to get from tokenizer, fallback to 0
+      int32_t pad_id = 0;
+      input_ids_flat.insert(input_ids_flat.end(), tokens.begin(), tokens.end());
+      input_ids_flat.insert(input_ids_flat.end(), pad_len, pad_id);
+      for (int64_t j = 0; j < max_seq_len; ++j) {
+        attention_mask_flat.push_back(j < real_len ? 1 : 0);
+      }
+    }
+
+    torch::Tensor input_ids =
+        torch::tensor(input_ids_flat, torch::dtype(torch::kLong))
+            .view({batch_size, max_seq_len})
+            .to(device);
+    torch::Tensor attention_mask =
+        torch::tensor(attention_mask_flat, torch::dtype(torch::kBool))
+            .view({batch_size, max_seq_len})
+            .to(device);
+    torch::Tensor text_len = attention_mask.to(torch::kLong).sum(1);  // (B,)
+
+    // Get text embeddings from T5/UMT5
+    torch::Tensor text_condition = encode_text(input_ids, attention_mask);
+    // (B, max_seq_len, 768) float32
+
+    // Truncate text_condition and attention_mask to actual max token length,
+    // matching official Python which never pads text to max_seq_len.
+    // Padding zeros corrupt text_embed, ConvNeXtV2 and cross-attention K/V
+    // because: (1) Linear bias adds non-zero values on pad positions before the
+    // second masked_fill; (2) ConvNeXtV2 depthwise conv leaks bias across pad
+    // positions; (3) cross-attention attends over all 512 positions including
+    // dead ones.  Truncating removes all this noise.
+    // encode_text already slices to actual_len internally, so text_condition
+    // is (B, actual_len, 768). Always truncate attention_mask to match.
+    int64_t actual_text_len = text_condition.size(1);
+    attention_mask = attention_mask.slice(1, 0, actual_text_len);
+    // Null text for CFG/APG unconditional pass.
+    // Python reference uses neg_text=zeros with cond_mask=text_mask (the real
+    // mask, all-True for actual tokens).  AudioDiTEmbedder's two masked_fills
+    // only zero out *padding* positions, so the linear-bias output on real
+    // positions remains non-zero (text_std≈0.66 per reference log).
+    // Using an all-False mask would zero the entire text embedding and
+    // diverges.
+    torch::Tensor neg_text = torch::zeros_like(text_condition);
+    torch::Tensor neg_text_mask =
+        attention_mask;  // same real mask as cond pass
+    torch::Tensor neg_text_len = text_len.clone();  // keeps divisor non-zero
+
+    // ── 2. Encode prompt audio if provided ──────────────────────────────────
+    torch::Tensor prompt_latent;  // (B, prompt_frames, latent_dim)
+    int64_t prompt_dur = 0;
+
+    if (input.prompt_audio.defined() && input.prompt_audio.numel() > 0) {
+      std::tie(prompt_latent, prompt_dur) =
+          encode_prompt_audio(input.prompt_audio);
+    } else {
+      prompt_latent =
+          torch::empty({batch_size, 0, vae_->latent_dim_},
+                       torch::dtype(torch::kFloat32).device(device));
+    }
+
+    // ── 3. Duration ─────────────────────────────────────────────────────────
+    // audio_duration_frames: total latent frames (prompt + gen)
+    // 0 means auto-estimate from text, matching official Python:
+    //   approx_duration_from_text(text,
+    //   max_duration=max_wav_duration-prompt_time)
+    //   + ratio adjustment when prompt audio is present.
+    int64_t max_dur;
+    if (gp.audio_duration_frames > 0) {
+      max_dur = static_cast<int64_t>(gp.audio_duration_frames);
+    } else {
+      const int64_t kSampleRate = sampling_rate_;
+      constexpr float kMaxDuration = 30.0f;
+      constexpr float kEnDurPerChar = 0.082f;
+      constexpr float kZhDurPerChar = 0.21f;
+
+      // Count CJK / EN chars and estimate duration in seconds.
+      // Matches official Python utils.approx_duration_from_text.
+      auto approx_dur = [&](const std::string& text,
+                            float max_dur_sec) -> float {
+        int nzh = 0, nen = 0, nother = 0;
+        for (size_t ci = 0; ci < text.size();) {
+          unsigned char c = static_cast<unsigned char>(text[ci]);
+          if (c >= 0xE0 && ci + 2 < text.size()) {
+            uint32_t cp =
+                ((c & 0x0F) << 12) |
+                ((static_cast<unsigned char>(text[ci + 1]) & 0x3F) << 6) |
+                (static_cast<unsigned char>(text[ci + 2]) & 0x3F);
+            if (cp >= 0x4E00 && cp <= 0x9FFF)
+              ++nzh;
+            else
+              ++nother;
+            ci += 3;
+          } else if (c < 0x80) {
+            if (std::isalpha(c))
+              ++nen;
+            else if (c != ' ' && c != '\t' && c != '\n')
+              ++nother;
+            ++ci;
+          } else {
+            ++nother;
+            ++ci;
+          }
+        }
+        if (nzh > nen)
+          nzh += nother;
+        else
+          nen += nother;
+        float d = nzh * kZhDurPerChar + nen * kEnDurPerChar;
+        return std::min(d, max_dur_sec);
+      };
+
+      // The synthesis text is everything after "prompt_text " prefix.
+      // input.prompts[0] is full_text = prompt_text + " " + text (when voice
+      // cloning) or just text (TTS). audio_prompt_text holds the prompt_text
+      // portion so we can split them.
+      const std::string& full_text =
+          input.prompts.empty() ? "" : input.prompts[0];
+      const std::string& prompt_text_part = input.audio_prompt_text;
+
+      // Extract synthesis-only text
+      std::string synth_text = full_text;
+      if (!prompt_text_part.empty() &&
+          full_text.size() > prompt_text_part.size()) {
+        // full_text = prompt_text + " " + text  →  skip prefix + space
+        synth_text = full_text.substr(prompt_text_part.size() + 1);
+      }
+
+      float prompt_time = static_cast<float>(prompt_dur) *
+                          vae_->downsampling_ratio_ / kSampleRate;
+      float max_synth_dur = kMaxDuration - prompt_time;
+      float dur_sec = approx_dur(synth_text, max_synth_dur);
+      dur_sec = std::max(dur_sec, 1.0f);
+
+      // Voice cloning: apply ratio = clip(prompt_time / approx_pd, 1.0, 1.5)
+      if (prompt_dur > 0 && !prompt_text_part.empty()) {
+        float approx_pd = approx_dur(prompt_text_part, kMaxDuration);
+        if (approx_pd > 0.0f) {
+          float ratio = std::min(1.5f, std::max(1.0f, prompt_time / approx_pd));
+          dur_sec *= ratio;
+        }
+      }
+
+      int64_t gen_frames = static_cast<int64_t>(dur_sec * kSampleRate /
+                                                vae_->downsampling_ratio_);
+      max_dur = gen_frames + prompt_dur;
+      max_dur = std::min(max_dur,
+                         static_cast<int64_t>(kMaxDuration * kSampleRate /
+                                              vae_->downsampling_ratio_));
+    }
+    max_dur = std::max(max_dur, prompt_dur + 1);
+
+    // ── 4. Build masks ───────────────────────────────────────────────────────
+    // mask: (B, max_dur) all valid (True)
+    torch::Tensor mask = torch::ones({batch_size, max_dur},
+                                     torch::dtype(torch::kBool).device(device));
+    torch::Tensor text_mask = attention_mask;  // (B, max_seq_len)
+
+    // ── 5. Latent conditioning ───────────────────────────────────────────────
+    int64_t gen_len = max_dur - prompt_dur;
+    torch::Tensor latent_cond;
+    torch::Tensor empty_latent_cond;
+    if (prompt_dur > 0) {
+      // Pad prompt_latent to full duration
+      latent_cond = torch::nn::functional::pad(
+          prompt_latent,
+          torch::nn::functional::PadFuncOptions({0, 0, 0, gen_len}));
+      empty_latent_cond = torch::zeros_like(latent_cond);
+    } else {
+      latent_cond = torch::zeros({batch_size, max_dur, vae_->latent_dim_},
+                                 torch::dtype(torch::kFloat32).device(device));
+      empty_latent_cond = latent_cond;
+    }
+
+    // ── 6. Initialize noise ──────────────────────────────────────────────────
+    int64_t seed = gp.seed;
+    torch::TensorOptions noise_opts =
+        torch::dtype(torch::kFloat32).device(device);
+    std::vector<int64_t> noise_shape = {batch_size, max_dur, vae_->latent_dim_};
+    torch::Tensor y0 = randn_tensor(noise_shape, seed, noise_opts);
+
+    // ── 7. ODE Euler solve ───────────────────────────────────────────────────
+    int64_t steps = (gp.audio_steps > 0) ? gp.audio_steps : 16;
+    float cfg_strength = gp.guidance_scale;
+    const std::string& guidance_method = gp.audio_guidance_method;
+
+    // t: [0, 1] with `steps` points (inclusive)
+    torch::Tensor t_schedule = torch::linspace(
+        0.0f, 1.0f, steps, torch::dtype(torch::kFloat32).device(device));
+
+    // Snapshot of prompt frames' noise (for blending at each step)
+    torch::Tensor prompt_noise;
+    if (prompt_dur > 0) {
+      prompt_noise = y0.slice(1, 0, prompt_dur).clone();
+    }
+
+    // APG momentum buffer
+    MomentumBuffer apg_buf;
+    apg_buf.momentum = -0.3f;
+
+    // Euler integration
+    torch::Tensor y = y0;
+    for (int64_t i = 0; i < steps - 1; ++i) {
+      float t_val = t_schedule[i].item<float>();
+      float dt = t_schedule[i + 1].item<float>() - t_val;
+      torch::Tensor t_tensor = torch::full({batch_size}, t_val, noise_opts);
+
+      // Blend prompt frames
+      if (prompt_dur > 0) {
+        torch::Tensor blended = prompt_noise * (1.0f - t_val) +
+                                latent_cond.slice(1, 0, prompt_dur) * t_val;
+        y = y.clone();
+        y.slice(1, 0, prompt_dur) = blended;
+      }
+
+      // Conditional forward
+      torch::Tensor pred = transformer_->forward(y.to(torch::kFloat32),
+                                                 text_condition,
+                                                 text_len,
+                                                 t_tensor,
+                                                 mask,
+                                                 text_mask,
+                                                 latent_cond);
+      if (cfg_strength < 1e-5f) {
+        // No guidance
+        y = (y + pred * dt).detach();
+        continue;
+      }
+
+      // Zero out prompt frames for unconditional pass
+      torch::Tensor y_null = y.clone();
+      if (prompt_dur > 0) {
+        y_null.slice(1, 0, prompt_dur).zero_();
+      }
+      torch::Tensor null_pred =
+          transformer_->forward(y_null.to(torch::kFloat32),
+                                neg_text,
+                                neg_text_len,
+                                t_tensor,
+                                mask,
+                                neg_text_mask,
+                                empty_latent_cond);
+      torch::Tensor guided_pred;
+      if (guidance_method == "apg") {
+        // APG guidance on the generated frames only
+        torch::Tensor x_s = y.slice(1, prompt_dur);
+        torch::Tensor pred_s = pred.slice(1, prompt_dur);
+        torch::Tensor null_s = null_pred.slice(1, prompt_dur);
+        torch::Tensor pred_sample = x_s + (1.0f - t_val) * pred_s;
+        torch::Tensor null_sample = x_s + (1.0f - t_val) * null_s;
+        torch::Tensor apg_out = apg_forward(pred_sample,
+                                            null_sample,
+                                            cfg_strength,
+                                            &apg_buf,
+                                            /*eta=*/0.5f,
+                                            /*norm_threshold=*/0.0f);
+        torch::Tensor apg_velocity = (apg_out - x_s) / (1.0f - t_val + 1e-9f);
+        // Pad back prompt frames with zeros
+        guided_pred = torch::nn::functional::pad(
+            apg_velocity,
+            torch::nn::functional::PadFuncOptions({0, 0, prompt_dur, 0}));
+      } else {
+        // CFG: pred + (pred - null_pred) * cfg_strength
+        guided_pred =
+            pred.to(torch::kFloat32) +
+            (pred.to(torch::kFloat32) - null_pred.to(torch::kFloat32)) *
+                cfg_strength;
+      }
+
+      y = (y.to(torch::kFloat32) + guided_pred * dt).detach();
+    }
+
+    // ── 8. Decode latent -> waveform ─────────────────────────────────────────
+    // Use only the generated frames (skip prompt frames)
+    torch::Tensor pred_latent = y.slice(1, prompt_dur);  // (B, gen_len, 64)
+    pred_latent = pred_latent.permute({0, 2, 1}).to(torch::kFloat32);
+    // (B, 64, gen_len)
+    torch::Tensor waveform;
+    try {
+      waveform = vae_->decode(pred_latent).squeeze(1);  // (B, num_samples)
+    } catch (const std::exception& e) {
+      LOG(ERROR) << "[LongCat-AudioDiT] VAE decode failed: " << e.what();
+      waveform = torch::zeros({batch_size, vae_->downsampling_ratio_ * gen_len},
+                              noise_opts);
+    }
+
+    waveform = waveform.cpu().to(torch::kFloat32).contiguous();
+    DiTForwardOutput out;
+    out.tensors = torch::chunk(waveform, waveform.size(0), 0);
+    return out;
+  }
+
+  void load_model(std::unique_ptr<DiTModelLoader> loader) {
+    LOG(INFO) << "LongCat-AudioDiT pipeline loading model from "
+              << loader->model_root_path();
+
+    // Read sampling_rate from config.json, matching official Python's
+    // model.config.sampling_rate. Falls back to the default (24000) if absent.
+    {
+      const std::string config_path =
+          loader->model_root_path() + "/config.json";
+      JsonReader cfg;
+      if (cfg.parse(config_path)) {
+        if (auto v = cfg.value<int32_t>("sampling_rate")) {
+          sampling_rate_ = v.value();
+        }
+      }
+    }
+
+    if (loader->has_component("transformer")) {
+      // Component layout: separate subdirectories per component.
+      auto transformer_loader = loader->take_component_loader("transformer");
+      auto vae_loader = loader->take_component_loader("vae");
+      auto text_encoder_loader = loader->take_component_loader("text_encoder");
+      auto tokenizer_loader = loader->take_component_loader("tokenizer");
+
+      load_module_from_state_dicts(*transformer_loader,
+                                   transformer_.ptr().get());
+      transformer_->to(options_.device());
+      // Official inference runs transformer in float32, VAE in float16.
+      transformer_->to(torch::kFloat32);
+
+      load_module_from_state_dicts(*vae_loader, vae_.ptr().get());
+      vae_->to(options_.device());
+      vae_->to_half();
+
+      text_encoder_->load_model(std::move(text_encoder_loader));
+      text_encoder_->to(options_.device());
+      // Official runs text encoder in float32 (same as transformer).
+      text_encoder_->to(torch::kFloat32);
+
+      tokenizer_ = tokenizer_loader->tokenizer();
+    } else {
+      // Flat layout: single model.safetensors at root contains all weights.
+      // Keys are prefixed: "transformer.*", "vae.*", "text_encoder.*".
+      auto flat_loader = loader->take_component_loader("model");
+
+      load_module_from_state_dicts(
+          *flat_loader, transformer_.ptr().get(), "transformer.");
+      transformer_->to(options_.device());
+      // Official inference runs transformer in float32, VAE in float16.
+      transformer_->to(torch::kFloat32);
+
+      load_module_from_state_dicts(*flat_loader, vae_.ptr().get(), "vae.");
+      vae_->to(options_.device());
+      vae_->to_half();
+
+      text_encoder_->load_model_from_state_dicts(
+          flat_loader->get_state_dicts());
+      text_encoder_->to(options_.device());
+      // Official runs text encoder in float32 (same as transformer).
+      text_encoder_->to(torch::kFloat32);
+
+      tokenizer_ = flat_loader->tokenizer();
+    }
+  }
+
+ private:
+  // Encode text using T5/UMT5 encoder
+  // input_ids: (B, S) int64, attention_mask: (B, S) bool
+  // Returns: (B, S, 768) float32
+  torch::Tensor encode_text(const torch::Tensor& input_ids,
+                            const torch::Tensor& attention_mask) {
+    torch::NoGradGuard no_grad;
+    // Truncate to actual token length before T5 encoding to match official
+    // Python which never pads (tokenizer output has exact sequence length).
+    // Processing 512 tokens when only 25 are real pollutes T5 self-attention
+    // with 487 padding positions and changes the output for real tokens.
+    int64_t actual_len =
+        attention_mask.to(torch::kLong).sum(1).max().item<int64_t>();
+    torch::Tensor ids = input_ids.slice(1, 0, actual_len);
+    return text_encoder_->forward(ids);
+  }
+
+  // Encode prompt audio (B, 1, T) -> latent (B, frames, 64) + prompt_frames
+  std::pair<torch::Tensor, int64_t> encode_prompt_audio(
+      const torch::Tensor& prompt_audio) {
+    auto device = options_.device();
+    int64_t full_hop = vae_->downsampling_ratio_;
+    constexpr int64_t kOffset = 3;  // extra frames offset
+
+    torch::Tensor wav = prompt_audio.to(device);
+    if (wav.dim() == 2) {
+      wav = wav.unsqueeze(1);  // (B, 1, T)
+    }
+
+    // Pad to multiple of full_hop
+    int64_t T = wav.size(2);
+    if (T % full_hop != 0) {
+      int64_t pad_amt = full_hop - (T % full_hop);
+      wav = torch::nn::functional::pad(
+          wav, torch::nn::functional::PadFuncOptions({0, pad_amt}));
+    }
+    // Extra offset padding
+    wav = torch::nn::functional::pad(
+        wav, torch::nn::functional::PadFuncOptions({0, full_hop * kOffset}));
+
+    torch::Tensor latent = vae_->encode(wav);  // (B, 64, T')
+    // Remove offset frames
+    if (kOffset != 0) {
+      latent = latent.slice(2, 0, latent.size(2) - kOffset);
+    }
+    int64_t prompt_frames = latent.size(2);
+    return {latent.permute({0, 2, 1}).to(torch::kFloat32), prompt_frames};
+    // Returns (B, prompt_frames, 64)
+  }
+
+  // Member variables
+  DiTModelContext context_;
+  torch::TensorOptions options_;
+
+  // Audio config read from config.json (matches official
+  // model.config.sampling_rate)
+  int32_t sampling_rate_ = 24000;
+
+  // Model components
+  AudioDiTVae vae_{nullptr};
+  AudioDiTTransformer transformer_{nullptr};
+  UMT5TextEncoder text_encoder_{nullptr};
+  std::unique_ptr<Tokenizer> tokenizer_;
+};
+TORCH_MODULE(LongCatAudioDiTPipeline);
+
+// ============================================================================
+// Model registration
+// ============================================================================
+// Register under "audiodit" to match the model_type field in config.json.
+namespace {
+const bool longcat_audio_dit_registered = []() {
+  ModelRegistry::register_dit_model_factory(
+      "audiodit", [](const DiTModelContext& context) {
+        LongCatAudioDiTPipeline model(context);
+        model->eval();
+        return std::make_unique<DiTModelImpl<LongCatAudioDiTPipeline>>(
+            std::move(model), context.get_tensor_options());
+      });
+  return true;
+}();
+}  // namespace
+
+}  // namespace xllm

--- a/xllm/models/dit/transformer_longcat_audiodit.h
+++ b/xllm/models/dit/transformer_longcat_audiodit.h
@@ -1,0 +1,1738 @@
+/* Copyright 2026 The xLLM Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://github.com/jd-opensource/xllm/blob/main/LICENSE
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+// AudioDiT transformer model for LongCat-AudioDiT.
+// Ref:
+// https://github.com/meituan-longcat/LongCat-AudioDiT/blob/main/audiodit/modeling_audiodit.py
+// Components:
+//   - AudioDiTVae: WAV-VAE encoder/decoder with SnakeBeta activations and
+//     weight_norm convolutions.
+//   - AudioDiTTransformer: DiT backbone (24 blocks) with:
+//       timestep embedding, input/text embedders, ConvNeXtV2 text processing,
+//       rotary position embedding, self-attn + cross-attn + FFN per block,
+//       global AdaLN, long-skip connection.
+//   - APG guidance helpers.
+//   - UMT5TextEncoder: text encoder wrapper (google/umt5-base).
+//   - Weight loading utilities (checkpoint_key_to_cpp_key,
+//     load_module_from_state_dicts).
+
+#pragma once
+
+#include <torch/torch.h>
+
+#include <algorithm>
+#include <cmath>
+#include <functional>
+#include <limits>
+#include <memory>
+#include <optional>
+#include <string>
+#include <vector>
+
+#include "autoencoder_kl.h"  // randn_tensor
+#include "core/framework/dit_model_loader.h"
+#include "core/framework/model_context.h"
+#include "core/framework/request/dit_request_state.h"
+#include "umt5_encoder.h"
+
+namespace xllm {
+
+// ============================================================================
+// VAE helpers
+// ============================================================================
+
+// SnakeBeta activation: x + (1/beta) * sin(x * alpha)^2
+// alpha and beta are learnable per-channel parameters (log-scale by default).
+class AudioSnakeBetaImpl : public torch::nn::Module {
+ public:
+  explicit AudioSnakeBetaImpl(int64_t in_features, bool alpha_logscale = true)
+      : alpha_logscale_(alpha_logscale) {
+    alpha_ = register_parameter("alpha", torch::zeros({in_features}));
+    beta_ = register_parameter("beta", torch::zeros({in_features}));
+  }
+
+  torch::Tensor forward(const torch::Tensor& x) {
+    // x: (B, C, T)
+    torch::Tensor alpha = alpha_.unsqueeze(0).unsqueeze(-1);  // (1, C, 1)
+    torch::Tensor beta = beta_.unsqueeze(0).unsqueeze(-1);    // (1, C, 1)
+    if (alpha_logscale_) {
+      alpha = torch::exp(alpha);
+      beta = torch::exp(beta);
+    }
+    return x + (1.0 / (beta + 1e-9f)) * torch::sin(x * alpha).pow(2);
+  }
+
+ private:
+  torch::Tensor alpha_;
+  torch::Tensor beta_;
+  bool alpha_logscale_;
+};
+TORCH_MODULE(AudioSnakeBeta);
+
+// Pixel-unshuffle for 1-D signals: (B, C, W) -> (B, C*factor, W/factor)
+inline torch::Tensor pixel_unshuffle_1d(const torch::Tensor& x,
+                                        int64_t factor) {
+  int64_t b = x.size(0), c = x.size(1), w = x.size(2);
+  return x.view({b, c, w / factor, factor})
+      .permute({0, 1, 3, 2})
+      .contiguous()
+      .view({b, c * factor, w / factor});
+}
+
+// Pixel-shuffle for 1-D signals: (B, C*factor, W) -> (B, C, W*factor)
+inline torch::Tensor pixel_shuffle_1d(const torch::Tensor& x, int64_t factor) {
+  int64_t b = x.size(0), c_full = x.size(1), w = x.size(2);
+  int64_t c = c_full / factor;
+  return x.view({b, c, factor, w})
+      .permute({0, 1, 3, 2})
+      .contiguous()
+      .view({b, c, w * factor});
+}
+
+// Downsampling shortcut: pixel-unshuffle then average over groups
+class VaeDownsampleShortcutImpl : public torch::nn::Module {
+ public:
+  VaeDownsampleShortcutImpl(int64_t in_channels,
+                            int64_t out_channels,
+                            int64_t factor)
+      : factor_(factor),
+        group_size_(in_channels * factor / out_channels),
+        out_channels_(out_channels) {}
+
+  torch::Tensor forward(const torch::Tensor& x) {
+    torch::Tensor y = pixel_unshuffle_1d(x, factor_);
+    int64_t b = y.size(0), n = y.size(2);
+    return y.view({b, out_channels_, group_size_, n}).mean(2);
+  }
+
+ private:
+  int64_t factor_, group_size_, out_channels_;
+};
+TORCH_MODULE(VaeDownsampleShortcut);
+
+// Upsampling shortcut: repeat-interleave then pixel-shuffle
+class VaeUpsampleShortcutImpl : public torch::nn::Module {
+ public:
+  VaeUpsampleShortcutImpl(int64_t in_channels,
+                          int64_t out_channels,
+                          int64_t factor)
+      : factor_(factor), repeats_(out_channels * factor / in_channels) {}
+
+  torch::Tensor forward(const torch::Tensor& x) {
+    return pixel_shuffle_1d(x.repeat_interleave(repeats_, 1), factor_);
+  }
+
+ private:
+  int64_t factor_, repeats_;
+};
+TORCH_MODULE(VaeUpsampleShortcut);
+
+// Single residual unit: act -> wn_conv(dilation) -> act -> wn_conv(1x1)
+class VaeResidualUnitImpl : public torch::nn::Module {
+ public:
+  VaeResidualUnitImpl(int64_t in_channels,
+                      int64_t out_channels,
+                      int64_t dilation,
+                      bool use_snake = false,
+                      int64_t kernel_size = 7) {
+    int64_t padding = (dilation * (kernel_size - 1)) / 2;
+    if (use_snake) {
+      act0_ = register_module("layers_0", AudioSnakeBeta(out_channels));
+      act1_ = register_module("layers_2", AudioSnakeBeta(out_channels));
+      use_snake_ = true;
+    } else {
+      elu0_ = register_module("layers_0", torch::nn::ELU());
+      elu1_ = register_module("layers_2", torch::nn::ELU());
+      use_snake_ = false;
+    }
+    // Weight-normed convolutions
+    conv0_ = register_module(
+        "layers_1",
+        torch::nn::Conv1d(
+            torch::nn::Conv1dOptions(in_channels, out_channels, kernel_size)
+                .dilation(dilation)
+                .padding(padding)));
+    conv1_ = register_module("layers_3",
+                             torch::nn::Conv1d(torch::nn::Conv1dOptions(
+                                 out_channels, out_channels, 1)));
+  }
+
+  torch::Tensor forward(const torch::Tensor& x) {
+    torch::Tensor h;
+    if (use_snake_) {
+      h = act0_->forward(x);
+    } else {
+      h = elu0_->forward(x);
+    }
+    h = conv0_->forward(h);
+    if (use_snake_) {
+      h = act1_->forward(h);
+    } else {
+      h = elu1_->forward(h);
+    }
+    h = conv1_->forward(h);
+    return x + h;
+  }
+
+ private:
+  bool use_snake_ = false;
+  AudioSnakeBeta act0_{nullptr}, act1_{nullptr};
+  torch::nn::ELU elu0_{nullptr}, elu1_{nullptr};
+  torch::nn::Conv1d conv0_{nullptr}, conv1_{nullptr};
+};
+TORCH_MODULE(VaeResidualUnit);
+
+// Encoder block: 3x residual units + act + strided conv
+class VaeEncoderBlockImpl : public torch::nn::Module {
+ public:
+  VaeEncoderBlockImpl(int64_t in_ch,
+                      int64_t out_ch,
+                      int64_t stride,
+                      bool use_snake = false,
+                      bool use_downsample_shortcut = false) {
+    // Residual units: Python layers.0, layers.1, layers.2
+    int64_t layer_idx = 0;
+    for (int64_t d : {1LL, 3LL, 9LL}) {
+      enc_res_.push_back(
+          register_module("layers_" + std::to_string(layer_idx),
+                          VaeResidualUnit(in_ch, in_ch, d, use_snake)));
+      ++layer_idx;
+    }
+    // Activation: Python layers.3
+    if (use_snake) {
+      act_ = register_module("layers_" + std::to_string(layer_idx),
+                             AudioSnakeBeta(in_ch));
+      use_snake_ = true;
+    } else {
+      elu_ = register_module("layers_" + std::to_string(layer_idx),
+                             torch::nn::ELU());
+      use_snake_ = false;
+    }
+    ++layer_idx;
+    // Strided conv: Python layers.4
+    int64_t pad = static_cast<int64_t>(std::ceil(stride / 2.0));
+    down_conv_ = register_module(
+        "layers_" + std::to_string(layer_idx),
+        torch::nn::Conv1d(torch::nn::Conv1dOptions(in_ch, out_ch, 2 * stride)
+                              .stride(stride)
+                              .padding(pad)));
+    // Shortcut: Python res
+    if (use_downsample_shortcut) {
+      shortcut_ =
+          register_module("res", VaeDownsampleShortcut(in_ch, out_ch, stride));
+      has_shortcut_ = true;
+    }
+  }
+
+  torch::Tensor forward(const torch::Tensor& x) {
+    torch::Tensor h = x;
+    for (auto& r : enc_res_) {
+      h = r->forward(h);
+    }
+    if (use_snake_) {
+      h = act_->forward(h);
+    } else {
+      h = elu_->forward(h);
+    }
+    torch::Tensor out = down_conv_->forward(h);
+    if (has_shortcut_) {
+      out = out + shortcut_->forward(x);
+    }
+    return out;
+  }
+
+ private:
+  std::vector<VaeResidualUnit> enc_res_;
+  bool use_snake_ = false, has_shortcut_ = false;
+  AudioSnakeBeta act_{nullptr};
+  torch::nn::ELU elu_{nullptr};
+  torch::nn::Conv1d down_conv_{nullptr};
+  VaeDownsampleShortcut shortcut_{nullptr};
+};
+TORCH_MODULE(VaeEncoderBlock);
+
+// Decoder block: act + strided transpose conv + 3x residual units
+class VaeDecoderBlockImpl : public torch::nn::Module {
+ public:
+  VaeDecoderBlockImpl(int64_t in_ch,
+                      int64_t out_ch,
+                      int64_t stride,
+                      bool use_snake = false,
+                      bool use_upsample_shortcut = false) {
+    // Activation: Python layers.0
+    if (use_snake) {
+      act_ = register_module("layers_0", AudioSnakeBeta(in_ch));
+      use_snake_ = true;
+    } else {
+      elu_ = register_module("layers_0", torch::nn::ELU());
+      use_snake_ = false;
+    }
+    // Transposed conv: Python layers.1
+    int64_t pad = static_cast<int64_t>(std::ceil(stride / 2.0));
+    up_conv_ = register_module(
+        "layers_1",
+        torch::nn::ConvTranspose1d(
+            torch::nn::ConvTranspose1dOptions(in_ch, out_ch, 2 * stride)
+                .stride(stride)
+                .padding(pad)));
+    // Residual units: Python layers.2, layers.3, layers.4
+    int64_t res_layer_idx = 2;
+    for (int64_t d : {1LL, 3LL, 9LL}) {
+      dec_res_.push_back(
+          register_module("layers_" + std::to_string(res_layer_idx),
+                          VaeResidualUnit(out_ch, out_ch, d, use_snake)));
+      ++res_layer_idx;
+    }
+    // Shortcut: Python res
+    if (use_upsample_shortcut) {
+      shortcut_ =
+          register_module("res", VaeUpsampleShortcut(in_ch, out_ch, stride));
+      has_shortcut_ = true;
+    }
+  }
+
+  torch::Tensor forward(const torch::Tensor& x) {
+    // Official Python: layers = Sequential(act, conv_transpose, res1, res2,
+    // res3)
+    //   forward: layers(x) + res(x)   -- shortcut added to full block output
+    torch::Tensor h;
+    if (use_snake_) {
+      h = act_->forward(x);
+    } else {
+      h = elu_->forward(x);
+    }
+    torch::Tensor out = up_conv_->forward(h);
+    for (auto& r : dec_res_) {
+      out = r->forward(out);
+    }
+    if (has_shortcut_) {
+      out = out + shortcut_->forward(x);
+    }
+    return out;
+  }
+
+ private:
+  std::vector<VaeResidualUnit> dec_res_;
+  bool use_snake_ = false, has_shortcut_ = false;
+  AudioSnakeBeta act_{nullptr};
+  torch::nn::ELU elu_{nullptr};
+  torch::nn::ConvTranspose1d up_conv_{nullptr};
+  VaeUpsampleShortcut shortcut_{nullptr};
+};
+TORCH_MODULE(VaeDecoderBlock);
+
+// VAE Encoder: audio -> latent (batch, encoder_latent_dim,
+// T/downsampling_ratio)
+struct VaeEncoderConfig {
+  int64_t in_channels = 1;
+  int64_t channels = 128;
+  std::vector<int64_t> c_mults = {1, 2, 4, 8, 16};
+  std::vector<int64_t> strides = {2, 4, 4, 8, 8};
+  int64_t encoder_latent_dim = 128;  // 2 * latent_dim for VAE bottleneck
+  bool use_snake = true;
+  bool use_downsample_shortcut = false;  // "averaging" shortcut
+};
+
+class VaeEncoderImpl : public torch::nn::Module {
+ public:
+  explicit VaeEncoderImpl(const VaeEncoderConfig& cfg) {
+    std::vector<int64_t> c_mults_with_1 = {1};
+    c_mults_with_1.insert(
+        c_mults_with_1.end(), cfg.c_mults.begin(), cfg.c_mults.end());
+
+    // Initial conv (Python: layers.0)
+    int64_t ch0 = c_mults_with_1[0] * cfg.channels;
+    in_conv_ = register_module(
+        "layers_0",
+        torch::nn::Conv1d(
+            torch::nn::Conv1dOptions(cfg.in_channels, ch0, 7).padding(3)));
+
+    // Encoder blocks (Python: layers.1 ... layers.N-1)
+    for (int64_t i = 0; i < static_cast<int64_t>(c_mults_with_1.size()) - 1;
+         ++i) {
+      int64_t in_ch = c_mults_with_1[i] * cfg.channels;
+      int64_t out_ch = c_mults_with_1[i + 1] * cfg.channels;
+      int64_t s = cfg.strides[i];
+      enc_blocks_.push_back(register_module(
+          "layers_" + std::to_string(i + 1),
+          VaeEncoderBlock(
+              in_ch, out_ch, s, cfg.use_snake, cfg.use_downsample_shortcut)));
+    }
+
+    // Output conv (Python: layers.N)
+    int64_t ch_last = c_mults_with_1.back() * cfg.channels;
+    int64_t out_layer_idx =
+        static_cast<int64_t>(c_mults_with_1.size());  // = num_blocks + 1
+    out_conv_ = register_module(
+        "layers_" + std::to_string(out_layer_idx),
+        torch::nn::Conv1d(
+            torch::nn::Conv1dOptions(ch_last, cfg.encoder_latent_dim, 3)
+                .padding(1)));
+  }
+
+  torch::Tensor forward(const torch::Tensor& x) {
+    torch::Tensor h = in_conv_->forward(x);
+    for (auto& blk : enc_blocks_) {
+      h = blk->forward(h);
+    }
+    return out_conv_->forward(h);
+  }
+
+ private:
+  torch::nn::Conv1d in_conv_{nullptr};
+  std::vector<VaeEncoderBlock> enc_blocks_;
+  torch::nn::Conv1d out_conv_{nullptr};
+};
+TORCH_MODULE(VaeEncoder);
+
+// VAE Decoder: latent -> audio
+struct VaeDecoderConfig {
+  int64_t in_channels = 1;
+  int64_t channels = 128;
+  std::vector<int64_t> c_mults = {1, 2, 4, 8, 16};
+  std::vector<int64_t> strides = {2, 4, 4, 8, 8};
+  int64_t latent_dim = 64;
+  bool use_snake = true;
+  bool use_upsample_shortcut = false;  // per-block "duplicating" shortcut
+  bool use_in_shortcut = false;        // top-level "duplicating" in_shortcut
+  bool final_tanh = false;
+};
+
+class VaeDecoderImpl : public torch::nn::Module {
+ public:
+  explicit VaeDecoderImpl(const VaeDecoderConfig& cfg) {
+    std::vector<int64_t> c_mults_with_1 = {1};
+    c_mults_with_1.insert(
+        c_mults_with_1.end(), cfg.c_mults.begin(), cfg.c_mults.end());
+
+    // Top-level in_shortcut (Python: self.shortcut, stride=1 upsample of
+    // latent)
+    int64_t ch_last = c_mults_with_1.back() * cfg.channels;
+    if (cfg.use_in_shortcut) {
+      in_shortcut_ = register_module(
+          "shortcut", VaeUpsampleShortcut(cfg.latent_dim, ch_last, 1));
+      has_in_shortcut_ = true;
+    }
+
+    // Initial conv (Python: layers.0)
+    in_conv_ = register_module(
+        "layers_0",
+        torch::nn::Conv1d(
+            torch::nn::Conv1dOptions(cfg.latent_dim, ch_last, 7).padding(3)));
+
+    // Decoder blocks (reverse order; Python: layers.1 ... layers.N-1)
+    int64_t dec_layer_idx = 1;
+    for (int64_t i = static_cast<int64_t>(c_mults_with_1.size()) - 1; i > 0;
+         --i) {
+      int64_t in_ch = c_mults_with_1[i] * cfg.channels;
+      int64_t out_ch = c_mults_with_1[i - 1] * cfg.channels;
+      int64_t s = cfg.strides[i - 1];
+      dec_blocks_.push_back(register_module(
+          "layers_" + std::to_string(dec_layer_idx),
+          VaeDecoderBlock(
+              in_ch, out_ch, s, cfg.use_snake, cfg.use_upsample_shortcut)));
+      ++dec_layer_idx;
+    }
+
+    // Output activation (Python: layers.N) + conv (Python: layers.N+1)
+    int64_t ch0 = c_mults_with_1[0] * cfg.channels;
+    if (cfg.use_snake) {
+      out_act_snake_ = register_module(
+          "layers_" + std::to_string(dec_layer_idx), AudioSnakeBeta(ch0));
+      use_snake_ = true;
+    } else {
+      out_act_elu_ = register_module("layers_" + std::to_string(dec_layer_idx),
+                                     torch::nn::ELU());
+      use_snake_ = false;
+    }
+    ++dec_layer_idx;
+    out_conv_ = register_module(
+        "layers_" + std::to_string(dec_layer_idx),
+        torch::nn::Conv1d(torch::nn::Conv1dOptions(ch0, cfg.in_channels, 7)
+                              .padding(3)
+                              .bias(false)));
+    if (cfg.final_tanh) {
+      use_tanh_ = true;
+    }
+  }
+
+  torch::Tensor forward(const torch::Tensor& z) {
+    // Python: if shortcut: x = shortcut(z) + layers[0](z); x = layers[1:](x)
+    //         else:        return layers(z)
+    torch::Tensor h = in_conv_->forward(z);
+    if (has_in_shortcut_) {
+      h = h + in_shortcut_->forward(z);
+    }
+    for (auto& blk : dec_blocks_) {
+      h = blk->forward(h);
+    }
+    if (use_snake_) {
+      h = out_act_snake_->forward(h);
+    } else {
+      h = out_act_elu_->forward(h);
+    }
+    h = out_conv_->forward(h);
+    if (use_tanh_) {
+      h = torch::tanh(h);
+    }
+    return h;
+  }
+
+ private:
+  torch::nn::Conv1d in_conv_{nullptr};
+  VaeUpsampleShortcut in_shortcut_{nullptr};
+  bool has_in_shortcut_ = false;
+  std::vector<VaeDecoderBlock> dec_blocks_;
+  bool use_snake_ = false, use_tanh_ = false;
+  AudioSnakeBeta out_act_snake_{nullptr};
+  torch::nn::ELU out_act_elu_{nullptr};
+  torch::nn::Conv1d out_conv_{nullptr};
+};
+TORCH_MODULE(VaeDecoder);
+
+// Top-level WAV-VAE: encoder + VAE bottleneck + decoder
+// Encoder runs in float16 (matching original model_half=True).
+struct AudioDiTVaeConfig {
+  VaeEncoderConfig encoder_cfg;
+  VaeDecoderConfig decoder_cfg;
+  float scale = 0.71f;
+  int64_t downsampling_ratio = 2048;  // VAE temporal downsampling
+  int64_t latent_dim = 64;
+};
+
+class AudioDiTVaeImpl : public torch::nn::Module {
+ public:
+  explicit AudioDiTVaeImpl(const AudioDiTVaeConfig& cfg)
+      : scale_(cfg.scale),
+        downsampling_ratio_(cfg.downsampling_ratio),
+        latent_dim_(cfg.latent_dim) {
+    encoder_ = register_module("encoder", VaeEncoder(cfg.encoder_cfg));
+    decoder_ = register_module("decoder", VaeDecoder(cfg.decoder_cfg));
+  }
+
+  // Encode audio (batch,1,T) -> latent (batch,latent_dim,T/downsampling_ratio)
+  // VAE bottleneck: split encoder output into mean+logscale, sample.
+  torch::Tensor encode(const torch::Tensor& audio) {
+    // Check if encoder is in float16 mode
+    bool is_half = false;
+    for (const auto& kv : encoder_->named_parameters()) {
+      is_half = (kv.value().dtype() == torch::kFloat16);
+      break;
+    }
+    torch::Tensor x = is_half ? audio.to(torch::kFloat16) : audio;
+    torch::Tensor enc_out = encoder_->forward(x);  // (B, 2*latent_dim, T')
+
+    // VAE bottleneck (runs in encoder dtype)
+    std::vector<torch::Tensor> chunks = enc_out.chunk(2, 1);
+    torch::Tensor mean = chunks[0];
+    torch::Tensor scale_param = chunks[1];
+    torch::Tensor stdev =
+        torch::nn::functional::softplus(
+            scale_param,
+            torch::nn::functional::SoftplusFuncOptions().beta(1.0).threshold(
+                20.0)) +
+        1e-4f;
+    torch::Tensor noise = torch::randn_like(mean);
+    torch::Tensor latents = noise * stdev + mean;
+
+    if (is_half) {
+      latents = latents.to(torch::kFloat32);
+    }
+    return latents / scale_;
+  }
+
+  // Decode latent (batch,latent_dim,T') -> audio (batch,1,T)
+  torch::Tensor decode(const torch::Tensor& latents) {
+    torch::Tensor z = latents * scale_;
+    bool is_half = false;
+    for (const auto& kv : decoder_->named_parameters()) {
+      is_half = (kv.value().dtype() == torch::kFloat16);
+      break;
+    }
+    if (is_half) {
+      z = z.to(torch::kFloat16);
+    }
+    torch::Tensor decoded = decoder_->forward(z);
+    if (is_half) {
+      decoded = decoded.to(torch::kFloat32);
+    }
+    return decoded;
+  }
+
+  // Convert encoder/decoder to float16 (matching original model_half=True)
+  void to_half() {
+    encoder_->to(torch::kFloat16);
+    decoder_->to(torch::kFloat16);
+  }
+
+  VaeEncoder encoder_{nullptr};
+  VaeDecoder decoder_{nullptr};
+  float scale_;
+  int64_t downsampling_ratio_, latent_dim_;
+};
+TORCH_MODULE(AudioDiTVae);
+
+// ============================================================================
+// Transformer components
+// ============================================================================
+
+// RMS normalization
+class AudioRMSNormImpl : public torch::nn::Module {
+ public:
+  explicit AudioRMSNormImpl(int64_t dim, float eps = 1e-6f) : eps_(eps) {
+    weight_ = register_parameter("weight", torch::ones({dim}));
+  }
+
+  torch::Tensor forward(const torch::Tensor& x) {
+    // Compute in float32 for numerical stability, then cast back
+    torch::Tensor x_f = x.to(torch::kFloat32);
+    torch::Tensor variance = x_f.pow(2).mean(-1, /*keepdim=*/true);
+    x_f = x_f * torch::rsqrt(variance + eps_);
+    return x_f.to(x.dtype()) * weight_;
+  }
+
+ private:
+  float eps_;
+  torch::Tensor weight_;
+};
+TORCH_MODULE(AudioRMSNorm);
+
+// Sinusoidal position embedding for timesteps
+class AudioSinusPositionEmbeddingImpl : public torch::nn::Module {
+ public:
+  explicit AudioSinusPositionEmbeddingImpl(int64_t dim) : dim_(dim) {}
+
+  torch::Tensor forward(const torch::Tensor& x, float scale = 1000.0f) {
+    // x: (B,) scalar timesteps
+    torch::Device dev = x.device();
+    int64_t half_dim = dim_ / 2;
+    double log_val = std::log(10000.0);
+    torch::Tensor emb =
+        torch::arange(half_dim, torch::dtype(torch::kFloat32).device(dev))
+            .mul(-log_val / static_cast<double>(half_dim - 1))
+            .exp();
+    emb = scale * x.to(torch::kFloat32).unsqueeze(1) * emb.unsqueeze(0);
+    return torch::cat({emb.sin(), emb.cos()}, -1);
+  }
+
+ private:
+  int64_t dim_;
+};
+TORCH_MODULE(AudioSinusPositionEmbedding);
+
+// Timestep embedding: sinusoidal -> MLP(SiLU)
+class AudioTimestepEmbeddingImpl : public torch::nn::Module {
+ public:
+  explicit AudioTimestepEmbeddingImpl(int64_t dim,
+                                      int64_t freq_embed_dim = 256) {
+    time_embed_ = register_module("time_embed",
+                                  AudioSinusPositionEmbedding(freq_embed_dim));
+    time_mlp_ = register_module(
+        "time_mlp",
+        torch::nn::Sequential(torch::nn::Linear(freq_embed_dim, dim),
+                              torch::nn::SiLU(),
+                              torch::nn::Linear(dim, dim)));
+  }
+
+  torch::Tensor forward(const torch::Tensor& timestep) {
+    torch::Tensor h = time_embed_->forward(timestep);
+    h = h.to(timestep.dtype());
+    return time_mlp_->forward(h);
+  }
+
+ private:
+  AudioSinusPositionEmbedding time_embed_{nullptr};
+  torch::nn::Sequential time_mlp_{nullptr};
+};
+TORCH_MODULE(AudioTimestepEmbedding);
+
+// Rotary position embedding (Qwen2-style, lazy build)
+class AudioRotaryEmbeddingImpl : public torch::nn::Module {
+ public:
+  explicit AudioRotaryEmbeddingImpl(int64_t dim,
+                                    int64_t max_position_embeddings = 2048,
+                                    float base = 100000.0f)
+      : dim_(dim),
+        max_position_embeddings_(max_position_embeddings),
+        base_(base),
+        cached_len_(0) {}
+
+  // Returns (cos, sin) tensors each of shape (seq_len, dim)
+  std::pair<torch::Tensor, torch::Tensor> forward(const torch::Tensor& x,
+                                                  int64_t seq_len = -1) {
+    if (seq_len < 0) {
+      seq_len = x.size(1);
+    }
+    if (!cos_.defined() || seq_len > cached_len_ ||
+        x.device() != cached_device_) {
+      build(std::max(seq_len, max_position_embeddings_),
+            x.device(),
+            x.scalar_type());
+    }
+    return {cos_.slice(0, 0, seq_len).to(x.dtype()),
+            sin_.slice(0, 0, seq_len).to(x.dtype())};
+  }
+
+ private:
+  void build(int64_t seq_len, torch::Device device, torch::ScalarType dtype) {
+    auto arange_opts = torch::dtype(torch::kFloat32).device(torch::kCPU);
+    torch::Tensor inv_freq =
+        1.0f /
+        torch::pow(static_cast<float>(base_),
+                   torch::arange(0, dim_, 2, arange_opts).to(torch::kFloat32) /
+                       static_cast<float>(dim_));
+    torch::Tensor t = torch::arange(seq_len, arange_opts).to(torch::kFloat32);
+    torch::Tensor freqs = torch::outer(t, inv_freq);
+    torch::Tensor emb = torch::cat({freqs, freqs}, -1);
+    cos_ = emb.cos().to(dtype).to(device);
+    sin_ = emb.sin().to(dtype).to(device);
+    cached_len_ = seq_len;
+    cached_device_ = device;
+  }
+
+  int64_t dim_, max_position_embeddings_, cached_len_;
+  float base_;
+  torch::Device cached_device_{torch::kCPU};
+  torch::Tensor cos_, sin_;
+};
+TORCH_MODULE(AudioRotaryEmbedding);
+
+// Apply rotary embedding to (B, H, S, D) tensor
+inline torch::Tensor rotate_half(const torch::Tensor& x) {
+  std::vector<torch::Tensor> chunks = x.chunk(2, -1);
+  return torch::cat({-chunks[1], chunks[0]}, -1);
+}
+
+inline torch::Tensor apply_rotary_emb(const torch::Tensor& x,
+                                      const torch::Tensor& cos,
+                                      const torch::Tensor& sin) {
+  // cos/sin: (S, D); x: (B, H, S, D)
+  torch::Tensor c = cos.unsqueeze(0).unsqueeze(0).to(x.device());
+  torch::Tensor s = sin.unsqueeze(0).unsqueeze(0).to(x.device());
+  return (x.to(torch::kFloat32) * c + rotate_half(x).to(torch::kFloat32) * s)
+      .to(x.dtype());
+}
+
+// Global Response Normalization (GRN) for ConvNeXtV2
+class AudioGRNImpl : public torch::nn::Module {
+ public:
+  explicit AudioGRNImpl(int64_t dim) {
+    gamma_ = register_parameter("gamma", torch::zeros({1, 1, dim}));
+    beta_ = register_parameter("beta", torch::zeros({1, 1, dim}));
+  }
+
+  torch::Tensor forward(const torch::Tensor& x) {
+    // x: (B, S, D)
+    torch::Tensor gx = torch::norm(x, 2, 1, /*keepdim=*/true);
+    torch::Tensor nx = gx / (gx.mean(-1, /*keepdim=*/true) + 1e-6f);
+    return gamma_ * (x * nx) + beta_ + x;
+  }
+
+ private:
+  torch::Tensor gamma_, beta_;
+};
+TORCH_MODULE(AudioGRN);
+
+// ConvNeXtV2 block for 1-D sequence text conditioning
+class AudioConvNeXtV2BlockImpl : public torch::nn::Module {
+ public:
+  AudioConvNeXtV2BlockImpl(int64_t dim,
+                           int64_t intermediate_dim,
+                           int64_t dilation = 1,
+                           int64_t kernel_size = 7,
+                           float eps = 1e-6f) {
+    int64_t padding = (dilation * (kernel_size - 1)) / 2;
+    dwconv_ = register_module(
+        "dwconv",
+        torch::nn::Conv1d(torch::nn::Conv1dOptions(dim, dim, kernel_size)
+                              .padding(padding)
+                              .groups(dim)
+                              .dilation(dilation)));
+    norm_ = register_module(
+        "norm",
+        torch::nn::LayerNorm(torch::nn::LayerNormOptions({dim}).eps(eps)));
+    pwconv1_ =
+        register_module("pwconv1", torch::nn::Linear(dim, intermediate_dim));
+    act_ = register_module("act", torch::nn::SiLU());
+    grn_ = register_module("grn", AudioGRN(intermediate_dim));
+    pwconv2_ =
+        register_module("pwconv2", torch::nn::Linear(intermediate_dim, dim));
+  }
+
+  torch::Tensor forward(const torch::Tensor& x) {
+    // x: (B, S, D)
+    torch::Tensor h = x.transpose(1, 2);  // -> (B, D, S)
+    h = dwconv_->forward(h);
+    h = h.transpose(1, 2);  // -> (B, S, D)
+    h = norm_->forward(h);
+    h = pwconv1_->forward(h);
+    h = act_->forward(h);
+    h = grn_->forward(h);
+    h = pwconv2_->forward(h);
+    return x + h;
+  }
+
+ private:
+  torch::nn::Conv1d dwconv_{nullptr};
+  torch::nn::LayerNorm norm_{nullptr};
+  torch::nn::Linear pwconv1_{nullptr};
+  torch::nn::SiLU act_{nullptr};
+  AudioGRN grn_{nullptr};
+  torch::nn::Linear pwconv2_{nullptr};
+};
+TORCH_MODULE(AudioConvNeXtV2Block);
+
+// Embedder: linear projection with optional mask
+class AudioEmbedderImpl : public torch::nn::Module {
+ public:
+  AudioEmbedderImpl(int64_t in_dim, int64_t out_dim) {
+    proj_ = register_module(
+        "proj",
+        torch::nn::Sequential(torch::nn::Linear(in_dim, out_dim),
+                              torch::nn::SiLU(),
+                              torch::nn::Linear(out_dim, out_dim)));
+  }
+
+  torch::Tensor forward(const torch::Tensor& x,
+                        std::optional<torch::Tensor> mask = std::nullopt) {
+    torch::Tensor h = x;
+    if (mask.has_value()) {
+      h = h.masked_fill(mask->logical_not().unsqueeze(-1), 0.0f);
+    }
+    h = proj_->forward(h);
+    if (mask.has_value()) {
+      h = h.masked_fill(mask->logical_not().unsqueeze(-1), 0.0f);
+    }
+    return h;
+  }
+
+ private:
+  torch::nn::Sequential proj_{nullptr};
+};
+TORCH_MODULE(AudioEmbedder);
+
+// AdaLN MLP: SiLU -> Linear
+class AudioAdaLNMLPImpl : public torch::nn::Module {
+ public:
+  AudioAdaLNMLPImpl(int64_t in_dim, int64_t out_dim) {
+    mlp_ = register_module(
+        "mlp",
+        torch::nn::Sequential(torch::nn::SiLU(),
+                              torch::nn::Linear(in_dim, out_dim)));
+  }
+
+  torch::Tensor forward(const torch::Tensor& x) { return mlp_->forward(x); }
+
+ private:
+  torch::nn::Sequential mlp_{nullptr};
+};
+TORCH_MODULE(AudioAdaLNMLP);
+
+// AdaLayerNormZeroFinal: used for output normalization
+class AudioAdaLayerNormZeroFinalImpl : public torch::nn::Module {
+ public:
+  explicit AudioAdaLayerNormZeroFinalImpl(int64_t dim, float eps = 1e-6f) {
+    linear_ = register_module("linear", torch::nn::Linear(dim, dim * 2));
+    norm_ = register_module(
+        "norm",
+        torch::nn::LayerNorm(
+            torch::nn::LayerNormOptions({dim}).elementwise_affine(false).eps(
+                eps)));
+  }
+
+  torch::Tensor forward(const torch::Tensor& x, const torch::Tensor& emb) {
+    torch::Tensor e = linear_->forward(torch::silu(emb));
+    std::vector<torch::Tensor> chunks = e.chunk(2, -1);
+    torch::Tensor scale = chunks[0], shift = chunks[1];
+    torch::Tensor h = norm_->forward(x.to(torch::kFloat32)).to(x.dtype());
+    if (scale.dim() == 2) {
+      h = h * (1.0f + scale.unsqueeze(1)) + shift.unsqueeze(1);
+    } else {
+      h = h * (1.0f + scale) + shift;
+    }
+    return h;
+  }
+
+ private:
+  torch::nn::Linear linear_{nullptr};
+  torch::nn::LayerNorm norm_{nullptr};
+};
+TORCH_MODULE(AudioAdaLayerNormZeroFinal);
+
+// LayerNorm + modulate helper: normalize then apply (scale, shift)
+inline torch::Tensor audio_modulate(const torch::Tensor& x,
+                                    const torch::Tensor& scale,
+                                    const torch::Tensor& shift,
+                                    float eps = 1e-6f) {
+  torch::Tensor h = torch::layer_norm(x.to(torch::kFloat32),
+                                      {x.size(-1)},
+                                      /*weight=*/{},
+                                      /*bias=*/{},
+                                      eps)
+                        .to(x.dtype());
+  if (scale.dim() == 2) {
+    return h * (1.0f + scale.unsqueeze(1)) + shift.unsqueeze(1);
+  }
+  return h * (1.0f + scale) + shift;
+}
+
+// Self-attention with optional RoPE
+class AudioSelfAttentionImpl : public torch::nn::Module {
+ public:
+  AudioSelfAttentionImpl(int64_t dim,
+                         int64_t heads,
+                         int64_t dim_head,
+                         bool use_qk_norm = false,
+                         float eps = 1e-6f)
+      : heads_(heads), inner_dim_(dim_head * heads) {
+    to_q_ = register_module("to_q", torch::nn::Linear(dim, inner_dim_));
+    to_k_ = register_module("to_k", torch::nn::Linear(dim, inner_dim_));
+    to_v_ = register_module("to_v", torch::nn::Linear(dim, inner_dim_));
+    if (use_qk_norm) {
+      q_norm_ = register_module("q_norm", AudioRMSNorm(inner_dim_, eps));
+      k_norm_ = register_module("k_norm", AudioRMSNorm(inner_dim_, eps));
+      use_qk_norm_ = true;
+    }
+    // Python: to_out is a ModuleList [Linear, Dropout]; we only need to_out.0
+    out_proj_ = register_module("to_out_0", torch::nn::Linear(inner_dim_, dim));
+  }
+
+  torch::Tensor forward(const torch::Tensor& x,
+                        std::optional<torch::Tensor> mask = std::nullopt,
+                        std::optional<std::pair<torch::Tensor, torch::Tensor>>
+                            rope = std::nullopt) {
+    int64_t B = x.size(0);
+    int64_t S = x.size(1);
+    int64_t head_dim = inner_dim_ / heads_;
+
+    torch::Tensor q = to_q_->forward(x);
+    torch::Tensor k = to_k_->forward(x);
+    torch::Tensor v = to_v_->forward(x);
+
+    if (use_qk_norm_) {
+      q = q_norm_->forward(q);
+      k = k_norm_->forward(k);
+    }
+
+    // Reshape to (B, H, S, head_dim)
+    q = q.view({B, S, heads_, head_dim}).transpose(1, 2);
+    k = k.view({B, S, heads_, head_dim}).transpose(1, 2);
+    v = v.view({B, S, heads_, head_dim}).transpose(1, 2);
+
+    if (rope.has_value()) {
+      q = apply_rotary_emb(q, rope->first, rope->second);
+      k = apply_rotary_emb(k, rope->first, rope->second);
+    }
+
+    // Attention mask: convert bool (True=attend) to additive float mask.
+    // cuDNN/Flash backends require a float additive mask, not a bool mask.
+    std::optional<torch::Tensor> attn_mask;
+    if (mask.has_value()) {
+      // mask: (B, S) -> (B, 1, 1, S) -> broadcast to (B, H, S, S)
+      torch::Tensor bool_mask = mask->unsqueeze(1)
+                                    .unsqueeze(1)
+                                    .expand({B, heads_, S, S})
+                                    .contiguous();
+      attn_mask = torch::zeros_like(bool_mask, q.options())
+                      .masked_fill_(~bool_mask,
+                                    -std::numeric_limits<float>::infinity());
+    }
+
+    // Manual attention to avoid torch::scaled_dot_product_attention dispatch,
+    // which may select the cuDNN backend (unsupported for AudioDiT head_dim).
+    double scale = 1.0 / std::sqrt(static_cast<double>(head_dim));
+    torch::Tensor scores =
+        torch::matmul(q, k.transpose(-2, -1)) * scale;  // (B,H,S,S)
+    if (attn_mask.has_value()) {
+      scores = scores + attn_mask.value();
+    }
+    torch::Tensor weights =
+        torch::softmax(scores.to(torch::kFloat32), -1).to(q.dtype());
+    torch::Tensor out = torch::matmul(weights, v);  // (B,H,S,head_dim)
+
+    out =
+        out.transpose(1, 2).contiguous().view({B, S, inner_dim_}).to(q.dtype());
+    return out_proj_->forward(out);
+  }
+
+ private:
+  int64_t heads_, inner_dim_;
+  bool use_qk_norm_ = false;
+  torch::nn::Linear to_q_{nullptr}, to_k_{nullptr}, to_v_{nullptr};
+  torch::nn::Linear out_proj_{nullptr};
+  AudioRMSNorm q_norm_{nullptr}, k_norm_{nullptr};
+};
+TORCH_MODULE(AudioSelfAttention);
+
+// Cross-attention
+class AudioCrossAttentionImpl : public torch::nn::Module {
+ public:
+  AudioCrossAttentionImpl(int64_t q_dim,
+                          int64_t kv_dim,
+                          int64_t heads,
+                          int64_t dim_head,
+                          bool use_qk_norm = false,
+                          float eps = 1e-6f)
+      : heads_(heads), inner_dim_(dim_head * heads) {
+    to_q_ = register_module("to_q", torch::nn::Linear(q_dim, inner_dim_));
+    to_k_ = register_module("to_k", torch::nn::Linear(kv_dim, inner_dim_));
+    to_v_ = register_module("to_v", torch::nn::Linear(kv_dim, inner_dim_));
+    if (use_qk_norm) {
+      q_norm_ = register_module("q_norm", AudioRMSNorm(inner_dim_, eps));
+      k_norm_ = register_module("k_norm", AudioRMSNorm(inner_dim_, eps));
+      use_qk_norm_ = true;
+    }
+    // Python: to_out is a ModuleList [Linear, Dropout]; we only need to_out.0
+    out_proj_ =
+        register_module("to_out_0", torch::nn::Linear(inner_dim_, q_dim));
+  }
+
+  torch::Tensor forward(
+      const torch::Tensor& x,
+      const torch::Tensor& cond,
+      std::optional<torch::Tensor> mask = std::nullopt,
+      std::optional<torch::Tensor> cond_mask = std::nullopt,
+      std::optional<std::pair<torch::Tensor, torch::Tensor>> rope =
+          std::nullopt,
+      std::optional<std::pair<torch::Tensor, torch::Tensor>> cond_rope =
+          std::nullopt) {
+    int64_t B = x.size(0);
+    int64_t S = x.size(1);
+    int64_t Sc = cond.size(1);
+    int64_t head_dim = inner_dim_ / heads_;
+
+    torch::Tensor q = to_q_->forward(x);
+    torch::Tensor k = to_k_->forward(cond);
+    torch::Tensor v = to_v_->forward(cond);
+
+    if (use_qk_norm_) {
+      q = q_norm_->forward(q);
+      k = k_norm_->forward(k);
+    }
+
+    q = q.view({B, S, heads_, head_dim}).transpose(1, 2);
+    k = k.view({B, Sc, heads_, head_dim}).transpose(1, 2);
+    v = v.view({B, Sc, heads_, head_dim}).transpose(1, 2);
+
+    if (rope.has_value()) {
+      q = apply_rotary_emb(q, rope->first, rope->second);
+    }
+    if (cond_rope.has_value()) {
+      k = apply_rotary_emb(k, cond_rope->first, cond_rope->second);
+    }
+
+    // Build cross-attn mask from cond_mask: (B, H, S, Sc)
+    // cond_mask is True for valid (attend) tokens.
+    // Convert bool to additive float mask for cuDNN/Flash backend
+    // compatibility.
+    std::optional<torch::Tensor> attn_mask;
+    if (cond_mask.has_value()) {
+      // cond_mask: (B, Sc) -> (B, 1, 1, Sc) -> broadcast to (B, H, S, Sc)
+      torch::Tensor bool_mask = cond_mask->unsqueeze(1)
+                                    .unsqueeze(1)
+                                    .expand({B, heads_, S, Sc})
+                                    .contiguous();
+      attn_mask = torch::zeros_like(bool_mask, q.options())
+                      .masked_fill_(~bool_mask,
+                                    -std::numeric_limits<float>::infinity());
+    }
+
+    // Manual attention to avoid torch::scaled_dot_product_attention dispatch,
+    // which may select the cuDNN backend (unsupported for AudioDiT head_dim).
+    double scale = 1.0 / std::sqrt(static_cast<double>(head_dim));
+    torch::Tensor scores =
+        torch::matmul(q, k.transpose(-2, -1)) * scale;  // (B,H,S,Sc)
+    if (attn_mask.has_value()) {
+      scores = scores + attn_mask.value();
+    }
+    // nan_to_num(0): when all keys are masked (all-false cond_mask), every
+    // score is -inf and softmax produces NaN (0/0).  Replace NaN with 0 so the
+    // unconditional branch returns zeros from cross-attention instead of NaN.
+    torch::Tensor weights =
+        torch::nan_to_num(torch::softmax(scores.to(torch::kFloat32), -1), 0.0)
+            .to(q.dtype());
+    torch::Tensor out = torch::matmul(weights, v);  // (B,H,S,head_dim)
+
+    out =
+        out.transpose(1, 2).contiguous().view({B, S, inner_dim_}).to(q.dtype());
+    return out_proj_->forward(out);
+  }
+
+ private:
+  int64_t heads_, inner_dim_;
+  bool use_qk_norm_ = false;
+  torch::nn::Linear to_q_{nullptr}, to_k_{nullptr}, to_v_{nullptr};
+  torch::nn::Linear out_proj_{nullptr};
+  AudioRMSNorm q_norm_{nullptr}, k_norm_{nullptr};
+};
+TORCH_MODULE(AudioCrossAttention);
+
+// FeedForward: Linear -> GELU(tanh) -> Dropout -> Linear
+// Official Python: self.ff = nn.Sequential(Linear, GELU, Dropout, Linear)
+// Checkpoint keys: "ff.0.weight" (first Linear), "ff.3.weight" (second Linear).
+// load_module_from_state_dicts applies checkpoint_key_to_cpp_key to both sides
+// so "ff.0" -> "ff_0" and "ff.3" -> "ff_3" match correctly.
+class AudioFeedForwardImpl : public torch::nn::Module {
+ public:
+  explicit AudioFeedForwardImpl(int64_t dim,
+                                float mult = 4.0f,
+                                float dropout = 0.0f) {
+    int64_t inner = static_cast<int64_t>(dim * mult);
+    ff_ = register_module(
+        "ff",
+        torch::nn::Sequential(
+            torch::nn::Linear(dim, inner),
+            torch::nn::GELU(torch::nn::GELUOptions().approximate("tanh")),
+            torch::nn::Dropout(torch::nn::DropoutOptions(dropout)),
+            torch::nn::Linear(inner, dim)));
+  }
+
+  torch::Tensor forward(const torch::Tensor& x) { return ff_->forward(x); }
+
+ private:
+  torch::nn::Sequential ff_{nullptr};
+};
+TORCH_MODULE(AudioFeedForward);
+
+// ============================================================================
+// AudioDiT Transformer Block
+// ============================================================================
+
+struct AudioDiTBlockConfig {
+  int64_t dim = 1536;
+  int64_t heads = 24;
+  float ff_mult = 4.0f;
+  bool use_cross_attn = true;
+  bool use_cross_attn_norm = false;  // dit_cross_attn_norm=False by default
+  bool use_qk_norm = true;           // dit_qk_norm=True by default
+  // "global" uses a single global AdaLN MLP; "local" uses per-block MLP
+  std::string adaln_type = "global";
+  float eps = 1e-6f;
+};
+
+class AudioDiTBlockImpl : public torch::nn::Module {
+ public:
+  explicit AudioDiTBlockImpl(const AudioDiTBlockConfig& cfg)
+      : use_cross_attn_(cfg.use_cross_attn),
+        use_cross_attn_norm_(cfg.use_cross_attn_norm),
+        adaln_type_(cfg.adaln_type) {
+    int64_t dim = cfg.dim;
+    int64_t heads = cfg.heads;
+    int64_t dim_head = dim / heads;
+
+    // AdaLN gating params
+    if (cfg.adaln_type == "local") {
+      adaln_mlp_ = register_module("adaln_mlp", AudioAdaLNMLP(dim, dim * 6));
+    } else {
+      // Global: per-block learnable scale_shift offset
+      adaln_scale_shift_ = register_parameter(
+          "adaln_scale_shift",
+          torch::randn({dim * 6}) / std::sqrt(static_cast<float>(dim)));
+    }
+
+    self_attn_ = register_module(
+        "self_attn",
+        AudioSelfAttention(dim, heads, dim_head, cfg.use_qk_norm, cfg.eps));
+
+    if (cfg.use_cross_attn) {
+      cross_attn_ = register_module(
+          "cross_attn",
+          AudioCrossAttention(
+              dim, dim, heads, dim_head, cfg.use_qk_norm, cfg.eps));
+      if (cfg.use_cross_attn_norm) {
+        cross_attn_norm_x_ = register_module(
+            "cross_attn_norm",
+            torch::nn::LayerNorm(
+                torch::nn::LayerNormOptions({dim}).elementwise_affine(true).eps(
+                    cfg.eps)));
+        cross_attn_norm_cond_ = register_module(
+            "cross_attn_norm_c",
+            torch::nn::LayerNorm(
+                torch::nn::LayerNormOptions({dim}).elementwise_affine(true).eps(
+                    cfg.eps)));
+      }
+    }
+
+    ffn_ = register_module("ffn", AudioFeedForward(dim, cfg.ff_mult));
+  }
+
+  // forward: returns updated x
+  // adaln_global_out: pre-computed global AdaLN output if adaln_type=="global"
+  torch::Tensor forward(
+      const torch::Tensor& x,
+      const torch::Tensor& t,
+      const torch::Tensor& cond,
+      std::optional<torch::Tensor> mask = std::nullopt,
+      std::optional<torch::Tensor> cond_mask = std::nullopt,
+      std::optional<std::pair<torch::Tensor, torch::Tensor>> rope =
+          std::nullopt,
+      std::optional<std::pair<torch::Tensor, torch::Tensor>> cond_rope =
+          std::nullopt,
+      std::optional<torch::Tensor> adaln_global_out = std::nullopt) {
+    torch::Tensor adaln_out;
+    if (adaln_type_ == "local") {
+      adaln_out = adaln_mlp_->forward(t);
+    } else {
+      // global: add per-block learnable offset to pre-computed global out
+      adaln_out = adaln_global_out.value() +
+                  adaln_scale_shift_.unsqueeze(0);  // (1, dim*6) broadcast
+    }
+
+    // Split into 6 chunks: gate_sa, scale_sa, shift_sa, gate_ffn, scale_ffn,
+    // shift_ffn
+    std::vector<torch::Tensor> chunks = adaln_out.chunk(6, -1);
+    torch::Tensor gate_sa = chunks[0];
+    torch::Tensor scale_sa = chunks[1];
+    torch::Tensor shift_sa = chunks[2];
+    torch::Tensor gate_ffn = chunks[3];
+    torch::Tensor scale_ffn = chunks[4];
+    torch::Tensor shift_ffn = chunks[5];
+
+    torch::Tensor h = x;
+
+    // Self-attention with AdaLN modulation
+    torch::Tensor norm_x = audio_modulate(h, scale_sa, shift_sa);
+    torch::Tensor sa_out = self_attn_->forward(norm_x, mask, rope);
+    // gate: (B, dim) -> unsqueeze to (B, 1, dim) to broadcast over seq
+    h = h + gate_sa.unsqueeze(1) * sa_out;
+
+    // Cross-attention (no gating — plain residual add)
+    torch::Tensor ca_out;
+    if (use_cross_attn_) {
+      torch::Tensor xn = h, cn = cond;
+      if (use_cross_attn_norm_) {
+        xn = cross_attn_norm_x_->forward(h);
+        cn = cross_attn_norm_cond_->forward(cond);
+      }
+      ca_out = cross_attn_->forward(xn, cn, mask, cond_mask, rope, cond_rope);
+      h = h + ca_out;
+    }
+
+    // FFN with AdaLN modulation
+    torch::Tensor norm_h = audio_modulate(h, scale_ffn, shift_ffn);
+    torch::Tensor ff_out = ffn_->forward(norm_h);
+    h = h + gate_ffn.unsqueeze(1) * ff_out;
+
+    return h;
+  }
+
+ private:
+  bool use_cross_attn_, use_cross_attn_norm_;
+  std::string adaln_type_;
+  AudioAdaLNMLP adaln_mlp_{nullptr};
+  torch::Tensor adaln_scale_shift_;  // (dim*6,) parameter for global AdaLN
+  AudioSelfAttention self_attn_{nullptr};
+  AudioCrossAttention cross_attn_{nullptr};
+  torch::nn::LayerNorm cross_attn_norm_x_{nullptr};
+  torch::nn::LayerNorm cross_attn_norm_cond_{nullptr};
+  AudioFeedForward ffn_{nullptr};
+};
+TORCH_MODULE(AudioDiTBlock);
+
+// ============================================================================
+// AudioDiT Transformer (backbone)
+// ============================================================================
+
+struct AudioDiTTransformerConfig {
+  int64_t dim = 1536;
+  int64_t depth = 24;
+  int64_t heads = 24;
+  float ff_mult = 4.0f;
+  int64_t latent_dim = 64;
+  int64_t text_dim = 768;  // UMT5-base output dim
+  bool long_skip = true;
+  bool text_conv = true;  // 4 ConvNeXtV2 blocks on text
+  bool use_latent_condition = true;
+  std::string adaln_type = "global";
+  float eps = 1e-6f;
+  // Official Python: repa_dit_layer (default 8). After block (repa_layer-1),
+  // apply long_skip early: x = x + x_clone. Then apply again after all blocks.
+  int64_t repa_layer = 8;
+};
+
+class AudioDiTTransformerImpl final : public torch::nn::Module {
+ public:
+  explicit AudioDiTTransformerImpl(const AudioDiTTransformerConfig& cfg)
+      : dim_(cfg.dim),
+        depth_(cfg.depth),
+        long_skip_(cfg.long_skip),
+        text_conv_(cfg.text_conv),
+        use_latent_condition_(cfg.use_latent_condition),
+        adaln_type_(cfg.adaln_type),
+        repa_layer_(cfg.repa_layer) {
+    int64_t dim_head = cfg.dim / cfg.heads;
+
+    time_embed_ =
+        register_module("time_embed", AudioTimestepEmbedding(cfg.dim));
+    input_embed_ =
+        register_module("input_embed", AudioEmbedder(cfg.latent_dim, cfg.dim));
+    text_embed_ =
+        register_module("text_embed", AudioEmbedder(cfg.text_dim, cfg.dim));
+    rotary_embed_ = register_module(
+        "rotary_embed", AudioRotaryEmbedding(dim_head, 2048, 100000.0f));
+
+    // Transformer blocks
+    AudioDiTBlockConfig blk_cfg;
+    blk_cfg.dim = cfg.dim;
+    blk_cfg.heads = cfg.heads;
+    blk_cfg.ff_mult = cfg.ff_mult;
+    blk_cfg.use_cross_attn = true;
+    blk_cfg.use_cross_attn_norm = false;  // dit_cross_attn_norm=False
+    blk_cfg.use_qk_norm = true;           // dit_qk_norm=True
+    blk_cfg.adaln_type = cfg.adaln_type;
+    blk_cfg.eps = cfg.eps;
+    for (int64_t i = 0; i < cfg.depth; ++i) {
+      dit_blocks_.push_back(register_module("blocks_" + std::to_string(i),
+                                            AudioDiTBlock(blk_cfg)));
+    }
+
+    // Output
+    norm_out_ = register_module("norm_out",
+                                AudioAdaLayerNormZeroFinal(cfg.dim, cfg.eps));
+    proj_out_ =
+        register_module("proj_out", torch::nn::Linear(cfg.dim, cfg.latent_dim));
+
+    // Global AdaLN MLP
+    if (cfg.adaln_type == "global") {
+      adaln_global_mlp_ = register_module("adaln_global_mlp",
+                                          AudioAdaLNMLP(cfg.dim, cfg.dim * 6));
+    }
+
+    // Text ConvNeXtV2 stack
+    if (cfg.text_conv) {
+      for (int64_t i = 0; i < 4; ++i) {
+        text_conv_blocks_.push_back(
+            register_module("text_conv_layer_" + std::to_string(i),
+                            AudioConvNeXtV2Block(cfg.dim, cfg.dim * 2)));
+      }
+    }
+
+    // Latent conditioning
+    if (cfg.use_latent_condition) {
+      latent_embed_ = register_module("latent_embed",
+                                      AudioEmbedder(cfg.latent_dim, cfg.dim));
+      latent_cond_embedder_ = register_module(
+          "latent_cond_embedder", AudioEmbedder(cfg.dim * 2, cfg.dim));
+    }
+  }
+
+  // Forward pass
+  // x:    (B, S, latent_dim)   — noised latent
+  // text: (B, Sc, text_dim)    — text embeddings
+  // text_len: (B,)             — number of valid text tokens
+  // time: (B,) or scalar       — timestep in [0,1]
+  // mask: (B, S) bool          — valid latent frames
+  // cond_mask: (B, Sc) bool    — valid text tokens
+  // latent_cond: (B, S, latent_dim) — prompt conditioning
+  torch::Tensor forward(
+      const torch::Tensor& x_in,
+      const torch::Tensor& text_in,
+      const torch::Tensor& text_len,
+      const torch::Tensor& time,
+      std::optional<torch::Tensor> mask = std::nullopt,
+      std::optional<torch::Tensor> cond_mask = std::nullopt,
+      std::optional<torch::Tensor> latent_cond = std::nullopt) {
+    // Cast to model dtype (use proj_out_ weight as reference)
+    auto dtype = proj_out_->weight.scalar_type();
+    torch::Tensor x = x_in.to(dtype);
+    // text_in is already truncated to actual token length at the pipeline level
+    // (no padding zeros), matching official Python which never pads text.
+    torch::Tensor text = text_in.to(dtype);
+    torch::Tensor t_in = time.to(dtype);
+
+    int64_t B = x.size(0);
+    if (t_in.dim() == 0) {
+      t_in = t_in.repeat(B);
+    }
+
+    // Timestep embedding
+    torch::Tensor t = time_embed_->forward(t_in);  // (B, dim)
+
+    // Text embedding + optional ConvNeXtV2 processing
+    text = text_embed_->forward(text, cond_mask);
+    if (text_conv_) {
+      for (size_t ci = 0; ci < text_conv_blocks_.size(); ++ci) {
+        text = text_conv_blocks_[ci]->forward(text);
+      }
+      if (cond_mask.has_value()) {
+        text = text.masked_fill(cond_mask->logical_not().unsqueeze(-1), 0.0f);
+      }
+    }
+
+    // Input embedding + optional latent conditioning
+    x = input_embed_->forward(x, mask);
+    if (use_latent_condition_ && latent_cond.has_value()) {
+      torch::Tensor lc =
+          latent_embed_->forward(latent_cond.value().to(dtype), mask);
+      // Do NOT pass mask here: input_embed and latent_embed have already
+      // zeroed out padding positions; passing mask again would corrupt the
+      // valid positions after the concat+proj. (Matches official Python code.)
+      x = latent_cond_embedder_->forward(torch::cat({x, lc}, -1));
+    }
+
+    // Long skip clone
+    torch::Tensor x_clone;
+    if (long_skip_) {
+      x_clone = x.clone();
+    }
+
+    // Rotary embeddings
+    int64_t seq_len = x.size(1);
+    int64_t text_seq_len = text.size(1);
+    auto [cos_x, sin_x] = rotary_embed_->forward(x, seq_len);
+    auto [cos_t, sin_t] = rotary_embed_->forward(text, text_seq_len);
+    auto rope = std::make_optional(std::make_pair(cos_x, sin_x));
+    auto cond_rope = std::make_optional(std::make_pair(cos_t, sin_t));
+
+    // Global AdaLN
+    std::optional<torch::Tensor> adaln_mlp_out;
+    torch::Tensor norm_cond;
+    if (adaln_type_ == "global") {
+      // Use text mean for conditioning.
+      // Compute in float32 to avoid fp16 underflow: 1e-9 < fp16 min (6e-5).
+      if (cond_mask.has_value()) {
+        torch::Tensor text_len_f =
+            text_len.unsqueeze(1).to(torch::kFloat32) + 1e-9f;
+        torch::Tensor text_mean =
+            (text.to(torch::kFloat32).sum(1) / text_len_f).to(text.dtype());
+        norm_cond = t + text_mean;
+      } else {
+        norm_cond = t;
+      }
+      adaln_mlp_out = adaln_global_mlp_->forward(norm_cond);
+    }
+
+    // Run blocks
+    for (int64_t i = 0; i < depth_; ++i) {
+      x = dit_blocks_[i]->forward(
+          x, t, text, mask, cond_mask, rope, cond_rope, adaln_mlp_out);
+      // Official Python: after block (repa_layer-1), apply long_skip early.
+      // repa_dit_layer=8 → after block index 7, x = x + x_clone.
+      // The long_skip is then applied again after all blocks (total 2
+      // additions).
+      if (long_skip_ && repa_layer_ > 0 && i == repa_layer_ - 1) {
+        x = x + x_clone;
+      }
+    }
+
+    // Long skip connection (second application, after all blocks)
+    if (long_skip_) {
+      x = x + x_clone;
+    }
+
+    // Output normalization and projection
+    torch::Tensor cond_for_out =
+        (adaln_type_ == "global" && norm_cond.defined()) ? norm_cond : t;
+    x = norm_out_->forward(x, cond_for_out);
+    x = proj_out_->forward(x);  // (B, S, latent_dim)
+    return x;
+  }
+
+ private:
+  int64_t dim_, depth_, repa_layer_;
+  bool long_skip_, text_conv_, use_latent_condition_;
+  std::string adaln_type_;
+
+  AudioTimestepEmbedding time_embed_{nullptr};
+  AudioEmbedder input_embed_{nullptr};
+  AudioEmbedder text_embed_{nullptr};
+  AudioRotaryEmbedding rotary_embed_{nullptr};
+  std::vector<AudioDiTBlock> dit_blocks_;
+  AudioAdaLayerNormZeroFinal norm_out_{nullptr};
+  torch::nn::Linear proj_out_{nullptr};
+  AudioAdaLNMLP adaln_global_mlp_{nullptr};
+  std::vector<AudioConvNeXtV2Block> text_conv_blocks_;
+  AudioEmbedder latent_embed_{nullptr};
+  AudioEmbedder latent_cond_embedder_{nullptr};
+};
+TORCH_MODULE(AudioDiTTransformer);
+
+// ============================================================================
+// APG (Adaptive Projected Guidance) helpers
+// ============================================================================
+
+struct MomentumBuffer {
+  float momentum = -0.3f;
+  torch::Tensor running_average;
+};
+
+inline void momentum_buffer_update(MomentumBuffer& buf,
+                                   const torch::Tensor& update_value) {
+  if (!buf.running_average.defined()) {
+    buf.running_average = update_value.clone();
+  } else {
+    buf.running_average = update_value + buf.momentum * buf.running_average;
+  }
+}
+
+// Project v0 onto the direction of v1 (and orthogonal complement)
+inline std::pair<torch::Tensor, torch::Tensor> apg_project(
+    const torch::Tensor& v0,
+    const torch::Tensor& v1) {
+  // Work in double precision for numerical stability
+  torch::Tensor v0d = v0.to(torch::kDouble);
+  torch::Tensor v1d = v1.to(torch::kDouble);
+  // Normalize v1 over last two dims
+  torch::Tensor v1_norm =
+      v1d.norm(2, {-1, -2}, /*keepdim=*/true).clamp_min(1e-12);
+  torch::Tensor v1n = v1d / v1_norm;
+  torch::Tensor v0_parallel = (v0d * v1n).sum({-1, -2}, /*keepdim=*/true) * v1n;
+  torch::Tensor v0_orthogonal = v0d - v0_parallel;
+  return {v0_parallel.to(v0.dtype()), v0_orthogonal.to(v0.dtype())};
+}
+
+// APG guidance: combine cond/uncond predictions with momentum + projection
+inline torch::Tensor apg_forward(const torch::Tensor& pred_cond,
+                                 const torch::Tensor& pred_uncond,
+                                 float guidance_scale,
+                                 MomentumBuffer* buffer,
+                                 float eta = 0.5f,
+                                 float norm_threshold = 0.0f) {
+  torch::Tensor diff = pred_cond - pred_uncond;
+  if (buffer != nullptr) {
+    momentum_buffer_update(*buffer, diff);
+    diff = buffer->running_average;
+  }
+  if (norm_threshold > 0.0f) {
+    torch::Tensor ones = torch::ones_like(diff);
+    torch::Tensor diff_norm = diff.norm(2, {-1, -2}, /*keepdim=*/true);
+    torch::Tensor scale_factor = torch::minimum(
+        ones, torch::tensor(norm_threshold).to(diff.device()) / diff_norm);
+    diff = diff * scale_factor;
+  }
+  auto [diff_parallel, diff_orthogonal] = apg_project(diff, pred_cond);
+  torch::Tensor normalized_update = diff_orthogonal + eta * diff_parallel;
+  return pred_cond + guidance_scale * normalized_update;
+}
+
+// ============================================================================
+// UMT5 Text Encoder wrapper
+// ============================================================================
+
+// Wraps UMT5EncoderModel with UMT5-specific post-processing matching the
+// official Python AudioDiTModel.encode_text():
+//   emb = F.layer_norm(last_hidden_state, (d_model,), eps=1e-6)
+//   first_hidden = F.layer_norm(embed_tokens(input_ids), (d_model,), eps=1e-6)
+//   return (emb + first_hidden).float()
+class UMT5TextEncoderImpl : public torch::nn::Module {
+ public:
+  explicit UMT5TextEncoderImpl(const ModelContext& context)
+      : context_(context) {
+    umt5_ = register_module("umt5", UMT5EncoderModel(context));
+    d_model_ = context.get_model_args().d_model();
+  }
+
+  // Encode text tokens to embeddings.
+  // input_ids: (B, S) int64
+  // Returns: (B, S, d_model) float32
+  torch::Tensor forward(const torch::Tensor& input_ids) {
+    // UMT5EncoderModel applies final_layer_norm internally.
+    // Apply F.layer_norm (no learnable params) to match official Python.
+    torch::Tensor umt5_out = umt5_->forward(input_ids).to(torch::kFloat32);
+    torch::Tensor last_hidden =
+        torch::layer_norm(umt5_out, {d_model_}, {}, {}, 1e-6f);
+
+    torch::Tensor embed_out =
+        umt5_->get_input_embeddings()->forward(input_ids).to(torch::kFloat32);
+    torch::Tensor first_hidden =
+        torch::layer_norm(embed_out, {d_model_}, {}, {}, 1e-6f);
+
+    return last_hidden + first_hidden;
+  }
+
+  void load_model(std::unique_ptr<DiTFolderLoader> loader) {
+    umt5_->load_model(std::move(loader));
+  }
+
+  void load_model_from_state_dicts(
+      std::vector<std::unique_ptr<StateDict>>& state_dicts,
+      const std::string& key_prefix = "text_encoder.") {
+    umt5_->load_from_state_dicts(state_dicts, key_prefix);
+  }
+
+ private:
+  ModelContext context_;
+  UMT5EncoderModel umt5_{nullptr};
+  int64_t d_model_ = 768;
+};
+TORCH_MODULE(UMT5TextEncoder);
+
+// ============================================================================
+// Weight loading helper
+// ============================================================================
+
+// Load all weights from a DiTFolderLoader into a torch::nn::Module by matching
+// named parameters/buffers. This is a bulk copy approach that works for any
+// standard torch::nn module hierarchy without requiring hand-written
+// load_state_dict methods.
+//
+// Weight names in the checkpoint are expected to match the C++ module's
+// named_parameters() keys exactly (as produced by TORCH_MODULE registration).
+// Load weights from state dicts into a module.
+// If key_prefix is non-empty, only keys starting with that prefix are loaded,
+// with the prefix stripped before matching against the module's parameters.
+// This supports both per-component loaders (prefix="") and flat loaders where
+// all components share one safetensors file (prefix="transformer.", "vae.",
+// etc.) Translate a checkpoint key to the C++ module key. libtorch
+// register_module forbids dots in names, so we register with underscores (e.g.
+// "layers_0", "blocks_3", "to_out_0") while checkpoints use dots (e.g.
+// "layers.0", "blocks.3", "to_out.0"). This function replaces ".<digit>" with
+// "_<digit>" throughout the key.
+inline std::string checkpoint_key_to_cpp_key(const std::string& key) {
+  std::string result;
+  result.reserve(key.size());
+  for (size_t i = 0; i < key.size(); ++i) {
+    if (key[i] == '.' && i + 1 < key.size() && std::isdigit(key[i + 1])) {
+      result += '_';
+    } else {
+      result += key[i];
+    }
+  }
+  return result;
+}
+
+inline void load_module_from_state_dicts(DiTFolderLoader& folder_loader,
+                                         torch::nn::Module* module,
+                                         const std::string& key_prefix = "") {
+  // Keep named_parameters/named_buffers alive while we hold pointers into them.
+  auto params = module->named_parameters(/*recurse=*/true);
+  auto buffers = module->named_buffers(/*recurse=*/true);
+
+  // Build param_map keyed by checkpoint_key_to_cpp_key(named_param_key) so that
+  // lookup against the converted checkpoint key always succeeds.
+  // Background: torch::nn::Sequential names children "0","1","2",... so
+  // named_parameters() returns e.g. "mlp.1.weight".
+  // checkpoint_key_to_cpp_key converts ".1" -> "_1", giving "mlp_1.weight".
+  // If we store by raw key "mlp.1.weight" the lookup for "mlp_1.weight" fails.
+  // Solution: store by the converted key so both sides use the same format.
+  std::unordered_map<std::string, torch::Tensor*> param_map;
+  for (auto& kv : params) {
+    std::string mapped = checkpoint_key_to_cpp_key(kv.key());
+    param_map[mapped] = &kv.value();
+  }
+  for (auto& kv : buffers) {
+    param_map[checkpoint_key_to_cpp_key(kv.key())] = &kv.value();
+  }
+
+  // First pass: collect weight_g / weight_v pairs for weight_norm
+  // reconstruction. PyTorch weight_norm stores a Conv's weight as two params:
+  // weight_g (magnitude) and weight_v (direction). The effective weight = g * v
+  // / ||v||. checkpoint key pattern: "some.module.weight_g" /
+  // "some.module.weight_v" C++ param key pattern:  "some.module.weight"
+  auto strip_prefix_fn = [&](const std::string& raw) -> std::string {
+    if (key_prefix.empty()) return raw;
+    if (raw.substr(0, key_prefix.size()) != key_prefix) return "";
+    return raw.substr(key_prefix.size());
+  };
+
+  // key = stripped key (still dot-separated, no digit->underscore yet)
+  std::unordered_map<std::string, torch::Tensor> wn_g, wn_v;
+  static const std::string kSuffixG = ".weight_g";
+  static const std::string kSuffixV = ".weight_v";
+  for (const auto& state_dict_ptr : folder_loader.get_state_dicts()) {
+    for (const auto& kv : *state_dict_ptr) {
+      std::string key = strip_prefix_fn(kv.first);
+      if (key.empty()) continue;
+      if (key.size() > kSuffixG.size() &&
+          key.substr(key.size() - kSuffixG.size()) == kSuffixG) {
+        wn_g[key.substr(0, key.size() - kSuffixG.size())] = kv.second;
+      } else if (key.size() > kSuffixV.size() &&
+                 key.substr(key.size() - kSuffixV.size()) == kSuffixV) {
+        wn_v[key.substr(0, key.size() - kSuffixV.size())] = kv.second;
+      }
+    }
+  }
+
+  int64_t loaded = 0;
+  for (const auto& state_dict_ptr : folder_loader.get_state_dicts()) {
+    for (const auto& kv : *state_dict_ptr) {
+      const std::string& raw_key = kv.first;
+      const torch::Tensor& src_tensor = kv.second;
+
+      // Strip prefix if specified
+      std::string key = raw_key;
+      if (!key_prefix.empty()) {
+        if (raw_key.substr(0, key_prefix.size()) != key_prefix) {
+          continue;
+        }
+        key = raw_key.substr(key_prefix.size());
+      }
+
+      // Skip weight_norm components; they are reconstructed separately below.
+      if ((key.size() > kSuffixG.size() &&
+           key.substr(key.size() - kSuffixG.size()) == kSuffixG) ||
+          (key.size() > kSuffixV.size() &&
+           key.substr(key.size() - kSuffixV.size()) == kSuffixV)) {
+        continue;
+      }
+
+      // Translate checkpoint key (dots before digits) to C++ key (underscores)
+      std::string cpp_key = checkpoint_key_to_cpp_key(key);
+
+      auto it = param_map.find(cpp_key);
+      if (it == param_map.end()) {
+        if (key_prefix.empty()) {
+          LOG(WARNING) << "[AudioDiT load] Unknown key in checkpoint: " << key;
+        }
+        continue;
+      }
+      torch::Tensor& dst = *(it->second);
+      if (!dst.defined()) {
+        LOG(WARNING) << "[AudioDiT load] Skipping key with undefined dst: "
+                     << key;
+        continue;
+      }
+      torch::NoGradGuard no_grad;
+      dst.copy_(src_tensor.to(dst.dtype()).to(dst.device()));
+      ++loaded;
+    }
+  }
+
+  // Second pass: reconstruct weight_norm weights.
+  // effective_weight = weight_g * weight_v / ||weight_v||_per_output_channel
+  for (const auto& gkv : wn_g) {
+    const std::string& base = gkv.first;  // e.g. "encoder.in_conv"
+    auto vit = wn_v.find(base);
+    if (vit == wn_v.end()) continue;
+
+    // The plain weight key in C++ is base + ".weight" (with digit->_
+    // translation)
+    std::string weight_cpp_key = checkpoint_key_to_cpp_key(base + ".weight");
+    auto it = param_map.find(weight_cpp_key);
+    if (it == param_map.end()) {
+      LOG(WARNING) << "[AudioDiT load] weight_norm base not found in module: "
+                   << weight_cpp_key;
+      continue;
+    }
+
+    torch::Tensor g = gkv.second.to(torch::kFloat32);
+    torch::Tensor v = vit->second.to(torch::kFloat32);
+    // Norm over all dims except output channel (dim 0): reshape to (C_out, -1)
+    int64_t c_out = v.size(0);
+    torch::Tensor v_norm = v.view({c_out, -1}).norm(2, 1, /*keepdim=*/true);
+    // Reshape v_norm back to (C_out, 1, 1, ...) for broadcasting
+    std::vector<int64_t> norm_shape(v.dim(), 1);
+    norm_shape[0] = c_out;
+    v_norm = v_norm.view(norm_shape);
+    torch::Tensor w = g * v / (v_norm + 1e-12f);
+
+    torch::Tensor& dst = *(it->second);
+    torch::NoGradGuard no_grad;
+    dst.copy_(w.to(dst.dtype()).to(dst.device()));
+    ++loaded;
+  }
+}
+
+}  // namespace xllm

--- a/xllm/models/dit/umt5_encoder.h
+++ b/xllm/models/dit/umt5_encoder.h
@@ -1,0 +1,265 @@
+/* Copyright 2026 The xLLM Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://github.com/jd-opensource/xllm/blob/main/LICENSE
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+// UMT5 encoder model compatible with HuggingFace weights.
+// ref:
+// https://github.com/huggingface/transformers/tree/main/src/transformers/models/umt5
+//
+// Key differences from T5:
+//   - Every block has its own relative_attention_bias (not just block 0).
+//   - position_bias is NOT carried across blocks; each block recomputes it.
+//   - UMT5Attention.forward does not accept or return position_bias.
+//   - Weight key for embed_tokens is "encoder.embed_tokens.weight" (tied to
+//     "shared.weight" in the full model).
+
+#pragma once
+#include <torch/torch.h>
+
+#include <memory>
+#include <string>
+#include <vector>
+
+#include "core/framework/dit_model_loader.h"
+#include "core/framework/model/model_input_params.h"
+#include "core/framework/state_dict/state_dict.h"
+#include "core/framework/state_dict/utils.h"
+#include "framework/model_context.h"
+#include "models/model_registry.h"
+#include "t5_encoder.h"  // reuse T5LayerNorm, T5DenseInterface, T5LayerFFN
+
+namespace xllm {
+
+// ---------------------------------------------------------------------------
+// UMT5LayerSelfAttention
+// ---------------------------------------------------------------------------
+// Unlike T5LayerSelfAttention:
+//   - has_relative_attention_bias is always true (every block owns a bias).
+//   - forward() does not accept a position_bias argument.
+//   - forward() does not return position_bias in its outputs.
+// ---------------------------------------------------------------------------
+class UMT5LayerSelfAttentionImpl : public torch::nn::Module {
+ public:
+  explicit UMT5LayerSelfAttentionImpl(const ModelContext& context) {
+    // UMT5: every self-attention layer has its own relative_attention_bias.
+    self_attention_ = register_module(
+        "SelfAttention",
+        T5Attention(context, /*has_relative_attention_bias=*/true));
+    layer_norm_ = register_module("layer_norm", T5LayerNorm(context));
+  }
+
+  // Returns {hidden_states} — no position_bias in output, matching UMT5.
+  torch::Tensor forward(
+      const torch::Tensor& hidden_states,
+      const std::optional<torch::Tensor>& attention_mask = std::nullopt) {
+    torch::Tensor normed = layer_norm_->forward(hidden_states);
+    // Pass empty position_bias so T5Attention recomputes it from its own bias.
+    auto attn_outputs = self_attention_->forward(
+        normed, attention_mask, /*position_bias=*/std::nullopt);
+    // attn_outputs[0] = attn_output, attn_outputs[1] = position_bias (unused)
+    return hidden_states + attn_outputs[0];
+  }
+
+  void load_state_dict(const StateDict& state_dict) {
+    self_attention_->load_state_dict(
+        state_dict.get_dict_with_prefix("SelfAttention."));
+    layer_norm_->load_state_dict(
+        state_dict.get_dict_with_prefix("layer_norm."));
+  }
+
+  void verify_loaded_weights(const std::string& prefix) const {
+    self_attention_->verify_loaded_weights(prefix + "SelfAttention.");
+    layer_norm_->verify_loaded_weights(prefix + "layer_norm.");
+  }
+
+ private:
+  T5Attention self_attention_{nullptr};
+  T5LayerNorm layer_norm_{nullptr};
+};
+TORCH_MODULE(UMT5LayerSelfAttention);
+
+// ---------------------------------------------------------------------------
+// UMT5Block
+// ---------------------------------------------------------------------------
+// Unlike T5Block:
+//   - forward() does not accept or return position_bias.
+//   - Internally calls UMT5LayerSelfAttention which handles bias independently.
+// ---------------------------------------------------------------------------
+class UMT5BlockImpl : public torch::nn::Module {
+ public:
+  explicit UMT5BlockImpl(const ModelContext& context) {
+    self_attention_ =
+        register_module("layer_0", UMT5LayerSelfAttention(context));
+    ff_layer_ = register_module("layer_1", T5LayerFFN(context));
+  }
+
+  // Returns {hidden_states} — no position_bias, matching UMT5Block.forward.
+  std::vector<torch::Tensor> forward(
+      const torch::Tensor& hidden_states,
+      const std::optional<torch::Tensor>& attention_mask = std::nullopt) {
+    torch::Tensor curr =
+        self_attention_->forward(hidden_states, attention_mask);
+    if (curr.dtype() == torch::kFloat16) {
+      curr = clamp_inf_values(curr);
+    }
+    curr = ff_layer_->forward(curr);
+    if (curr.dtype() == torch::kFloat16) {
+      curr = clamp_inf_values(curr);
+    }
+    return {curr};
+  }
+
+  void load_state_dict(const StateDict& state_dict) {
+    self_attention_->load_state_dict(
+        state_dict.get_dict_with_prefix("layer.0."));
+    ff_layer_->load_state_dict(state_dict.get_dict_with_prefix("layer.1."));
+  }
+
+  void verify_loaded_weights(const std::string& prefix) const {
+    self_attention_->verify_loaded_weights(prefix + "layer.0.");
+    ff_layer_->verify_loaded_weights(prefix + "layer.1.");
+  }
+
+ private:
+  torch::Tensor clamp_inf_values(const torch::Tensor& x) const {
+    const float max_val = 65504.0f;  // fp16 max
+    torch::Tensor clamp_val =
+        torch::where(torch::isinf(x).any(),
+                     torch::tensor(max_val - 1000.0f, x.options()),
+                     torch::tensor(max_val, x.options()));
+    return torch::clamp(x, -clamp_val, clamp_val);
+  }
+
+  UMT5LayerSelfAttention self_attention_{nullptr};
+  T5LayerFFN ff_layer_{nullptr};
+};
+TORCH_MODULE(UMT5Block);
+
+// ---------------------------------------------------------------------------
+// UMT5EncoderModel
+// ---------------------------------------------------------------------------
+// Matches HuggingFace UMT5Stack (encoder only):
+//   - All blocks have their own relative_attention_bias.
+//   - position_bias is never passed between blocks.
+//   - embed_tokens weight key: "encoder.embed_tokens.weight".
+// ---------------------------------------------------------------------------
+class UMT5EncoderModelImpl final : public torch::nn::Module {
+ public:
+  explicit UMT5EncoderModelImpl(const ModelContext& context) {
+    auto model_args = context.get_model_args();
+    auto options = context.get_tensor_options();
+
+    embed_tokens_ = register_module(
+        "embed_tokens",
+        torch::nn::Embedding(model_args.vocab_size(), model_args.d_model()));
+    embed_tokens_->weight.set_data(embed_tokens_->weight.to(options));
+
+    blocks_ = register_module("blocks", torch::nn::ModuleList{});
+    layers_.reserve(model_args.num_layers());
+    for (int64_t i = 0; i < model_args.num_layers(); ++i) {
+      auto block = UMT5Block(context);
+      blocks_->push_back(block);
+      layers_.push_back(block);
+    }
+
+    final_layer_norm_ =
+        register_module("final_layer_norm", T5LayerNorm(context));
+  }
+
+  torch::nn::Embedding& get_input_embeddings() { return embed_tokens_; }
+
+  void set_input_embeddings(const torch::nn::Embedding& new_embeddings) {
+    embed_tokens_ = new_embeddings;
+  }
+
+  torch::Tensor forward(const torch::Tensor& input_ids) {
+    torch::Tensor hidden_states = embed_tokens_->forward(input_ids);
+    // UMT5: no position_bias passed between blocks — each block recomputes it.
+    for (size_t i = 0; i < layers_.size(); ++i) {
+      auto layer_outputs = layers_[i]->forward(hidden_states);
+      hidden_states = layer_outputs[0];
+    }
+    hidden_states = final_layer_norm_->forward(hidden_states);
+    return hidden_states;
+  }
+
+  void load_model(std::unique_ptr<DiTFolderLoader> loader) {
+    load_from_state_dicts(loader->get_state_dicts(), "");
+  }
+
+  // Load from state dicts with an optional key_prefix (e.g. "text_encoder."
+  // when all components share a single flat safetensors file).
+  void load_from_state_dicts(
+      std::vector<std::unique_ptr<StateDict>>& state_dicts,
+      const std::string& key_prefix) {
+    for (const auto& state_dict : state_dicts) {
+      StateDict sd = key_prefix.empty()
+                         ? state_dict->get_dict_with_prefix("")
+                         : state_dict->get_dict_with_prefix(key_prefix);
+      weight::load_weight(sd,
+                          "encoder.embed_tokens.weight",
+                          embed_tokens_->weight,
+                          is_embed_tokens_loaded_);
+      final_layer_norm_->load_state_dict(
+          sd.get_dict_with_prefix("encoder.final_layer_norm."));
+      for (int64_t i = 0; i < static_cast<int64_t>(layers_.size()); ++i) {
+        const std::string block_prefix =
+            "encoder.block." + std::to_string(i) + ".";
+        layers_[i]->load_state_dict(sd.get_dict_with_prefix(block_prefix));
+      }
+    }
+    verify_loaded_weights();
+    LOG(INFO) << "UMT5EncoderModel loaded successfully.";
+  }
+
+  void verify_loaded_weights() const {
+    CHECK(is_embed_tokens_loaded_)
+        << "weight is not loaded for encoder.embed_tokens.weight";
+    final_layer_norm_->verify_loaded_weights("encoder.final_layer_norm.");
+    for (int64_t i = 0; i < static_cast<int64_t>(layers_.size()); ++i) {
+      const std::string block_prefix =
+          "encoder.block." + std::to_string(i) + ".";
+      layers_[i]->verify_loaded_weights(block_prefix);
+    }
+  }
+
+ private:
+  T5LayerNorm final_layer_norm_{nullptr};
+  torch::nn::Embedding embed_tokens_{nullptr};
+  bool is_embed_tokens_loaded_ = false;
+  std::vector<UMT5Block> layers_;
+  torch::nn::ModuleList blocks_{nullptr};
+};
+TORCH_MODULE(UMT5EncoderModel);
+
+// Model args for UMT5-base (google/umt5-base defaults).
+REGISTER_MODEL_ARGS(UMT5EncoderModel, [&] {
+  LOAD_ARG_OR(dtype, "torch_dtype", "float32");
+  LOAD_ARG_OR(model_type, "model_type", "umt5");
+  LOAD_ARG_OR(vocab_size, "vocab_size", 256384);
+  LOAD_ARG_OR(d_model, "d_model", 768);
+  LOAD_ARG_OR(num_layers, "num_layers", 12);
+  LOAD_ARG_OR(d_kv, "d_kv", 64);
+  LOAD_ARG_OR(n_heads, "num_heads", 12);
+  LOAD_ARG_OR(d_ff, "d_ff", 2048);
+  LOAD_ARG_OR(act_fn, "dense_act_fn", "gelu_new");
+  LOAD_ARG_OR(is_gated_act, "is_gated_act", true);
+  LOAD_ARG_OR(
+      relative_attention_num_buckets, "relative_attention_num_buckets", 32);
+  LOAD_ARG_OR(
+      relative_attention_max_distance, "relative_attention_max_distance", 128);
+  LOAD_ARG_OR(layer_norm_eps, "layer_norm_epsilon", 1e-6f);
+});
+
+}  // namespace xllm

--- a/xllm/models/models.h
+++ b/xllm/models/models.h
@@ -85,6 +85,7 @@ limitations under the License.
 #include "llm/qwen3.h"      // IWYU pragma: keep
 #include "llm/qwen3_moe.h"  // IWYU pragma: keep
 #elif defined(USE_CUDA)
+#include "dit/pipeline_longcat_audiodit.h"    // IWYU pragma: keep
 #include "dit/pipeline_longcat_image.h"       // IWYU pragma: keep
 #include "dit/pipeline_longcat_image_edit.h"  // IWYU pragma: keep
 #include "llm/qwen2.h"                        // IWYU pragma: keep

--- a/xllm/proto/CMakeLists.txt
+++ b/xllm/proto/CMakeLists.txt
@@ -19,6 +19,7 @@ proto_library(
     xllm_service.proto
     xservice.proto
     image_generation.proto
+    audio_generation.proto
     mooncake_transfer_engine.proto
     embedding_data.proto
     anthropic.proto

--- a/xllm/proto/audio_generation.proto
+++ b/xllm/proto/audio_generation.proto
@@ -1,0 +1,109 @@
+/* Copyright 2026 The xLLM Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://github.com/jd-opensource/xllm/blob/main/LICENSE
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+syntax = "proto3";
+
+option go_package = "jd.com/jd-infer/xllm;xllm";
+package xllm.proto;
+
+// Input parameters for audio generation (LongCat-AudioDiT)
+message AudioInput {
+  // Text to synthesize (TTS) or text of the target speech (voice cloning).
+  // For voice cloning: full_text = prompt_text + " " + text.
+  string prompt = 1;
+
+  // Prompt audio for voice cloning: base64-encoded PCM WAV, mono 24 kHz.
+  // When set the model clones the speaker's voice from this reference clip.
+  optional string prompt_audio = 2;
+
+  // Transcript of the prompt audio (for voice cloning duration estimation).
+  // The full tokenized text is prompt_text + " " + prompt (passed in `prompt`).
+  optional string prompt_text = 3;
+}
+
+// Generation parameters for audio generation
+message AudioParameters {
+  // Random seed value for audio generation
+  optional int64 seed = 1;
+
+  // Maximum sequence length for text processing
+  optional int32 max_sequence_length = 2;
+
+  // Guidance scale value for prompt adherence (CFG/APG strength)
+  optional float guidance_scale = 3;
+
+  // Target total duration in latent frames (prompt + generation). 0 = auto.
+  optional int32 audio_duration_frames = 4;
+
+  // Number of ODE Euler steps for audio generation (default 16).
+  optional int32 audio_steps = 5;
+
+  // Guidance method: "cfg" (default) or "apg".
+  optional string audio_guidance_method = 6;
+
+  // Sample rate of the model in Hz, read from model config.json.
+  // Clients should not set this field manually; it is populated from the model
+  // config (config.json "sampling_rate") and defaults to 24000.
+  optional int32 sampling_rate = 7;
+}
+
+// Request structure for audio generation tasks (LongCat-AudioDiT)
+message AudioGenerationRequest {
+  // ID of the audio generation model (e.g. "LongCat-AudioDiT-1B")
+  string model = 1;
+
+  AudioInput input = 2;
+
+  AudioParameters parameters = 3;
+
+  // Unique identifier representing the end-user
+  optional string user = 4;
+
+  // ID used by server to identify the request for tracking and troubleshooting
+  optional string request_id = 5;
+}
+
+// Individual audio generation result
+message AudioGenData {
+  // Base64-encoded PCM WAV audio output
+  optional string audio = 1;
+
+  // Seed used for generating this audio clip
+  int64 seed = 2;
+}
+
+// Output container for audio generation task results
+message AudioGenerationOutput {
+  // List of generated audio data
+  repeated AudioGenData results = 1;
+}
+
+// Response structure for audio generation requests
+message AudioGenerationResponse {
+  // The ID of the response
+  string id = 1;
+
+  // The object type
+  string object = 2;
+
+  // Unix timestamp of when the response was created
+  int64 created = 3;
+
+  // The model used to generate the audio
+  string model = 4;
+
+  // Contains task details and generation results
+  AudioGenerationOutput output = 5;
+}

--- a/xllm/proto/worker.proto
+++ b/xllm/proto/worker.proto
@@ -223,6 +223,10 @@ message DiTForwardInput {
   
   // generation params
   DiTGenerationParams generation_params = 16;
+
+  // Voice cloning fields (LongCat-AudioDiT)
+  optional Tensor prompt_audio = 17;
+  optional string audio_prompt_text = 18;
 }
 
 message DiTForwardOutput {

--- a/xllm/proto/xllm_service.proto
+++ b/xllm/proto/xllm_service.proto
@@ -10,6 +10,7 @@ import "sample.proto";
 import "chat.proto";
 import "embedding.proto";
 import "image_generation.proto";
+import "audio_generation.proto";
 import "rerank.proto";
 import "models.proto";
 import "anthropic.proto";
@@ -64,6 +65,9 @@ service XllmAPIService {
 
   rpc ImageGeneration(ImageGenerationRequest) returns (ImageGenerationResponse);
   rpc ImageGenerationHttp(HttpRequest) returns (HttpResponse);
+
+  rpc AudioGeneration(AudioGenerationRequest) returns (AudioGenerationResponse);
+  rpc AudioGenerationHttp(HttpRequest) returns (HttpResponse);
 
   rpc Rerank (RerankRequest) returns (RerankResponse);
   rpc RerankHttp (HttpRequest) returns (HttpResponse);

--- a/xllm/server/xllm_server.cpp
+++ b/xllm/server/xllm_server.cpp
@@ -43,6 +43,7 @@ constexpr const char* kApiServiceRoutes =
     "v1/embeddings => EmbeddingsHttp,"
     "v1/models => ModelsHttp,"
     "v1/image/generation => ImageGenerationHttp,"
+    "v1/audio/generation => AudioGenerationHttp,"
     "v1/rerank => RerankHttp,"
     "v1/messages => AnthropicMessagesHttp,"
     "v2/repository/index => ModelVersionsHttp,"


### PR DESCRIPTION
This PR supports LongCat-AudioDit on cuda device.

The test program and the generated audios are as follows.
* OS: Ubuntu22.04
* device: NVIDIA A800-SXM4-40GB 
* model: [LongCat-AudioDit-1B](https://www.modelscope.cn/models/meituan-longcat/LongCat-AudioDiT-1B/summary)
```python
"""
LongCat-AudioDiT xLLM HTTP client
===================================

Usage:
    # TTS
    python run_longcat_audio.py \
        --text "Hello, how are you today?" \
        --output tts.wav

    # 指定参数
    python run_longcat_audio.py \
        --text "今天天气真好，阳光明媚。" \
        --steps 16 \
        --guidance-scale 4.0 \
        --seed 42 \
        --output output.wav

    # Voice cloning (需要服务端支持 prompt_audio 字段)
    python run_longcat_audio.py \
        --text "今天晴暖转阴雨，空气质量优至良，空气相对湿度较低。" \
        --prompt-text "小偷却一点也不气馁，继续在抽屉里翻找。" \
        --prompt-audio assets/prompt.wav \
        --guidance-method apg \
        --output output_vc.wav

    # 运行所有 demo
    python run_longcat_audio.py --demo
"""

import argparse
import base64
import json
import os
import sys
import time
import urllib.request

# ---------------------------------------------------------------------------
# HTTP helpers (stdlib only)
# ---------------------------------------------------------------------------


def _post(url: str, payload: dict, timeout: int = 300) -> dict:
    data = json.dumps(payload).encode()
    req = urllib.request.Request(
        url,
        data=data,
        headers={"Content-Type": "application/json"},
        method="POST",
    )
    try:
        with urllib.request.urlopen(req, timeout=timeout) as resp:
            return json.loads(resp.read())
    except urllib.error.HTTPError as e:
        body = e.read().decode(errors="replace")
        raise RuntimeError(f"HTTP {e.code}: {body}") from None


# ---------------------------------------------------------------------------
# Core generation function
# ---------------------------------------------------------------------------


def _load_wav_b64(path: str) -> str:
    """Read a WAV file and return its content as a base64 string."""
    with open(path, "rb") as f:
        return base64.b64encode(f.read()).decode()


def generate_audio(
    base_url: str,
    text: str,
    *,
    model: str = "LongCat-AudioDiT-1B",
    num_inference_steps: int = 16,
    guidance_scale: float = 4.0,
    seed: int = 1024,
    audio_duration_frames: int = 0,
    audio_guidance_method: str = "cfg",
    prompt_audio: str | None = None,
    prompt_text: str | None = None,
    output_file: str = "output.wav",
    timeout: int = 300,
) -> bytes:
    """
    Call the xLLM LongCat-AudioDiT server to generate audio via
    the v1/audio/generation endpoint (reused for DiT models).

    The server returns base64-encoded WAV bytes in
    response.output.results[0].audio.

    For voice cloning, pass prompt_audio (path to WAV file) and
    prompt_text (transcript of the prompt audio).  The server must
    support the prompt_audio field in the Input proto message.
    """
    # For voice cloning, prepend prompt_text to text (matching official Python)
    full_text = text
    if prompt_text is not None:
        full_text = f"{prompt_text} {text}"

    payload = {
        "model": model,
        "input": {
            "prompt": full_text,
        },
        "parameters": {
            "num_inference_steps": num_inference_steps,
            "guidance_scale": guidance_scale,
            "seed": seed,
        },
    }
    if audio_duration_frames > 0:
        payload["parameters"]["audio_duration_frames"] = audio_duration_frames
    if audio_guidance_method != "cfg":
        payload["parameters"]["audio_guidance_method"] = audio_guidance_method
    if prompt_audio is not None:
        payload["input"]["prompt_audio"] = _load_wav_b64(prompt_audio)
    if prompt_text is not None:
        payload["input"]["prompt_text"] = prompt_text

    url = f"{base_url.rstrip('/')}/v1/audio/generation"
    resp = _post(url, payload, timeout=timeout)

    results = resp.get("output", {}).get("results", [])
    if not results:
        raise RuntimeError(
            f"Server returned no results. Full response:\n"
            f"{json.dumps(resp, indent=2, ensure_ascii=False)}"
        )

    b64 = results[0].get("audio", "")
    if not b64:
        raise RuntimeError(f"No audio data in response: {results[0]}")

    wav_bytes = base64.b64decode(b64)

    os.makedirs(os.path.dirname(os.path.abspath(output_file)), exist_ok=True)
    with open(output_file, "wb") as f:
        f.write(wav_bytes)

    return wav_bytes


# ---------------------------------------------------------------------------
# WAV duration helper
# ---------------------------------------------------------------------------


def _get_wav_duration(wav_bytes: bytes) -> float:
    import io
    import struct

    f = io.BytesIO(wav_bytes)
    try:
        f.seek(24)
        sample_rate = struct.unpack("<I", f.read(4))[0]
        f.seek(0, 2)
        file_size = f.tell()
        num_samples = (file_size - 44) // 2  # 16-bit mono
        return num_samples / sample_rate if sample_rate > 0 else 0.0
    except Exception:
        return 0.0


# ---------------------------------------------------------------------------
# Demo
# ---------------------------------------------------------------------------


def run_demo(base_url: str, model: str, output_dir: str):
    os.makedirs(output_dir, exist_ok=True)

    demos = [
        {
            "name": "中文 TTS",
            "text": "今天晴暖转阴雨，空气质量优至良，空气相对湿度较低。",
            "output_file": f"{output_dir}/zh_tts.wav",
        },
        {
            "name": "Voice cloning (APG)",
            "text": "今天晴暖转阴雨，空气质量优至良，空气相对湿度较低。",
            "output_file": f"{output_dir}/voice_clone_apg.wav",
            "prompt_text": "小偷却一点也不气馁，继续在抽屉里翻找。",
            "prompt_audio": "/root/code/LongCat-AudioDiT/assets/prompt.wav",
            "audio_guidance_method": "apg",
        },
    ]

    print(f"\n{'='*60}")
    print(f"LongCat-AudioDiT demo  ({base_url})")
    print(f"Model: {model}  Output dir: {output_dir}")
    print(f"{'='*60}\n")

    for demo in demos:
        name = demo.pop("name")
        text = demo.pop("text")
        output_file = demo.pop("output_file")
        print(f"[{name}]")
        print(f"  text: {text[:60]}")
        t0 = time.perf_counter()
        try:
            wav_bytes = generate_audio(base_url, text,
                                       model=model,
                                       output_file=output_file,
                                       **demo)
            elapsed = time.perf_counter() - t0
            dur = _get_wav_duration(wav_bytes)
            rtf = elapsed / dur if dur > 0 else float("inf")
            print(f"  OK: {output_file}")
            print(f"  dur={dur:.2f}s  elapsed={elapsed:.1f}s  RTF={rtf:.2f}x")
        except Exception as e:
            elapsed = time.perf_counter() - t0
            print(f"  FAILED ({elapsed:.1f}s): {e}")
        print()

    print(f"Demo complete. Output dir: {output_dir}\n")


# ---------------------------------------------------------------------------
# CLI
# ---------------------------------------------------------------------------


def main():
    parser = argparse.ArgumentParser(
        description="LongCat-AudioDiT xLLM HTTP client",
        formatter_class=argparse.RawDescriptionHelpFormatter,
        epilog=__doc__,
    )
    parser.add_argument("--host", default="127.0.0.1")
    parser.add_argument("--port", type=int, default=9977)
    parser.add_argument("--model", default="LongCat-AudioDiT-1B",
                        help="Model name registered in xLLM (default: last segment of --model path)")
    parser.add_argument("--text", "-t", default=None,
                        help="Text to synthesize")
    parser.add_argument("--output", "-o", default="output.wav",
                        help="Output WAV file path")
    parser.add_argument("--steps", type=int, default=16,
                        help="Number of ODE steps (default 16)")
    parser.add_argument("--guidance-scale", type=float, default=4.0,
                        help="CFG strength (default 4.0)")
    parser.add_argument("--guidance-method", choices=["cfg", "apg"],
                        default="cfg")
    parser.add_argument("--duration-frames", type=int, default=0,
                        help="Target duration in latent frames (0 = auto)")
    parser.add_argument("--prompt-audio", default=None,
                        help="Path to prompt WAV file for voice cloning")
    parser.add_argument("--prompt-text", default=None,
                        help="Transcript of the prompt audio (required for voice cloning)")
    parser.add_argument("--seed", type=int, default=1024)
    parser.add_argument("--demo", action="store_true",
                        help="Run all demo cases")
    parser.add_argument("--output-dir", default="/tmp/xllm_audiodit",
                        help="Demo output directory")
    args = parser.parse_args()

    base_url = f"http://{args.host}:{args.port}"

    if args.demo:
        run_demo(base_url, args.model, args.output_dir)
        return

    if not args.text:
        parser.error("Please provide --text, or use --demo to run demos")

    print(f"Server : {base_url}")
    print(f"Model  : {args.model}")
    print(f"Text   : {args.text}")
    if args.prompt_audio:
        print(f"Prompt : {args.prompt_audio}  ({args.prompt_text})")

    t0 = time.perf_counter()
    try:
        wav_bytes = generate_audio(
            base_url,
            text=args.text,
            model=args.model,
            num_inference_steps=args.steps,
            guidance_scale=args.guidance_scale,
            seed=args.seed,
            audio_duration_frames=args.duration_frames,
            audio_guidance_method=args.guidance_method,
            prompt_audio=args.prompt_audio,
            prompt_text=args.prompt_text,
            output_file=args.output,
        )
        elapsed = time.perf_counter() - t0
        dur = _get_wav_duration(wav_bytes)
        rtf = elapsed / dur if dur > 0 else float("inf")
        print(f"\nOK: {args.output}")
        print(f"dur={dur:.2f}s  elapsed={elapsed:.1f}s  RTF={rtf:.2f}x")
    except Exception as e:
        elapsed = time.perf_counter() - t0
        print(f"\nFAILED ({elapsed:.1f}s): {e}", file=sys.stderr)
        sys.exit(1)


if __name__ == "__main__":
    main()

```


```shell
./build/xllm/core/server/xllm --model=/root/models/LongCat-AudioDiT-1B --port=9977 --devices 'cuda:0'
```

```shell
python run_longcat_audio.py --demo

============================================================
LongCat-AudioDiT demo  (http://127.0.0.1:9977)
Model: LongCat-AudioDiT-1B  Output dir: /tmp/xllm_audiodit
============================================================

[中文 TTS]
  text: 今天晴暖转阴雨，空气质量优至良，空气相对湿度较低。
  OK: /tmp/xllm_audiodit/zh_tts.wav
  dur=5.21s  elapsed=3.4s  RTF=0.66x

[Voice cloning (APG)]
  text: 今天晴暖转阴雨，空气质量优至良，空气相对湿度较低。
  OK: /tmp/xllm_audiodit/voice_clone_apg.wav
  dur=6.66s  elapsed=2.0s  RTF=0.30x

Demo complete. Output dir: /tmp/xllm_audiodit
```
[tts.wav](https://github.com/user-attachments/files/26508639/tts.wav)

[prompt.wav](https://github.com/user-attachments/files/26508666/prompt.wav)
[clone.wav](https://github.com/user-attachments/files/26508642/clone.wav)
