### PR TITLE
refactor: replace devices flag with device_id.

### DIFF
--- a/tests/core/util/CMakeLists.txt
+++ b/tests/core/util/CMakeLists.txt
@@ -5,6 +5,7 @@ cc_test(
     util_test
   SRCS
     blocking_counter_test.cpp
+    device_name_utils_test.cpp
     suffix_decoding_cache_test.cpp
     threadpool_test.cpp
   DEPS

--- a/tests/core/util/device_name_utils_test.cpp
+++ b/tests/core/util/device_name_utils_test.cpp
@@ -1,5 +1,4 @@
-/* Copyright 2025 The xLLM Authors. All Rights Reserved.
-Copyright 2024 The ScaleLLM Authors. All Rights Reserved.
+/* Copyright 2026 The xLLM Authors. All Rights Reserved.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -14,37 +13,32 @@ See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
 
-#pragma once
+#include "core/util/device_name_utils.h"
 
-#include <torch/torch.h>
+#include <gtest/gtest.h>
 
-#include <cstdint>
-#include <sstream>
 #include <string>
 #include <vector>
 
+#include "core/platform/device.h"
+
 namespace xllm {
+namespace {
 
-class DeviceNameUtils {
- public:
-  static std::string to_device_string(int32_t device_id);
+TEST(DeviceNameUtilsTest, ToDeviceStringUsesCompiledDeviceType) {
+  const std::string device_string = DeviceNameUtils::to_device_string(3);
 
-  static std::vector<torch::Device> parse_devices(
-      const std::string& device_str);
+  EXPECT_EQ(device_string, Device::type_str() + ":3");
+}
 
-  template <typename T>
-  static std::string to_string(const std::vector<T>& items) {
-    std::stringstream ss;
-    for (size_t i = 0; i < items.size(); ++i) {
-      const auto& item = items[i];
-      if (i == 0) {
-        ss << item;
-      } else {
-        ss << "," << item;
-      }
-    }
-    return ss.str();
-  }
-};
+TEST(DeviceNameUtilsTest, ParseGeneratedDeviceString) {
+  const std::vector<torch::Device> devices =
+      DeviceNameUtils::parse_devices(DeviceNameUtils::to_device_string(2));
 
+  ASSERT_EQ(devices.size(), 1);
+  EXPECT_EQ(devices[0].type(), Device::type_torch());
+  EXPECT_EQ(devices[0].index(), 2);
+}
+
+}  // namespace
 }  // namespace xllm

--- a/xllm/core/common/global_flags.h
+++ b/xllm/core/common/global_flags.h
@@ -41,6 +41,8 @@ DECLARE_string(task);
 
 DECLARE_string(devices);
 
+DECLARE_int32(device_id);
+
 DECLARE_int32(limit_image_per_prompt);
 
 // --- kvcache config ---

--- a/xllm/core/framework/config/model_config.cpp
+++ b/xllm/core/framework/config/model_config.cpp
@@ -19,6 +19,7 @@ limitations under the License.
 
 #include "core/common/global_flags.h"
 #include "core/framework/config/config_json_utils.h"
+#include "core/util/device_name_utils.h"
 
 DEFINE_string(model_id, "", "hf model name.");
 
@@ -35,8 +36,11 @@ DEFINE_string(task,
               "The task to use the model for(e.g. generate, embed, mm_embed).");
 
 DEFINE_string(devices,
-              "npu:0",
-              "Devices to run the model on, e.g. npu:0, npu:0,npu:1.");
+              "",
+              "Deprecated. Use --device_id instead. Devices to run the model "
+              "on, e.g. npu:0, npu:0,npu:1.");
+
+DEFINE_int32(device_id, -1, "Device id to run the model on, e.g. 0.");
 
 DEFINE_int32(limit_image_per_prompt,
              8,
@@ -91,6 +95,14 @@ bool is_cpp_chat_template_supported_model(const std::string& model_type) {
   return model_type == "deepseek_v32" || model_type == "deepseek_v4";
 }
 
+bool is_flag_specified(const std::string& flag_name) {
+  google::CommandLineFlagInfo flag_info;
+  if (!google::GetCommandLineFlagInfo(flag_name.c_str(), &flag_info)) {
+    return false;
+  }
+  return !flag_info.is_default;
+}
+
 }  // namespace
 
 void ModelConfig::from_flags() {
@@ -98,7 +110,19 @@ void ModelConfig::from_flags() {
   XLLM_CONFIG_ASSIGN_FROM_FLAG(model);
   XLLM_CONFIG_ASSIGN_FROM_FLAG(backend);
   XLLM_CONFIG_ASSIGN_FROM_FLAG(task);
-  XLLM_CONFIG_ASSIGN_FROM_FLAG(devices);
+  XLLM_CONFIG_ASSIGN_FROM_FLAG(device_id);
+  const bool devices_specified = is_flag_specified("devices");
+  const bool device_id_specified = is_flag_specified("device_id");
+  if (devices_specified) {
+    LOG(WARNING) << "--devices is deprecated and will be removed in a future "
+                    "release. Use --device_id instead.";
+  }
+  if (devices_specified && !device_id_specified) {
+    XLLM_CONFIG_ASSIGN_FROM_FLAG(devices);
+  } else {
+    CHECK(device_id() >= 0) << "--device_id must be >= 0.";
+    devices(DeviceNameUtils::to_device_string(device_id()));
+  }
   XLLM_CONFIG_ASSIGN_FROM_FLAG(limit_image_per_prompt);
   XLLM_CONFIG_ASSIGN_FROM_FLAG(max_encoder_cache_size);
   XLLM_CONFIG_ASSIGN_FROM_FLAG(reasoning_parser);
@@ -130,6 +154,7 @@ void ModelConfig::from_json(const JsonReader& json) {
   XLLM_CONFIG_ASSIGN_FROM_JSON(backend);
   XLLM_CONFIG_ASSIGN_FROM_JSON(task);
   // don't read rank-related config
+  // XLLM_CONFIG_ASSIGN_FROM_JSON(device_id);
   // XLLM_CONFIG_ASSIGN_FROM_JSON(devices);
   XLLM_CONFIG_ASSIGN_FROM_JSON(limit_image_per_prompt);
   XLLM_CONFIG_ASSIGN_FROM_JSON(max_encoder_cache_size);
@@ -151,6 +176,8 @@ void ModelConfig::append_config_json(
   APPEND_CONFIG_JSON_VALUE_IF_NOT_DEFAULT(config_json, default_config, backend);
   APPEND_CONFIG_JSON_VALUE_IF_NOT_DEFAULT(config_json, default_config, task);
   // don't dump rank-related config
+  //  APPEND_CONFIG_JSON_VALUE_IF_NOT_DEFAULT(config_json, default_config,
+  //  device_id);
   //  APPEND_CONFIG_JSON_VALUE_IF_NOT_DEFAULT(config_json, default_config,
   //  devices);
   APPEND_CONFIG_JSON_VALUE_IF_NOT_DEFAULT(

--- a/xllm/core/framework/config/model_config.h
+++ b/xllm/core/framework/config/model_config.h
@@ -46,6 +46,7 @@ class ModelConfig final {
          "model",
          "backend",
          "task",
+         "device_id",
          "devices",
          "limit_image_per_prompt",
          "max_encoder_cache_size",
@@ -67,7 +68,9 @@ class ModelConfig final {
 
   PROPERTY(std::string, task) = "generate";
 
-  PROPERTY(std::string, devices) = "npu:0";
+  PROPERTY(int32_t, device_id) = -1;
+
+  PROPERTY(std::string, devices) = "";
 
   PROPERTY(int32_t, limit_image_per_prompt) = 8;
 

--- a/xllm/core/util/device_name_utils.cpp
+++ b/xllm/core/util/device_name_utils.cpp
@@ -20,23 +20,32 @@ limitations under the License.
 #include <absl/strings/str_split.h>
 #include <glog/logging.h>
 
+#include <cstdint>
+#include <string>
+#include <unordered_set>
+#include <vector>
+
 #include "platform/device.h"
 
 namespace xllm {
+
+std::string DeviceNameUtils::to_device_string(int32_t device_id) {
+  return Device::type_str() + ":" + std::to_string(device_id);
+}
 
 std::vector<torch::Device> DeviceNameUtils::parse_devices(
     const std::string& device_str) {
   std::vector<torch::Device> devices;
   if (device_str == "auto" || device_str.empty()) {
     // use all available devices if any
-    const auto num_devices = Device::device_count();
+    const int32_t num_devices = static_cast<int32_t>(Device::device_count());
     if (num_devices == 0) {
       LOG(INFO) << "no devices found, using cpu.";
       return {torch::kCPU};
     }
     devices.reserve(num_devices);
-    for (int i = 0; i < num_devices; ++i) {
-      std::string device_name = Device::type_str() + ":" + std::to_string(i);
+    for (int32_t i = 0; i < num_devices; ++i) {
+      std::string device_name = to_device_string(i);
       devices.emplace_back(torch::Device(device_name));
     }
     return devices;
@@ -52,7 +61,7 @@ std::vector<torch::Device> DeviceNameUtils::parse_devices(
     CHECK(parts[0] == Device::type_str())
         << "Unsupported device type: " << parts[0];
 
-    int device_index;
+    int32_t device_index = 0;
     CHECK(absl::SimpleAtoi(parts[1], &device_index))
         << "Invalid device index: " << parts[1];
 

--- a/xllm/core/util/threadpool.cpp
+++ b/xllm/core/util/threadpool.cpp
@@ -43,8 +43,8 @@ ThreadPool::ThreadPool(size_t num_threads,
 ThreadPool::ThreadPool(size_t num_threads,
                        Runnable init_func,
                        bool cpu_binding,
-                      //  const char* fn,
-                      //  int32_t ln,
+                       //  const char* fn,
+                       //  int32_t ln,
                        const std::string& pool_name)
     : queues_(num_threads), pool_name_(pool_name) {
   log_threadpool_creation(

--- a/xllm/xllm.cpp
+++ b/xllm/xllm.cpp
@@ -484,9 +484,8 @@ int main(int argc, char** argv) {
   FLAGS_alsologtostderr = true;
   FLAGS_minloglevel = 0;
   google::ParseCommandLineFlags(&argc, &argv, true);
-  initialize_configs();
-
   google::InitGoogleLogging("xllm");
+  initialize_configs();
 
   // Check if model path is provided
   if (::xllm::ModelConfig::get_instance().model().empty()) {


### PR DESCRIPTION
## Description

<!-- What does this PR do? Briefly describe the changes and why they are needed. -->

add `device_id` flag to replace `devices`, but still keep `devices` for backwards. 

## Related Issues

<!-- Link related issues here. Use "Fixes #123" when this PR closes an issue. -->

## Change Type

- [ ] Bug fix
- [ ] New feature
- [ ] Performance improvement
- [x] Refactor
- [ ] Documentation
- [ ] Test
- [ ] Build or CI

## Pull Request Checklist

Thank you for contributing to xLLM. Before requesting review, please make sure the following items are complete.

### PR Title and Commit Messages

- [x] The PR title and each commit message follow the xLLM commit format: `<type>: <subject>`.

> Allowed types: feat, bugfix, docs, test, refactor, chore, style, revert, perf, model, build, release.
> The subject should use clear English, start with a verb, include at least 4 words, and end with `.`.

### Pre-commit Checks

- [x] I have installed `pre-commit` by running `pip install pre-commit` or an equivalent command.
- [x] I have installed the hooks with `pre-commit install`.
- [x] I have run `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

### Self Review

- [x] I have self-reviewed the code according to `.agents/skills/code-review/references/custom-code-style.md`, especially code written or assisted by AI.
- [x] I have rebased this PR onto the latest `main` branch.

### Build and Test Coverage

- [x] Tests have been added or updated as needed.
- [x] CUDA: `python setup.py build test` has passed on a CUDA machine.
- [ ] NPU: `python setup.py build test` has passed on an NPU machine.
- [ ] MLU: `python setup.py build test` has passed on an MLU machine.

## Reviewer Notes

<!-- Optional: anything reviewers should focus on, known risks, follow-ups, or validation gaps. -->
