### PR TITLE
[WIP]perf: overlap mtp draft extend preparation

### DIFF
--- a/xllm/core/runtime/mtp_worker_impl.cpp
+++ b/xllm/core/runtime/mtp_worker_impl.cpp
@@ -571,6 +571,13 @@ std::optional<ForwardOutput> MTPWorkerImpl::run_validate(
   Timer timer;
   timer.reset();
   auto future = impl_->step_async(validate_input);
+
+  DraftExtendPrepareContext draft_extend_context;
+  if (!input.input_params.embedding_ids.empty()) {
+    prepare_draft_extend_context(
+        input, options_.num_speculative_tokens() + 1, draft_extend_context);
+  }
+
   ForwardOutput target_output = std::move(future).get().value();
   COUNTER_ADD(speculative_execution_latency_seconds_target,
               timer.elapsed_seconds());
@@ -584,7 +591,11 @@ std::optional<ForwardOutput> MTPWorkerImpl::run_validate(
 
   // update cache and clear embeddings
   timer.reset();
-  run_draft_extend(input, val_output);
+  if (draft_extend_context.prepared) {
+    run_draft_extend(input, val_output, draft_extend_context);
+  } else {
+    run_draft_extend(input, val_output);
+  }
   COUNTER_ADD(speculative_execution_latency_seconds_draft,
               timer.elapsed_seconds());
 
@@ -620,22 +631,65 @@ void MTPWorkerImpl::prepare_draft_extend_inputs(
     const ForwardInput& base_input,
     const SampleOutput& validate_output,
     ForwardInput& extend_input) {
-  extend_input = base_input.to(device_, dtype_);
-  auto& input_params = extend_input.input_params;
+  DraftExtendPrepareContext context;
+  prepare_draft_extend_context(
+      base_input, validate_output.next_tokens.size(1), context);
+  finish_draft_extend_inputs(context, validate_output, extend_input);
+}
+
+void MTPWorkerImpl::prepare_draft_extend_context(
+    const ForwardInput& base_input,
+    int32_t num_val_tokens,
+    DraftExtendPrepareContext& context) {
+  CHECK_GT(num_val_tokens, 0) << "num_val_tokens must be positive";
+
+  context.extend_input = base_input.to(device_, dtype_);
+  auto& input_params = context.extend_input.input_params;
   const int32_t num_sequences = input_params.num_sequences;
 
   const int32_t block_size = options_.block_size();
+  context.token_ids_cpu = safe_to(base_input.token_ids, torch::kCPU);
+  context.positions_cpu = safe_to(base_input.positions, torch::kCPU);
+  context.block_tables_cpu = safe_to(input_params.block_tables, torch::kCPU);
+  auto view = specBuilder::make_decode_cpu_view(context.token_ids_cpu,
+                                                context.positions_cpu,
+                                                context.block_tables_cpu,
+                                                input_params.kv_seq_lens_vec);
+
+  context.input_token_ids.reserve(num_sequences);
+  context.num_sequences = num_sequences;
+  context.num_val_tokens = num_val_tokens;
+  context.block_size = block_size;
+  context.use_chunked_prefill = FLAGS_enable_atb_spec_kernel;
+
+  for (int32_t seq_id = 0; seq_id < num_sequences; ++seq_id) {
+    const int32_t input_token_id = view.token_ids[seq_id];
+    CHECK_GE(input_token_id, 0);
+    context.input_token_ids.emplace_back(input_token_id);
+  }
+
+  context.prepared = true;
+}
+
+void MTPWorkerImpl::finish_draft_extend_inputs(
+    const DraftExtendPrepareContext& context,
+    const SampleOutput& validate_output,
+    ForwardInput& extend_input) {
+  CHECK(context.prepared) << "draft extend context is not prepared";
+  extend_input = context.extend_input;
+  auto& input_params = extend_input.input_params;
+  const int32_t num_sequences = context.num_sequences;
+
   torch::TensorOptions int_options = extend_input.token_ids.options();
-  torch::Tensor token_ids = safe_to(base_input.token_ids, torch::kCPU);
-  torch::Tensor positions = safe_to(base_input.positions, torch::kCPU);
-  torch::Tensor block_tables = safe_to(input_params.block_tables, torch::kCPU);
-  auto view = specBuilder::make_decode_cpu_view(
-      token_ids, positions, block_tables, input_params.kv_seq_lens_vec);
   torch::Tensor accepted_tokens =
       safe_to(validate_output.next_tokens, torch::kCPU);
   const auto accepted_embeddings = validate_output.embeddings;
   constexpr int32_t num_extend_tokens = 2;
-  const bool use_chunked_prefill = FLAGS_enable_atb_spec_kernel;
+  const bool use_chunked_prefill = context.use_chunked_prefill;
+  auto view = specBuilder::make_decode_cpu_view(context.token_ids_cpu,
+                                                context.positions_cpu,
+                                                context.block_tables_cpu,
+                                                input_params.kv_seq_lens_vec);
 
   specBuilder::DecodeBuildBuffers buf;
   buf.out_token_ids.reserve(num_sequences * num_extend_tokens);
@@ -654,26 +708,6 @@ void MTPWorkerImpl::prepare_draft_extend_inputs(
   selected_row_idx.reserve(num_sequences);
 
   for (int32_t seq_id = 0; seq_id < num_sequences; ++seq_id) {
-    auto add_row = [&](int32_t token_id,
-                       int32_t relative_offset,
-                       const torch::Tensor& embedding) {
-      specBuilder::RowSpec row;
-      row.seq_id = seq_id;
-      row.token_id = token_id;
-      row.position_offset = relative_offset;
-      row.append_kv_len = !use_chunked_prefill;
-      row.append_q_len_one = !use_chunked_prefill;
-      row.append_block_table = !use_chunked_prefill;
-      specBuilder::append_decode_row(input_params, view, row, block_size, buf);
-      if (embedding.defined()) {
-        expanded_embeddings.emplace_back(embedding.to(device_));
-      } else {
-        expanded_embeddings.emplace_back(
-            torch::zeros({get_embedding_placeholder_size()},
-                         torch::dtype(dtype_).device(device_)));
-      }
-    };
-
     int32_t last_idx = -1;
     int32_t last_token_id = 0;
     for (int32_t i = 0; i < accepted_tokens.size(1); ++i) {
@@ -685,9 +719,10 @@ void MTPWorkerImpl::prepare_draft_extend_inputs(
     }
     CHECK_GE(last_idx, 0)
         << "each sequence must have at least one accepted token";
+    CHECK_LT(last_idx, context.num_val_tokens)
+        << "accepted token index exceeds prepared draft extend candidates";
 
-    int32_t prev_token_id = view.token_ids[seq_id];
-    CHECK_GE(prev_token_id, 0);
+    int32_t prev_token_id = context.input_token_ids[seq_id];
     torch::Tensor prev_embedding = torch::Tensor();
     const int32_t prev_idx = last_idx - 1;
     if (prev_idx >= 0) {
@@ -698,10 +733,25 @@ void MTPWorkerImpl::prepare_draft_extend_inputs(
     }
     torch::Tensor last_embedding = accepted_embeddings[seq_id][last_idx];
 
+    buf.out_token_ids.emplace_back(prev_token_id);
+    buf.out_token_ids.emplace_back(last_token_id);
+
+    auto add_row = [&](int32_t relative_offset) {
+      specBuilder::RowSpec row;
+      row.seq_id = seq_id;
+      row.position_offset = relative_offset;
+      row.append_token = false;
+      row.append_kv_len = !use_chunked_prefill;
+      row.append_q_len_one = !use_chunked_prefill;
+      row.append_block_table = !use_chunked_prefill;
+      specBuilder::append_decode_row(
+          input_params, view, row, context.block_size, buf);
+    };
+
     const int32_t prev_offset = (last_idx > 0) ? (last_idx - 1) : -1;
     const int32_t last_offset = last_idx;
-    add_row(prev_token_id, prev_offset, prev_embedding);
-    add_row(last_token_id, last_offset, last_embedding);
+    add_row(prev_offset);
+    add_row(last_offset);
     if (use_chunked_prefill) {
       specBuilder::append_seq_len_by_layout(buf.out_q_seq_lens,
                                             num_extend_tokens);
@@ -710,6 +760,15 @@ void MTPWorkerImpl::prepare_draft_extend_inputs(
       specBuilder::update_kv_seq_lens_and_max(
           buf.out_kv_seq_lens, kv_len, buf.kv_max_seq_len);
     }
+
+    if (prev_embedding.defined()) {
+      expanded_embeddings.emplace_back(prev_embedding.to(device_));
+    } else {
+      expanded_embeddings.emplace_back(
+          torch::zeros({get_embedding_placeholder_size()},
+                       torch::dtype(dtype_).device(device_)));
+    }
+    expanded_embeddings.emplace_back(last_embedding.to(device_));
     selected_row_idx.emplace_back(num_extend_tokens * seq_id + 1);
   }
 
@@ -773,6 +832,32 @@ void MTPWorkerImpl::run_draft_extend(const ForwardInput& input,
 
   ForwardInput extend_input;
   prepare_draft_extend_inputs(input, validate_output, extend_input);
+  auto extend_future = draft_impl_->step_async(extend_input);
+  auto extend_output_opt = std::move(extend_future).get();
+  CHECK(extend_output_opt.has_value()) << "draft extend output is empty";
+  ForwardOutput extend_output = std::move(extend_output_opt.value());
+  process_draft_sample_output(extend_output.sample_output);
+  auto& sample_output = extend_output.sample_output;
+  embedding_cache_->write(input.input_params.embedding_ids,
+                          sample_output.next_tokens,
+                          sample_output.embeddings,
+                          sample_output.probs,
+                          validate_output.next_tokens);
+}
+
+void MTPWorkerImpl::run_draft_extend(const ForwardInput& input,
+                                     const SampleOutput& validate_output,
+                                     const DraftExtendPrepareContext& context) {
+  CHECK(!input.input_params.embedding_ids.empty())
+      << "draft extend requires non-empty embedding_ids";
+  CHECK(validate_output.next_tokens.defined())
+      << "draft extend requires validate next_tokens";
+  CHECK(validate_output.embeddings.defined())
+      << "draft extend requires validate embeddings";
+  CHECK(context.prepared) << "draft extend context is not prepared";
+
+  ForwardInput extend_input;
+  finish_draft_extend_inputs(context, validate_output, extend_input);
   auto extend_future = draft_impl_->step_async(extend_input);
   auto extend_output_opt = std::move(extend_future).get();
   CHECK(extend_output_opt.has_value()) << "draft extend output is empty";

--- a/xllm/core/runtime/mtp_worker_impl.h
+++ b/xllm/core/runtime/mtp_worker_impl.h
@@ -15,6 +15,8 @@ limitations under the License.
 
 #pragma once
 
+#include <vector>
+
 #include "framework/kv_cache/embedding_cache.h"
 #if defined(USE_NPU)
 #include "framework/kv_cache_transfer/spec_kv_cache_transfer.h"
@@ -116,9 +118,33 @@ class MTPWorkerImpl : public SpeculativeWorkerImpl {
                                    const SampleOutput& validate_output,
                                    ForwardInput& extend_input);
 
+  struct DraftExtendPrepareContext {
+    ForwardInput extend_input;
+    torch::Tensor token_ids_cpu;
+    torch::Tensor positions_cpu;
+    torch::Tensor block_tables_cpu;
+    std::vector<int32_t> input_token_ids;
+    int32_t num_sequences = 0;
+    int32_t num_val_tokens = 0;
+    int32_t block_size = 0;
+    bool use_chunked_prefill = false;
+    bool prepared = false;
+  };
+
+  void prepare_draft_extend_context(const ForwardInput& base_input,
+                                    int32_t num_val_tokens,
+                                    DraftExtendPrepareContext& context);
+
+  void finish_draft_extend_inputs(const DraftExtendPrepareContext& context,
+                                  const SampleOutput& validate_output,
+                                  ForwardInput& extend_input);
+
   // Run one draft extend forward and write next-step seed into embedding cache.
   void run_draft_extend(const ForwardInput& input,
                         const SampleOutput& validate_output);
+  void run_draft_extend(const ForwardInput& input,
+                        const SampleOutput& validate_output,
+                        const DraftExtendPrepareContext& context);
 
  protected:
   // Draft model worker


### PR DESCRIPTION
## Summary

This PR overlaps the lightweight MTP draft-extend input preparation with target-model validation.

The change is intentionally conservative: it does **not** pre-dispatch draft computation and does **not** write draft KV before target validation finishes. It only moves target-output-independent preparation into the window after `impl_->step_async(validate_input)` and before `future.get()`.

## Optimization Idea

This follows the xLLM NPU optimization skill workflow:

1. Profile first and identify the MTP draft/validate bubble.
2. Separate work that depends on target validation output from deterministic host-side preparation.
3. Implement the smallest equivalent overlap first.
4. Validate both performance and accuracy before submitting.

In `MTPWorkerImpl::run_validate()`:

- Target validate is launched asynchronously.
- While target runs on device, xLLM prepares a `DraftExtendPrepareContext`.
- After target validate returns, the real accepted prefix is used to finish the draft extend input.
- The draft model is then executed exactly as before.

Prepared early:

- `base_input.to(device_, dtype_)`
- CPU views for `token_ids`, `positions`, `block_tables`
- input token ids
- sequence count, token count, block size, chunked-prefill mode

Still delayed until target validation completes:

- accepted-token scan
- actual `last_idx`
- target embeddings
- position/cache-slot/seq-len construction for the accepted prefix
- draft model dispatch
- embedding cache write

## Important Negative Result

I also tested a more aggressive P0 version that enumerated all possible `last_idx` candidates before target validation completed. That was equivalent but slower because it introduced extra CPU/vector construction work for candidates that are never used.

So this PR keeps only the low-risk P0b version.

## Benchmark

Environment:

- Model: Qwen35-27B
- Draft model: Qwen35-27B-mtp
- Hardware: Ascend 910B3 A3, Phy 8-11
- TP: 4
- MTP: `--num_speculative_tokens 3`
- Chunk prefill: enabled
- Dataset: random 20k input / 1k output
- EvalScope: `parallel=1`, `number=5`

| Version | Avg Latency(s) | TTFT(ms) | TPOT(ms) | Output TPS | Decoded/Iter | Accept |
|---|---:|---:|---:|---:|---:|---:|
| transpose-opt baseline | 14.03 | 2471.5 | 11.57 | 69.31 | 3.13 | 68.0% |
| P0 enumerate candidates | 14.81 | 2358.6 | 12.46 | 65.75 | 2.90 | 65.5% |
| P0b light prepare | 13.85 | 2466.0 | 11.39 | 70.18 | 3.09 | 67.6% |

Compared with transpose-opt baseline:

- Output TPS: `69.31 -> 70.18` (`+1.3%`)
- TPOT: `11.57 ms -> 11.39 ms` (`-1.6%`)
- Avg latency: `14.03 s -> 13.85 s` (`-1.3%`)

Artifacts:

- Benchmark: `/home/g00510989/xllm/runs/20260525_mtp3_async_draft_p0b/perf/random20k_1k_p1_n5/20260525_072650/Qwen35-27B/performance_summary.txt`
- Analysis report: `/home/g00510989/xllm/runs/20260525_mtp3_async_draft_p0b/analysis/mtp_draft_extend_prepare_overlap_report.md`

## Accuracy

GSM8K smoke test:

- `limit=10`
- `mean_acc=1.0`

Artifact:

- `/home/g00510989/xllm/runs/20260525_mtp3_async_draft_p0b/accuracy/gsm8k_limit10/reports/Qwen35-27B/gsm8k.json`

## Tests

- `sampler_test`: 11 passed, 2 skipped
- EvalScope random 20k/1k benchmark passed
- EvalScope GSM8K `limit=10` accuracy passed

## Follow-up

The larger vLLM-style async draft-dispatch optimization likely requires a shadow/pending draft KV state or double-buffered KV with commit/rollback after target validation. This PR is the safe first step and keeps the draft KV semantics unchanged.
