### PR TITLE
bugfix: keep padding slot 0 reserved in single block manager.

### DIFF
--- a/xllm/core/framework/block/block_manager_test.cpp
+++ b/xllm/core/framework/block/block_manager_test.cpp
@@ -209,7 +209,7 @@ TEST(BlockManagerPoolTest, AllocateAssignsSingleBlockWhenEnabled) {
   Sequence seq = MakeSequence(0, /*prompt_tokens=*/{1, 2, 3});
   EXPECT_TRUE(pool.allocate(&seq));
   EXPECT_TRUE(seq.has_single_block_id());
-  EXPECT_GE(seq.get_single_block_id(), 0);
+  EXPECT_GT(seq.get_single_block_id(), 0);
 }
 
 TEST(BlockManagerPoolTest, DeallocateReleasesSingleBlockId) {
@@ -234,14 +234,14 @@ TEST(BlockManagerPoolTest, DeallocateReleasesSingleBlockId) {
 }
 
 TEST(BlockManagerPoolTest, TryAllocateKvFailureRollsBackSingleBlock) {
-  // unified scheduler-side single-block pool has 2 ids.
   ScopedValue<int32_t> max_seqs_guard(&FLAGS_max_seqs_per_batch, 0);
 
   BlockManagerPool::Options options;
   options.num_blocks(3).host_num_blocks(0).block_size(1).enable_prefix_cache(
       false);
-  options.single_block_capacity(FLAGS_max_seqs_per_batch + 2)
-      .enable_linear_state(true);
+  // id 0 is reserved for padding, so capacity 3 exposes 2 usable single-block
+  // ids, enough for the two sequences allocated after the rollback.
+  options.single_block_capacity(3).enable_linear_state(true);
   BlockManagerPool pool(options, /*dp_size=*/1);
 
   // This sequence needs far more KV blocks than available, forcing KV failure
@@ -265,10 +265,11 @@ TEST(BlockManagerPoolTest, SingleBlockCapacityCanBeLowerThanMaxSeqs) {
   ScopedValue<int32_t> max_seqs_guard(&FLAGS_max_seqs_per_batch, 8);
 
   BlockManagerPool::Options options;
+  // id 0 is reserved for padding, so capacity 4 exposes 3 usable single blocks.
   options.num_blocks(16)
       .host_num_blocks(0)
       .block_size(1)
-      .single_block_capacity(3)
+      .single_block_capacity(4)
       .enable_prefix_cache(false);
   options.enable_linear_state(true);
   BlockManagerPool pool(options, /*dp_size=*/1);
@@ -293,10 +294,12 @@ TEST(BlockManagerPoolTest, DpRankSelectionSkipsExhaustedSingleBlockPool) {
   ScopedValue<int32_t> max_seqs_guard(&FLAGS_max_seqs_per_batch, 8);
 
   BlockManagerPool::Options options;
+  // id 0 is reserved for padding, so capacity 2 exposes 1 usable block per
+  // rank.
   options.num_blocks(16)
       .host_num_blocks(0)
       .block_size(1)
-      .single_block_capacity(1)
+      .single_block_capacity(2)
       .enable_prefix_cache(false);
   options.enable_linear_state(true);
   BlockManagerPool pool(options, /*dp_size=*/2);
@@ -314,10 +317,12 @@ TEST(BlockManagerPoolTest, SingleBlockExhaustionBehavesLikeKvBlockExhaustion) {
   ScopedValue<int32_t> max_seqs_guard(&FLAGS_max_seqs_per_batch, 8);
 
   BlockManagerPool::Options options;
+  // id 0 is reserved for padding, so capacity 2 exposes 1 usable block per
+  // rank.
   options.num_blocks(16)
       .host_num_blocks(0)
       .block_size(1)
-      .single_block_capacity(1)
+      .single_block_capacity(2)
       .enable_prefix_cache(false);
   options.enable_linear_state(true);
   BlockManagerPool pool(options, /*dp_size=*/2);

--- a/xllm/core/framework/block/single_block_manager.cpp
+++ b/xllm/core/framework/block/single_block_manager.cpp
@@ -41,13 +41,31 @@ SingleBlockManager::SingleBlockManager(uint32_t num_blocks,
       resource_name_(std::move(resource_name)),
       exhaustion_message_(std::move(exhaustion_message)) {
   CHECK_GT(num_blocks, 0) << "No blocks to allocate";
+  // Reserve id 0 as the padding slot, matching BlockManagerImpl's contract:
+  // `num_blocks` is the number of physical slots, id 0 is permanently held for
+  // padding, and only ids [1, num_blocks - 1] are handed out to sequences. This
+  // keeps the scheduler-side single-block ids inside the worker-side live
+  // region, whose row 0 is kPaddingLinearStateId; ids must never reach the
+  // checkpoint rows.
+  //
+  // BlockManagerImpl reserves id 0 by actually calling allocate() in its
+  // constructor and parking the returned Block in a member (padding_block_),
+  // relying on that Block's refcount staying >= 1 so free(0) is never reached.
+  // That indirection only exists because BlockManagerImpl has no in-use bitmap
+  // -- a Block handle is its only way to keep an id out of the free list. This
+  // manager already tracks occupancy in `in_use_ids_`, so it reserves id 0
+  // directly: mark it in use and never push it onto `free_ids_`. The observable
+  // contract is identical (id 0 unallocatable, usable count == num_blocks - 1,
+  // free(0) is a no-op); only the mechanism is simpler because the data
+  // structure differs.
   in_use_ids_.resize(num_blocks, false);
   usage_accounted_ids_.resize(num_blocks, false);
-  free_ids_.reserve(num_blocks);
-  for (uint32_t id = 0; id < num_blocks; ++id) {
-    free_ids_.push_back(static_cast<int32_t>(num_blocks - id - 1));
+  in_use_ids_[0] = true;
+  free_ids_.reserve(num_blocks - 1);
+  for (uint32_t id = 1; id < num_blocks; ++id) {
+    free_ids_.emplace_back(static_cast<int32_t>(num_blocks - id));
   }
-  num_free_blocks_.store(num_blocks, std::memory_order_relaxed);
+  num_free_blocks_.store(free_ids_.size(), std::memory_order_relaxed);
 }
 
 std::vector<Block> SingleBlockManager::allocate(size_t num_blocks) {
@@ -62,7 +80,7 @@ std::vector<Block> SingleBlockManager::allocate(size_t num_blocks) {
     size_t prev_count =
         num_free_blocks_.fetch_sub(1, std::memory_order_relaxed);
     const int32_t block_id = free_ids_[prev_count - 1];
-    CHECK_GE(block_id, 0);
+    CHECK_GT(block_id, 0);
     CHECK_LT(static_cast<size_t>(block_id), in_use_ids_.size());
     CHECK(!in_use_ids_[block_id])
         << resource_name_ << " id " << block_id << " was allocated repeatedly";
@@ -85,7 +103,7 @@ Block SingleBlockManager::allocate() {
   }
   size_t prev_count = num_free_blocks_.fetch_sub(1, std::memory_order_relaxed);
   const int32_t block_id = free_ids_[prev_count - 1];
-  CHECK_GE(block_id, 0);
+  CHECK_GT(block_id, 0);
   CHECK_LT(static_cast<size_t>(block_id), in_use_ids_.size());
   CHECK(!in_use_ids_[block_id])
       << resource_name_ << " id " << block_id << " was allocated repeatedly";
@@ -157,7 +175,13 @@ double SingleBlockManager::kv_cache_utilization() const {
 }
 
 void SingleBlockManager::free(int32_t block_id) {
-  if (block_id < 0) {
+  // id 0 is the reserved padding slot and is never returned to the pool. This
+  // mirrors BlockManagerImpl::free(), which guards the same id with
+  // `if (block_id != 0)`. The guard matters at teardown too: BlockManagerImpl's
+  // padding_block_ destructs and calls free(0), and here a stray Block(0) (e.g.
+  // from a defaulted/zeroed handle) could do the same -- both must be no-ops so
+  // the padding id is never recycled.
+  if (block_id <= 0) {
     return;
   }
   std::lock_guard<std::mutex> lock(mutex_);

--- a/xllm/core/framework/block/single_block_manager_test.cpp
+++ b/xllm/core/framework/block/single_block_manager_test.cpp
@@ -20,7 +20,9 @@ limitations under the License.
 namespace xllm {
 
 TEST(SingleBlockManagerTest, AllocateAndFreeRoundTrip) {
-  SingleBlockManager manager(3, "single");
+  // id 0 is reserved for padding (matching BlockManagerImpl), so a pool sized
+  // for 4 physical slots exposes 3 usable blocks.
+  SingleBlockManager manager(4, "single");
 
   EXPECT_EQ(manager.num_total_blocks(), 3);
   EXPECT_EQ(manager.num_blocks_in_prefix_cache(), 0);
@@ -30,6 +32,9 @@ TEST(SingleBlockManagerTest, AllocateAndFreeRoundTrip) {
 
   auto blocks = manager.allocate(2);
   ASSERT_EQ(blocks.size(), 2);
+  for (const auto& block : blocks) {
+    EXPECT_GE(block.id(), 1) << "padding slot 0 must never be allocated";
+  }
   EXPECT_EQ(manager.num_free_blocks(), 1);
   EXPECT_EQ(manager.num_used_blocks(), 2);
   EXPECT_DOUBLE_EQ(manager.kv_cache_utilization(), 2.0 / 3.0);
@@ -45,16 +50,19 @@ TEST(SingleBlockManagerTest, AllocateAndFreeRoundTrip) {
 }
 
 TEST(SingleBlockManagerTest, AllocateReturnsEmptyWhenExhausted) {
-  SingleBlockManager manager(2, "single");
+  // id 0 is reserved internally, so 3 physical slots expose 2 usable blocks.
+  SingleBlockManager manager(3, "single");
   auto blocks = manager.allocate(2);
   ASSERT_EQ(blocks.size(), 2);
   EXPECT_TRUE(manager.allocate(1).empty());
 }
 
 TEST(SingleBlockManagerTest, AllocateSingleDiesWhenExhausted) {
-  SingleBlockManager manager(1, "single");
+  // id 0 is reserved internally, so 2 physical slots expose a single usable
+  // block, whose id is 1.
+  SingleBlockManager manager(2, "single");
   Block block = manager.allocate();
-  EXPECT_EQ(block.id(), 0);
+  EXPECT_EQ(block.id(), 1);
   EXPECT_DEATH(manager.allocate(), "No more single blocks available");
 }
 
@@ -87,7 +95,9 @@ TEST(SingleBlockManagerTest, PrefixCacheStyleApisAreSafeNoopsWhenDisabled) {
 }
 
 TEST(SingleBlockManagerTest, UsedBlocksAccountingDoesNotLeakWithAliases) {
-  SingleBlockManager manager(1, "single");
+  // id 0 is reserved internally, so 2 physical slots expose a single usable
+  // block.
+  SingleBlockManager manager(2, "single");
   EXPECT_EQ(manager.num_used_blocks(), 0u);
   EXPECT_EQ(manager.num_free_blocks(), 1u);
 
@@ -115,6 +125,25 @@ TEST(SingleBlockManagerTest, UsedBlocksAccountingDoesNotLeakWithAliases) {
   // When the last alias is released, used block accounting should converge.
   EXPECT_EQ(manager.num_used_blocks(), 0u);
   EXPECT_EQ(manager.num_free_blocks(), 1u);
+}
+
+TEST(SingleBlockManagerTest, ReservesPaddingSlotZero) {
+  // Draining the whole pool must never yield the reserved padding id 0, which
+  // padded batch rows use as kPaddingLinearStateId. 4 physical slots expose 3
+  // usable blocks.
+  SingleBlockManager manager(4, "single");
+  EXPECT_EQ(manager.num_total_blocks(), 3);
+
+  std::vector<Block> blocks = manager.allocate(3);
+  ASSERT_EQ(blocks.size(), 3u);
+  for (const auto& block : blocks) {
+    EXPECT_NE(block.id(), 0) << "padding slot 0 must stay reserved";
+  }
+  EXPECT_TRUE(manager.allocate(1).empty());
+
+  // Releasing every usable block must not free the reserved id either.
+  blocks.clear();
+  EXPECT_EQ(manager.num_free_blocks(), 3u);
 }
 
 TEST(SingleBlockManagerTest, ConstructorRejectsZeroBlocks) {


### PR DESCRIPTION
## Description

<!-- What does this PR do? Briefly describe the changes and why they are needed. -->

## Related Issues

<!-- Link related issues here. Use "Fixes #123" when this PR closes an issue. -->

## Change Type

- [x] Bug fix
- [ ] New feature
- [ ] Performance improvement
- [ ] Refactor
- [ ] Documentation
- [ ] Test
- [ ] Build or CI

## Pull Request Checklist

Thank you for contributing to xLLM. Before requesting review, please make sure the following items are complete.

### PR Title and Commit Messages

- [x] The PR title and each commit message follow the xLLM commit format: `<type>: <subject>`.

> Allowed types: feat, bugfix, docs, test, refactor, chore, style, revert, perf, model, build, release.
> The subject should use clear English, start with a verb, include at least 4 words, and end with `.`.

### Pre-commit Checks

- [x] I have installed `pre-commit` by running `pip install pre-commit` or an equivalent command.
- [x] I have installed the hooks with `pre-commit install`.
- [x] I have run `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

### Self Review

- [ ] I have self-reviewed the code according to `.agents/skills/code-review/references/custom-code-style.md`, especially code written or assisted by AI.
- [ ] I have rebased this PR onto the latest `main` branch.

### Build and Test Coverage

- [ ] Tests have been added or updated as needed.
- [ ] CUDA: `python setup.py build test` has passed on a CUDA machine.
- [x] NPU: `python setup.py build test` has passed on an NPU machine.
- [ ] MLU: `python setup.py build test` has passed on an MLU machine.

## Reviewer Notes

<!-- Optional: anything reviewers should focus on, known risks, follow-ups, or validation gaps. -->
