### PR TITLE
build: speed up incremental rebuilds and adaptive test parallelism.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -468,6 +468,10 @@ class TestUT(Command):
         pass
 
     def run_ctest(self, cmake_dir: str) -> int:
+        default_parallel: int = max(os.cpu_count() or 1, 8)
+        test_parallel: str = os.getenv("CTEST_PARALLEL", str(default_parallel))
+        logger.info(f"Test parallelism: {test_parallel} (set CTEST_PARALLEL to override)")
+
         def run_subprocess_with_streaming(
             cmd: list[str],
             error_message: str,
@@ -514,7 +518,7 @@ class TestUT(Command):
                 logger.info(f"Running tests in parallel (excluding: {', '.join(self.SEQUENTIAL_TESTS)})...")
                 logger.info("=" * 80)
                 run_subprocess_with_streaming(
-                    ['ctest', '--parallel', '8', '--repeat', 'until-pass:5', '-E', exclude_pattern],
+                    ['ctest', '--parallel', test_parallel, '--repeat', 'until-pass:5', '-E', exclude_pattern],
                     "Parallel tests failed."
                 )
             else:
@@ -522,7 +526,7 @@ class TestUT(Command):
                 logger.info("Running all tests in parallel...")
                 logger.info("=" * 80)
                 run_subprocess_with_streaming(
-                    ['ctest', '--parallel', '8', '--repeat', 'until-pass:5'],
+                    ['ctest', '--parallel', test_parallel, '--repeat', 'until-pass:5'],
                     "Parallel tests failed."
                 )
             

--- a/xllm/CMakeLists.txt
+++ b/xllm/CMakeLists.txt
@@ -13,8 +13,10 @@ if(XLLM_BUILD_VERSION STREQUAL "")
   set(XLLM_BUILD_VERSION "unknown")
 endif()
 file(MAKE_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/core/common")
-file(WRITE "${CMAKE_CURRENT_BINARY_DIR}/core/common/xllm_build_info.h"
-     "#pragma once\n\n#define XLLM_BUILD_VERSION \"${XLLM_BUILD_VERSION}\"\n")
+configure_file(
+  "${CMAKE_CURRENT_SOURCE_DIR}/core/common/xllm_build_info.h.in"
+  "${CMAKE_CURRENT_BINARY_DIR}/core/common/xllm_build_info.h"
+  @ONLY)
 include_directories("${CMAKE_CURRENT_BINARY_DIR}")
 
 # Set warning-as-error for xllm code (third-party headers are marked as SYSTEM)

--- a/xllm/compiler/tilelang/common/manifest.py
+++ b/xllm/compiler/tilelang/common/manifest.py
@@ -73,6 +73,14 @@ class KernelFamilyManifest:
             encoding="utf-8",
         )
 
+    def write_if_changed(self, path: str | Path) -> None:
+        output = Path(path)
+        content = json.dumps(self.to_json_dict(), indent=2, sort_keys=True) + "\n"
+        if output.is_file() and output.read_text(encoding="utf-8") == content:
+            return
+        output.parent.mkdir(parents=True, exist_ok=True)
+        output.write_text(content, encoding="utf-8")
+
     @classmethod
     def read(cls, path: str | Path) -> "KernelFamilyManifest":
         data = json.loads(Path(path).read_text(encoding="utf-8"))

--- a/xllm/compiler/tilelang/targets/ascend/kernel_family_builder.py
+++ b/xllm/compiler/tilelang/targets/ascend/kernel_family_builder.py
@@ -51,6 +51,12 @@ def _variant_entry_symbol(spec: KernelCompileSpec) -> str:
     return f"{kernel_entry_name}__{spec.variant_key}_call"
 
 
+def _write_text_if_changed(path: Path, content: str) -> None:
+    if path.is_file() and path.read_text(encoding="utf-8") == content:
+        return
+    path.write_text(content, encoding="utf-8")
+
+
 def _run_variant_worker(args: _VariantWorkerArgs) -> _VariantBuildResult:
     mod = importlib.import_module(args.kernel_cls_module)
     kernel_cls = getattr(mod, args.kernel_cls_name)
@@ -333,17 +339,18 @@ def build_kernel_family(
         )
 
     variants_inc_path = family_output_dir / "variants.inc"
-    variants_inc_path.write_text(
+    _write_text_if_changed(
+        variants_inc_path,
         _render_variants_inc(
             family.kernel_name,
             family.kernel_cls,
             family.dispatch_schema,
             variant_manifests,
         ),
-        encoding="utf-8",
     )
     registry_inc_path = family_output_dir / "registry.inc"
-    registry_inc_path.write_text(
+    _write_text_if_changed(
+        registry_inc_path,
         _render_registry_inc(
             family.kernel_name,
             family.kernel_cls,
@@ -351,7 +358,6 @@ def build_kernel_family(
             family_kernel_abi,
             variant_manifests,
         ),
-        encoding="utf-8",
     )
 
     manifest = KernelFamilyManifest(
@@ -364,5 +370,5 @@ def build_kernel_family(
         kernel_abi=family_kernel_abi,
         variants=variant_manifests,
     )
-    manifest.write(manifest_path)
+    manifest.write_if_changed(manifest_path)
     return manifest

--- a/xllm/compiler/tilelang/targets/ascend/toolchain.py
+++ b/xllm/compiler/tilelang/targets/ascend/toolchain.py
@@ -6,7 +6,7 @@ from pathlib import Path
 
 from scripts.logger import logger
 
-from ...common.toolchain import git_head, require_env
+from ...common.toolchain import require_env
 from .kernels.utils import DEFAULT_ASCEND_BISHENG_ARCH
 
 TILELANG_BISHENG_COMMON_FLAGS = [
@@ -115,7 +115,6 @@ def build_fingerprint(bisheng_executable: str, bisheng_arch: str) -> dict[str, s
     return {
         "target": "ascend",
         "tl_root": tl_root,
-        "tilelang_git_head": git_head(tl_root),
         "npu_home_path": npu_home_path,
         "bisheng_executable": bisheng_executable,
         "bisheng_arch": bisheng_arch,

--- a/xllm/core/common/xllm_build_info.h.in
+++ b/xllm/core/common/xllm_build_info.h.in
@@ -1,0 +1,18 @@
+/* Copyright 2026 The xLLM Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://github.com/jd-opensource/xllm/blob/main/LICENSE
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#pragma once
+
+#define XLLM_BUILD_VERSION "@XLLM_BUILD_VERSION@"


### PR DESCRIPTION
## Description

This PR contains three build-system improvements that reduce wasted work
during incremental rebuilds and let the test suite scale with the host:

1. **Adaptive test parallelism** — `run_ctest` now derives the default
   ctest `--parallel` degree from `max(os.cpu_count(), 8)` instead of a
   hard-coded `8`, and honors a `CTEST_PARALLEL` env override. On
   many-core build hosts this lets the test suite use the available cores
   instead of being capped at 8.

2. **Skip rewriting unchanged TileLang codegen artifacts** — when the
   codegen cache is hit, `build_kernel_family` previously rewrote
   `variants.inc` / `registry.inc` / `manifest.json` unconditionally,
   bumping their mtime and forcing ninja to recompile the kernel wrappers
   and relink `tilelang_kernels` on every build. These writes are now
   content-aware (write only when changed), so an unchanged codegen run no
   longer triggers downstream recompilation. Also drops the
   `tilelang_git_head` fingerprint field, which always resolved to an empty
   string because `TL_ROOT` points at the pip-installed wheel (not a git
   repo) and contributed nothing to the cache key.

3. **Avoid rewriting the build-info header** — `xllm_build_info.h` was
   produced with `file(WRITE)` on every cmake configure, so its mtime
   changed each build and forced `master.cpp` and the final `.so` to
   rebuild. It now uses `configure_file` with a
   `core/common/xllm_build_info.h.in` template, which preserves the mtime
   when the version is unchanged.

Net effect: a no-source-change rebuild no longer recompiles TileLang
wrappers or `master.cpp`, nor relinks the shared library.

## Related Issues

<!-- None. -->

## Change Type

- [ ] Bug fix
- [ ] New feature
- [ ] Performance improvement
- [ ] Refactor
- [ ] Documentation
- [ ] Test
- [x] Build or CI

## Pull Request Checklist

Thank you for contributing to xLLM. Before requesting review, please make sure the following items are complete.

### PR Title and Commit Messages

- [x] The PR title and each commit message follow the xLLM commit format: `<type>: <subject>`.

> Allowed types: feat, bugfix, docs, test, refactor, chore, style, revert, perf, model, build, release.
> The subject should use clear English, start with a verb, include at least 4 words, and end with `.`.

### Pre-commit Checks

- [x] I have installed `pre-commit` by running `pip install pre-commit` or an equivalent command.
- [x] I have installed the hooks with `pre-commit install`.
- [x] I have run `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

### Self Review

- [x] I have self-reviewed the code according to `.agents/skills/code-review/references/custom-code-style.md`, especially code written or assisted by AI.
- [x] I have rebased this PR onto the latest `main` branch.

### Build and Test Coverage

- [x] Tests have been added or updated as needed.
- [ ] CUDA: `python setup.py build test` has passed on a CUDA machine.
- [x] NPU: `python setup.py build test` has passed on an NPU machine.
- [ ] MLU: `python setup.py build test` has passed on an MLU machine.

## Reviewer Notes

- All three changes are build-system only; no runtime behavior changes.
- Verified on NPU (`zmc-hc-8.5`): after a warm build, a no-source-change
  rebuild produces zero TileLang wrapper recompiles and no `tilelang_kernels`
  relink (down from 9 ninja steps), and `master.cpp` is no longer rebuilt.
  The four TileLang wrapper tests pass.
- Note: removing `tilelang_git_head` changes the codegen cache key, so the
  first build after this lands will do a one-time full TileLang recompile,
  then stabilize.
- This branch is built on top of an earlier "adaptive test parallelism"
  commit; no CUDA/MLU machine was available, so only the NPU box was used
  for validation.