### PR TITLE
perf: reuse causal_conv1d for Qwen3.5 MTP verify on npu device.

### DIFF
--- a/xllm/core/framework/model/model_input_params.h
+++ b/xllm/core/framework/model/model_input_params.h
@@ -373,6 +373,7 @@ struct ModelInputParams {
     params.extra_token_ids = std::move(extra_token_ids);
     params.is_spec_verify = is_spec_verify;
     params.num_accepted_tokens = safe_to(num_accepted_tokens, device, true);
+    params.num_accepted_tokens_vec = std::move(num_accepted_tokens_vec);
     params.dp_ep_padding_data = dp_ep_padding_data;
     params.cp_ep_padding_data
         .attn_padding_idx(
@@ -585,6 +586,7 @@ struct ModelInputParams {
 
   bool is_spec_verify = false;
   torch::Tensor num_accepted_tokens;
+  std::vector<int64_t> num_accepted_tokens_vec;
 
   // swap
   std::vector<BlockTransferInfo> swap_blocks;

--- a/xllm/core/layers/npu_torch/qwen3_gated_delta_net_base.cpp
+++ b/xllm/core/layers/npu_torch/qwen3_gated_delta_net_base.cpp
@@ -16,6 +16,7 @@ limitations under the License.
 #include <torch/torch.h>
 
 #include <tuple>
+#include <vector>
 
 #include "xllm/core/kernels/ops_api.h"
 
@@ -296,40 +297,51 @@ torch::Tensor build_linear_state_base_indices(
   return logical_state_indices * checkpoint_stride;
 }
 
+std::vector<int64_t> tensor_to_int64_vector(const torch::Tensor& tensor,
+                                            int64_t expected_size,
+                                            const char* name) {
+  CHECK(tensor.defined()) << name << " must be defined.";
+  torch::Tensor cpu_tensor = tensor.to(torch::kCPU, torch::kInt64).contiguous();
+  CHECK_EQ(cpu_tensor.numel(), expected_size)
+      << name << " size mismatch, expected " << expected_size << ", got "
+      << cpu_tensor.numel();
+  const int64_t* data = cpu_tensor.data_ptr<int64_t>();
+  return std::vector<int64_t>(data, data + cpu_tensor.numel());
+}
+
 torch::Tensor run_spec_verify_conv(const torch::Tensor& mixed_qkv,
                                    const torch::Tensor& conv_cache,
-                                   const torch::Tensor& logical_state_indices,
-                                   const torch::Tensor& num_accepted_tokens,
-                                   const torch::Tensor& q_cu_seq_lens,
+                                   const std::vector<int32_t>& linear_state_ids,
+                                   const std::vector<int64_t>& query_start_loc,
+                                   std::vector<int64_t> num_accepted_tokens,
                                    const torch::Tensor& conv_weight,
                                    int32_t conv_kernel_size) {
   const int64_t batch_size = mixed_qkv.size(0);
-  const int64_t seq_len = mixed_qkv.size(2);
+  const int64_t seq_len = mixed_qkv.size(1);
   const int64_t expanded_state_len = conv_cache.size(1);
   CHECK_EQ(expanded_state_len, conv_kernel_size - 1 + seq_len - 1)
       << "unexpected speculative conv cache len, expected "
       << (conv_kernel_size - 1 + seq_len - 1) << ", got " << expanded_state_len;
+  CHECK_EQ(num_accepted_tokens.size(), static_cast<size_t>(batch_size))
+      << "num_accepted_tokens must be per sequence.";
 
-  xllm::kernel::CausalConv1dUpdateParams conv1d_params;
-  conv1d_params.x = mixed_qkv.transpose(1, 2)
-                        .reshape({batch_size * seq_len, mixed_qkv.size(1)})
-                        .contiguous();
-  conv1d_params.conv_state = conv_cache.transpose(1, 2);
-  conv1d_params.weight = conv_weight;
-  conv1d_params.activation = true;
-  conv1d_params.conv_state_indices = logical_state_indices.contiguous();
-  conv1d_params.num_accepted_tokens =
-      num_accepted_tokens.to(mixed_qkv.device(), torch::kInt32).contiguous();
-  conv1d_params.query_start_loc = q_cu_seq_lens;
-  conv1d_params.max_query_len = static_cast<int32_t>(seq_len);
-
+  std::vector<int64_t> linear_state_indices(linear_state_ids.begin(),
+                                            linear_state_ids.end());
+  torch::IntArrayRef has_initial_state;
   torch::Tensor conv_output =
-      xllm::kernel::causal_conv1d_update(conv1d_params)
-          .view({batch_size, seq_len, mixed_qkv.size(1)})
-          .transpose(1, 2)
-          .contiguous();
+      xllm::kernel::causal_conv1d(mixed_qkv,
+                                  conv_weight,
+                                  conv_cache,
+                                  std::optional<torch::Tensor>(),
+                                  torch::IntArrayRef(query_start_loc),
+                                  torch::IntArrayRef(linear_state_indices),
+                                  has_initial_state,
+                                  torch::IntArrayRef(num_accepted_tokens),
+                                  1,
+                                  -1,
+                                  1);
 
-  return conv_output;
+  return conv_output.view({batch_size, -1, conv_output.size(-1)}).contiguous();
 }
 
 torch::Tensor run_spec_verify_gated_delta_rule(
@@ -586,17 +598,22 @@ torch::Tensor Qwen3GatedDeltaNetBaseImpl::forward(
   } else if (use_spec_verify) {
     CHECK(input_params.num_accepted_tokens.defined())
         << "num_accepted_tokens must be populated for Qwen3.5 spec verify";
-    torch::Tensor conv_weight_for_update =
-        conv_weight.transpose(0, 1).contiguous();
-    torch::Tensor pre_conv_mixed_qkv = mixed_qkv.transpose(1, 2);
-    mixed_qkv =
-        run_spec_verify_conv(pre_conv_mixed_qkv,
-                             conv_cache,
-                             logical_state_indices,
-                             input_params.num_accepted_tokens.to(device),
-                             attn_metadata.q_cu_seq_lens,
-                             conv_weight_for_update,
-                             conv_kernel_size_);
+    std::vector<int64_t> num_accepted_tokens =
+        input_params.num_accepted_tokens_vec;
+    if (num_accepted_tokens.empty()) {
+      num_accepted_tokens = tensor_to_int64_vector(
+          input_params.num_accepted_tokens, batch_size, "num_accepted_tokens");
+    }
+    mixed_qkv = run_spec_verify_conv(mixed_qkv,
+                                     conv_cache,
+                                     input_params.linear_state_ids,
+                                     input_params.query_start_loc,
+                                     std::move(num_accepted_tokens),
+                                     conv_weight,
+                                     conv_kernel_size_);
+    // run_spec_verify_conv returns [B, T, C]; convert to [B, C, T] to
+    // align with the other conv branches before process_mixed_qkv.
+    mixed_qkv = mixed_qkv.transpose(1, 2).contiguous();
   } else {
     torch::Tensor conv_weight_for_update =
         conv_weight.transpose(0, 1).contiguous();
@@ -923,6 +940,7 @@ torch::Tensor Qwen3GatedDeltaNetBaseImpl::reshape_qkvz_with_pad(
 
 std::tuple<torch::Tensor, torch::Tensor, torch::Tensor>
 Qwen3GatedDeltaNetBaseImpl::process_mixed_qkv(torch::Tensor& mixed_qkv) const {
+  // Caller guarantees mixed_qkv is in [B, C, T] layout after conv path.
   mixed_qkv = mixed_qkv.transpose(1, 2);
   int64_t batch_size = mixed_qkv.size(0);
   int64_t seq_len = mixed_qkv.size(1);

--- a/xllm/core/runtime/acl_graph_executor_impl.cpp
+++ b/xllm/core/runtime/acl_graph_executor_impl.cpp
@@ -599,6 +599,9 @@ std::optional<ModelInputParams> GraphPersistentParam::update(
     if (params.num_accepted_tokens.defined()) {
       params_for_capture->num_accepted_tokens =
           persistent_num_accepted_tokens(padded_batch_size);
+      params_for_capture->num_accepted_tokens_vec =
+          params.num_accepted_tokens_vec;
+      params_for_capture->num_accepted_tokens_vec.resize(padded_batch_size, 1);
     }
     if (use_expanded_spec_decode_attention) {
       params_for_capture->graph_buffer

--- a/xllm/core/runtime/mtp_worker_impl.cpp
+++ b/xllm/core/runtime/mtp_worker_impl.cpp
@@ -548,6 +548,8 @@ void MTPWorkerImpl::prepare_validate_inputs(const ForwardInput& input,
   }
   input_params.num_accepted_tokens =
       torch::tensor(accepted_prefix_lengths, int_options);
+  input_params.num_accepted_tokens_vec.assign(accepted_prefix_lengths.begin(),
+                                              accepted_prefix_lengths.end());
 }
 
 void MTPWorkerImpl::fill_validate_input_from_draft_outputs(


### PR DESCRIPTION
## Summary

This PR optimizes the Qwen3.5 MTP spec-verify GatedDeltaNet conv path on NPU by reusing the existing `causal_conv1d` path instead of the MTP-only `causal_conv1d_update` path.

The key root cause is that non-MTP decode already uses the optimized `causal_conv1d` flow, where host-side parameters and convolution weight layout are prepared outside the hot device path. MTP spec-verify did not reuse that path, so it repeatedly paid extra layout/transpose overhead around causal conv.

## Change

- Replace the MTP spec-verify conv helper from `causal_conv1d_update` to `causal_conv1d`.
- Pass host-side `query_start_loc`, `linear_state_ids`, and `num_accepted_tokens` into the helper as vectors / `IntArrayRef`, avoiding repeated tensor preparation in the hot path.
- Keep `num_accepted_tokens_vec` in `ModelInputParams` so MTP validate inputs can reuse the host values directly.
- Preserve graph capture padding by resizing `num_accepted_tokens_vec` together with the persistent graph input.

## Comparison Method

Baseline is the latest upstream preview branch:

- Base branch: `origin/preview/qwen3.5-qwen3.6`
- Base commit: `7cdaa866 bugfix: qwen3.5 resolve causal_conv1d tiling failure for concurrent decode requests. (#1585)`
- Submodules: `git submodule update --init --recursive --force`
- Recursive submodule check: no missing or drifted submodules
- Build: `python setup.py build --device npu`

Runtime configuration:

- Model: `Qwen35-27B`
- Draft model: `Qwen35-27B-mtp`
- TP: 4
- Devices: `12,13,14,15`
- MTP: 3 speculative tokens
- Chunk prefill: enabled
- Schedule overlap: enabled
- Dataset: evalscope random, 512 input tokens, 1024 output tokens
- Requests: `parallel=1`, `number=10`

Evalscope command:

```bash
evalscope perf \
  --parallel 1 \
  --number 10 \
  --model Qwen35-27B \
  --url http://127.0.0.1:38050/v1/chat/completions \
  --api openai \
  --dataset random \
  --max-tokens 1024 \
  --min-tokens 1024 \
  --prefix-length 0 \
  --min-prompt-length 512 \
  --max-prompt-length 512 \
  --tokenizer-path /home/data/weights/Qwen35-27B \
  --extra-args '{"ignore_eos": true}'
```

Before performance testing, all-card occupancy was checked with `npu-smi info`; NPU 6/7, physical devices `12,13,14,15`, had no running processes and were used for both runs.

## Result

| Metric | Latest preview baseline | This PR | Change |
|---|---:|---:|---:|
| Success | 10/10 | 10/10 | same |
| Avg Latency | 13.27 s | 11.86 s | -10.6% |
| TTFT | 461.37 ms | 453.17 ms | -1.8% |
| TPOT | 12.52 ms | 11.15 ms | -10.9% |
| Output Throughput | 74.64 tok/s | 83.19 tok/s | +11.5% |
| Decode Throughput | 79.87 tok/s | 89.69 tok/s | +12.3% |
| Decoded Tok/Iter | 2.99 | 3.29 | +10.0% |
| Spec Accept Rate | 66.5% | 69.6% | +3.1 pp |

The MTP accept rate does not regress, so this does not show obvious main-model correctness drift in the 10-request sanity run. The performance result shows no regression: TPOT improves by about 10.9% and output throughput improves by about 11.5% under the tested workload.

## Local Artifacts

- Baseline run: `/home/g00510989/xllm/runs/20260529_evalscope_512_1024_preview_qwen35_baseline_devices_12_15_retry`
- This PR run: `/home/g00510989/xllm/runs/20260529_evalscope_512_1024_reuse_conv_devices_12_15_retry`