### PR TITLE
bugfix: resolve causal_conv1d tiling failure for qwen3.5 gdn decode with padded batches.

### DIFF
--- a/xllm/core/layers/npu_torch/qwen3_gated_delta_net_base.cpp
+++ b/xllm/core/layers/npu_torch/qwen3_gated_delta_net_base.cpp
@@ -381,12 +381,34 @@ torch::Tensor Qwen3GatedDeltaNetBaseImpl::forward(
         torch::IntArrayRef(input_params.parallel.has_initial_state);
   }
 
+  // For decode path, reshape mixed_qkv from [batch, seq_len, dim] to
+  // [batch * seq_len, dim] to match kernel expectations for run_mode=1.
+  // Also build per-token query_start_loc that covers all tokens including
+  // padding entries, since input_params.parallel.query_start_loc only covers
+  // actual requests.
+  torch::Tensor mixed_qkv_input = mixed_qkv;
+  std::vector<int64_t> query_start_loc_decode;
+  if (!attn_metadata.is_prefill && mixed_qkv.dim() == 3) {
+    int64_t num_tokens = batch_size * seq_len;
+    mixed_qkv_input = mixed_qkv.view({num_tokens, mixed_qkv.size(-1)});
+
+    query_start_loc_decode.reserve(num_tokens + 1);
+    for (int64_t i = 0; i <= num_tokens; ++i) {
+      query_start_loc_decode.push_back(i);
+    }
+  }
+
+  const std::vector<int64_t>& query_start_loc_to_use =
+      !attn_metadata.is_prefill && !query_start_loc_decode.empty()
+          ? query_start_loc_decode
+          : input_params.parallel.query_start_loc;
+
   mixed_qkv = xllm::kernel::causal_conv1d(
-      mixed_qkv,
+      mixed_qkv_input,
       conv_weight,
       conv_cache,
       std::optional<torch::Tensor>(),  // bias (no bias for qwen3)
-      torch::IntArrayRef(input_params.parallel.query_start_loc),
+      torch::IntArrayRef(query_start_loc_to_use),
       torch::IntArrayRef(linear_state_indices_vec),
       has_initial_state,
       num_accepted_tokens_opt,

--- a/xllm/core/layers/npu_torch/qwen3_gated_delta_net_base.cpp
+++ b/xllm/core/layers/npu_torch/qwen3_gated_delta_net_base.cpp
@@ -385,16 +385,26 @@ torch::Tensor Qwen3GatedDeltaNetBaseImpl::forward(
   // [batch * seq_len, dim] to match kernel expectations for run_mode=1.
   // Also build per-token query_start_loc that covers all tokens including
   // padding entries, since input_params.parallel.query_start_loc only covers
-  // actual requests.
+  // actual requests. Similarly expand linear_state_indices_vec so each token
+  // maps to the correct conv cache slot.
   torch::Tensor mixed_qkv_input = mixed_qkv;
   std::vector<int64_t> query_start_loc_decode;
+  std::vector<int64_t> linear_state_indices_vec_decode;
   if (!attn_metadata.is_prefill && mixed_qkv.dim() == 3) {
     int64_t num_tokens = batch_size * seq_len;
     mixed_qkv_input = mixed_qkv.view({num_tokens, mixed_qkv.size(-1)});
 
-    query_start_loc_decode.reserve(num_tokens + 1);
+    query_start_loc_decode.reserve(static_cast<size_t>(num_tokens + 1));
     for (int64_t i = 0; i <= num_tokens; ++i) {
-      query_start_loc_decode.push_back(i);
+      query_start_loc_decode.emplace_back(i);
+    }
+
+    linear_state_indices_vec_decode.reserve(static_cast<size_t>(num_tokens));
+    for (int64_t i = 0; i < batch_size; ++i) {
+      for (int64_t j = 0; j < seq_len; ++j) {
+        linear_state_indices_vec_decode.emplace_back(
+            linear_state_indices_vec[i]);
+      }
     }
   }
 
@@ -403,13 +413,18 @@ torch::Tensor Qwen3GatedDeltaNetBaseImpl::forward(
           ? query_start_loc_decode
           : input_params.parallel.query_start_loc;
 
+  const std::vector<int64_t>& linear_state_indices_to_use =
+      !attn_metadata.is_prefill && !linear_state_indices_vec_decode.empty()
+          ? linear_state_indices_vec_decode
+          : linear_state_indices_vec;
+
   mixed_qkv = xllm::kernel::causal_conv1d(
       mixed_qkv_input,
       conv_weight,
       conv_cache,
       std::optional<torch::Tensor>(),  // bias (no bias for qwen3)
       torch::IntArrayRef(query_start_loc_to_use),
-      torch::IntArrayRef(linear_state_indices_vec),
+      torch::IntArrayRef(linear_state_indices_to_use),
       has_initial_state,
       num_accepted_tokens_opt,
       1,        // activation_mode


### PR DESCRIPTION

## Summary

Cherry-pick PR#1428 fix from preview-qwen3.5-qwen3.6 branch to main, resolving the  decode path tiling failure for padded batches in Qwen3.5 GDN (causal_conv1d_update).

## PR Relationship & Code History

This fix traces through the following PR chain on the **develop** branch:

| PR | Description | Status |
|---|---|---|
| **#1357** | Replace `causal_conv1d_update` (AscendC) with unified `causal_conv1d` for decode path | Merged to develop, cherry-picked to main as **#1467** |
| **#1411** | Revert #1357 — restore separate prefill/decode dual paths due to functional issues | Merged to develop (revert of #1357) |
| **#1428** | Revert #1411 and fix #1357's bug — keep unified  but fix padded batch handling in decode path | Merged to develop (this is the fix we're cherry-picking) |
| **#1467** | Cherry-pick of #1357 to main | Merged to main (**has the bug**) |

**Current state on main**: PR#1467 (cherry-pick of #1357) is already merged, which introduced the unified  approach but **carries the bug** — the decode path () fails for padded batches because:
1.  is passed in 3D shape  instead of the 2D  expected by the kernel
2.  only covers actual requests, not all tokens including padding entries

**This PR**: Cherry-picks the fix from develop PR#1428 (commit ) to main, adapting API naming differences between the two branches.

## Changes

Only one file modified: 

**Fix logic** (adapted from PR#1428 to main branch API):

1. **Decode reshape**: When  and , reshape from  to  to match kernel expectations for 
2. **Per-token query_start_loc**: Build  covering all tokens including padding entries, since  only covers actual requests
3. **Conditional selection**: Use  for decode path, fall back to  for prefill path

**API adaptation** (develop → main):
-  → 
-  → 
-  → 

## Verification

The fix logic is identical to develop PR#1428 (commit ), only adapted for main branch API naming. The prefill path () remains unchanged — only the decode path () is fixed.
