### PR TITLE
bugfix: pad MTP conv host params for concurrent graph.

### DIFF
--- a/xllm/core/layers/npu_torch/qwen3_gated_delta_net_base.cpp
+++ b/xllm/core/layers/npu_torch/qwen3_gated_delta_net_base.cpp
@@ -18,6 +18,7 @@ limitations under the License.
 #include <tuple>
 #include <vector>
 
+#include "xllm/core/framework/kv_cache/kv_cache_utils.h"
 #include "xllm/core/kernels/ops_api.h"
 
 namespace xllm {
@@ -322,18 +323,46 @@ torch::Tensor run_spec_verify_conv(const torch::Tensor& mixed_qkv,
   CHECK_EQ(expanded_state_len, conv_kernel_size - 1 + seq_len - 1)
       << "unexpected speculative conv cache len, expected "
       << (conv_kernel_size - 1 + seq_len - 1) << ", got " << expanded_state_len;
-  CHECK_EQ(num_accepted_tokens.size(), static_cast<size_t>(batch_size))
-      << "num_accepted_tokens must be per sequence.";
 
   std::vector<int64_t> linear_state_indices(linear_state_ids.begin(),
                                             linear_state_ids.end());
+  if (linear_state_indices.size() < static_cast<size_t>(batch_size)) {
+    linear_state_indices.resize(batch_size, kPaddingLinearStateId);
+  }
+  CHECK_EQ(linear_state_indices.size(), static_cast<size_t>(batch_size))
+      << "linear_state_indices must be per sequence.";
+
+  const std::vector<int64_t>* query_start_loc_ptr = &query_start_loc;
+  std::vector<int64_t> padded_query_start_loc;
+  const size_t target_qsl_size = static_cast<size_t>(batch_size + 1);
+  if (query_start_loc.size() < target_qsl_size) {
+    padded_query_start_loc = query_start_loc;
+    CHECK(!padded_query_start_loc.empty())
+        << "query_start_loc must not be empty.";
+    int64_t offset = padded_query_start_loc.back();
+    padded_query_start_loc.reserve(target_qsl_size);
+    while (padded_query_start_loc.size() < target_qsl_size) {
+      offset += seq_len;
+      padded_query_start_loc.emplace_back(offset);
+    }
+    query_start_loc_ptr = &padded_query_start_loc;
+  }
+  CHECK_EQ(query_start_loc_ptr->size(), target_qsl_size)
+      << "query_start_loc must match the padded speculative batch.";
+
+  if (num_accepted_tokens.size() < static_cast<size_t>(batch_size)) {
+    num_accepted_tokens.resize(batch_size, 1);
+  }
+  CHECK_EQ(num_accepted_tokens.size(), static_cast<size_t>(batch_size))
+      << "num_accepted_tokens must be per sequence.";
+
   torch::IntArrayRef has_initial_state;
   torch::Tensor conv_output =
       xllm::kernel::causal_conv1d(mixed_qkv,
                                   conv_weight,
                                   conv_cache,
                                   std::optional<torch::Tensor>(),
-                                  torch::IntArrayRef(query_start_loc),
+                                  torch::IntArrayRef(*query_start_loc_ptr),
                                   torch::IntArrayRef(linear_state_indices),
                                   has_initial_state,
                                   torch::IntArrayRef(num_accepted_tokens),


### PR DESCRIPTION
## 背景
PR #1536 将 Qwen3.5 GDN MTP verify conv 路径复用为 host vector 参数的 causal_conv1d，用于减少 MTP decode transpose。并发 ACL graph 场景下 executor 使用 padded batch，mixed_qkv 的 batch 维是 padded_batch_size，但 prepare_input_params_for_linear_attention 生成的 query_start_loc 只覆盖实际 batch，导致 causal_conv1d host 参数长度与 padded mixed_qkv 不匹配。

典型触发：实际 batch=3、padded batch=4、MTP seq_len=4，query_start_loc=[0,4,8,12]，而 causal_conv1d 对 B=4 需要 B+1 个边界 [0,4,8,12,16]。

## 修改
- 以 mixed_qkv.size(0) 作为 run_spec_verify_conv 中 causal_conv1d 的 batch 合约。
- linear_state_indices 补齐到 padded batch，padding 使用 kPaddingLinearStateId。
- query_start_loc 补齐到 padded batch + 1，MTP verify 中按固定 seq_len 递增补边界。
- num_accepted_tokens 补齐到 padded batch，padding 使用 1。
- 增加 CHECK，保证 host vector 参数长度与 padded mixed_qkv 对齐。

## 验证
- python setup.py build test：通过。
- 提交后再次 python setup.py build test：通过。