### PR TITLE
feat: add mlu deepseek v4 dsa metadata support.

### DIFF
--- a/tests/core/framework/kv_cache/kv_cache_test.cpp
+++ b/tests/core/framework/kv_cache/kv_cache_test.cpp
@@ -29,9 +29,20 @@ std::vector<int64_t> shape_vec(const torch::Tensor& tensor) {
   return tensor.sizes().vec();
 }
 
+std::vector<int64_t> dsv4_block_shape(int64_t block_count,
+                                      int64_t block_size,
+                                      int64_t n_heads,
+                                      int64_t head_dim) {
+#if defined(USE_MLU)
+  return {block_count, n_heads, block_size, head_dim};
+#else
+  return {block_count, block_size, n_heads, head_dim};
+#endif
+}
+
 }  // namespace
 
-TEST(KVCacheTest, DeepSeekV4SwaCacheUsesBlockRows) {
+TEST(KVCacheTest, DeepSeekV4FourDimCachesUseDeviceLayout) {
   constexpr int64_t kSwaCount = 10;
   constexpr int64_t kC4Count = 32;
   constexpr int64_t kC128Count = 1;
@@ -66,19 +77,35 @@ TEST(KVCacheTest, DeepSeekV4SwaCacheUsesBlockRows) {
   ASSERT_EQ(caches.size(), 3u);
 
   EXPECT_EQ(shape_vec(caches[0].get_swa_cache()),
-            (std::vector<int64_t>{kSwaCount, kBlockSize, 1, kHeadDim}));
+            dsv4_block_shape(kSwaCount, kBlockSize, 1, kHeadDim));
   EXPECT_FALSE(caches[0].get_compress_kv_state().defined());
 
+  EXPECT_EQ(shape_vec(caches[1].get_k_cache()),
+            dsv4_block_shape(kC4Count, kBlockSize, 1, kHeadDim));
+  EXPECT_EQ(shape_vec(caches[1].get_index_cache()),
+            dsv4_block_shape(kC4Count, kBlockSize, 1, kIndexHeadDim));
   EXPECT_EQ(shape_vec(caches[1].get_swa_cache()),
-            (std::vector<int64_t>{kSwaCount, kBlockSize, 1, kHeadDim}));
+            dsv4_block_shape(kSwaCount, kBlockSize, 1, kHeadDim));
+  if (caches[1].get_indexer_cache_scale().defined()) {
+    EXPECT_EQ(shape_vec(caches[1].get_indexer_cache_scale()),
+              (std::vector<int64_t>{kC4Count, kBlockSize, 1}));
+  }
   EXPECT_EQ(shape_vec(caches[1].get_compress_kv_state()),
+            (std::vector<int64_t>{kSwaCount, kBlockSize, 2 * kHeadDim}));
+  EXPECT_EQ(shape_vec(caches[1].get_compress_score_state()),
             (std::vector<int64_t>{kSwaCount, kBlockSize, 2 * kHeadDim}));
   EXPECT_EQ(shape_vec(caches[1].get_compress_index_kv_state()),
             (std::vector<int64_t>{kSwaCount, kBlockSize, 2 * kIndexHeadDim}));
+  EXPECT_EQ(shape_vec(caches[1].get_compress_index_score_state()),
+            (std::vector<int64_t>{kSwaCount, kBlockSize, 2 * kIndexHeadDim}));
 
+  EXPECT_EQ(shape_vec(caches[2].get_k_cache()),
+            dsv4_block_shape(kC128Count, kBlockSize, 1, kHeadDim));
   EXPECT_EQ(shape_vec(caches[2].get_swa_cache()),
-            (std::vector<int64_t>{kSwaCount, kBlockSize, 1, kHeadDim}));
+            dsv4_block_shape(kSwaCount, kBlockSize, 1, kHeadDim));
   EXPECT_EQ(shape_vec(caches[2].get_compress_kv_state()),
+            (std::vector<int64_t>{kSwaCount, kBlockSize, kHeadDim}));
+  EXPECT_EQ(shape_vec(caches[2].get_compress_score_state()),
             (std::vector<int64_t>{kSwaCount, kBlockSize, kHeadDim}));
 }
 

--- a/tests/core/layers/mlu/CMakeLists.txt
+++ b/tests/core/layers/mlu/CMakeLists.txt
@@ -28,6 +28,19 @@ cc_test(
     GTest::gtest_main
 )
 
+cc_test(
+  NAME
+    deepseek_v4_dsa_metadata_builder_test
+  SRCS
+    dsa_metadata_builder_mlu_test.cpp
+  DEPS
+    :mlu_layers
+    :common_layers
+    glog::glog
+    torch
+    GTest::gtest_main
+)
+
 # MoE Gate unit test for MLU (uses layers/mlu/moe_gate)
 cc_test(
   NAME

--- a/tests/core/layers/mlu/dsa_metadata_builder_mlu_test.cpp
+++ b/tests/core/layers/mlu/dsa_metadata_builder_mlu_test.cpp
@@ -213,6 +213,57 @@ TEST(DSAMetadataBuilderMluTest, ExpandsBlockTablesAndSlotMappings) {
             std::vector<int64_t>({123, 124, 167}));
 }
 
+TEST(DSAMetadataBuilderMluTest, SwaSlotsUseAbsoluteBlockColumns) {
+  ModelInputParams params =
+      make_params(BatchForwardType::CHUNKED_PREFILL, {0, 1}, {0, 24});
+  params.multi_block_tables = {
+      torch::tensor({10, 11}, torch::kInt32).view({1, 2})};
+  std::vector<DSAGroupInfo> group_infos = {
+      {DSACacheType::SLIDING_WINDOW, 1, 4}};
+  std::vector<std::vector<DSACacheInfo>> caches_info = {
+      {{0, DSACacheType::SLIDING_WINDOW, 1, 4}}};
+
+  AttentionMetadata metadata =
+      DSAMetadataBuilderMlu::build(params,
+                                   torch::tensor({23}, torch::kInt32),
+                                   caches_info,
+                                   group_infos,
+                                   /*window_size=*/4);
+  const DSAMetadata& dsa = *metadata.dsa_metadata;
+
+  ASSERT_EQ(dsa.block_tables.size(), 1);
+  ASSERT_EQ(dsa.block_tables[0].size(), 1);
+  EXPECT_EQ(tensor_vec(dsa.block_tables[0][0].flatten()),
+            std::vector<int64_t>({10, 11, 0, 0, 0, 0}));
+  EXPECT_EQ(tensor_vec(dsa.slot_mappings[0][0]), std::vector<int64_t>({-1}));
+}
+
+TEST(DSAMetadataBuilderMluTest, SwaKeepsSparseAbsoluteReadTable) {
+  ModelInputParams params =
+      make_params(BatchForwardType::CHUNKED_PREFILL, {0, 2, 5}, {0, 24, 43});
+  params.multi_block_tables = {torch::tensor(
+      {{-1, -1, -1, -1, -1, 50}, {-1, -1, -1, -1, 60, -1}}, torch::kInt32)};
+  std::vector<DSAGroupInfo> group_infos = {
+      {DSACacheType::SLIDING_WINDOW, 1, 4}};
+  std::vector<std::vector<DSACacheInfo>> caches_info = {
+      {{0, DSACacheType::SLIDING_WINDOW, 1, 4}}};
+
+  AttentionMetadata metadata = DSAMetadataBuilderMlu::build(
+      params,
+      torch::tensor({22, 23, 16, 17, 18}, torch::kInt32),
+      caches_info,
+      group_infos,
+      /*window_size=*/4);
+  const DSAMetadata& dsa = *metadata.dsa_metadata;
+
+  ASSERT_EQ(dsa.block_tables.size(), 1);
+  ASSERT_EQ(dsa.block_tables[0].size(), 1);
+  EXPECT_EQ(tensor_vec(dsa.block_tables[0][0].flatten()),
+            std::vector<int64_t>({0, 0, 0, 0, 0, 50, 0, 0, 0, 0, 60, 0}));
+  EXPECT_EQ(tensor_vec(dsa.slot_mappings[0][0]),
+            std::vector<int64_t>({202, 203, 240, 241, 242}));
+}
+
 TEST(DSAMetadataBuilderMluTest, BuildsC128AttentionMetadata) {
   ModelInputParams params =
       make_params(BatchForwardType::DECODE, {0, 1}, {0, 128});

--- a/tests/core/layers/mlu/dsa_metadata_builder_mlu_test.cpp
+++ b/tests/core/layers/mlu/dsa_metadata_builder_mlu_test.cpp
@@ -1,0 +1,295 @@
+/* Copyright 2026 The xLLM Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://github.com/jd-opensource/xllm/blob/main/LICENSE
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include "layers/mlu/deepseek_v4/dsa_metadata_builder_mlu.h"
+
+#include <gtest/gtest.h>
+#include <torch/torch.h>
+
+#include <algorithm>
+#include <cstdint>
+#include <vector>
+
+#include "framework/model/model_input_params.h"
+#include "layers/common/attention_metadata.h"
+
+namespace xllm {
+namespace layer {
+namespace {
+
+ModelInputParams make_params(BatchForwardType forward_type,
+                             const std::vector<int32_t>& q_cu_lens,
+                             const std::vector<int32_t>& kv_cu_lens) {
+  ModelInputParams params;
+  params.meta.batch_forward_type = forward_type;
+  params.meta.num_sequences = static_cast<int32_t>(q_cu_lens.size()) - 1;
+  params.meta.actual_num_sequences = params.meta.num_sequences;
+  params.meta.q_max_seq_len = 0;
+  params.meta.kv_max_seq_len = 0;
+  std::vector<int32_t> q_lens;
+  std::vector<int32_t> kv_lens;
+  q_lens.reserve(q_cu_lens.size() - 1);
+  kv_lens.reserve(kv_cu_lens.size() - 1);
+  for (int32_t idx = 1; idx < static_cast<int32_t>(q_cu_lens.size()); ++idx) {
+    const int32_t q_len = q_cu_lens[idx] - q_cu_lens[idx - 1];
+    const int32_t kv_len = kv_cu_lens[idx] - kv_cu_lens[idx - 1];
+    q_lens.emplace_back(q_len);
+    kv_lens.emplace_back(kv_len);
+    params.meta.q_max_seq_len = std::max(params.meta.q_max_seq_len, q_len);
+    params.meta.kv_max_seq_len = std::max(params.meta.kv_max_seq_len, kv_len);
+  }
+  params.attention.host.q_seq_lens = q_cu_lens;
+  params.attention.host.kv_seq_lens = kv_cu_lens;
+  params.attention.host.q_cu_seq_lens.assign(q_cu_lens.begin() + 1,
+                                             q_cu_lens.end());
+  params.attention.device.q_seq_lens = torch::tensor(q_cu_lens, torch::kInt32);
+  params.attention.device.kv_seq_lens =
+      torch::tensor(kv_cu_lens, torch::kInt32);
+  params.attention.device.q_cu_seq_lens =
+      torch::tensor(params.attention.host.q_cu_seq_lens, torch::kInt32);
+  params.attention.device.new_cache_slots = torch::arange(
+      q_cu_lens.back(), torch::TensorOptions().dtype(torch::kInt32));
+  params.attention.device.block_tables =
+      torch::empty({0, 0}, torch::TensorOptions().dtype(torch::kInt32));
+  return params;
+}
+
+std::vector<int64_t> tensor_vec(const torch::Tensor& tensor) {
+  torch::Tensor cpu_tensor = tensor.to(torch::kCPU).to(torch::kInt64);
+  std::vector<int64_t> values;
+  values.reserve(static_cast<size_t>(cpu_tensor.numel()));
+  for (int64_t idx = 0; idx < cpu_tensor.numel(); ++idx) {
+    values.emplace_back(cpu_tensor[idx].item<int64_t>());
+  }
+  return values;
+}
+
+AttentionMetadata build_metadata(ModelInputParams params,
+                                 const torch::Tensor& positions,
+                                 int64_t window_size = 0) {
+  return DSAMetadataBuilderMlu::build(params, positions, {}, {}, window_size);
+}
+
+TEST(DSAMetadataBuilderMluTest, BuildsCanonicalSeqMetadataFromCuLens) {
+  ModelInputParams params =
+      make_params(BatchForwardType::PREFILL, {0, 2, 3}, {0, 5, 9});
+  torch::Tensor positions = torch::tensor({3, 4, 8}, torch::kInt32);
+  AttentionMetadata metadata = build_metadata(params, positions);
+
+  ASSERT_NE(metadata.dsa_metadata, nullptr);
+  const DSAMetadata& dsa = *metadata.dsa_metadata;
+  EXPECT_EQ(tensor_vec(metadata.q_cu_seq_lens),
+            std::vector<int64_t>({0, 2, 3}));
+  EXPECT_EQ(tensor_vec(metadata.kv_cu_seq_lens),
+            std::vector<int64_t>({0, 5, 9}));
+  EXPECT_EQ(tensor_vec(metadata.q_seq_lens), std::vector<int64_t>({2, 1}));
+  EXPECT_EQ(tensor_vec(metadata.kv_seq_lens), std::vector<int64_t>({5, 4}));
+  EXPECT_EQ(tensor_vec(dsa.q_seq_lens), std::vector<int64_t>({2, 1}));
+  EXPECT_EQ(tensor_vec(dsa.kv_seq_lens), std::vector<int64_t>({5, 4}));
+  EXPECT_EQ(dsa.query_start_offsets, std::vector<int64_t>({0, 2, 3}));
+  EXPECT_EQ(dsa.start_pos_vec, std::vector<int64_t>({3, 3}));
+  EXPECT_TRUE(torch::equal(dsa.seq_lens, dsa.kv_seq_lens));
+  EXPECT_TRUE(torch::equal(dsa.seq_lens_q, dsa.q_seq_lens));
+  EXPECT_TRUE(torch::equal(dsa.actual_seq_lengths_query, dsa.q_cu_seq_lens));
+  EXPECT_TRUE(torch::equal(dsa.actual_seq_lengths_kv, dsa.kv_seq_lens));
+  EXPECT_EQ(dsa.max_seqlen_q.item<int32_t>(), 2);
+  EXPECT_EQ(dsa.max_seqlen_kv.item<int32_t>(), 5);
+}
+
+TEST(DSAMetadataBuilderMluTest, UsesAttentionMetadataSeqLens) {
+  ModelInputParams params =
+      make_params(BatchForwardType::PREFILL, {0, 2, 3}, {0, 5, 9});
+  params.attention.host.q_cu_seq_lens.clear();
+  params.attention.host.kv_cu_seq_lens.clear();
+  params.attention.host.q_seq_lens = {99};
+  params.attention.host.kv_seq_lens = {199};
+
+  AttentionMetadata metadata =
+      build_metadata(params, torch::tensor({3, 4, 8}, torch::kInt32));
+
+  ASSERT_NE(metadata.dsa_metadata, nullptr);
+  EXPECT_EQ(tensor_vec(metadata.q_cu_seq_lens),
+            std::vector<int64_t>({0, 2, 3}));
+  EXPECT_EQ(tensor_vec(metadata.kv_cu_seq_lens),
+            std::vector<int64_t>({0, 5, 9}));
+  EXPECT_EQ(tensor_vec(metadata.q_seq_lens), std::vector<int64_t>({2, 1}));
+  EXPECT_EQ(tensor_vec(metadata.kv_seq_lens), std::vector<int64_t>({5, 4}));
+}
+
+TEST(DSAMetadataBuilderMluTest, PreservesAttentionFlags) {
+  ModelInputParams prefill =
+      make_params(BatchForwardType::PREFILL, {0, 1}, {0, 1});
+  prefill.graph.attn_mask = torch::ones({1, 1}, torch::kFloat32);
+  AttentionMetadata prefill_metadata =
+      build_metadata(prefill, torch::tensor({0}, torch::kInt32));
+  ASSERT_NE(prefill_metadata.dsa_metadata, nullptr);
+  EXPECT_TRUE(prefill_metadata.is_prefill);
+  EXPECT_TRUE(prefill_metadata.attn_mask.defined());
+  EXPECT_FALSE(prefill_metadata.dsa_metadata->attn_mask.defined());
+
+  ModelInputParams mixed = make_params(BatchForwardType::MIXED, {0, 1}, {0, 4});
+  AttentionMetadata mixed_metadata =
+      build_metadata(mixed, torch::tensor({3}, torch::kInt32));
+  EXPECT_TRUE(mixed_metadata.is_chunked_prefill);
+
+  ModelInputParams dummy = make_params(BatchForwardType::DECODE, {0}, {0});
+  dummy.meta.q_max_seq_len = 0;
+  AttentionMetadata dummy_metadata =
+      build_metadata(dummy, torch::empty({0}, torch::kInt32));
+  EXPECT_TRUE(dummy_metadata.is_dummy);
+}
+
+TEST(DSAMetadataBuilderMluTest, BuildsSwaPlan) {
+  ModelInputParams params =
+      make_params(BatchForwardType::CHUNKED_PREFILL, {0, 2, 3}, {0, 5, 12});
+  AttentionMetadata metadata =
+      build_metadata(params, torch::tensor({3, 4, 11}, torch::kInt32), 4);
+  const DSAMetadata& dsa = *metadata.dsa_metadata;
+
+  EXPECT_EQ(dsa.swa_start_pos_vec, std::vector<int64_t>({0, 3}));
+  EXPECT_EQ(tensor_vec(dsa.swa_history_lens), std::vector<int64_t>({3, 3}));
+  EXPECT_EQ(tensor_vec(dsa.swa_context_lens), std::vector<int64_t>({4, 5, 4}));
+  EXPECT_EQ(dsa.swa_max_history_len, 3);
+  EXPECT_EQ(dsa.swa_max_context_len, 5);
+}
+
+TEST(DSAMetadataBuilderMluTest, BuildsCompressedPositionMetadata) {
+  ModelInputParams params =
+      make_params(BatchForwardType::PREFILL, {0, 3, 6}, {0, 3, 6});
+  torch::Tensor positions =
+      torch::tensor({2, 3, 4, 126, 127, 128}, torch::kInt32);
+  AttentionMetadata metadata = build_metadata(params, positions);
+  const DSAMetadata& dsa = *metadata.dsa_metadata;
+
+  EXPECT_TRUE(torch::equal(dsa.input_positions, positions));
+  EXPECT_EQ(tensor_vec(dsa.c4_pad_positions),
+            std::vector<int64_t>({0, 124, 0}));
+  EXPECT_EQ(tensor_vec(dsa.c128_pad_positions), std::vector<int64_t>({0, 0}));
+  EXPECT_FALSE(dsa.cos_table.defined());
+  EXPECT_FALSE(dsa.sin_table.defined());
+  EXPECT_FALSE(dsa.compressed_cos_table.defined());
+  EXPECT_FALSE(dsa.compressed_sin_table.defined());
+}
+
+TEST(DSAMetadataBuilderMluTest, ExpandsBlockTablesAndSlotMappings) {
+  ModelInputParams params =
+      make_params(BatchForwardType::CHUNKED_PREFILL, {0, 2, 3}, {0, 5, 9});
+  params.multi_block_tables = {
+      torch::tensor({10, 11, 20, 21}, torch::kInt32).view({2, 2}),
+      torch::tensor({30, 31, 40, 41, 42, 43}, torch::kInt32).view({2, 3})};
+  std::vector<DSAGroupInfo> group_infos = {
+      {DSACacheType::TOKEN, 4, 16}, {DSACacheType::SLIDING_WINDOW, 1, 4}};
+  std::vector<std::vector<DSACacheInfo>> caches_info = {
+      {{0, DSACacheType::TOKEN, 4, 16},
+       {0, DSACacheType::TOKEN, 4, 16},
+       {1, DSACacheType::SLIDING_WINDOW, 1, 4}}};
+
+  AttentionMetadata metadata =
+      DSAMetadataBuilderMlu::build(params,
+                                   torch::tensor({3, 4, 8}, torch::kInt32),
+                                   caches_info,
+                                   group_infos,
+                                   /*window_size=*/4);
+  const DSAMetadata& dsa = *metadata.dsa_metadata;
+
+  ASSERT_EQ(dsa.block_tables.size(), 1);
+  ASSERT_EQ(dsa.block_tables[0].size(), 3);
+  EXPECT_TRUE(torch::equal(dsa.block_tables[0][0], dsa.block_tables[0][1]));
+  EXPECT_EQ(tensor_vec(dsa.slot_mappings[0][0]),
+            std::vector<int64_t>({160, 320}));
+  EXPECT_EQ(tensor_vec(dsa.slot_mappings[0][2]),
+            std::vector<int64_t>({123, 124, 167}));
+}
+
+TEST(DSAMetadataBuilderMluTest, BuildsC128AttentionMetadata) {
+  ModelInputParams params =
+      make_params(BatchForwardType::DECODE, {0, 1}, {0, 128});
+  params.multi_block_tables = {
+      torch::tensor({7}, torch::TensorOptions().dtype(torch::kInt32))
+          .view({1, 1})};
+  std::vector<DSAGroupInfo> group_infos = {{DSACacheType::TOKEN, 128, 16}};
+  std::vector<std::vector<DSACacheInfo>> caches_info = {
+      {{0, DSACacheType::TOKEN, 128, 16}}};
+
+  AttentionMetadata metadata =
+      DSAMetadataBuilderMlu::build(params,
+                                   torch::tensor({127}, torch::kInt32),
+                                   caches_info,
+                                   group_infos,
+                                   /*window_size=*/0);
+  const DSAMetadata& dsa = *metadata.dsa_metadata;
+
+  EXPECT_EQ(tensor_vec(dsa.c128_attn_metadata.context_lens),
+            std::vector<int64_t>({1}));
+  EXPECT_EQ(tensor_vec(dsa.c128_attn_metadata.block_table_for_attn),
+            std::vector<int64_t>({7}));
+  EXPECT_EQ(dsa.c128_attn_metadata.max_context_len, 1);
+  EXPECT_FALSE(dsa.c128_metadata.defined());
+}
+
+TEST(DSAMetadataBuilderMluTest, BuildsDecodeCompressedSlotMapping) {
+  ModelInputParams params =
+      make_params(BatchForwardType::DECODE, {0, 1}, {0, 129});
+  params.multi_block_tables = {
+      torch::tensor({10, 11, 12}, torch::kInt32).view({1, 3})};
+  std::vector<DSAGroupInfo> group_infos = {{DSACacheType::TOKEN, 4, 16}};
+  std::vector<std::vector<DSACacheInfo>> caches_info = {
+      {{0, DSACacheType::TOKEN, 4, 16}}};
+
+  AttentionMetadata metadata =
+      DSAMetadataBuilderMlu::build(params,
+                                   torch::tensor({128}, torch::kInt32),
+                                   caches_info,
+                                   group_infos,
+                                   /*window_size=*/0);
+  ASSERT_EQ(metadata.dsa_metadata->slot_mappings.size(), 1);
+  ASSERT_EQ(metadata.dsa_metadata->slot_mappings[0].size(), 1);
+  EXPECT_EQ(tensor_vec(metadata.dsa_metadata->slot_mappings[0][0]),
+            std::vector<int64_t>({192}));
+  EXPECT_FALSE(metadata.dsa_metadata->cmp_slots_dict.contains(4));
+
+  params.meta.batch_forward_type = BatchForwardType::PREFILL;
+  AttentionMetadata prefill_metadata =
+      DSAMetadataBuilderMlu::build(params,
+                                   torch::tensor({128}, torch::kInt32),
+                                   caches_info,
+                                   group_infos,
+                                   /*window_size=*/0);
+  EXPECT_FALSE(prefill_metadata.dsa_metadata->cmp_slots_dict.contains(4));
+}
+
+TEST(DSAMetadataBuilderMluTest, IgnoresLegacyCuLensFields) {
+  ModelInputParams params =
+      make_params(BatchForwardType::PREFILL, {0, 2, 3}, {0, 5, 9});
+  params.attention.host.q_cu_seq_lens = {99, 100};
+  params.attention.host.kv_cu_seq_lens = {88, 89};
+
+  AttentionMetadata metadata =
+      build_metadata(params, torch::tensor({3, 4, 8}, torch::kInt32));
+
+  ASSERT_NE(metadata.dsa_metadata, nullptr);
+  EXPECT_EQ(tensor_vec(metadata.q_cu_seq_lens),
+            std::vector<int64_t>({0, 2, 3}));
+  EXPECT_EQ(tensor_vec(metadata.kv_cu_seq_lens),
+            std::vector<int64_t>({0, 5, 9}));
+  EXPECT_EQ(tensor_vec(metadata.dsa_metadata->q_seq_lens),
+            std::vector<int64_t>({2, 1}));
+  EXPECT_EQ(tensor_vec(metadata.dsa_metadata->kv_seq_lens),
+            std::vector<int64_t>({5, 4}));
+}
+
+}  // namespace
+}  // namespace layer
+}  // namespace xllm

--- a/xllm/core/framework/kv_cache/deepseek_v4_kv_cache_impl.cpp
+++ b/xllm/core/framework/kv_cache/deepseek_v4_kv_cache_impl.cpp
@@ -62,6 +62,17 @@ torch::Tensor cast_to_nd_format(const torch::Tensor& tensor) {
 #endif
 }
 
+std::vector<int64_t> dsv4_block_shape(int64_t block_count,
+                                      int64_t block_size,
+                                      int64_t n_heads,
+                                      int64_t head_dim) {
+#if defined(USE_MLU)
+  return {block_count, n_heads, block_size, head_dim};
+#else
+  return {block_count, block_size, n_heads, head_dim};
+#endif
+}
+
 std::string tensor_shape_string(const torch::Tensor& tensor) {
   if (!tensor.defined()) {
     return "undefined";
@@ -194,18 +205,22 @@ DeepSeekV4KVCacheTensors create_dsv4_cache_tensors(
   DeepSeekV4KVCacheTensors tensors;
   if (compress_ratio == 1) {
     tensors.swa_cache =
-        torch::empty({swa_count, block_size, n_heads, head_dim}, cache_options);
+        torch::empty(dsv4_block_shape(swa_count, block_size, n_heads, head_dim),
+                     cache_options);
   } else if (compress_ratio == 4) {
     tensors.key_cache =
-        torch::empty({c4_count, block_size, n_heads, head_dim}, cache_options);
+        torch::empty(dsv4_block_shape(c4_count, block_size, n_heads, head_dim),
+                     cache_options);
     tensors.index_cache = torch::empty(
-        {c4_count, block_size, index_n_heads, index_head_dim}, index_options);
+        dsv4_block_shape(c4_count, block_size, index_n_heads, index_head_dim),
+        index_options);
     if (cache_policy.has_indexer_cache_scale) {
       tensors.indexer_cache_scale =
           torch::empty({c4_count, block_size, 1}, scale_options);
     }
     tensors.swa_cache =
-        torch::empty({swa_count, block_size, n_heads, head_dim}, cache_options);
+        torch::empty(dsv4_block_shape(swa_count, block_size, n_heads, head_dim),
+                     cache_options);
     tensors.compress_kv_state =
         torch::empty({swa_count, block_size, 2 * head_dim}, state_options);
     tensors.compress_score_state =
@@ -216,16 +231,19 @@ DeepSeekV4KVCacheTensors create_dsv4_cache_tensors(
         {swa_count, block_size, 2 * index_head_dim}, state_options);
   } else if (compress_ratio == 128) {
     tensors.key_cache = torch::empty(
-        {c128_count, block_size, n_heads, head_dim}, cache_options);
+        dsv4_block_shape(c128_count, block_size, n_heads, head_dim),
+        cache_options);
     tensors.swa_cache =
-        torch::empty({swa_count, block_size, n_heads, head_dim}, cache_options);
+        torch::empty(dsv4_block_shape(swa_count, block_size, n_heads, head_dim),
+                     cache_options);
     tensors.compress_kv_state =
         torch::empty({swa_count, block_size, head_dim}, state_options);
     tensors.compress_score_state =
         torch::empty({swa_count, block_size, head_dim}, state_options);
   } else {
     tensors.swa_cache =
-        torch::empty({swa_count, block_size, n_heads, head_dim}, cache_options);
+        torch::empty(dsv4_block_shape(swa_count, block_size, n_heads, head_dim),
+                     cache_options);
   }
 
   tensors.key_cache = cast_to_nd_format(tensors.key_cache);

--- a/xllm/core/framework/model/model_input_params.h
+++ b/xllm/core/framework/model/model_input_params.h
@@ -341,6 +341,7 @@ struct AttentionHostInput {
   std::vector<int32_t> q_seq_lens;
   std::vector<int32_t> q_cu_seq_lens;
   std::vector<int32_t> kv_seq_lens;
+  std::vector<int32_t> kv_cu_seq_lens;
   std::vector<int32_t> new_cache_slots;
   std::vector<int32_t> kv_cache_tokens_nums;
   std::vector<int32_t> ring_cur_seqlen;

--- a/xllm/core/kernels/mlu/attention.cpp
+++ b/xllm/core/kernels/mlu/attention.cpp
@@ -150,7 +150,10 @@ void batch_decode(const torch::Tensor& query,
                   int64_t window_size_right,
                   float scale,
                   bool return_lse,
-                  int64_t kv_cache_quant_bit_size) {
+                  int64_t kv_cache_quant_bit_size,
+                  const std::optional<torch::Tensor>& cu_seq_q,
+                  int64_t max_seq_q,
+                  const std::optional<torch::Tensor>& sink) {
   tmo::torch_api::single_query_cached_kv_attn(query,
                                               k_cache,
                                               output,
@@ -170,7 +173,21 @@ void batch_decode(const torch::Tensor& query,
                                               window_size_right,
                                               scale,
                                               return_lse,
-                                              kv_cache_quant_bit_size);
+                                              kv_cache_quant_bit_size,
+                                              cu_seq_q,
+                                              max_seq_q,
+                                              sink);
+}
+
+void update_out_and_lse(torch::Tensor& out,
+                        torch::Tensor& lse,
+                        const torch::Tensor& block_out,
+                        const torch::Tensor& block_lse,
+                        const std::optional<torch::Tensor>& seq_offsets,
+                        const std::optional<torch::Tensor>& cu_seqs,
+                        const std::optional<torch::Tensor>& block_cu_seqs) {
+  tmo::torch_api::update_out_and_lse(
+      out, lse, block_out, block_lse, seq_offsets, cu_seqs, block_cu_seqs);
 }
 
 void masked_indexer_select_paged_kv(

--- a/xllm/core/kernels/mlu/compressor.cpp
+++ b/xllm/core/kernels/mlu/compressor.cpp
@@ -1,0 +1,81 @@
+/* Copyright 2026 The xLLM Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://github.com/jd-opensource/xllm/blob/main/LICENSE
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include "mlu_ops_api.h"
+
+namespace xllm::kernel::mlu {
+
+void fused_compress_single_kv(
+    const torch::Tensor& kv,
+    const torch::Tensor& score,
+    const torch::Tensor& position,
+    const std::optional<torch::Tensor>& state_ids,
+    const torch::Tensor& ape,
+    torch::Tensor& kv_state,
+    torch::Tensor& score_state,
+    const torch::Tensor& gamma,
+    const torch::Tensor& sin,
+    const torch::Tensor& cos,
+    const std::optional<torch::Tensor>& hadamard_matrix,
+    const torch::Tensor& slot_mapping,
+    torch::Tensor& kv_cache,
+    const std::optional<torch::Tensor>& kv_cache_scale,
+    double eps,
+    bool overlap,
+    const std::optional<torch::Tensor>& cu_query_len,
+    int64_t mtp_token_num) {
+  tmo::torch_api::fused_compress_single_kv(kv,
+                                           score,
+                                           position,
+                                           state_ids,
+                                           ape,
+                                           kv_state,
+                                           score_state,
+                                           gamma,
+                                           sin,
+                                           cos,
+                                           hadamard_matrix,
+                                           slot_mapping,
+                                           kv_cache,
+                                           kv_cache_scale,
+                                           eps,
+                                           overlap,
+                                           cu_query_len,
+                                           mtp_token_num);
+}
+
+void fused_compress_multi_kv(const torch::Tensor& kv,
+                             const torch::Tensor& score,
+                             torch::Tensor& kv_state,
+                             torch::Tensor& score_state,
+                             const torch::Tensor& cu_seqlens,
+                             const std::optional<torch::Tensor>& batch_ids,
+                             const torch::Tensor& ape,
+                             int64_t max_seqlen,
+                             bool overlap,
+                             torch::Tensor& compressed_kv) {
+  tmo::torch_api::fused_compress_multi_kv(kv,
+                                          score,
+                                          kv_state,
+                                          score_state,
+                                          cu_seqlens,
+                                          batch_ids,
+                                          ape,
+                                          max_seqlen,
+                                          overlap,
+                                          compressed_kv);
+}
+
+}  // namespace xllm::kernel::mlu

--- a/xllm/core/kernels/mlu/fused_layernorm.cpp
+++ b/xllm/core/kernels/mlu/fused_layernorm.cpp
@@ -20,7 +20,7 @@ namespace xllm::kernel::mlu {
 void fused_layernorm(const torch::Tensor& input,
                      torch::Tensor& output,
                      const std::optional<torch::Tensor>& residual,
-                     const torch::Tensor& weight,
+                     const std::optional<torch::Tensor>& weight,
                      const std::optional<torch::Tensor>& beta,
                      const std::optional<torch::Tensor>& bias,
                      const std::optional<torch::Tensor>& quant_scale,

--- a/xllm/core/kernels/mlu/fused_moe.cpp
+++ b/xllm/core/kernels/mlu/fused_moe.cpp
@@ -51,6 +51,31 @@ std::tuple<torch::Tensor, torch::Tensor> moe_active_topk(
   return std::make_tuple(reduce_weight, expert_id);
 }
 
+std::tuple<torch::Tensor, torch::Tensor> moe_softplus_topk(
+    const torch::Tensor& input,
+    int64_t topk,
+    const std::optional<torch::Tensor>& input_ids,
+    const std::optional<torch::Tensor>& tid2eid,
+    const std::optional<torch::Tensor>& bias,
+    float route_scale) {
+  std::vector<int64_t> out_shape = input.sizes().vec();
+  out_shape.pop_back();
+  out_shape.push_back(topk);
+  auto reduce_weight = torch::empty(
+      out_shape, torch::dtype(torch::kFloat).device(input.device()));
+  auto expert_id = torch::empty(
+      out_shape, torch::dtype(torch::kInt32).device(input.device()));
+  tmo::torch_api::moe_softplus_topk(input,
+                                    input_ids,
+                                    tid2eid,
+                                    bias,
+                                    topk,
+                                    route_scale,
+                                    reduce_weight,
+                                    expert_id);
+  return std::make_tuple(reduce_weight, expert_id);
+}
+
 std::vector<torch::Tensor> moe_gen_idx(const torch::Tensor& expert_id,
                                        int64_t expert_num) {
   return tmo::torch_api::moe_gen_idx(expert_id, expert_num);

--- a/xllm/core/kernels/mlu/hyper_connection.cpp
+++ b/xllm/core/kernels/mlu/hyper_connection.cpp
@@ -1,0 +1,60 @@
+/* Copyright 2026 The xLLM Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://github.com/jd-opensource/xllm/blob/main/LICENSE
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include "mlu_ops_api.h"
+
+namespace xllm::kernel::mlu {
+
+torch::Tensor fused_mul_reduce_sum(const torch::Tensor& x,
+                                   const torch::Tensor& w) {
+  return tmo::torch_api::fused_mul_reduce_sum(x, w);
+}
+
+std::tuple<torch::Tensor, torch::Tensor, torch::Tensor> hc_split_sinkhorn(
+    const torch::Tensor& mixes,
+    const torch::Tensor& hc_scale,
+    const torch::Tensor& hc_base,
+    const std::optional<torch::Tensor>& pre_scale,
+    int64_t hc_mult,
+    int64_t sinkhorn_iter,
+    double eps) {
+  std::vector<torch::Tensor> outputs = tmo::torch_api::hc_split_sinkhorn(
+      mixes, hc_scale, hc_base, pre_scale, hc_mult, sinkhorn_iter, eps);
+  return {outputs[0], outputs[1], outputs[2]};
+}
+
+std::tuple<torch::Tensor, torch::Tensor> fused_mhc_post(
+    const torch::Tensor& x,
+    const torch::Tensor& residual,
+    const torch::Tensor& post,
+    const torch::Tensor& comb,
+    bool compute_rms,
+    double eps) {
+  torch::Tensor output = torch::empty_like(residual);
+  torch::Tensor output_rms;
+  if (compute_rms) {
+    output_rms = torch::empty({x.size(0)}, x.options().dtype(torch::kFloat32));
+  } else {
+    output_rms = torch::empty({0}, x.options().dtype(torch::kFloat32));
+  }
+  tmo::torch_api::fused_mhc_post(
+      x, residual, post, comb, output, output_rms, compute_rms, eps);
+  if (!compute_rms) {
+    output_rms = torch::Tensor();
+  }
+  return {output, output_rms};
+}
+
+}  // namespace xllm::kernel::mlu

--- a/xllm/core/kernels/mlu/mlu_ops_api.h
+++ b/xllm/core/kernels/mlu/mlu_ops_api.h
@@ -19,6 +19,7 @@ limitations under the License.
 
 #include <optional>
 #include <string>
+#include <tuple>
 #include <vector>
 
 #include "ATen/Tensor.h"
@@ -142,7 +143,19 @@ void batch_decode(const torch::Tensor& query,
                   int64_t window_size_right,
                   float scale,
                   bool return_lse,
-                  int64_t kv_cache_quant_bit_size);
+                  int64_t kv_cache_quant_bit_size,
+                  const std::optional<torch::Tensor>& cu_seq_q = std::nullopt,
+                  int64_t max_seq_q = -1,
+                  const std::optional<torch::Tensor>& sink = std::nullopt);
+
+void update_out_and_lse(
+    torch::Tensor& out,
+    torch::Tensor& lse,
+    const torch::Tensor& block_out,
+    const torch::Tensor& block_lse,
+    const std::optional<torch::Tensor>& seq_offsets = std::nullopt,
+    const std::optional<torch::Tensor>& cu_seqs = std::nullopt,
+    const std::optional<torch::Tensor>& block_cu_seqs = std::nullopt);
 
 void masked_indexer_select_paged_kv(
     const torch::Tensor& query,
@@ -169,7 +182,7 @@ void masked_indexer_select_paged_kv(
 void fused_layernorm(const torch::Tensor& input,
                      torch::Tensor& output,
                      const std::optional<torch::Tensor>& residual,
-                     const torch::Tensor& weight,
+                     const std::optional<torch::Tensor>& weight,
                      const std::optional<torch::Tensor>& beta,
                      const std::optional<torch::Tensor>& bias,
                      const std::optional<torch::Tensor>& quant_scale,
@@ -329,6 +342,26 @@ void gather_split(const torch::Tensor& input,
                   const torch::Tensor& output_head,
                   const torch::Tensor& output_tail);
 
+torch::Tensor fused_mul_reduce_sum(const torch::Tensor& x,
+                                   const torch::Tensor& w);
+
+std::tuple<torch::Tensor, torch::Tensor, torch::Tensor> hc_split_sinkhorn(
+    const torch::Tensor& mixes,
+    const torch::Tensor& hc_scale,
+    const torch::Tensor& hc_base,
+    const std::optional<torch::Tensor>& pre_scale,
+    int64_t hc_mult,
+    int64_t sinkhorn_iter,
+    double eps);
+
+std::tuple<torch::Tensor, torch::Tensor> fused_mhc_post(
+    const torch::Tensor& x,
+    const torch::Tensor& residual,
+    const torch::Tensor& post,
+    const torch::Tensor& comb,
+    bool compute_rms,
+    double eps);
+
 void fused_mla_q(const torch::Tensor& input,
                  torch::Tensor& output,
                  torch::Tensor& output_scale,
@@ -401,5 +434,44 @@ torch::Tensor gemma_rms_norm(const torch::Tensor& x,
                              const torch::Tensor& gamma,
                              double eps,
                              torch::Tensor& norm_out);
+
+std::tuple<torch::Tensor, torch::Tensor> moe_softplus_topk(
+    const torch::Tensor& input,
+    int64_t topk,
+    const std::optional<torch::Tensor>& input_ids = std::nullopt,
+    const std::optional<torch::Tensor>& tid2eid = std::nullopt,
+    const std::optional<torch::Tensor>& bias = std::nullopt,
+    float route_scale = 1.0);
+
+void fused_compress_single_kv(
+    const torch::Tensor& kv,
+    const torch::Tensor& score,
+    const torch::Tensor& position,
+    const std::optional<torch::Tensor>& state_ids,
+    const torch::Tensor& ape,
+    torch::Tensor& kv_state,
+    torch::Tensor& score_state,
+    const torch::Tensor& gamma,
+    const torch::Tensor& sin,
+    const torch::Tensor& cos,
+    const std::optional<torch::Tensor>& hadamard_matrix,
+    const torch::Tensor& slot_mapping,
+    torch::Tensor& kv_cache,
+    const std::optional<torch::Tensor>& kv_cache_scale,
+    double eps,
+    bool overlap,
+    const std::optional<torch::Tensor>& cu_query_len = std::nullopt,
+    int64_t mtp_token_num = 0);
+
+void fused_compress_multi_kv(const torch::Tensor& kv,
+                             const torch::Tensor& score,
+                             torch::Tensor& kv_state,
+                             torch::Tensor& score_state,
+                             const torch::Tensor& cu_seqlens,
+                             const std::optional<torch::Tensor>& batch_ids,
+                             const torch::Tensor& ape,
+                             int64_t max_seqlen,
+                             bool overlap,
+                             torch::Tensor& compressed_kv);
 
 }  // namespace xllm::kernel::mlu

--- a/xllm/core/kernels/ops_api.cpp
+++ b/xllm/core/kernels/ops_api.cpp
@@ -757,7 +757,10 @@ void masked_indexer_select_paged_kv(MaskedIndexerSelectPagedKVParams& params) {
                                       params.q_scale,
                                       params.k_scale_cache,
                                       params.sparse_block_table,
-                                      params.sparse_context_lens);
+                                      params.sparse_context_lens,
+                                      params.is_score_float,
+                                      params.compress_ratio,
+                                      params.kv_cache_block_table_offset);
 #else
   NOT_IMPLEMENTED();
 #endif

--- a/xllm/core/kernels/param.h
+++ b/xllm/core/kernels/param.h
@@ -987,6 +987,9 @@ struct MaskedIndexerSelectPagedKVParams {
   // New sparse block table output tensor. Shape: [batch_num] (prefill) or
   // [batch_num] (decode). Type: int32. Must be contiguous.
   torch::Tensor sparse_context_lens;
+  bool is_score_float = false;
+  int64_t compress_ratio = 1;
+  std::optional<torch::Tensor> kv_cache_block_table_offset = std::nullopt;
 };
 
 struct GatherSplitParams {

--- a/xllm/core/layers/common/attention_metadata_builder.cpp
+++ b/xllm/core/layers/common/attention_metadata_builder.cpp
@@ -84,7 +84,7 @@ AttentionMetadata build_attention_metadata(
   attn_metadata.unshared_plan_info = std::make_shared<PlanInfo>();
 #endif
 
-#if defined(USE_CUDA) || defined(USE_NPU)
+#if defined(USE_CUDA) || defined(USE_NPU) || defined(USE_MLU)
   // Use explicit attn_mask if provided; otherwise fall back to
   // graph_buffer.attn_mask (e.g. Qwen2_5_VL sets graph_buffer.attn_mask for
   // LongCat text encoding)
@@ -180,7 +180,7 @@ AttentionMetadata build_attention_metadata(
       params.meta.batch_forward_type.is_chunked_prefill();
   attn_metadata.is_prefill = params.meta.batch_forward_type.is_prefill();
 
-  // enable_mla is for DeepSeekv32 on mlu device
+  // MLA-family MLU paths require per-sequence q/kv lengths during prefill.
   if (!attn_metadata.is_prefill || enable_mla) {
     attn_metadata.block_table = params.attention.device.block_tables;
 #if !defined(USE_NPU) && !defined(USE_CUDA)

--- a/xllm/core/layers/common/dsa_metadata.h
+++ b/xllm/core/layers/common/dsa_metadata.h
@@ -47,6 +47,12 @@ struct DSAGroupInfo {
 
 namespace layer {
 
+struct DSACompressedAttentionMetadata {
+  torch::Tensor context_lens;
+  torch::Tensor block_table_for_attn;
+  int64_t max_context_len = 0;
+};
+
 // DSAMetadata contains DeepSeek V4 sparse attention specific metadata,
 // aligned with Python DSAMetadata(AttentionMetadata) class.
 // It is built once at the beginning of model forward pass and reused by
@@ -75,6 +81,7 @@ struct DSAMetadata {
   // cp_input_dict: context-parallel inputs placeholder (reserved, optional)
   std::unordered_map<std::string, torch::Tensor> cp_input_dict;
 
+  // NPU-only DSA metadata fields.
   // RoPE caches selected for the current layer's q/kv/output RoPE.
   torch::Tensor cos;
   torch::Tensor sin;
@@ -134,6 +141,43 @@ struct DSAMetadata {
   // single host-to-device transfer. Individual metadata tensors may be views
   // into this buffer.
   torch::Tensor packed_metadata_buffer;
+
+  std::unordered_map<int64_t, torch::Tensor> cmp_slots_dict;
+
+  // Host-side batch metadata for MLU small operators.
+  // query_start_offsets: [0, cumsum(seq_lens_q)].
+  std::vector<int64_t> query_start_offsets;
+  // start_pos_vec[i] = actual_seq_lengths_kv[i] - seq_lens_q[i].
+  std::vector<int64_t> start_pos_vec;
+  // SWA window plan derived from start_pos_vec and model window_size.
+  // swa_start_pos_vec[i] is the absolute first token retained for sequence i.
+  std::vector<int64_t> swa_start_pos_vec;
+  // swa_history_lens: per-sequence persisted SWA history to read before q.
+  torch::Tensor swa_history_lens;
+  // swa_context_lens: per-query-token local context length from swa_start.
+  torch::Tensor swa_context_lens;
+  int64_t swa_max_history_len = 0;
+  int64_t swa_max_context_len = 0;
+
+  // MLU-only canonical sequence lengths consumed by DSA operators.
+  // q_cu_seq_lens / kv_cu_seq_lens: (batch_size+1,) with leading 0.
+  torch::Tensor q_cu_seq_lens;
+  torch::Tensor kv_cu_seq_lens;
+  // kv_seq_lens / q_seq_lens: (batch_size,) per-sequence lengths.
+  torch::Tensor kv_seq_lens;
+  torch::Tensor q_seq_lens;
+  // index_c4_seq_lens: (batch_size,) compressed kv lengths for indexer.
+  torch::Tensor index_c4_seq_lens;
+  int64_t index_total_c4_len = 0;
+  int64_t index_max_c4_len = 0;
+
+  // MLU-only ratio=128 compressed attention final decode inputs.
+  // Built once per model forward before layer iteration.
+  DSACompressedAttentionMetadata c128_attn_metadata;
+
+  // MLU-only RoPE cos/sin tables (shared across all layers, set per forward).
+  torch::Tensor compressed_cos_table;
+  torch::Tensor compressed_sin_table;
 
   // Cache spec per layer
   // caches_info[layer_id][cache_idx] = {group_id, type, ratio, block_size}

--- a/xllm/core/layers/common/dsa_metadata.h
+++ b/xllm/core/layers/common/dsa_metadata.h
@@ -68,6 +68,8 @@ struct DSAMetadata {
   // cos_table / sin_table: base RoPE cos/sin tables
   torch::Tensor cos_table;
   torch::Tensor sin_table;
+  // inverse_sin_table: precomputed -sin_table for inverse RoPE.
+  torch::Tensor inverse_sin_table;
 
   // ===== DSA-specific fields =====
   // layer_id: current layer (Python per-layer, C++ shared across layers)
@@ -178,6 +180,8 @@ struct DSAMetadata {
   // MLU-only RoPE cos/sin tables (shared across all layers, set per forward).
   torch::Tensor compressed_cos_table;
   torch::Tensor compressed_sin_table;
+  // compressed_inverse_sin_table: precomputed -compressed_sin_table.
+  torch::Tensor compressed_inverse_sin_table;
 
   // Cache spec per layer
   // caches_info[layer_id][cache_idx] = {group_id, type, ratio, block_size}

--- a/xllm/core/layers/common/dsa_metadata_builder.cpp
+++ b/xllm/core/layers/common/dsa_metadata_builder.cpp
@@ -160,8 +160,7 @@ void DSAMetadataBuilder::build_dsa_fields(
   }
 
   if (positions.defined()) {
-    const int64_t total_tokens = positions.numel();
-    build_positions(params, batch_size, total_tokens, dsa);
+    build_positions(params, batch_size, dsa);
   }
 
   (void)dsa_c4_cos_sin;
@@ -651,7 +650,6 @@ void DSAMetadataBuilder::build_seq_lengths(const ModelInputParams& params,
 
 void DSAMetadataBuilder::build_positions(const ModelInputParams& params,
                                          int32_t batch_size,
-                                         int64_t total_tokens,
                                          DSAMetadata& dsa_metadata) {
   if (!dsa_metadata.input_positions.defined()) return;
 

--- a/xllm/core/layers/mlu/CMakeLists.txt
+++ b/xllm/core/layers/mlu/CMakeLists.txt
@@ -9,6 +9,8 @@ cc_library(
     deepseek_v2_decoder_layer_impl.h
     deepseek_v2_sparse_moe_block.h
     indexer.h
+    deepseek_v4/dsa_cache_mapping.h
+    deepseek_v4/dsa_metadata_builder_mlu.h
     deepseek_v32_sp_context.h
     deepseek_v32_sp_plan.h
     moe_gate.h
@@ -23,6 +25,7 @@ cc_library(
     deepseek_v2_decoder_layer_impl.cpp
     deepseek_v2_sparse_moe_block.cpp
     indexer.cpp
+    deepseek_v4/dsa_metadata_builder_mlu.cpp
     moe_gate.cpp
     fused_moe.cpp
     fused_moe_base.cpp

--- a/xllm/core/layers/mlu/deepseek_v4/dsa_cache_mapping.h
+++ b/xllm/core/layers/mlu/deepseek_v4/dsa_cache_mapping.h
@@ -1,0 +1,33 @@
+/* Copyright 2026 The xLLM Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://github.com/jd-opensource/xllm/blob/main/LICENSE
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#pragma once
+
+#include <cstdint>
+
+namespace xllm {
+
+// DeepSeek V4 MLU cache index mapping for one DSA layer.
+struct DSACacheMapping {
+  int64_t cmp_cache_idx = -1;
+  int64_t index_cache_idx = -1;
+  int64_t ori_cache_idx = -1;
+  int64_t kv_state_cache_idx = -1;
+  int64_t score_state_cache_idx = -1;
+  int64_t index_kv_state_cache_idx = -1;
+  int64_t index_score_state_cache_idx = -1;
+};
+
+}  // namespace xllm

--- a/xllm/core/layers/mlu/deepseek_v4/dsa_metadata_builder_mlu.cpp
+++ b/xllm/core/layers/mlu/deepseek_v4/dsa_metadata_builder_mlu.cpp
@@ -21,7 +21,6 @@ limitations under the License.
 #include <cmath>
 #include <cstdint>
 #include <memory>
-#include <unordered_set>
 #include <vector>
 
 #include "framework/model/model_input_params.h"
@@ -35,35 +34,6 @@ namespace xllm::layer {
 namespace {
 
 constexpr int64_t kIndexC4Ratio = 4;
-
-void mask_stale_swa_slots(torch::Tensor& slots,
-                          const std::vector<int32_t>& ctx_lens,
-                          const std::vector<int32_t>& q_lens,
-                          int32_t batch_size) {
-  auto slots_acc = slots.accessor<int32_t, 1>();
-  int64_t start_idx = 0;
-  for (int32_t seq = 0; seq < batch_size; ++seq) {
-    const int64_t ctx_len = static_cast<int64_t>(ctx_lens[seq]);
-    const int64_t q_len =
-        std::clamp<int64_t>(static_cast<int64_t>(q_lens[seq]), 0, ctx_len);
-    std::unordered_set<int32_t> seen_slots;
-    seen_slots.reserve(static_cast<size_t>(q_len));
-
-    for (int64_t i = q_len; i > 0; --i) {
-      const int64_t slot_idx = start_idx + i - 1;
-      const int32_t slot = slots_acc[slot_idx];
-      if (slot < 0) {
-        continue;
-      }
-      auto inserted = seen_slots.emplace(slot);
-      if (!inserted.second) {
-        slots_acc[slot_idx] = -1;
-      }
-    }
-
-    start_idx += q_len;
-  }
-}
 
 std::vector<int32_t> tensor_to_vec(const torch::Tensor& tensor,
                                    const char* name) {
@@ -79,6 +49,13 @@ std::vector<int32_t> tensor_to_vec(const torch::Tensor& tensor,
     values.emplace_back(tensor_acc[idx]);
   }
   return values;
+}
+
+torch::Tensor sanitize_block_table(const torch::Tensor& table) {
+  if (!table.defined()) {
+    return table;
+  }
+  return torch::where(table.lt(0), torch::zeros_like(table), table);
 }
 
 void sync_dsa_seq_metadata(AttentionMetadata& attn_metadata,
@@ -239,6 +216,7 @@ void DSAMetadataBuilderMlu::build_dsa_fields(
                     total_tokens,
                     proc_bt[m],
                     proc_slots[m]);
+      proc_bt[m] = sanitize_block_table(proc_bt[m]);
     }
 
     build_c128_meta(dsa, proc_bt, group_infos, batch_size);
@@ -482,6 +460,9 @@ void DSAMetadataBuilderMlu::process_swa_group(
                           << block_size;
   CHECK_EQ(raw_bt.dim(), 2)
       << "process_swa_group requires raw_bt dim == 2, got " << raw_bt.dim();
+  CHECK_GE(raw_bt.size(0), batch_size)
+      << "process_swa_group requires raw_bt rows >= batch_size, got "
+      << raw_bt.size(0) << " vs " << batch_size;
 
   int64_t query_total_tokens = 0;
   for (int32_t seq = 0; seq < batch_size; ++seq) {
@@ -496,14 +477,17 @@ void DSAMetadataBuilderMlu::process_swa_group(
       torch::full({query_total_tokens}, -1, raw_bt.options());
   auto out_slots_acc = out_slots_tensor.accessor<int32_t, 1>();
   auto raw_bt_acc = raw_bt.accessor<int32_t, 2>();
-  const int64_t max_blocks = raw_bt.size(1);
+  const int64_t current_cols = raw_bt.size(1);
   const int64_t block_size_i64 = static_cast<int64_t>(block_size);
 
   auto slot_for_position = [&](int32_t seq, int64_t pos) -> int32_t {
-    if (max_blocks <= 0) {
+    if (current_cols <= 0) {
       return -1;
     }
-    const int64_t block_idx = (pos / block_size_i64) % max_blocks;
+    const int64_t block_idx = pos / block_size_i64;
+    if (block_idx >= current_cols) {
+      return -1;
+    }
     const int32_t block_id = raw_bt_acc[seq][block_idx];
     if (block_id < 0) {
       return -1;
@@ -524,31 +508,29 @@ void DSAMetadataBuilderMlu::process_swa_group(
     }
   }
 
-  mask_stale_swa_slots(out_slots_tensor, ctx_lens, q_lens, batch_size);
   out_slots = out_slots_tensor;
 
-  int32_t current_cols = raw_bt.size(1);
   int32_t max_dst_len = 0;
-  std::vector<int32_t> dst_lens(batch_size);
   for (int32_t s = 0; s < batch_size; ++s) {
-    dst_lens[s] = static_cast<int32_t>(
+    const int32_t dst_len = static_cast<int32_t>(
         std::ceil(static_cast<double>(ctx_lens[s]) / block_size));
-    max_dst_len = std::max(max_dst_len, dst_lens[s]);
+    max_dst_len = std::max(max_dst_len, dst_len);
   }
-  max_dst_len = std::max(max_dst_len, current_cols);
+  max_dst_len = std::max(max_dst_len, static_cast<int32_t>(current_cols));
 
-  auto new_bt = torch::full({batch_size, max_dst_len}, -1, raw_bt.options());
+  if (current_cols >= max_dst_len && raw_bt.size(0) == batch_size) {
+    out_bt = raw_bt;
+    return;
+  }
+
+  torch::Tensor new_bt =
+      torch::full({batch_size, max_dst_len}, -1, raw_bt.options());
   auto new_acc = new_bt.accessor<int32_t, 2>();
   auto old_acc = raw_bt.accessor<int32_t, 2>();
 
   for (int32_t s = 0; s < batch_size; ++s) {
-    const int32_t retained_cols = std::min(current_cols, dst_lens[s]);
-    const int32_t start_col = dst_lens[s] - retained_cols;
-    for (int32_t j = 0; j < retained_cols; ++j) {
-      const int32_t logical_col = start_col + j;
-      // Keep the read-side block table aligned with slot_for_position().
-      const int32_t physical_col = logical_col % current_cols;
-      new_acc[s][logical_col] = old_acc[s][physical_col];
+    for (int64_t col = 0; col < current_cols; ++col) {
+      new_acc[s][col] = old_acc[s][col];
     }
   }
   out_bt = new_bt;

--- a/xllm/core/layers/mlu/deepseek_v4/dsa_metadata_builder_mlu.cpp
+++ b/xllm/core/layers/mlu/deepseek_v4/dsa_metadata_builder_mlu.cpp
@@ -1,0 +1,796 @@
+/* Copyright 2026 The xLLM Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://github.com/jd-opensource/xllm/blob/main/LICENSE
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include "layers/mlu/deepseek_v4/dsa_metadata_builder_mlu.h"
+
+#include <glog/logging.h>
+
+#include <algorithm>
+#include <cmath>
+#include <cstdint>
+#include <memory>
+#include <unordered_set>
+#include <vector>
+
+#include "framework/model/model_input_params.h"
+#include "layers/common/attention_metadata.h"
+#include "layers/common/attention_metadata_builder.h"
+#include "layers/common/dsa_metadata.h"
+#include "util/tensor_helper.h"
+
+namespace xllm::layer {
+
+namespace {
+
+constexpr int64_t kIndexC4Ratio = 4;
+
+void mask_stale_swa_slots(torch::Tensor& slots,
+                          const std::vector<int32_t>& ctx_lens,
+                          const std::vector<int32_t>& q_lens,
+                          int32_t batch_size) {
+  auto slots_acc = slots.accessor<int32_t, 1>();
+  int64_t start_idx = 0;
+  for (int32_t seq = 0; seq < batch_size; ++seq) {
+    const int64_t ctx_len = static_cast<int64_t>(ctx_lens[seq]);
+    const int64_t q_len =
+        std::clamp<int64_t>(static_cast<int64_t>(q_lens[seq]), 0, ctx_len);
+    std::unordered_set<int32_t> seen_slots;
+    seen_slots.reserve(static_cast<size_t>(q_len));
+
+    for (int64_t i = q_len; i > 0; --i) {
+      const int64_t slot_idx = start_idx + i - 1;
+      const int32_t slot = slots_acc[slot_idx];
+      if (slot < 0) {
+        continue;
+      }
+      auto inserted = seen_slots.emplace(slot);
+      if (!inserted.second) {
+        slots_acc[slot_idx] = -1;
+      }
+    }
+
+    start_idx += q_len;
+  }
+}
+
+std::vector<int32_t> tensor_to_vec(const torch::Tensor& tensor,
+                                   const char* name) {
+  CHECK(tensor.defined()) << "DSAMetadataBuilderMlu requires " << name << ".";
+  CHECK_EQ(tensor.dim(), 1)
+      << "DSAMetadataBuilderMlu expects " << name << " to be 1D.";
+  torch::Tensor cpu_tensor =
+      tensor.to(torch::kCPU).to(torch::kInt32).contiguous();
+  std::vector<int32_t> values;
+  values.reserve(static_cast<size_t>(cpu_tensor.numel()));
+  auto tensor_acc = cpu_tensor.accessor<int32_t, 1>();
+  for (int64_t idx = 0; idx < cpu_tensor.numel(); ++idx) {
+    values.emplace_back(tensor_acc[idx]);
+  }
+  return values;
+}
+
+void sync_dsa_seq_metadata(AttentionMetadata& attn_metadata,
+                           const DSAMetadata& dsa_metadata) {
+  attn_metadata.q_cu_seq_lens = dsa_metadata.q_cu_seq_lens;
+  attn_metadata.kv_cu_seq_lens = dsa_metadata.kv_cu_seq_lens;
+  attn_metadata.q_seq_lens = dsa_metadata.q_seq_lens;
+  attn_metadata.kv_seq_lens = dsa_metadata.kv_seq_lens;
+}
+
+torch::Tensor build_decode_slot_mapping(const torch::Tensor& cache_block_table,
+                                        const xllm::layer::DSAMetadata& dsa,
+                                        int64_t compress_ratio,
+                                        int64_t block_size,
+                                        const torch::Device& device) {
+  const int64_t batch_size = static_cast<int64_t>(dsa.start_pos_vec.size());
+  if (batch_size == 0 || !dsa.input_positions.defined() ||
+      dsa.input_positions.numel() == 0) {
+    return torch::empty(
+        {0}, torch::TensorOptions().dtype(torch::kInt32).device(device));
+  }
+  CHECK_EQ(static_cast<int64_t>(dsa.query_start_offsets.size()), batch_size + 1)
+      << "DSAMetadataBuilderMlu: query_start_offsets size must equal "
+         "batch_size + 1.";
+
+  std::vector<torch::Tensor> per_seq_slots;
+  per_seq_slots.reserve(static_cast<size_t>(batch_size));
+  for (int64_t seq_idx = 0; seq_idx < batch_size; ++seq_idx) {
+    const int64_t q_begin = dsa.query_start_offsets[seq_idx];
+    const int64_t q_end = dsa.query_start_offsets[seq_idx + 1];
+    if (q_end <= q_begin) {
+      continue;
+    }
+    torch::Tensor seq_positions = dsa.input_positions.slice(0, q_begin, q_end);
+    torch::Tensor compressed_row = seq_positions / compress_ratio;
+    torch::Tensor block_col =
+        (compressed_row / block_size).to(torch::kInt64).unsqueeze(0);
+    torch::Tensor block_offset = compressed_row % block_size;
+    torch::Tensor block_id =
+        cache_block_table[seq_idx].unsqueeze(0).gather(1, block_col).squeeze(0);
+    per_seq_slots.emplace_back(
+        (block_id * block_size + block_offset).to(torch::kInt32));
+  }
+  if (per_seq_slots.empty()) {
+    return torch::empty(
+        {0}, torch::TensorOptions().dtype(torch::kInt32).device(device));
+  }
+  return torch::cat(per_seq_slots, 0).to(device);
+}
+
+}  // namespace
+
+AttentionMetadata DSAMetadataBuilderMlu::build(
+    const ModelInputParams& params,
+    const torch::Tensor& positions,
+    const std::vector<std::vector<DSACacheInfo>>& caches_info,
+    const std::vector<DSAGroupInfo>& group_infos,
+    int64_t window_size) {
+  // 1. Build base AttentionMetadata (q_cu_seq_lens, block_table, etc.)
+  AttentionMetadata attn_metadata =
+      AttentionMetadataBuilder::build(params, /*enable_mla=*/true);
+
+  // 2. Keep DSA metadata independent while syncing base attention tensors.
+  auto dsa_metadata = std::make_shared<DSAMetadata>();
+  if (attn_metadata.is_dummy) {
+    attn_metadata.dsa_metadata = std::move(dsa_metadata);
+    return attn_metadata;
+  }
+
+  // 3. Build DSA-specific fields
+  build_dsa_fields(params,
+                   attn_metadata,
+                   positions,
+                   caches_info,
+                   group_infos,
+                   window_size,
+                   *dsa_metadata);
+
+  // 4. Sync canonical DSA sequence metadata to AttentionMetadata.
+  sync_dsa_seq_metadata(attn_metadata, *dsa_metadata);
+
+  // 5. Attach to AttentionMetadata
+  attn_metadata.dsa_metadata = std::move(dsa_metadata);
+
+  return attn_metadata;
+}
+
+void DSAMetadataBuilderMlu::build_dsa_fields(
+    const ModelInputParams& params,
+    const AttentionMetadata& attn_metadata,
+    const torch::Tensor& positions,
+    const std::vector<std::vector<DSACacheInfo>>& caches_info,
+    const std::vector<DSAGroupInfo>& group_infos,
+    int64_t window_size,
+    DSAMetadata& dsa) {
+  const bool is_decode = params.meta.batch_forward_type.is_decode();
+  const int32_t batch_size = params.meta.num_sequences;
+  std::vector<int32_t> q_lens_vec;
+  std::vector<int32_t> kv_lens_vec;
+
+  dsa.input_positions = positions;
+
+  // Build per-batch sequence length metadata.
+  build_seq_lengths(attn_metadata, batch_size, dsa, q_lens_vec, kv_lens_vec);
+  if (window_size > 0) {
+    build_swa_plan(dsa, q_lens_vec, window_size);
+  }
+
+  if (positions.defined()) {
+    build_positions(params, batch_size, dsa);
+  }
+
+  // --- Block tables / slots expansion ---
+  if (!params.multi_block_tables.empty() && !caches_info.empty()) {
+    std::vector<torch::Tensor> active_multi_block_tables =
+        params.multi_block_tables;
+    int32_t manager_num =
+        static_cast<int32_t>(active_multi_block_tables.size());
+    if (manager_num == 1 && batch_size == 1 &&
+        active_multi_block_tables[0].defined() &&
+        active_multi_block_tables[0].dim() == 2 &&
+        active_multi_block_tables[0].size(0) > 1 &&
+        static_cast<size_t>(active_multi_block_tables[0].size(0)) <=
+            group_infos.size()) {
+      const auto packed = active_multi_block_tables[0].contiguous();
+      std::vector<torch::Tensor> unpacked_tables;
+      unpacked_tables.reserve(packed.size(0));
+      for (int64_t m = 0; m < packed.size(0); ++m) {
+        unpacked_tables.push_back(packed[m].unsqueeze(0).contiguous());
+      }
+      active_multi_block_tables = std::move(unpacked_tables);
+      manager_num = static_cast<int32_t>(active_multi_block_tables.size());
+      LOG(WARNING)
+          << "DSAMetadataBuilderMlu detected packed multi_block_tables layout "
+          << "([manager, blocks]) while batch_size==1; auto-unpacked to "
+          << "[manager][batch, blocks]. manager_num=" << manager_num;
+    }
+
+    CHECK_LE(manager_num, static_cast<int32_t>(group_infos.size()))
+        << "DSAMetadataBuilderMlu: manager_num(" << manager_num
+        << ") exceeds group_infos size(" << group_infos.size()
+        << "), cannot align manager/group mapping.";
+    const int32_t n_layers = static_cast<int32_t>(caches_info.size());
+    const std::vector<int32_t>& ctx_lens = kv_lens_vec;
+    int64_t total_tokens = 0;
+    for (int32_t len : ctx_lens) {
+      total_tokens += static_cast<int64_t>(len);
+    }
+
+    std::vector<torch::Tensor> proc_slots(manager_num);
+    std::vector<torch::Tensor> proc_bt(manager_num);
+    for (int32_t m = 0; m < manager_num; ++m) {
+      process_group(active_multi_block_tables[m],
+                    group_infos[m],
+                    ctx_lens,
+                    q_lens_vec,
+                    batch_size,
+                    total_tokens,
+                    proc_bt[m],
+                    proc_slots[m]);
+    }
+
+    build_c128_meta(dsa, proc_bt, group_infos, batch_size);
+
+    // Metadata expansion uses CPU accessor paths. Move processed tables and
+    // slots back to model device once per forward for downstream MLU kernels.
+    const torch::Device target_device =
+        positions.defined() ? positions.device() : torch::Device(torch::kCPU);
+    if (!target_device.is_cpu()) {
+      for (int32_t m = 0; m < manager_num; ++m) {
+        if (proc_bt[m].defined() && proc_bt[m].device() != target_device) {
+          proc_bt[m] = safe_to(
+              proc_bt[m], proc_bt[m].options().device(target_device), true);
+        }
+        if (proc_slots[m].defined() &&
+            proc_slots[m].device() != target_device) {
+          proc_slots[m] = safe_to(proc_slots[m],
+                                  proc_slots[m].options().device(target_device),
+                                  true);
+        }
+      }
+    }
+
+    std::vector<torch::Tensor> decode_slots(manager_num);
+    if (is_decode) {
+      for (int32_t m = 0; m < manager_num; ++m) {
+        const int64_t ratio = static_cast<int64_t>(group_infos[m].ratio);
+        if (group_infos[m].type == DSACacheType::TOKEN && ratio > 1) {
+          decode_slots[m] = build_decode_slot_mapping(
+              proc_bt[m], dsa, ratio, group_infos[m].block_size, target_device);
+        }
+      }
+    }
+
+    // Step 3: expand by layer using group_id.
+    dsa.block_tables.resize(n_layers);
+    dsa.slot_mappings.resize(n_layers);
+    for (int32_t lid = 0; lid < n_layers; ++lid) {
+      const auto& lci = caches_info[lid];
+      dsa.block_tables[lid].resize(lci.size());
+      dsa.slot_mappings[lid].resize(lci.size());
+      for (size_t ci = 0; ci < lci.size(); ++ci) {
+        int32_t gid = lci[ci].group_id;
+        if (gid < manager_num) {
+          dsa.block_tables[lid][ci] = proc_bt[gid];
+          torch::Tensor slot_mapping = proc_slots[gid];
+          if (is_decode && lci[ci].type == DSACacheType::TOKEN &&
+              lci[ci].ratio > 1 && decode_slots[gid].defined()) {
+            slot_mapping = decode_slots[gid];
+          }
+          dsa.slot_mappings[lid][ci] = slot_mapping;
+        }
+      }
+    }
+  }
+
+  // Attach cache spec pointer
+  dsa.caches_info = &caches_info;
+}
+
+torch::Tensor DSAMetadataBuilderMlu::expand_blocks_to_slots(
+    const torch::Tensor& block_table,
+    const DSAGroupInfo& gi,
+    const std::vector<int32_t>& ctx_lens,
+    int32_t batch_size,
+    int64_t total_tokens) {
+  const int32_t bs = gi.block_size;
+  auto slots = torch::full({total_tokens}, -1, torch::kInt32);
+  auto slots_acc = slots.accessor<int32_t, 1>();
+  auto bt_acc = block_table.accessor<int32_t, 2>();
+  const int32_t max_blocks = block_table.size(1);
+
+  int64_t start_idx = 0;
+  for (int32_t seq = 0; seq < batch_size; ++seq) {
+    int64_t token_len = ctx_lens[seq];
+    int64_t slot_num = compute_slot_num(gi, token_len);
+
+    int64_t filled = 0;
+    for (int32_t blk = 0; blk < max_blocks && filled < slot_num; ++blk) {
+      int32_t block_id = bt_acc[seq][blk];
+      if (block_id < 0) break;
+      for (int32_t off = 0; off < bs && filled < slot_num; ++off) {
+        slots_acc[start_idx + filled] =
+            static_cast<int32_t>(static_cast<int64_t>(block_id) * bs + off);
+        ++filled;
+      }
+    }
+    start_idx += token_len;
+  }
+  return slots;
+}
+
+int64_t DSAMetadataBuilderMlu::compute_slot_num(const DSAGroupInfo& gi,
+                                                int64_t token_len) {
+  if (gi.type == DSACacheType::TOKEN) {
+    return token_len / gi.ratio;
+  }
+  // SLIDING_WINDOW
+  const int32_t bs = gi.block_size;
+  if (token_len > bs) {
+    return token_len % bs + bs;
+  }
+  int64_t n = token_len % bs;
+  return (n == 0 && token_len > 0) ? bs : n;
+}
+
+void DSAMetadataBuilderMlu::process_group(const torch::Tensor& raw_bt,
+                                          const DSAGroupInfo& gi,
+                                          const std::vector<int32_t>& ctx_lens,
+                                          const std::vector<int32_t>& q_lens,
+                                          int32_t batch_size,
+                                          int64_t total_tokens,
+                                          torch::Tensor& out_bt,
+                                          torch::Tensor& out_slots) {
+  if (gi.type == DSACacheType::TOKEN) {
+    process_token_group(raw_bt,
+                        gi.ratio,
+                        gi.block_size,
+                        ctx_lens,
+                        q_lens,
+                        batch_size,
+                        total_tokens,
+                        out_bt,
+                        out_slots);
+  } else if (gi.type == DSACacheType::SLIDING_WINDOW) {
+    process_swa_group(
+        raw_bt, gi.block_size, ctx_lens, q_lens, batch_size, out_bt, out_slots);
+  } else {
+    torch::Tensor raw_slots =
+        expand_blocks_to_slots(raw_bt, gi, ctx_lens, batch_size, total_tokens);
+    out_slots =
+        torch::where(raw_slots.eq(-1), torch::zeros_like(raw_slots), raw_slots);
+    out_bt = raw_bt;
+  }
+}
+
+void DSAMetadataBuilderMlu::process_token_group(
+    const torch::Tensor& raw_bt,
+    int32_t ratio,
+    int32_t block_size,
+    const std::vector<int32_t>& ctx_lens,
+    const std::vector<int32_t>& q_lens,
+    int32_t batch_size,
+    int64_t total_tokens,
+    torch::Tensor& out_bt,
+    torch::Tensor& out_slots) {
+  CHECK_EQ(static_cast<int32_t>(ctx_lens.size()), batch_size)
+      << "process_token_group requires ctx_lens.size == batch_size, got "
+      << ctx_lens.size() << " vs " << batch_size;
+  CHECK_EQ(static_cast<int32_t>(q_lens.size()), batch_size)
+      << "process_token_group requires q_lens.size == batch_size, got "
+      << q_lens.size() << " vs " << batch_size;
+  CHECK_GT(ratio, 0) << "process_token_group requires ratio > 0, got " << ratio;
+  CHECK_GT(block_size, 0) << "process_token_group requires block_size > 0, got "
+                          << block_size;
+  CHECK_EQ(raw_bt.dim(), 2)
+      << "process_token_group requires raw_bt dim == 2, got " << raw_bt.dim();
+
+  int64_t query_total_tokens = 0;
+  for (const int32_t q_len : q_lens) {
+    query_total_tokens += static_cast<int64_t>(q_len);
+  }
+
+  // Token caches commit one row only when a sequence crosses a compression
+  // boundary. Count rows per sequence so multi-batch padding/dummy rows do not
+  // become cache writes.
+  int64_t committed_rows = 0;
+  for (int32_t seq = 0; seq < batch_size; ++seq) {
+    const int64_t ctx_len = static_cast<int64_t>(ctx_lens[seq]);
+    const int64_t q_len =
+        std::clamp<int64_t>(static_cast<int64_t>(q_lens[seq]), 0, ctx_len);
+    const int64_t prev_ctx_len = ctx_len - q_len;
+    committed_rows += ctx_len / ratio - prev_ctx_len / ratio;
+  }
+
+  // Token caches write only the compressed rows produced by the current
+  // forward step. Padded RoPE/compressor rows must not become cache writes.
+  auto out_slots_tensor = torch::full({committed_rows}, -1, raw_bt.options());
+  auto out_slots_acc = out_slots_tensor.accessor<int32_t, 1>();
+  auto raw_bt_acc = raw_bt.accessor<int32_t, 2>();
+  const int64_t max_blocks = raw_bt.size(1);
+  const int64_t block_size_i64 = static_cast<int64_t>(block_size);
+
+  auto slot_for_compressed_index = [&](int32_t seq,
+                                       int64_t compressed_idx) -> int32_t {
+    if (max_blocks <= 0) {
+      return -1;
+    }
+    const int64_t block_idx = compressed_idx / block_size_i64;
+    if (block_idx >= max_blocks) {
+      return -1;
+    }
+    const int32_t block_id = raw_bt_acc[seq][block_idx];
+    if (block_id < 0) {
+      return -1;
+    }
+    const int64_t block_offset = compressed_idx % block_size_i64;
+    return static_cast<int32_t>(
+        static_cast<int64_t>(block_id) * block_size_i64 + block_offset);
+  };
+
+  int64_t write_idx = 0;
+  for (int32_t seq = 0; seq < batch_size; ++seq) {
+    const int64_t ctx_len = static_cast<int64_t>(ctx_lens[seq]);
+    const int64_t q_len =
+        std::clamp<int64_t>(static_cast<int64_t>(q_lens[seq]), 0, ctx_len);
+    const int64_t prev_ctx_len = ctx_len - q_len;
+    const int64_t prev_committed = prev_ctx_len / ratio;
+    const int64_t committed = ctx_len / ratio;
+    const int64_t new_committed = committed - prev_committed;
+    for (int64_t i = 0; i < new_committed; ++i) {
+      out_slots_acc[write_idx++] =
+          slot_for_compressed_index(seq, prev_committed + i);
+    }
+  }
+
+  CHECK_EQ(write_idx, committed_rows)
+      << "process_token_group committed slot count mismatch: write_idx="
+      << write_idx << ", committed_rows=" << committed_rows
+      << ", query_total_tokens=" << query_total_tokens << ", ratio=" << ratio
+      << ", batch_size=" << batch_size << ", total_tokens=" << total_tokens;
+  out_slots = out_slots_tensor;
+  out_bt = raw_bt;  // keep original right-padded block_tables
+}
+
+void DSAMetadataBuilderMlu::process_swa_group(
+    const torch::Tensor& raw_bt,
+    int32_t block_size,
+    const std::vector<int32_t>& ctx_lens,
+    const std::vector<int32_t>& q_lens,
+    int32_t batch_size,
+    torch::Tensor& out_bt,
+    torch::Tensor& out_slots) {
+  CHECK_EQ(static_cast<int32_t>(ctx_lens.size()), batch_size)
+      << "process_swa_group requires ctx_lens.size == batch_size, got "
+      << ctx_lens.size() << " vs " << batch_size;
+  CHECK_EQ(static_cast<int32_t>(q_lens.size()), batch_size)
+      << "process_swa_group requires q_lens.size == batch_size, got "
+      << q_lens.size() << " vs " << batch_size;
+  CHECK_GT(block_size, 0) << "process_swa_group requires block_size > 0, got "
+                          << block_size;
+  CHECK_EQ(raw_bt.dim(), 2)
+      << "process_swa_group requires raw_bt dim == 2, got " << raw_bt.dim();
+
+  int64_t query_total_tokens = 0;
+  for (int32_t seq = 0; seq < batch_size; ++seq) {
+    query_total_tokens += std::clamp<int64_t>(
+        static_cast<int64_t>(q_lens[seq]), 0, ctx_lens[seq]);
+  }
+
+  // SWA cache writes only the tokens produced by the current forward step.
+  // Decode has one kv row; prefix slot 0 would incorrectly overwrite cache row
+  // 0.
+  auto out_slots_tensor =
+      torch::full({query_total_tokens}, -1, raw_bt.options());
+  auto out_slots_acc = out_slots_tensor.accessor<int32_t, 1>();
+  auto raw_bt_acc = raw_bt.accessor<int32_t, 2>();
+  const int64_t max_blocks = raw_bt.size(1);
+  const int64_t block_size_i64 = static_cast<int64_t>(block_size);
+
+  auto slot_for_position = [&](int32_t seq, int64_t pos) -> int32_t {
+    if (max_blocks <= 0) {
+      return -1;
+    }
+    const int64_t block_idx = (pos / block_size_i64) % max_blocks;
+    const int32_t block_id = raw_bt_acc[seq][block_idx];
+    if (block_id < 0) {
+      return -1;
+    }
+    const int64_t block_offset = pos % block_size_i64;
+    return static_cast<int32_t>(
+        static_cast<int64_t>(block_id) * block_size_i64 + block_offset);
+  };
+
+  int64_t write_idx = 0;
+  for (int32_t seq = 0; seq < batch_size; ++seq) {
+    const int64_t ctx_len = static_cast<int64_t>(ctx_lens[seq]);
+    const int64_t q_len =
+        std::clamp<int64_t>(static_cast<int64_t>(q_lens[seq]), 0, ctx_len);
+    const int64_t q_start = ctx_len - q_len;
+    for (int64_t i = 0; i < q_len; ++i) {
+      out_slots_acc[write_idx++] = slot_for_position(seq, q_start + i);
+    }
+  }
+
+  mask_stale_swa_slots(out_slots_tensor, ctx_lens, q_lens, batch_size);
+  out_slots = out_slots_tensor;
+
+  int32_t current_cols = raw_bt.size(1);
+  int32_t max_dst_len = 0;
+  std::vector<int32_t> dst_lens(batch_size);
+  for (int32_t s = 0; s < batch_size; ++s) {
+    dst_lens[s] = static_cast<int32_t>(
+        std::ceil(static_cast<double>(ctx_lens[s]) / block_size));
+    max_dst_len = std::max(max_dst_len, dst_lens[s]);
+  }
+  max_dst_len = std::max(max_dst_len, current_cols);
+
+  auto new_bt = torch::full({batch_size, max_dst_len}, -1, raw_bt.options());
+  auto new_acc = new_bt.accessor<int32_t, 2>();
+  auto old_acc = raw_bt.accessor<int32_t, 2>();
+
+  for (int32_t s = 0; s < batch_size; ++s) {
+    const int32_t retained_cols = std::min(current_cols, dst_lens[s]);
+    const int32_t start_col = dst_lens[s] - retained_cols;
+    for (int32_t j = 0; j < retained_cols; ++j) {
+      const int32_t logical_col = start_col + j;
+      // Keep the read-side block table aligned with slot_for_position().
+      const int32_t physical_col = logical_col % current_cols;
+      new_acc[s][logical_col] = old_acc[s][physical_col];
+    }
+  }
+  out_bt = new_bt;
+}
+
+void DSAMetadataBuilderMlu::build_c128_meta(
+    DSAMetadata& dsa_metadata,
+    const std::vector<torch::Tensor>& proc_bt,
+    const std::vector<DSAGroupInfo>& group_infos,
+    int32_t batch_size) {
+  const int32_t manager_num = static_cast<int32_t>(proc_bt.size());
+  int32_t c128_gid = -1;
+  for (int32_t gid = 0; gid < static_cast<int32_t>(group_infos.size()); ++gid) {
+    if (group_infos[gid].type == DSACacheType::TOKEN &&
+        group_infos[gid].ratio == 128) {
+      c128_gid = gid;
+      break;
+    }
+  }
+  if (c128_gid < 0) {
+    return;
+  }
+
+  CHECK_LT(c128_gid, manager_num)
+      << "DSAMetadataBuilderMlu: c128 group id exceeds processed block tables.";
+  const DSAGroupInfo& c128_group = group_infos[c128_gid];
+  const torch::Tensor& block_table = proc_bt[c128_gid];
+  const int32_t block_size = c128_group.block_size;
+
+  const int64_t total_tokens = dsa_metadata.query_start_offsets.back();
+  int64_t max_context_len = 0;
+  for (int32_t seq_idx = 0; seq_idx < batch_size; ++seq_idx) {
+    const int64_t q_begin = dsa_metadata.query_start_offsets[seq_idx];
+    const int64_t q_end = dsa_metadata.query_start_offsets[seq_idx + 1];
+    const int64_t q_len = q_end - q_begin;
+    if (q_len > 0) {
+      const int64_t last_context_len =
+          (dsa_metadata.start_pos_vec[seq_idx] + q_len) / 128;
+      max_context_len = std::max(max_context_len, last_context_len);
+    }
+  }
+
+  const torch::TensorOptions int_options =
+      torch::TensorOptions().dtype(torch::kInt32);
+  const int64_t table_cols =
+      std::max<int64_t>((max_context_len + block_size - 1) / block_size, 1);
+  torch::Tensor table =
+      torch::full({total_tokens, table_cols}, -1, int_options);
+  torch::Tensor src =
+      block_table.to(torch::kCPU).to(torch::kInt32).contiguous();
+  auto table_acc = table.accessor<int32_t, 2>();
+  auto src_acc = src.accessor<int32_t, 2>();
+
+  std::vector<int32_t> context_lens;
+  context_lens.reserve(static_cast<size_t>(total_tokens));
+  int64_t row = 0;
+  for (int32_t seq_idx = 0; seq_idx < batch_size; ++seq_idx) {
+    const int64_t q_len = dsa_metadata.query_start_offsets[seq_idx + 1] -
+                          dsa_metadata.query_start_offsets[seq_idx];
+    for (int64_t token_idx = 0; token_idx < q_len; ++token_idx) {
+      const int64_t context_len =
+          (dsa_metadata.start_pos_vec[seq_idx] + token_idx + 1) / 128;
+      context_lens.emplace_back(static_cast<int32_t>(context_len));
+      const int64_t blocks = (context_len + block_size - 1) / block_size;
+      const int64_t cols = std::min<int64_t>(blocks, src.size(1));
+      for (int64_t col = 0; col < cols; ++col) {
+        table_acc[row][col] = src_acc[seq_idx][col];
+      }
+      ++row;
+    }
+  }
+  dsa_metadata.c128_attn_metadata.context_lens =
+      torch::tensor(context_lens, int_options);
+  dsa_metadata.c128_attn_metadata.max_context_len = max_context_len;
+  dsa_metadata.c128_attn_metadata.block_table_for_attn = table;
+}
+
+void DSAMetadataBuilderMlu::build_seq_lengths(
+    const AttentionMetadata& attn_metadata,
+    int32_t batch_size,
+    DSAMetadata& dsa_metadata,
+    std::vector<int32_t>& q_lens_vec,
+    std::vector<int32_t>& kv_lens_vec) {
+  std::vector<int32_t> q_cu_lens_vec;
+  std::vector<int32_t> kv_cu_lens_vec;
+  torch::Tensor q_cu_lens;
+  torch::Tensor kv_cu_lens;
+  torch::Tensor q_lens;
+  torch::Tensor kv_lens;
+
+  q_cu_lens_vec = tensor_to_vec(attn_metadata.q_cu_seq_lens, "q_cu_seq_lens");
+  kv_cu_lens_vec =
+      tensor_to_vec(attn_metadata.kv_cu_seq_lens, "kv_cu_seq_lens");
+  q_lens_vec = tensor_to_vec(attn_metadata.q_seq_lens, "q_seq_lens");
+  kv_lens_vec = tensor_to_vec(attn_metadata.kv_seq_lens, "kv_seq_lens");
+
+  q_cu_lens = attn_metadata.q_cu_seq_lens.to(torch::kInt32).contiguous();
+  kv_cu_lens = attn_metadata.kv_cu_seq_lens.to(torch::kInt32).contiguous();
+  q_lens = attn_metadata.q_seq_lens.to(torch::kInt32).contiguous();
+  kv_lens = attn_metadata.kv_seq_lens.to(torch::kInt32).contiguous();
+
+  std::vector<int32_t> index_c4_lens_vec;
+  index_c4_lens_vec.reserve(static_cast<size_t>(batch_size));
+  dsa_metadata.index_total_c4_len = 0;
+  dsa_metadata.index_max_c4_len = 0;
+  for (int32_t seq_idx = 0; seq_idx < batch_size; ++seq_idx) {
+    const int64_t q_len = static_cast<int64_t>(q_lens_vec[seq_idx]);
+    const int64_t kv_len = static_cast<int64_t>(kv_lens_vec[seq_idx]);
+    CHECK_GE(q_len, 0) << "DSAMetadataBuilderMlu: q_len must be non-negative.";
+    CHECK_GE(kv_len, q_len)
+        << "DSAMetadataBuilderMlu: kv_len must be >= q_len.";
+    const int64_t c4_len = kv_len / kIndexC4Ratio;
+    dsa_metadata.index_total_c4_len += c4_len;
+    dsa_metadata.index_max_c4_len =
+        std::max(dsa_metadata.index_max_c4_len, c4_len);
+    index_c4_lens_vec.emplace_back(static_cast<int32_t>(c4_len));
+  }
+
+  torch::Tensor index_c4_lens = torch::tensor(index_c4_lens_vec, torch::kInt32);
+
+  dsa_metadata.q_cu_seq_lens = q_cu_lens;
+  dsa_metadata.kv_cu_seq_lens = kv_cu_lens;
+  dsa_metadata.q_seq_lens = q_lens;
+  dsa_metadata.kv_seq_lens = kv_lens;
+  dsa_metadata.index_c4_seq_lens = index_c4_lens;
+  dsa_metadata.seq_lens = kv_lens;
+  dsa_metadata.actual_seq_lengths_kv = kv_lens;
+
+  dsa_metadata.query_start_offsets.clear();
+  dsa_metadata.query_start_offsets.reserve(static_cast<size_t>(batch_size) + 1);
+  dsa_metadata.query_start_offsets.emplace_back(0);
+  dsa_metadata.start_pos_vec.clear();
+  dsa_metadata.start_pos_vec.reserve(static_cast<size_t>(batch_size));
+  int64_t query_offset = 0;
+  for (int32_t seq_idx = 0; seq_idx < batch_size; ++seq_idx) {
+    const int64_t q_len = static_cast<int64_t>(q_lens_vec[seq_idx]);
+    const int64_t kv_len = static_cast<int64_t>(kv_lens_vec[seq_idx]);
+    query_offset += q_len;
+    dsa_metadata.query_start_offsets.emplace_back(query_offset);
+    dsa_metadata.start_pos_vec.emplace_back(kv_len - q_len);
+  }
+
+  // cumsum with leading 0: shape (batch_size+1,)
+  dsa_metadata.actual_seq_lengths_query = q_cu_lens;
+  dsa_metadata.seq_lens_q = q_lens;
+
+  auto int_options = torch::TensorOptions().dtype(torch::kInt32);
+  if (kv_lens.numel() > 0) {
+    dsa_metadata.max_seqlen_kv = torch::max(kv_lens).to(torch::kInt32);
+  } else {
+    dsa_metadata.max_seqlen_kv = torch::zeros({1}, int_options);
+  }
+
+  if (q_lens.numel() > 0) {
+    dsa_metadata.max_seqlen_q = torch::max(q_lens).to(torch::kInt32);
+  } else {
+    dsa_metadata.max_seqlen_q = torch::zeros({1}, int_options);
+  }
+}
+
+void DSAMetadataBuilderMlu::build_swa_plan(
+    DSAMetadata& dsa_metadata,
+    const std::vector<int32_t>& q_lens_vec,
+    int64_t window_size) {
+  const int64_t batch_size =
+      static_cast<int64_t>(dsa_metadata.start_pos_vec.size());
+  CHECK_EQ(static_cast<int64_t>(q_lens_vec.size()), batch_size)
+      << "DSAMetadataBuilderMlu: q_lens size must match start_pos size.";
+
+  std::vector<int32_t> history_lens;
+  std::vector<int32_t> context_lens;
+  history_lens.reserve(static_cast<size_t>(batch_size));
+  context_lens.reserve(
+      static_cast<size_t>(dsa_metadata.query_start_offsets.back()));
+  dsa_metadata.swa_start_pos_vec.clear();
+  dsa_metadata.swa_start_pos_vec.reserve(static_cast<size_t>(batch_size));
+  dsa_metadata.swa_max_history_len = 0;
+  dsa_metadata.swa_max_context_len = 0;
+
+  const bool has_window = window_size > 0;
+  const int64_t window_left =
+      has_window ? std::max<int64_t>(window_size - 1, 0) : 0;
+  for (int64_t seq_idx = 0; seq_idx < batch_size; ++seq_idx) {
+    const int64_t start_pos = dsa_metadata.start_pos_vec[seq_idx];
+    const int64_t swa_start =
+        has_window ? std::max<int64_t>(0, start_pos - window_left) : 0;
+    const int64_t history_len = start_pos - swa_start;
+    dsa_metadata.swa_start_pos_vec.emplace_back(swa_start);
+    history_lens.emplace_back(static_cast<int32_t>(history_len));
+    dsa_metadata.swa_max_history_len =
+        std::max(dsa_metadata.swa_max_history_len, history_len);
+
+    const int64_t q_len = static_cast<int64_t>(q_lens_vec[seq_idx]);
+    for (int64_t token_idx = 0; token_idx < q_len; ++token_idx) {
+      const int64_t token_abs_pos = start_pos + token_idx;
+      const int64_t context_len = token_abs_pos - swa_start + 1;
+      context_lens.emplace_back(static_cast<int32_t>(context_len));
+      dsa_metadata.swa_max_context_len =
+          std::max(dsa_metadata.swa_max_context_len, context_len);
+    }
+  }
+
+  dsa_metadata.swa_history_lens =
+      torch::tensor(history_lens, torch::TensorOptions().dtype(torch::kInt32));
+  dsa_metadata.swa_context_lens =
+      torch::tensor(context_lens, torch::TensorOptions().dtype(torch::kInt32));
+}
+
+void DSAMetadataBuilderMlu::build_positions(const ModelInputParams& params,
+                                            int32_t batch_size,
+                                            DSAMetadata& dsa_metadata) {
+  (void)params;
+  if (!dsa_metadata.input_positions.defined()) return;
+
+  auto input_positions = dsa_metadata.input_positions;
+  int64_t num_tokens = input_positions.size(0);
+
+  // C4 compressed positions
+  auto c4_mask = ((input_positions + 1) % 4).eq(0);
+  auto c4_pos = input_positions.index({c4_mask});
+  c4_pos = (c4_pos + 1) - 4;
+  int64_t c4_target = std::min(num_tokens, num_tokens / 4 + batch_size);
+  int64_t c4_pad_right = c4_target - c4_pos.size(0);
+  if (c4_pad_right > 0) {
+    dsa_metadata.c4_pad_positions =
+        torch::cat({c4_pos, torch::zeros({c4_pad_right}, c4_pos.options())});
+  } else {
+    dsa_metadata.c4_pad_positions = c4_pos.slice(0, 0, c4_target);
+  }
+
+  // C128 compressed positions
+  auto c128_mask = ((input_positions + 1) % 128).eq(0);
+  auto c128_pos = input_positions.index({c128_mask});
+  c128_pos = (c128_pos + 1) - 128;
+  int64_t c128_target = std::min(num_tokens, num_tokens / 128 + batch_size);
+  int64_t c128_pad_right = c128_target - c128_pos.size(0);
+  if (c128_pad_right > 0) {
+    dsa_metadata.c128_pad_positions = torch::cat(
+        {c128_pos, torch::zeros({c128_pad_right}, c128_pos.options())});
+  } else {
+    dsa_metadata.c128_pad_positions = c128_pos.slice(0, 0, c128_target);
+  }
+}
+
+}  // namespace xllm::layer

--- a/xllm/core/layers/mlu/deepseek_v4/dsa_metadata_builder_mlu.h
+++ b/xllm/core/layers/mlu/deepseek_v4/dsa_metadata_builder_mlu.h
@@ -17,6 +17,7 @@ limitations under the License.
 
 #include <torch/torch.h>
 
+#include <cstdint>
 #include <vector>
 
 namespace xllm {
@@ -29,41 +30,25 @@ namespace layer {
 struct AttentionMetadata;
 struct DSAMetadata;
 
-// Builder class for DSAMetadata.
-// Builds a complete AttentionMetadata (with dsa_metadata populated) from
-// ModelInputParams and model-specific data.  This replaces the need for a
-// separate AttentionMetadataBuilder::build() call in DeepSeek V4.
-class DSAMetadataBuilder {
+// MLU DeepSeek V4 builder for DSAMetadata.
+class DSAMetadataBuilderMlu final {
  public:
-  // Build a complete AttentionMetadata with DSAMetadata populated inside.
-  // Internally constructs the base AttentionMetadata fields (q_cu_seq_lens,
-  // block_table, slot_mapping, etc.) and the DSA-specific fields (RoPE,
-  // block tables, slot mappings, sequence lengths, compressed positions).
-  //
-  //   params: batch-level model input params
-  //   positions: token position IDs tensor
-  //   dsa_cos_sin: precomputed RoPE cos/sin table (optional, can be undefined)
-  //   caches_info: per-layer cache specs [layer_id][cache_idx]
-  //   group_infos: per-group info [group_id]
   static AttentionMetadata build(
       const ModelInputParams& params,
       const torch::Tensor& positions,
-      const torch::Tensor& dsa_cos_sin,
       const std::vector<std::vector<DSACacheInfo>>& caches_info,
       const std::vector<DSAGroupInfo>& group_infos,
-      const torch::Tensor& dsa_c4_cos_sin = torch::Tensor(),
-      const torch::Tensor& dsa_c128_cos_sin = torch::Tensor());
+      int64_t window_size);
 
  private:
   // Build DSA-specific fields into dsa_metadata.
   static void build_dsa_fields(
       const ModelInputParams& params,
+      const AttentionMetadata& attn_metadata,
       const torch::Tensor& positions,
-      const torch::Tensor& dsa_cos_sin,
-      const torch::Tensor& dsa_c4_cos_sin,
-      const torch::Tensor& dsa_c128_cos_sin,
       const std::vector<std::vector<DSACacheInfo>>& caches_info,
       const std::vector<DSAGroupInfo>& group_infos,
+      int64_t window_size,
       DSAMetadata& dsa_metadata);
 
   // Step 1: expand block_table to slot array for one manager.
@@ -77,15 +62,13 @@ class DSAMetadataBuilder {
   // Compute how many slots a single seq needs for this group.
   static int64_t compute_slot_num(const DSAGroupInfo& gi, int64_t token_len);
 
-  // Step 2: per-group processing.
+  // Per-group processing.
   static void process_group(const torch::Tensor& raw_bt,
                             const DSAGroupInfo& gi,
                             const std::vector<int32_t>& ctx_lens,
                             const std::vector<int32_t>& q_lens,
                             int32_t batch_size,
                             int64_t total_tokens,
-                            int64_t graph_slot_capacity,
-                            int32_t block_table_capacity_cols,
                             torch::Tensor& out_bt,
                             torch::Tensor& out_slots);
 
@@ -96,8 +79,6 @@ class DSAMetadataBuilder {
                                   const std::vector<int32_t>& q_lens,
                                   int32_t batch_size,
                                   int64_t total_tokens,
-                                  int64_t graph_slot_capacity,
-                                  int32_t block_table_capacity_cols,
                                   torch::Tensor& out_bt,
                                   torch::Tensor& out_slots);
 
@@ -106,22 +87,29 @@ class DSAMetadataBuilder {
                                 const std::vector<int32_t>& ctx_lens,
                                 const std::vector<int32_t>& q_lens,
                                 int32_t batch_size,
-                                int64_t graph_slot_capacity,
-                                int32_t block_table_capacity_cols,
                                 torch::Tensor& out_bt,
                                 torch::Tensor& out_slots);
 
-  // Build actual_seq_lengths_kv and actual_seq_lengths_query.
-  static void build_seq_lengths(const ModelInputParams& params,
-                                const torch::Device& target_device,
+  static void build_c128_meta(DSAMetadata& dsa_metadata,
+                              const std::vector<torch::Tensor>& proc_bt,
+                              const std::vector<DSAGroupInfo>& group_infos,
+                              int32_t batch_size);
+
+  // Build sequence length tensors and host-side MLU batch metadata.
+  static void build_seq_lengths(const AttentionMetadata& attn_metadata,
                                 int32_t batch_size,
-                                DSAMetadata& dsa_metadata);
+                                DSAMetadata& dsa_metadata,
+                                std::vector<int32_t>& q_lens_vec,
+                                std::vector<int32_t>& kv_lens_vec);
+
+  static void build_swa_plan(DSAMetadata& dsa_metadata,
+                             const std::vector<int32_t>& q_lens_vec,
+                             int64_t window_size);
 
   // Build input_positions, c4_pad_positions, c128_pad_positions.
   static void build_positions(const ModelInputParams& params,
                               int32_t batch_size,
                               DSAMetadata& dsa_metadata);
 };
-
 }  // namespace layer
 }  // namespace xllm


### PR DESCRIPTION
## Description

  This PR adds MLU support for DeepSeek V4 DSA metadata construction.

  The changes introduce an MLU-specific `DSAMetadataBuilderMlu` that builds canonical q/kv sequence metadata, SWA
  planning metadata, compressed position metadata, block table expansion, slot mappings, and ratio-128 compressed
  attention metadata for DeepSeek V4. It also adds the required MLU DSA cache mapping structure and extends shared DSA
  metadata fields for MLU execution.

  This PR also updates DeepSeek V4 KV cache allocation to use the MLU-specific 4D cache layout, wires the new MLU
  layer files into CMake, and exposes the related MLU kernel APIs needed by the DeepSeek V4 path, including
  compression, hyper-connection, softplus top-k routing, and extended attention/indexer parameters.

  Unit coverage is added for the new MLU metadata builder and expanded for DeepSeek V4 KV cache tensor layouts.

  ## Related Issues

  N/A

  ## Change Type

  - [ ] Bug fix
  - [x] New feature
  - [ ] Performance improvement
  - [ ] Refactor
  - [ ] Documentation
  - [x] Test
  - [x] Build or CI

  ## Pull Request Checklist

  Thank you for contributing to xLLM. Before requesting review, please make sure the following items are complete.

  ### PR Title and Commit Messages

  - [x] The PR title and each commit message follow the xLLM commit format: `<type>: <subject>`.

  > Allowed types: feat, bugfix, docs, test, refactor, chore, style, revert, perf, model, build, release.
  > The subject should use clear English, start with a verb, include at least 4 words, and end with `.`.

  ### Pre-commit Checks

  - [x] I have installed `pre-commit` by running `pip install pre-commit` or an equivalent command.
  - [x] I have installed the hooks with `pre-commit install`.
  - [x] I have run `pre-commit run --all-files` and fixed any reported issues.

  > If you are unsure how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

  ### Self Review

  - [x] I have self-reviewed the code according to `.agents/skills/code-review/references/custom-code-style.md`,
  especially code written or assisted by AI.
  - [ ] I have rebased this PR onto the latest `main` branch.

  ### Build and Test Coverage

  - [x] Tests have been added or updated as needed.
  - [ ] CUDA: `python setup.py build test` has passed on a CUDA machine.
  - [x] NPU: `python setup.py build test` has passed on an NPU machine.
  - [x] MLU: `python setup.py build test` has passed on an MLU machine.

  ## Reviewer Notes

  Please focus review on the MLU-specific DeepSeek V4 DSA metadata construction, especially q/kv sequence length
  derivation, SWA window planning, compressed slot mappings, ratio-128 attention metadata, and the MLU KV cache tensor
  layout.

  Validation not run in this session: pre-commit and device build/test results should be filled in after running them
  on the corresponding machines.
