### PR TITLE
fix: add const qualifiers to reasoning_detector input parameters

### DIFF
--- a/xllm/parser/reasoning_detector.cpp
+++ b/xllm/parser/reasoning_detector.cpp
@@ -39,7 +39,7 @@ ReasoningDetector::ReasoningDetector(const std::string& think_start_token,
       in_reasoning_(force_reasoning),
       stream_reasoning_(stream_reasoning) {}
 
-ReasoningResult ReasoningDetector::detect_and_parse(std::string& text) {
+ReasoningResult ReasoningDetector::detect_and_parse(const std::string& text) {
   bool in_reasoning =
       in_reasoning_ || absl::StrContains(text, think_start_token_);
 
@@ -64,7 +64,7 @@ ReasoningResult ReasoningDetector::detect_and_parse(std::string& text) {
   return ReasoningResult(normal_text, reasoning_text);
 }
 
-ReasoningResult ReasoningDetector::parse_streaming_increment(
+ReasoningResult ReasoningDetector::parse_streaming_increment(const 
     std::string& new_text) {
   buffer_.append(new_text.data(), new_text.size());
   std::string current_text = buffer_;

--- a/xllm/parser/reasoning_detector.h
+++ b/xllm/parser/reasoning_detector.h
@@ -43,7 +43,7 @@ class ReasoningDetector {
 
   // Detects and parses reasoning sections in the provided text. Returns both
   // reasoning content and normal text separately.
-  ReasoningResult detect_and_parse(std::string& text);
+  ReasoningResult detect_and_parse(const std::string& text);
 
   // Streaming incremental parsing for reasoning content.
   // Handles partial reasoning tags and content.
@@ -52,7 +52,7 @@ class ReasoningDetector {
   //     Accumulates reasoning content until the end tag is found
   // If stream_reasoning is True:
   //     Streams reasoning content as it arrives
-  ReasoningResult parse_streaming_increment(std::string& new_text);
+  ReasoningResult parse_streaming_increment(const std::string& new_text);
 
  protected:
   std::string think_start_token_;


### PR DESCRIPTION
Both `detect_and_parse` and `parse_streaming_increment` take input string references that are never modified internally. Marking them `const` improves API correctness and enables passing temporaries or const references directly.