### PR TITLE
build: support xllm_ops incremental build and ci build cache.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -37,10 +37,17 @@ if(USE_NPU)
     set(XLLM_OPS_GIT_HEAD_CACHED "$ENV{XLLM_OPS_GIT_HEAD_CACHED}")
   endif()
 
+  if(DEFINED ENV{XLLM_OPS_BUILD_DIR})
+    get_filename_component(XLLM_OPS_BUILD_DIR "$ENV{XLLM_OPS_BUILD_DIR}" ABSOLUTE)
+  else()
+    set(XLLM_OPS_BUILD_DIR "${CMAKE_SOURCE_DIR}/third_party/xllm_ops/build")
+  endif()
+
   if(NOT DEFINED XLLM_OPS_GIT_HEAD_CACHED OR NOT XLLM_OPS_GIT_HEAD STREQUAL XLLM_OPS_GIT_HEAD_CACHED)
     message(STATUS "xllm_ops git HEAD changed; running precompile via execute_process")
     execute_process(
-      COMMAND bash ${CMAKE_SOURCE_DIR}/third_party/xllm_ops/build.sh
+      COMMAND ${CMAKE_COMMAND} -E env "XLLM_OPS_BUILD_DIR=${XLLM_OPS_BUILD_DIR}"
+              bash ${CMAKE_SOURCE_DIR}/third_party/xllm_ops/build.sh
       WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}/third_party/xllm_ops
       RESULT_VARIABLE XLLM_OPS_RESULT
     )

--- a/cibuild/build_npu.sh
+++ b/cibuild/build_npu.sh
@@ -8,6 +8,9 @@ function error() {
 
 IMAGE="quay.io/jd_xllm/xllm-ai:xllm-dev-a2-x86-20260429"
 
+XLLM_OPS_CACHE="/export/home/npu_xllm_ops_build_cache"
+mkdir -p "${XLLM_OPS_CACHE}"
+
 RUN_OPTS=(
   --rm
   -t
@@ -24,8 +27,10 @@ RUN_OPTS=(
   -v /usr/local/sbin/:/usr/local/sbin/
   -v /export/home:/export/home
   -v /export/home/npu_vcpkg_cache_abi_1:/root/.cache/vcpkg # cached vcpkg installed dir
+  -v "${XLLM_OPS_CACHE}":"${XLLM_OPS_CACHE}" # cached xllm_ops build dir
   -v /etc/hccn.conf:/etc/hccn.conf
   -w /export/home
+  -e XLLM_OPS_BUILD_DIR="${XLLM_OPS_CACHE}"
 )
 
 CMD="$*"


### PR DESCRIPTION
## Description

支持 xllm_ops 增量编译，加速 NPU CI 构建。

### 问题

此前 xllm_ops 每次构建都会执行全量清理重编——`build.sh` 在编译前会 `rm -rf` 整个 build 目录。即使只有一个算子源码发生变更，所有算子也必须从头编译。这是 NPU CI 中最耗时的环节。

### 增量编译原理

加速依赖 xllm_ops 和 xllm 两侧的配合改动：

**xllm_ops 侧**（子模块更新至 `6aa9361 build: enable incremental compilation for custom operators.`）：
1. 移除 `clean()` 中对 build/output 目录的 `rm -rf`，改为 `mkdir -p`——使 CMake 增量编译机制得以生效。
2. 在 `cmake/func.cmake` 中为源码拷贝和二进制编译的 custom target 添加 `DEPENDS` 声明，使 CMake 能正确追踪哪些算子需要重编、跳过未变更的算子。
3. `build.sh` 读取 `XLLM_OPS_BUILD_DIR` 环境变量，支持将构建产物放到外部目录（`${XLLM_OPS_BUILD_DIR:-${CURRENT_DIR}/build}`）。

以上改动使 xllm_ops 本身具备增量编译能力——无论是否设置 `XLLM_OPS_BUILD_DIR`，只要 build 目录未被删除，重复构建时只会重编变更的算子。

**xllm 侧**（本 PR）：
1. `CMakeLists.txt`——从环境变量读取 `XLLM_OPS_BUILD_DIR`（转换为绝对路径以保证健壮性），并通过 `cmake -E env` 传递给 xllm_ops 构建脚本。未设置时默认为 `third_party/xllm_ops/build`，本地开发无需额外配置即可享受增量编译。
2. `cibuild/build_npu.sh`——在 CI Docker 容器中挂载一个宿主机持久化目录作为 xllm_ops 构建缓存，并设置 `XLLM_OPS_BUILD_DIR`。CI 容器使用 `--rm` 运行、每次 fresh checkout，源码树内的 build 目录无法跨运行保留，因此需要将构建产物外置到宿主机挂载路径，使缓存在多次 CI 运行间持久化。

### 总结

- **增量编译能力**由 xllm_ops 侧提供（去掉 `rm -rf` + 添加 `DEPENDS`），本地开发默认即可生效。
- **CI 缓存持久化**由 xllm 侧提供（`XLLM_OPS_BUILD_DIR` + 宿主机挂载），解决 CI 环境下构建产物无法跨运行保留的问题。

## Related Issues

N/A

## Change Type

- [ ] Bug fix
- [ ] New feature
- [ ] Performance improvement
- [ ] Refactor
- [ ] Documentation
- [ ] Test
- [x] Build or CI

## Pull Request Checklist

### PR Title and Commit Messages

- [x] The PR title and each commit message follow the xLLM commit format: `<type>: <subject>`.

### Pre-commit Checks

- [x] I have installed `pre-commit` by running `pip install pre-commit` or an equivalent command.
- [x] I have installed the hooks with `pre-commit install`.
- [x] I have run `pre-commit run --all-files` and fixed any reported issues.

### Self Review

- [x] I have self-reviewed the code according to `.agents/skills/code-review/references/custom-code-style.md`, especially code written or assisted by AI.
- [x] I have rebased this PR onto the latest `main` branch.

### Build and Test Coverage

- [x] Tests have been added or updated as needed.
- [ ] CUDA: `python setup.py build test` has passed on a CUDA machine.
- [x] NPU: `python setup.py build test` has passed on an NPU machine.
- [ ] MLU: `python setup.py build test` has passed on an MLU machine.

## Reviewer Notes

- `XLLM_OPS_BUILD_DIR` 未设置时默认为 `third_party/xllm_ops/build`，现有本地工作流不受影响。
- 子模块更新是必需的——xllm_ops 必须支持 `XLLM_OPS_BUILD_DIR` 并具备正确的 `DEPENDS` 声明，增量编译才能正常工作。