### PR TITLE
bugfix: fix DSV4 single-block leaks and composite allocation rollback.

### DIFF
--- a/tests/core/framework/block/block_manager_test.cpp
+++ b/tests/core/framework/block/block_manager_test.cpp
@@ -263,6 +263,27 @@ TEST(BlockManagerPoolTest, DeallocateReleasesSingleBlockId) {
   EXPECT_EQ(GetSingleBlockIdOrFail(seq2), id1);
 }
 
+TEST(BlockManagerPoolTest, SingleBlockCapacityUsesOptionsMaxSeqs) {
+  ScopedValue<int32_t> max_seqs_guard(&FLAGS_max_seqs_per_batch, 0);
+
+  BlockManagerPool::Options options;
+  options.num_blocks(16)
+      .host_num_blocks(0)
+      .block_size(1)
+      .enable_prefix_cache(false)
+      .max_seqs_per_batch(4);
+  ASSERT_TRUE(EnableLinearStateOrFail(options));
+  BlockManagerPool pool(options, /*dp_size=*/1);
+
+  std::vector<Sequence> sequences;
+  sequences.reserve(4);
+  for (size_t i = 0; i < 4; ++i) {
+    sequences.emplace_back(MakeSequence(i, /*prompt_tokens=*/{1}));
+    EXPECT_TRUE(pool.allocate(&sequences.back()));
+    EXPECT_TRUE(HasSingleBlockIdOrFail(sequences.back()));
+  }
+}
+
 TEST(BlockManagerPoolTest, TryAllocateKvFailureRollsBackSingleBlock) {
   // unified scheduler-side single-block pool has 2 ids.
   ScopedValue<int32_t> max_seqs_guard(&FLAGS_max_seqs_per_batch, 0);

--- a/tests/core/framework/block/composite_block_manager_test.cpp
+++ b/tests/core/framework/block/composite_block_manager_test.cpp
@@ -270,6 +270,49 @@ TEST(CompositeBlockManagerTest, AllocateForSequence_NullSeqReturnsFalse) {
   EXPECT_FALSE(manager.allocate_for_sequence(nullptr, 10));
 }
 
+TEST(CompositeBlockManagerTest, FailedGrowthRollsBackNewBlocks) {
+  BlockManager::Options opts = MakeCompositeOptions(/*base_num_blocks=*/128,
+                                                    kBaseBlockSize,
+                                                    /*window_size=*/12,
+                                                    /*max_seqs_per_batch=*/4);
+  CompositeBlockManager manager(opts);
+
+  Sequence seq = MakeTestSequence(0, {1});
+  ASSERT_TRUE(manager.allocate_for_sequence(&seq, 1024));
+  const size_t used_before = manager.num_used_blocks();
+  const auto& before = seq.kv_state().composite_blocks();
+  ASSERT_EQ(before.size(), 3u);
+  const size_t swa_blocks_before = before[0].size();
+  const size_t c4_blocks_before = before[1].size();
+  const size_t c128_blocks_before = before[2].size();
+
+  EXPECT_FALSE(manager.allocate_for_sequence(&seq, 4096));
+  EXPECT_EQ(manager.num_used_blocks(), used_before);
+
+  const auto& after = seq.kv_state().composite_blocks();
+  ASSERT_EQ(after.size(), 3u);
+  EXPECT_EQ(after[0].size(), swa_blocks_before);
+  EXPECT_EQ(after[1].size(), c4_blocks_before);
+  EXPECT_EQ(after[2].size(), c128_blocks_before);
+
+  manager.deallocate_sequence(&seq);
+}
+
+TEST(CompositeBlockManagerTest, DeallocateToleratesRolledBackEmptySequence) {
+  BlockManager::Options opts = MakeCompositeOptions(/*base_num_blocks=*/128,
+                                                    kBaseBlockSize,
+                                                    /*window_size=*/12,
+                                                    /*max_seqs_per_batch=*/4);
+  CompositeBlockManager manager(opts);
+
+  Sequence seq = MakeTestSequence(0, {1});
+
+  EXPECT_FALSE(manager.allocate_for_sequence(&seq, 4096));
+  EXPECT_NO_FATAL_FAILURE(manager.deallocate_sequence(&seq));
+  EXPECT_TRUE(seq.kv_state().composite_blocks().empty());
+  EXPECT_EQ(manager.num_used_blocks(), 0u);
+}
+
 // Verifies that when seq token count increases, CompositeBlockManager correctly
 // adds blocks (only appends new blocks; existing block ids are preserved).
 TEST(CompositeBlockManagerTest, TokenIncrease_AddsBlocksIncrementally) {

--- a/xllm/core/distributed_runtime/llm_engine.cpp
+++ b/xllm/core/distributed_runtime/llm_engine.cpp
@@ -25,6 +25,7 @@ limitations under the License.
 #include <boost/algorithm/string.hpp>
 #include <chrono>
 #include <cstdint>
+#include <limits>
 #include <memory>
 
 #include "common/device_monitor.h"
@@ -814,7 +815,8 @@ bool LLMEngine::allocate_kv_cache(const KVCacheCapacity& kv_cache_cap) {
       .enable_xtensor(FLAGS_enable_xtensor)
       .num_layers(args_.n_layers())
       .slot_size(kv_cache_cap.slot_size())
-      .model_id(options_.model_id());
+      .model_id(options_.model_id())
+      .max_seqs_per_batch(options_.max_seqs_per_batch());
   if (util::is_deepseek_v4_model_type(args_.model_type())) {
     constexpr uint32_t kManagerTypeBlockManagerImpl = 0;
     constexpr uint32_t kManagerTypeSlidingWindowBlockManager = 1;
@@ -850,7 +852,9 @@ bool LLMEngine::allocate_kv_cache(const KVCacheCapacity& kv_cache_cap) {
         .max_tokens_per_batch(options_.max_tokens_per_batch())
         .manager_types(std::move(manager_types))
         .compress_ratios(std::move(manager_compress_ratios))
-        .max_seqs_per_batch(options_.max_seqs_per_batch());
+        .max_seqs_per_batch(options_.max_seqs_per_batch())
+        .num_single_blocks(static_cast<uint32_t>(std::min<int64_t>(
+            kv_cache_cap.swa_count(), std::numeric_limits<uint32_t>::max())));
   }
 
   if (options_.host_blocks_factor() > 1.0 || options_.enable_kvcache_store()) {

--- a/xllm/core/framework/block/block_manager_pool.cpp
+++ b/xllm/core/framework/block/block_manager_pool.cpp
@@ -49,6 +49,14 @@ BlockManagerPool::BlockManagerPool(const Options& options, int32_t dp_size)
       .compress_ratios(options_.compress_ratios())
       .max_seqs_per_batch(options_.max_seqs_per_batch());
 
+  const uint32_t max_single_block_sequences =
+      options_.max_seqs_per_batch() > 0
+          ? options_.max_seqs_per_batch()
+          : static_cast<uint32_t>(std::max(FLAGS_max_seqs_per_batch, 0));
+  const uint32_t num_single_blocks = std::max<uint32_t>(
+      options_.num_single_blocks(), max_single_block_sequences + 2);
+  CHECK_GT(num_single_blocks, 0u) << "num_single_blocks must be positive";
+
   for (int32_t i = 0; i < dp_size; ++i) {
     if (options_.enable_xtensor()) {
       // Use XTensorBlockManagerImpl for xtensor mode.
@@ -82,7 +90,7 @@ BlockManagerPool::BlockManagerPool(const Options& options, int32_t dp_size)
     // pool. Worker-side embedding and linear-state caches remain physically
     // separate and are addressed via transport fields.
     single_block_managers_.emplace_back(std::make_unique<SingleBlockManager>(
-        /*num_blocks=*/FLAGS_max_seqs_per_batch + 2,
+        /*num_blocks=*/num_single_blocks,
         /*resource_name=*/"single block",
         /*exhaustion_message=*/"No more single-block ids available"));
   }
@@ -130,7 +138,13 @@ bool BlockManagerPool::allocate_single_block(Sequence* sequence,
 
   auto single_blocks = single_block_managers_[dp_rank]->allocate(1);
   if (single_blocks.empty()) {
-    LOG(ERROR) << "Failed to allocate single block!";
+    const auto* manager = single_block_managers_[dp_rank].get();
+    LOG(ERROR) << "Failed to allocate single block! dp_rank=" << dp_rank
+               << ", free=" << manager->num_free_blocks()
+               << ", used=" << manager->num_used_blocks()
+               << ", total=" << manager->num_total_blocks()
+               << ", max_seqs_per_batch=" << options_.max_seqs_per_batch()
+               << ", configured_single_blocks=" << options_.num_single_blocks();
     return false;
   }
   sequence->set_single_block(std::move(single_blocks[0]));
@@ -169,6 +183,7 @@ void BlockManagerPool::deallocate(Sequence* sequence) {
   if (block_managers_[dp_rank]->is_composite()) {
     // TODO: not supporte prefix cache for composite manager yet.
     block_managers_[dp_rank]->deallocate_sequence(sequence);
+    deallocate_single_block(sequence, dp_rank);
     sequence->reset();
     return;
   }
@@ -214,8 +229,14 @@ bool BlockManagerPool::allocate(Sequence* sequence, size_t num_tokens) {
 
   if (block_managers_[dp_rank]->is_composite()) {
     // TODO: not supporte prefix cache for composite manager yet.
-    return block_managers_[dp_rank]->allocate_for_sequence(sequence,
-                                                           num_tokens);
+    if (!block_managers_[dp_rank]->allocate_for_sequence(sequence,
+                                                         num_tokens)) {
+      if (needs_single_block) {
+        deallocate_single_block(sequence, dp_rank);
+      }
+      return false;
+    }
+    return true;
   }
 
   // first try to allocate shared blocks

--- a/xllm/core/framework/block/block_manager_pool.h
+++ b/xllm/core/framework/block/block_manager_pool.h
@@ -49,6 +49,7 @@ class BlockManagerPool : public KVCacheManager {
     PROPERTY(std::vector<uint32_t>, manager_types) = {};
     PROPERTY(std::vector<uint32_t>, compress_ratios) = {};
     PROPERTY(uint32_t, max_seqs_per_batch) = 0;
+    PROPERTY(uint32_t, num_single_blocks) = 0;
   };
 
   explicit BlockManagerPool(const Options& options, int32_t dp_size = 1);

--- a/xllm/core/framework/block/composite_block_manager.cpp
+++ b/xllm/core/framework/block/composite_block_manager.cpp
@@ -97,7 +97,26 @@ bool CompositeBlockManager::allocate_for_sequence(Sequence* seq,
   }
   std::vector<std::vector<Block>>* composite =
       seq->kv_state().mutable_composite_blocks();
+  const size_t original_manager_count = composite->size();
   composite->resize(sub_managers_.size());
+  std::vector<size_t> original_sizes(composite->size(), 0);
+  for (size_t i = 0; i < composite->size(); ++i) {
+    original_sizes[i] = composite->at(i).size();
+  }
+
+  auto rollback_new_blocks = [&]() {
+    for (size_t i = 0; i < composite->size(); ++i) {
+      auto& manager_blocks = composite->at(i);
+      if (manager_blocks.size() <= original_sizes[i]) {
+        continue;
+      }
+      sub_managers_[i]->deallocate(
+          Slice<Block>(manager_blocks.data() + original_sizes[i],
+                       manager_blocks.size() - original_sizes[i]));
+      manager_blocks.resize(original_sizes[i]);
+    }
+    composite->resize(original_manager_count);
+  };
 
   auto& swa_blocks = composite->at(0);
   const size_t block_size = sub_managers_[0]->block_size();
@@ -128,6 +147,7 @@ bool CompositeBlockManager::allocate_for_sequence(Sequence* seq,
         sub_managers_[0]->allocate(swa_blocks_needed - old_size);
     if (blocks.size() != swa_blocks_needed - old_size) {
       swa_blocks.resize(old_size);
+      composite->resize(original_manager_count);
       return false;
     }
     std::move(blocks.begin(), blocks.end(), swa_blocks.begin() + old_size);
@@ -145,6 +165,7 @@ bool CompositeBlockManager::allocate_for_sequence(Sequence* seq,
 
     const auto blocks = sub_managers_[i]->allocate(num_additional_blocks);
     if (blocks.size() != num_additional_blocks) {
+      rollback_new_blocks();
       return false;
     }
 
@@ -160,7 +181,8 @@ void CompositeBlockManager::deallocate_sequence(Sequence* seq) {
   }
   const std::vector<std::vector<Block>>& composite =
       seq->kv_state().composite_blocks();
-  for (size_t i = 0; i < sub_managers_.size(); ++i) {
+  const size_t n = std::min(composite.size(), sub_managers_.size());
+  for (size_t i = 0; i < n; ++i) {
     if (!composite[i].empty()) {
       sub_managers_[i]->deallocate(composite[i]);
     }


### PR DESCRIPTION
This change fixes `Failed to allocate single block!` failures seen when running DeepSeek V4.

The root cause was that the DSV4 path uses `CompositeBlockManager`, but the composite deallocation path did not release the per-sequence single-block handle. As requests completed or failed, single-block IDs could be leaked and eventually exhaust the `SingleBlockManager` pool.

This PR fixes the issue by:
- Releasing the single-block handle when deallocating composite-managed sequences.
- Rolling back the single-block handle if composite KV allocation fails after the handle was allocated.
- Making `CompositeBlockManager::allocate_for_sequence()` transactional for newly appended blocks, so partial allocation failures do not leave leaked or half-attached blocks on the sequence.
- Making composite sequence deallocation tolerate rolled-back or partially initialized composite state.
- Sizing the DSV4 single-block pool from `swa_count`, matching the worker-side cache ID space.
- Adding diagnostics to single-block allocation failure logs.
- Adding regression tests for single-block capacity and composite allocation rollback.
