### PR TITLE
bugfix: split glm4 gate up before tensor parallel sharding.

### DIFF
--- a/xllm/core/layers/npu/loader/glm4_decoder_loader.cpp
+++ b/xllm/core/layers/npu/loader/glm4_decoder_loader.cpp
@@ -52,7 +52,9 @@ void Glm4DecoderLoader::load_state_dict(const StateDict& state_dict) {
 }
 
 void Glm4DecoderLoader::merge_host_at_weights() {
-  auto& w = working_tensors();
+  std::vector<at::Tensor>& w = working_tensors();
+
+  merge_gate_up();
 
   w[IN_Q_WEIGHT] =
       torch::cat({w[IN_Q_WEIGHT], w[IN_K_WEIGHT], w[IN_V_WEIGHT]}, 0)
@@ -65,6 +67,28 @@ void Glm4DecoderLoader::merge_host_at_weights() {
        {IN_MLP_W1_WEIGHT, IN_K_WEIGHT, IN_V_WEIGHT, IN_K_BIAS, IN_V_BIAS}) {
     w[idx] = zero_like_working(idx);
   }
+}
+
+void Glm4DecoderLoader::merge_gate_up() {
+  std::vector<at::Tensor>& w = working_tensors();
+
+  const int32_t world_size = parallel_args_.world_size();
+  if (world_size <= 1) {
+    return;
+  }
+
+  torch::Tensor gate_up_weight = w[IN_MLP_GATEUP_WEIGHT];
+  const int64_t gate_up_size = gate_up_weight.size(0);
+  const int64_t intermediate_size = gate_up_size / 2;
+
+  const int32_t rank = parallel_args_.rank();
+  torch::Tensor gate_weight = gate_up_weight.slice(0, 0, intermediate_size);
+  torch::Tensor up_weight =
+      gate_up_weight.slice(0, intermediate_size, gate_up_size);
+  w[IN_MLP_GATEUP_WEIGHT] = torch::cat({gate_weight.chunk(world_size, 0)[rank],
+                                        up_weight.chunk(world_size, 0)[rank]},
+                                       0)
+                                .contiguous();
 }
 
 void Glm4DecoderLoader::verify_loaded_weights() const {

--- a/xllm/core/layers/npu/loader/glm4_decoder_loader.h
+++ b/xllm/core/layers/npu/loader/glm4_decoder_loader.h
@@ -34,6 +34,9 @@ class Glm4DecoderLoader : public BaseLoader {
 
  protected:
   void merge_host_at_weights() override;
+
+ private:
+  void merge_gate_up();
 };
 
 }  // namespace layer

--- a/xllm/core/layers/npu/loader/glm_loader_constants.h
+++ b/xllm/core/layers/npu/loader/glm_loader_constants.h
@@ -109,7 +109,6 @@ static std::map<int, int> WEIGHT_SHARD = {{IN_Q_WEIGHT, 0},
                                           {IN_V_WEIGHT, 0},
                                           {IN_V_BIAS, 0},
                                           {IN_ATTENTION_OUT_WEIGHT, 1},
-                                          {IN_MLP_GATEUP_WEIGHT, 0},
                                           {IN_MLP_CPROJ_WEIGHT, 1}};
 
 }  // namespace glm4_decoder_constants


### PR DESCRIPTION
## Description

GLM4 fused gate_up weights cannot be sharded directly on dim0, because that splits across the concatenated gate/up layout and mixes the two projections. Load the fused tensor first, split it into gate and up slices during loader merge, shard each slice by tensor-parallel rank, then concatenate them back.

## Related Issues

<!-- Link related issues here. Use "Fixes #123" when this PR closes an issue. -->

## Change Type

- [x] Bug fix
- [ ] New feature
- [ ] Performance improvement
- [ ] Refactor
- [ ] Documentation
- [ ] Test
- [ ] Build or CI

## Pull Request Checklist

Thank you for contributing to xLLM. Before requesting review, please make sure the following items are complete.

### PR Title and Commit Messages

- [x] The PR title and each commit message follow the xLLM commit format: `<type>: <subject>`.

> Allowed types: feat, bugfix, docs, test, refactor, chore, style, revert, perf, model, build, release.
> The subject should use clear English, start with a verb, include at least 4 words, and end with `.`.

### Pre-commit Checks

- [x] I have installed `pre-commit` by running `pip install pre-commit` or an equivalent command.
- [x] I have installed the hooks with `pre-commit install`.
- [x] I have run `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

### Self Review

- [x] I have self-reviewed the code according to `.agents/skills/code-review/references/custom-code-style.md`, especially code written or assisted by AI.
- [x] I have rebased this PR onto the latest `main` branch.

### Build and Test Coverage

- [ ] Tests have been added or updated as needed.
- [ ] CUDA: `python setup.py build test` has passed on a CUDA machine.
- [x] NPU: `python setup.py build test` has passed on an NPU machine.
- [ ] MLU: `python setup.py build test` has passed on an MLU machine.

## Reviewer Notes

<!-- Optional: anything reviewers should focus on, known risks, follow-ups, or validation gaps. -->
