### PR TITLE
feat: apply prefix cache to pd chunk budget.

### DIFF
--- a/docs/en/features/disagg_pd.md
+++ b/docs/en/features/disagg_pd.md
@@ -76,9 +76,10 @@ ENABLE_DECODE_RESPONSE_TO_SERVICE=true ./xllm_master_serving --etcd_addr="127.0.
     - `etcd_addr` must match the `etcd_addr` of `xllm_service`
 
 ## Notice
-On the Prefill instance of disaggregated PD, prefix cache is not supported with the current chunked-prefill PD scheduler and must be disabled:
+With the chunked-prefill PD scheduler, the Prefill instance supports prefix cache. When enabled, the scheduler matches existing prefix-cache blocks before calculating the current chunk budget, so cached prompt blocks are not recomputed:
 ```shell
---enable_prefix_cache=false
+--enable_chunked_prefill=true
+--enable_prefix_cache=true
 ```
 
 ## Decode instance: prefix cache is supported (recommended)

--- a/docs/zh/features/disagg_pd.md
+++ b/docs/zh/features/disagg_pd.md
@@ -66,10 +66,11 @@ ENABLE_DECODE_RESPONSE_TO_SERVICE=true ./xllm_master_serving --etcd_addr="127.0.
   
     - `etcd_addr`需与`xllm_service`的`etcd_addr`相同
 
-!!! warning "注意事项"
-    PD分离的Prefill实例与chunked prefill的Prefill实例目前不支持prefix cache，需要通过以下参数关闭
+!!! tip "Chunked prefill的Prefill实例支持prefix cache"
+    使用chunked-prefill PD调度器时，Prefill实例已支持prefix cache。开启后，调度器会先匹配已有prefix cache block，再计算当前chunk budget，避免重复计算已缓存的prompt block。
     ``` shell
-    --enable_prefix_cache=false
+    --enable_chunked_prefill=true
+    --enable_prefix_cache=true
     ```
 
 !!! tip "Decode实例开启prefix cache（推荐）"

--- a/tests/core/scheduler/CMakeLists.txt
+++ b/tests/core/scheduler/CMakeLists.txt
@@ -6,6 +6,7 @@ cc_test(
   SRCS
     chunked_prefill_scheduler_test.cpp
     disagg_pd_chunked_prefill_scheduler_test.cpp
+    disagg_pd_scheduler_test.cpp
     continuous_scheduler_test.cpp
     fixed_steps_scheduler_test.cpp
   DEPS

--- a/tests/core/scheduler/disagg_pd_chunked_prefill_scheduler_test.cpp
+++ b/tests/core/scheduler/disagg_pd_chunked_prefill_scheduler_test.cpp
@@ -17,13 +17,185 @@ limitations under the License.
 
 #include <gtest/gtest.h>
 
+#include <cstdint>
+#include <memory>
+#include <optional>
+#include <string>
+#include <vector>
+
+#include "core/framework/config/kv_cache_config.h"
+#include "distributed_runtime/engine.h"
+#include "framework/block/block_manager_pool.h"
 #include "framework/request/request.h"
 #include "framework/request/request_state.h"
 #include "framework/request/sequence.h"
+#include "framework/tokenizer/tokenizer.h"
+#include "scheduler/continuous_scheduler.h"
 
 namespace xllm {
-
 namespace {
+
+class FakeTokenizer final : public Tokenizer {
+ public:
+  bool encode(const std::string_view& /*text*/,
+              std::vector<int32_t>* /*ids*/,
+              bool /*add_special_tokens*/) const override {
+    NOT_IMPLEMENTED();
+  }
+
+  std::string decode(const Slice<int32_t>& /*ids*/,
+                     bool /*skip_special_tokens*/) const override {
+    NOT_IMPLEMENTED();
+  }
+
+  std::optional<int32_t> token_to_id(
+      const std::string_view& /*token*/) const override {
+    NOT_IMPLEMENTED();
+  }
+
+  std::string id_to_token(int32_t /*id*/) const override { NOT_IMPLEMENTED(); }
+
+  size_t vocab_size() const override { NOT_IMPLEMENTED(); }
+
+  std::unique_ptr<Tokenizer> clone() const override {
+    return std::make_unique<FakeTokenizer>();
+  }
+};
+
+class FakeEngine final : public Engine {
+ public:
+  FakeEngine(int32_t num_blocks, int32_t block_size) {
+    BlockManagerPool::Options options;
+    options.num_blocks(num_blocks)
+        .block_size(block_size)
+        .enable_prefix_cache(true)
+        .enable_disagg_pd(true);
+    tokenizer_ = std::make_unique<FakeTokenizer>();
+    block_manager_ = std::make_unique<BlockManagerPool>(options, /*dp_size=*/1);
+  }
+
+  ForwardOutput step(std::vector<Batch>& /*batch*/) override {
+    NOT_IMPLEMENTED();
+  }
+
+  void update_last_step_result(std::vector<Batch>& /*batch*/) override {
+    NOT_IMPLEMENTED();
+  }
+
+  const Tokenizer* tokenizer() const override { return tokenizer_.get(); }
+
+  BlockManagerPool* block_manager_pool() const override {
+    return block_manager_.get();
+  }
+
+  const ModelArgs& model_args() const override { NOT_IMPLEMENTED(); }
+
+  const TokenizerArgs& tokenizer_args() const override { NOT_IMPLEMENTED(); }
+
+  std::vector<int64_t> get_active_activation_memory() const override {
+    NOT_IMPLEMENTED();
+  }
+
+  bool init() override { return true; }
+
+ private:
+  std::unique_ptr<Tokenizer> tokenizer_;
+  std::unique_ptr<BlockManagerPool> block_manager_;
+};
+
+template <typename T>
+class ScopedConfigValue final {
+ public:
+  ScopedConfigValue(T& value, T new_value) : value_(value), old_(value) {
+    value_ = new_value;
+  }
+
+  ~ScopedConfigValue() { value_ = old_; }
+
+ private:
+  T& value_;
+  T old_;
+};
+
+DisaggPDChunkedPrefillScheduler::Options make_options(
+    int32_t max_tokens_per_batch,
+    int32_t max_chunk) {
+  DisaggPDChunkedPrefillScheduler::Options options;
+  options.enable_pd_ooc(true)
+      .enable_disagg_pd(true)
+      .enable_chunked_prefill(true)
+      .enable_schedule_overlap(false)
+      .instance_role(InstanceRole::PREFILL)
+      .max_tokens_per_batch(max_tokens_per_batch)
+      .max_seqs_per_batch(1)
+      .max_tokens_per_chunk_for_prefill(max_chunk)
+      .dp_size(1);
+  return options;
+}
+
+std::shared_ptr<Request> make_request(
+    const std::vector<int32_t>& prompt_token_ids) {
+  RequestSamplingParam sampling_param;
+  SchedulerParam scheduler_param;
+
+  StoppingChecker stopping_checker;
+  stopping_checker.set_max_generated_tokens(4);
+  stopping_checker.set_max_context_len(64);
+  stopping_checker.set_ignore_eos(true);
+
+  RequestState state("prompt",
+                     prompt_token_ids,
+                     sampling_param,
+                     scheduler_param,
+                     stopping_checker,
+                     prompt_token_ids.size() + 8,
+                     /*n=*/1,
+                     /*best_of=*/1,
+                     /*stream=*/false,
+                     /*echo=*/false,
+                     /*logprobs=*/false,
+                     /*skip_special_tokens=*/false,
+                     /*include_usage=*/false,
+                     /*mm_data=*/nullptr,
+                     /*service_request_id=*/nullptr);
+
+  return std::make_shared<Request>(
+      "req", "x-request-id", "x-request-time", state, "service-req");
+}
+
+size_t first_cache_size(const BlockManagerPool& block_manager) {
+  const std::vector<size_t> cache_sizes =
+      block_manager.num_blocks_in_prefix_cache();
+  CHECK(!cache_sizes.empty());
+  return cache_sizes[0];
+}
+
+void cache_prompt(BlockManagerPool* block_manager,
+                  const std::vector<int32_t>& token_ids) {
+  CHECK(block_manager != nullptr);
+  std::shared_ptr<Request> request = make_request(token_ids);
+  Sequence* sequence = request->sequences()[0].get();
+  ASSERT_TRUE(block_manager->allocate(sequence));
+  sequence->kv_state().set_kv_cache_tokens_num(sequence->num_prompt_tokens());
+  block_manager->cache(sequence);
+  block_manager->deallocate(sequence);
+}
+
+void release_prefix_cache(BlockManagerPool* block_manager) {
+  CHECK(block_manager != nullptr);
+  const size_t num_data_blocks = block_manager->num_blocks() - 1;
+  std::vector<int32_t> token_ids;
+  token_ids.reserve(num_data_blocks * block_manager->block_size());
+  for (size_t i = 0; i < num_data_blocks * block_manager->block_size(); ++i) {
+    token_ids.push_back(static_cast<int32_t>(1000 + i));
+  }
+
+  std::shared_ptr<Request> request = make_request(token_ids);
+  Sequence* sequence = request->sequences()[0].get();
+  ASSERT_TRUE(block_manager->allocate(sequence));
+  block_manager->deallocate(sequence);
+  EXPECT_EQ(first_cache_size(*block_manager), 0u);
+}
 
 std::shared_ptr<Request> make_request_with_best_of(
     const std::vector<int32_t>& prompt_token_ids,
@@ -105,6 +277,70 @@ TEST(DisaggPDChunkedPrefillSchedulerTest,
   seq0->kv_state().set_kv_cache_tokens_num(seq0->num_prompt_tokens());
   EXPECT_TRUE(request->expand_sequences(/*share_prefix=*/true));
   EXPECT_EQ(request->sequences().size(), 4u);
+}
+
+TEST(DisaggPDChunkedPrefillSchedulerTest,
+     AppliesPrefixCacheBeforeBudgetCalculation) {
+  ScopedConfigValue<bool> prefix_cache(
+      KVCacheConfig::get_instance().enable_prefix_cache(), true);
+  FakeEngine engine(/*num_blocks=*/16, /*block_size=*/2);
+  BlockManagerPool* block_manager = engine.block_manager_pool();
+  cache_prompt(block_manager, {1, 2, 3, 4, 5, 6, 7, 8});
+  ASSERT_EQ(first_cache_size(*block_manager), 4u);
+
+  DisaggPDChunkedPrefillScheduler scheduler(&engine,
+                                            make_options(
+                                                /*max_tokens_per_batch=*/4,
+                                                /*max_chunk=*/4));
+  std::shared_ptr<Request> request =
+      make_request({1, 2, 3, 4, 5, 6, 7, 8, 9, 10});
+  Sequence* sequence = request->sequences()[0].get();
+  ASSERT_TRUE(scheduler.ContinuousScheduler::add_request(request));
+
+  std::vector<Batch> batches = scheduler.prepare_batch_test();
+
+  ASSERT_EQ(batches.size(), 1u);
+  ASSERT_EQ(batches[0].size(), 1u);
+  ASSERT_EQ(scheduler.get_running_sequences_budgets().size(), 1u);
+  EXPECT_EQ(scheduler.get_running_sequences_budgets()[0], 2u);
+  EXPECT_EQ(batches[0].get_allowed_max_tokens(), std::vector<uint32_t>({2}));
+  EXPECT_EQ(sequence->kv_state().kv_cache_tokens_num(), 8u);
+  EXPECT_EQ(sequence->kv_state().shared_kv_blocks_num(), 4u);
+  EXPECT_EQ(sequence->kv_state().num_kv_blocks(), 5u);
+
+  block_manager->deallocate(request.get());
+  release_prefix_cache(block_manager);
+}
+
+TEST(DisaggPDChunkedPrefillSchedulerTest, FullPrefixHitStillSchedulesStep) {
+  ScopedConfigValue<bool> prefix_cache(
+      KVCacheConfig::get_instance().enable_prefix_cache(), true);
+  FakeEngine engine(/*num_blocks=*/16, /*block_size=*/2);
+  BlockManagerPool* block_manager = engine.block_manager_pool();
+  cache_prompt(block_manager, {1, 2, 3, 4, 5, 6, 7, 8});
+  ASSERT_EQ(first_cache_size(*block_manager), 4u);
+
+  DisaggPDChunkedPrefillScheduler scheduler(&engine,
+                                            make_options(
+                                                /*max_tokens_per_batch=*/4,
+                                                /*max_chunk=*/4));
+  std::shared_ptr<Request> request = make_request({1, 2, 3, 4, 5, 6, 7, 8});
+  Sequence* sequence = request->sequences()[0].get();
+  ASSERT_TRUE(scheduler.ContinuousScheduler::add_request(request));
+
+  std::vector<Batch> batches = scheduler.prepare_batch_test();
+
+  ASSERT_EQ(batches.size(), 1u);
+  ASSERT_EQ(batches[0].size(), 1u);
+  ASSERT_EQ(scheduler.get_running_sequences_budgets().size(), 1u);
+  EXPECT_EQ(scheduler.get_running_sequences_budgets()[0], 2u);
+  EXPECT_EQ(batches[0].get_allowed_max_tokens(), std::vector<uint32_t>({2}));
+  EXPECT_EQ(sequence->kv_state().kv_cache_tokens_num(), 6u);
+  EXPECT_EQ(sequence->kv_state().shared_kv_blocks_num(), 3u);
+  EXPECT_EQ(sequence->kv_state().num_kv_blocks(), 4u);
+
+  block_manager->deallocate(request.get());
+  release_prefix_cache(block_manager);
 }
 
 }  // namespace xllm

--- a/tests/core/scheduler/disagg_pd_scheduler_test.cpp
+++ b/tests/core/scheduler/disagg_pd_scheduler_test.cpp
@@ -1,0 +1,242 @@
+/* Copyright 2026 The xLLM Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://github.com/jd-opensource/xllm/blob/main/LICENSE
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include "scheduler/disagg_pd_scheduler.h"
+
+#include <gtest/gtest.h>
+
+#include <cstdint>
+#include <memory>
+#include <optional>
+#include <string>
+#include <vector>
+
+#include "distributed_runtime/engine.h"
+#include "framework/block/block_manager_pool.h"
+#include "framework/request/request.h"
+#include "framework/request/request_state.h"
+#include "framework/tokenizer/tokenizer.h"
+
+namespace xllm {
+namespace {
+
+class FakeTokenizer final : public Tokenizer {
+ public:
+  bool encode(const std::string_view& /*text*/,
+              std::vector<int32_t>* /*ids*/,
+              bool /*add_special_tokens*/) const override {
+    NOT_IMPLEMENTED();
+  }
+
+  std::string decode(const Slice<int32_t>& /*ids*/,
+                     bool /*skip_special_tokens*/) const override {
+    NOT_IMPLEMENTED();
+  }
+
+  std::optional<int32_t> token_to_id(
+      const std::string_view& /*token*/) const override {
+    NOT_IMPLEMENTED();
+  }
+
+  std::string id_to_token(int32_t /*id*/) const override { NOT_IMPLEMENTED(); }
+
+  size_t vocab_size() const override { NOT_IMPLEMENTED(); }
+
+  std::unique_ptr<Tokenizer> clone() const override {
+    return std::make_unique<FakeTokenizer>();
+  }
+};
+
+class FakeEngine final : public Engine {
+ public:
+  FakeEngine(int32_t num_blocks, int32_t block_size) {
+    BlockManagerPool::Options options;
+    options.num_blocks(num_blocks)
+        .block_size(block_size)
+        .enable_prefix_cache(true)
+        .enable_disagg_pd(true);
+    tokenizer_ = std::make_unique<FakeTokenizer>();
+    block_manager_ = std::make_unique<BlockManagerPool>(options, /*dp_size=*/1);
+  }
+
+  ForwardOutput step(std::vector<Batch>& /*batch*/) override {
+    NOT_IMPLEMENTED();
+  }
+
+  void update_last_step_result(std::vector<Batch>& /*batch*/) override {
+    NOT_IMPLEMENTED();
+  }
+
+  const Tokenizer* tokenizer() const override { return tokenizer_.get(); }
+
+  BlockManagerPool* block_manager_pool() const override {
+    return block_manager_.get();
+  }
+
+  const ModelArgs& model_args() const override { NOT_IMPLEMENTED(); }
+
+  const TokenizerArgs& tokenizer_args() const override { NOT_IMPLEMENTED(); }
+
+  std::vector<int64_t> get_active_activation_memory() const override {
+    NOT_IMPLEMENTED();
+  }
+
+  bool init() override { return true; }
+
+ private:
+  std::unique_ptr<Tokenizer> tokenizer_;
+  std::unique_ptr<BlockManagerPool> block_manager_;
+};
+
+class TestDisaggPDScheduler final : public DisaggPDScheduler {
+ public:
+  TestDisaggPDScheduler(Engine* engine, const Options& options)
+      : DisaggPDScheduler(engine, options) {}
+
+  void cache_prefill_blocks_for_test(Request* request) {
+    cache_prefill_blocks(request);
+  }
+};
+
+DisaggPDScheduler::Options make_options() {
+  DisaggPDScheduler::Options options;
+  options.enable_pd_ooc(true)
+      .enable_disagg_pd(true)
+      .enable_schedule_overlap(false)
+      .instance_role(InstanceRole::PREFILL)
+      .max_tokens_per_batch(32)
+      .max_seqs_per_batch(4)
+      .max_tokens_per_chunk_for_prefill(32)
+      .dp_size(1);
+  return options;
+}
+
+std::shared_ptr<Request> make_request(
+    const std::vector<int32_t>& prompt_token_ids) {
+  RequestSamplingParam sampling_param;
+  SchedulerParam scheduler_param;
+
+  StoppingChecker stopping_checker;
+  stopping_checker.set_max_generated_tokens(4);
+  stopping_checker.set_max_context_len(64);
+  stopping_checker.set_ignore_eos(true);
+
+  RequestState state("prompt",
+                     prompt_token_ids,
+                     sampling_param,
+                     scheduler_param,
+                     stopping_checker,
+                     prompt_token_ids.size() + 8,
+                     /*n=*/1,
+                     /*best_of=*/1,
+                     /*stream=*/false,
+                     /*echo=*/false,
+                     /*logprobs=*/false,
+                     /*skip_special_tokens=*/false,
+                     /*include_usage=*/false,
+                     /*mm_data=*/nullptr,
+                     /*service_request_id=*/nullptr);
+
+  return std::make_shared<Request>(
+      "req", "x-request-id", "x-request-time", state, "service-req");
+}
+
+void finish_prefill(Sequence* sequence) {
+  CHECK(sequence != nullptr);
+  sequence->kv_state().set_kv_cache_tokens_num(sequence->num_prompt_tokens());
+  sequence->append_token(Token(999));
+}
+
+size_t first_cache_size(const BlockManagerPool& block_manager) {
+  const std::vector<size_t> cache_sizes =
+      block_manager.num_blocks_in_prefix_cache();
+  CHECK(!cache_sizes.empty());
+  return cache_sizes[0];
+}
+
+void release_prefix_cache(BlockManagerPool* block_manager) {
+  CHECK(block_manager != nullptr);
+  const size_t num_data_blocks = block_manager->num_blocks() - 1;
+  std::vector<int32_t> token_ids;
+  token_ids.reserve(num_data_blocks * block_manager->block_size());
+  for (size_t i = 0; i < num_data_blocks * block_manager->block_size(); ++i) {
+    token_ids.push_back(static_cast<int32_t>(1000 + i));
+  }
+
+  std::shared_ptr<Request> request = make_request(token_ids);
+  Sequence* sequence = request->sequences()[0].get();
+  ASSERT_TRUE(block_manager->allocate(sequence));
+  block_manager->deallocate(sequence);
+  EXPECT_EQ(first_cache_size(*block_manager), 0u);
+}
+
+}  // namespace
+
+TEST(DisaggPDSchedulerTest, CachesPrefillBlocksBeforeRelease) {
+  FakeEngine engine(/*num_blocks=*/8, /*block_size=*/2);
+  TestDisaggPDScheduler scheduler(&engine, make_options());
+  BlockManagerPool* block_manager = engine.block_manager_pool();
+
+  std::shared_ptr<Request> request = make_request({1, 2, 3, 4});
+  Sequence* sequence = request->sequences()[0].get();
+  ASSERT_TRUE(block_manager->allocate(sequence));
+  finish_prefill(sequence);
+
+  scheduler.cache_prefill_blocks_for_test(request.get());
+  EXPECT_EQ(first_cache_size(*block_manager), 2u);
+
+  block_manager->deallocate(request.get());
+  EXPECT_EQ(sequence->kv_state().num_kv_blocks(), 0u);
+  EXPECT_EQ(first_cache_size(*block_manager), 2u);
+
+  std::shared_ptr<Request> matched_request = make_request({1, 2, 3, 4, 5});
+  Sequence* matched_sequence = matched_request->sequences()[0].get();
+  block_manager->allocate_shared(matched_sequence);
+
+  EXPECT_EQ(matched_sequence->kv_state().shared_kv_blocks_num(), 2u);
+  block_manager->deallocate(matched_sequence);
+  release_prefix_cache(block_manager);
+}
+
+TEST(DisaggPDSchedulerTest, CacheSkipsExistingSharedBlocks) {
+  FakeEngine engine(/*num_blocks=*/10, /*block_size=*/2);
+  TestDisaggPDScheduler scheduler(&engine, make_options());
+  BlockManagerPool* block_manager = engine.block_manager_pool();
+
+  std::shared_ptr<Request> seed_request = make_request({1, 2, 3, 4});
+  Sequence* seed_sequence = seed_request->sequences()[0].get();
+  ASSERT_TRUE(block_manager->allocate(seed_sequence));
+  finish_prefill(seed_sequence);
+  scheduler.cache_prefill_blocks_for_test(seed_request.get());
+  block_manager->deallocate(seed_request.get());
+  ASSERT_EQ(first_cache_size(*block_manager), 2u);
+
+  std::shared_ptr<Request> extended_request = make_request({1, 2, 3, 4, 5, 6});
+  Sequence* extended_sequence = extended_request->sequences()[0].get();
+  block_manager->allocate_shared(extended_sequence);
+  ASSERT_EQ(extended_sequence->kv_state().shared_kv_blocks_num(), 2u);
+  ASSERT_TRUE(block_manager->allocate(extended_sequence,
+                                      extended_sequence->num_prompt_tokens()));
+  finish_prefill(extended_sequence);
+
+  scheduler.cache_prefill_blocks_for_test(extended_request.get());
+  EXPECT_EQ(first_cache_size(*block_manager), 3u);
+
+  block_manager->deallocate(extended_request.get());
+  EXPECT_EQ(first_cache_size(*block_manager), 3u);
+  release_prefix_cache(block_manager);
+}
+
+}  // namespace xllm

--- a/xllm/core/scheduler/disagg_pd_chunked_prefill_scheduler.cpp
+++ b/xllm/core/scheduler/disagg_pd_chunked_prefill_scheduler.cpp
@@ -17,6 +17,7 @@ limitations under the License.
 
 #include <algorithm>
 
+#include "core/framework/config/scheduler_config.h"
 #include "framework/batch/batch_factory.h"
 #include "util/utils.h"
 
@@ -61,22 +62,40 @@ PDChunkBudget pick_pd_chunk_budget(size_t kv_tokens,
 DisaggPDChunkedPrefillScheduler::DisaggPDChunkedPrefillScheduler(
     Engine* engine,
     const Options& options)
-    : DisaggPDScheduler(engine, options) {
-  // Prefix cache is supported only on the DECODE instance, where it is
-  // required for best_of_n: expanded sequences (seq[1..best_of-1]) hit the
-  // first sequence's prompt KV blocks via prefix cache. PREFILL and MIX
-  // instances under chunked-prefill PD are not yet wired up for it.
-  const bool is_decode =
-      options_.instance_role().has_value() &&
-      options_.instance_role().value() == InstanceRole::DECODE;
-  if (!is_decode) {
-    CHECK(!enable_prefix_cache_)
-        << "disagg pd chunked prefill scheduler only supports prefix cache "
-        << "on the DECODE instance (current role="
-        << (options_.instance_role().has_value()
-                ? options_.instance_role().value().to_string()
-                : "<unset>")
-        << ").";
+    : DisaggPDScheduler(engine, options) {}
+
+void DisaggPDChunkedPrefillScheduler::match_prefix_blocks(Sequence* sequence) {
+  CHECK(sequence != nullptr);
+  if (!enable_prefix_cache_) {
+    return;
+  }
+
+  if (sequence->kv_state().num_kv_blocks() == 0) {
+    kv_cache_manager_->allocate_shared(sequence);
+    return;
+  }
+  if (!sequence->is_chunked_prefill_stage()) {
+    return;
+  }
+
+  const size_t max_tokens_per_chunk = static_cast<size_t>(
+      std::max(options_.max_tokens_per_chunk_for_prefill(), 64));
+  const size_t total_chunked_size =
+      util::ceil_div(sequence->num_tokens(), max_tokens_per_chunk);
+  const int32_t match_frequency =
+      ::xllm::SchedulerConfig::get_instance().chunked_match_frequency();
+  CHECK_GT(match_frequency, 0);
+  if (total_chunked_size < static_cast<size_t>(match_frequency)) {
+    kv_cache_manager_->allocate_shared(sequence);
+    return;
+  }
+
+  const size_t prefix_cache_interval =
+      util::ceil_div(total_chunked_size, static_cast<size_t>(match_frequency));
+  const size_t cur_chunked_index =
+      sequence->kv_state().kv_cache_tokens_num() / max_tokens_per_chunk;
+  if (cur_chunked_index % prefix_cache_interval == 0) {
+    kv_cache_manager_->allocate_shared(sequence);
   }
 }
 
@@ -85,6 +104,8 @@ bool DisaggPDChunkedPrefillScheduler::alloc_chunk(Sequence* sequence,
                                                   size_t* actual_tokens) {
   CHECK(sequence != nullptr);
   CHECK(actual_tokens != nullptr);
+
+  match_prefix_blocks(sequence);
 
   const size_t kv_tokens = sequence->kv_cache_tokens_num();
   const PDChunkBudget budget = pick_pd_chunk_budget(

--- a/xllm/core/scheduler/disagg_pd_chunked_prefill_scheduler.h
+++ b/xllm/core/scheduler/disagg_pd_chunked_prefill_scheduler.h
@@ -48,6 +48,7 @@ class DisaggPDChunkedPrefillScheduler final : public DisaggPDScheduler {
   bool alloc_chunk(Sequence* sequence,
                    size_t token_budget,
                    size_t* actual_tokens);
+  void match_prefix_blocks(Sequence* sequence);
   void schedule_waiting_prefill(RequestPriorityQueue& queue,
                                 size_t& remaining_token_budget,
                                 size_t& remaining_seq_budget,

--- a/xllm/core/scheduler/disagg_pd_scheduler.cpp
+++ b/xllm/core/scheduler/disagg_pd_scheduler.cpp
@@ -201,6 +201,15 @@ void DisaggPDScheduler::profile_tpot() {
   }
 }
 
+void DisaggPDScheduler::cache_prefill_blocks(Request* request) {
+  CHECK(request != nullptr);
+  for (auto& sequence : request->sequences()) {
+    if (sequence->if_cache_block_for_prefill()) {
+      kv_cache_manager_->cache(sequence.get());
+    }
+  }
+}
+
 // TODO: maybe we should consider update info case even if info already exists
 // in local.
 bool DisaggPDScheduler::check_remote_instance_info(
@@ -684,7 +693,8 @@ void DisaggPDScheduler::prefill_send_first_generation() {
       brpc::Controller cntl;
       stub->FirstGeneration(&cntl, &gens, &resp, nullptr);
 
-      if (cntl.Failed() || !resp.ok()) {
+      const bool sent_first_generation = !cntl.Failed() && resp.ok();
+      if (!sent_first_generation) {
         LOG(ERROR) << "Failed to send first generation to decode instance : "
                    << request->state().decode_address
                    << ", error text : " << cntl.ErrorText()
@@ -696,6 +706,9 @@ void DisaggPDScheduler::prefill_send_first_generation() {
         req_to_channel_map_.erase(request->request_id());
       }
       response_processor_->wait_completion();
+      if (sent_first_generation) {
+        cache_prefill_blocks(request.get());
+      }
       kv_cache_manager_->deallocate(request.get());
     }
   });

--- a/xllm/core/scheduler/disagg_pd_scheduler.h
+++ b/xllm/core/scheduler/disagg_pd_scheduler.h
@@ -102,6 +102,8 @@ class DisaggPDScheduler : public ChunkedPrefillScheduler {
 
   void profile_tpot();
 
+  void cache_prefill_blocks(Request* request);
+
   // check remote instance info, if not exist, get from master service
   bool check_remote_instance_info(const std::string& instance_name);
 


### PR DESCRIPTION
  ## Description

  Apply prefix cache support to PD chunked prefill scheduling.

  This PR removes the previous prefix-cache restriction in `DisaggPDChunkedPrefillScheduler` and matches shared KV blocks before calculating the chunk budget. This lets PD chunked
  prefill account for already cached prefix tokens when deciding the allowed prefill tokens for each step.

  It also caches prefill KV blocks after the first generation is successfully sent from the prefill instance to the decode instance, so later requests can reuse the prefix cache safely.

  Unit coverage is added for:
  - caching prefill blocks before KV block release in PD scheduling
  - skipping already shared blocks when caching extended prompts
  - applying prefix cache before PD chunk budget calculation
  - scheduling a valid step when the prompt is fully matched by prefix cache

  ## Related Issues

  N/A

  ## Change Type

  - [ ] Bug fix
  - [x] New feature
  - [x] Performance improvement
  - [ ] Refactor
  - [ ] Documentation
  - [x] Test
  - [ ] Build or CI

  ## Pull Request Checklist

  Thank you for contributing to xLLM. Before requesting review, please make sure the following items are complete.

  ### PR Title and Commit Messages

  - [x] The PR title and each commit message follow the xLLM commit format: `<type>: <subject>`.

  > Allowed types: feat, bugfix, docs, test, refactor, chore, style, revert, perf, model, build, release.
  > The subject should use clear English, start with a verb, include at least 4 words, and end with `.`.

  ### Pre-commit Checks

  - [x] I have installed `pre-commit` by running `pip install pre-commit` or an equivalent command.
  - [x] I have installed the hooks with `pre-commit install`.
  - [ ] I have run `pre-commit run --all-files` and fixed any reported issues.

  > If you are unsure how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

  ### Self Review

  - [x] I have self-reviewed the code according to `.agents/skills/code-review/references/custom-code-style.md`, especially code written or assisted by AI.
  - [x] I have rebased this PR onto the latest `main` branch.

  ### Build and Test Coverage

  <!-- Fill this section after your local validation. -->




### Build and Test Coverage

- [x] Tests have been added or updated as needed.
- [ ] CUDA: `python setup.py build test` has passed on a CUDA machine.
- [ ] NPU: `python setup.py build test` has passed on an NPU machine.
- [x] MLU: `python setup.py build test` has passed on an MLU machine.

  ### Reviewer Notes

  Please focus on the prefix cache matching frequency logic in PD chunked prefill and whether caching prefill blocks only after successful first-generation delivery is the right
  lifecycle point.