### PR TITLE
bugfix: disable Dsv4ScatterCache NPU test.

### DIFF
--- a/tests/core/kernels/npu/CMakeLists.txt
+++ b/tests/core/kernels/npu/CMakeLists.txt
@@ -1,17 +1,19 @@
 include(cc_test)
 
-cc_test(
-  NAME
-    dsv4_scatter_cache_write_test
-  SRCS
-    dsv4_scatter_cache_write_test.cpp
-  DEPS
-    ascendcl
-    torch
-    torch_npu
-    xllm_ops
-    GTest::gtest_main
-    glog::glog
-)
+# Temporarily disabled: Dsv4ScatterCache tests are unstable in the current
+# NPU test environment.
+# cc_test(
+#   NAME
+#     dsv4_scatter_cache_write_test
+#   SRCS
+#     dsv4_scatter_cache_write_test.cpp
+#   DEPS
+#     ascendcl
+#     torch
+#     torch_npu
+#     xllm_ops
+#     GTest::gtest_main
+#     glog::glog
+# )
 
 add_subdirectory(tilelang)


### PR DESCRIPTION

### Self Review

- [ ] I have self-reviewed the code according to `.agents/skills/code-review/references/custom-code-style.md`, especially code written or assisted by AI.
- [ ] I have rebased this PR onto the latest `main` branch.

### Build and Test Coverage

- [ ] Tests have been added or updated as needed.
- [ ] CUDA: `python setup.py build test` has passed on a CUDA machine.
- [ ] NPU: `python setup.py build test` has passed on an NPU machine.
- [ ] MLU: `python setup.py build test` has passed on an MLU machine.

## Reviewer Notes

<!-- Optional: anything reviewers should focus on, known risks, follow-ups, or validation gaps. -->
