### PR TITLE
bugfix: fix qwen3.5 mtp validate attention path

### DIFF
--- a/xllm/core/layers/npu_torch/attention.cpp
+++ b/xllm/core/layers/npu_torch/attention.cpp
@@ -15,7 +15,6 @@ limitations under the License.
 
 #include "attention.h"
 
-#include "core/framework/config/speculative_config.h"
 #include "kernels/npu/npu_ops_api.h"
 #include "kernels/ops_api.h"
 
@@ -110,9 +109,7 @@ void AttentionImpl::prefill_forward(torch::Tensor& query,
         "TND");
     output.copy_(std::get<0>(fia_result).view_as(output));
   } else if (attn_metadata.is_chunked_prefill) {
-    const bool speculative_enabled =
-        ::xllm::SpeculativeConfig::get_instance().num_speculative_tokens() > 0;
-    if (speculative_enabled) {
+    if (attn_metadata.is_spec_verify) {
       torch::Tensor kv_seq_lens = attn_metadata.kv_seq_lens_host.defined()
                                       ? attn_metadata.kv_seq_lens_host
                                       : attn_metadata.kv_seq_lens;

--- a/xllm/core/runtime/mtp_worker_impl.cpp
+++ b/xllm/core/runtime/mtp_worker_impl.cpp
@@ -871,6 +871,32 @@ void MTPWorkerImpl::prepare_validate_inputs(const ForwardInput& input,
   }
 
   input_params.attention.rebuild_device_buffer(device_);
+  if (use_qwen3_5_spec_verify_path() && use_atb_spec_kernel) {
+    CHECK(input_params.attention.device.block_tables.defined())
+        << "spec verify expanded decode requires block tables";
+    std::vector<int32_t> expanded_kv_seq_lens;
+    expanded_kv_seq_lens.reserve(total_num_val_tokens);
+    const auto& q_seq_lens = input_params.attention.host.q_seq_lens;
+    const auto& kv_seq_lens_after = input_params.attention.host.kv_seq_lens;
+    CHECK_EQ(q_seq_lens.size(), static_cast<size_t>(num_sequences));
+    CHECK_EQ(kv_seq_lens_after.size(), static_cast<size_t>(num_sequences));
+    for (int32_t seq_id = 0; seq_id < num_sequences; ++seq_id) {
+      const int32_t q_len = q_seq_lens[seq_id];
+      const int32_t kv_len = kv_seq_lens_after[seq_id];
+      CHECK_EQ(q_len, num_val_tokens);
+      CHECK_GE(kv_len, q_len);
+      for (int32_t token_idx = 0; token_idx < q_len; ++token_idx) {
+        expanded_kv_seq_lens.emplace_back(kv_len - q_len + token_idx + 1);
+      }
+    }
+    input_params.graph.use_expanded_decode_for_spec_verify_attention = true;
+    input_params.graph.expanded_kv_seq_lens =
+        torch::tensor(expanded_kv_seq_lens, token_options);
+    input_params.graph.expanded_kv_seq_lens_vec = expanded_kv_seq_lens;
+    input_params.graph.expanded_block_tables =
+        input_params.attention.device.block_tables.repeat_interleave(
+            /*repeats=*/num_val_tokens, /*dim=*/0);
+  }
   validate_input.device_tensors_ready = true;
   prepare_stream_->synchronize();
 }


### PR DESCRIPTION
## Summary
- Restrict NPU chunked speculative paged prefill to real spec-verify batches instead of all requests when speculative decoding is enabled.
- Prepare expanded decode attention metadata for Qwen3.5 MTP validate inputs so eager validate can use the same per-token KV lengths/block tables semantics as the graph spec-verify path.
- Avoid routing normal MTP draft/chunked-prefill warmup through the ATB speculative PagedAttention path, which can fail during startup and cause incorrect MTP validation behavior.

## Root Cause
When `--num_speculative_tokens > 0` is enabled, the current NPU attention code routes every chunked-prefill batch through `batch_chunked_paged_prefill`. This also affects non-validate chunked-prefill paths such as MTP draft extend and graph warmup. On Qwen3.5 MTP this can trigger `PagedAttentionOperation setup failed` and prevents the correct Qwen3.5 MTP validate path from running stably.

## Validation
Tested locally with Qwen35-27B TP=4 using:
- model: `/home/data/weights/Qwen35-27B`
- draft model: `/home/data/weights/Qwen35-27B-mtp`
- script: `/home/g00510989/xllm/xllm-main/xllm.sh`
- request: `/home/g00510989/xllm/xllm-main/req.sh`

Results:
- `python setup.py build --device npu` passed.
- Server startup passed with MTP enabled.
- Logs showed `Prefill warmup completed`, decode graph captures, `Decode warmup completed`, and `Application startup complete`.
- No `PagedAttentionOperation setup failed` or speculative conv cache fatal was observed.
- One `req.sh` request returned normal text instead of garbled output.
- 10 consecutive `Who are you?` requests passed without garbled output.
