### PR TITLE
bugfix: serialize qwen3 next attention weight transforms.

### DIFF
--- a/xllm/core/layers/npu_torch/qwen3_next_attention.cpp
+++ b/xllm/core/layers/npu_torch/qwen3_next_attention.cpp
@@ -202,10 +202,13 @@ torch::Tensor Qwen3NextAttentionImpl::forward(
 }
 
 void Qwen3NextAttentionImpl::load_state_dict(const StateDict& state_dict) {
+  std::lock_guard<std::mutex> lock(load_state_dict_mutex_);
+
+  const bool qkv_weight_was_loaded = qkv_proj_->is_weight_loaded();
   qkv_proj_->load_state_dict(state_dict, {"q_proj.", "k_proj.", "v_proj."});
 
-  if (attn_output_gate_ && qkv_proj_->is_weight_loaded() &&
-      !qkv_weight_reordered_) {
+  if (attn_output_gate_ && !qkv_weight_was_loaded &&
+      qkv_proj_->is_weight_loaded()) {
     // Rearrange q_proj rows from per-head interleaved [q0,g0,q1,g1,...]
     // to grouped [q0,q1,...,g0,g1,...] so forward output is [Q|G|K|V].
     auto w = qkv_proj_->weight();
@@ -218,13 +221,14 @@ void Qwen3NextAttentionImpl::load_state_dict(const StateDict& state_dict) {
         {q_part.reshape({q_size_, hidden}), g_part.reshape({q_size_, hidden})},
         0);
     qg_rows.copy_(reordered);
-    qkv_weight_reordered_ = true;
   }
 
   o_proj_->load_state_dict(state_dict.get_dict_with_prefix("o_proj."));
+  const bool q_norm_weight_was_loaded = q_norm_->is_weight_loaded();
   if (auto w = state_dict.get_tensor("q_norm.weight"); w.defined()) {
     q_norm_->load_state_dict(StateDict({{"weight", w}}));
   }
+  const bool k_norm_weight_was_loaded = k_norm_->is_weight_loaded();
   if (auto w = state_dict.get_tensor("k_norm.weight"); w.defined()) {
     k_norm_->load_state_dict(StateDict({{"weight", w}}));
   }
@@ -233,13 +237,11 @@ void Qwen3NextAttentionImpl::load_state_dict(const StateDict& state_dict) {
   // uses standard RMSNorm (w only). Pre-add 1 so the fused kernel produces
   // the same result as Qwen3NextRMSNorm (gemma_rms_norm).
   if (use_fused_qkv_) {
-    if (q_norm_->is_weight_loaded() && !q_norm_weight_adjusted_) {
+    if (!q_norm_weight_was_loaded && q_norm_->is_weight_loaded()) {
       q_norm_->weight().add_(1.0);
-      q_norm_weight_adjusted_ = true;
     }
-    if (k_norm_->is_weight_loaded() && !k_norm_weight_adjusted_) {
+    if (!k_norm_weight_was_loaded && k_norm_->is_weight_loaded()) {
       k_norm_->weight().add_(1.0);
-      k_norm_weight_adjusted_ = true;
     }
   }
 }

--- a/xllm/core/layers/npu_torch/qwen3_next_attention.h
+++ b/xllm/core/layers/npu_torch/qwen3_next_attention.h
@@ -17,6 +17,7 @@ limitations under the License.
 
 #include <torch/torch.h>
 
+#include <mutex>
 #include <vector>
 
 #include "attention.h"
@@ -53,6 +54,8 @@ class Qwen3NextAttentionImpl : public torch::nn::Module {
   void load_state_dict(const StateDict& state_dict);
 
  private:
+  std::mutex load_state_dict_mutex_;
+
   int64_t num_heads_;
   int64_t num_kv_heads_;
   int64_t num_kv_head_replicas_;
@@ -67,9 +70,6 @@ class Qwen3NextAttentionImpl : public torch::nn::Module {
   float rms_norm_eps_;
   bool use_fused_qkv_;
   bool is_interleaved_;
-  bool qkv_weight_reordered_ = false;
-  bool q_norm_weight_adjusted_ = false;
-  bool k_norm_weight_adjusted_ = false;
   std::vector<int64_t> mrope_section_;
   torch::Tensor mrope_gather_pattern_;
 


### PR DESCRIPTION
## Summary

Fix a race in `Qwen3NextAttentionImpl::load_state_dict()` introduced around the PR #1400 weight-transform guards.

The model loader reads multiple safetensor shards concurrently. With ordinary per-transform bool flags, two loader threads can enter the same attention layer at the same time and both observe an unprocessed state before running the in-place transforms. That can repeat:

- Q/G row reorder for fused QKV weights
- `q_norm.weight().add_(1.0)` / `k_norm.weight().add_(1.0)` for the fused qkv rmsnorm path

This PR serializes the per-layer `load_state_dict()` critical section and changes the guards to the real weight-loaded transition (`!was_loaded && is_weight_loaded()`), so each transform runs exactly when the corresponding submodule first becomes loaded.

## Skill / investigation notes

Following the local xLLM NPU optimization skill review flow:

- Checked the safetensor load logs and confirmed the Qwen35-27B load path fans out over 11 shard-loading threads.
- Treated in-place weight transforms (`copy_`, `add_`) as precision-sensitive critical sections.
- Avoided relying on standalone bool flags for cross-thread state transitions.

The detailed local analysis was recorded in:

- `xllm-npu-optimization-skills/docs/pr-1400-qwen3-next-weight-transform-race.md`

## Validation

Build / unit:

- `cmake --build /home/g00510989/xllm/xllm/build/cmake.linux-aarch64-cpython-311 --target xllm -j 16`
- `/home/g00510989/xllm/xllm/build/lib.linux-aarch64-cpython-311/xllm/sampler_test`
  - 11 passed, 2 skipped (MLU-only)

Precision smoke:

- TP=2, Qwen35-27B, chunked prefill on, schedule overlap on, graph on
- 10 short deterministic math / sanity prompts: fixed version `PASS 10/10`
- The same 10 prompts also pass on the unfixed version, so they are only sanity checks, not reproduction evidence.

CEval A/B evidence:

- Dataset: CEval
- Subsets: `operating_system`, `computer_architecture`
- Samples: first 10 from each subset, 5-shot
- Generation config: `max_tokens=30000`, `temperature=0.6`, `top_p=0.95`, `top_k=20`, thinking mode enabled
- TP=2, `ASCEND_RT_VISIBLE_DEVICES=2,3`

| Version | operating_system | computer_architecture | overall |
| --- | ---: | ---: | ---: |
| unfixed #1400 guards | 9/10 | 10/10 | 19/20 |
| this PR | 10/10 | 10/10 | 20/20 |

Key differing sample:

- subset: `operating_system`
- index: 8
- target: `B`
- unfixed output: `答案：D`
- fixed output: `答案：B`
