### PR TITLE
feat: support best of n in disaggregated PD mode.

### DIFF
--- a/docs/en/features/disagg_pd.md
+++ b/docs/en/features/disagg_pd.md
@@ -76,8 +76,19 @@ ENABLE_DECODE_RESPONSE_TO_SERVICE=true ./xllm_master_serving --etcd_addr="127.0.
     - `etcd_addr` must match the `etcd_addr` of `xllm_service`
 
 ## Notice
-Disaggregated PD **does not support** enabling prefix cache or chunked prefill. These features must be disabled using the following parameters:
+On the Prefill instance of disaggregated PD, prefix cache is not supported with the current chunked-prefill PD scheduler and must be disabled:
 ```shell
---enable_prefix_cache=false  
---enable_chunked_prefill=false  
+--enable_prefix_cache=false
 ```
+
+## Decode instance: prefix cache is supported (recommended)
+Starting from xLLM v0.x, the Decode instance supports `--enable_prefix_cache=true`. **When a request carries `best_of > 1` (best-of-N sampling), the Decode instance must enable prefix cache**, otherwise the request is rejected. With prefix cache enabled, expanded candidate sequences reuse the first sequence's prompt KV via the prefix cache, avoiding duplicate compute and memory.
+```shell
+--enable_prefix_cache=true
+```
+
+## best_of_n support in disaggregated PD
+- **Requirements**: Decode instance must enable `--enable_prefix_cache=true`. Any request with `best_of > 1` while the Decode instance has `enable_prefix_cache=false` is rejected.
+- **Flow**: The Prefill instance only prefills the first sequence and ships its KV to the Decode instance. On the Decode side, after the first token is received, the prompt KV is registered into the prefix cache so that the expanded `best_of-1` candidate sequences hit it via prefix match.
+- **MLU platform**: PD + best_of_n is not supported yet (gated by `normalize_mlu`).
+- **`best_of != n`**: Streaming is forcibly disabled (same as the non-PD behavior).

--- a/docs/zh/features/disagg_pd.md
+++ b/docs/zh/features/disagg_pd.md
@@ -67,8 +67,19 @@ ENABLE_DECODE_RESPONSE_TO_SERVICE=true ./xllm_master_serving --etcd_addr="127.0.
     - `etcd_addr`需与`xllm_service`的`etcd_addr`相同
 
 !!! warning "注意事项"
-    PD分离目前不支持开启prefix cache及chunked prefill功能，需要通过以下参数关闭
+    PD分离的Prefill实例与chunked prefill的Prefill实例目前不支持prefix cache，需要通过以下参数关闭
     ``` shell
     --enable_prefix_cache=false
-    --enable_chunked_prefill=false
     ```
+
+!!! tip "Decode实例开启prefix cache（推荐）"
+    从xLLM v0.x开始，Decode实例支持开启prefix cache。**当请求带 `best_of > 1` 时（best-of-N采样），Decode实例必须开启prefix cache**，否则请求会被拒绝。开启后扩展出的候选序列会通过prefix cache复用第一条序列的prompt KV，避免重复算力与显存浪费。
+    ``` shell
+    --enable_prefix_cache=true
+    ```
+
+!!! info "PD分离下的best_of_n支持"
+    - **必要条件**：Decode实例 `--enable_prefix_cache=true`；任意请求 `best_of > 1` + Decode `enable_prefix_cache=false` 会被拒绝并返回错误。
+    - **流程**：Prefill实例只对第一条序列做prefill并把KV发到Decode；Decode实例在收到first token后通过prefix cache将prompt KV共享给扩展出的 `best_of-1` 条候选序列。
+    - **MLU平台**：暂不支持 PD + best_of_n（受 `normalize_mlu` 限制）。
+    - **`best_of != n`时**：流式输出仍会被强制关闭（与non-PD行为一致）。

--- a/tests/core/scheduler/continuous_scheduler_test.cpp
+++ b/tests/core/scheduler/continuous_scheduler_test.cpp
@@ -217,6 +217,39 @@ std::shared_ptr<Request> generate_request_with_prompt_tokens(
   return std::make_shared<Request>("1", "1", "1", std::move(req_state), "1");
 }
 
+std::shared_ptr<Request> generate_request_with_best_of(
+    const std::vector<int32_t>& prompt_token_ids,
+    int32_t max_tokens,
+    int32_t max_context_len,
+    size_t n,
+    size_t best_of) {
+  RequestSamplingParam sampling_param;
+  SchedulerParam scheduler_param;
+
+  StoppingChecker stopping_checker;
+  stopping_checker.set_max_generated_tokens(max_tokens);
+  stopping_checker.set_max_context_len(max_context_len);
+  stopping_checker.set_ignore_eos(true);
+
+  RequestState req_state("x",
+                         prompt_token_ids,
+                         sampling_param,
+                         scheduler_param,
+                         stopping_checker,
+                         prompt_token_ids.size() + 30000,
+                         n,
+                         best_of,
+                         false,
+                         false,
+                         false,
+                         false,
+                         false,
+                         nullptr,
+                         nullptr);
+
+  return std::make_shared<Request>("1", "1", "1", std::move(req_state), "1");
+}
+
 // dont not consider speculative decoding.
 void update_requests(std::vector<std::shared_ptr<Request>> requests) {
   for (auto req : requests) {
@@ -758,6 +791,90 @@ TEST(BlockManagerPoolTest, AllocateFailureRollsBackSharedPrefixBlocks) {
   EXPECT_EQ(later_sequence->kv_state().num_kv_blocks(), 1);
 
   (void)engine.release();
+}
+
+TEST(ContinuousSchedulerTest,
+     PDDecodeBestOfNExpandsAndSharesPromptViaPrefixCache) {
+  // Disagg PD decode instance flow:
+  //   1. request arrives from the prefill instance with kv_cache_tokens_num
+  //      already advanced (try_allocate + append_token(first_token)).
+  //   2. ContinuousScheduler::prepare_batch must short-circuit the waiting
+  //      queue and push directly into running_requests_.
+  //   3. handle_running_requests must trigger expand_sequences(true) and
+  //      cache(seq[0]) so the expanded seq[1..best_of-1] can hit the
+  //      shared prompt blocks via prefix cache.
+  ContinuousScheduler::Options opt =
+      create_scheduler_options(1024, 16, 0, 1024, 1);
+  auto engine =
+      std::make_unique<FakeEngine>(32, 4, /*enable_prefix_cache=*/true);
+  auto scheduler = std::make_unique<ContinuousScheduler>(engine.get(), opt);
+  BlockManagerPool* block_manager_pool = engine->block_manager_pool();
+
+  constexpr size_t kBestOf = 4;
+  constexpr size_t kN = 2;
+  auto request = generate_request_with_best_of({1, 2, 3, 4, 5, 6, 7, 8},
+                                               /*max_tokens=*/4,
+                                               /*max_context_len=*/30000,
+                                               kN,
+                                               kBestOf);
+
+  Sequence* seq0 = request->sequences()[0].get();
+  ASSERT_TRUE(block_manager_pool->try_allocate(seq0));
+  ASSERT_EQ(seq0->kv_state().kv_cache_tokens_num(), seq0->num_prompt_tokens());
+  Token first(42);
+  seq0->append_token(first);
+
+  scheduler->add_request(request);
+
+  auto batch = scheduler->prepare_batch_test();
+  EXPECT_EQ(batch.size(), 1);
+  EXPECT_EQ(request->sequences().size(), kBestOf);
+  EXPECT_EQ(batch[0].size(), kBestOf);
+
+  for (size_t i = 1; i < kBestOf; ++i) {
+    EXPECT_GT(request->sequences()[i]->kv_state().shared_kv_blocks_num(), 0u)
+        << "expanded seq " << i
+        << " should reuse seq[0] prompt blocks via prefix cache";
+  }
+
+  scheduler.reset();
+  (void)engine.release();
+}
+
+TEST(ContinuousSchedulerTest, PDDecodeBestOfOneSkipsExpansionAndShares) {
+  // Sanity check: best_of==n==1 should not trigger any expansion, and the
+  // request should still flow through the PD-decode short-circuit.
+  auto request = generate_request_with_best_of({1, 2, 3, 4, 5, 6, 7, 8},
+                                               /*max_tokens=*/4,
+                                               /*max_context_len=*/30000,
+                                               /*n=*/1,
+                                               /*best_of=*/1);
+  Sequence* seq0 = request->sequences()[0].get();
+
+  ContinuousScheduler::Options opt =
+      create_scheduler_options(1024, 16, 0, 1024, 1);
+  // Prefix cache is not under test here; disabling it avoids teardown putting
+  // blocks into the prefix-cache table instead of the free list.
+  auto engine =
+      std::make_unique<FakeEngine>(32, 4, /*enable_prefix_cache=*/false);
+  auto scheduler = std::make_unique<ContinuousScheduler>(engine.get(), opt);
+  BlockManagerPool* block_manager_pool = engine->block_manager_pool();
+
+  ASSERT_TRUE(block_manager_pool->try_allocate(seq0));
+  ASSERT_EQ(seq0->kv_state().kv_cache_tokens_num(), seq0->num_prompt_tokens());
+  Token first(42);
+  seq0->append_token(first);
+
+  scheduler->add_request(request);
+
+  auto batch = scheduler->prepare_batch_test();
+  EXPECT_EQ(batch.size(), 1);
+  EXPECT_EQ(request->sequences().size(), 1u);
+  EXPECT_EQ(batch[0].size(), 1u);
+
+  // prepare_batch may allocate extra decode blocks; release them before engine
+  // teardown (BlockManagerImpl checks all blocks are on the free list).
+  block_manager_pool->deallocate_without_cache(seq0);
 }
 
 }  // namespace xllm

--- a/tests/core/scheduler/disagg_pd_chunked_prefill_scheduler_test.cpp
+++ b/tests/core/scheduler/disagg_pd_chunked_prefill_scheduler_test.cpp
@@ -17,7 +17,45 @@ limitations under the License.
 
 #include <gtest/gtest.h>
 
+#include "framework/request/request.h"
+#include "framework/request/request_state.h"
+#include "framework/request/sequence.h"
+
 namespace xllm {
+
+namespace {
+
+std::shared_ptr<Request> make_request_with_best_of(
+    const std::vector<int32_t>& prompt_token_ids,
+    size_t n,
+    size_t best_of) {
+  RequestSamplingParam sampling_param;
+  SchedulerParam scheduler_param;
+
+  StoppingChecker stopping_checker;
+  stopping_checker.set_max_generated_tokens(8);
+  stopping_checker.set_max_context_len(30000);
+  stopping_checker.set_ignore_eos(true);
+
+  RequestState req_state("x",
+                         prompt_token_ids,
+                         sampling_param,
+                         scheduler_param,
+                         stopping_checker,
+                         prompt_token_ids.size() + 30000,
+                         n,
+                         best_of,
+                         false,
+                         false,
+                         false,
+                         false,
+                         false,
+                         nullptr,
+                         nullptr);
+  return std::make_shared<Request>("1", "1", "1", std::move(req_state), "1");
+}
+
+}  // namespace
 
 TEST(DisaggPDChunkedPrefillSchedulerTest, PicksCurrentChunkBudget) {
   const PDChunkBudget budget = pick_pd_chunk_budget(32, 96, 40, 64);
@@ -35,6 +73,38 @@ TEST(DisaggPDChunkedPrefillSchedulerTest, EmptyBudgetRejectsSchedule) {
   const PDChunkBudget budget = pick_pd_chunk_budget(32, 96, 40, 0);
   EXPECT_EQ(budget.next_tokens, 0);
   EXPECT_EQ(budget.max_tokens, 32);
+}
+
+// Regression test: in disagg PD mode, expansion of best_of_n sequences must
+// be deferred to the DECODE instance (where prefix cache lets seq[1..N-1]
+// share seq[0]'s prompt KV). Expanding on the PREFILL instance would waste
+// N x prefill compute. expand_sequences(false) is still the API used in
+// non-PD ChunkedPrefillScheduler, so this test pins the contract: a fresh
+// request created with best_of=4 starts with exactly one sequence, and the
+// PD-PREFILL prepare_batch is expected NOT to call expand_sequences(false).
+TEST(DisaggPDChunkedPrefillSchedulerTest,
+     BestOfNRequestStartsWithSingleSequence) {
+  auto request = make_request_with_best_of(
+      {1, 2, 3, 4, 5, 6, 7, 8}, /*n=*/2, /*best_of=*/4);
+  EXPECT_EQ(request->sequences().size(), 1u);
+}
+
+// Regression test: expand_sequences(true) should be a no-op while the first
+// sequence has not finished prefill yet (kv_cache_tokens_num <
+// num_prompt_tokens). This is the precondition that makes the two-phase
+// flow on the decode instance correct: seq[1..best_of-1] are only created
+// after seq[0]'s prompt KV is available for prefix-cache reuse.
+TEST(DisaggPDChunkedPrefillSchedulerTest,
+     ExpandSharePrefixWaitsForFirstSequencePrefill) {
+  auto request = make_request_with_best_of(
+      {1, 2, 3, 4, 5, 6, 7, 8}, /*n=*/2, /*best_of=*/4);
+  EXPECT_FALSE(request->expand_sequences(/*share_prefix=*/true));
+  EXPECT_EQ(request->sequences().size(), 1u);
+
+  Sequence* seq0 = request->sequences()[0].get();
+  seq0->kv_state().set_kv_cache_tokens_num(seq0->num_prompt_tokens());
+  EXPECT_TRUE(request->expand_sequences(/*share_prefix=*/true));
+  EXPECT_EQ(request->sequences().size(), 4u);
 }
 
 }  // namespace xllm

--- a/xllm/core/distributed_runtime/disagg_pd_service_impl.cpp
+++ b/xllm/core/distributed_runtime/disagg_pd_service_impl.cpp
@@ -38,13 +38,14 @@ DisaggPDServiceImpl::DisaggPDServiceImpl(DisaggPDScheduler* scheduler,
 
 std::shared_ptr<Request> DisaggPDServiceImpl::generate_request(
     const proto::DisaggRequest& req) {
-  // TODO: support best_of > 1 in disaggregated PD mode.
-  // The current prefill instance only allocates blocks for the first
-  // sequence, so an expanded request would have under-allocated KV cache
-  // for the remaining sequences. Reject upfront instead of producing
-  // silently wrong outputs.
-  if (req.best_of() > 1) {
-    LOG(ERROR) << "best_of > 1 is not supported in disaggregated PD mode, "
+  // best_of > 1 in disaggregated PD requires prefix cache on the decode
+  // instance: only the first sequence's KV is pulled from prefill, and
+  // the remaining best_of-1 sequences are expanded locally and reuse the
+  // first sequence's prompt KV via prefix cache.
+  if (req.best_of() > 1 &&
+      !::xllm::KVCacheConfig::get_instance().enable_prefix_cache()) {
+    LOG(ERROR) << "best_of > 1 in disaggregated PD mode requires "
+               << "enable_prefix_cache=true on the decode instance, "
                << "request_id=" << req.req_id()
                << ", best_of=" << req.best_of();
     return nullptr;

--- a/xllm/core/framework/kv_cache_transfer/llm_data_dist_transfer.cpp
+++ b/xllm/core/framework/kv_cache_transfer/llm_data_dist_transfer.cpp
@@ -57,28 +57,31 @@ LlmDataDistTransfer::LlmDataDistTransfer(const uint16_t listen_port,
       enable_lighting_indexer_(enable_lighting_indexer),
       model_type_(model_type),
       KVCacheTransfer() {
-  LlmRole role;
   if (instance_role == InstanceRole::PREFILL) {
     LOG(INFO) << "Create LlmDataDistTransfer for prefill instance.";
-    role = LlmRole::kPrompt;
+    role_ = LlmRole::kPrompt;
   } else if (instance_role == InstanceRole::DECODE) {
     LOG(INFO) << "Create LlmDataDistTransfer for decode instance.";
-    role = LlmRole::kDecoder;
+    role_ = LlmRole::kDecoder;
   } else {
     LOG(INFO) << "Create LlmDataDistTransfer for mix instance.";
-    role = LlmRole::kMix;
+    role_ = LlmRole::kMix;
   }
   host_ip_ = net::get_local_ip_addr();
+  CHECK(!host_ip_.empty()) << "Failed to get NPU/host IP for LlmDataDist.";
   cluster_id_ = net::convert_ip_port_to_uint64(host_ip_, listen_port);
-  llm_data_dist_ = std::make_shared<LlmDataDist>(cluster_id_, role);
+  llm_data_dist_ = std::make_shared<LlmDataDist>(cluster_id_, role_);
 }
 
 void LlmDataDistTransfer::initialize(int32_t device_id) {
   std::map<AscendString, AscendString> options;
   options[OPTION_DEVICE_ID] = std::to_string(device_id).c_str();
 
-  std::string local_ip_info = host_ip_ + ":" + std::to_string(listen_port_);
-  options[OPTION_LISTEN_IP_INFO] = local_ip_info.c_str();
+  // Prompt(Prefill) must publish listen endpoint; Decoder only needs device_id.
+  if (role_ == LlmRole::kPrompt) {
+    std::string local_ip_info = host_ip_ + ":" + std::to_string(listen_port_);
+    options[OPTION_LISTEN_IP_INFO] = local_ip_info.c_str();
+  }
 
   auto ret = llm_data_dist_->Initialize(options);
   CHECK(ret == LLM_SUCCESS)

--- a/xllm/core/framework/kv_cache_transfer/llm_data_dist_transfer.h
+++ b/xllm/core/framework/kv_cache_transfer/llm_data_dist_transfer.h
@@ -100,6 +100,7 @@ class LlmDataDistTransfer : public KVCacheTransfer {
   bool enable_mla_ = false;
   bool enable_lighting_indexer_ = false;
   std::string model_type_;
+  LlmRole role_ = LlmRole::kMix;
   std::unordered_set<uint64_t> linked_cluster_ids;
 
   std::shared_ptr<LlmDataDist> llm_data_dist_;

--- a/xllm/core/scheduler/disagg_pd_chunked_prefill_scheduler.cpp
+++ b/xllm/core/scheduler/disagg_pd_chunked_prefill_scheduler.cpp
@@ -62,8 +62,22 @@ DisaggPDChunkedPrefillScheduler::DisaggPDChunkedPrefillScheduler(
     Engine* engine,
     const Options& options)
     : DisaggPDScheduler(engine, options) {
-  CHECK(!enable_prefix_cache_)
-      << "disagg pd chunked prefill scheduler does not support prefix cache";
+  // Prefix cache is supported only on the DECODE instance, where it is
+  // required for best_of_n: expanded sequences (seq[1..best_of-1]) hit the
+  // first sequence's prompt KV blocks via prefix cache. PREFILL and MIX
+  // instances under chunked-prefill PD are not yet wired up for it.
+  const bool is_decode =
+      options_.instance_role().has_value() &&
+      options_.instance_role().value() == InstanceRole::DECODE;
+  if (!is_decode) {
+    CHECK(!enable_prefix_cache_)
+        << "disagg pd chunked prefill scheduler only supports prefix cache "
+        << "on the DECODE instance (current role="
+        << (options_.instance_role().has_value()
+                ? options_.instance_role().value().to_string()
+                : "<unset>")
+        << ").";
+  }
 }
 
 bool DisaggPDChunkedPrefillScheduler::alloc_chunk(Sequence* sequence,
@@ -151,10 +165,10 @@ std::vector<Batch> DisaggPDChunkedPrefillScheduler::prepare_batch() {
   std::shared_ptr<Request> request;
   while (request_queue_.read(request)) {
     CHECK(request);
-    if (!enable_prefix_cache_) {
-      request->expand_sequences(/*shared_prefix=*/false);
-    }
-
+    // PREFILL/MIX path in disagg PD only handles the first sequence.
+    // For best_of_n, expansion to best_of sequences is deferred to the
+    // DECODE instance (where prefix cache lets seq[1..best_of-1] reuse
+    // seq[0]'s prompt KV). Expanding here would waste N x prefill compute.
     if (request->offline()) {
       waiting_priority_queue_offline_->push(request);
     } else {

--- a/xllm/core/scheduler/disagg_pd_scheduler.cpp
+++ b/xllm/core/scheduler/disagg_pd_scheduler.cpp
@@ -286,6 +286,33 @@ void DisaggPDScheduler::step(const absl::Duration& timeout) {
 }
 
 std::vector<Batch> DisaggPDScheduler::prepare_batch() {
+  // For PREFILL / MIX in disagg PD, drain newly arrived requests here and
+  // skip the eager expand_sequences(false) that the base prepare_batch would
+  // otherwise call when enable_prefix_cache is off. For best_of_n requests,
+  // expansion to best_of sequences is deferred to the DECODE instance (where
+  // prefix cache lets seq[1..best_of-1] reuse seq[0]'s prompt KV). Without
+  // this guard, the PREFILL instance would waste N x prefill compute on
+  // candidates that are never used.
+  const bool is_decode =
+      options_.instance_role().has_value() &&
+      options_.instance_role().value() == InstanceRole::DECODE;
+  if (!is_decode) {
+    std::shared_ptr<Request> request;
+    while (request_queue_.read(request)) {
+      CHECK(request);
+      if (request->sequences()[0]->kv_state().kv_cache_tokens_num() == 0) {
+        if (request->offline()) {
+          waiting_priority_queue_offline_->push(request);
+        } else {
+          waiting_priority_queue_->push(request);
+        }
+      } else {
+        // request from prefill instance in disagge pd mode.
+        running_requests_.emplace_back(request);
+      }
+    }
+  }
+
   if (options_.enable_chunked_prefill()) {
     return ChunkedPrefillScheduler::prepare_batch();
   }

--- a/xllm/core/scheduler/pd_ooc_scheduler.cpp
+++ b/xllm/core/scheduler/pd_ooc_scheduler.cpp
@@ -184,12 +184,11 @@ std::vector<Batch> PDOOCScheduler::prepare_batch() {
   while (request_queue_.read(request)) {
     CHECK(request);
 
-    // expand sequences to the target number if prefix cache is disabled.
-    if (!enable_prefix_cache_) {
-      // expand sequences to the target number
-      request->expand_sequences(false);
-    }
-
+    // In disagg PD, expansion of best_of_n sequences is always handled
+    // on the DECODE instance (where prefix cache lets seq[1..best_of-1]
+    // reuse seq[0]'s prompt KV). On the PREFILL/MIX instance we keep a
+    // single sequence -- expanding here would waste N x prefill compute
+    // on candidates that are never shipped to the DECODE instance.
     if (request->sequences()[0]->kv_state().kv_cache_tokens_num() == 0) {
       if (request->offline()) {
         int current_offline_decode_bs =


### PR DESCRIPTION
- DECODE-side scheduler now expands sequences and reuses seq[0]'s prompt KV via prefix cache; PREFILL side keeps a single sequence and only ships one KV blob to DECODE.
- Lift the unconditional prefix-cache CHECK in DisaggPDChunkedPrefillScheduler for DECODE role only; reject best_of > 1 upfront when DECODE's prefix cache is disabled.
- LlmDataDistTransfer: only publish the listen endpoint for PREFILL, and pick up the configured device_ip when available.
- Add regression tests covering the PD-decode best_of_n flow and the PD-prefill no-expand contract; update zh/en disagg_pd docs.