### PR TITLE
refactor: optimize worker  stream orchestration for performance.

### DIFF
--- a/xllm/core/distributed_runtime/worker_service.cpp
+++ b/xllm/core/distributed_runtime/worker_service.cpp
@@ -19,6 +19,7 @@ limitations under the License.
 #include <glog/logging.h>
 #include <torch/torch.h>
 
+#include <algorithm>
 #include <boost/algorithm/string.hpp>
 #include <vector>
 
@@ -55,6 +56,62 @@ int32_t get_num_decode_seqs_for_schedule_overlap(const ForwardInput& input) {
   }
   return static_cast<int32_t>(
       unpacked_input.sampling_params.sample_idxes.size(0));
+}
+
+template <typename T>
+int64_t count_negative_tokens(const torch::Tensor& tokens) {
+  const T* data = tokens.const_data_ptr<T>();
+  const int64_t numel = tokens.numel();
+  int64_t count = 0;
+  for (int64_t i = 0; i < numel; ++i) {
+    if (data[i] < static_cast<T>(0)) {
+      ++count;
+    }
+  }
+  return count;
+}
+
+void record_speculative_metrics_from_output(const torch::Tensor& next_tokens,
+                                            const runtime::Options& options) {
+  if (!options.enable_speculative_decode() || !next_tokens.defined() ||
+      next_tokens.dim() != 2 || next_tokens.numel() == 0) {
+    return;
+  }
+
+  const int64_t batch_size = next_tokens.size(0);
+  const int64_t token_width = next_tokens.size(1);
+  const int64_t num_speculative_tokens = options.num_speculative_tokens();
+  if (num_speculative_tokens <= 0 ||
+      token_width != num_speculative_tokens + 1) {
+    return;
+  }
+
+  torch::Tensor tokens = next_tokens.contiguous();
+  int64_t rejected_count = 0;
+  switch (tokens.scalar_type()) {
+    case torch::kInt64:
+      rejected_count = count_negative_tokens<int64_t>(tokens);
+      break;
+    case torch::kInt32:
+      rejected_count = count_negative_tokens<int32_t>(tokens);
+      break;
+    case torch::kInt16:
+      rejected_count = count_negative_tokens<int16_t>(tokens);
+      break;
+    case torch::kInt8:
+      rejected_count = count_negative_tokens<int8_t>(tokens);
+      break;
+    default:
+      LOG(WARNING) << "Unsupported speculative next_tokens dtype for metrics: "
+                   << tokens.scalar_type();
+      return;
+  }
+
+  const int64_t num_draft_tokens = batch_size * num_speculative_tokens;
+  rejected_count = std::min(rejected_count, num_draft_tokens);
+  COUNTER_ADD(speculative_num_draft_tokens_total, num_draft_tokens);
+  COUNTER_ADD(speculative_num_accepted_tokens_total,
+              num_draft_tokens - rejected_count);
 }
 
 }  // namespace
@@ -123,8 +180,9 @@ void WorkerService::step(ForwardInput& fwd_input,
           forward_outputs.value().beam_search_output;
       const auto& dit_forward_output =
           forward_outputs.value().dit_forward_output;
-      expert_load_data =
-          safe_to(forward_outputs.value().expert_load_data, torch::kCPU, true);
+      expert_load_data = safe_to(forward_outputs.value().expert_load_data,
+                                 torch::kCPU,
+                                 /*non_blocking=*/true);
       prepared_layer_id = forward_outputs.value().prepared_layer_id;
 
       {
@@ -134,52 +192,62 @@ void WorkerService::step(ForwardInput& fwd_input,
           embeddings =
               safe_to(sample_output.embeddings,
                       torch::dtype(torch::kFloat32).device(torch::kCPU),
-                      true);
+                      /*non_blocking=*/true);
 
           mm_embeddings.clear();
           mm_embeddings.reserve(sample_output.mm_embeddings.size());
           for (auto mm_embedding : sample_output.mm_embeddings) {
             mm_embeddings.emplace_back(
-                safe_to(mm_embedding, torch::kCPU, true));
+                safe_to(mm_embedding, torch::kCPU, /*non_blocking=*/true));
           }
 
           dit_images.clear();
           dit_images.reserve(dit_forward_output.tensors.size());
           for (auto dit_image : dit_forward_output.tensors) {
-            dit_images.emplace_back(safe_to(dit_image, torch::kCPU, true));
+            dit_images.emplace_back(
+                safe_to(dit_image, torch::kCPU, /*non_blocking=*/true));
           }
 
           // [num_seq]
-          next_tokens = safe_to(sample_output.next_tokens, torch::kCPU, true);
+          next_tokens = safe_to(sample_output.next_tokens,
+                                torch::kCPU,
+                                /*non_blocking=*/true);
           if (next_tokens.defined()) {
             // [num_seq]
-            logprobs = safe_to(sample_output.logprobs, torch::kCPU, true);
+            logprobs = safe_to(sample_output.logprobs,
+                               torch::kCPU,
+                               /*non_blocking=*/true);
 
             if (!beam_search_output.src_seq_idxes.defined()) {
               // beam search kernel will provide final tokens/logprobs in beam
               // search output, so keep top_tokens/top_logprobs undefined to
               // avoid returning them.
               // [num_seq, topk]
-              top_tokens = safe_to(sample_output.top_tokens, torch::kCPU, true);
+              top_tokens = safe_to(sample_output.top_tokens,
+                                   torch::kCPU,
+                                   /*non_blocking=*/true);
               // [num_seq, topk]
-              top_logprobs =
-                  safe_to(sample_output.top_logprobs, torch::kCPU, true);
+              top_logprobs = safe_to(sample_output.top_logprobs,
+                                     torch::kCPU,
+                                     /*non_blocking=*/true);
             }
           }
 
           // beam search output
           // [num_seq]
-          src_seq_idxes =
-              safe_to(beam_search_output.src_seq_idxes, torch::kCPU, true);
+          src_seq_idxes = safe_to(beam_search_output.src_seq_idxes,
+                                  torch::kCPU,
+                                  /*non_blocking=*/true);
           if (src_seq_idxes.defined()) {
             // [num_seq]
-            out_tokens =
-                safe_to(beam_search_output.out_tokens, torch::kCPU, true);
+            out_tokens = safe_to(beam_search_output.out_tokens,
+                                 torch::kCPU,
+                                 /*non_blocking=*/true);
             // [num_seq]
             out_logprobs =
                 safe_to(beam_search_output.out_logprobs,
                         torch::dtype(torch::kFloat32).device(torch::kCPU),
-                        true);
+                        /*non_blocking=*/true);
           }
         };
         if (use_default_stream) {
@@ -193,6 +261,7 @@ void WorkerService::step(ForwardInput& fwd_input,
         } else {
           stream_->synchronize();
         }
+        record_speculative_metrics_from_output(next_tokens, options_);
       }
     }
   } else {
@@ -694,12 +763,11 @@ void WorkerService::GetLastStepResult(
         auto future = worker_->get_last_step_result_async();
         auto forward_outputs = std::move(future).get();
         if (forward_outputs) {
-          const auto& sample_output = forward_outputs.value().sample_output;
-          const auto& expert_load_data = safe_to(
-              forward_outputs.value().expert_load_data, torch::kCPU, true);
-          int32_t prepared_layer_id = forward_outputs.value().prepared_layer_id;
-          const auto& beam_search_output =
-              forward_outputs.value().beam_search_output;
+          const ForwardOutput& forward_output = forward_outputs.value();
+          const auto& sample_output = forward_output.sample_output;
+          int32_t prepared_layer_id = forward_output.prepared_layer_id;
+          const auto& beam_search_output = forward_output.beam_search_output;
+          torch::Tensor expert_load_data;
           torch::Tensor embeddings;
           torch::Tensor next_tokens;
           torch::Tensor logprobs;
@@ -710,39 +778,59 @@ void WorkerService::GetLastStepResult(
           torch::Tensor out_logprobs;
           std::vector<torch::Tensor> dit_images;
           auto copy_output_to_host = [&]() {
+            if (options_.enable_schedule_overlap()) {
+              CHECK(stream_->wait_event(forward_output.ready_event))
+                  << "failed to wait forward output ready event";
+            }
+            expert_load_data = safe_to(forward_output.expert_load_data,
+                                       torch::kCPU,
+                                       /*non_blocking=*/true);
+
             // [num_seq, ..., embed_dim]
-            embeddings = safe_to(sample_output.embeddings, torch::kCPU, true);
-            embeddings = safe_to(embeddings, torch::kFloat32, true);
+            embeddings = safe_to(sample_output.embeddings,
+                                 torch::kCPU,
+                                 /*non_blocking=*/true);
+            embeddings = safe_to(embeddings,
+                                 torch::kFloat32,
+                                 /*non_blocking=*/true);
 
             dit_images.reserve(
-                forward_outputs.value().dit_forward_output.tensors.size());
-            for (auto image :
-                 forward_outputs.value().dit_forward_output.tensors) {
+                forward_output.dit_forward_output.tensors.size());
+            for (auto image : forward_output.dit_forward_output.tensors) {
               dit_images.emplace_back(image);
             }
 
             // [num_seq]
-            next_tokens = safe_to(sample_output.next_tokens, torch::kCPU, true);
+            next_tokens = safe_to(sample_output.next_tokens,
+                                  torch::kCPU,
+                                  /*non_blocking=*/true);
             if (next_tokens.defined() ||
                 ::xllm::EPLBConfig::get_instance().enable_eplb()) {
               // [num_seq] FloatTensor
-              logprobs = safe_to(sample_output.logprobs, torch::kCPU, true);
+              logprobs = safe_to(sample_output.logprobs,
+                                 torch::kCPU,
+                                 /*non_blocking=*/true);
               // [num_seq, topk]
-              top_tokens = safe_to(sample_output.top_tokens, torch::kCPU, true);
+              top_tokens = safe_to(sample_output.top_tokens,
+                                   torch::kCPU,
+                                   /*non_blocking=*/true);
               // [num_seq, topk]
-              top_logprobs =
-                  safe_to(sample_output.top_logprobs, torch::kCPU, true);
+              top_logprobs = safe_to(sample_output.top_logprobs,
+                                     torch::kCPU,
+                                     /*non_blocking=*/true);
               // [num_seq]
-              src_seq_idxes =
-                  safe_to(beam_search_output.src_seq_idxes, torch::kCPU, true);
+              src_seq_idxes = safe_to(beam_search_output.src_seq_idxes,
+                                      torch::kCPU,
+                                      /*non_blocking=*/true);
               // [num_seq]
-              out_tokens =
-                  safe_to(beam_search_output.out_tokens, torch::kCPU, true);
+              out_tokens = safe_to(beam_search_output.out_tokens,
+                                   torch::kCPU,
+                                   /*non_blocking=*/true);
               // [num_seq]
               out_logprobs =
                   safe_to(beam_search_output.out_logprobs,
                           torch::dtype(torch::kFloat32).device(torch::kCPU),
-                          true);
+                          /*non_blocking=*/true);
             }
           };
 
@@ -757,6 +845,7 @@ void WorkerService::GetLastStepResult(
           } else {
             stream_->synchronize();
           }
+          record_speculative_metrics_from_output(next_tokens, options_);
 
           if (next_tokens.defined() ||
               ::xllm::EPLBConfig::get_instance().enable_eplb()) {

--- a/xllm/core/framework/kv_cache/embedding_cache.cpp
+++ b/xllm/core/framework/kv_cache/embedding_cache.cpp
@@ -25,6 +25,17 @@ limitations under the License.
 #include "util/utils.h"
 
 namespace xllm {
+namespace {
+
+torch::Tensor to_cpu_int64_contiguous(const torch::Tensor& tensor) {
+  torch::Tensor cpu_tensor = safe_to(tensor, torch::kCPU).contiguous();
+  if (cpu_tensor.scalar_type() != torch::kInt64) {
+    cpu_tensor = cpu_tensor.to(torch::kInt64);
+  }
+  return cpu_tensor;
+}
+
+}  // namespace
 
 EmbeddingCache::EmbeddingCache(int32_t total_nums) {
   CHECK_GT(total_nums, 0) << "No embeddings to allocate";
@@ -61,9 +72,11 @@ void EmbeddingCache::write_prefill_target_context(
   CHECK_EQ(target_embeddings.size(0), static_cast<int64_t>(ids.size()))
       << "prefill target embedding count mismatch";
 
-  torch::Tensor next_tokens_cpu = safe_to(next_tokens, torch::kCPU);
-  for (int32_t i = 0; i < static_cast<int32_t>(ids.size()); ++i) {
-    const int64_t token = next_tokens_cpu[i].item<int64_t>();
+  torch::Tensor next_tokens_cpu = to_cpu_int64_contiguous(next_tokens);
+  const int64_t* next_tokens_data = next_tokens_cpu.const_data_ptr<int64_t>();
+  const int32_t num_ids = static_cast<int32_t>(ids.size());
+  for (int32_t i = 0; i < num_ids; ++i) {
+    const int64_t token = next_tokens_data[i];
     CHECK_GE(token, 0) << "prefill target token should be valid";
     CHECK_LE(token, static_cast<int64_t>(std::numeric_limits<int32_t>::max()))
         << "prefill target token overflow";
@@ -76,7 +89,7 @@ void EmbeddingCache::write_prefill_target_context(
     state.all_draft_accepted = false;
     state.token_id = static_cast<int32_t>(token);
     state.position_offset = 0;
-    state.embedding = target_embeddings[i].detach().clone();
+    state.embedding = target_embeddings.select(/*dim=*/0, i).detach();
 
     DecodeState& tail = mutable_tail(ids[i]);
     tail = std::move(state);
@@ -106,16 +119,19 @@ void EmbeddingCache::write_target_context(
       << "accepted token/embedding width mismatch";
   CHECK_GE(num_speculative_tokens, 0) << "invalid speculative token count";
 
-  torch::Tensor accepted_tokens_cpu = safe_to(accepted_tokens, torch::kCPU);
-  for (int32_t i = 0; i < static_cast<int32_t>(ids.size()); ++i) {
+  torch::Tensor accepted_tokens_cpu = to_cpu_int64_contiguous(accepted_tokens);
+  const int64_t* accepted_tokens_data =
+      accepted_tokens_cpu.const_data_ptr<int64_t>();
+  const int32_t num_ids = static_cast<int32_t>(ids.size());
+  const int32_t token_width = static_cast<int32_t>(accepted_tokens_cpu.size(1));
+  for (int32_t i = 0; i < num_ids; ++i) {
     int32_t accepted_len = 0;
     int32_t last_token_id = -1;
     int32_t correction_token = -1;
     int32_t correction_offset = -1;
-    const int32_t token_width =
-        static_cast<int32_t>(accepted_tokens_cpu.size(1));
+    const int64_t row_offset = static_cast<int64_t>(i) * token_width;
     for (int32_t j = 0; j < token_width; ++j) {
-      const int64_t token = accepted_tokens_cpu[i][j].item<int64_t>();
+      const int64_t token = accepted_tokens_data[row_offset + j];
       if (token < 0) {
         break;
       }
@@ -128,10 +144,6 @@ void EmbeddingCache::write_target_context(
     }
     CHECK_GT(accepted_len, 0)
         << "each sequence must have at least one accepted target token";
-    for (int32_t j = accepted_len; j < token_width; ++j) {
-      const int64_t token = accepted_tokens_cpu[i][j].item<int64_t>();
-      CHECK_LT(token, 0) << "accepted tokens should be a contiguous prefix";
-    }
 
     const int32_t last_idx = accepted_len - 1;
     DecodeState state;
@@ -144,13 +156,16 @@ void EmbeddingCache::write_target_context(
     state.position_offset = last_idx;
     state.correction_token_id = correction_token;
     state.correction_position_offset = correction_offset;
-    state.embedding = accepted_embeddings[i][last_idx].detach().clone();
+    state.embedding = accepted_embeddings.select(/*dim=*/0, i)
+                          .select(/*dim=*/0, last_idx)
+                          .detach();
     if (last_idx > 0) {
       const int64_t prev_token =
-          accepted_tokens_cpu[i][last_idx - 1].item<int64_t>();
+          accepted_tokens_data[row_offset + last_idx - 1];
       state.prev_token_id = static_cast<int32_t>(prev_token);
-      state.prev_embedding =
-          accepted_embeddings[i][last_idx - 1].detach().clone();
+      state.prev_embedding = accepted_embeddings.select(/*dim=*/0, i)
+                                 .select(/*dim=*/0, last_idx - 1)
+                                 .detach();
     }
 
     DecodeState& tail = mutable_tail(ids[i]);
@@ -165,11 +180,6 @@ void EmbeddingCache::set_placeholder(
 
 const torch::Tensor& EmbeddingCache::embedding_placeholder() const {
   return embedding_placeholder_;
-}
-
-void EmbeddingCache::set_probs_placeholder(
-    const torch::Tensor& probs_placeholder) {
-  probs_placeholder_ = probs_placeholder;
 }
 
 std::vector<EmbeddingCache::DecodeState> EmbeddingCache::read_decode_states(

--- a/xllm/core/framework/kv_cache/embedding_cache.h
+++ b/xllm/core/framework/kv_cache/embedding_cache.h
@@ -44,6 +44,9 @@ class EmbeddingCache final {
     // current real position from this offset.
     int32_t token_id = -1;
     int32_t position_offset = 0;
+    // Store detached views into target outputs instead of cloning. The views
+    // keep their storage alive until replaced, trading short-lived HBM
+    // retention for avoiding per-step embedding copies.
     torch::Tensor embedding;
 
     // Previous accepted target token. Its position is derived as
@@ -53,7 +56,6 @@ class EmbeddingCache final {
 
     int32_t correction_token_id = 0;  // accepted token for step correction
     int32_t correction_position_offset = 0;
-    torch::Tensor probs;
   };
 
   EmbeddingCache(int32_t total_nums);
@@ -85,7 +87,6 @@ class EmbeddingCache final {
   // PD first decode. MTP uses hidden_size; Eagle3 uses 3 * hidden_size.
   void set_placeholder(const torch::Tensor& embedding_placeholder);
   const torch::Tensor& embedding_placeholder() const;
-  void set_probs_placeholder(const torch::Tensor& probs_placeholder);
 
   // Non-failing read used by PD first decode. Missing entries are materialized
   // as fake target states so workers can follow the normal decode path.
@@ -100,8 +101,6 @@ class EmbeddingCache final {
  private:
   std::vector<DecodeState> decode_tails_;
   torch::Tensor embedding_placeholder_;
-  torch::Tensor probs_placeholder_;
-  int32_t token_id_placeholder_ = 0;
 
   DecodeState& mutable_tail(int32_t embedding_id);
   const DecodeState& get_tail(int32_t embedding_id) const;

--- a/xllm/core/kernels/npu/xllm_ops/replace_token.cpp
+++ b/xllm/core/kernels/npu/xllm_ops/replace_token.cpp
@@ -60,8 +60,6 @@ void replace_token(torch::Tensor& dst, torch::Tensor& src) {
   CHECK_ACL_SUCCESS(
       aclnnReplaceToken(workspace_addr, workspace_size, executor, stream),
       "replace_token: failed to replace token");
-  CHECK_ACL_SUCCESS(aclrtSynchronizeStream(stream),
-                    "replace_token: failed to synchronize stream");
   aclDestroyTensor(dst_ids);
   aclDestroyTensor(src_ids);
 }

--- a/xllm/core/kernels/npu/xllm_ops/top_k_top_p.cpp
+++ b/xllm/core/kernels/npu/xllm_ops/top_k_top_p.cpp
@@ -20,6 +20,7 @@ limitations under the License.
 #include <torch_npu/torch_npu.h>
 
 #include <nlohmann/json.hpp>
+#include <unordered_map>
 #ifdef TORCH_HIGHER_THAN_PTA6
 #include <torch_npu/csrc/framework/OpCommand.h>
 #else
@@ -34,6 +35,62 @@ limitations under the License.
 #include "xllm_ops_api.h"
 
 namespace xllm::kernel::npu {
+
+namespace {
+
+class AclWorkspaceCache final {
+ public:
+  ~AclWorkspaceCache() {
+    for (auto& workspace : workspaces_) {
+      if (workspace.second.addr_ != nullptr) {
+        aclrtSynchronizeStream(workspace.first);
+        aclrtFree(workspace.second.addr_);
+      }
+    }
+  }
+
+  void* get(aclrtStream stream, uint64_t workspace_size) {
+    if (workspace_size == 0) {
+      return nullptr;
+    }
+
+    AclWorkspace& workspace = workspaces_[stream];
+    if (workspace.addr_ != nullptr && workspace.size_ >= workspace_size) {
+      return workspace.addr_;
+    }
+
+    if (workspace.addr_ != nullptr) {
+      CHECK_ACL_SUCCESS(aclrtSynchronizeStream(stream),
+                        "top_k_top_p: failed to synchronize stream before "
+                        "workspace resize");
+      CHECK_ACL_SUCCESS(aclrtFree(workspace.addr_),
+                        "top_k_top_p: failed to free resized workspace");
+    }
+
+    CHECK_ACL_SUCCESS(
+        aclrtMalloc(
+            &workspace.addr_, workspace_size, ACL_MEM_MALLOC_HUGE_FIRST),
+        "top_k_top_p: failed to allocate workspace");
+    workspace.size_ = workspace_size;
+    return workspace.addr_;
+  }
+
+ private:
+  class AclWorkspace final {
+   public:
+    void* addr_ = nullptr;
+    uint64_t size_ = 0;
+  };
+
+  std::unordered_map<aclrtStream, AclWorkspace> workspaces_;
+};
+
+AclWorkspaceCache& workspace_cache() {
+  thread_local AclWorkspaceCache cache;
+  return cache;
+}
+
+}  // namespace
 
 // Used by the sampling logits preprocessing path on NPU.
 // This wrapper applies top-k and top-p filtering before token sampling so the
@@ -67,23 +124,12 @@ void top_k_top_p(torch::Tensor& logits,
                                                        &workspace_size,
                                                        &executor),
                     "top_k_top_p: failed to get workspace size");
-  void* workspace_addr = nullptr;
-  if (workspace_size > 0) {
-    CHECK_ACL_SUCCESS(
-        aclrtMalloc(&workspace_addr, workspace_size, ACL_MEM_MALLOC_HUGE_FIRST),
-        "top_k_top_p: failed to allocate workspace");
-  }
+  void* workspace_addr = workspace_cache().get(stream, workspace_size);
   CHECK_ACL_SUCCESS(
       aclnnApplyTopKTopP(workspace_addr, workspace_size, executor, stream),
       "top_k_top_p: failed to apply top k top p");
-  CHECK_ACL_SUCCESS(aclrtSynchronizeStream(stream),
-                    "top_k_top_p: failed to synchronize stream");
   aclDestroyTensor(logits_ids);
   aclDestroyTensor(topK_ids);
   aclDestroyTensor(topP_ids);
-  if (workspace_size > 0) {
-    CHECK_ACL_SUCCESS(aclrtFree(workspace_addr),
-                      "top_k_top_p: failed to free workspace");
-  }
 }
 }  // namespace xllm::kernel::npu

--- a/xllm/core/platform/stream.cpp
+++ b/xllm/core/platform/stream.cpp
@@ -13,11 +13,37 @@ See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
 
-#include "stream.h"
+#include "core/platform/stream.h"
 
+#include <glog/logging.h>
+
+#include <exception>
+#include <memory>
 #include <ostream>
 
 namespace xllm {
+
+namespace {
+
+#if defined(USE_NPU)
+c10::Stream to_c10_stream(const c10_npu::NPUStream& stream) {
+  return stream.unwrap();
+}
+#elif defined(USE_MLU)
+c10::Stream to_c10_stream(const torch_mlu::MLUStream& stream) {
+  return stream.unwrap();
+}
+#elif defined(USE_CUDA) || defined(USE_ILU)
+c10::Stream to_c10_stream(const c10::cuda::CUDAStream& stream) {
+  return stream;
+}
+#elif defined(USE_MUSA)
+c10::Stream to_c10_stream(const c10::musa::MUSAStream& stream) {
+  return stream;
+}
+#endif
+
+}  // namespace
 
 #if defined(USE_NPU)
 Stream::Stream(const int32_t timeout)
@@ -72,17 +98,88 @@ c10::StreamGuard Stream::set_stream_guard() const {
 
 void Stream::wait_stream(const Stream& other_stream) {
   // get the c10::Stream objects for the current stream and the other stream
-#if defined(USE_CUDA) || defined(USE_ILU)
-  const c10::Stream& current_c10_stream = this->stream_;
-  const c10::Stream& target_c10_stream = other_stream.stream_;
-#else
-  c10::Stream current_c10_stream = this->stream_.unwrap();
-  c10::Stream target_c10_stream = other_stream.stream_.unwrap();
-#endif
+  c10::Stream current_c10_stream = to_c10_stream(stream_);
+  c10::Stream target_c10_stream = to_c10_stream(other_stream.stream_);
 
   c10::Event event(current_c10_stream.device_type());
   event.record(target_c10_stream);
   event.block(current_c10_stream);
+}
+
+StreamEventPtr Stream::record_event() const {
+#if defined(USE_NPU)
+  aclrtEvent event = nullptr;
+  aclError ret = aclrtCreateEventWithFlag(&event, ACL_EVENT_SYNC);
+  if (ret != ACL_SUCCESS) {
+    ret = aclrtCreateEvent(&event);
+  }
+  if (ret != ACL_SUCCESS) {
+    LOG(ERROR) << "Failed to create NPU stream event: " << ret;
+    return nullptr;
+  }
+
+  ret = aclrtRecordEvent(event, stream_.stream());
+  if (ret != ACL_SUCCESS) {
+    LOG(ERROR) << "Failed to record NPU stream event: " << ret;
+    aclrtDestroyEvent(event);
+    return nullptr;
+  }
+  return std::make_shared<StreamEvent>(event);
+#else
+  try {
+    c10::Stream current_c10_stream = to_c10_stream(stream_);
+    StreamEventPtr event =
+        std::make_shared<StreamEvent>(current_c10_stream.device_type());
+    event->c10_event().record(current_c10_stream);
+    return event;
+  } catch (const std::exception& e) {
+    LOG(ERROR) << "Failed to record stream event: " << e.what();
+  } catch (...) {
+    LOG(ERROR) << "Failed to record stream event: unknown exception";
+  }
+  return nullptr;
+#endif
+}
+
+bool Stream::wait_event(const StreamEventPtr& event) const {
+  if (event == nullptr) {
+    return true;
+  }
+#if defined(USE_NPU)
+  aclError ret = aclrtStreamWaitEvent(stream_.stream(), event->npu_event());
+  if (ret == ACL_SUCCESS) {
+    return true;
+  }
+  LOG(ERROR) << "Failed to wait NPU stream event: " << ret
+             << "; falling back to event synchronize.";
+  ret = aclrtSynchronizeEvent(event->npu_event());
+  if (ret == ACL_SUCCESS) {
+    return true;
+  }
+  LOG(ERROR) << "Failed to synchronize NPU stream event: " << ret;
+  return false;
+#else
+  try {
+    event->c10_event().block(to_c10_stream(stream_));
+    return true;
+  } catch (const std::exception& e) {
+    LOG(ERROR) << "Failed to wait stream event: " << e.what()
+               << "; falling back to event synchronize.";
+  } catch (...) {
+    LOG(ERROR) << "Failed to wait stream event: unknown exception; falling "
+                  "back to event synchronize.";
+  }
+
+  try {
+    event->c10_event().synchronize();
+    return true;
+  } catch (const std::exception& e) {
+    LOG(ERROR) << "Failed to synchronize stream event: " << e.what();
+  } catch (...) {
+    LOG(ERROR) << "Failed to synchronize stream event: unknown exception";
+  }
+  return false;
+#endif
 }
 
 std::ostream& operator<<(std::ostream& os, const Stream& stream) {

--- a/xllm/core/platform/stream.h
+++ b/xllm/core/platform/stream.h
@@ -21,7 +21,6 @@ limitations under the License.
 #endif
 // clang-format on
 
-#include <c10/core/Event.h>
 #include <c10/core/Stream.h>
 #include <c10/core/StreamGuard.h>
 
@@ -37,6 +36,8 @@ limitations under the License.
 #elif defined(USE_MUSA)
 #include <c10/musa/MUSAGuard.h>
 #endif
+
+#include "core/platform/stream_event.h"
 
 namespace xllm {
 
@@ -68,8 +69,14 @@ class Stream {
   torch_mlu::MLUStream* get_stream() { return &stream_; }
 #elif defined(USE_CUDA)
   c10::cuda::CUDAStream* get_stream() { return &stream_; }
+#elif defined(USE_ILU)
+  c10::cuda::CUDAStream* get_stream() { return &stream_; }
+#elif defined(USE_MUSA)
+  c10::musa::MUSAStream* get_stream() { return &stream_; }
 #endif
   void wait_stream(const Stream& other_stream);
+  StreamEventPtr record_event() const;
+  bool wait_event(const StreamEventPtr& event) const;
 
   // Support for LOG(INFO) output
   friend std::ostream& operator<<(std::ostream& os, const Stream& stream);

--- a/xllm/core/platform/stream_event.h
+++ b/xllm/core/platform/stream_event.h
@@ -1,0 +1,60 @@
+/* Copyright 2026 The xLLM Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://github.com/jd-opensource/xllm/blob/main/LICENSE
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#pragma once
+
+#include <memory>
+
+#if defined(USE_NPU)
+#include <acl/acl.h>
+#else
+#include <c10/core/Event.h>
+#endif
+
+#include "common/macros.h"
+
+namespace xllm {
+
+class StreamEvent final {
+ public:
+#if defined(USE_NPU)
+  explicit StreamEvent(aclrtEvent event) : npu_event_(event) {}
+
+  ~StreamEvent() {
+    if (npu_event_ != nullptr) {
+      aclrtDestroyEvent(npu_event_);
+    }
+  }
+
+  aclrtEvent npu_event() const { return npu_event_; }
+#else
+  explicit StreamEvent(c10::DeviceType device_type) : c10_event_(device_type) {}
+
+  c10::Event& c10_event() { return c10_event_; }
+#endif
+
+  DISALLOW_COPY_AND_ASSIGN(StreamEvent);
+
+ private:
+#if defined(USE_NPU)
+  aclrtEvent npu_event_ = nullptr;
+#else
+  c10::Event c10_event_;
+#endif
+};
+
+using StreamEventPtr = std::shared_ptr<StreamEvent>;
+
+}  // namespace xllm

--- a/xllm/core/runtime/forward_params.h
+++ b/xllm/core/runtime/forward_params.h
@@ -20,6 +20,7 @@ limitations under the License.
 
 #include <algorithm>
 #include <cstring>
+#include <memory>
 #include <nlohmann/json.hpp>
 #include <numeric>
 #include <optional>
@@ -599,6 +600,11 @@ struct ForwardInput {
 
   // True once cp::cp_partition_inplace has produced the per-CP-rank slice.
   bool cp_partitioned = false;
+
+  // Device-side readiness dependencies for inputs prepared on a different
+  // stream. These are local runtime handles and are intentionally not included
+  // in proto or shared-memory transport.
+  StreamEventPtr metadata_ready_event;
 };
 
 #if 0  // Legacy engine-side CP partition; superseded by
@@ -896,6 +902,12 @@ struct ForwardOutput {
   // max number of top logprobs in the batch
   int64_t max_top_logprobs = 0;
   SampleOutput sample_output;
+  // Keep no-sync input tensor handles alive until downstream consumers finish
+  // using outputs on the same compute stream.
+  std::shared_ptr<ForwardInput> retained_input;
+  // Device-side readiness dependency for no-sync outputs. This local runtime
+  // handle is intentionally not included in proto or shared-memory transport.
+  StreamEventPtr ready_event;
   torch::Tensor logits;
   torch::Tensor embedding;
 

--- a/xllm/core/runtime/llm_worker_impl.cpp
+++ b/xllm/core/runtime/llm_worker_impl.cpp
@@ -45,6 +45,24 @@ limitations under the License.
 
 namespace xllm {
 
+namespace {
+
+void wait_input_ready_events(const ForwardInput& input, const Stream& stream) {
+  CHECK(stream.wait_event(input.metadata_ready_event))
+      << "failed to wait ForwardInput metadata ready event";
+}
+
+StreamEventPtr record_current_stream_event(const Device& device) {
+  std::unique_ptr<Stream> stream = device.current_stream();
+  StreamEventPtr event = stream->record_event();
+  if (event == nullptr) {
+    stream->synchronize();
+  }
+  return event;
+}
+
+}  // namespace
+
 LLMWorkerImpl::LLMWorkerImpl(const ParallelArgs& parallel_args,
                              const torch::Device& device,
                              const runtime::Options& options)
@@ -80,6 +98,43 @@ bool LLMWorkerImpl::init_model(ModelContext& context) {
   return true;
 }
 
+std::optional<ForwardOutput> LLMWorkerImpl::step_no_sync(
+    const ForwardInput& input) {
+  ForwardInput input_on_device;
+  prepare_work_before_execute(input, input_on_device);
+  std::unique_ptr<Stream> current_stream = device_.current_stream();
+  return execute_no_sync_on_stream(input_on_device, *current_stream);
+}
+
+std::optional<ForwardOutput> LLMWorkerImpl::execute_no_sync_on_stream(
+    const ForwardInput& input,
+    Stream& compute_stream) {
+  const ForwardSyncPolicy sync_policy = ForwardSyncPolicy::NO_SYNC;
+  c10::StreamGuard stream_guard = compute_stream.set_stream_guard();
+  if (::xllm::LoadConfig::get_instance().enable_manual_loader()) {
+#if defined(USE_NPU)
+    if (!enable_schedule_overlap() && options_.backend() == "llm") {
+      aclrtStream current_acl_stream =
+          c10_npu::getCurrentNPUStream(device_.index()).stream();
+      atb::Context* atb_context =
+          const_cast<atb::Context*>(context_.get_atb_context());
+      atb_context->SetExecuteStream(current_acl_stream);
+      wait_input_ready_events(input, compute_stream);
+      return step_internal(input, sync_policy);
+    } else {
+      SET_ATB_EXECUTE_STREAM((&compute_stream), device_, context_);
+      wait_input_ready_events(input, compute_stream);
+      return step_internal(input, sync_policy);
+    }
+#else
+    wait_input_ready_events(input, compute_stream);
+    return step_internal(input, sync_policy);
+#endif
+  }
+  wait_input_ready_events(input, compute_stream);
+  return step_internal(input, sync_policy);
+}
+
 std::optional<ForwardOutput> LLMWorkerImpl::step(const ForwardInput& input) {
   if (::xllm::LoadConfig::get_instance().enable_manual_loader()) {
 #if defined(USE_NPU)
@@ -89,17 +144,65 @@ std::optional<ForwardOutput> LLMWorkerImpl::step(const ForwardInput& input) {
       atb::Context* atb_context =
           const_cast<atb::Context*>(context_.get_atb_context());
       atb_context->SetExecuteStream(current_stream);
+      std::unique_ptr<Stream> stream = device_.current_stream();
+      wait_input_ready_events(input, *stream);
+      return step_internal(input, ForwardSyncPolicy::LEGACY);
     } else {
       SET_ATB_EXECUTE_STREAM(compute_stream_, device_, context_);
+      wait_input_ready_events(input, *compute_stream_);
+      return step_internal(input, ForwardSyncPolicy::LEGACY);
     }
+#else
+    std::unique_ptr<Stream> stream = device_.current_stream();
+    wait_input_ready_events(input, *stream);
+    return step_internal(input, ForwardSyncPolicy::LEGACY);
 #endif
-    return step_internal(input);
   }
-  return step_internal(input);
+  std::unique_ptr<Stream> stream = device_.current_stream();
+  wait_input_ready_events(input, *stream);
+  return step_internal(input, ForwardSyncPolicy::LEGACY);
+}
+
+folly::SemiFuture<std::optional<ForwardOutput>>
+LLMWorkerImpl::step_async_no_sync(const ForwardInput& input) {
+  CHECK(!enable_schedule_overlap())
+      << "step_async_no_sync is only supported for non-overlap workers";
+  ForwardInput input_on_device;
+
+  prepare_work_before_execute(input, input_on_device);
+
+  folly::Promise<std::optional<ForwardOutput>> promise;
+  auto future = promise.getSemiFuture();
+  threadpool_.schedule([this,
+                        input = std::move(input_on_device),
+                        promise = std::move(promise)]() mutable {
+    if (hierarchy_kv_cache_transfer_ != nullptr) {
+      hierarchy_kv_cache_transfer_->set_layer_synchronizer(input.input_params);
+    }
+
+    const auto output = this->step_no_sync(input);
+    promise.setValue(output);
+  });
+  return future;
+}
+
+std::optional<ForwardOutput> LLMWorkerImpl::step_for_schedule_overlap(
+    const ForwardInput& input) {
+  return execute_no_sync_on_stream(input, *compute_stream_);
+}
+
+ForwardInput
+LLMWorkerImpl::update_input_by_last_step_output_for_schedule_overlap(
+    ForwardInput& input) {
+  c10::StreamGuard stream_guard = compute_stream_->set_stream_guard();
+  CHECK(compute_stream_->wait_event(last_step_output_.ready_event))
+      << "failed to wait last step output ready event";
+  return update_input_by_last_step_output(input);
 }
 
 std::optional<ForwardOutput> LLMWorkerImpl::step_internal(
-    const ForwardInput& input) {
+    const ForwardInput& input,
+    ForwardSyncPolicy sync_policy) {
   MULTI_MODEL_STEP_LOCK(::xllm::KVCacheConfig::get_instance().enable_xtensor());
 
   Timer timer;
@@ -172,6 +275,9 @@ std::optional<ForwardOutput> LLMWorkerImpl::step_internal(
   if (!enable_schedule_overlap() && !driver_ && !dp_driver_ &&
       !options_.enable_speculative_decode()) {
     MULTI_MODEL_STEP_UNLOCK();
+    if (sync_policy == ForwardSyncPolicy::NO_SYNC) {
+      return std::nullopt;
+    }
     auto ret = device_.synchronize_default_stream();
     // in p-d disaggregation scene, all micro batches should be in same
     // prefill/decode stage, so, to judge transfer_kv_infos.empty,
@@ -253,6 +359,13 @@ std::optional<ForwardOutput> LLMWorkerImpl::step_internal(
   }
 
   MULTI_MODEL_STEP_UNLOCK();
+  if (sync_policy == ForwardSyncPolicy::NO_SYNC) {
+    output.retained_input = std::make_shared<ForwardInput>(input);
+    if (enable_schedule_overlap()) {
+      output.ready_event = record_current_stream_event(device_);
+    }
+    return output;
+  }
   auto ret = device_.synchronize_default_stream();
 
   if (options_.kv_cache_transfer_mode() == "PUSH" &&

--- a/xllm/core/runtime/llm_worker_impl.h
+++ b/xllm/core/runtime/llm_worker_impl.h
@@ -32,6 +32,11 @@ namespace xllm {
 
 class LLMWorkerImpl : public WorkerImpl {
  public:
+  enum class ForwardSyncPolicy : int8_t {
+    LEGACY = 0,
+    NO_SYNC,
+  };
+
   LLMWorkerImpl(const ParallelArgs& parallel_args,
                 const torch::Device& device,
                 const runtime::Options& options);
@@ -43,8 +48,25 @@ class LLMWorkerImpl : public WorkerImpl {
 
   std::optional<ForwardOutput> step(const ForwardInput& input) override;
 
-  std::optional<ForwardOutput> step_internal(const ForwardInput& input);
+  std::optional<ForwardOutput> step_no_sync(const ForwardInput& input);
+  std::optional<ForwardOutput> execute_no_sync_on_stream(
+      const ForwardInput& input,
+      Stream& compute_stream);
 
+  folly::SemiFuture<std::optional<ForwardOutput>> step_async_no_sync(
+      const ForwardInput& input);
+
+  std::optional<ForwardOutput> step_internal(
+      const ForwardInput& input,
+      ForwardSyncPolicy sync_policy = ForwardSyncPolicy::LEGACY);
+
+ protected:
+  std::optional<ForwardOutput> step_for_schedule_overlap(
+      const ForwardInput& input) override;
+  ForwardInput update_input_by_last_step_output_for_schedule_overlap(
+      ForwardInput& input) override;
+
+ public:
 #if defined(USE_NPU)
   layer::NpuLmHead get_npu_lm_head() { return model_->get_npu_lm_head(); };
 

--- a/xllm/core/runtime/mtp_worker_impl.cpp
+++ b/xllm/core/runtime/mtp_worker_impl.cpp
@@ -19,6 +19,7 @@ limitations under the License.
 
 #include <algorithm>
 #include <cctype>
+#include <memory>
 
 #include "common/global_flags.h"
 #include "common/metrics.h"
@@ -95,17 +96,62 @@ torch::Tensor make_cpu_int_tensor(const std::vector<int32_t>& values) {
                            .pinned_memory(true));
 }
 
+void record_metadata_ready_event(Stream& stream, ForwardInput& input) {
+  StreamEventPtr event = stream.record_event();
+  if (event == nullptr) {
+    stream.synchronize();
+  }
+  input.metadata_ready_event = event;
+}
+
+void finish_metadata_prepare(Stream& stream, ForwardInput& input) {
+  record_metadata_ready_event(stream, input);
+}
+
+void record_current_metadata_ready_event(ForwardInput& input, Stream& stream) {
+  CHECK(stream.wait_event(input.metadata_ready_event))
+      << "failed to wait speculative metadata ready event";
+  record_metadata_ready_event(stream, input);
+}
+
+void wait_metadata_ready_event(const ForwardInput& input, Stream& stream) {
+  CHECK(stream.wait_event(input.metadata_ready_event))
+      << "failed to wait speculative metadata ready event";
+}
+
+void clear_output_embeddings(ForwardOutput& output) {
+  output.sample_output.embeddings = torch::Tensor();
+  output.sample_output.selected_embeddings = torch::Tensor();
+}
+
+void clear_ready_events(ForwardInput& input) {
+  input.metadata_ready_event.reset();
+}
+
+std::optional<ForwardOutput> run_llm_no_sync_impl(LLMWorkerImpl& worker,
+                                                  const ForwardInput& input,
+                                                  Stream& prepare_stream,
+                                                  Stream& compute_stream) {
+  ForwardInput processed_input;
+  worker.prepare_work_before_execute_on_stream(
+      input, processed_input, prepare_stream);
+  return worker.execute_no_sync_on_stream(processed_input, compute_stream);
+}
+
 void set_token_ids_device_tensor(ForwardInput& input,
                                  const torch::Tensor& token_ids,
-                                 const torch::TensorOptions& token_options) {
+                                 const torch::TensorOptions& token_options,
+                                 Stream& compute_stream) {
   CHECK(token_ids.defined()) << "draft token_ids must be defined";
   torch::Tensor flat_token_ids = token_ids.flatten();
   CHECK_EQ(flat_token_ids.numel(), input.input_params.meta.num_sequences)
       << "draft token count must match num_sequences";
 
+  c10::StreamGuard stream_guard = compute_stream.set_stream_guard();
   input.device_tensors_ready = false;
   input.token_ids_host = torch::Tensor();
-  input.token_ids = safe_to(flat_token_ids, token_options, true);
+  input.token_ids =
+      safe_to(flat_token_ids, token_options, /*non_blocking=*/true);
   input.device_tensors_ready = true;
 }
 
@@ -185,7 +231,8 @@ void apply_cp_mtp_prefill_target_tokens(
   CHECK_EQ(next_seq_idx, next_cpu.numel())
       << "unused target next_tokens for CP MTP prefill";
 
-  input.token_ids = safe_to(input.token_ids_host, token_options, true);
+  input.token_ids =
+      safe_to(input.token_ids_host, token_options, /*non_blocking=*/true);
   embedding.mtp_shifted_token_ids = input.token_ids;
   input.device_tensors_ready = true;
 }
@@ -226,7 +273,8 @@ void replace_host_token_placeholders(ForwardInput& input,
       << "unused speculative replacement tokens";
 
   if (refresh_device) {
-    input.token_ids = safe_to(input.token_ids_host, token_options, true);
+    input.token_ids =
+        safe_to(input.token_ids_host, token_options, /*non_blocking=*/true);
     input.device_tensors_ready = true;
   }
 }
@@ -239,8 +287,10 @@ void set_token_position_tensors(ForwardInput& input,
   input.device_tensors_ready = false;
   input.token_ids_host = make_cpu_int_tensor(token_ids);
   input.positions_host = make_cpu_int_tensor(positions);
-  input.token_ids = safe_to(input.token_ids_host, token_options, true);
-  input.positions = safe_to(input.positions_host, position_options, true);
+  input.token_ids =
+      safe_to(input.token_ids_host, token_options, /*non_blocking=*/true);
+  input.positions =
+      safe_to(input.positions_host, position_options, /*non_blocking=*/true);
   input.device_tensors_ready = true;
 }
 
@@ -249,7 +299,8 @@ void set_positions_tensor(ForwardInput& input,
                           const torch::TensorOptions& device_options) {
   input.device_tensors_ready = false;
   input.positions_host = make_cpu_int_tensor(positions);
-  input.positions = safe_to(input.positions_host, device_options, true);
+  input.positions =
+      safe_to(input.positions_host, device_options, /*non_blocking=*/true);
   input.device_tensors_ready = true;
 }
 
@@ -445,8 +496,6 @@ bool MTPWorkerImpl::allocate_kv_cache(const KVCacheShape& kv_cache_shape) {
   // init_model() must run first so dtype_/embedding_size_ are initialized.
   embedding_cache_ = std::make_shared<EmbeddingCache>(num_blocks);
   if (embedding_cache_) {
-    embedding_cache_->set_probs_placeholder(
-        torch::ones({}, torch::dtype(torch::kFloat32).device(torch::kCPU)));
     int64_t size = get_embedding_placeholder_size();
     if (size > 0) {
       embedding_cache_->set_placeholder(
@@ -524,8 +573,6 @@ bool MTPWorkerImpl::allocate_kv_cache_with_transfer(
 
   embedding_cache_ = std::make_shared<EmbeddingCache>(num_blocks);
   if (embedding_cache_) {
-    embedding_cache_->set_probs_placeholder(
-        torch::ones({}, torch::dtype(torch::kFloat32).device(device_)));
     int64_t size = get_embedding_placeholder_size();
     if (size > 0) {
       embedding_cache_->set_placeholder(
@@ -549,10 +596,12 @@ void MTPWorkerImpl::prepare_work_before_execute(const ForwardInput& input,
 std::optional<ForwardOutput> MTPWorkerImpl::step_empty(
     const ForwardInput& input) {
   if (!input.input_params.meta.batch_forward_type.is_decode()) {
-    auto output = impl_->step(input);
-    auto draft_output = draft_impl_->step(input);
+    auto output =
+        run_llm_no_sync_impl(*impl_, input, *prepare_stream_, *compute_stream_);
+    auto draft_output = run_llm_no_sync_impl(
+        *draft_impl_, input, *prepare_stream_, *compute_stream_);
     (void)draft_output;
-    output->sample_output.embeddings = torch::Tensor();
+    clear_output_embeddings(*output);
     return output;
   } else {
     ForwardInput new_input = input;
@@ -560,14 +609,17 @@ std::optional<ForwardOutput> MTPWorkerImpl::step_empty(
          new_input.input_params.parallel.dp_global_token_nums) {
       token_num *= 2;
     }
-    auto draft_extend_future = draft_impl_->step_async(new_input);
     ForwardOutput draft_extend_output =
-        std::move(draft_extend_future).get().value();
+        run_llm_no_sync_impl(
+            *draft_impl_, new_input, *prepare_stream_, *compute_stream_)
+            .value();
     (void)draft_extend_output;
 
     for (int32_t i = 1; i < options_.num_speculative_tokens(); ++i) {
-      auto draft_future = draft_impl_->step_async(input);
-      ForwardOutput draft_output = std::move(draft_future).get().value();
+      ForwardOutput draft_output =
+          run_llm_no_sync_impl(
+              *draft_impl_, input, *prepare_stream_, *compute_stream_)
+              .value();
       (void)draft_output;
     }
 
@@ -576,9 +628,11 @@ std::optional<ForwardOutput> MTPWorkerImpl::step_empty(
          new_input.input_params.parallel.dp_global_token_nums) {
       token_num *= options_.num_speculative_tokens() + 1;
     }
-    auto future = impl_->step_async(new_input);
-    ForwardOutput output = std::move(future).get().value();
-    output.sample_output.embeddings = torch::Tensor();
+    ForwardOutput output =
+        run_llm_no_sync_impl(
+            *impl_, new_input, *prepare_stream_, *compute_stream_)
+            .value();
+    clear_output_embeddings(output);
     return output;
   }
 }
@@ -587,8 +641,9 @@ std::optional<ForwardOutput> MTPWorkerImpl::step_prefill(
     const ForwardInput& input) {
   Timer timer;
   // run the target model to get first token and hidden states
-  auto future = impl_->step_async(input);
-  ForwardOutput output = std::move(future).get().value();
+  ForwardOutput output =
+      run_llm_no_sync_impl(*impl_, input, *prepare_stream_, *compute_stream_)
+          .value();
   COUNTER_ADD(speculative_execution_latency_seconds_target,
               timer.elapsed_seconds());
 
@@ -603,6 +658,7 @@ std::optional<ForwardOutput> MTPWorkerImpl::step_prefill(
     prefill_input.input_params.embedding.input_embedding = embeddings.clone();
   }
   if (output.sample_output.next_tokens.defined()) {
+    c10::StreamGuard stream_guard = compute_stream_->set_stream_guard();
     const auto& extra_token_ids =
         prefill_input.input_params.embedding.extra_token_ids;
     if (options_.cp_size() > 1 &&
@@ -618,10 +674,15 @@ std::optional<ForwardOutput> MTPWorkerImpl::step_prefill(
                                       prefill_input.token_ids.options());
     }
   }
+  if (embeddings.defined() || output.sample_output.next_tokens.defined()) {
+    record_current_metadata_ready_event(prefill_input, *compute_stream_);
+  }
   // generate kv cache for draft model
   timer.reset();
-  auto draft_future = draft_impl_->step_async(prefill_input);
-  ForwardOutput draft_output = std::move(draft_future).get().value();
+  ForwardOutput draft_output =
+      run_llm_no_sync_impl(
+          *draft_impl_, prefill_input, *prepare_stream_, *compute_stream_)
+          .value();
   process_draft_sample_output(draft_output.sample_output);
   COUNTER_ADD(speculative_execution_latency_seconds_draft,
               timer.elapsed_seconds());
@@ -643,8 +704,7 @@ std::optional<ForwardOutput> MTPWorkerImpl::step_prefill(
         target_hidden,
         input.sampling_params.selected_token_idxes);
   }
-  output.sample_output.embeddings = torch::Tensor();
-  output.sample_output.selected_embeddings = torch::Tensor();
+  clear_output_embeddings(output);
 
   if (!enable_schedule_overlap() && !driver_ && !dp_driver_) {
     return std::nullopt;
@@ -656,6 +716,7 @@ void MTPWorkerImpl::prepare_prefill_inputs(const ForwardInput& input,
                                            ForwardInput& prefill_input) {
   c10::StreamGuard stream_guard = prepare_stream_->set_stream_guard();
   prefill_input = input.to(device_, dtype_);
+  clear_ready_events(prefill_input);
   auto& input_params = prefill_input.input_params;
   if (options_.cp_size() > 1) {
     CHECK(input_params.embedding.mtp_shifted_token_ids.defined());
@@ -669,6 +730,7 @@ void MTPWorkerImpl::prepare_prefill_inputs(const ForwardInput& input,
       shifted_cpu = shifted_cpu.to(torch::kInt32);
     }
     prefill_input.token_ids_host = shifted_cpu.contiguous();
+    finish_metadata_prepare(*prepare_stream_, prefill_input);
     return;
   }
 
@@ -693,10 +755,11 @@ void MTPWorkerImpl::prepare_prefill_inputs(const ForwardInput& input,
   }
   prefill_input.device_tensors_ready = false;
   prefill_input.token_ids_host = make_cpu_int_tensor(new_token_ids);
-  prefill_input.token_ids = safe_to(
-      prefill_input.token_ids_host, prefill_input.positions.options(), true);
+  prefill_input.token_ids = safe_to(prefill_input.token_ids_host,
+                                    prefill_input.positions.options(),
+                                    /*non_blocking=*/true);
   prefill_input.device_tensors_ready = true;
-  prepare_stream_->synchronize();
+  finish_metadata_prepare(*prepare_stream_, prefill_input);
 }
 
 std::optional<ForwardOutput> MTPWorkerImpl::step_decode(
@@ -720,7 +783,8 @@ std::optional<ForwardOutput> MTPWorkerImpl::step_decode(
   prepare_draft_extend_inputs(input, last_states, current_draft_input);
   draft_outputs.reserve(num_speculative_tokens);
   for (int32_t draft_idx = 0; draft_idx < num_speculative_tokens; ++draft_idx) {
-    auto future = draft_impl_->step_async(current_draft_input);
+    std::optional<ForwardOutput> draft_output_opt = run_llm_no_sync_impl(
+        *draft_impl_, current_draft_input, *prepare_stream_, *compute_stream_);
 
     // Overlap next-step input preparation with async draft forward.
     if (draft_idx == num_speculative_tokens - 1) {
@@ -729,7 +793,6 @@ std::optional<ForwardOutput> MTPWorkerImpl::step_decode(
       prepare_draft_inputs(input, next_step_input, draft_idx + 1);
     }
 
-    std::optional<ForwardOutput> draft_output_opt = std::move(future).get();
     CHECK(draft_output_opt.has_value())
         << "draft output is empty in speculative step";
 
@@ -743,9 +806,14 @@ std::optional<ForwardOutput> MTPWorkerImpl::step_decode(
     current_draft_input = next_step_input;
     set_token_ids_device_tensor(current_draft_input,
                                 last_output.next_tokens,
-                                current_draft_input.token_ids.options());
-    current_draft_input.input_params.embedding.input_embedding =
-        last_output.embeddings;
+                                current_draft_input.token_ids.options(),
+                                *compute_stream_);
+    if (last_output.embeddings.defined()) {
+      current_draft_input.input_params.embedding.input_embedding =
+          last_output.embeddings;
+      record_current_metadata_ready_event(current_draft_input,
+                                          *compute_stream_);
+    }
   }
   COUNTER_ADD(speculative_execution_latency_seconds_draft,
               timer.elapsed_seconds());
@@ -754,7 +822,8 @@ std::optional<ForwardOutput> MTPWorkerImpl::step_decode(
 
 void MTPWorkerImpl::fill_validate_input_from_draft_outputs(
     const std::vector<ForwardOutput>& draft_outputs,
-    ForwardInput& validate_input) {
+    ForwardInput& validate_input,
+    Stream& compute_stream) {
   const int32_t num_speculative_tokens = options_.num_speculative_tokens();
   const int32_t num_val_tokens = num_speculative_tokens + 1;
   CHECK_EQ(draft_outputs.size(), static_cast<size_t>(num_speculative_tokens))
@@ -769,6 +838,8 @@ void MTPWorkerImpl::fill_validate_input_from_draft_outputs(
   const int64_t total_num_val_tokens = validate_input.token_ids.numel();
   const int64_t num_sequences = total_num_val_tokens / num_val_tokens;
   const auto token_options = validate_input.token_ids.options();
+  c10::StreamGuard stream_guard = compute_stream.set_stream_guard();
+  wait_metadata_ready_event(validate_input, compute_stream);
   torch::Tensor validate_token_rows =
       validate_input.token_ids.view({num_sequences, num_val_tokens});
 
@@ -794,9 +865,12 @@ std::optional<ForwardOutput> MTPWorkerImpl::run_validate(
     ForwardInput& validate_input) {
   // run the target model to get the verification scores
   Timer timer;
-  fill_validate_input_from_draft_outputs(draft_outputs, validate_input);
-  auto future = impl_->step_async(validate_input);
-  ForwardOutput target_output = std::move(future).get().value();
+  fill_validate_input_from_draft_outputs(
+      draft_outputs, validate_input, *compute_stream_);
+  ForwardOutput target_output =
+      run_llm_no_sync_impl(
+          *impl_, validate_input, *prepare_stream_, *compute_stream_)
+          .value();
   COUNTER_ADD(speculative_execution_latency_seconds_target,
               timer.elapsed_seconds());
 
@@ -804,16 +878,17 @@ std::optional<ForwardOutput> MTPWorkerImpl::run_validate(
   timer.reset();
   SampleOutput val_output =
       validate(input.sampling_params, draft_outputs, target_output);
-  record_validate_metrics(val_output);
   COUNTER_ADD(speculative_execution_latency_seconds_validation,
               timer.elapsed_seconds());
 
+  compute_stream_->synchronize();
   val_output.next_tokens = val_output.next_tokens.to(torch::kCPU);
   write_target_context_to_cache(input, val_output);
 
   if (!enable_schedule_overlap() && !driver_ && !dp_driver_) {
     return std::nullopt;
   }
+  clear_output_embeddings(target_output);
   val_output.embeddings = torch::Tensor();
   target_output.sample_output = val_output;
   return target_output;
@@ -832,21 +907,6 @@ void MTPWorkerImpl::write_target_context_to_cache(
       validate_output.next_tokens,
       validate_output.embeddings,
       options_.num_speculative_tokens());
-}
-
-void MTPWorkerImpl::record_validate_metrics(
-    const SampleOutput& validate_output) const {
-  CHECK(validate_output.next_tokens.defined())
-      << "validate output tokens are undefined";
-  const int32_t batch_size =
-      static_cast<int32_t>(validate_output.next_tokens.size(0));
-  const int32_t num_draft_tokens =
-      batch_size * options_.num_speculative_tokens();
-  torch::Tensor mask = (validate_output.next_tokens == -1).to(torch::kInt64);
-  const int64_t rejected_count = mask.sum().item<int64_t>();
-  COUNTER_ADD(speculative_num_draft_tokens_total, num_draft_tokens);
-  COUNTER_ADD(speculative_num_accepted_tokens_total,
-              num_draft_tokens - rejected_count);
 }
 
 void MTPWorkerImpl::process_draft_sample_output(SampleOutput& sample_output) {
@@ -933,8 +993,10 @@ void MTPWorkerImpl::prepare_validate_inputs(const ForwardInput& input,
                                             ForwardInput& validate_input) {
   c10::StreamGuard stream_guard = prepare_stream_->set_stream_guard();
   validate_input = input;
+  clear_ready_events(validate_input);
   validate_input.device_tensors_ready = false;
   auto& input_params = validate_input.input_params;
+  input_params.embedding.input_embedding = torch::Tensor();
   torch::TensorOptions token_options = validate_input.token_ids.options();
   torch::TensorOptions position_options = validate_input.positions.options();
 
@@ -1065,14 +1127,16 @@ void MTPWorkerImpl::prepare_validate_inputs(const ForwardInput& input,
 
   input_params.attention.rebuild_device_buffer(device_);
   validate_input.device_tensors_ready = true;
-  prepare_stream_->synchronize();
+  finish_metadata_prepare(*prepare_stream_, validate_input);
 }
 
 void MTPWorkerImpl::prepare_draft_extend_inputs(
     const ForwardInput& base_input,
     const std::vector<EmbeddingCache::DecodeState>& last_states,
     ForwardInput& extend_input) {
+  c10::StreamGuard stream_guard = prepare_stream_->set_stream_guard();
   extend_input = base_input;
+  clear_ready_events(extend_input);
   extend_input.device_tensors_ready = false;
   auto& input_params = extend_input.input_params;
   const int32_t num_sequences = input_params.meta.num_sequences;
@@ -1263,6 +1327,7 @@ void MTPWorkerImpl::prepare_draft_extend_inputs(
     params.sample_idxes = torch::arange(num_sequences, idx_options);
   }
   extend_input.device_tensors_ready = true;
+  finish_metadata_prepare(*prepare_stream_, extend_input);
 }
 
 void MTPWorkerImpl::prepare_draft_inputs(const ForwardInput& input,
@@ -1270,9 +1335,11 @@ void MTPWorkerImpl::prepare_draft_inputs(const ForwardInput& input,
                                          int32_t position_offset) {
   c10::StreamGuard stream_guard = prepare_stream_->set_stream_guard();
   draft_input = input;
+  clear_ready_events(draft_input);
   draft_input.device_tensors_ready = false;
 
   auto& input_params = draft_input.input_params;
+  input_params.embedding.input_embedding = torch::Tensor();
   const int32_t num_sequences = input_params.meta.num_sequences;
   const int32_t block_size = options_.block_size();
   specBuilder::DecodeRowContext row_ctx =
@@ -1318,7 +1385,7 @@ void MTPWorkerImpl::prepare_draft_inputs(const ForwardInput& input,
   // token_ids is intentionally filled later from the previous draft output.
   draft_input.device_tensors_ready = false;
 
-  prepare_stream_->synchronize();
+  finish_metadata_prepare(*prepare_stream_, draft_input);
 }
 
 SampleOutput MTPWorkerImpl::validate(

--- a/xllm/core/runtime/mtp_worker_impl.h
+++ b/xllm/core/runtime/mtp_worker_impl.h
@@ -76,7 +76,8 @@ class MTPWorkerImpl : public SpeculativeWorkerImpl {
 
   void fill_validate_input_from_draft_outputs(
       const std::vector<ForwardOutput>& draft_outputs,
-      ForwardInput& validate_input);
+      ForwardInput& validate_input,
+      Stream& compute_stream);
   std::optional<ForwardOutput> run_validate(
       const ForwardInput& input,
       const std::vector<ForwardOutput>& draft_outputs,
@@ -124,7 +125,6 @@ class MTPWorkerImpl : public SpeculativeWorkerImpl {
 
   void write_target_context_to_cache(const ForwardInput& input,
                                      const SampleOutput& validate_output);
-  void record_validate_metrics(const SampleOutput& validate_output) const;
 
  protected:
   // Draft model worker

--- a/xllm/core/runtime/suffix_worker_impl.cpp
+++ b/xllm/core/runtime/suffix_worker_impl.cpp
@@ -423,13 +423,6 @@ SampleOutput SuffixWorkerImpl::validate(
   sample_output.embeddings =
       embeddings.view({batch_size, num_val_tokens, embeddings.size(-1)});
 
-  torch::Tensor mask = (sample_output.next_tokens == -1).to(torch::kInt64);
-  size_t count = mask.sum().item<int64_t>();
-  size_t num_draft_tokens =
-      static_cast<size_t>(batch_size) * options_.num_speculative_tokens();
-  COUNTER_ADD(speculative_num_draft_tokens_total, num_draft_tokens);
-  COUNTER_ADD(speculative_num_accepted_tokens_total, num_draft_tokens - count);
-
   return sample_output;
 }
 

--- a/xllm/core/runtime/worker_impl.cpp
+++ b/xllm/core/runtime/worker_impl.cpp
@@ -238,7 +238,7 @@ WorkerImpl::WorkerImpl(const ParallelArgs& parallel_args,
   device_.init_device_context();
   threadpool_.schedule([this]() mutable { device_.set_device(); });
   prepare_stream_ = device_.get_stream_from_pool();
-  compute_stream_ = device_.get_stream_from_pool();
+  compute_stream_ = device_.current_stream();
   sampler_ = std::make_unique<Sampler>();
 
 #if !defined(USE_NPU) && !defined(USE_CUDA)
@@ -533,6 +533,16 @@ ForwardInput WorkerImpl::update_input_by_last_step_output(
   return inputs;
 }
 
+std::optional<ForwardOutput> WorkerImpl::step_for_schedule_overlap(
+    const ForwardInput& input) {
+  return step(input);
+}
+
+ForwardInput WorkerImpl::update_input_by_last_step_output_for_schedule_overlap(
+    ForwardInput& input) {
+  return update_input_by_last_step_output(input);
+}
+
 #if defined(USE_NPU)
 torch::Tensor WorkerImpl::recompute_new_cache_slots(const ForwardInput& input) {
   auto old_cache_slots = input.input_params.attention.device.new_cache_slots;
@@ -647,6 +657,14 @@ torch::Tensor WorkerImpl::compute_in_prefix_slots(const ForwardInput& input) {
 
 void WorkerImpl::prepare_work_before_execute(const ForwardInput& input,
                                              ForwardInput& processed_input) {
+  prepare_work_before_execute_on_stream(
+      input, processed_input, *prepare_stream_);
+}
+
+void WorkerImpl::prepare_work_before_execute_on_stream(
+    const ForwardInput& input,
+    ForwardInput& processed_input,
+    Stream& prepare_stream) {
 #if defined(USE_NPU)
   // Without device_capture_lock, ACL graph capture will be interrupted by the
   // synchronization H2D of data update streams asynchronously scheduled by
@@ -665,9 +683,9 @@ void WorkerImpl::prepare_work_before_execute(const ForwardInput& input,
     lock_guard.emplace(capture_lock);
   }
 #endif
-
-  const bool use_default_stream =
-      !enable_schedule_overlap() && options_.backend() == "llm";
+  c10::StreamGuard stream_guard = prepare_stream.set_stream_guard();
+  CHECK(prepare_stream.wait_event(input.metadata_ready_event))
+      << "failed to wait input metadata ready event on worker prepare stream";
 
   // CP partition is now done worker-side (formerly engine-side in
   // LLMEngine::step). torch::Tensor fields are handles, so assigning new
@@ -864,16 +882,13 @@ void WorkerImpl::prepare_work_before_execute(const ForwardInput& input,
 #endif
   };
 
-  if (use_default_stream) {
-    prepare_device_on_stream();
-  } else {
-    c10::StreamGuard stream_guard = prepare_stream_->set_stream_guard();
-    prepare_device_on_stream();
-  }
+  prepare_device_on_stream();
 
-  if (!use_default_stream) {
-    prepare_stream_->synchronize();
+  StreamEventPtr event = prepare_stream.record_event();
+  if (event == nullptr) {
+    prepare_stream.synchronize();
   }
+  processed_input.metadata_ready_event = event;
 }
 
 void WorkerImpl::apply_kv_block_swaps(const ModelInputParams& input_params) {
@@ -1020,10 +1035,10 @@ folly::SemiFuture<std::optional<ForwardOutput>> WorkerImpl::step_async(
       if (last_step_output_valid_ && input.token_ids.numel() > 0 &&
           input.input_params.meta.batch_forward_type.has_decode()) {
         // replace step i model input with true output of step i-1
-        input = update_input_by_last_step_output(input);
+        input = update_input_by_last_step_output_for_schedule_overlap(input);
       }
 
-      const auto output = this->step(input);
+      const auto output = this->step_for_schedule_overlap(input);
       if (output.has_value()) {
         if (is_driver() || ::xllm::EPLBConfig::get_instance().enable_eplb()) {
           std::unique_lock<std::mutex> lock(mtx_);

--- a/xllm/core/runtime/worker_impl.h
+++ b/xllm/core/runtime/worker_impl.h
@@ -111,6 +111,9 @@ class WorkerImpl {
   // prepare work before model execution
   virtual void prepare_work_before_execute(const ForwardInput& inputs,
                                            ForwardInput& processed_inputs);
+  void prepare_work_before_execute_on_stream(const ForwardInput& input,
+                                             ForwardInput& processed_input,
+                                             Stream& prepare_stream);
 
   // Internal helper shared by worker pipelines before model execution.
   virtual void apply_kv_block_swaps(const ModelInputParams& input_params);
@@ -199,6 +202,10 @@ class WorkerImpl {
 
  protected:
   void update_last_step_output(const std::optional<ForwardOutput>& output);
+  virtual std::optional<ForwardOutput> step_for_schedule_overlap(
+      const ForwardInput& input);
+  virtual ForwardInput update_input_by_last_step_output_for_schedule_overlap(
+      ForwardInput& input);
   // Only used for deepseek chunked prefill ops on npu device
   void prepare_mla_prefixcache_inputs(ModelInputParams& input_params);
 


### PR DESCRIPTION
## Description
- add stream event helpers and ForwardInput metadata readiness propagation

- expose no-sync LLM worker execution

- keep prepare work on a dedicated prepare stream and record metadata-ready events after async input setup

- route speculative compute through the current/default stream to reduce extra output synchronization on the hot path

<!-- What does this PR do? Briefly describe the changes and why they are needed. -->

## Related Issues

<!-- Link related issues here. Use "Fixes #123" when this PR closes an issue. -->

## Change Type

- [ ] Bug fix
- [ ] New feature
- [x] Performance improvement
- [ ] Refactor
- [ ] Documentation
- [ ] Test
- [ ] Build or CI

## Pull Request Checklist

Thank you for contributing to xLLM. Before requesting review, please make sure the following items are complete.

### PR Title and Commit Messages

- [x] The PR title and each commit message follow the xLLM commit format: `<type>: <subject>`.

> Allowed types: feat, bugfix, docs, test, refactor, chore, style, revert, perf, model, build, release.
> The subject should use clear English, start with a verb, include at least 4 words, and end with `.`.

### Pre-commit Checks

- [x] I have installed `pre-commit` by running `pip install pre-commit` or an equivalent command.
- [x] I have installed the hooks with `pre-commit install`.
- [x] I have run `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

### Self Review

- [x] I have self-reviewed the code according to `.agents/skills/code-review/references/custom-code-style.md`, especially code written or assisted by AI.
- [x] I have rebased this PR onto the latest `main` branch.

### Build and Test Coverage

- [ ] Tests have been added or updated as needed.
- [ ] CUDA: `python setup.py build test` has passed on a CUDA machine.
- [x] NPU: `python setup.py build test` has passed on an NPU machine.
- [ ] MLU: `python setup.py build test` has passed on an MLU machine.

## Reviewer Notes

<!-- Optional: anything reviewers should focus on, known risks, follow-ups, or validation gaps. -->
