### PR TITLE
bugfix: use max_concurrent_requests for single block and linear state allocation

### DIFF
--- a/xllm/core/distributed_runtime/llm_engine.cpp
+++ b/xllm/core/distributed_runtime/llm_engine.cpp
@@ -546,8 +546,7 @@ KVCacheCapacity LLMEngine::estimate_kv_cache_capacity() {
   }
 #endif
 
-  kv_cache_cap.num_linear_state_blocks() =
-      ::xllm::SchedulerConfig::get_instance().max_seqs_per_batch() + 2;
+  kv_cache_cap.num_linear_state_blocks() = FLAGS_max_concurrent_requests + 2;
   for (int64_t layer_id = 0; layer_id < kv_cache_cap.n_layers(); ++layer_id) {
     if (is_full_attention_layer(args_, layer_id)) {
       ++kv_cache_cap.num_full_attention_layers();
@@ -570,9 +569,8 @@ KVCacheCapacity LLMEngine::estimate_kv_cache_capacity() {
     CHECK_GT(kv_cache_cap.cache_size_in_bytes(),
              kv_cache_cap.linear_cache_size_in_bytes())
         << "failed to reserve linear state cache for linear-attention layers: "
-        << "max_seqs_per_batch ("
-        << ::xllm::SchedulerConfig::get_instance().max_seqs_per_batch()
-        << ") is too large. Please reduce max_seqs_per_batch to less than "
+        << "max_concurrent_requests (" << FLAGS_max_concurrent_requests
+        << ") is too large. Please reduce max_concurrent_requests to less than "
         << kv_cache_cap.cache_size_in_bytes() /
                    (kv_cache_cap.num_linear_attention_layers() *
                     kv_cache_cap.linear_slot_size()) -

--- a/xllm/core/framework/block/block_manager_pool.cpp
+++ b/xllm/core/framework/block/block_manager_pool.cpp
@@ -75,9 +75,7 @@ BlockManagerPool::BlockManagerPool(const Options& options, int32_t dp_size)
     // pool. Worker-side embedding and linear-state caches remain physically
     // separate and are addressed via transport fields.
     single_block_managers_.emplace_back(std::make_unique<SingleBlockManager>(
-        /*num_blocks=*/::xllm::SchedulerConfig::get_instance()
-                .max_seqs_per_batch() +
-            2,
+        /*num_blocks=*/FLAGS_max_concurrent_requests + 2,
         /*resource_name=*/"single block",
         /*exhaustion_message=*/"No more single-block ids available"));
   }


### PR DESCRIPTION
## Summary

Cherry-pick two bugfixes from `preview/qwen3.5-qwen3.6` branch to `main`.

### Changes

**1. Single block manager allocation** `(original: 005adbd1, #1413)`
- **File:** `xllm/core/framework/block/block_manager_pool.cpp`
- **Change:** `SingleBlockManager` num_blocks from `max_seqs_per_batch + 2` → `max_concurrent_requests + 2`
- **Impact:** Prevents single-block ID exhaustion when concurrent requests exceed `max_seqs_per_batch`

**2. Linear state overflow fix** `(original: c7ec380f, #1422)`
- **File:** `xllm/core/distributed_runtime/llm_engine.cpp`
- **Change:** `num_linear_state_blocks` from `max_seqs_per_batch + 2` → `max_concurrent_requests + 2`, update error messages accordingly
- **Impact:** Fixes linear state cache overflow under high concurrency by correctly reserving blocks based on actual concurrent capacity

### Root Cause
Both bugs stem from using `max_seqs_per_batch` as the allocation basis for shared single-block and linear-state resources. When `max_concurrent_requests > max_seqs_per_batch` (common in pipeline/scheduler setups), the reserved block count is insufficient, leading to resource exhaustion and overflow errors under load.

### Original Commits
- `005adbd1` — *bugfix: change single block manager blocks to max concurrent requests* by Yingxu Deng
- `c7ec380f` — *bugfix: fix high concurrency linear state overflow* by Joey Gao

### Notes
- VLMEngine (`vlm_engine.cpp`) change from the original `c7ec380f` commit is **not included** — the VLMEngine on `main` has been refactored and no longer contains the linear-state reservation logic.
- `max_seqs_per_batch` references in error messages updated to `max_concurrent_requests` for consistency.