### PR TITLE
bugfix: fix DeepSeek V4 NPU DP graph execution.

### DIFF
--- a/tests/core/runtime/acl_graph_executor_test.cpp
+++ b/tests/core/runtime/acl_graph_executor_test.cpp
@@ -560,6 +560,57 @@ TEST_F(AclGraphExecutorTest, DifferentBatchSizes) {
   }
 }
 
+// Test decode batch-size threshold fallback: ACL graph should fall back to
+// eager when batch_size exceeds the configured limit (default: 16).
+TEST_F(AclGraphExecutorTest, DecodeBatchSizeThresholdFallsBackToEager) {
+  constexpr uint32_t batch_size = 17;
+  sequences_.clear();
+  auto batch = std::make_unique<Batch>();
+
+  for (uint32_t i = 0; i < batch_size; ++i) {
+    sequences_.emplace_back(i,
+                            std::vector<int32_t>{static_cast<int32_t>(1 + i),
+                                                 static_cast<int32_t>(3 + i),
+                                                 static_cast<int32_t>(5 + i),
+                                                 static_cast<int32_t>(7 + i)},
+                            input_embedding_,
+                            mm_data_,
+                            fake_decoder_,
+                            seq_params_);
+    auto& sequence = sequences_.back();
+    sequence.add_kv_blocks(block_manager_->allocate(2));
+    sequence.kv_state().incr_kv_cache_tokens_num(/*size=*/4);
+    sequence.append_token(100 + i);
+    batch->add(&sequence);
+  }
+
+  auto forward_input = batch->prepare_forward_input(
+      options_.num_decoding_tokens(), 0, model_args_);
+  forward_input = forward_input.to(*device_, torch::kFloat32);
+
+  auto npu_executor = std::make_unique<BaseExecutorImpl>(
+      model_.get(), model_args_, *device_, options_);
+  auto graph_executor = std::make_unique<::xllm::npu::AclGraphExecutorImpl>(
+      model_.get(), model_args_, *device_, options_);
+
+  auto eager_out = npu_executor->run({forward_input.token_ids},
+                                     {forward_input.positions},
+                                     kv_caches_,
+                                     {forward_input.input_params});
+  auto graph_out = graph_executor->run({forward_input.token_ids},
+                                       {forward_input.positions},
+                                       kv_caches_,
+                                       {forward_input.input_params});
+
+  EXPECT_EQ(graph_out.hidden_states.size(0),
+            batch_size * options_.num_decoding_tokens());
+  EXPECT_EQ(graph_out.hidden_states.size(1), model_args_.hidden_size());
+  EXPECT_TRUE(torch::allclose(eager_out.hidden_states,
+                              graph_out.hidden_states,
+                              /*rtol=*/1e-5,
+                              /*atol=*/1e-6));
+}
+
 // Test ACL graph executor against original NPU executor implementation
 TEST_F(AclGraphExecutorTest, AclGraphExecutorVsBaseExecutorImpl) {
   // Create test batch

--- a/xllm/core/common/global_flags.cpp
+++ b/xllm/core/common/global_flags.cpp
@@ -104,6 +104,12 @@ DEFINE_int32(max_tokens_for_graph_mode,
              2048,
              "Maximum number of tokens for graph execution. "
              "If 0, no limit is applied.");
+
+DEFINE_int32(acl_graph_decode_batch_size_limit,
+             16,
+             "Decode batch size threshold for ACL graph on NPU. "
+             "When actual decode batch_size > this value, ACL graph decode "
+             "falls back to eager mode to avoid OOM.");
 // --- vlm config ---
 
 DEFINE_int32(limit_image_per_prompt,

--- a/xllm/core/common/global_flags.h
+++ b/xllm/core/common/global_flags.h
@@ -109,6 +109,7 @@ DECLARE_bool(enable_prefill_piecewise_graph);
 DECLARE_bool(enable_graph_vmm_pool);
 
 DECLARE_int32(max_tokens_for_graph_mode);
+DECLARE_int32(acl_graph_decode_batch_size_limit);
 
 DECLARE_bool(enable_chunked_prefill);
 

--- a/xllm/core/common/help_formatter.h
+++ b/xllm/core/common/help_formatter.h
@@ -47,6 +47,7 @@ const OptionCategory kCommonOptions = {"COMMON OPTIONS",
                                         "enable_graph_mode_decode_no_padding",
                                         "enable_prefill_piecewise_graph",
                                         "max_tokens_for_graph_mode",
+                                        "acl_graph_decode_batch_size_limit",
                                         "communication_backend",
                                         "task"}};
 

--- a/xllm/core/distributed_runtime/llm_engine.cpp
+++ b/xllm/core/distributed_runtime/llm_engine.cpp
@@ -34,6 +34,7 @@ limitations under the License.
 #include "common/options.h"
 #include "framework/block/hierarchy_block_manager_pool.h"
 #include "framework/kv_cache/kv_cache_shape.h"
+#include "framework/kv_cache/kv_cache_utils.h"
 #include "framework/model/model_args.h"
 #include "framework/model_loader.h"
 #include "framework/xtensor/page_allocator.h"
@@ -467,7 +468,7 @@ KVCacheCapacity LLMEngine::estimate_kv_cache_capacity() {
 
   if (options_.enable_mla()) {
 #if defined(USE_NPU)
-    if (args_.model_type() == "deepseek_v3" && FLAGS_enable_prefix_cache) {
+    if (use_npu_nz_kv_cache_layout(args_.model_type())) {
       slot_size =
           cache_dtype_size *
           ((args_.kv_lora_rank() + NZ_ALIGNMENT - 1) / NZ_ALIGNMENT +

--- a/xllm/core/framework/kv_cache/kv_cache_shape.cpp
+++ b/xllm/core/framework/kv_cache/kv_cache_shape.cpp
@@ -22,6 +22,7 @@ limitations under the License.
 #include <utility>
 
 #include "common/global_flags.h"
+#include "framework/kv_cache/kv_cache_utils.h"
 #include "util/utils.h"
 #include "worker.pb.h"
 
@@ -217,7 +218,7 @@ void KVCacheShape::init_key_cache_shape(const KVCacheCapacity& kv_cache_cap,
                                         int64_t world_size) {
   if (model_args.enable_mla()) {
 #if defined(USE_NPU)
-    if (model_args.model_type() == "deepseek_v3" && FLAGS_enable_prefix_cache) {
+    if (use_npu_nz_kv_cache_layout(model_args.model_type())) {
       key_cache_shape_ = std::vector<int64_t>{
           kv_cache_cap.n_blocks(),
           util::ceil_div(model_args.kv_lora_rank(), kNzAlignment),
@@ -248,7 +249,7 @@ void KVCacheShape::init_value_cache_shape(const KVCacheCapacity& kv_cache_cap,
                                           int64_t world_size) {
   if (model_args.enable_mla()) {
 #if defined(USE_NPU)
-    if (model_args.model_type() == "deepseek_v3" && FLAGS_enable_prefix_cache) {
+    if (use_npu_nz_kv_cache_layout(model_args.model_type())) {
       value_cache_shape_ = std::vector<int64_t>{
           kv_cache_cap.n_blocks(),
           util::ceil_div(model_args.qk_rope_head_dim(), kNzAlignment),

--- a/xllm/core/framework/kv_cache/kv_cache_utils.cpp
+++ b/xllm/core/framework/kv_cache/kv_cache_utils.cpp
@@ -27,6 +27,11 @@ bool is_linear_attention_layer(int64_t layer_idx,
   return (layer_idx + 1) % full_attention_interval != 0;
 }
 
+bool use_npu_nz_kv_cache_layout(const std::string& model_type) {
+  return (model_type == "deepseek_v3" || model_type == "deepseek_v3_mtp") &&
+         FLAGS_enable_prefix_cache;
+}
+
 KVCacheTensors create_kv_cache_tensors(
     const KVCacheShape& kv_cache_shape,
     const KVCacheCreateOptions& create_options) {
@@ -152,9 +157,8 @@ LinearAttentionKVCacheTensors create_linear_attention_kv_cache_tensors(
 
 #if defined(USE_NPU)
 aclFormat get_npu_kv_cache_format(const std::string& model_type) {
-  return model_type == "deepseek_v3" && FLAGS_enable_prefix_cache
-             ? ACL_FORMAT_FRACTAL_NZ
-             : ACL_FORMAT_ND;
+  return use_npu_nz_kv_cache_layout(model_type) ? ACL_FORMAT_FRACTAL_NZ
+                                                : ACL_FORMAT_ND;
 }
 #endif
 

--- a/xllm/core/framework/kv_cache/kv_cache_utils.h
+++ b/xllm/core/framework/kv_cache/kv_cache_utils.h
@@ -125,6 +125,9 @@ struct DeepSeekV4KVCacheTensors {
 bool is_linear_attention_layer(int64_t layer_idx,
                                int64_t full_attention_interval);
 
+// Whether NPU KV cache should use FRACTAL_NZ layout for a model type.
+bool use_npu_nz_kv_cache_layout(const std::string& model_type);
+
 KVCacheTensors create_kv_cache_tensors(
     const KVCacheShape& kv_cache_shape,
     const KVCacheCreateOptions& create_options);

--- a/xllm/core/framework/kv_cache_transfer/llm_data_dist_transfer.cpp
+++ b/xllm/core/framework/kv_cache_transfer/llm_data_dist_transfer.cpp
@@ -17,6 +17,7 @@ limitations under the License.
 
 #include <glog/logging.h>
 
+#include "framework/kv_cache/kv_cache_utils.h"
 #include "util/net.h"
 
 namespace xllm {
@@ -155,10 +156,7 @@ void LlmDataDistTransfer::allocate_kv_cache(
   }
 
   // convert memory addrs to torch tensors
-  aclFormat npu_format_type =
-      model_type_ == "deepseek_v3" && FLAGS_enable_prefix_cache
-          ? ACL_FORMAT_FRACTAL_NZ
-          : ACL_FORMAT_ND;
+  aclFormat npu_format_type = get_npu_kv_cache_format(model_type_);
 
   auto k_torch_tensors = convert_to_torch_tensor(
       key_cache_shape, dtype, k_cache_.tensor_addrs, npu_format_type);

--- a/xllm/core/framework/kv_cache_transfer/mooncake_kv_cache_transfer.cpp
+++ b/xllm/core/framework/kv_cache_transfer/mooncake_kv_cache_transfer.cpp
@@ -31,6 +31,7 @@ limitations under the License.
 #endif
 
 #include "common/global_flags.h"
+#include "framework/kv_cache/kv_cache_utils.h"
 #include "framework/kv_cache_transfer/push_route.h"
 #include "framework/xtensor/global_xtensor.h"
 #include "framework/xtensor/xtensor_allocator.h"
@@ -302,10 +303,7 @@ void MooncakeKVCacheTransferDefault::allocate_kv_cache_impl(
   }
 
   // convert memory addrs to torch tensors
-  aclFormat npu_format_type =
-      model_type_ == "deepseek_v3" && FLAGS_enable_prefix_cache
-          ? ACL_FORMAT_FRACTAL_NZ
-          : ACL_FORMAT_ND;
+  aclFormat npu_format_type = get_npu_kv_cache_format(model_type_);
   auto k_torch_tensors = convert_to_torch_tensor(
       key_cache_shape, dtype, k_tensor_addrs, npu_format_type);
   auto v_torch_tensors = convert_to_torch_tensor(

--- a/xllm/core/framework/kv_cache_transfer/spec_kv_cache_transfer.cpp
+++ b/xllm/core/framework/kv_cache_transfer/spec_kv_cache_transfer.cpp
@@ -18,6 +18,8 @@ limitations under the License.
 #include <glog/logging.h>
 #include <torch_npu/csrc/core/npu/NPUFormat.h>
 
+#include "framework/kv_cache/kv_cache_utils.h"
+
 namespace xllm {
 namespace {
 #define CHECK_LDD_RET(ret)  \
@@ -133,10 +135,7 @@ void SpecKVCacheTransfer::allocate_kv_cache_internal(
   }
 
   // convert memory addrs to torch tensors
-  aclFormat npu_format_type =
-      model_type_ == "deepseek_v3" && FLAGS_enable_prefix_cache
-          ? ACL_FORMAT_FRACTAL_NZ
-          : ACL_FORMAT_ND;
+  aclFormat npu_format_type = get_npu_kv_cache_format(model_type_);
   auto k_torch_tensors = convert_to_torch_tensor(
       key_cache_shape, dtype, k_cache.tensor_addrs, npu_format_type);
   auto v_torch_tensors = convert_to_torch_tensor(

--- a/xllm/core/framework/parallel_state/collective_communicator.cpp
+++ b/xllm/core/framework/parallel_state/collective_communicator.cpp
@@ -48,11 +48,11 @@ struct DispatchAndCombineComm {
   HcclComm comm = nullptr;
 };
 
-DispatchAndCombineComm create_dispatch_and_combine_comm(int global_rank,
-                                                        int world_size,
-                                                        int dp_size,
-                                                        int ep_size,
-                                                        int cp_size) {
+DispatchAndCombineComm create_dispatch_and_combine_mapping(int global_rank,
+                                                           int world_size,
+                                                           int dp_size,
+                                                           int ep_size,
+                                                           int cp_size) {
   const int32_t normalized_cp_size = cp_size > 0 ? cp_size : 1;
   const int32_t attn_tp_size = world_size / (dp_size * normalized_cp_size);
 
@@ -70,26 +70,6 @@ DispatchAndCombineComm create_dispatch_and_combine_comm(int global_rank,
   DispatchAndCombineComm result;
   result.mapping_data = mapping_npu.to_json();
   result.mapping.ParseParam(result.mapping_data);
-  result.mapping.InitGlobalCommDomain(FLAGS_communication_backend);
-
-  auto moe_ep_parallel_info = result.mapping.Get(atb_speed::base::MOE_EP);
-  const bool moe_ep_is_world =
-      moe_ep_parallel_info.rankIds.size() == static_cast<size_t>(world_size);
-  const uint32_t comm_buffer_size =
-      moe_ep_is_world ? 0 : moe_ep_parallel_info.bufferSize;
-  const bool reuse_comm_domain = moe_ep_is_world;
-  result.domain =
-      atb_speed::GetSingleton<atb_speed::ExternalCommManager>().GetCommDomain(
-          moe_ep_parallel_info.groupId,
-          moe_ep_parallel_info.rankIds,
-          moe_ep_parallel_info.rank,
-          FLAGS_communication_backend,
-          comm_buffer_size,
-          0,
-          reuse_comm_domain);
-  result.comm =
-      atb_speed::GetSingleton<atb_speed::ExternalCommManager>().GetCommPtr(
-          result.domain);
   return result;
 }
 
@@ -348,8 +328,12 @@ void CollectiveCommunicator::create_process_groups(
 #if defined(USE_NPU)
   if (FLAGS_npu_kernel_backend == "TORCH" &&
       FLAGS_expert_parallel_degree == 2 && ep_size == world_size) {
-    auto dispatch_and_combine_comm = create_dispatch_and_combine_comm(
+    auto dispatch_and_combine_comm = create_dispatch_and_combine_mapping(
         global_rank, world_size, dp_size, ep_size, cp_size);
+    CHECK(parallel_args_->moe_ep_group_ != nullptr)
+        << "DeepSeek-V4 EP2 dispatch/combine requires moe_ep_group.";
+    dispatch_and_combine_comm.domain =
+        parallel_args_->moe_ep_group_->hccl_comm_name();
     parallel_args_->mapping_data(dispatch_and_combine_comm.mapping_data);
     parallel_args_->mapping(dispatch_and_combine_comm.mapping);
     parallel_args_->dispatchAndCombinecommDomain(

--- a/xllm/core/framework/parallel_state/mapping_npu.cpp
+++ b/xllm/core/framework/parallel_state/mapping_npu.cpp
@@ -17,12 +17,42 @@ limitations under the License.
 
 #include <glog/logging.h>
 
+#include <cerrno>
+#include <cstdlib>
+#include <limits>
+
 #define MAX_LCCL_COMM_DOMAIN 63
 #define ENV_enable_extra_o_proj_tp false
 #define ENV_lm_head_local_tp false
 #define ENV_hccl_moe_ep_buffer 512
 #define ENV_hccl_moe_tp_buffer 64
 #define ENV_enable_dp_partition_up true
+
+namespace {
+
+constexpr char kHcclBuffsizeEnv[] = "HCCL_BUFFSIZE";
+
+int32_t get_hccl_buffer_size_or_default(int32_t default_buffer_size) {
+  const char* env_value = std::getenv(kHcclBuffsizeEnv);
+  if (env_value == nullptr || env_value[0] == '\0') {
+    return default_buffer_size;
+  }
+
+  errno = 0;
+  char* parse_end = nullptr;
+  long parsed_value = std::strtol(env_value, &parse_end, 10);
+  if (errno != 0 || parse_end == env_value || *parse_end != '\0' ||
+      parsed_value <= 0 || parsed_value > std::numeric_limits<int32_t>::max()) {
+    LOG(WARNING) << kHcclBuffsizeEnv
+                 << " should be a positive int32 value, got: " << env_value
+                 << ". Use default " << default_buffer_size;
+    return default_buffer_size;
+  }
+
+  return static_cast<int32_t>(parsed_value);
+}
+
+}  // namespace
 
 namespace xllm {
 
@@ -91,8 +121,22 @@ MappingNPU::MappingNPU(const std::string rank_table_file,
       num_lccl_per_shards * (lccl_comm_shard_id + 1);
 
   mlp_tp_.domain(std::to_string(MAX_LCCL_COMM_DOMAIN));
-  moe_ep_.buffer_size(ENV_hccl_moe_ep_buffer);
-  moe_tp_.buffer_size(ENV_hccl_moe_tp_buffer);
+  int32_t unified_buffer =
+      get_hccl_buffer_size_or_default(ENV_hccl_moe_ep_buffer);
+  word_embed_tp_.buffer_size(unified_buffer);
+  word_embed_dp_.buffer_size(unified_buffer);
+  attn_tp_.buffer_size(unified_buffer);
+  attn_dp_.buffer_size(unified_buffer);
+  attn_inner_sp_.buffer_size(unified_buffer);
+  attn_o_proj_tp_.buffer_size(unified_buffer);
+  attn_o_proj_dp_.buffer_size(unified_buffer);
+  mlp_tp_.buffer_size(unified_buffer);
+  mlp_dp_.buffer_size(unified_buffer);
+  moe_tp_.buffer_size(unified_buffer);
+  moe_ep_.buffer_size(unified_buffer);
+  lm_head_tp_.buffer_size(unified_buffer);
+  lm_head_dp_.buffer_size(unified_buffer);
+  attn_cp_.buffer_size(unified_buffer);
   attn_inner_sp_.domain(attn_tp_.domain());
 }
 

--- a/xllm/core/layers/deepseek_v4_decoder_layer.cpp
+++ b/xllm/core/layers/deepseek_v4_decoder_layer.cpp
@@ -24,28 +24,6 @@ limitations under the License.
 namespace xllm {
 namespace layer {
 
-namespace {
-
-int64_t tensor_bytes(const torch::Tensor& tensor) {
-  if (!tensor.defined()) {
-    return 0;
-  }
-  return tensor.numel() * tensor.element_size();
-}
-
-int64_t module_registered_tensor_bytes(const torch::nn::Module& module) {
-  int64_t total_bytes = 0;
-  for (const auto& item : module.named_parameters(/*recurse=*/true)) {
-    total_bytes += tensor_bytes(item.value());
-  }
-  for (const auto& item : module.named_buffers(/*recurse=*/true)) {
-    total_bytes += tensor_bytes(item.value());
-  }
-  return total_bytes;
-}
-
-}  // namespace
-
 DeepseekV4DecoderLayerImpl::DeepseekV4DecoderLayerImpl(
     const ModelContext& context,
     int32_t layer_id) {
@@ -151,38 +129,6 @@ void DeepseekV4DecoderLayerImpl::load_state_dict(const StateDict& state_dict) {
 }
 
 void DeepseekV4DecoderLayerImpl::verify_loaded_weights() const {}
-
-DeepseekV4LayerWeightMemStats DeepseekV4DecoderLayerImpl::get_weight_mem_stats()
-    const {
-  DeepseekV4LayerWeightMemStats stats;
-
-  if (attention_) {
-    stats.attn_bytes = module_registered_tensor_bytes(*attention_) +
-                       attention_->non_registered_weight_bytes();
-  }
-
-  if (moe_mlp_) {
-    stats.expert_bytes += module_registered_tensor_bytes(*moe_mlp_);
-  }
-  if (gate_) {
-    stats.expert_bytes += module_registered_tensor_bytes(*gate_);
-  }
-
-  stats.hc_bytes = tensor_bytes(hc_attn_fn_) + tensor_bytes(hc_ffn_fn_) +
-                   tensor_bytes(hc_attn_base_) + tensor_bytes(hc_ffn_base_) +
-                   tensor_bytes(hc_attn_scale_) + tensor_bytes(hc_ffn_scale_);
-
-  stats.total_bytes = module_registered_tensor_bytes(*this);
-  if (attention_) {
-    stats.total_bytes += attention_->non_registered_weight_bytes();
-  }
-
-  const int64_t categorized =
-      stats.attn_bytes + stats.expert_bytes + stats.hc_bytes;
-  stats.other_bytes = std::max<int64_t>(stats.total_bytes - categorized, 0);
-
-  return stats;
-}
 
 torch::Tensor DeepseekV4DecoderLayerImpl::forward(
     torch::Tensor& x,

--- a/xllm/core/layers/deepseek_v4_decoder_layer.h
+++ b/xllm/core/layers/deepseek_v4_decoder_layer.h
@@ -35,14 +35,6 @@ limitations under the License.
 namespace xllm {
 namespace layer {
 
-struct DeepseekV4LayerWeightMemStats {
-  int64_t attn_bytes = 0;
-  int64_t expert_bytes = 0;
-  int64_t hc_bytes = 0;
-  int64_t other_bytes = 0;
-  int64_t total_bytes = 0;
-};
-
 class DeepseekV4DecoderLayerImpl : public torch::nn::Module {
  public:
   explicit DeepseekV4DecoderLayerImpl(const ModelContext& context,
@@ -50,7 +42,6 @@ class DeepseekV4DecoderLayerImpl : public torch::nn::Module {
 
   void load_state_dict(const StateDict& state_dict);
   void verify_loaded_weights() const;
-  DeepseekV4LayerWeightMemStats get_weight_mem_stats() const;
 
   torch::Tensor forward(
       torch::Tensor& x,

--- a/xllm/core/layers/npu/npu_deepseek_v32_decoder_layer_impl.cpp
+++ b/xllm/core/layers/npu/npu_deepseek_v32_decoder_layer_impl.cpp
@@ -334,7 +334,10 @@ void NpuDeepseekV32DecoderLayerImpl::initialize_basic_parameters(
     param.enableSpeculate = true;
   }
   param.maskfree = true;  // TODO
-  param.enableSwiGLUQuantForSharedExperts = false;
+  const bool is_shared_expert_layer =
+      layer_id_ >= args.first_k_dense_replace() && args.n_shared_experts() > 0;
+  param.enableSwiGLUQuantForSharedExperts =
+      quantize_type_ == "w8a8_dynamic" && is_shared_expert_layer;
   num_key_value_heads_ = static_cast<int>(args.n_kv_heads().value());
   qk_nope_head_dim_ = args.qk_nope_head_dim();
   v_head_dim_ = args.v_head_dim();

--- a/xllm/core/layers/npu/npu_glm4_decoder_layer_impl.cpp
+++ b/xllm/core/layers/npu/npu_glm4_decoder_layer_impl.cpp
@@ -91,7 +91,9 @@ NpuGlm4DecoderLayerImpl::NpuGlm4DecoderLayerImpl(const ModelContext& context)
   auto options = context.get_tensor_options();
 
   param_from_args(prefill_param_, model_args, parallel_args, true);
-  param_from_args(decode_param_, model_args, parallel_args, false);
+  param_from_args(decode_graph_param_, model_args, parallel_args, false);
+  decode_eager_param_ = decode_graph_param_;
+  decode_eager_param_.enableAclGraphPagedAttention = false;
   atb_weight_tensors_.resize(WEIGHT_COUNT_PER_LAYER);
   placeholder_vec_ = {1};
   dtype_ = c10::typeMetaToScalarType(options.dtype());
@@ -110,7 +112,10 @@ int64_t NpuGlm4DecoderLayerImpl::init_layer() {
   name_ = "glm4_decoder_layer";
   model_name_ = "glm4";
   CHECK_OPERATION_STATUS_RETURN(init_node(prefill_node_, prefill_param_));
-  CHECK_OPERATION_STATUS_RETURN(init_node(decode_node_, decode_param_));
+  CHECK_OPERATION_STATUS_RETURN(
+      init_node(decode_graph_node_, decode_graph_param_));
+  CHECK_OPERATION_STATUS_RETURN(
+      init_node(decode_eager_node_, decode_eager_param_));
 
   return atb::NO_ERROR;
 }
@@ -172,21 +177,27 @@ torch::Tensor NpuGlm4DecoderLayerImpl::forward(torch::Tensor& x,
                             attn_mask,
                             kv_cache,
                             input_params,
-                            true);
+                            true,
+                            false);
     // mstxRangeEnd(id);
     st = execute_node(prefill_node_, node_id, event, event_flag);
     LOG_IF(FATAL, st != 0) << model_name_
                            << "excute prefill layer fail, error code: " << st;
   } else {
-    build_node_variant_pack(decode_node_,
+    const bool use_graph_decode_input =
+        FLAGS_enable_graph && input_params.graph_buffer.tiling_data.defined();
+    auto& decode_node =
+        use_graph_decode_input ? decode_graph_node_ : decode_eager_node_;
+    build_node_variant_pack(decode_node,
                             x,
                             cos_pos,
                             sin_pos,
                             decode_attn_mask_,
                             kv_cache,
                             input_params,
-                            false);
-    st = execute_node(decode_node_, node_id + 1000, event, event_flag);
+                            false,
+                            use_graph_decode_input);
+    st = execute_node(decode_node, node_id + 1000, event, event_flag);
     LOG_IF(FATAL, st != 0) << model_name_
                            << "excute decode layer fail, error code: " << st;
   }
@@ -202,7 +213,8 @@ void NpuGlm4DecoderLayerImpl::build_node_variant_pack(
     at::Tensor& attn_mask,
     KVCache& kv_cache,
     ModelInputParams& input_params,
-    bool is_prefill) {
+    bool is_prefill,
+    bool use_graph_decode_input) {
   internal_tensors_ = atb_speed::Utils::AtTensor2Tensor(x);
   // std::cout<<"node.variantPack.inTensors.size:"<<node.variantPack.inTensors.size()<<std::endl;
   node.variantPack.inTensors.at(WEIGHT_COUNT_PER_LAYER) = internal_tensors_;
@@ -237,7 +249,7 @@ void NpuGlm4DecoderLayerImpl::build_node_variant_pack(
         input_params.q_seq_lens_vec.data();
   }
 
-  if (FLAGS_enable_graph && !is_prefill &&
+  if (!is_prefill && use_graph_decode_input &&
       input_params.graph_buffer.tiling_data.defined()) {
     node.variantPack.inTensors.at(input_idx++) =
         atb_speed::Utils::AtTensor2Tensor(

--- a/xllm/core/layers/npu/npu_glm4_decoder_layer_impl.h
+++ b/xllm/core/layers/npu/npu_glm4_decoder_layer_impl.h
@@ -75,7 +75,8 @@ class NpuGlm4DecoderLayerImpl : public BaseLayer {
                                torch::Tensor& attn_mask,
                                KVCache& kv_cache,
                                ModelInputParams& input_params,
-                               bool is_prefill);
+                               bool is_prefill,
+                               bool use_graph_decode_input);
 
   void initialize_quantization_parameters(
       atb_speed::chatglm::ChatglmLayerParam& param);
@@ -86,10 +87,12 @@ class NpuGlm4DecoderLayerImpl : public BaseLayer {
   int64_t init_attn_mask();
 
   atb_speed::Model::Node prefill_node_;
-  atb_speed::Model::Node decode_node_;
+  atb_speed::Model::Node decode_graph_node_;
+  atb_speed::Model::Node decode_eager_node_;
   std::string model_name_;
   atb_speed::chatglm::ChatglmLayerParam prefill_param_;
-  atb_speed::chatglm::ChatglmLayerParam decode_param_;
+  atb_speed::chatglm::ChatglmLayerParam decode_graph_param_;
+  atb_speed::chatglm::ChatglmLayerParam decode_eager_param_;
   atb::Tensor internal_tensors_;
   atb::Tensor placeholder_;
 

--- a/xllm/core/layers/npu/npu_glm4_moe_decoder_layer.cpp
+++ b/xllm/core/layers/npu/npu_glm4_moe_decoder_layer.cpp
@@ -46,7 +46,9 @@ NpuGlm4MoeDecoderImpl::NpuGlm4MoeDecoderImpl(const ModelContext& context,
   end_expert_id_ = start_expert_id_ + num_experts_per_partition_ - 1;
 
   param_from_args(prefill_param_, model_args, parallel_args, true);
-  param_from_args(decode_param_, model_args, parallel_args, false);
+  param_from_args(decode_graph_param_, model_args, parallel_args, false);
+  decode_eager_param_ = decode_graph_param_;
+  decode_eager_param_.enableAclGraphPagedAttention = false;
   atb_weight_tensors_.resize(WEIGHT_COUNT_PER_LAYER);
   placeholder_vec_ = {1};
   device_id_ = options.device().index();
@@ -300,7 +302,10 @@ int64_t NpuGlm4MoeDecoderImpl::init_layer() {
   BaseLayer::name_ = "glm4_moe_decoder_layer " + std::to_string(layer_id_);
   model_name_ = "Glm4_Moe";
   CHECK_OPERATION_STATUS_RETURN(init_node(prefill_node_, prefill_param_));
-  CHECK_OPERATION_STATUS_RETURN(init_node(decode_node_, decode_param_));
+  CHECK_OPERATION_STATUS_RETURN(
+      init_node(decode_graph_node_, decode_graph_param_));
+  CHECK_OPERATION_STATUS_RETURN(
+      init_node(decode_eager_node_, decode_eager_param_));
 
   return atb::NO_ERROR;
 }
@@ -356,20 +361,26 @@ torch::Tensor NpuGlm4MoeDecoderImpl::forward(
                             attn_mask,
                             kv_cache,
                             input_params,
-                            true);
+                            true,
+                            false);
     st = execute_node(prefill_node_, node_id, event, event_flag);
     LOG_IF(FATAL, st != 0) << model_name_
                            << " excute prefill layer fail, error code: " << st;
   } else {
-    build_node_variant_pack(decode_node_,
+    const bool use_graph_decode_input =
+        FLAGS_enable_graph && input_params.graph_buffer.tiling_data.defined();
+    auto& decode_node =
+        use_graph_decode_input ? decode_graph_node_ : decode_eager_node_;
+    build_node_variant_pack(decode_node,
                             x,
                             cos_pos,
                             sin_pos,
                             /*attn_mask*/ tensor_placeholder_,
                             kv_cache,
                             input_params,
-                            false);
-    st = execute_node(decode_node_, node_id + 1000, event, event_flag);
+                            false,
+                            use_graph_decode_input);
+    st = execute_node(decode_node, node_id + 1000, event, event_flag);
     LOG_IF(FATAL, st != 0) << model_name_
                            << " excute decode layer fail, error code: " << st;
   }
@@ -385,7 +396,8 @@ void NpuGlm4MoeDecoderImpl::build_node_variant_pack(
     torch::Tensor& attn_mask,
     KVCache& kv_cache,
     const ModelInputParams& input_params,
-    bool is_prefill) {
+    bool is_prefill,
+    bool use_graph_decode_input) {
   internal_tensor_ = atb_speed::Utils::AtTensor2Tensor(x);
   auto& dp_ep_padding = input_params.dp_ep_padding_data;
 
@@ -458,7 +470,7 @@ void NpuGlm4MoeDecoderImpl::build_node_variant_pack(
   node.variantPack.inTensors.at(input_idx++) =
       atb_speed::Utils::AtTensor2Tensor(tensor_placeholder_);
 
-  if (FLAGS_enable_graph && !is_prefill &&
+  if (!is_prefill && use_graph_decode_input &&
       input_params.graph_buffer.tiling_data.defined()) {
     node.variantPack.inTensors.at(input_idx++) =
         atb_speed::Utils::AtTensor2Tensor(

--- a/xllm/core/layers/npu/npu_glm4_moe_decoder_layer.h
+++ b/xllm/core/layers/npu/npu_glm4_moe_decoder_layer.h
@@ -99,7 +99,8 @@ class NpuGlm4MoeDecoderImpl : public BaseLayer {
                                torch::Tensor& attn_mask,
                                KVCache& kv_cache,
                                const ModelInputParams& input_params,
-                               bool is_prefill);
+                               bool is_prefill,
+                               bool use_graph_decode_input);
 
   std::string model_name_;
 
@@ -116,10 +117,12 @@ class NpuGlm4MoeDecoderImpl : public BaseLayer {
 
   int32_t num_speculative_tokens_ = 0;
   atb_speed::glm::MoeLayerParam prefill_param_;
-  atb_speed::glm::MoeLayerParam decode_param_;
+  atb_speed::glm::MoeLayerParam decode_graph_param_;
+  atb_speed::glm::MoeLayerParam decode_eager_param_;
 
   atb_speed::Model::Node prefill_node_;
-  atb_speed::Model::Node decode_node_;
+  atb_speed::Model::Node decode_graph_node_;
+  atb_speed::Model::Node decode_eager_node_;
 
   atb::Tensor internal_tensor_;
 

--- a/xllm/core/layers/npu/npu_qwen3_decoder_layer_impl.cpp
+++ b/xllm/core/layers/npu/npu_qwen3_decoder_layer_impl.cpp
@@ -157,7 +157,9 @@ NpuQwen3DecoderLayerImpl::NpuQwen3DecoderLayerImpl(const ModelContext& context)
   auto options = context.get_tensor_options();
 
   param_from_args(prefill_param_, model_args, parallel_args, true);
-  param_from_args(decode_param_, model_args, parallel_args, false);
+  param_from_args(decode_graph_param_, model_args, parallel_args, false);
+  decode_eager_param_ = decode_graph_param_;
+  decode_eager_param_.enableAclGraphPagedAttention = false;
   atb_weight_tensors_.resize(WEIGHT_COUNT_PER_LAYER);
   placeholder_vec_ = {1};
   dtype_ = c10::typeMetaToScalarType(options.dtype());
@@ -181,7 +183,10 @@ int64_t NpuQwen3DecoderLayerImpl::init_layer() {
   name_ = "qwen3_decoder_layer";
   model_name_ = "qwen3";
   CHECK_OPERATION_STATUS_RETURN(init_node(prefill_node_, prefill_param_));
-  CHECK_OPERATION_STATUS_RETURN(init_node(decode_node_, decode_param_));
+  CHECK_OPERATION_STATUS_RETURN(
+      init_node(decode_graph_node_, decode_graph_param_));
+  CHECK_OPERATION_STATUS_RETURN(
+      init_node(decode_eager_node_, decode_eager_param_));
 
   return atb::NO_ERROR;
 }
@@ -239,13 +244,18 @@ torch::Tensor NpuQwen3DecoderLayerImpl::forward(torch::Tensor& x,
                             kv_cache,
                             input_params,
                             /*is_prefill=*/true,
-                            node_id);
+                            node_id,
+                            /*use_graph_decode_input=*/false);
     // mstxRangeEnd(id);
     st = execute_node(prefill_node_, node_id, event, event_flag);
     LOG_IF(FATAL, st != 0) << model_name_
                            << "excute prefill layer fail, error code: " << st;
   } else {
-    build_node_variant_pack(decode_node_,
+    const bool use_graph_decode_input =
+        FLAGS_enable_graph && input_params.graph_buffer.tiling_data.defined();
+    auto& decode_node =
+        use_graph_decode_input ? decode_graph_node_ : decode_eager_node_;
+    build_node_variant_pack(decode_node,
                             x,
                             cos_pos,
                             sin_pos,
@@ -253,8 +263,9 @@ torch::Tensor NpuQwen3DecoderLayerImpl::forward(torch::Tensor& x,
                             kv_cache,
                             input_params,
                             /*is_prefill=*/false,
-                            node_id);
-    st = execute_node(decode_node_, node_id + 1000, event, event_flag);
+                            node_id,
+                            use_graph_decode_input);
+    st = execute_node(decode_node, node_id + 1000, event, event_flag);
     LOG_IF(FATAL, st != 0) << model_name_
                            << "excute decode layer fail, error code: " << st;
   }
@@ -271,7 +282,8 @@ void NpuQwen3DecoderLayerImpl::build_node_variant_pack(
     KVCache& kv_cache,
     ModelInputParams& input_params,
     bool is_prefill,
-    int node_id) {
+    int node_id,
+    bool use_graph_decode_input) {
   internal_tensors_ = atb_speed::Utils::AtTensor2Tensor(x);
   node.variantPack.inTensors.at(WEIGHT_COUNT_PER_LAYER) = internal_tensors_;
   node.variantPack.inTensors.at(WEIGHT_COUNT_PER_LAYER + 1) =
@@ -335,7 +347,7 @@ void NpuQwen3DecoderLayerImpl::build_node_variant_pack(
         input_params.q_seq_lens_vec.data();
   }
 
-  if (FLAGS_enable_graph && !is_prefill &&
+  if (!is_prefill && use_graph_decode_input &&
       input_params.graph_buffer.tiling_data.defined()) {
     node.variantPack.inTensors.at(input_idx++) =
         atb_speed::Utils::AtTensor2Tensor(

--- a/xllm/core/layers/npu/npu_qwen3_decoder_layer_impl.h
+++ b/xllm/core/layers/npu/npu_qwen3_decoder_layer_impl.h
@@ -75,7 +75,8 @@ class NpuQwen3DecoderLayerImpl : public BaseLayer {
                                KVCache& kv_cache,
                                ModelInputParams& input_params,
                                bool is_prefill,
-                               int node_id);
+                               int node_id,
+                               bool use_graph_decode_input);
 
   void initialize_parallel_parameters(atb_speed::qwen::QwenLayerParam& param,
                                       const ParallelArgs& parallel_args);
@@ -89,10 +90,12 @@ class NpuQwen3DecoderLayerImpl : public BaseLayer {
   int64_t init_attn_mask();
 
   atb_speed::Model::Node prefill_node_;
-  atb_speed::Model::Node decode_node_;
+  atb_speed::Model::Node decode_graph_node_;
+  atb_speed::Model::Node decode_eager_node_;
   std::string model_name_;
   atb_speed::qwen::QwenLayerParam prefill_param_;
-  atb_speed::qwen::QwenLayerParam decode_param_;
+  atb_speed::qwen::QwenLayerParam decode_graph_param_;
+  atb_speed::qwen::QwenLayerParam decode_eager_param_;
   atb::Tensor internal_tensors_;
   atb::Tensor placeholder_;
 

--- a/xllm/core/layers/npu/npu_qwen3_moe_decoder_layer_impl.cpp
+++ b/xllm/core/layers/npu/npu_qwen3_moe_decoder_layer_impl.cpp
@@ -54,7 +54,9 @@ NpuQwen3MoeDecoderLayerImpl::NpuQwen3MoeDecoderLayerImpl(
   dp_local_tp_rank_ = parallel_args.rank() % dp_local_tp_size_;
 
   param_from_args(prefill_param_, model_args, parallel_args, true);
-  param_from_args(decode_param_, model_args, parallel_args, false);
+  param_from_args(decode_graph_param_, model_args, parallel_args, false);
+  decode_eager_param_ = decode_graph_param_;
+  decode_eager_param_.enableAclGraphPagedAttention = false;
   loader_ = std::make_unique<Qwen3MoeDecoderLoader>(
       WEIGHT_COUNT_PER_LAYER,
       context,
@@ -275,7 +277,10 @@ int64_t NpuQwen3MoeDecoderLayerImpl::init_layer() {
   name_ = "qwen3_moe_decoder_layer " + std::to_string(layer_id_);
   model_name_ = "Qwen3_Moe";
   CHECK_OPERATION_STATUS_RETURN(init_node(prefill_node_, prefill_param_));
-  CHECK_OPERATION_STATUS_RETURN(init_node(decode_node_, decode_param_));
+  CHECK_OPERATION_STATUS_RETURN(
+      init_node(decode_graph_node_, decode_graph_param_));
+  CHECK_OPERATION_STATUS_RETURN(
+      init_node(decode_eager_node_, decode_eager_param_));
 
   return atb::NO_ERROR;
 }
@@ -326,12 +331,17 @@ torch::Tensor NpuQwen3MoeDecoderLayerImpl::forward(
                             attn_mask,
                             kv_cache,
                             input_params,
-                            true);
+                            true,
+                            false);
     st = execute_node(prefill_node_, node_id, event, event_flag);
     LOG_IF(FATAL, st != 0) << model_name_
                            << "excute prefill layer fail, error code: " << st;
   } else {
-    build_node_variant_pack(decode_node_,
+    const bool use_graph_decode_input =
+        FLAGS_enable_graph && input_params.graph_buffer.tiling_data.defined();
+    auto& decode_node =
+        use_graph_decode_input ? decode_graph_node_ : decode_eager_node_;
+    build_node_variant_pack(decode_node,
                             x,
                             residual,
                             cos_pos,
@@ -339,8 +349,9 @@ torch::Tensor NpuQwen3MoeDecoderLayerImpl::forward(
                             /*attn_mask*/ tensor_placeholder_,
                             kv_cache,
                             input_params,
-                            false);
-    st = execute_node(decode_node_, node_id + 1000, event, event_flag);
+                            false,
+                            use_graph_decode_input);
+    st = execute_node(decode_node, node_id + 1000, event, event_flag);
     LOG_IF(FATAL, st != 0) << model_name_
                            << "excute decode layer fail, error code: " << st;
   }
@@ -357,7 +368,8 @@ void NpuQwen3MoeDecoderLayerImpl::build_node_variant_pack(
     torch::Tensor& attn_mask,
     KVCache& kv_cache,
     const ModelInputParams& input_params,
-    bool is_prefill) {
+    bool is_prefill,
+    bool use_graph_decode_input) {
   internal_tensor_ = atb_speed::Utils::AtTensor2Tensor(x);
   int32_t input_idx = 0;
   auto& dp_ep_padding = input_params.dp_ep_padding_data;
@@ -429,7 +441,7 @@ void NpuQwen3MoeDecoderLayerImpl::build_node_variant_pack(
         const_cast<int32_t*>(input_params.q_seq_lens_vec.data());
   }
 
-  if (FLAGS_enable_graph && !is_prefill &&
+  if (!is_prefill && use_graph_decode_input &&
       input_params.graph_buffer.tiling_data.defined()) {
     node.variantPack.inTensors.at(input_idx++) =
         atb_speed::Utils::AtTensor2Tensor(

--- a/xllm/core/layers/npu/npu_qwen3_moe_decoder_layer_impl.h
+++ b/xllm/core/layers/npu/npu_qwen3_moe_decoder_layer_impl.h
@@ -105,7 +105,8 @@ class NpuQwen3MoeDecoderLayerImpl : public BaseLayer {
                                torch::Tensor& attn_mask,
                                KVCache& kv_cache,
                                const ModelInputParams& input_params,
-                               bool is_prefill);
+                               bool is_prefill,
+                               bool use_graph_decode_input);
 
   torch::Tensor block_tables_placeholder_;
   std::string model_name_;
@@ -129,10 +130,12 @@ class NpuQwen3MoeDecoderLayerImpl : public BaseLayer {
 
   int32_t num_speculative_tokens_ = 0;
   atb_speed::qwen::MoeDecoderLayerParam prefill_param_;
-  atb_speed::qwen::MoeDecoderLayerParam decode_param_;
+  atb_speed::qwen::MoeDecoderLayerParam decode_graph_param_;
+  atb_speed::qwen::MoeDecoderLayerParam decode_eager_param_;
 
   atb_speed::Model::Node prefill_node_;
-  atb_speed::Model::Node decode_node_;
+  atb_speed::Model::Node decode_graph_node_;
+  atb_speed::Model::Node decode_eager_node_;
 
   atb::Tensor internal_tensor_;
 

--- a/xllm/core/layers/npu_torch/fused_moe.cpp
+++ b/xllm/core/layers/npu_torch/fused_moe.cpp
@@ -35,8 +35,8 @@ limitations under the License.
 #include "framework/parallel_state/parallel_state.h"
 #include "kernels/ops_api.h"
 #include "layers/common/dp_utils.h"
-#include "util/utils.h"
 #include "platform/device.h"
+#include "util/utils.h"
 
 namespace xllm {
 namespace layer {
@@ -1365,9 +1365,10 @@ torch::Tensor FusedMoEImpl::forward_with_selected_experts_ep2(
   int64_t global_bs = input_2d.size(0) * ep_world_size;
   if (parallel_args_.dp_size() > 1 &&
       !input_params.dp_global_token_nums.empty()) {
-    global_bs = std::accumulate(input_params.dp_global_token_nums.begin(),
-                                input_params.dp_global_token_nums.end(),
-                                int64_t{0});
+    // NOTE: aclnnMoeDistributeDispatchV2 only supports globalBS=0 (auto) or
+    // globalBS=max(bs_on_all_ranks)*epWorldSize. Using 0 to let the operator
+    // calculate the correct value automatically.
+    global_bs = 0;
   }
 
   if (dispatch_ffn_combine_prepared_) {

--- a/xllm/core/runtime/acl_graph_executor_impl.cpp
+++ b/xllm/core/runtime/acl_graph_executor_impl.cpp
@@ -23,6 +23,7 @@ limitations under the License.
 #include <torch_npu/torch_npu.h>
 
 #include <algorithm>
+#include <cmath>
 #include <numeric>
 #include <tuple>
 
@@ -35,6 +36,7 @@ limitations under the License.
 #endif
 #include "core/common/global_flags.h"
 #include "core/common/metrics.h"
+#include "core/platform/device.h"
 #include "core/util/utils.h"
 #include "platform/npu/device_capture_lock.h"
 
@@ -70,6 +72,39 @@ int64_t get_decode_graph_capacity(const runtime::Options& options) {
     return options.max_seqs_per_batch() * options.num_decoding_tokens();
   }
   return options.max_seqs_per_batch();
+}
+
+float get_dp_ep_all2all_buffer_factor(int64_t length) {
+  const std::vector<std::pair<int64_t, float>> length_thresholds = {
+      {1048576, 1.32f},
+      {524288, 1.4f},
+      {262144, 1.53f},
+      {131072, 1.8f},
+      {32768, 3.0f},
+      {8192, 5.2f},
+      {0, 8.0f}};
+
+  for (const auto& threshold : length_thresholds) {
+    if (length >= threshold.first) {
+      return threshold.second;
+    }
+  }
+  return 8.0f;
+}
+
+int64_t get_dp_ep_padding_buffer_capacity(const ModelArgs& args,
+                                          const runtime::Options& options) {
+  const int64_t dp_size = std::max<int64_t>(options.dp_size(), 1);
+  const int64_t graph_capacity = get_decode_graph_capacity(options);
+  const int64_t topk = std::max<int64_t>(args.num_experts_per_tok(), 1);
+  const int64_t base_length = graph_capacity * topk;
+  const int64_t global_length = base_length * dp_size;
+  const float buffer_factor = get_dp_ep_all2all_buffer_factor(global_length);
+  const int64_t moe_buffer_capacity =
+      static_cast<int64_t>(std::ceil(base_length * buffer_factor));
+  const int64_t aligned_moe_buffer_capacity =
+      ((moe_buffer_capacity + dp_size - 1) / dp_size) * dp_size;
+  return std::max(graph_capacity * dp_size, aligned_moe_buffer_capacity);
 }
 
 int64_t infer_actual_batch_size(const ModelInputParams& params) {
@@ -203,6 +238,36 @@ GraphPersistentParam::GraphPersistentParam(const ModelArgs& args,
   q_cu_seq_lens_ = torch::zeros({max_seqs_per_batch + 1},
                                 torch::dtype(torch::kInt).device(device));
 
+  // Pre-allocate persistent dp/cp ep padding buffers with maximum capacity.
+  const int64_t padding_buf_capacity =
+      get_dp_ep_padding_buffer_capacity(args, options);
+  auto int_opts = torch::dtype(torch::kInt32).device(device);
+
+  persistent_dp_ep_padding_
+      .attn_padding_idx(torch::zeros({padding_buf_capacity}, int_opts))
+      .attn_unpadding_idx(torch::zeros({padding_buf_capacity}, int_opts))
+      .ffn_padding_idx(torch::zeros({padding_buf_capacity}, int_opts))
+      .ffn_unpadding_idx(torch::zeros({padding_buf_capacity}, int_opts))
+      .lm_head_skip_padding_token_indices(
+          torch::zeros({padding_buf_capacity}, int_opts))
+      .gather_prenorm_idx(torch::zeros({padding_buf_capacity}, int_opts))
+      .padding_idx(torch::zeros({padding_buf_capacity}, int_opts))
+      .un_padding_idx(torch::zeros({padding_buf_capacity}, int_opts))
+      .dynamic_ep_idx(torch::zeros({padding_buf_capacity}, int_opts))
+      .moe_idx(torch::zeros({padding_buf_capacity}, int_opts))
+      .expert_array(torch::zeros({padding_buf_capacity, 1}, int_opts))
+      .post_lmhead_gather_indices(
+          torch::zeros({padding_buf_capacity}, int_opts));
+
+  persistent_cp_ep_padding_
+      .attn_padding_idx(torch::zeros({padding_buf_capacity}, int_opts))
+      .attn_unpadding_idx(torch::zeros({padding_buf_capacity}, int_opts))
+      .ffn_padding_idx(torch::zeros({padding_buf_capacity}, int_opts))
+      .ffn_unpadding_idx(torch::zeros({padding_buf_capacity}, int_opts))
+      .lm_head_skip_padding_token_indices(
+          torch::zeros({padding_buf_capacity}, int_opts))
+      .gather_prenorm_idx(torch::zeros({padding_buf_capacity}, int_opts));
+
   // Do not need to create ATB context and custom paged attention operation
   if (args_.head_dim() == 0) {
     return;
@@ -213,6 +278,80 @@ GraphPersistentParam::GraphPersistentParam(const ModelArgs& args,
   }
 
   initialize_paged_attention_plan_context(device);
+}
+
+namespace {
+// Copy src into a pre-allocated persistent buffer. The buffer must already be
+// large enough (allocated in GraphPersistentParam constructor).
+void copy_into_persistent(torch::Tensor& persistent, const torch::Tensor& src) {
+  if (!src.defined() || src.numel() == 0 || !persistent.defined()) {
+    return;
+  }
+  CHECK_LE(src.size(0), persistent.size(0))
+      << "dp_ep_padding persistent buffer overflow: src size " << src.size(0)
+      << " exceeds pre-allocated capacity " << persistent.size(0);
+  persistent.slice(/*dim=*/0, /*start=*/0, /*end=*/src.size(0))
+      .copy_(src, /*non_blocking=*/true);
+}
+}  // namespace
+
+void GraphPersistentParam::update_persistent_dp_ep_padding(
+    const DpEpPaddingData& src,
+    uint32_t /*padded_tokens*/) {
+  // Skip when dp ep padding is not enabled. When enabled, build() always
+  // populates attn_padding_idx first, so it is a reliable signal.
+  if (!src.attn_padding_idx().defined() ||
+      src.attn_padding_idx().numel() == 0) {
+    return;
+  }
+  copy_into_persistent(persistent_dp_ep_padding_.attn_padding_idx(),
+                       src.attn_padding_idx());
+  copy_into_persistent(persistent_dp_ep_padding_.attn_unpadding_idx(),
+                       src.attn_unpadding_idx());
+  copy_into_persistent(persistent_dp_ep_padding_.ffn_padding_idx(),
+                       src.ffn_padding_idx());
+  copy_into_persistent(persistent_dp_ep_padding_.ffn_unpadding_idx(),
+                       src.ffn_unpadding_idx());
+  copy_into_persistent(
+      persistent_dp_ep_padding_.lm_head_skip_padding_token_indices(),
+      src.lm_head_skip_padding_token_indices());
+  copy_into_persistent(persistent_dp_ep_padding_.gather_prenorm_idx(),
+                       src.gather_prenorm_idx());
+  copy_into_persistent(persistent_dp_ep_padding_.padding_idx(),
+                       src.padding_idx());
+  copy_into_persistent(persistent_dp_ep_padding_.un_padding_idx(),
+                       src.un_padding_idx());
+  copy_into_persistent(persistent_dp_ep_padding_.dynamic_ep_idx(),
+                       src.dynamic_ep_idx());
+  copy_into_persistent(persistent_dp_ep_padding_.moe_idx(), src.moe_idx());
+  copy_into_persistent(persistent_dp_ep_padding_.expert_array(),
+                       src.expert_array());
+  copy_into_persistent(persistent_dp_ep_padding_.post_lmhead_gather_indices(),
+                       src.post_lmhead_gather_indices());
+}
+
+void GraphPersistentParam::update_persistent_cp_ep_padding(
+    const CpEpPaddingData& src,
+    uint32_t /*padded_tokens*/) {
+  // Skip when cp ep padding is not enabled. When enabled, build() always
+  // populates attn_padding_idx first, so it is a reliable signal.
+  if (!src.attn_padding_idx().defined() ||
+      src.attn_padding_idx().numel() == 0) {
+    return;
+  }
+  copy_into_persistent(persistent_cp_ep_padding_.attn_padding_idx(),
+                       src.attn_padding_idx());
+  copy_into_persistent(persistent_cp_ep_padding_.attn_unpadding_idx(),
+                       src.attn_unpadding_idx());
+  copy_into_persistent(persistent_cp_ep_padding_.ffn_padding_idx(),
+                       src.ffn_padding_idx());
+  copy_into_persistent(persistent_cp_ep_padding_.ffn_unpadding_idx(),
+                       src.ffn_unpadding_idx());
+  copy_into_persistent(
+      persistent_cp_ep_padding_.lm_head_skip_padding_token_indices(),
+      src.lm_head_skip_padding_token_indices());
+  copy_into_persistent(persistent_cp_ep_padding_.gather_prenorm_idx(),
+                       src.gather_prenorm_idx());
 }
 
 GraphPersistentParam::~GraphPersistentParam() {
@@ -302,6 +441,23 @@ std::optional<ModelInputParams> GraphPersistentParam::update(
       persistent_positions_
           .slice(/*dim=*/0, /*start=*/0, /*end=*/actual_num_tokens)
           .copy_(positions, /*non_blocking=*/true);
+    }
+  }
+  // Zero out padded position slots to prevent stale values from previous
+  // replays causing out-of-bounds access in rotary embedding.
+  const int64_t graph_num_tokens =
+      persistent_positions_.size(use_mrope_ ? 1 : 0);
+  if (actual_num_tokens < graph_num_tokens) {
+    if (use_mrope_) {
+      persistent_positions_
+          .slice(
+              /*dim=*/1, /*start=*/actual_num_tokens, /*end=*/graph_num_tokens)
+          .zero_();
+    } else {
+      persistent_positions_
+          .slice(
+              /*dim=*/0, /*start=*/actual_num_tokens, /*end=*/graph_num_tokens)
+          .zero_();
     }
   }
   int64_t q_copy_len = 0;
@@ -494,6 +650,12 @@ std::optional<ModelInputParams> GraphPersistentParam::update(
     }
   }
 
+  // Update persistent dp/cp ep padding buffers. For capture this ensures
+  // stable device addresses are recorded by the graph; for replay this
+  // refreshes the data at those same addresses before graph_.replay().
+  update_persistent_dp_ep_padding(params.dp_ep_padding_data, padded_num_tokens);
+  update_persistent_cp_ep_padding(params.cp_ep_padding_data, padded_num_tokens);
+
   // Return ModelInputParams with persistent buffer references if requested
   if (return_capture_params) {
     std::optional<ModelInputParams> params_for_capture =
@@ -557,6 +719,81 @@ std::optional<ModelInputParams> GraphPersistentParam::update(
           q_cu_seq_lens_.slice(/*dim=*/0,
                                /*start=*/0,
                                /*end=*/padded_batch_size);
+    }
+
+    // Replace dp/cp ep padding with slices of persistent buffers so that
+    // the graph records stable device addresses.  Each slice has the same
+    // size as the original tensor but points into the persistent buffer.
+    // dp ep and cp ep are mutually exclusive; when neither is enabled the
+    // src fields are all undefined and we leave dst untouched so that the
+    // captured graph behaves identically to eager mode.
+    auto slice_like = [](const torch::Tensor& persistent,
+                         const torch::Tensor& src) -> torch::Tensor {
+      if (!src.defined() || src.numel() == 0 || !persistent.defined()) {
+        return persistent;
+      }
+      return persistent.slice(/*dim=*/0, /*start=*/0, /*end=*/src.size(0));
+    };
+
+    const auto& src_dp = params.dp_ep_padding_data;
+    if (src_dp.attn_padding_idx().defined() &&
+        src_dp.attn_padding_idx().numel() > 0) {
+      auto& dst_dp = params_for_capture->dp_ep_padding_data;
+      dst_dp.attn_padding_idx(
+          slice_like(persistent_dp_ep_padding_.attn_padding_idx(),
+                     src_dp.attn_padding_idx()));
+      dst_dp.attn_unpadding_idx(
+          slice_like(persistent_dp_ep_padding_.attn_unpadding_idx(),
+                     src_dp.attn_unpadding_idx()));
+      dst_dp.ffn_padding_idx(
+          slice_like(persistent_dp_ep_padding_.ffn_padding_idx(),
+                     src_dp.ffn_padding_idx()));
+      dst_dp.ffn_unpadding_idx(
+          slice_like(persistent_dp_ep_padding_.ffn_unpadding_idx(),
+                     src_dp.ffn_unpadding_idx()));
+      dst_dp.lm_head_skip_padding_token_indices(slice_like(
+          persistent_dp_ep_padding_.lm_head_skip_padding_token_indices(),
+          src_dp.lm_head_skip_padding_token_indices()));
+      dst_dp.gather_prenorm_idx(
+          slice_like(persistent_dp_ep_padding_.gather_prenorm_idx(),
+                     src_dp.gather_prenorm_idx()));
+      dst_dp.padding_idx(slice_like(persistent_dp_ep_padding_.padding_idx(),
+                                    src_dp.padding_idx()));
+      dst_dp.un_padding_idx(slice_like(
+          persistent_dp_ep_padding_.un_padding_idx(), src_dp.un_padding_idx()));
+      dst_dp.dynamic_ep_idx(slice_like(
+          persistent_dp_ep_padding_.dynamic_ep_idx(), src_dp.dynamic_ep_idx()));
+      dst_dp.moe_idx(
+          slice_like(persistent_dp_ep_padding_.moe_idx(), src_dp.moe_idx()));
+      dst_dp.expert_array(slice_like(persistent_dp_ep_padding_.expert_array(),
+                                     src_dp.expert_array()));
+      dst_dp.post_lmhead_gather_indices(
+          slice_like(persistent_dp_ep_padding_.post_lmhead_gather_indices(),
+                     src_dp.post_lmhead_gather_indices()));
+    }
+
+    const auto& src_cp = params.cp_ep_padding_data;
+    if (src_cp.attn_padding_idx().defined() &&
+        src_cp.attn_padding_idx().numel() > 0) {
+      auto& dst_cp = params_for_capture->cp_ep_padding_data;
+      dst_cp.attn_padding_idx(
+          slice_like(persistent_cp_ep_padding_.attn_padding_idx(),
+                     src_cp.attn_padding_idx()));
+      dst_cp.attn_unpadding_idx(
+          slice_like(persistent_cp_ep_padding_.attn_unpadding_idx(),
+                     src_cp.attn_unpadding_idx()));
+      dst_cp.ffn_padding_idx(
+          slice_like(persistent_cp_ep_padding_.ffn_padding_idx(),
+                     src_cp.ffn_padding_idx()));
+      dst_cp.ffn_unpadding_idx(
+          slice_like(persistent_cp_ep_padding_.ffn_unpadding_idx(),
+                     src_cp.ffn_unpadding_idx()));
+      dst_cp.lm_head_skip_padding_token_indices(slice_like(
+          persistent_cp_ep_padding_.lm_head_skip_padding_token_indices(),
+          src_cp.lm_head_skip_padding_token_indices()));
+      dst_cp.gather_prenorm_idx(
+          slice_like(persistent_cp_ep_padding_.gather_prenorm_idx(),
+                     src_cp.gather_prenorm_idx()));
     }
 
     return params_for_capture;
@@ -1083,6 +1320,7 @@ bool AclGraph::capture(CausalLM* model,
   // executing simultaneously, which would trigger synchronous operations
   // that conflict with capture mode
   auto device_idx = tensor_options.device().index();
+  Device::empty_cache(device_idx);
 
   bool need_restore_stream = false;
   graph_stream_ = stream;
@@ -1280,16 +1518,21 @@ ModelOutput AclGraphExecutorImpl::run(const torch::Tensor& tokens,
   }
   // Keep actual n_tokens for replay output slicing.
   const uint32_t n_tokens = tokens_tensor.size(/*dim=*/0);
-  const uint32_t actual_batch_size = n_tokens / options_.num_decoding_tokens();
+  const uint32_t local_batch_size = n_tokens / options_.num_decoding_tokens();
+  const uint32_t global_batch_size =
+      graph_num_tokens / options_.num_decoding_tokens();
 
   // Large decode batches create too many/too large ACL graphs and may OOM.
   // Fall back to eager mode when batch size exceeds the safety threshold.
+  // Use global_batch_size so all DP ranks make the same decision and stay in
+  // sync on HCCL collectives.
   const uint32_t decode_batch_size_limit = static_cast<uint32_t>(
-      std::max<int32_t>(1, options_.max_seqs_per_batch()));
-  if (actual_batch_size > decode_batch_size_limit) {
+      std::max(1, FLAGS_acl_graph_decode_batch_size_limit));
+  if (global_batch_size > decode_batch_size_limit) {
     LOG_FIRST_N(WARNING, 1)
-        << "Falling back to eager mode because decode batch_size ("
-        << actual_batch_size << ") > " << decode_batch_size_limit
+        << "Falling back to eager mode because decode batch_size (global="
+        << global_batch_size << ", local=" << local_batch_size << ") > "
+        << decode_batch_size_limit
         << "; ACL graph is disabled for this request size to avoid OOM. "
         << "This message is logged only once. "
         << "Monitor counter 'num_model_execution_total_eager' for frequency.";
@@ -1345,14 +1588,23 @@ ModelOutput AclGraphExecutorImpl::run(const torch::Tensor& tokens,
   auto graph = std::make_unique<AclGraph>(*persistent_param_, device_.index());
   VLOG(kGraphExecutorLogVerboseLevel)
       << "AclGraphExecutorImpl::run() in capture mode";
-  bool capture_success = graph->capture(model_,
-                                        args_,
-                                        options_,
-                                        tokens_tensor,
-                                        positions_tensor,
-                                        params_single,
-                                        kv_caches,
-                                        bucket_num_tokens);
+  bool capture_success = false;
+  try {
+    capture_success = graph->capture(model_,
+                                     args_,
+                                     options_,
+                                     tokens_tensor,
+                                     positions_tensor,
+                                     params_single,
+                                     kv_caches,
+                                     bucket_num_tokens);
+  } catch (const std::exception& e) {
+    LOG(ERROR) << "ACL graph capture threw exception for bucket num_tokens="
+               << bucket_num_tokens << ": " << e.what()
+               << ". Falling back to eager mode.";
+    COUNTER_INC(num_model_execution_total_eager);
+    return model_->forward(tokens, positions, kv_caches, params);
+  }
 
   if (capture_success) {
     LOG(INFO) << "Lazy capturing ACL graph for bucket num_tokens: "

--- a/xllm/core/runtime/acl_graph_executor_impl.h
+++ b/xllm/core/runtime/acl_graph_executor_impl.h
@@ -249,6 +249,18 @@ class GraphPersistentParam {
   // Flag indicating whether attention plan needs to be updated based on model
   // type
   bool need_update_attention_plan_;
+
+  // Persistent dp/cp ep padding buffers. Pre-allocated in constructor with
+  // max decode capacity so that graph capture and replay always reference
+  // stable device addresses, regardless of actual vs bucket token counts.
+  DpEpPaddingData persistent_dp_ep_padding_;
+  CpEpPaddingData persistent_cp_ep_padding_;
+
+  // Copy src padding data into pre-allocated persistent buffers.
+  void update_persistent_dp_ep_padding(const DpEpPaddingData& src,
+                                       uint32_t padded_tokens);
+  void update_persistent_cp_ep_padding(const CpEpPaddingData& src,
+                                       uint32_t padded_tokens);
 };
 
 // ACL graph executor using libtorch NPUGraph for memory management

--- a/xllm/core/runtime/forward_shared_memory_manager.cpp
+++ b/xllm/core/runtime/forward_shared_memory_manager.cpp
@@ -2111,7 +2111,10 @@ inline void deserialize_raw_forward_input(const char*& buffer,
                 mgr_table,
                 /*stream=*/nullptr,
                 /*force_host_materialize=*/true);
-    input_params.multi_block_tables.emplace_back(std::move(mgr_table));
+    // Clone to decouple from shared memory buffer. With schedule_overlap the
+    // buffer may be overwritten by the next step while the worker is still
+    // reading multi_block_tables (which stay on CPU for DSA metadata).
+    input_params.multi_block_tables.emplace_back(mgr_table.clone());
   }
 
   read_dit_forward_input(context, input_params.dit_forward_input);

--- a/xllm/models/llm/deepseek_v4.h
+++ b/xllm/models/llm/deepseek_v4.h
@@ -24,10 +24,8 @@ limitations under the License.
 #include <cmath>
 #include <cstdint>
 #include <cstring>
-#include <iomanip>
 #include <limits>
 #include <memory>
-#include <sstream>
 #include <tuple>
 #include <unordered_map>
 #include <unordered_set>
@@ -69,27 +67,6 @@ inline torch::Tensor deepseek_v4_create_hadamard_matrix(
     matrix = torch::cat({top, bottom}, 0);
   }
   return matrix;
-}
-
-inline std::string deepseek_v4_format_bytes(int64_t bytes) {
-  static constexpr const char* kUnits[] = {"B", "KiB", "MiB", "GiB", "TiB"};
-  double value = static_cast<double>(bytes);
-  int unit_idx = 0;
-  while (value >= 1024.0 && unit_idx < 4) {
-    value /= 1024.0;
-    ++unit_idx;
-  }
-
-  std::ostringstream os;
-  if (value < 10.0 && unit_idx > 0) {
-    os << std::fixed << std::setprecision(2);
-  } else if (value < 100.0 && unit_idx > 0) {
-    os << std::fixed << std::setprecision(1);
-  } else {
-    os << std::fixed << std::setprecision(0);
-  }
-  os << value << " " << kUnits[unit_idx];
-  return os.str();
 }
 
 inline torch::Tensor maybe_to_device(const torch::Tensor& tensor,
@@ -656,8 +633,6 @@ class DeepseekV4ModelImpl
     CHECK(input_params.attn_metadata)
         << "DeepSeek V4 ACL graph requires DSA metadata";
   }
-
-  void log_weight_mem_stats() const { log_layer_weight_mem_stats(); }
 
   ModelOutput forward(torch::Tensor tokens,
                       torch::Tensor positions,
@@ -1492,47 +1467,6 @@ class DeepseekV4ModelImpl
         xllm::kernel::quant_lightning_indexer_metadata(qli_params);
   }
 
-  void log_layer_weight_mem_stats() const {
-    int64_t total_bytes = 0;
-    int64_t attn_bytes = 0;
-    int64_t expert_bytes = 0;
-    int64_t hc_bytes = 0;
-    int64_t other_bytes = 0;
-
-    for (size_t i = 0; i < layers_.size(); ++i) {
-      const auto stats = layers_[i]->get_weight_mem_stats();
-      total_bytes += stats.total_bytes;
-      attn_bytes += stats.attn_bytes;
-      expert_bytes += stats.expert_bytes;
-      hc_bytes += stats.hc_bytes;
-      other_bytes += stats.other_bytes;
-
-      LOG(INFO) << "[WEIGHT_MEM][DeepseekV4] layer=" << i
-                << " total=" << deepseek_v4_format_bytes(stats.total_bytes)
-                << " (" << stats.total_bytes << " B)"
-                << ", attn=" << deepseek_v4_format_bytes(stats.attn_bytes)
-                << " (" << stats.attn_bytes << " B)"
-                << ", expert=" << deepseek_v4_format_bytes(stats.expert_bytes)
-                << " (" << stats.expert_bytes << " B)"
-                << ", hc_=" << deepseek_v4_format_bytes(stats.hc_bytes) << " ("
-                << stats.hc_bytes << " B)"
-                << ", other=" << deepseek_v4_format_bytes(stats.other_bytes)
-                << " (" << stats.other_bytes << " B)";
-    }
-
-    LOG(INFO) << "[WEIGHT_MEM][DeepseekV4][Summary] layers=" << layers_.size()
-              << ", total=" << deepseek_v4_format_bytes(total_bytes) << " ("
-              << total_bytes << " B)"
-              << ", attn=" << deepseek_v4_format_bytes(attn_bytes) << " ("
-              << attn_bytes << " B)"
-              << ", expert=" << deepseek_v4_format_bytes(expert_bytes) << " ("
-              << expert_bytes << " B)"
-              << ", hc_=" << deepseek_v4_format_bytes(hc_bytes) << " ("
-              << hc_bytes << " B)"
-              << ", other=" << deepseek_v4_format_bytes(other_bytes) << " ("
-              << other_bytes << " B)";
-  }
-
   torch::Tensor hc_head(const torch::Tensor& x) {
     auto x_float = x.to(torch::kFloat32);
     auto x_flatten = x_float.flatten(-2, -1);
@@ -1585,7 +1519,6 @@ class DeepseekV4ForCausalLMImpl
                   std::string prefix = "model.") override {
     LlmForCausalLMImplBase<DeepseekV4Model>::load_model(std::move(loader),
                                                         std::move(prefix));
-    this->model_->log_weight_mem_stats();
   }
 
   bool requires_graph_forward_metadata() {


### PR DESCRIPTION
Fix the DeepSeek V4 NPU DP graph path by aligning graph capture/replay with DP/EP padding and rank-local token counts.

Also update KV cache shape and transfer handling for MLA KV layout, adjust NPU collective setup for DP graph execution, remove temporary DeepSeek V4 weight memory debug logs, and add ACL graph executor coverage for the new behavior.