### PR TITLE
bugfix: fix loop output when both CP and KV split are enabled.

### DIFF
--- a/xllm/core/framework/parallel_state/npu_cp_prepare.cpp
+++ b/xllm/core/framework/parallel_state/npu_cp_prepare.cpp
@@ -415,7 +415,7 @@ CpPrefillInputs prepare_cp_prefill_inputs(
     const torch::Tensor& input_ids,
     const torch::Tensor& position_ids,
     const torch::Tensor& input_lengths,
-    bool enable_kvcache_split,
+    bool have_prefix_slots,
     const std::vector<int32_t>& kv_cache_tokens_per_seq,
     int block_size,
     int kv_split_size) {
@@ -459,7 +459,7 @@ CpPrefillInputs prepare_cp_prefill_inputs(
   auto actual_seq_lengths_kv_cp_prev = position_ids_prev.to(torch::kInt32);
   auto actual_seq_lengths_kv_cp_next = position_ids_next.to(torch::kInt32);
 
-  if (enable_kvcache_split) {
+  if (have_prefix_slots) {
     // Strip the per-seq full-prefix length from the SFA-logical KV lengths to
     // obtain how much each seq's prev/next half needs from merged_kv's current
     // segment. Prefix-less seqs get prefix_kv_len_total == 0 and fall through

--- a/xllm/core/framework/parallel_state/npu_cp_prepare.h
+++ b/xllm/core/framework/parallel_state/npu_cp_prepare.h
@@ -69,7 +69,7 @@ CpPrefillInputs prepare_cp_prefill_inputs(
     const torch::Tensor& input_ids,
     const torch::Tensor& position_ids,
     const torch::Tensor& input_lengths,
-    bool enable_kvcache_split,
+    bool have_prefix_slots,
     const std::vector<int32_t>& kv_cache_tokens_per_seq,
     int block_size,
     int kv_split_size = -1);

--- a/xllm/core/runtime/worker_impl.cpp
+++ b/xllm/core/runtime/worker_impl.cpp
@@ -708,8 +708,7 @@ void WorkerImpl::prepare_work_before_execute(const ForwardInput& input,
       needs_cp_prefill_side && util::enable_kvcache_split();
   const bool needs_in_prefix_slots =
       needs_cp_prefill_side &&
-      (needs_kv_split_prep ||
-       ::xllm::KVCacheConfig::get_instance().enable_prefix_cache() ||
+      (::xllm::KVCacheConfig::get_instance().enable_prefix_cache() ||
        ::xllm::SchedulerConfig::get_instance().enable_chunked_prefill());
 #endif
 
@@ -725,7 +724,7 @@ void WorkerImpl::prepare_work_before_execute(const ForwardInput& input,
           cp_working.host_token_ids(),
           cp_working.host_positions(),
           cp_working.input_params.attention.device.q_seq_lens,
-          util::enable_kvcache_split(),
+          needs_in_prefix_slots,
           cp_working.input_params.attention.host.kv_cache_tokens_nums,
           options_.block_size(),
           parallel_args_.kv_split_size_effective());

--- a/xllm/core/runtime/worker_impl.cpp
+++ b/xllm/core/runtime/worker_impl.cpp
@@ -706,7 +706,7 @@ void WorkerImpl::prepare_work_before_execute(const ForwardInput& input,
 #if defined(USE_NPU)
   const bool needs_kv_split_prep =
       needs_cp_prefill_side && util::enable_kvcache_split();
-  const bool needs_in_prefix_slots =
+  const bool have_prefix_slots =
       needs_cp_prefill_side &&
       (::xllm::KVCacheConfig::get_instance().enable_prefix_cache() ||
        ::xllm::SchedulerConfig::get_instance().enable_chunked_prefill());
@@ -724,7 +724,7 @@ void WorkerImpl::prepare_work_before_execute(const ForwardInput& input,
           cp_working.host_token_ids(),
           cp_working.host_positions(),
           cp_working.input_params.attention.device.q_seq_lens,
-          needs_in_prefix_slots,
+          have_prefix_slots,
           cp_working.input_params.attention.host.kv_cache_tokens_nums,
           options_.block_size(),
           parallel_args_.kv_split_size_effective());
@@ -745,7 +745,7 @@ void WorkerImpl::prepare_work_before_execute(const ForwardInput& input,
       processed_input.input_params.attention.device.new_cache_slots =
           new_cache_slots.to(device_);
     }
-    if (needs_in_prefix_slots) {
+    if (have_prefix_slots) {
       torch::Tensor in_prefix_slots = compute_in_prefix_slots(*cp_input);
       processed_input.input_params.attention.device.in_prefix_slots =
           in_prefix_slots.to(device_);


### PR DESCRIPTION
## Description

<!-- What does this PR do? Briefly describe the changes and why they are needed. -->

## Related Issues

<!-- Link related issues here. Use "Fixes #123" when this PR closes an issue. -->

## Change Type

- [x] Bug fix
- [ ] New feature
- [ ] Performance improvement
- [ ] Refactor
- [ ] Documentation
- [ ] Test
- [ ] Build or CI

## Pull Request Checklist

Thank you for contributing to xLLM. Before requesting review, please make sure the following items are complete.

### PR Title and Commit Messages

- [x] The PR title and each commit message follow the xLLM commit format: `<type>: <subject>`.

> Allowed types: feat, bugfix, docs, test, refactor, chore, style, revert, perf, model, build, release.
> The subject should use clear English, start with a verb, include at least 4 words, and end with `.`.

### Pre-commit Checks

- [x] I have installed `pre-commit` by running `pip install pre-commit` or an equivalent command.
- [x] I have installed the hooks with `pre-commit install`.
- [x] I have run `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

### Self Review

- [x] I have self-reviewed the code according to `.agents/skills/code-review/references/custom-code-style.md`, especially code written or assisted by AI.
- [x] I have rebased this PR onto the latest `main` branch.

### Build and Test Coverage

- [ ] Tests have been added or updated as needed.
- [x] CUDA: `python setup.py build test` has passed on a CUDA machine.
- [x] NPU: `python setup.py build test` has passed on an NPU machine.
- [ ] MLU: `python setup.py build test` has passed on an MLU machine.

## Reviewer Notes

<!-- Optional: anything reviewers should focus on, known risks, follow-ups, or validation gaps. -->
