### PR TITLE
bugfix: qwen3.5 resolve causal_conv1d tiling failure for concurrent decode requests.

### DIFF
--- a/xllm/core/layers/npu_torch/qwen3_gated_delta_net_base.cpp
+++ b/xllm/core/layers/npu_torch/qwen3_gated_delta_net_base.cpp
@@ -552,12 +552,26 @@ torch::Tensor Qwen3GatedDeltaNetBaseImpl::forward(
     std::vector<int64_t> linear_state_indices_vec(
         input_params.linear_state_ids.begin(),
         input_params.linear_state_ids.end());
+    const std::vector<int64_t>* qsl_ptr = &input_params.query_start_loc;
+    std::vector<int64_t> padded_query_start_loc;
+    const int64_t actual_qsl_size =
+        static_cast<int64_t>(input_params.query_start_loc.size());
+    const int64_t target_qsl_size = batch_size + 1;
+    if (actual_qsl_size < target_qsl_size) {
+      padded_query_start_loc = input_params.query_start_loc;
+      const int64_t last_val = padded_query_start_loc.back();
+      for (int64_t i = actual_qsl_size; i < target_qsl_size; ++i) {
+        padded_query_start_loc.push_back(last_val + (i - actual_qsl_size + 1));
+      }
+      qsl_ptr = &padded_query_start_loc;
+    }
+
     mixed_qkv = xllm::kernel::causal_conv1d(
         mixed_qkv,
         conv_weight,
         conv_cache,
         std::optional<torch::Tensor>(),  // bias (no bias for qwen3)
-        torch::IntArrayRef(input_params.query_start_loc),
+        torch::IntArrayRef(*qsl_ptr),
         torch::IntArrayRef(linear_state_indices_vec),
         has_initial_state,
         num_accepted_tokens_opt,


### PR DESCRIPTION
## Description

Fix causal_conv1d tiling failure (EZ9999) when concurrent decode requests are present. In the decode path (checkpoint_stride == 1), mixed_qkv is padded to padded_batch_size rows for graph capture, but query_start_loc only has actual_batch_size + 1 elements, causing a shape mismatch in the operator's tiling validation. This change pads query_start_loc to padded_batch_size + 1 on the fly when sizes mismatch, matching the convention already used by attn_metadata.q_cu_seq_lens in the spec-verify and checkpoint branches.

## Change Type

- [x] Bug fix
- [ ] New feature
- [ ] Performance improvement
- [ ] Refactor
- [ ] Documentation
- [ ] Test
- [ ] Build or CI

### Self Review

- [x] I have self-reviewed the code according to `.agents/skills/code-review/references/custom-code-style.md`, especially code written or assisted by AI.
- [ ] I have rebased this PR onto the latest `main` branch.

### Build and Test Coverage

- [x] Tests have been added or updated as needed.
- [ ] CUDA: `python setup.py build test` has passed on a CUDA machine.
- [x] NPU: `python setup.py build test` has passed on an NPU machine.
- [ ] MLU: `python setup.py build test` has passed on an MLU machine.
<img width="964" height="355" alt="image" src="https://github.com/user-attachments/assets/e9a2836c-735a-4d0e-86af-b22f15f1f711" />
