### PR TITLE
feat: optimize DeepSeek V4 NPU fused ops.

### DIFF
--- a/tests/core/kernels/npu/CMakeLists.txt
+++ b/tests/core/kernels/npu/CMakeLists.txt
@@ -1,1 +1,17 @@
+include(cc_test)
+
+cc_test(
+  NAME
+    dsv4_scatter_cache_write_test
+  SRCS
+    dsv4_scatter_cache_write_test.cpp
+  DEPS
+    ascendcl
+    torch
+    torch_npu
+    xllm_ops
+    GTest::gtest_main
+    glog::glog
+)
+
 add_subdirectory(tilelang)

--- a/tests/core/kernels/npu/dsv4_scatter_cache_write_test.cpp
+++ b/tests/core/kernels/npu/dsv4_scatter_cache_write_test.cpp
@@ -1,0 +1,256 @@
+/* Copyright 2026 The xLLM Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://github.com/jd-opensource/xllm/blob/main/LICENSE
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include <gtest/gtest.h>
+#include <torch/torch.h>
+#include <torch_npu/torch_npu.h>
+
+#include <algorithm>
+#include <string>
+#include <vector>
+
+#include "core/kernels/npu/xllm_ops/xllm_ops_api.h"
+
+namespace {
+
+class Dsv4ScatterCacheWriteTest : public ::testing::Test {
+ protected:
+  static void SetUpTestSuite() { torch_npu::init_npu("npu:0"); }
+
+  static void TearDownTestSuite() { torch_npu::finalize_npu(); }
+};
+
+struct CacheWriteCase {
+  std::string name;
+  int64_t num_tokens;
+  int64_t num_blocks;
+  int64_t block_size;
+  int64_t num_kv_heads;
+  int64_t head_dim;
+  bool keep_update_head_dim;
+};
+
+torch::Tensor build_slot_mapping(int64_t num_tokens,
+                                 int64_t num_blocks,
+                                 int64_t block_size,
+                                 const torch::Device& device) {
+  const int64_t cache_rows = num_blocks * block_size;
+  torch::Tensor slots = torch::arange(
+      num_tokens, torch::TensorOptions().dtype(torch::kLong).device(device));
+  return torch::remainder(slots * 37 + 11, cache_rows);
+}
+
+torch::Tensor flatten_updates_for_case(const torch::Tensor& update) {
+  return update.reshape({-1, update.size(update.dim() - 1)});
+}
+
+void xllm_scatter_by_slot_mirror(torch::Tensor& cache,
+                                 const torch::Tensor& slot_mapping,
+                                 const torch::Tensor& value) {
+  if (!cache.defined() || !slot_mapping.defined() || !value.defined()) {
+    return;
+  }
+  if (slot_mapping.numel() == 0 || value.numel() == 0) {
+    return;
+  }
+
+  torch::Tensor value_2d = flatten_updates_for_case(value);
+  torch::Tensor cache_2d = cache.view({-1, value_2d.size(1)});
+  torch::Tensor slots =
+      slot_mapping.reshape({-1}).to(torch::kLong).to(cache.device());
+  const int64_t update_rows = std::min(slots.size(0), value_2d.size(0));
+  if (update_rows <= 0) {
+    return;
+  }
+
+  torch::Tensor slots_slice =
+      slots.slice(/*dim=*/0, /*start=*/0, /*end=*/update_rows);
+  torch::Tensor value_slice =
+      value_2d.slice(/*dim=*/0, /*start=*/0, /*end=*/update_rows);
+  torch::Tensor safe_slots = slots_slice.clamp_min(0);
+  torch::Tensor valid_mask = slots_slice.ge(0).unsqueeze(1);
+  torch::Tensor old_values = cache_2d.index_select(/*dim=*/0, safe_slots);
+  torch::Tensor safe_values = torch::where(valid_mask, value_slice, old_values);
+  cache_2d.index_copy_(/*dim=*/0, safe_slots, safe_values);
+}
+
+void verify_cache_write_case(const CacheWriteCase& test_case) {
+  ASSERT_GT(test_case.num_tokens, 0);
+  ASSERT_GT(test_case.num_blocks, 0);
+  ASSERT_GT(test_case.block_size, 0);
+  ASSERT_GT(test_case.num_kv_heads, 0);
+  ASSERT_GT(test_case.head_dim, 0);
+
+  const torch::Device npu_device("npu:0");
+  const torch::TensorOptions bf16_options =
+      torch::TensorOptions().dtype(torch::kBFloat16).device(npu_device);
+
+  torch::manual_seed(20260518);
+  torch::Tensor base_cache = torch::randn({test_case.num_blocks,
+                                           test_case.block_size,
+                                           test_case.num_kv_heads,
+                                           test_case.head_dim},
+                                          bf16_options);
+  torch::Tensor update =
+      test_case.keep_update_head_dim
+          ? torch::randn({test_case.num_tokens,
+                          test_case.num_kv_heads,
+                          test_case.head_dim},
+                         bf16_options)
+          : torch::randn({test_case.num_tokens, test_case.head_dim},
+                         bf16_options);
+  torch::Tensor slot_mapping = build_slot_mapping(test_case.num_tokens,
+                                                  test_case.num_blocks,
+                                                  test_case.block_size,
+                                                  npu_device);
+  torch::Tensor indices = slot_mapping.unsqueeze(-1);
+
+  torch::Tensor xllm_cache = base_cache.clone();
+  torch::Tensor npu_cache = base_cache.clone();
+  xllm_scatter_by_slot_mirror(xllm_cache, slot_mapping, update);
+  torch::Tensor npu_cache_2d =
+      npu_cache.view({-1, update.size(update.dim() - 1)});
+  xllm::kernel::npu::scatter_nd_update(npu_cache_2d, indices, update);
+  EXPECT_TRUE(torch::allclose(xllm_cache, npu_cache, /*rtol=*/0, /*atol=*/0))
+      << "cache write mismatch for " << test_case.name;
+}
+
+void verify_cache_write_case_with_padding_slot(
+    const CacheWriteCase& test_case) {
+  ASSERT_GT(test_case.num_tokens, 1);
+  ASSERT_GT(test_case.num_blocks, 0);
+  ASSERT_GT(test_case.block_size, 0);
+  ASSERT_GT(test_case.num_kv_heads, 0);
+  ASSERT_GT(test_case.head_dim, 0);
+
+  const torch::Device npu_device("npu:0");
+  const torch::TensorOptions bf16_options =
+      torch::TensorOptions().dtype(torch::kBFloat16).device(npu_device);
+
+  torch::manual_seed(20260520);
+  torch::Tensor base_cache = torch::randn({test_case.num_blocks,
+                                           test_case.block_size,
+                                           test_case.num_kv_heads,
+                                           test_case.head_dim},
+                                          bf16_options);
+  torch::Tensor update =
+      test_case.keep_update_head_dim
+          ? torch::randn({test_case.num_tokens,
+                          test_case.num_kv_heads,
+                          test_case.head_dim},
+                         bf16_options)
+          : torch::randn({test_case.num_tokens, test_case.head_dim},
+                         bf16_options);
+  torch::Tensor slot_mapping = build_slot_mapping(test_case.num_tokens,
+                                                  test_case.num_blocks,
+                                                  test_case.block_size,
+                                                  npu_device);
+  slot_mapping.index_put_({0}, -1);
+
+  torch::Tensor expected_cache = base_cache.clone();
+  xllm_scatter_by_slot_mirror(expected_cache, slot_mapping, update);
+
+  torch::Tensor actual_cache = base_cache.clone();
+  torch::Tensor update_2d = flatten_updates_for_case(update);
+  torch::Tensor actual_cache_2d = actual_cache.view({-1, update_2d.size(1)});
+  torch::Tensor slots = slot_mapping.reshape({-1}).to(torch::kLong);
+  const int64_t update_rows = std::min(slots.size(0), update_2d.size(0));
+  torch::Tensor slots_slice =
+      slots.slice(/*dim=*/0, /*start=*/0, /*end=*/update_rows);
+  torch::Tensor value_slice =
+      update_2d.slice(/*dim=*/0, /*start=*/0, /*end=*/update_rows);
+  torch::Tensor safe_slots = slots_slice.clamp_min(0);
+  torch::Tensor valid_mask = slots_slice.ge(0).unsqueeze(1);
+  torch::Tensor old_values =
+      actual_cache_2d.index_select(/*dim=*/0, safe_slots);
+  torch::Tensor safe_values = torch::where(valid_mask, value_slice, old_values);
+  xllm::kernel::npu::scatter_nd_update(
+      actual_cache_2d, safe_slots.reshape({-1, 1}), safe_values);
+
+  EXPECT_TRUE(
+      torch::allclose(expected_cache, actual_cache, /*rtol=*/0, /*atol=*/0))
+      << "padding slot cache write mismatch for " << test_case.name;
+}
+
+}  // namespace
+
+TEST_F(Dsv4ScatterCacheWriteTest, OriginalKvCacheWrite) {
+  const std::vector<CacheWriteCase> cases = {
+      {.name = "ori_decode_1_token",
+       .num_tokens = 1,
+       .num_blocks = 1024,
+       .block_size = 128,
+       .num_kv_heads = 1,
+       .head_dim = 576,
+       .keep_update_head_dim = true},
+      {.name = "ori_decode_8_tokens",
+       .num_tokens = 8,
+       .num_blocks = 1024,
+       .block_size = 128,
+       .num_kv_heads = 1,
+       .head_dim = 576,
+       .keep_update_head_dim = true},
+      {.name = "ori_decode_64_tokens",
+       .num_tokens = 64,
+       .num_blocks = 1024,
+       .block_size = 128,
+       .num_kv_heads = 1,
+       .head_dim = 576,
+       .keep_update_head_dim = true},
+  };
+  for (const CacheWriteCase& test_case : cases) {
+    verify_cache_write_case(test_case);
+  }
+}
+
+TEST_F(Dsv4ScatterCacheWriteTest, CompressedKvCacheWrite) {
+  const std::vector<CacheWriteCase> cases = {
+      {.name = "cmp_decode_1_token",
+       .num_tokens = 1,
+       .num_blocks = 256,
+       .block_size = 128,
+       .num_kv_heads = 1,
+       .head_dim = 576,
+       .keep_update_head_dim = false},
+      {.name = "cmp_decode_8_tokens",
+       .num_tokens = 8,
+       .num_blocks = 256,
+       .block_size = 128,
+       .num_kv_heads = 1,
+       .head_dim = 576,
+       .keep_update_head_dim = false},
+      {.name = "cmp_decode_64_tokens",
+       .num_tokens = 64,
+       .num_blocks = 256,
+       .block_size = 128,
+       .num_kv_heads = 1,
+       .head_dim = 576,
+       .keep_update_head_dim = false},
+  };
+  for (const CacheWriteCase& test_case : cases) {
+    verify_cache_write_case(test_case);
+  }
+}
+
+TEST_F(Dsv4ScatterCacheWriteTest, PaddingSlotIsIgnored) {
+  const CacheWriteCase test_case = {.name = "cmp_decode_padding_slot",
+                                    .num_tokens = 8,
+                                    .num_blocks = 16,
+                                    .block_size = 128,
+                                    .num_kv_heads = 1,
+                                    .head_dim = 576,
+                                    .keep_update_head_dim = false};
+  verify_cache_write_case_with_padding_slot(test_case);
+}

--- a/xllm/core/common/global_flags.cpp
+++ b/xllm/core/common/global_flags.cpp
@@ -239,6 +239,16 @@ DEFINE_double(eplb_update_threshold, 0.8, "EPLB update threshold.");
 
 DEFINE_int32(expert_parallel_degree, 0, "Expert parallel degree.");
 
+DEFINE_int32(enable_fused_mc2,
+             0,
+             "Fused MC2 mode for NPU EP MoE. 0 disables fused MC2, 1 uses "
+             "DispatchFFNCombine, 2 uses DispatchGmmCombineDecode.");
+
+DEFINE_bool(
+    enable_fused_moe_gmm_swiglu,
+    false,
+    "Whether to fuse W8A8 MoE grouped matmul1 and dequant+swiglu+quant.");
+
 DEFINE_string(rank_tablefile, "", "ATB HCCL rank table file.");
 
 // --- profile config ---

--- a/xllm/core/common/global_flags.h
+++ b/xllm/core/common/global_flags.h
@@ -150,6 +150,10 @@ DECLARE_double(prefill_scheduling_memory_usage_threshold);
 
 DECLARE_int32(expert_parallel_degree);
 
+DECLARE_int32(enable_fused_mc2);
+
+DECLARE_bool(enable_fused_moe_gmm_swiglu);
+
 DECLARE_int32(max_reconnect_count);
 
 DECLARE_bool(enable_customize_mla_kernel);

--- a/xllm/core/common/help_formatter.h
+++ b/xllm/core/common/help_formatter.h
@@ -56,9 +56,12 @@ const OptionCategory kCacheOptions = {"KV CACHE OPTIONS",
                                        "max_memory_utilization",
                                        "kv_cache_dtype"}};
 
-const OptionCategory kMoeModelOptions = {
-    "MOE MODEL OPTIONS",
-    {"dp_size", "ep_size", "expert_parallel_degree"}};
+const OptionCategory kMoeModelOptions = {"MOE MODEL OPTIONS",
+                                         {"dp_size",
+                                          "ep_size",
+                                          "expert_parallel_degree",
+                                          "enable_fused_mc2",
+                                          "enable_fused_moe_gmm_swiglu"}};
 
 const OptionCategory kDiTModelOptions = {
     "DiT MODEL OPTIONS",

--- a/xllm/core/framework/state_dict/utils.cpp
+++ b/xllm/core/framework/state_dict/utils.cpp
@@ -18,29 +18,11 @@ limitations under the License.
 
 #include <glog/logging.h>
 
-#include <sstream>
-
 namespace xllm {
 
 namespace weight {
 
 namespace {
-std::string tensor_shape(const torch::Tensor& tensor) {
-  if (!tensor.defined()) {
-    return "undef";
-  }
-  std::ostringstream os;
-  os << "[";
-  for (int64_t i = 0; i < tensor.dim(); ++i) {
-    if (i > 0) {
-      os << ", ";
-    }
-    os << tensor.size(i);
-  }
-  os << "]";
-  return os.str();
-}
-
 bool should_relax_quant_vector_shape_check(const std::string& name) {
   return name == "weight_scale" || name == "weight_offset";
 }
@@ -243,6 +225,32 @@ void load_moe_weight(const StateDict& state_dict,
                      std::vector<torch::Tensor>& accumulated_tensors,
                      torch::Tensor& weight,
                      bool& weight_is_loaded) {
+  load_moe_weight(state_dict,
+                  sub_prefix,
+                  name,
+                  nullptr,
+                  dim,
+                  rank,
+                  world_size,
+                  start_expert_id,
+                  num_experts_per_rank,
+                  accumulated_tensors,
+                  weight,
+                  weight_is_loaded);
+}
+
+void load_moe_weight(const StateDict& state_dict,
+                     const std::string& sub_prefix,
+                     const std::string& name,
+                     TensorTransform transform_func,
+                     int64_t dim,
+                     int64_t rank,
+                     int64_t world_size,
+                     int64_t start_expert_id,
+                     int64_t num_experts_per_rank,
+                     std::vector<torch::Tensor>& accumulated_tensors,
+                     torch::Tensor& weight,
+                     bool& weight_is_loaded) {
   // return if the weight is already loaded
   if (weight_is_loaded) {
     return;
@@ -264,7 +272,11 @@ void load_moe_weight(const StateDict& state_dict,
         << "weight size mismatch for " << state_dict.prefix() << "["
         << start_expert_id << ":" << (start_expert_id + num_experts_per_rank)
         << "]." << sub_prefix << name;
-    weight.copy_(reshaped_weight);
+    if (transform_func) {
+      weight.set_data(transform_func(reshaped_weight));
+    } else {
+      weight.copy_(reshaped_weight);
+    }
     // release the memory for weight_list
     accumulated_tensors.clear();
   }
@@ -320,6 +332,36 @@ void load_moe_fused_weight(const StateDict& state_dict,
                            bool& w1_is_loaded,
                            bool& w3_is_loaded,
                            bool& w13_is_loaded) {
+  load_moe_fused_weight(state_dict,
+                        prefixes,
+                        name,
+                        nullptr,
+                        rank,
+                        world_size,
+                        start_expert_id,
+                        num_experts_per_rank,
+                        w1_tensors,
+                        w3_tensors,
+                        w13,
+                        w1_is_loaded,
+                        w3_is_loaded,
+                        w13_is_loaded);
+}
+
+void load_moe_fused_weight(const StateDict& state_dict,
+                           const std::vector<std::string>& prefixes,
+                           const std::string& name,
+                           TensorTransform transform_func,
+                           int64_t rank,
+                           int64_t world_size,
+                           int64_t start_expert_id,
+                           int64_t num_experts_per_rank,
+                           std::vector<torch::Tensor>& w1_tensors,
+                           std::vector<torch::Tensor>& w3_tensors,
+                           torch::Tensor& w13,
+                           bool& w1_is_loaded,
+                           bool& w3_is_loaded,
+                           bool& w13_is_loaded) {
   // return if the weight is already loaded
   if (w13_is_loaded) {
     return;
@@ -352,28 +394,15 @@ void load_moe_fused_weight(const StateDict& state_dict,
     const auto merged_weight = torch::stack(w13_vec);
     const auto reshaped_weight =
         reshape_quant_vector_if_compatible(name, w13, merged_weight);
-    if (w13.sizes() != reshaped_weight.sizes()) {
-      std::ostringstream debug_msg;
-      debug_msg << "weight size mismatch for " << state_dict.prefix() << "["
-                << start_expert_id << ":"
-                << (start_expert_id + num_experts_per_rank) << "].{"
-                << prefixes[0] << ", " << prefixes[1] << "}." << name
-                << " | expected(w13)=" << tensor_shape(w13)
-                << ", merged=" << tensor_shape(merged_weight)
-                << ", rank/world=" << rank << "/" << world_size;
-      if (!w1_tensors.empty() && w1_tensors[0].defined()) {
-        debug_msg << ", first_w1=" << tensor_shape(w1_tensors[0]);
-      }
-      if (!w3_tensors.empty() && w3_tensors[0].defined()) {
-        debug_msg << ", first_w3=" << tensor_shape(w3_tensors[0]);
-      }
-      LOG(ERROR) << "[MOE_LOAD_DEBUG] " << debug_msg.str();
-    }
     CHECK_EQ(w13.sizes(), reshaped_weight.sizes())
         << "weight size mismatch for " << state_dict.prefix() << "["
         << start_expert_id << ":" << (start_expert_id + num_experts_per_rank)
         << "].{" << prefixes[0] << ", " << prefixes[1] << "}." << name;
-    w13.copy_(reshaped_weight);
+    if (transform_func) {
+      w13.set_data(transform_func(reshaped_weight));
+    } else {
+      w13.copy_(reshaped_weight);
+    }
 
     // release the memory for weight_list
     w1_tensors.clear();

--- a/xllm/core/framework/state_dict/utils.h
+++ b/xllm/core/framework/state_dict/utils.h
@@ -99,6 +99,19 @@ void load_moe_weight(const StateDict& state_dict,
                      torch::Tensor& weight,
                      bool& weight_is_loaded);
 
+void load_moe_weight(const StateDict& state_dict,
+                     const std::string& sub_prefix,
+                     const std::string& name,
+                     TensorTransform transform_func,
+                     int64_t dim,
+                     int64_t rank,
+                     int64_t world_size,
+                     int64_t start_expert_id,
+                     int64_t num_experts_per_rank,
+                     std::vector<torch::Tensor>& accumulated_tensors,
+                     torch::Tensor& weight,
+                     bool& weight_is_loaded);
+
 void load_moe_all_expert_weight(const StateDict& state_dict,
                                 const std::string& sub_prefix,
                                 const std::string& name,
@@ -113,6 +126,21 @@ void load_moe_all_expert_weight(const StateDict& state_dict,
 void load_moe_fused_weight(const StateDict& state_dict,
                            const std::vector<std::string>& prefixes,
                            const std::string& name,
+                           int64_t rank,
+                           int64_t world_size,
+                           int64_t start_expert_id,
+                           int64_t num_experts_per_rank,
+                           std::vector<torch::Tensor>& w1_tensors,
+                           std::vector<torch::Tensor>& w3_tensors,
+                           torch::Tensor& w13,
+                           bool& w1_is_loaded,
+                           bool& w3_is_loaded,
+                           bool& w13_is_loaded);
+
+void load_moe_fused_weight(const StateDict& state_dict,
+                           const std::vector<std::string>& prefixes,
+                           const std::string& name,
+                           TensorTransform transform_func,
                            int64_t rank,
                            int64_t world_size,
                            int64_t start_expert_id,
@@ -213,6 +241,20 @@ void load_merged_weight_v2(const StateDict& state_dict,
                           name##_,                  \
                           name##_is_loaded_);
 
+#define LOAD_MOE_WEIGHT_TRANSFORM(sub_prefix, key, name, transform, dim) \
+  weight::load_moe_weight(state_dict,                                    \
+                          sub_prefix,                                    \
+                          key,                                           \
+                          transform,                                     \
+                          dim,                                           \
+                          rank,                                          \
+                          world_size,                                    \
+                          start_expert_id,                               \
+                          num_experts_per_rank,                          \
+                          name##_list_,                                  \
+                          name##_,                                       \
+                          name##_is_loaded_);
+
 #define LOAD_MOE_ALL_EXPERT_WEIGHT(sub_prefix, key, name, dim) \
   weight::load_moe_all_expert_weight(state_dict,               \
                                      sub_prefix,               \
@@ -238,6 +280,22 @@ void load_merged_weight_v2(const StateDict& state_dict,
                                 w13##_,               \
                                 w1##_is_loaded_,      \
                                 w3##_is_loaded_,      \
+                                w13##_is_loaded_);
+
+#define LOAD_MOE_FUSED_WEIGHT_TRANSFORM(key, w1, w3, w13, transform) \
+  weight::load_moe_fused_weight(state_dict,                          \
+                                prefixes,                            \
+                                key,                                 \
+                                transform,                           \
+                                rank,                                \
+                                world_size,                          \
+                                start_expert_id,                     \
+                                num_experts_per_rank,                \
+                                w1##_list_,                          \
+                                w3##_list_,                          \
+                                w13##_,                              \
+                                w1##_is_loaded_,                     \
+                                w3##_is_loaded_,                     \
                                 w13##_is_loaded_);
 
 #define LOAD_MERGED_WEIGHT(name, dim)            \

--- a/xllm/core/kernels/npu/CMakeLists.txt
+++ b/xllm/core/kernels/npu/CMakeLists.txt
@@ -19,6 +19,8 @@ cc_library(
     npu_gemma_rms_norm.cpp
     npu_grouped_matmul.cpp
     npu_moe_gating_topk_softmax.cpp
+    npu_dispatch_ffn_combine.cpp
+    npu_dispatch_gmm_combine_decode.cpp
     npu_moe_distribute_combine_v2.cpp
     npu_moe_distribute_dispatch_v2.cpp
     npu_moe_init_routing_v2.cpp

--- a/xllm/core/kernels/npu/fused_layernorm.cpp
+++ b/xllm/core/kernels/npu/fused_layernorm.cpp
@@ -15,6 +15,9 @@ limitations under the License.
 #include <glog/logging.h>
 #include <torch_npu/csrc/aten/CustomFunctions.h>
 
+#include <array>
+
+#include "core/kernels/npu/aclnn/pytorch_npu_helper.hpp"
 #include "npu_ops_api.h"
 #include "ops_npu/npu_ops.h"
 
@@ -31,6 +34,51 @@ torch::Tensor rms_norm(const torch::Tensor& input,
       at_npu::native::custom_ops::npu_rms_norm(input, weight, eps);
   auto normalized_input = std::get<0>(result);
   return normalized_input;
+}
+
+std::tuple<torch::Tensor, torch::Tensor> rms_norm_dynamic_quant(
+    const torch::Tensor& input,
+    const torch::Tensor& weight,
+    double eps) {
+  CHECK(input.numel() > 0) << "Input tensor should not be empty.";
+  CHECK(weight.numel() > 0) << "Weight tensor should not be empty.";
+  CHECK(input.dim() >= 1) << "Input tensor dim should be >= 1.";
+  CHECK(weight.dim() == 1 && weight.size(0) == input.size(-1))
+      << "Weight dim must equal input last dim.";
+
+  at::SmallVector<int64_t, 8> scale_shape;
+  const int64_t scale_dim = input.dim() - 1;
+  for (int64_t index = 0; index < scale_dim; ++index) {
+    scale_shape.push_back(input.size(index));
+  }
+
+  torch::Tensor output =
+      torch::empty(input.sizes(), input.options().dtype(torch::kInt8));
+  torch::Tensor unused_output =
+      torch::empty({1}, input.options().dtype(torch::kInt8));
+  torch::Tensor scale =
+      torch::empty(scale_shape, input.options().dtype(torch::kFloat32));
+  torch::Tensor unused_scale = torch::empty_like(scale);
+  std::optional<torch::Tensor> smooth_scale = std::nullopt;
+  std::optional<torch::Tensor> smooth_scale2 = std::nullopt;
+  std::optional<torch::Tensor> beta = std::nullopt;
+  std::array<bool, 2>* output_mask = nullptr;
+  int64_t* dst_type = nullptr;
+
+  EXEC_NPU_CMD(aclnnRmsNormDynamicQuant,
+               input,
+               weight,
+               smooth_scale,
+               smooth_scale2,
+               beta,
+               eps,
+               output_mask,
+               dst_type,
+               output,
+               unused_output,
+               scale,
+               unused_scale);
+  return {output, scale};
 }
 
 std::tuple<torch::Tensor, torch::Tensor, torch::Tensor> add_rms_norm(

--- a/xllm/core/kernels/npu/npu_dispatch_ffn_combine.cpp
+++ b/xllm/core/kernels/npu/npu_dispatch_ffn_combine.cpp
@@ -1,0 +1,132 @@
+/* Copyright 2026 The xLLM Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://github.com/jd-opensource/xllm/blob/main/LICENSE
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include <optional>
+#include <string>
+#include <tuple>
+
+#include "core/kernels/npu/aclnn/pytorch_npu_helper.hpp"
+
+namespace xllm::kernel::npu {
+
+bool has_dispatch_ffn_combine() {
+  static const bool is_available =
+      aclnn::detail::get_op_api_func_addr(
+          "aclnnDispatchFFNCombineGetWorkspaceSize") != nullptr &&
+      aclnn::detail::get_op_api_func_addr("aclnnDispatchFFNCombine") != nullptr;
+  return is_available;
+}
+
+std::tuple<torch::Tensor, torch::Tensor> apply_npu_dispatch_ffn_combine(
+    const torch::Tensor& x,
+    const torch::TensorList weight1,
+    const torch::TensorList weight2,
+    const torch::Tensor& expert_ids,
+    const torch::TensorList scale1,
+    const torch::TensorList scale2,
+    const torch::Tensor& probs,
+    const std::string& group,
+    int64_t max_output_size,
+    double swiglu_limit,
+    const std::optional<torch::Tensor>& output,
+    const std::optional<torch::Tensor>& expert_token_nums) {
+  TORCH_CHECK(has_dispatch_ffn_combine(),
+              "aclnnDispatchFFNCombine is not available in libopapi.");
+  TORCH_CHECK(x.dim() == 2, "DispatchFFNCombine expects 2D x.");
+  TORCH_CHECK(x.scalar_type() == at::kHalf || x.scalar_type() == at::kBFloat16,
+              "DispatchFFNCombine expects fp16/bf16 x, got ",
+              c10::toString(x.scalar_type()));
+  TORCH_CHECK(!weight1.empty(),
+              "DispatchFFNCombine expects non-empty weight1 TensorList.");
+  TORCH_CHECK(!weight2.empty(),
+              "DispatchFFNCombine expects non-empty weight2 TensorList.");
+  TORCH_CHECK(weight1.size() == weight2.size(),
+              "DispatchFFNCombine weight1/weight2 list size mismatch: ",
+              weight1.size(),
+              " vs ",
+              weight2.size());
+  TORCH_CHECK(!scale1.empty(),
+              "DispatchFFNCombine expects non-empty scale1 TensorList.");
+  TORCH_CHECK(!scale2.empty(),
+              "DispatchFFNCombine expects non-empty scale2 TensorList.");
+  TORCH_CHECK(scale1.size() == weight1.size(),
+              "DispatchFFNCombine scale1/weight1 list size mismatch: ",
+              scale1.size(),
+              " vs ",
+              weight1.size());
+  TORCH_CHECK(scale2.size() == weight2.size(),
+              "DispatchFFNCombine scale2/weight2 list size mismatch: ",
+              scale2.size(),
+              " vs ",
+              weight2.size());
+  TORCH_CHECK(expert_ids.dim() == 2,
+              "DispatchFFNCombine expects 2D expert_ids.");
+  TORCH_CHECK(expert_ids.scalar_type() == at::kInt,
+              "DispatchFFNCombine expects int32 expert_ids, got ",
+              c10::toString(expert_ids.scalar_type()));
+  TORCH_CHECK(probs.dim() == 2, "DispatchFFNCombine expects 2D probs.");
+  TORCH_CHECK(probs.scalar_type() == at::kFloat,
+              "DispatchFFNCombine expects float32 probs, got ",
+              c10::toString(probs.scalar_type()));
+  TORCH_CHECK(probs.sizes() == expert_ids.sizes(),
+              "DispatchFFNCombine probs/expert_ids shape mismatch: ",
+              probs.sizes(),
+              " vs ",
+              expert_ids.sizes());
+  TORCH_CHECK(!group.empty(),
+              "DispatchFFNCombine requires non-empty HCCL group name.");
+  TORCH_CHECK(max_output_size > 0,
+              "DispatchFFNCombine requires max_output_size > 0.");
+
+  auto out = output.has_value() && output->defined() ? output.value()
+                                                     : at::empty_like(x);
+  TORCH_CHECK(out.sizes() == x.sizes(),
+              "DispatchFFNCombine output shape mismatch: ",
+              out.sizes(),
+              " vs ",
+              x.sizes());
+
+  int64_t expert_token_nums_size = static_cast<int64_t>(weight1.size());
+  auto expert_token_nums_out =
+      expert_token_nums.has_value() && expert_token_nums->defined()
+          ? expert_token_nums.value()
+          : at::empty({expert_token_nums_size}, x.options().dtype(at::kInt));
+  TORCH_CHECK(expert_token_nums_out.dim() == 1,
+              "DispatchFFNCombine expects 1D expert_token_nums output.");
+  TORCH_CHECK(expert_token_nums_out.scalar_type() == at::kInt,
+              "DispatchFFNCombine expects int32 expert_token_nums output, got ",
+              c10::toString(expert_token_nums_out.scalar_type()));
+
+  std::string group_copy = group;
+  char* group_ptr = group_copy.data();
+
+  EXEC_NPU_CMD(aclnnDispatchFFNCombine,
+               x,
+               weight1,
+               weight2,
+               expert_ids,
+               scale1,
+               scale2,
+               probs,
+               group_ptr,
+               max_output_size,
+               swiglu_limit,
+               out,
+               expert_token_nums_out);
+
+  return std::make_tuple(out, expert_token_nums_out);
+}
+
+}  // namespace xllm::kernel::npu

--- a/xllm/core/kernels/npu/npu_dispatch_gmm_combine_decode.cpp
+++ b/xllm/core/kernels/npu/npu_dispatch_gmm_combine_decode.cpp
@@ -1,0 +1,171 @@
+/* Copyright 2026 The xLLM Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://github.com/jd-opensource/xllm/blob/main/LICENSE
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include <optional>
+#include <string>
+#include <tuple>
+
+#include "core/kernels/npu/aclnn/pytorch_npu_helper.hpp"
+
+namespace xllm::kernel::npu {
+namespace {
+
+int64_t resolve_local_expert_num(int64_t ep_rank_size,
+                                 int64_t ep_rank_id,
+                                 int64_t moe_expert_num,
+                                 int64_t shared_expert_rank_num) {
+  const bool is_shared_expert_rank = ep_rank_id < shared_expert_rank_num;
+  if (is_shared_expert_rank) {
+    return 1;
+  }
+  const int64_t routed_ep_size = ep_rank_size - shared_expert_rank_num;
+  TORCH_CHECK(routed_ep_size > 0,
+              "invalid shared_expert_rank_num=",
+              shared_expert_rank_num,
+              " for ep_rank_size=",
+              ep_rank_size);
+  TORCH_CHECK(moe_expert_num % routed_ep_size == 0,
+              "moe_expert_num must be divisible by routed EP size, got ",
+              moe_expert_num,
+              " / ",
+              routed_ep_size);
+  return moe_expert_num / routed_ep_size;
+}
+
+}  // namespace
+
+bool has_dispatch_gmm_combine_decode() {
+  static const bool is_available =
+      aclnn::detail::get_op_api_func_addr(
+          "aclnnDispatchGmmCombineDecodeGetWorkspaceSize") != nullptr &&
+      aclnn::detail::get_op_api_func_addr("aclnnDispatchGmmCombineDecode") !=
+          nullptr;
+  return is_available;
+}
+
+std::tuple<torch::Tensor, torch::Tensor> apply_npu_dispatch_gmm_combine_decode(
+    const torch::Tensor& x,
+    const torch::Tensor& expert_ids,
+    const torch::TensorList gmm1_permuted_weight,
+    const torch::TensorList gmm1_permuted_weight_scale,
+    const torch::TensorList gmm2_weight,
+    const torch::TensorList gmm2_weight_scale,
+    const torch::Tensor& expert_scales,
+    const std::optional<torch::Tensor>& expert_smooth_scales,
+    const std::optional<torch::Tensor>& x_active_mask,
+    const std::string& group_ep,
+    int64_t ep_rank_size,
+    int64_t ep_rank_id,
+    int64_t moe_expert_num,
+    int64_t shared_expert_num,
+    int64_t shared_expert_rank_num,
+    int64_t quant_mode,
+    int64_t global_bs) {
+  TORCH_CHECK(has_dispatch_gmm_combine_decode(),
+              "aclnnDispatchGmmCombineDecode is not available in libopapi.");
+  TORCH_CHECK(x.dim() == 2, "DispatchGmmCombineDecode expects 2D x.");
+  TORCH_CHECK(x.scalar_type() == at::kHalf || x.scalar_type() == at::kBFloat16,
+              "DispatchGmmCombineDecode expects fp16/bf16 x, got ",
+              c10::toString(x.scalar_type()));
+  TORCH_CHECK(expert_ids.dim() == 2,
+              "DispatchGmmCombineDecode expects 2D expert_ids.");
+  TORCH_CHECK(expert_ids.scalar_type() == at::kInt,
+              "DispatchGmmCombineDecode expects int32 expert_ids, got ",
+              c10::toString(expert_ids.scalar_type()));
+  TORCH_CHECK(expert_scales.dim() == 2,
+              "DispatchGmmCombineDecode expects 2D expert_scales.");
+  TORCH_CHECK(expert_scales.scalar_type() == at::kFloat,
+              "DispatchGmmCombineDecode expects float32 expert_scales, got ",
+              c10::toString(expert_scales.scalar_type()));
+  TORCH_CHECK(expert_scales.sizes() == expert_ids.sizes(),
+              "DispatchGmmCombineDecode expert_scales/expert_ids shape "
+              "mismatch: ",
+              expert_scales.sizes(),
+              " vs ",
+              expert_ids.sizes());
+  TORCH_CHECK(!gmm1_permuted_weight.empty(),
+              "DispatchGmmCombineDecode expects non-empty gmm1 weight list.");
+  TORCH_CHECK(!gmm2_weight.empty(),
+              "DispatchGmmCombineDecode expects non-empty gmm2 weight list.");
+  TORCH_CHECK(gmm1_permuted_weight.size() == gmm2_weight.size(),
+              "DispatchGmmCombineDecode gmm1/gmm2 list size mismatch: ",
+              gmm1_permuted_weight.size(),
+              " vs ",
+              gmm2_weight.size());
+  TORCH_CHECK(gmm1_permuted_weight_scale.size() == gmm1_permuted_weight.size(),
+              "DispatchGmmCombineDecode gmm1 scale/weight list size "
+              "mismatch: ",
+              gmm1_permuted_weight_scale.size(),
+              " vs ",
+              gmm1_permuted_weight.size());
+  TORCH_CHECK(gmm2_weight_scale.size() == gmm2_weight.size(),
+              "DispatchGmmCombineDecode gmm2 scale/weight list size "
+              "mismatch: ",
+              gmm2_weight_scale.size(),
+              " vs ",
+              gmm2_weight.size());
+  TORCH_CHECK(!group_ep.empty(),
+              "DispatchGmmCombineDecode requires non-empty EP group name.");
+  TORCH_CHECK(ep_rank_size > 1,
+              "DispatchGmmCombineDecode requires ep_rank_size > 1.");
+  TORCH_CHECK(ep_rank_id >= 0 && ep_rank_id < ep_rank_size,
+              "invalid EP rank ",
+              ep_rank_id,
+              " for ep_rank_size ",
+              ep_rank_size);
+
+  torch::Tensor output = at::empty_like(x);
+  const int64_t local_expert_num = resolve_local_expert_num(
+      ep_rank_size, ep_rank_id, moe_expert_num, shared_expert_rank_num);
+  torch::Tensor expert_token_nums =
+      at::empty({local_expert_num}, expert_ids.options().dtype(at::kLong));
+
+  auto expert_smooth_scales_optional =
+      expert_smooth_scales.has_value() && expert_smooth_scales->defined()
+          ? c10::optional<at::Tensor>(expert_smooth_scales.value())
+          : c10::nullopt;
+  auto x_active_mask_optional =
+      x_active_mask.has_value() && x_active_mask->defined()
+          ? c10::optional<at::Tensor>(x_active_mask.value())
+          : c10::nullopt;
+
+  std::string group_ep_copy = group_ep;
+  char* group_ep_ptr = group_ep_copy.data();
+
+  EXEC_NPU_CMD(aclnnDispatchGmmCombineDecode,
+               x,
+               expert_ids,
+               gmm1_permuted_weight,
+               gmm1_permuted_weight_scale,
+               gmm2_weight,
+               gmm2_weight_scale,
+               expert_scales,
+               expert_smooth_scales_optional,
+               x_active_mask_optional,
+               group_ep_ptr,
+               ep_rank_size,
+               ep_rank_id,
+               moe_expert_num,
+               shared_expert_num,
+               shared_expert_rank_num,
+               quant_mode,
+               global_bs,
+               output,
+               expert_token_nums);
+
+  return std::make_tuple(output, expert_token_nums);
+}
+
+}  // namespace xllm::kernel::npu

--- a/xllm/core/kernels/npu/npu_ops_api.h
+++ b/xllm/core/kernels/npu/npu_ops_api.h
@@ -68,6 +68,11 @@ torch::Tensor rms_norm(const torch::Tensor& input,
                        double eps,
                        const std::string& mode);
 
+std::tuple<torch::Tensor, torch::Tensor> rms_norm_dynamic_quant(
+    const torch::Tensor& input,
+    const torch::Tensor& weight,
+    double eps);
+
 void npu_gemma_rms_norm(const torch::Tensor& x,
                         const torch::Tensor& gamma,
                         double epsilon,
@@ -185,6 +190,43 @@ torch::Tensor apply_npu_moe_distribute_combine_v2(
     const std::string& comm_alg);
 
 bool has_moe_distribute_dispatch_combine_v2();
+
+std::tuple<torch::Tensor, torch::Tensor> apply_npu_dispatch_ffn_combine(
+    const torch::Tensor& x,
+    const torch::TensorList weight1,
+    const torch::TensorList weight2,
+    const torch::Tensor& expert_ids,
+    const torch::TensorList scale1,
+    const torch::TensorList scale2,
+    const torch::Tensor& probs,
+    const std::string& group,
+    int64_t max_output_size,
+    double swiglu_limit,
+    const std::optional<torch::Tensor>& output,
+    const std::optional<torch::Tensor>& expert_token_nums);
+
+bool has_dispatch_ffn_combine();
+
+std::tuple<torch::Tensor, torch::Tensor> apply_npu_dispatch_gmm_combine_decode(
+    const torch::Tensor& x,
+    const torch::Tensor& expert_ids,
+    const torch::TensorList gmm1_permuted_weight,
+    const torch::TensorList gmm1_permuted_weight_scale,
+    const torch::TensorList gmm2_weight,
+    const torch::TensorList gmm2_weight_scale,
+    const torch::Tensor& expert_scales,
+    const std::optional<torch::Tensor>& expert_smooth_scales,
+    const std::optional<torch::Tensor>& x_active_mask,
+    const std::string& group_ep,
+    int64_t ep_rank_size,
+    int64_t ep_rank_id,
+    int64_t moe_expert_num,
+    int64_t shared_expert_num,
+    int64_t shared_expert_rank_num,
+    int64_t quant_mode,
+    int64_t global_bs);
+
+bool has_dispatch_gmm_combine_decode();
 
 std::pair<torch::Tensor, torch::Tensor> apply_npu_partial_rotary_embedding(
     const torch::Tensor& positions,

--- a/xllm/core/kernels/npu/xllm_ops/CMakeLists.txt
+++ b/xllm/core/kernels/npu/xllm_ops/CMakeLists.txt
@@ -13,6 +13,7 @@ cc_library(
     quantize.cpp
     quant_dynamic.cpp
     dequant_swiglu_quant.cpp
+    grouped_matmul_swiglu_quant.cpp
     compressor.cpp
     hc_post.cpp
     quant_lightning_indexer.cpp
@@ -22,6 +23,7 @@ cc_library(
     quant_lightning_indexer_metadata.cpp
     sparse_attn_sharedkv_metadata.cpp
     npu_inplace_partial_rotary_mul.cpp
+    scatter_nd_update.cpp
     moe_gating_top_k_hash.cpp
     sparse_attn_sharedkv.cpp
     sparse_flash_attention.cpp
@@ -36,6 +38,7 @@ cc_library(
     ${PROJECT_SOURCE_DIR}/third_party/xllm_ops/build/autogen
   DEPS
     atb
+    Python::Python
     torch_npu
     gflags::gflags
     nlohmann_json::nlohmann_json

--- a/xllm/core/kernels/npu/xllm_ops/grouped_matmul_swiglu_quant.cpp
+++ b/xllm/core/kernels/npu/xllm_ops/grouped_matmul_swiglu_quant.cpp
@@ -1,0 +1,37 @@
+/* Copyright 2026 The xLLM Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://github.com/jd-opensource/xllm/blob/main/LICENSE
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include <torch_npu/csrc/aten/CustomFunctions.h>
+
+#include "xllm_ops_api.h"
+
+namespace xllm::kernel::npu {
+
+std::tuple<at::Tensor, at::Tensor> grouped_matmul_swiglu_quant(
+    const at::Tensor& x,
+    const at::Tensor& weight,
+    const at::Tensor& group_list,
+    const at::Tensor& weight_scale,
+    const at::Tensor& x_scale,
+    const c10::optional<at::Tensor>& bias,
+    const c10::optional<at::Tensor>& offset) {
+  auto [output, output_scale, output_offset] =
+      at_npu::native::custom_ops::npu_grouped_matmul_swiglu_quant(
+          x, weight, group_list, weight_scale, x_scale, bias, offset);
+  (void)output_offset;
+  return std::make_tuple(output, output_scale);
+}
+
+}  // namespace xllm::kernel::npu

--- a/xllm/core/kernels/npu/xllm_ops/scatter_nd_update.cpp
+++ b/xllm/core/kernels/npu/xllm_ops/scatter_nd_update.cpp
@@ -1,0 +1,30 @@
+/* Copyright 2026 The xLLM Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://github.com/jd-opensource/xllm/blob/main/LICENSE
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include <torch/library.h>
+
+#include "core/kernels/npu/aclnn/pytorch_npu_helper.hpp"
+#include "xllm_ops_api.h"
+
+namespace xllm::kernel::npu {
+
+void scatter_nd_update(torch::Tensor& var,
+                       const torch::Tensor& indices,
+                       const torch::Tensor& updates) {
+  at::IntArrayRef var_stride = var.strides();
+  EXEC_NPU_CMD(aclnnScatterNdUpdateV2, var, indices, updates, var_stride);
+}
+
+}  // namespace xllm::kernel::npu

--- a/xllm/core/kernels/npu/xllm_ops/xllm_ops_api.h
+++ b/xllm/core/kernels/npu/xllm_ops/xllm_ops_api.h
@@ -151,6 +151,15 @@ std::tuple<at::Tensor, at::Tensor> dequant_swiglu_quant(
     bool activate_left,
     int64_t quant_mode);
 
+std::tuple<at::Tensor, at::Tensor> grouped_matmul_swiglu_quant(
+    const at::Tensor& x,
+    const at::Tensor& weight,
+    const at::Tensor& group_list,
+    const at::Tensor& weight_scale,
+    const at::Tensor& x_scale,
+    const c10::optional<at::Tensor>& bias,
+    const c10::optional<at::Tensor>& offset);
+
 at::Tensor hc_post(const at::Tensor& x,
                    const at::Tensor& residual,
                    const at::Tensor& post,
@@ -364,4 +373,8 @@ void npu_inplace_partial_rotary_mul(torch::Tensor& x,
                                     const torch::Tensor& r2,
                                     c10::string_view rotary_mode,
                                     at::IntArrayRef partial_slice);
+
+void scatter_nd_update(torch::Tensor& var,
+                       const torch::Tensor& indices,
+                       const torch::Tensor& updates);
 }  // namespace xllm::kernel::npu

--- a/xllm/core/kernels/ops_api.cpp
+++ b/xllm/core/kernels/ops_api.cpp
@@ -305,6 +305,15 @@ void fused_layernorm(FusedLayerNormParams& params) {
 #endif
 }
 
+std::tuple<torch::Tensor, torch::Tensor> rms_norm_dynamic_quant(
+    RmsNormDynamicQuantParams& params) {
+#if defined(USE_NPU)
+  return npu::rms_norm_dynamic_quant(params.input, params.weight, params.eps);
+#else
+  NOT_IMPLEMENTED();
+#endif
+}
+
 torch::Tensor matmul(MatmulParams& params) {
 #if defined(USE_MLU)
   return mlu::matmul(
@@ -441,6 +450,21 @@ std::tuple<torch::Tensor, torch::Tensor> dequant_swiglu_quant(
                                    params.group_index,
                                    params.activate_left,
                                    params.quant_mode);
+#else
+  NOT_IMPLEMENTED();
+#endif
+}
+
+std::tuple<torch::Tensor, torch::Tensor> grouped_matmul_swiglu_quant(
+    GroupedMatmulSwigluQuantParams& params) {
+#if defined(USE_NPU)
+  return npu::grouped_matmul_swiglu_quant(params.x,
+                                          params.weight,
+                                          params.group_list,
+                                          params.weight_scale,
+                                          params.x_scale,
+                                          params.bias,
+                                          params.offset);
 #else
   NOT_IMPLEMENTED();
 #endif
@@ -941,6 +965,68 @@ torch::Tensor moe_distribute_combine_v2(MoeDistributeCombineV2Params& params) {
 bool has_moe_distribute_dispatch_combine_v2() {
 #if defined(USE_NPU)
   return npu::has_moe_distribute_dispatch_combine_v2();
+#else
+  return false;
+#endif
+}
+
+std::tuple<torch::Tensor, torch::Tensor> dispatch_ffn_combine(
+    DispatchFFNCombineParams& params) {
+#if defined(USE_NPU)
+  return npu::apply_npu_dispatch_ffn_combine(params.x,
+                                             params.weight1,
+                                             params.weight2,
+                                             params.expert_ids,
+                                             params.scale1,
+                                             params.scale2,
+                                             params.probs,
+                                             params.group,
+                                             params.max_output_size,
+                                             params.swiglu_limit,
+                                             params.output,
+                                             params.expert_token_nums);
+#else
+  NOT_IMPLEMENTED();
+#endif
+}
+
+bool has_dispatch_ffn_combine() {
+#if defined(USE_NPU)
+  return npu::has_dispatch_ffn_combine();
+#else
+  return false;
+#endif
+}
+
+std::tuple<torch::Tensor, torch::Tensor> dispatch_gmm_combine_decode(
+    DispatchGmmCombineDecodeParams& params) {
+#if defined(USE_NPU)
+  return npu::apply_npu_dispatch_gmm_combine_decode(
+      params.x,
+      params.expert_ids,
+      params.gmm1_permuted_weight,
+      params.gmm1_permuted_weight_scale,
+      params.gmm2_weight,
+      params.gmm2_weight_scale,
+      params.expert_scales,
+      params.expert_smooth_scales,
+      params.x_active_mask,
+      params.group_ep,
+      params.ep_rank_size,
+      params.ep_rank_id,
+      params.moe_expert_num,
+      params.shared_expert_num,
+      params.shared_expert_rank_num,
+      params.quant_mode,
+      params.global_bs);
+#else
+  NOT_IMPLEMENTED();
+#endif
+}
+
+bool has_dispatch_gmm_combine_decode() {
+#if defined(USE_NPU)
+  return npu::has_dispatch_gmm_combine_decode();
 #else
   return false;
 #endif

--- a/xllm/core/kernels/ops_api.h
+++ b/xllm/core/kernels/ops_api.h
@@ -42,6 +42,9 @@ void dequant_from_paged_cache(ReshapeFromCacheParams& params);
 
 void fused_layernorm(FusedLayerNormParams& params);
 
+std::tuple<torch::Tensor, torch::Tensor> rms_norm_dynamic_quant(
+    RmsNormDynamicQuantParams& params);
+
 torch::Tensor matmul(MatmulParams& params);
 
 torch::Tensor quant_matmul(QuantMatmulParams& params);
@@ -55,6 +58,9 @@ torch::Tensor group_gemm(GroupGemmParams& params);
 
 std::tuple<torch::Tensor, torch::Tensor> dequant_swiglu_quant(
     DequantSwigluQuantParams& params);
+
+std::tuple<torch::Tensor, torch::Tensor> grouped_matmul_swiglu_quant(
+    GroupedMatmulSwigluQuantParams& params);
 
 std::tuple<torch::Tensor,
            torch::Tensor,
@@ -132,6 +138,16 @@ moe_distribute_dispatch_v2(MoeDistributeDispatchV2Params& params);
 torch::Tensor moe_distribute_combine_v2(MoeDistributeCombineV2Params& params);
 
 bool has_moe_distribute_dispatch_combine_v2();
+
+std::tuple<torch::Tensor, torch::Tensor> dispatch_ffn_combine(
+    DispatchFFNCombineParams& params);
+
+bool has_dispatch_ffn_combine();
+
+std::tuple<torch::Tensor, torch::Tensor> dispatch_gmm_combine_decode(
+    DispatchGmmCombineDecodeParams& params);
+
+bool has_dispatch_gmm_combine_decode();
 
 // FP8 scaled quantize: quantizes input tensor to FP8 e4m3 format
 // Returns: (quantized_output, scale)

--- a/xllm/core/kernels/param.h
+++ b/xllm/core/kernels/param.h
@@ -277,6 +277,12 @@ struct FusedLayerNormParams {
   bool dynamic_quant = false;
 };
 
+struct RmsNormDynamicQuantParams {
+  torch::Tensor input;
+  torch::Tensor weight;
+  double eps;
+};
+
 // Matmul parameters
 struct MatmulParams {
   // Left input tensor A. Must be 2D or 3D. Must have same dimension as b.
@@ -459,6 +465,29 @@ struct DequantSwigluQuantParams {
   bool activate_left = true;
   // Quantization mode: 0 static quant, 1 dynamic quant.
   int64_t quant_mode = 1;
+};
+
+struct GroupedMatmulSwigluQuantParams {
+  // Quantized activation tensor.
+  // Shape: [total_tokens, hidden_size]. Dtype: int8. Format: ND.
+  torch::Tensor x;
+  // W13 expert weight tensor in NPU FRACTAL_NZ format.
+  // Logical shape: [num_experts, hidden_size, intermediate_size * 2].
+  // Dtype: int8.
+  torch::Tensor weight;
+  // Cumulative token count per local expert.
+  // Shape: [num_experts]. Dtype: int64.
+  torch::Tensor group_list;
+  // W13 dequant scale.
+  // Shape: [num_experts, intermediate_size * 2]. Dtype: float32/fp16/bf16.
+  torch::Tensor weight_scale;
+  // Per-token activation scale from dynamic quant.
+  // Shape: [total_tokens]. Dtype: float32.
+  torch::Tensor x_scale;
+  // Optional matrix bias. Reserved by the underlying operator.
+  std::optional<torch::Tensor> bias;
+  // Optional asymmetric dequant offset. Reserved by the underlying operator.
+  std::optional<torch::Tensor> offset;
 };
 
 // Ascend W4A8_DYNAMIC MoE weight post-load processing for version 1.0.0.
@@ -1359,6 +1388,55 @@ struct MoeDistributeCombineV2Params {
   int64_t global_bs = 0;
   int64_t comm_quant_mode = 0;
   std::string comm_alg;
+};
+
+struct DispatchFFNCombineParams {
+  // Input hidden states. Shape: [num_tokens, hidden_size].
+  // Dtype: fp16/bf16 for W8A8 dynamic path.
+  torch::Tensor x;
+  // First/second expert weights as TensorList. For W8A8 int8 path the fused
+  // CANN op expects NZ-formatted int8 weights.
+  torch::TensorList weight1;
+  torch::TensorList weight2;
+  // Expert ids. Shape: [num_tokens, topk], dtype int32.
+  torch::Tensor expert_ids;
+  // W8A8 scales as TensorList. CANN DispatchFFNCombine expects the int64
+  // bit-packed representation used by vLLM/sgl wrappers, not raw fp32 scales.
+  torch::TensorList scale1;
+  torch::TensorList scale2;
+  // Router probabilities. Shape: [num_tokens, topk], dtype fp32.
+  torch::Tensor probs;
+  // HCCL communication group name.
+  std::string group;
+  int64_t max_output_size = 0;
+  double swiglu_limit = 0.0;
+  // Optional preallocated outputs. If absent, wrapper allocates them.
+  std::optional<torch::Tensor> output = std::nullopt;
+  std::optional<torch::Tensor> expert_token_nums = std::nullopt;
+};
+
+struct DispatchGmmCombineDecodeParams {
+  // Input hidden states. Shape: [num_tokens, hidden_size].
+  torch::Tensor x;
+  // Expert ids after routing. Shape: [num_tokens, topk], dtype int32.
+  torch::Tensor expert_ids;
+  // W8A8 expert weights and fp32 scales in TensorList form.
+  torch::TensorList gmm1_permuted_weight;
+  torch::TensorList gmm1_permuted_weight_scale;
+  torch::TensorList gmm2_weight;
+  torch::TensorList gmm2_weight_scale;
+  // Router probabilities. Shape: [num_tokens, topk], dtype fp32.
+  torch::Tensor expert_scales;
+  std::optional<torch::Tensor> expert_smooth_scales = std::nullopt;
+  std::optional<torch::Tensor> x_active_mask = std::nullopt;
+  std::string group_ep;
+  int64_t ep_rank_size = 1;
+  int64_t ep_rank_id = 0;
+  int64_t moe_expert_num = 1;
+  int64_t shared_expert_num = 0;
+  int64_t shared_expert_rank_num = 0;
+  int64_t quant_mode = 0;
+  int64_t global_bs = 0;
 };
 
 // FP8 scaled quantize parameters

--- a/xllm/core/layers/common/linear.cpp
+++ b/xllm/core/layers/common/linear.cpp
@@ -645,6 +645,25 @@ torch::Tensor ColumnParallelLinearImpl::forward(torch::Tensor input) {
   return output;
 }
 
+bool ColumnParallelLinearImpl::uses_w8a8_dynamic_quant() const {
+  return is_w8a8_dynamic_quant(resolved_weight_quant_method_);
+}
+
+torch::Tensor ColumnParallelLinearImpl::w8a8_dynamic_weight_scale() const {
+  CHECK(uses_w8a8_dynamic_quant())
+      << "w8a8_dynamic_weight_scale requires w8a8_dynamic quant method.";
+  CHECK(weight_scale_is_loaded_ && weight_scale_.defined())
+      << "weight_scale is required for w8a8_dynamic quant matmul.";
+  return weight_scale_;
+}
+
+std::optional<torch::Tensor> ColumnParallelLinearImpl::bias() const {
+  if (bias_.defined()) {
+    return bias_;
+  }
+  return std::nullopt;
+}
+
 // load the weight from the checkpoint
 void ColumnParallelLinearImpl::load_state_dict(const StateDict& state_dict) {
   const int64_t rank = world_size_ == 1 ? 0 : rank_;
@@ -1480,7 +1499,9 @@ ReplicatedLinearImpl::ReplicatedLinearImpl(
     const QuantArgs& quant_args,
     const torch::TensorOptions& options,
     const LinearExtraArgs& linear_extra_args)
-    : quant_args_(quant_args), options_(options) {
+    : quant_args_(quant_args),
+      options_(options),
+      output_dtype_(c10::typeMetaToScalarType(options.dtype())) {
   (void)linear_extra_args;
   if (!quant_args_.quant_descs().empty()) {
     // quant_descs is not empty: default initialize weight as kInt8.
@@ -1541,6 +1562,29 @@ torch::Tensor ReplicatedLinearImpl::forward(torch::Tensor input) {
 
   auto output = xllm::kernel::matmul(matmul_params);
   return output;
+}
+
+bool ReplicatedLinearImpl::uses_w8a8_dynamic_quant() const {
+  return is_w8a8_dynamic_quant(resolved_weight_quant_method_);
+}
+
+torch::Tensor ReplicatedLinearImpl::w8a8_dynamic_weight_scale() const {
+  CHECK(uses_w8a8_dynamic_quant())
+      << "w8a8_dynamic_weight_scale requires w8a8_dynamic quant method.";
+  CHECK(weight_scale_is_loaded_ && weight_scale_.defined())
+      << "weight_scale is required for w8a8_dynamic quant matmul.";
+  return weight_scale_;
+}
+
+at::ScalarType ReplicatedLinearImpl::output_dtype() const {
+  return output_dtype_;
+}
+
+std::optional<torch::Tensor> ReplicatedLinearImpl::bias() const {
+  if (bias_.defined()) {
+    return bias_;
+  }
+  return std::nullopt;
 }
 
 // load the weight from the checkpoint

--- a/xllm/core/layers/common/linear.h
+++ b/xllm/core/layers/common/linear.h
@@ -81,6 +81,9 @@ class ColumnParallelLinearImpl : public torch::nn::Module {
   }
   torch::Tensor per_channel_scale() const { return per_channel_scale_; }
   torch::Tensor weight_scale() const { return weight_scale_; }
+  bool uses_w8a8_dynamic_quant() const;
+  torch::Tensor w8a8_dynamic_weight_scale() const;
+  std::optional<torch::Tensor> bias() const;
   ProcessGroup* process_group() const { return process_group_; }
   std::optional<torch::Tensor> smooth() const {
     if (smooth_is_loaded_) {
@@ -328,6 +331,10 @@ class ReplicatedLinearImpl : public torch::nn::Module {
 
   // return the weight (for testing)
   torch::Tensor weight() const { return weight_; }
+  bool uses_w8a8_dynamic_quant() const;
+  torch::Tensor w8a8_dynamic_weight_scale() const;
+  at::ScalarType output_dtype() const;
+  std::optional<torch::Tensor> bias() const;
 
  private:
   // parameter members, must be registered
@@ -344,6 +351,7 @@ class ReplicatedLinearImpl : public torch::nn::Module {
   DEFINE_WEIGHT(weight_offset);  // Dynamic W8A8 checkpoint parity placeholder.
   QuantArgs quant_args_;
   torch::TensorOptions options_;
+  at::ScalarType output_dtype_;
   std::optional<std::string> resolved_weight_quant_method_;
 };
 TORCH_MODULE(ReplicatedLinear);

--- a/xllm/core/layers/npu_torch/deepseek_sparse_attention.cpp
+++ b/xllm/core/layers/npu_torch/deepseek_sparse_attention.cpp
@@ -31,6 +31,31 @@ namespace xllm {
 namespace layer {
 namespace {
 
+struct Dsv4PreprocessOutputs {
+  torch::Tensor qr;
+  std::optional<torch::Tensor> qr_pertoken_scale;
+  torch::Tensor q;
+  torch::Tensor kv;
+};
+
+torch::Tensor w8a8_dynamic_linear_forward(
+    const torch::Tensor& quantized_input,
+    const torch::Tensor& weight,
+    const torch::Tensor& weight_scale,
+    const torch::Tensor& pertoken_scale,
+    const std::optional<torch::Tensor>& bias,
+    at::ScalarType output_dtype) {
+  xllm::kernel::QuantMatmulParams params;
+  params.x1 = quantized_input;
+  params.x2 = weight;
+  params.transpose2 = true;
+  params.scale = weight_scale;
+  params.pertoken_scale = pertoken_scale;
+  params.bias = bias;
+  params.output_dtype = output_dtype;
+  return xllm::kernel::quant_matmul(params);
+}
+
 struct DsaCacheMapping {
   int64_t cmp_cache_idx = -1;
   int64_t index_cache_idx = -1;
@@ -202,7 +227,8 @@ void scatter_by_slot(torch::Tensor& cache,
     auto valid_mask = slots_slice.ge(0).unsqueeze(1);
     auto old_values = cache_2d.index_select(/*dim=*/0, safe_slots);
     auto safe_values = torch::where(valid_mask, value_slice, old_values);
-    cache_2d.index_copy_(/*dim=*/0, safe_slots, safe_values);
+    xllm::kernel::npu::scatter_nd_update(
+        cache_2d, safe_slots.reshape({-1, 1}), safe_values);
     return;
   }
 
@@ -302,6 +328,66 @@ std::tuple<torch::Tensor, torch::Tensor> build_prefill_pa_nd_kv(
   auto table = table_cpu.to(
       block_table_hint.defined() ? block_table_hint.device() : kv.device());
   return {packed_kv, table};
+}
+
+Dsv4PreprocessOutputs run_dsv4_preprocess_fallback(
+    ReplicatedLinear& q_a_proj,
+    RMSNorm& q_layernorm,
+    ColumnParallelLinear& q_b_proj,
+    ReplicatedLinear& kv_proj,
+    RMSNorm& kv_layernorm,
+    const torch::Tensor& hidden_states,
+    int64_t n_local_heads,
+    int64_t head_dim,
+    int64_t qk_head_dim,
+    int64_t nope_head_dim,
+    int64_t rope_head_dim,
+    double eps,
+    const torch::Tensor& q_rms_gamma,
+    const torch::Tensor& cos,
+    const torch::Tensor& sin) {
+  Dsv4PreprocessOutputs outputs;
+
+  auto q_down = q_a_proj->forward(hidden_states);
+  if (q_b_proj->uses_w8a8_dynamic_quant()) {
+    xllm::kernel::RmsNormDynamicQuantParams rms_quant_params;
+    rms_quant_params.input = q_down;
+    rms_quant_params.weight = q_layernorm->weight();
+    rms_quant_params.eps = eps;
+    torch::Tensor q_pertoken_scale;
+    std::tie(outputs.qr, q_pertoken_scale) =
+        xllm::kernel::rms_norm_dynamic_quant(rms_quant_params);
+    outputs.qr_pertoken_scale = q_pertoken_scale;
+    outputs.q =
+        w8a8_dynamic_linear_forward(outputs.qr,
+                                    q_b_proj->weight(),
+                                    q_b_proj->w8a8_dynamic_weight_scale(),
+                                    q_pertoken_scale,
+                                    q_b_proj->bias(),
+                                    hidden_states.scalar_type())
+            .view({-1, n_local_heads, head_dim});
+  } else {
+    outputs.qr = std::get<0>(q_layernorm->forward(q_down));
+    outputs.q =
+        q_b_proj->forward(outputs.qr).view({-1, n_local_heads, head_dim});
+  }
+
+  xllm::kernel::FusedLayerNormParams q_rmsnorm_params;
+  q_rmsnorm_params.input = outputs.q;
+  q_rmsnorm_params.weight = q_rms_gamma;
+  q_rmsnorm_params.mode = "rmsnorm";
+  q_rmsnorm_params.eps = eps;
+  xllm::kernel::fused_layernorm(q_rmsnorm_params);
+  outputs.q = q_rmsnorm_params.output;
+
+  auto kv_down = kv_proj->forward(hidden_states);
+  outputs.kv = std::get<0>(kv_layernorm->forward(kv_down));
+  outputs.kv = outputs.kv.view({-1, 1, qk_head_dim});
+
+  apply_partial_rope(outputs.q, nope_head_dim, rope_head_dim, cos, sin);
+  apply_partial_rope(outputs.kv, nope_head_dim, rope_head_dim, cos, sin);
+
+  return outputs;
 }
 
 AttentionMetadata build_indexer_attention_metadata(
@@ -529,30 +615,28 @@ DSAttentionImpl::forward(const DSAMetadata& attn_metadata,
 
   auto [c1_metadata, c4_metadata, c128_metadata, qli_metadata] =
       compress_metadata;
-
-  // 1) q projection + q rmsnorm
-  auto q_down = q_a_proj_->forward(hidden_states);
-  auto qr = std::get<0>(q_layernorm_->forward(q_down));
-  auto q = q_b_proj_->forward(qr).view({-1, n_local_heads_, head_dim_});
-
-  xllm::kernel::FusedLayerNormParams q_rmsnorm_params;
-  q_rmsnorm_params.input = q;
-  q_rmsnorm_params.weight = q_rms_gamma_;
-  q_rmsnorm_params.mode = "rmsnorm";
-  q_rmsnorm_params.eps = eps_;
-  xllm::kernel::fused_layernorm(q_rmsnorm_params);
-  q = q_rmsnorm_params.output;
-
-  // 2) kv projection
-  auto kv_down = kv_proj_->forward(hidden_states);
-  auto kv = std::get<0>(kv_layernorm_->forward(kv_down));
-  kv = kv.view({-1, 1, qk_head_dim_});
-
-  // 3) RoPE (q and kv)
   auto cos = attn_metadata.cos;
   auto sin = attn_metadata.sin;
-  apply_partial_rope(q, nope_head_dim_, rope_head_dim_, cos, sin);
-  apply_partial_rope(kv, nope_head_dim_, rope_head_dim_, cos, sin);
+  Dsv4PreprocessOutputs preprocess_outputs =
+      run_dsv4_preprocess_fallback(q_a_proj_,
+                                   q_layernorm_,
+                                   q_b_proj_,
+                                   kv_proj_,
+                                   kv_layernorm_,
+                                   hidden_states,
+                                   n_local_heads_,
+                                   head_dim_,
+                                   qk_head_dim_,
+                                   nope_head_dim_,
+                                   rope_head_dim_,
+                                   eps_,
+                                   q_rms_gamma_,
+                                   cos,
+                                   sin);
+  auto qr = preprocess_outputs.qr;
+  auto qr_pertoken_scale = preprocess_outputs.qr_pertoken_scale;
+  auto q = preprocess_outputs.q;
+  auto kv = preprocess_outputs.kv;
 
   // 4) resolve per-layer cache mapping
   const int64_t compress_ratio_i = static_cast<int64_t>(compress_ratio_);
@@ -697,6 +781,7 @@ DSAttentionImpl::forward(const DSAMetadata& attn_metadata,
     compress_topk_idxs =
         indexer_->select_qli(hidden_states,
                              qr,
+                             qr_pertoken_scale,
                              index_cache,
                              &indexer_cache_scale,
                              indexer_metadata,

--- a/xllm/core/layers/npu_torch/deepseek_v4_indexer.cpp
+++ b/xllm/core/layers/npu_torch/deepseek_v4_indexer.cpp
@@ -23,6 +23,7 @@ limitations under the License.
 #include <vector>
 
 #include "kernels/ops_api.h"
+#include "xllm/core/kernels/npu/xllm_ops/xllm_ops_api.h"
 
 namespace xllm {
 namespace layer {
@@ -86,61 +87,100 @@ torch::Tensor rotate_activation_with_hadamard(const torch::Tensor& x,
   return out;
 }
 
+struct SlotScatterPlan {
+  torch::Tensor slots_slice;
+  torch::Tensor safe_indices;
+  int64_t update_rows = 0;
+};
+
+SlotScatterPlan prepare_slot_scatter_plan(const torch::Tensor& slot_mapping,
+                                          int64_t value_rows,
+                                          const c10::Device& device) {
+  SlotScatterPlan plan;
+  if (!slot_mapping.defined() || slot_mapping.numel() == 0 || value_rows <= 0) {
+    return plan;
+  }
+
+  torch::Tensor slots = slot_mapping.reshape({-1}).to(torch::kLong).to(device);
+  plan.update_rows = std::min<int64_t>(slots.size(0), value_rows);
+  if (plan.update_rows <= 0) {
+    return plan;
+  }
+
+  plan.slots_slice =
+      slots.slice(/*dim=*/0, /*start=*/0, /*end=*/plan.update_rows);
+  if (!device.is_cpu()) {
+    plan.safe_indices = plan.slots_slice.clamp_min(0).reshape({-1, 1});
+  }
+  return plan;
+}
+
 // Scatter a row-major tensor into a flattened cache according to slot ids.
 // Each valid slot in `slot_mapping` selects the destination row for the same
 // row in `value`; negative slots are treated as padding and ignored.
+void scatter_rows_by_prepared_slot(torch::Tensor& cache,
+                                   const SlotScatterPlan& plan,
+                                   const torch::Tensor& value) {
+  if (!cache.defined() || !value.defined() || !plan.slots_slice.defined()) {
+    return;
+  }
+  if (plan.update_rows <= 0 || value.numel() == 0) {
+    return;
+  }
+
+  auto value_2d = value.reshape({-1, value.size(value.dim() - 1)});
+  auto cache_2d = cache.view({-1, value_2d.size(1)});
+  const int64_t update_rows =
+      std::min<int64_t>(plan.update_rows, value_2d.size(0));
+  if (update_rows <= 0) {
+    return;
+  }
+
+  torch::Tensor slots_slice =
+      plan.slots_slice.slice(/*dim=*/0, /*start=*/0, /*end=*/update_rows);
+  torch::Tensor value_slice =
+      value_2d.slice(/*dim=*/0, /*start=*/0, /*end=*/update_rows);
+
+  if (!cache.device().is_cpu()) {
+    torch::Tensor safe_indices =
+        plan.safe_indices.defined()
+            ? plan.safe_indices.slice(/*dim=*/0,
+                                      /*start=*/0,
+                                      /*end=*/update_rows)
+            : slots_slice.clamp_min(0).reshape({-1, 1});
+    xllm::kernel::npu::scatter_nd_update(cache_2d, safe_indices, value_slice);
+    return;
+  }
+
+  // Negative slots mean "unused" entries in the metadata. Skip them so the
+  // caller can pass padded or partially-filled mappings safely.
+  torch::Tensor valid_mask = slots_slice.ge(0);
+  torch::Tensor valid_slots = slots_slice.index({valid_mask});
+  if (valid_slots.numel() == 0) {
+    return;
+  }
+
+  torch::Tensor valid_values = value_slice.index({valid_mask});
+  const int64_t cache_rows = cache_2d.size(0);
+  const int64_t max_slot = valid_slots.max().item<int64_t>();
+  CHECK_LT(max_slot, cache_rows)
+      << "scatter_rows_by_slot slot index out of range: max_slot=" << max_slot
+      << ", cache_rows=" << cache_rows << ", value_shape=" << value.sizes();
+  // Write the valid rows into the flattened cache view.
+  cache_2d.index_copy_(/*dim=*/0, valid_slots, valid_values);
+}
+
 void scatter_rows_by_slot(torch::Tensor& cache,
                           const torch::Tensor& slot_mapping,
                           const torch::Tensor& value) {
   if (!cache.defined() || !slot_mapping.defined() || !value.defined()) {
     return;
   }
-  if (slot_mapping.numel() == 0 || value.numel() == 0) {
-    return;
-  }
 
-  auto value_2d = value.reshape({-1, value.size(value.dim() - 1)});
-  auto cache_2d = cache.view({-1, value_2d.size(1)});
-  // slot_mapping and value are both flattened to row-major form. We only
-  // update the rows that have matching source data.
-  auto slots = slot_mapping.reshape({-1}).to(torch::kLong).to(cache.device());
-  const int64_t update_rows =
-      std::min<int64_t>(slots.size(0), value_2d.size(0));
-  if (update_rows <= 0) {
-    return;
-  }
-
-  auto slots_slice = slots.slice(/*dim=*/0, /*start=*/0, /*end=*/update_rows);
-  auto value_slice =
-      value_2d.slice(/*dim=*/0, /*start=*/0, /*end=*/update_rows);
-
-  if (!cache.device().is_cpu()) {
-    auto safe_slots = slots_slice.clamp_min(0);
-    auto valid_mask = slots_slice.ge(0).unsqueeze(1);
-    auto old_values = cache_2d.index_select(/*dim=*/0, safe_slots);
-    auto safe_values = torch::where(valid_mask, value_slice, old_values);
-    cache_2d.index_copy_(/*dim=*/0, safe_slots, safe_values);
-    return;
-  }
-
-  // Negative slots mean "unused" entries in the metadata. Skip them so the
-  // caller can pass padded or partially-filled mappings safely.
-  auto valid_mask = slots_slice.ge(0);
-  auto valid_slots = slots_slice.index({valid_mask});
-  if (valid_slots.numel() == 0) {
-    return;
-  }
-
-  auto valid_values = value_slice.index({valid_mask});
-  const int64_t cache_rows = cache_2d.size(0);
-  const int64_t max_slot = valid_slots.max().item<int64_t>();
-  CHECK_LT(max_slot, cache_rows)
-      << "scatter_rows_by_slot slot index out of range: max_slot=" << max_slot
-      << ", cache_rows=" << cache_rows
-      << ", slot_shape=" << slot_mapping.sizes()
-      << ", value_shape=" << value.sizes();
-  // Write the valid rows into the flattened cache view.
-  cache_2d.index_copy_(/*dim=*/0, valid_slots, valid_values);
+  torch::Tensor value_2d = value.reshape({-1, value.size(value.dim() - 1)});
+  SlotScatterPlan plan =
+      prepare_slot_scatter_plan(slot_mapping, value_2d.size(0), cache.device());
+  scatter_rows_by_prepared_slot(cache, plan, value);
 }
 
 torch::Tensor apply_partial_rope(torch::Tensor q,
@@ -185,6 +225,18 @@ torch::Tensor apply_partial_rope(torch::Tensor q,
 
 std::tuple<torch::Tensor, torch::Tensor> dynamic_quant_int8(
     const torch::Tensor& input) {
+  if (!input.device().is_cpu()) {
+    xllm::kernel::NpuQuantizeParams quant_params;
+    quant_params.input = input;
+
+    torch::Tensor quant;
+    std::optional<torch::Tensor> scale;
+    std::tie(quant, scale) = xllm::kernel::dynamic_quant(quant_params);
+    CHECK(scale.has_value() && scale->defined())
+        << "DeepseekV4Indexer dynamic_quant must return scale.";
+    return {quant, scale.value()};
+  }
+
   auto max_abs = input.abs().amax(-1, true).to(torch::kFloat32);
   auto safe_max = torch::where(max_abs > 0, max_abs, torch::ones_like(max_abs));
   auto scale = safe_max / 127.0;
@@ -262,6 +314,26 @@ torch::Tensor DeepseekV4IndexerImpl::build_query(const torch::Tensor& qr) {
   return q;
 }
 
+torch::Tensor DeepseekV4IndexerImpl::build_query(
+    const torch::Tensor& qr,
+    const std::optional<torch::Tensor>& qr_pertoken_scale) {
+  CHECK(qr.defined()) << "DeepseekV4Indexer::build_query: qr is undefined";
+  if (wq_b_->uses_w8a8_dynamic_quant() && qr_pertoken_scale.has_value() &&
+      qr_pertoken_scale->defined()) {
+    xllm::kernel::QuantMatmulParams params;
+    params.x1 = qr;
+    params.x2 = wq_b_->weight();
+    params.transpose2 = true;
+    params.scale = wq_b_->w8a8_dynamic_weight_scale();
+    params.pertoken_scale = qr_pertoken_scale;
+    params.bias = wq_b_->bias();
+    params.output_dtype = wq_b_->output_dtype();
+    auto q = xllm::kernel::quant_matmul(params);
+    return q.view({q.size(0), n_heads_, head_dim_});
+  }
+  return build_query(qr);
+}
+
 torch::Tensor DeepseekV4IndexerImpl::build_weights(const torch::Tensor& x) {
   CHECK(x.defined()) << "DeepseekV4Indexer::build_weights: x is undefined";
   return weights_proj_->forward(x) * indexer_softmax_mul_head_dim_sqrt_;
@@ -321,6 +393,7 @@ std::tuple<torch::Tensor, torch::Tensor> DeepseekV4IndexerImpl::forward(
 torch::Tensor DeepseekV4IndexerImpl::select_qli(
     const torch::Tensor& x,
     const torch::Tensor& qr,
+    const std::optional<torch::Tensor>& qr_pertoken_scale,
     torch::Tensor& index_cache,
     torch::Tensor* quant_index_cache,
     const AttentionMetadata& attn_metadata,
@@ -338,7 +411,7 @@ torch::Tensor DeepseekV4IndexerImpl::select_qli(
       << "DeepseekV4Indexer::select_qli: index_cache is undefined";
 
   (void)with_prefill;
-  auto q = build_query(qr);
+  auto q = build_query(qr, qr_pertoken_scale);
   if (cos.has_value() && sin.has_value()) {
     const int64_t rope_start_dim =
         std::max<int64_t>(head_dim_ - rope_head_dim_, 0);
@@ -371,10 +444,13 @@ torch::Tensor DeepseekV4IndexerImpl::select_qli(
   }
 
   if (kv.numel() > 0) {
-    scatter_rows_by_slot(index_cache, attn_metadata.slot_mapping, kv_quant);
+    torch::Tensor kv_quant_2d =
+        kv_quant.reshape({-1, kv_quant.size(kv_quant.dim() - 1)});
+    SlotScatterPlan scatter_plan = prepare_slot_scatter_plan(
+        attn_metadata.slot_mapping, kv_quant_2d.size(0), index_cache.device());
+    scatter_rows_by_prepared_slot(index_cache, scatter_plan, kv_quant);
     if (quant_index_cache != nullptr && quant_index_cache->defined()) {
-      scatter_rows_by_slot(
-          *quant_index_cache, attn_metadata.slot_mapping, kv_scale);
+      scatter_rows_by_prepared_slot(*quant_index_cache, scatter_plan, kv_scale);
     }
   }
 
@@ -460,6 +536,7 @@ torch::Tensor DeepseekV4IndexerImpl::select_qli(
 torch::Tensor DeepseekV4IndexerImpl::select_qli(
     const torch::Tensor& x,
     const torch::Tensor& qr,
+    const std::optional<torch::Tensor>& qr_pertoken_scale,
     torch::Tensor& index_cache,
     const AttentionMetadata& attn_metadata,
     const std::optional<torch::Tensor>& cos,
@@ -474,6 +551,7 @@ torch::Tensor DeepseekV4IndexerImpl::select_qli(
     std::tuple<torch::Tensor, torch::Tensor>* compressor_block_tables) {
   return select_qli(x,
                     qr,
+                    qr_pertoken_scale,
                     index_cache,
                     /*quant_index_cache=*/nullptr,
                     attn_metadata,

--- a/xllm/core/layers/npu_torch/deepseek_v4_indexer.h
+++ b/xllm/core/layers/npu_torch/deepseek_v4_indexer.h
@@ -50,6 +50,7 @@ class DeepseekV4IndexerImpl : public torch::nn::Module {
   torch::Tensor select_qli(
       const torch::Tensor& x,
       const torch::Tensor& qr,
+      const std::optional<torch::Tensor>& qr_pertoken_scale,
       torch::Tensor& index_cache,
       torch::Tensor* quant_index_cache,
       const AttentionMetadata& attn_metadata,
@@ -69,6 +70,7 @@ class DeepseekV4IndexerImpl : public torch::nn::Module {
   torch::Tensor select_qli(
       const torch::Tensor& x,
       const torch::Tensor& qr,
+      const std::optional<torch::Tensor>& qr_pertoken_scale,
       torch::Tensor& index_cache,
       const AttentionMetadata& attn_metadata,
       const std::optional<torch::Tensor>& cos = std::nullopt,
@@ -85,6 +87,9 @@ class DeepseekV4IndexerImpl : public torch::nn::Module {
           nullptr);
 
   torch::Tensor build_query(const torch::Tensor& qr);
+  torch::Tensor build_query(
+      const torch::Tensor& qr,
+      const std::optional<torch::Tensor>& qr_pertoken_scale);
 
   torch::Tensor build_weights(const torch::Tensor& x);
 

--- a/xllm/core/layers/npu_torch/fused_moe.cpp
+++ b/xllm/core/layers/npu_torch/fused_moe.cpp
@@ -24,10 +24,18 @@ limitations under the License.
 #include <string>
 #include <vector>
 
+#ifdef TORCH_HIGHER_THAN_PTA6
+#include <torch_npu/csrc/aten/CustomFunctions.h>
+#include <torch_npu/csrc/core/npu/NPUFormat.h>
+#else
+#include <torch_npu/csrc/aten/NPUNativeFunctions.h>
+#endif
+
 #include "common/global_flags.h"
 #include "framework/parallel_state/parallel_state.h"
 #include "kernels/ops_api.h"
 #include "layers/common/dp_utils.h"
+#include "platform/device.h"
 
 namespace xllm {
 namespace layer {
@@ -100,6 +108,52 @@ bool is_supported_dynamic_moe_quant_method(
     const std::optional<std::string>& quant_method) {
   return is_w8a8_dynamic_quant_method(quant_method) ||
          is_w4a8_dynamic_quant_method(quant_method);
+}
+
+torch::Tensor convert_fp32_scale_to_int64(const torch::Tensor& scale) {
+  return scale.to(torch::kFloat32).view(torch::kInt32).to(torch::kInt64);
+}
+
+int64_t get_tensor_npu_format(const torch::Tensor& tensor) {
+#ifdef TORCH_HIGHER_THAN_PTA6
+  return at_npu::native::get_npu_format(tensor);
+#else
+  return at_npu::native::NPUNativeFunctions::get_npu_format(tensor);
+#endif
+}
+
+torch::Tensor npu_format_cast(const torch::Tensor& tensor, int64_t format) {
+#ifdef TORCH_HIGHER_THAN_PTA6
+  return at_npu::native::npu_format_cast(tensor, format);
+#else
+  return at_npu::native::NPUNativeFunctions::npu_format_cast(tensor, format);
+#endif
+}
+
+void empty_cache_for_tensor(const torch::Tensor& tensor) {
+  if (!tensor.defined() || tensor.device().is_cpu() ||
+      tensor.device().index() < 0) {
+    return;
+  }
+  xllm::Device::empty_cache(static_cast<int32_t>(tensor.device().index()));
+}
+
+bool maybe_trans_nz(torch::Tensor& weight) {
+  if (weight.device().is_cpu() ||
+      get_tensor_npu_format(weight) == ACL_FORMAT_FRACTAL_NZ) {
+    return false;
+  }
+  weight.set_data(npu_format_cast(weight, ACL_FORMAT_FRACTAL_NZ));
+  empty_cache_for_tensor(weight);
+  return true;
+}
+
+void ensure_contiguous_for_fused_mc2(torch::Tensor& weight) {
+  if (weight.is_contiguous()) {
+    return;
+  }
+  weight.set_data(weight.contiguous());
+  empty_cache_for_tensor(weight);
 }
 
 bool should_apply_shared_expert_gate(
@@ -631,7 +685,7 @@ void FusedMoEImpl::ensure_group_gemm_weight_layout(torch::Tensor& weight,
 
   if (!prepared) {
     if (weight.size(1) == output_dim && weight.size(2) == input_dim) {
-      weight = weight.transpose(1, 2);
+      weight.set_data(weight.transpose(1, 2));
     } else if (weight.size(1) == input_dim && weight.size(2) == output_dim) {
       // Already in grouped-matmul [expert, input, output] layout.
     } else {
@@ -775,7 +829,26 @@ torch::Tensor FusedMoEImpl::forward_expert(
                                     local_intermediate_size_ * 2,
                                     "w13");
 
-    {
+    // Step 5-6: first grouped matmul + fused dequant + swiglu + quant.
+    torch::Tensor act_quantized;
+    torch::Tensor act_scale;
+    if (FLAGS_enable_fused_moe_gmm_swiglu) {
+      CHECK(is_gated_ && (hidden_act_ == "silu" || hidden_act_ == "swiglu"))
+          << "--enable_fused_moe_gmm_swiglu requires gated SiLU/SwiGLU MoE, "
+          << "got is_gated=" << (is_gated_ ? "true" : "false")
+          << ", hidden_act=" << hidden_act_;
+      maybe_trans_nz(w13_);
+
+      xllm::kernel::GroupedMatmulSwigluQuantParams params;
+      params.x = quantized_expand_hidden_states;
+      params.weight = w13_;
+      params.group_list =
+          torch::cumsum(selected_expert_info.token_count_slice, 0);
+      params.weight_scale = w13_scale_;
+      params.x_scale = pertoken_scale.value();
+      std::tie(act_quantized, act_scale) =
+          xllm::kernel::grouped_matmul_swiglu_quant(params);
+    } else {
       std::vector<torch::Tensor> x_list = {quantized_expand_hidden_states};
       std::vector<torch::Tensor> weight_list = {w13_};
       xllm::kernel::GroupGemmParams group_gemm_params;
@@ -787,12 +860,7 @@ torch::Tensor FusedMoEImpl::forward_expert(
       group_gemm_params.group_list_type = 1;
       group_gemm_params.output_dtype = torch::kInt32;
       gemm1_out = xllm::kernel::group_gemm(group_gemm_params);
-    }
 
-    // Step 6: fused dequant + swiglu + quant.
-    torch::Tensor act_quantized;
-    torch::Tensor act_scale;
-    {
       xllm::kernel::DequantSwigluQuantParams params;
       params.x = gemm1_out;
       params.weight_scale = w13_scale_;
@@ -1047,9 +1115,6 @@ bool FusedMoEImpl::can_use_ep2_dispatch_combine(
   if (!enable_ep2_dispatch_combine_) {
     return false;
   }
-  if (!all_dp_ranks_are_decode(input_params)) {
-    return false;
-  }
   if (hidden_states.scalar_type() != torch::kHalf &&
       hidden_states.scalar_type() != torch::kBFloat16) {
     return false;
@@ -1064,7 +1129,201 @@ bool FusedMoEImpl::can_use_ep2_dispatch_combine(
   if (is_w4a8_dynamic_quant_method(resolved_moe_quant_method_)) {
     return false;
   }
+  const int32_t mode = fused_mc2_mode();
+  if (mode == 1) {
+    return is_w8a8_dynamic_quant_method(resolved_moe_quant_method_) &&
+           xllm::kernel::has_dispatch_ffn_combine() && w13_is_loaded_ &&
+           w2_is_loaded_ && w13_scale_is_loaded_ && w2_scale_is_loaded_ &&
+           hidden_act_ == xllm::kernel::kActModeSilu && is_gated_;
+  }
+  if (!all_dp_ranks_are_decode(input_params)) {
+    return false;
+  }
+  if (mode == 2) {
+    return is_w8a8_dynamic_quant_method(resolved_moe_quant_method_) &&
+           xllm::kernel::has_dispatch_gmm_combine_decode() && w13_is_loaded_ &&
+           w2_is_loaded_ && w13_scale_is_loaded_ && w2_scale_is_loaded_ &&
+           hidden_act_ == xllm::kernel::kActModeSilu && is_gated_;
+  }
   return xllm::kernel::has_moe_distribute_dispatch_combine_v2();
+}
+
+int32_t FusedMoEImpl::fused_mc2_mode() const {
+  CHECK_GE(FLAGS_enable_fused_mc2, 0)
+      << "--enable_fused_mc2 must be 0, 1, or 2.";
+  CHECK_LE(FLAGS_enable_fused_mc2, 2)
+      << "--enable_fused_mc2 must be 0, 1, or 2.";
+  return FLAGS_enable_fused_mc2;
+}
+
+bool FusedMoEImpl::prepare_dispatch_ffn_combine_inputs() {
+  if (fused_mc2_mode() != 1) {
+    return false;
+  }
+  if (!is_w8a8_dynamic_quant_method(resolved_moe_quant_method_)) {
+    return false;
+  }
+  if (!xllm::kernel::has_dispatch_ffn_combine()) {
+    return false;
+  }
+  if (!(w13_is_loaded_ && w2_is_loaded_ && w13_scale_is_loaded_ &&
+        w2_scale_is_loaded_)) {
+    return false;
+  }
+  if (hidden_act_ != xllm::kernel::kActModeSilu || !is_gated_) {
+    return false;
+  }
+  if (dispatch_ffn_combine_prepared_) {
+    return true;
+  }
+
+  ensure_group_gemm_weight_layout(w13_,
+                                  w13_group_gemm_layout_prepared_,
+                                  hidden_size_,
+                                  local_intermediate_size_ * 2,
+                                  "w13");
+  ensure_group_gemm_weight_layout(w2_,
+                                  w2_group_gemm_layout_prepared_,
+                                  local_intermediate_size_,
+                                  hidden_size_,
+                                  "w2");
+  ensure_contiguous_for_fused_mc2(w13_);
+  ensure_contiguous_for_fused_mc2(w2_);
+  empty_cache_for_tensor(w13_);
+  empty_cache_for_tensor(w2_);
+  maybe_trans_nz(w13_);
+  maybe_trans_nz(w2_);
+  w13_group_gemm_layout_prepared_ = false;
+  w2_group_gemm_layout_prepared_ = false;
+  dispatch_ffn_w13_scale_ =
+      convert_fp32_scale_to_int64(w13_scale_).contiguous();
+  dispatch_ffn_w2_scale_ = convert_fp32_scale_to_int64(w2_scale_).contiguous();
+  empty_cache_for_tensor(dispatch_ffn_w13_scale_);
+  empty_cache_for_tensor(dispatch_ffn_w2_scale_);
+  dispatch_ffn_combine_prepared_ = true;
+  return true;
+}
+
+bool FusedMoEImpl::prepare_dispatch_gmm_combine_decode_inputs() {
+  if (fused_mc2_mode() != 2) {
+    return false;
+  }
+  if (!is_w8a8_dynamic_quant_method(resolved_moe_quant_method_)) {
+    return false;
+  }
+  if (!xllm::kernel::has_dispatch_gmm_combine_decode()) {
+    return false;
+  }
+  if (!(w13_is_loaded_ && w2_is_loaded_ && w13_scale_is_loaded_ &&
+        w2_scale_is_loaded_)) {
+    return false;
+  }
+  if (hidden_act_ != xllm::kernel::kActModeSilu || !is_gated_) {
+    return false;
+  }
+  if (dispatch_gmm_combine_decode_prepared_) {
+    return true;
+  }
+
+  ensure_group_gemm_weight_layout(w13_,
+                                  w13_group_gemm_layout_prepared_,
+                                  hidden_size_,
+                                  local_intermediate_size_ * 2,
+                                  "w13");
+  ensure_group_gemm_weight_layout(w2_,
+                                  w2_group_gemm_layout_prepared_,
+                                  local_intermediate_size_,
+                                  hidden_size_,
+                                  "w2");
+  ensure_contiguous_for_fused_mc2(w13_);
+  ensure_contiguous_for_fused_mc2(w2_);
+  empty_cache_for_tensor(w13_);
+  empty_cache_for_tensor(w2_);
+  maybe_trans_nz(w13_);
+  maybe_trans_nz(w2_);
+  w13_group_gemm_layout_prepared_ = false;
+  w2_group_gemm_layout_prepared_ = false;
+  w13_scale_ = w13_scale_.to(torch::kFloat32).contiguous();
+  w2_scale_ = w2_scale_.contiguous();
+  empty_cache_for_tensor(w13_scale_);
+  empty_cache_for_tensor(w2_scale_);
+  dispatch_gmm_combine_decode_prepared_ = true;
+  return true;
+}
+
+torch::Tensor FusedMoEImpl::forward_with_dispatch_ffn_combine(
+    const torch::Tensor& input_2d,
+    const torch::Tensor& weights_2d,
+    const torch::Tensor& ids_2d,
+    at::IntArrayRef hidden_states_shape) {
+  std::vector<torch::Tensor> weight1_list = {w13_};
+  std::vector<torch::Tensor> weight2_list = {w2_};
+  std::vector<torch::Tensor> scale1_list = {dispatch_ffn_w13_scale_};
+  std::vector<torch::Tensor> scale2_list = {dispatch_ffn_w2_scale_};
+
+  xllm::kernel::DispatchFFNCombineParams params;
+  params.x = input_2d;
+  params.weight1 = torch::TensorList(weight1_list);
+  params.weight2 = torch::TensorList(weight2_list);
+  params.expert_ids = ids_2d;
+  params.scale1 = torch::TensorList(scale1_list);
+  params.scale2 = torch::TensorList(scale2_list);
+  params.probs = weights_2d;
+  params.group = get_moe_ep_group_name();
+  params.max_output_size = 65536;
+  params.swiglu_limit = is_deepseek_v4_ ? 10.0 : 0.0;
+  params.output = torch::empty_like(input_2d);
+  params.expert_token_nums = torch::empty(
+      {num_experts_per_rank_}, ids_2d.options().dtype(torch::kInt32));
+
+  torch::Tensor final_hidden_states_2d;
+  torch::Tensor expert_token_nums;
+  std::tie(final_hidden_states_2d, expert_token_nums) =
+      xllm::kernel::dispatch_ffn_combine(params);
+  (void)expert_token_nums;
+  if (is_deepseek_v4_) {
+    final_hidden_states_2d = final_hidden_states_2d * route_scale_;
+  }
+  return final_hidden_states_2d.reshape(hidden_states_shape);
+}
+
+torch::Tensor FusedMoEImpl::forward_with_dispatch_gmm_combine_decode(
+    const torch::Tensor& input_2d,
+    const torch::Tensor& weights_2d,
+    const torch::Tensor& ids_2d,
+    at::IntArrayRef hidden_states_shape,
+    int64_t global_bs) {
+  std::vector<torch::Tensor> weight1_list = {w13_};
+  std::vector<torch::Tensor> weight2_list = {w2_};
+  std::vector<torch::Tensor> scale1_list = {w13_scale_};
+  std::vector<torch::Tensor> scale2_list = {w2_scale_};
+
+  xllm::kernel::DispatchGmmCombineDecodeParams params;
+  params.x = input_2d;
+  params.expert_ids = ids_2d;
+  params.gmm1_permuted_weight = torch::TensorList(weight1_list);
+  params.gmm1_permuted_weight_scale = torch::TensorList(scale1_list);
+  params.gmm2_weight = torch::TensorList(weight2_list);
+  params.gmm2_weight_scale = torch::TensorList(scale2_list);
+  params.expert_scales = weights_2d;
+  params.group_ep = get_moe_ep_group_name();
+  params.ep_rank_size = parallel_args_.moe_ep_group_->world_size();
+  params.ep_rank_id = parallel_args_.moe_ep_group_->rank();
+  params.moe_expert_num = num_total_experts_;
+  params.shared_expert_num = 0;
+  params.shared_expert_rank_num = 0;
+  params.quant_mode = 0;
+  params.global_bs = global_bs;
+
+  torch::Tensor final_hidden_states_2d;
+  torch::Tensor expert_token_nums;
+  std::tie(final_hidden_states_2d, expert_token_nums) =
+      xllm::kernel::dispatch_gmm_combine_decode(params);
+  (void)expert_token_nums;
+  if (is_deepseek_v4_) {
+    final_hidden_states_2d = final_hidden_states_2d * route_scale_;
+  }
+  return final_hidden_states_2d.reshape(hidden_states_shape);
 }
 
 const std::string& FusedMoEImpl::get_moe_ep_group_name() {
@@ -1083,6 +1342,9 @@ torch::Tensor FusedMoEImpl::forward_with_selected_experts_ep2(
     const torch::Tensor& topk_ids,
     const ModelInputParams& input_params) {
   (void)input_params;
+  prepare_dispatch_ffn_combine_inputs();
+  prepare_dispatch_gmm_combine_decode_inputs();
+
   const auto hidden_states_shape = hidden_states.sizes();
   auto input_2d =
       hidden_states.reshape({-1, hidden_states.size(-1)}).contiguous();
@@ -1106,6 +1368,14 @@ torch::Tensor FusedMoEImpl::forward_with_selected_experts_ep2(
                                 int64_t{0});
   }
 
+  if (dispatch_ffn_combine_prepared_) {
+    return forward_with_dispatch_ffn_combine(
+        input_2d, weights_2d, ids_2d, hidden_states_shape);
+  }
+  if (dispatch_gmm_combine_decode_prepared_) {
+    return forward_with_dispatch_gmm_combine_decode(
+        input_2d, weights_2d, ids_2d, hidden_states_shape, global_bs);
+  }
   xllm::kernel::MoeDistributeDispatchV2Params dispatch_params;
   dispatch_params.x = input_2d;
   dispatch_params.expert_ids = ids_2d;
@@ -1156,7 +1426,25 @@ torch::Tensor FusedMoEImpl::forward_with_selected_experts_ep2(
                                     quantized_expand_hidden_states.size(1),
                                     local_intermediate_size_ * 2,
                                     "w13");
-    {
+
+    torch::Tensor act_quantized;
+    torch::Tensor act_scale;
+    if (FLAGS_enable_fused_moe_gmm_swiglu) {
+      CHECK(is_gated_ && (hidden_act_ == "silu" || hidden_act_ == "swiglu"))
+          << "--enable_fused_moe_gmm_swiglu requires gated SiLU/SwiGLU MoE, "
+          << "got is_gated=" << (is_gated_ ? "true" : "false")
+          << ", hidden_act=" << hidden_act_;
+      maybe_trans_nz(w13_);
+
+      xllm::kernel::GroupedMatmulSwigluQuantParams params;
+      params.x = quantized_expand_hidden_states;
+      params.weight = w13_;
+      params.group_list = torch::cumsum(group_list.to(torch::kInt64), 0);
+      params.weight_scale = w13_scale_;
+      params.x_scale = pertoken_scale.value();
+      std::tie(act_quantized, act_scale) =
+          xllm::kernel::grouped_matmul_swiglu_quant(params);
+    } else {
       std::vector<torch::Tensor> x_list = {quantized_expand_hidden_states};
       std::vector<torch::Tensor> weight_list = {w13_};
       xllm::kernel::GroupGemmParams group_gemm_params;
@@ -1168,11 +1456,7 @@ torch::Tensor FusedMoEImpl::forward_with_selected_experts_ep2(
       group_gemm_params.group_list_type = 1;
       group_gemm_params.output_dtype = torch::kInt32;
       gemm1_out = xllm::kernel::group_gemm(group_gemm_params);
-    }
 
-    torch::Tensor act_quantized;
-    torch::Tensor act_scale;
-    {
       xllm::kernel::DequantSwigluQuantParams params;
       params.x = gemm1_out;
       params.weight_scale = w13_scale_;

--- a/xllm/core/layers/npu_torch/fused_moe.h
+++ b/xllm/core/layers/npu_torch/fused_moe.h
@@ -143,6 +143,20 @@ class FusedMoEImpl : public torch::nn::Module {
   bool should_gather_dp_inputs_for_moe() const;
   bool can_use_ep2_dispatch_combine(const ModelInputParams& input_params,
                                     const torch::Tensor& hidden_states) const;
+  int32_t fused_mc2_mode() const;
+  bool prepare_dispatch_ffn_combine_inputs();
+  bool prepare_dispatch_gmm_combine_decode_inputs();
+  torch::Tensor forward_with_dispatch_ffn_combine(
+      const torch::Tensor& input_2d,
+      const torch::Tensor& weights_2d,
+      const torch::Tensor& ids_2d,
+      at::IntArrayRef hidden_states_shape);
+  torch::Tensor forward_with_dispatch_gmm_combine_decode(
+      const torch::Tensor& input_2d,
+      const torch::Tensor& weights_2d,
+      const torch::Tensor& ids_2d,
+      at::IntArrayRef hidden_states_shape,
+      int64_t global_bs);
   torch::Tensor forward_with_selected_experts_ep2(
       const torch::Tensor& hidden_states,
       const torch::Tensor& topk_weights,
@@ -151,6 +165,10 @@ class FusedMoEImpl : public torch::nn::Module {
   const std::string& get_moe_ep_group_name();
 
   bool enable_ep2_dispatch_combine_ = false;
+  bool dispatch_ffn_combine_prepared_ = false;
+  bool dispatch_gmm_combine_decode_prepared_ = false;
+  torch::Tensor dispatch_ffn_w13_scale_;
+  torch::Tensor dispatch_ffn_w2_scale_;
   std::string moe_ep_group_name_;
 };
 TORCH_MODULE(FusedMoE);


### PR DESCRIPTION
Add NPU scatter cache writes and dynamic quant preprocess paths for DeepSeek V4 attention.

Add fused MC2 and grouped matmul-swiglu NPU wrappers behind feature flags.

Cover DSV4 scatter cache write behavior with NPU tests.