### PR TITLE
bugfix: fix main unit test failures.

### DIFF
--- a/xllm/core/framework/batch/batch_input_builder.cpp
+++ b/xllm/core/framework/batch/batch_input_builder.cpp
@@ -804,7 +804,7 @@ ForwardInput BatchInputBuilder::state_to_forward_input() {
 
   auto& input_params = forward_input.input_params;
   input_params.meta.batch_forward_type = state_.batch_forward_type;
-  input_params.meta.num_sequences = state_.block_tables_vec.size();
+  input_params.meta.num_sequences = static_cast<int32_t>(num_sequences_);
   input_params.meta.kv_max_seq_len = state_.max_seq_len;
   input_params.meta.q_max_seq_len = state_.q_max_seq_len;
   input_params.attention.device.kv_seq_lens =

--- a/xllm/core/framework/kv_cache/deepseek_v4_kv_cache_impl.cpp
+++ b/xllm/core/framework/kv_cache/deepseek_v4_kv_cache_impl.cpp
@@ -53,6 +53,9 @@ torch::Tensor cast_to_nd_format(const torch::Tensor& tensor) {
     return tensor;
   }
 #if defined(USE_NPU)
+  if (!tensor.device().is_privateuseone()) {
+    return tensor;
+  }
   return at_npu::native::npu_format_cast(tensor, ACL_FORMAT_ND);
 #else
   return tensor;


### PR DESCRIPTION
- keep the logical decode sequence count when decode batches are padded.

- avoid NPU format casting for CPU DeepSeek V4 cache tensors.