### PR TITLE
bugfix: fix qwen3.5/3.6 mtp verify shape mismatch (mtp=4/5).

### DIFF
--- a/xllm/core/layers/npu_torch/qwen3_gated_delta_net_base.cpp
+++ b/xllm/core/layers/npu_torch/qwen3_gated_delta_net_base.cpp
@@ -482,6 +482,8 @@ torch::Tensor Qwen3GatedDeltaNetBaseImpl::forward(
     const AttentionMetadata& attn_metadata,
     KVCache& kv_cache,
     const ModelInputParams& input_params) {
+  // Save original hidden_states size for potential padding later
+  const int64_t original_num_tokens = hidden_states.size(0);
   auto [qkvz_padded, ba_padded] =
       project_padded_inputs(hidden_states, attn_metadata);
   int64_t batch_size = qkvz_padded.size(0);
@@ -811,8 +813,15 @@ torch::Tensor Qwen3GatedDeltaNetBaseImpl::forward(
   auto rearranged_norm =
       norm_out.reshape({norm_out.size(0), norm_out.size(1) * norm_out.size(2)});
   rearranged_norm = reshape_qkvz_unpad(attn_metadata, rearranged_norm);
-  auto attn_output = o_proj_->forward(rearranged_norm);
-  return attn_output;
+  // For chunked prefill or spec verify, reshape_qkvz_with_pad may pad each
+  // batch to max_len, causing output tokens > original_num_tokens. We need to
+  // slice back to original_num_tokens to match residual shape for add_rms_norm.
+  if (rearranged_norm.size(0) > original_num_tokens) {
+    // Slice excess padding tokens
+    rearranged_norm =
+        rearranged_norm.slice(0, 0, original_num_tokens).contiguous();
+  }
+  return o_proj_->forward(rearranged_norm);
 }
 
 torch::Tensor Qwen3GatedDeltaNetBaseImpl::reshape_qkvz_unpad(

--- a/xllm/core/runtime/worker_impl.cpp
+++ b/xllm/core/runtime/worker_impl.cpp
@@ -116,6 +116,7 @@ class ScopedAtenLoadThreads {
   bool active_ = false;
 };
 
+#if defined(USE_NPU)
 void prepare_input_params_for_linear_attention(ModelInputParams& input_params) {
   int64_t batch_size = input_params.block_tables.size(0);
   input_params.query_start_loc.resize(batch_size + 1, 0);
@@ -134,6 +135,7 @@ void prepare_input_params_for_linear_attention(ModelInputParams& input_params) {
                            has_initial_state_int64.data_ptr<int64_t>() +
                                has_initial_state_int64.size(0));
 }
+#endif
 
 }  // namespace
 


### PR DESCRIPTION
**Issue**: Crash in `npu_add_rms_norm` during speculative decode graph capture when using `num_speculative_tokens=5` with Qwen3.5-27B MTP model.

**Error Message**:
```
Input x2/x1 shape invalid, shape is not equal x1 shape.
input shape=[12, 5120], residual shape=[8, 5120]
```

**Root Cause**: GDN (Gated Delta Net) layer incorrectly processes padding sequences in spec verify mode, causing output shape mismatch with residual tensor.
