### PR TITLE
bugfix: crash when MTP with schedule overlap on Qwen3.5.

### DIFF
--- a/xllm/core/runtime/speculative_worker_impl.cpp
+++ b/xllm/core/runtime/speculative_worker_impl.cpp
@@ -315,9 +315,14 @@ void SpeculativeWorkerImpl::prepare_work_before_execute(
 
 folly::SemiFuture<std::optional<ForwardOutput>>
 SpeculativeWorkerImpl::step_async(const ForwardInput& input) {
+  ForwardInput input_on_device;
+  prepare_work_before_execute(input, input_on_device);
+
   folly::Promise<std::optional<ForwardOutput>> promise;
   auto future = promise.getSemiFuture();
-  threadpool_.schedule([this, input, promise = std::move(promise)]() mutable {
+  threadpool_.schedule([this,
+                        input = std::move(input_on_device),
+                        promise = std::move(promise)]() mutable {
     ForwardInput step_input = input;
     if (enable_schedule_overlap() && last_step_output_valid_ &&
         step_input.token_ids.numel() > 0 &&

--- a/xllm/core/runtime/worker_impl.cpp
+++ b/xllm/core/runtime/worker_impl.cpp
@@ -567,7 +567,8 @@ void WorkerImpl::prepare_work_before_execute(const ForwardInput& input,
       }
     }
 
-    if (has_linear_attention_layers(context_.get_model_args())) {
+    if (has_linear_attention_layers(context_.get_model_args()) &&
+        linear_state_checkpoint_mgr_ != nullptr) {
       prepare_input_params_for_linear_attention(processed_input.input_params);
       linear_state_checkpoint_mgr_->evict(
           processed_input.input_params.linear_state_evict_prefix_hashes);


### PR DESCRIPTION
## Description
SpeculativeWorkerImpl::step_async (added in 3c7b8adc) skipped calling prepare_work_before_execute, causing input tensors to not be moved to device. Additionally, WorkerImpl::prepare_work_before_execute assumed linear_state_checkpoint_mgr_ was always non-null, which crashes for the outer speculative worker that doesn't own KV caches.

- Add null check for linear_state_checkpoint_mgr_ in prepare_work_before_execute
- Add prepare_work_before_execute call in SpeculativeWorkerImpl::step_async

### Build and Test Coverage

- [x] Tests have been added or updated as needed.
- [ ] CUDA: `python setup.py build test` has passed on a CUDA machine.
- [x] NPU: `python setup.py build test` has passed on an NPU machine.
- [ ] MLU: `python setup.py build test` has passed on an MLU machine.

<img width="873" height="504" alt="image" src="https://github.com/user-attachments/assets/afe6f683-b1c5-4e5a-8605-557ab23f185e" />

