### PR TITLE
bugfix: fix qwen3.5/3.6 mtp verify shape mismatch.

### DIFF
--- a/xllm/core/layers/npu_torch/qwen3_gated_delta_net_base.cpp
+++ b/xllm/core/layers/npu_torch/qwen3_gated_delta_net_base.cpp
@@ -509,6 +509,8 @@ torch::Tensor Qwen3GatedDeltaNetBaseImpl::forward(
     const AttentionMetadata& attn_metadata,
     KVCache& kv_cache,
     const ModelInputParams& input_params) {
+  // Save original hidden_states size for potential padding later
+  const int64_t original_num_tokens = hidden_states.size(0);
   auto [qkvz_padded, ba_padded] =
       project_padded_inputs(hidden_states, attn_metadata);
   int64_t batch_size = qkvz_padded.size(0);
@@ -877,8 +879,15 @@ torch::Tensor Qwen3GatedDeltaNetBaseImpl::forward(
   auto rearranged_norm =
       norm_out.reshape({norm_out.size(0), norm_out.size(1) * norm_out.size(2)});
   rearranged_norm = reshape_qkvz_unpad(attn_metadata, rearranged_norm);
-  auto attn_output = o_proj_->forward(rearranged_norm);
-  return attn_output;
+  // For chunked prefill or spec verify, reshape_qkvz_with_pad may pad each
+  // batch to max_len, causing output tokens > original_num_tokens. We need to
+  // slice back to original_num_tokens to match residual shape for add_rms_norm.
+  if (rearranged_norm.size(0) > original_num_tokens) {
+    // Slice excess padding tokens
+    rearranged_norm =
+        rearranged_norm.slice(0, 0, original_num_tokens).contiguous();
+  }
+  return o_proj_->forward(rearranged_norm);
 }
 
 torch::Tensor Qwen3GatedDeltaNetBaseImpl::reshape_qkvz_unpad(


### PR DESCRIPTION
## Description

Issue: Crash in npu_add_rms_norm during speculative decode graph capture when using num_speculative_tokens=5 with Qwen3.5-27B MTP model.

Error Message:

Input x2/x1 shape invalid, shape is not equal x1 shape.
input shape=[12, 5120], residual shape=[8, 5120]
Root Cause: GDN (Gated Delta Net) layer incorrectly processes padding sequences in spec verify mode, causing output shape mismatch with residual tensor.

## Change Type

- [x] Bug fix
- [ ] New feature
- [ ] Performance improvement
- [ ] Refactor
- [ ] Documentation
- [ ] Test
- [ ] Build or CI

### Self Review

- [ ] I have self-reviewed the code according to `.agents/skills/code-review/references/custom-code-style.md`, especially code written or assisted by AI.
- [ ] I have rebased this PR onto the latest `main` branch.

### Build and Test Coverage

- [x] Tests have been added or updated as needed.
- [ ] CUDA: `python setup.py build test` has passed on a CUDA machine.
- [x] NPU: `python setup.py build test` has passed on an NPU machine.
- [ ] MLU: `python setup.py build test` has passed on an MLU machine.

NPU TEST RESULT:
<img width="1177" height="429" alt="image" src="https://github.com/user-attachments/assets/69c097c1-73f3-4387-8682-bfcccbef99b5" />
