### PR TITLE
feat: qwen3.5 support chunked prefill.

### DIFF
--- a/xllm/core/kernels/npu/CMakeLists.txt
+++ b/xllm/core/kernels/npu/CMakeLists.txt
@@ -16,6 +16,7 @@ cc_library(
     fused_layernorm.cpp
     matmul.cpp
     npu_causal_conv1d.cpp
+    npu_fused_infer_attention.cpp
     npu_gemma_rms_norm.cpp
     npu_grouped_matmul.cpp
     npu_moe_gating_topk_softmax.cpp

--- a/xllm/core/kernels/npu/npu_fused_infer_attention.cpp
+++ b/xllm/core/kernels/npu/npu_fused_infer_attention.cpp
@@ -1,0 +1,199 @@
+/* Copyright 2026 The xLLM Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://github.com/jd-opensource/xllm/blob/main/LICENSE
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include <glog/logging.h>
+
+#include "core/kernels/npu/aclnn/pytorch_npu_helper.hpp"
+#include "core/kernels/npu/npu_ops_api.h"
+#include "core/kernels/npu/utils.h"
+
+namespace {
+
+constexpr int64_t kSwaIntMax = 2147483647;
+
+torch::Tensor infer_attention_output(
+    const torch::Tensor& query,
+    const torch::Tensor& value,
+    const std::optional<torch::Tensor>& block_table,
+    int64_t num_heads,
+    const std::string& input_layout) {
+  if (input_layout == "TND" || input_layout == "NTD") {
+    int64_t value_dim = query.size(-1);
+    if (!block_table.has_value() && value.dim() >= 3) {
+      value_dim = value.size(-1);
+    }
+    return torch::empty({query.size(0), num_heads, value_dim}, query.options());
+  }
+
+  if (input_layout == "BSH") {
+    return torch::empty_like(query);
+  }
+
+  if (input_layout == "BNSD") {
+    int64_t value_dim = query.size(-1);
+    if (!block_table.has_value() && value.dim() >= 4) {
+      value_dim = value.size(-1);
+    }
+    return torch::empty(
+        {query.size(0), query.size(1), query.size(2), value_dim},
+        query.options());
+  }
+
+  LOG(FATAL) << "Unsupported FIA input_layout: " << input_layout;
+  return torch::Tensor();
+}
+
+torch::Tensor infer_softmax_lse(const torch::Tensor& query,
+                                int64_t num_heads,
+                                const std::string& input_layout,
+                                bool softmax_lse_flag) {
+  auto options = query.options().dtype(torch::kFloat32);
+  if (!softmax_lse_flag) {
+    return torch::empty({0}, options);
+  }
+
+  if (input_layout == "TND" || input_layout == "NTD") {
+    return torch::empty({query.size(0), num_heads, 1}, options);
+  }
+
+  if (input_layout == "BSH") {
+    return torch::empty({query.size(0), num_heads, query.size(1), 1}, options);
+  }
+
+  if (input_layout == "BNSD") {
+    return torch::empty({query.size(0), query.size(1), query.size(2), 1},
+                        options);
+  }
+
+  LOG(FATAL) << "Unsupported FIA input_layout: " << input_layout;
+  return torch::Tensor();
+}
+
+std::optional<torch::Tensor> to_optional_tensor(
+    const std::optional<torch::Tensor>& tensor_opt) {
+  if (tensor_opt.has_value() && tensor_opt.value().defined()) {
+    return tensor_opt.value();
+  }
+  return std::nullopt;
+}
+
+}  // namespace
+
+namespace xllm::kernel::npu {
+
+std::tuple<torch::Tensor, torch::Tensor> npu_fused_infer_attention(
+    const torch::Tensor& query,
+    const torch::Tensor& key,
+    const torch::Tensor& value,
+    const std::optional<torch::Tensor>& atten_mask,
+    const std::optional<torch::Tensor>& block_table,
+    const std::vector<int64_t>& actual_seq_lengths,
+    const std::vector<int64_t>& actual_seq_lengths_kv,
+    int64_t num_heads,
+    int64_t num_key_value_heads,
+    double scale,
+    int64_t block_size,
+    int64_t sparse_mode,
+    const std::string& input_layout,
+    bool softmax_lse_flag) {
+  check_tensor(query, "query", "npu_fused_infer_attention");
+  check_tensor(key, "key", "npu_fused_infer_attention");
+  check_tensor(value, "value", "npu_fused_infer_attention");
+  CHECK_GT(num_heads, 0) << "num_heads must be positive";
+  CHECK(!actual_seq_lengths.empty()) << "actual_seq_lengths must not be empty";
+  CHECK(!actual_seq_lengths_kv.empty())
+      << "actual_seq_lengths_kv must not be empty";
+
+  torch::Tensor output = infer_attention_output(
+      query, value, block_table, num_heads, input_layout);
+  torch::Tensor softmax_lse =
+      infer_softmax_lse(query, num_heads, input_layout, softmax_lse_flag);
+
+  std::vector<torch::Tensor> key_tensors_vec{key};
+  std::vector<torch::Tensor> value_tensors_vec{value};
+  torch::TensorList key_tensors(key_tensors_vec);
+  torch::TensorList value_tensors(value_tensors_vec);
+
+  std::optional<torch::Tensor> none_tensor = std::nullopt;
+  std::optional<torch::Tensor> atten_mask_tensor =
+      to_optional_tensor(atten_mask);
+  std::optional<torch::Tensor> block_table_tensor =
+      to_optional_tensor(block_table);
+
+  torch::IntArrayRef actual_seq_lengths_ref(actual_seq_lengths);
+  torch::IntArrayRef actual_seq_lengths_kv_ref(actual_seq_lengths_kv);
+  std::optional<torch::IntArrayRef> actual_seq_lengths_opt =
+      actual_seq_lengths_ref;
+  std::optional<torch::IntArrayRef> actual_seq_lengths_kv_opt =
+      actual_seq_lengths_kv_ref;
+  std::optional<torch::IntArrayRef> none_int_array = std::nullopt;
+
+  std::string layout = input_layout;
+  char* input_layout_ptr = const_cast<char*>(layout.c_str());
+  int64_t pre_tokens = kSwaIntMax;
+  int64_t next_tokens = 0;
+  int64_t inner_precise = 0;
+  int64_t antiquant_mode = 0;
+  int64_t key_antiquant_mode = 0;
+  int64_t value_antiquant_mode = 0;
+
+  EXEC_NPU_CMD(aclnnFusedInferAttentionScoreV3,
+               query,
+               key_tensors,
+               value_tensors,
+               none_tensor,  // pse_shift
+               atten_mask_tensor,
+               actual_seq_lengths_opt,
+               actual_seq_lengths_kv_opt,
+               none_tensor,  // dequant_scale1
+               none_tensor,  // quant_scale1
+               none_tensor,  // dequant_scale2
+               none_tensor,  // quant_scale2
+               none_tensor,  // quant_offset2
+               none_tensor,  // antiquant_scale
+               none_tensor,  // antiquant_offset
+               block_table_tensor,
+               none_tensor,     // query_padding_size
+               none_tensor,     // kv_padding_size
+               none_tensor,     // key_antiquant_scale
+               none_tensor,     // key_antiquant_offset
+               none_tensor,     // value_antiquant_scale
+               none_tensor,     // value_antiquant_offset
+               none_tensor,     // key_shared_prefix
+               none_tensor,     // value_shared_prefix
+               none_int_array,  // actual_shared_prefix_len
+               none_tensor,     // query_rope
+               none_tensor,     // key_rope
+               none_tensor,     // key_rope_antiquant_scale
+               num_heads,
+               scale,
+               pre_tokens,
+               next_tokens,
+               input_layout_ptr,
+               num_key_value_heads,
+               sparse_mode,
+               inner_precise,
+               block_size,
+               antiquant_mode,
+               softmax_lse_flag,
+               key_antiquant_mode,
+               value_antiquant_mode,
+               output,
+               softmax_lse);
+
+  return {output, softmax_lse};
+}
+
+}  // namespace xllm::kernel::npu

--- a/xllm/core/kernels/npu/npu_ops_api.h
+++ b/xllm/core/kernels/npu/npu_ops_api.h
@@ -17,7 +17,9 @@ limitations under the License.
 #include <torch/torch.h>
 
 #include <optional>
+#include <string>
 #include <tuple>
+#include <vector>
 
 #include "custom_functions_npu/atb_common.h"
 
@@ -44,6 +46,22 @@ void batch_decode(const torch::Tensor& query,
                   const torch::Tensor& block_table,
                   const torch::Tensor& seq_lens,
                   torch::Tensor& output);
+
+std::tuple<torch::Tensor, torch::Tensor> npu_fused_infer_attention(
+    const torch::Tensor& query,
+    const torch::Tensor& key,
+    const torch::Tensor& value,
+    const std::optional<torch::Tensor>& atten_mask,
+    const std::optional<torch::Tensor>& block_table,
+    const std::vector<int64_t>& actual_seq_lengths,
+    const std::vector<int64_t>& actual_seq_lengths_kv,
+    int64_t num_heads,
+    int64_t num_key_value_heads,
+    double scale,
+    int64_t block_size,
+    int64_t sparse_mode,
+    const std::string& input_layout,
+    bool softmax_lse_flag = false);
 
 // Custom batch decode for ACL graph execution
 // This variant uses CustomPagedAttention to avoid .to(kCPU) operations

--- a/xllm/core/layers/common/attention_metadata.h
+++ b/xllm/core/layers/common/attention_metadata.h
@@ -156,7 +156,13 @@ struct AttentionMetadata {
   // If defined, use this instead of kv_seq_lens_host to avoid .to(kCPU)
   // operations that break ACL graph capture.
   torch::Tensor paged_attention_tiling_data;
-
+  // Pre-computed attention mask for npu_fused_infer_attention.
+  torch::Tensor fia_attn_mask;
+  // Host vectors for npu_fused_infer_attention (kernel requires host memory).
+  std::vector<int64_t> q_cu_seq_lens_host_vec;
+  std::vector<int64_t> kv_cu_seq_lens_host_vec;
+  // Non-cumulative per-sequence lengths for chunked_prefill mode.
+  std::vector<int64_t> kv_seq_lens_host_vec;
 #endif
 };
 

--- a/xllm/core/layers/common/attention_metadata_builder.cpp
+++ b/xllm/core/layers/common/attention_metadata_builder.cpp
@@ -100,6 +100,43 @@ AttentionMetadata build_attention_metadata(
     attn_metadata.kv_seq_lens_host =
         torch::tensor(params.attention.host.kv_seq_lens, torch::kInt);
   }
+  if (!params.attention.host.q_cu_seq_lens.empty()) {
+    attn_metadata.q_cu_seq_lens_host_vec.reserve(
+        params.attention.host.q_cu_seq_lens.size());
+    for (int32_t len : params.attention.host.q_cu_seq_lens) {
+      attn_metadata.q_cu_seq_lens_host_vec.emplace_back(len);
+    }
+  }
+  if (!params.attention.host.kv_seq_lens.empty()) {
+    attn_metadata.kv_seq_lens_host_vec.reserve(
+        params.attention.host.kv_seq_lens.size());
+    std::vector<int64_t> kv_cu;
+    kv_cu.reserve(params.attention.host.kv_seq_lens.size());
+    int64_t total = 0;
+    for (int32_t len : params.attention.host.kv_seq_lens) {
+      total += len;
+      kv_cu.emplace_back(total);
+      attn_metadata.kv_seq_lens_host_vec.emplace_back(len);
+    }
+    attn_metadata.kv_cu_seq_lens_host_vec = std::move(kv_cu);
+  }
+  if (!is_decode) {
+    constexpr int64_t kFiaSplitFuseMaskSize = 2048;
+    auto cpu_options = torch::TensorOptions().dtype(torch::kFloat32);
+    torch::Device mask_device = torch::kCPU;
+    if (params.attention.device.q_seq_lens.defined()) {
+      mask_device = params.attention.device.q_seq_lens.device();
+    } else if (params.embedding.input_embedding.defined()) {
+      mask_device = params.embedding.input_embedding.device();
+    }
+    attn_metadata.fia_attn_mask =
+        torch::triu(torch::ones({kFiaSplitFuseMaskSize, kFiaSplitFuseMaskSize},
+                                cpu_options),
+                    1)
+            .to(torch::kInt8)
+            .to(mask_device)
+            .contiguous();
+  }
 #endif
   attn_metadata.is_chunked_prefill =
       params.meta.batch_forward_type.is_mixed() ||

--- a/xllm/core/layers/npu_torch/attention.cpp
+++ b/xllm/core/layers/npu_torch/attention.cpp
@@ -89,21 +89,46 @@ void AttentionImpl::prefill_forward(torch::Tensor& query,
     key = key.view({-1, num_kv_heads_, head_size_});
     value = value.view({-1, num_kv_heads_, head_size_});
 
-    xllm::kernel::npu::batch_prefill(query,
-                                     key,
-                                     value,
-                                     attn_metadata.attn_mask,
-                                     attn_metadata.kv_seq_lens_host,
-                                     scale_,
-                                     output);
+    auto fia_result = xllm::kernel::npu::npu_fused_infer_attention(
+        query,
+        key,
+        value,
+        attn_metadata.fia_attn_mask.defined()
+            ? std::make_optional(attn_metadata.fia_attn_mask)
+            : std::nullopt,
+        std::nullopt,
+        attn_metadata.q_cu_seq_lens_host_vec,
+        attn_metadata.kv_cu_seq_lens_host_vec,
+        num_heads_,
+        num_kv_heads_,
+        scale_,
+        /*block_size=*/0,
+        /*sparse_mode=*/3,
+        "TND");
+    output.copy_(std::get<0>(fia_result).view_as(output));
   } else if (attn_metadata.is_chunked_prefill) {
-    xllm::kernel::npu::batch_prefill(query,
-                                     k_cache,
-                                     v_cache.value(),
-                                     attn_metadata.attn_mask,
-                                     attn_metadata.kv_seq_lens_host,
-                                     scale_,
-                                     output);
+    torch::Tensor k = k_cache.view({k_cache.size(0), k_cache.size(1), -1});
+    torch::Tensor v = v_cache.value().view(
+        {v_cache.value().size(0), v_cache.value().size(1), -1});
+    auto fia_result = xllm::kernel::npu::npu_fused_infer_attention(
+        query,
+        k,
+        v,
+        attn_metadata.fia_attn_mask.defined()
+            ? std::make_optional(attn_metadata.fia_attn_mask)
+            : std::nullopt,
+        attn_metadata.block_table.defined()
+            ? std::make_optional(attn_metadata.block_table)
+            : std::nullopt,
+        attn_metadata.q_cu_seq_lens_host_vec,
+        attn_metadata.kv_seq_lens_host_vec,
+        num_heads_,
+        num_kv_heads_,
+        scale_,
+        /*block_size=*/k_cache.size(1),
+        /*sparse_mode=*/3,
+        "TND");
+    output.copy_(std::get<0>(fia_result).view_as(output));
   }
 }
 

--- a/xllm/core/layers/npu_torch/qwen3_gated_delta_net_base.cpp
+++ b/xllm/core/layers/npu_torch/qwen3_gated_delta_net_base.cpp
@@ -332,7 +332,9 @@ torch::Tensor Qwen3GatedDeltaNetBaseImpl::forward(
   torch::Tensor ba_flat;
   int64_t batch_size = 0;
   int64_t seq_len = 0;
-  if (attn_metadata.is_prefill) {
+  bool is_any_prefill =
+      attn_metadata.is_prefill || attn_metadata.is_chunked_prefill;
+  if (is_any_prefill) {
     std::tie(qkvz_flat, ba_flat) = project_flat_inputs(hidden_states);
     batch_size = 1;
     seq_len = qkvz_flat.size(0);
@@ -355,7 +357,7 @@ torch::Tensor Qwen3GatedDeltaNetBaseImpl::forward(
   std::tie(mixed_qkv, z, b, a) =
       xllm::kernel::fused_qkvzba_split_reshape_cat(fused_params);
 
-  if (!attn_metadata.is_prefill) {
+  if (!is_any_prefill) {
     mixed_qkv = mixed_qkv.view({batch_size, seq_len, mixed_qkv.size(-1)});
   }
   z = z.view({batch_size, seq_len, num_v_heads_ / tp_size_, head_v_dim_});
@@ -374,7 +376,7 @@ torch::Tensor Qwen3GatedDeltaNetBaseImpl::forward(
       input_params.embedding.linear_state_ids.begin(),
       input_params.embedding.linear_state_ids.end());
   int64_t run_mode = 1;
-  if (attn_metadata.is_prefill) {
+  if (is_any_prefill) {
     run_mode = 0;
     has_initial_state =
         torch::IntArrayRef(input_params.parallel.has_initial_state);
@@ -435,7 +437,7 @@ torch::Tensor Qwen3GatedDeltaNetBaseImpl::forward(
   mixed_qkv = mixed_qkv.view({batch_size, -1, mixed_qkv.size(-1)}).contiguous();
   mixed_qkv = mixed_qkv.transpose(1, 2);
   // Compute gated delta net decay and beta terms.
-  if (attn_metadata.is_prefill) {
+  if (is_any_prefill) {
     xllm::kernel::FusedGdnGatingParams gdn_params;
     gdn_params.A_log = A_log_;
     gdn_params.a = a.contiguous().view({-1, a.size(-1)});
@@ -458,7 +460,7 @@ torch::Tensor Qwen3GatedDeltaNetBaseImpl::forward(
   }
   auto [processed_q, processed_k, processed_v] = process_mixed_qkv(mixed_qkv);
   // Apply chunked or recurrent gated-delta attention and update caches.
-  if (attn_metadata.is_prefill) {
+  if (is_any_prefill) {
     xllm::kernel::ChunkGatedDeltaRuleParams chunk_gated_delta_params;
     chunk_gated_delta_params.q = processed_q;
     chunk_gated_delta_params.k = processed_k;
@@ -478,6 +480,12 @@ torch::Tensor Qwen3GatedDeltaNetBaseImpl::forward(
         initial_state_tensor.select(0, static_cast<int64_t>(i)).fill_(0.0);
       }
     }
+
+    if (attn_metadata.is_chunked_prefill) {
+      initial_state_tensor =
+          initial_state_tensor.transpose(-1, -2).contiguous();
+    }
+
     chunk_gated_delta_params.initial_state = initial_state_tensor;
     chunk_gated_delta_params.output_final_state = true;
     chunk_gated_delta_params.cu_seqlens = attn_metadata.q_cu_seq_lens;


### PR DESCRIPTION
## Description
### Added chunked prefill support for Qwen3.5 model

### Changed Files:
- npu_fused_infer_attention.cpp (+199 lines) - New NPU fused infer attention kernel implementation
- attention_metadata.h (+7 lines) - Extended attention metadata structure
- attention_metadata_builder.cpp (+37 lines) - Updated metadata builder logic
- attention.cpp (+53/-5 lines) - Adjusted NPU torch attention layer
- qwen3_gated_delta_net_base.cpp (+18/-14 lines) - Adapted Qwen3 model
- npu_ops_api.h (+18 lines) - Added NPU ops API declarations
- CMakeLists.txt (+1 line) - Build configuration update

## Change Type

- [ ] Bug fix
- [x] New feature
- [ ] Performance improvement
- [ ] Refactor
- [ ] Documentation
- [ ] Test
- [ ] Build or CI

### Self Review

- [x] I have self-reviewed the code according to `.agents/skills/code-review/references/custom-code-style.md`, especially code written or assisted by AI.
- [x] I have rebased this PR onto the latest `main` branch.

### Build and Test Coverage

- [x] Tests have been added or updated as needed.
- [ ] CUDA: `python setup.py build test` has passed on a CUDA machine.
- [x] NPU: `python setup.py build test` has passed on an NPU machine.
- [ ] MLU: `python setup.py build test` has passed on an MLU machine.

<img width="1174" height="446" alt="image" src="https://github.com/user-attachments/assets/0d31be99-5402-491d-8d29-692465f9287f" />
