### PR TITLE
feat: support online profiling feature.

### DIFF
--- a/docs/en/features/online_profiling.md
+++ b/docs/en/features/online_profiling.md
@@ -1,0 +1,99 @@
+# Online Profiling
+
+## Background
+Timeline profiling is essential for diagnosing performance bottlenecks in an online serving deployment: where time is spent across host scheduling, device kernels, and communication. vLLM exposes this through two HTTP endpoints, `POST /start_profile` and `POST /stop_profile`, which toggle profiling on every worker so traces can be collected on a live server without restarting it.
+
+xLLM provides the equivalent capability with two backends, selected by `--profile_backend`:
+
+- **`torch` (default)** — records CPU and CUDA activities in-process via libtorch's Kineto profiler (the C++ equivalent of `torch.profiler.profile`) and writes a Chrome trace to disk on `/stop_profile`. No external profiler is required: just launch the server normally and drive the two endpoints. This mirrors vLLM's default `TorchProfilerWrapper`.
+- **`cuda`** — only toggles the CUDA profiler capture range (`cudaProfilerStart()` / `cudaProfilerStop()`). It records nothing on its own and must be paired with NVIDIA Nsight Systems (`nsys`): the server is launched under `nsys profile` with a capture range tied to the CUDA Profiler API, and the two endpoints open and close the window that `nsys` records.
+
+Both backends are CUDA only for now. Support for other backends will be added later.
+
+## Introduction
+The control flow mirrors the existing `sleep`/`wakeup` broadcast path:
+
+```
+HTTP POST /start_profile
+   -> APIService::StartProfileHttp        (xllm/api_service)
+   -> Master::start_profile               (xllm/core/distributed_runtime)
+   -> Engine::start_profile               (broadcast to all workers)
+        -> WorkerClient::start_profile_async   (local worker, in-process)
+        -> RemoteWorker::start_profile_async   (remote worker, over brpc)
+             -> WorkerService::StartProfile     (worker server handler)
+        -> WorkerImpl::start_profile
+             -> TorchProfiler::start            (Kineto, default)
+                or CudaProfiler::start          (cudaProfilerStart, --profile_backend=cuda)
+```
+
+The engine fans the request out to every worker concurrently and waits for all of them to acknowledge. Because xLLM runs one worker thread per device inside a single process and Kineto/CUPTI is process-global, each profiler is wrapped in a process-wide, idempotent singleton: the first `start` opens the collection window for the whole process, and repeated/overlapping `start`/`stop` calls are coalesced. `/stop_profile` closes the window.
+
+For the `torch` backend, the profiler is enabled and disabled on the worker's compute thread (the one that runs the forward pass), so host-side CPU operators are captured. On `/stop_profile`, libtorch writes the Chrome trace itself; the file goes to `--profile_dir` (the current working directory when unset). For the `cuda` backend, the trace output location is controlled by `nsys` (its `-o` flag), not by xLLM.
+
+## Usage
+
+Profiling is opt-in. Start the server with profiling enabled:
+
+```shell
+--enable_online_profile=true
+```
+
+`enable_online_profile`, `profile_backend`, and `profile_dir` can also be set via the JSON config file. The endpoints only act when `--enable_online_profile=true`; otherwise they respond with an error explaining how to enable the feature.
+
+### Default backend (`torch`, no nsys required)
+
+Just start the server normally and choose where traces are written:
+
+```shell
+<your xllm serve command> \
+    --enable_online_profile=true \
+    --profile_dir=/path/to/traces   # optional; defaults to the current directory
+```
+
+Then, against the running server:
+
+```shell
+# Start collecting
+curl -X POST http://127.0.0.1:9977/start_profile
+
+# ... send the inference requests you want to profile ...
+
+# Stop collecting (writes the trace at this point)
+curl -X POST http://127.0.0.1:9977/stop_profile
+```
+
+(Replace the host/port with your server's address.) On `/stop_profile`, each worker writes a Chrome trace named `xllm_rank<rank>_<pid>_<timestamp>.pt.trace.json` into `--profile_dir`. The absolute path is printed in the server log.
+
+### `cuda` backend (capture-range only, requires nsys)
+
+To use the capture-range path instead, set `--profile_backend=cuda` and launch the server under `nsys` with a capture range tied to the CUDA Profiler API:
+
+```shell
+# --capture-range=cudaProfilerApi makes nsys start/stop capturing exactly when
+# cudaProfilerStart/Stop are called, and --capture-range-end=repeat allows
+# multiple start/stop cycles in one session.
+nsys profile \
+    --trace=cuda,nvtx,osrt \
+    --capture-range=cudaProfilerApi \
+    --capture-range-end=repeat \
+    -o xllm_profile \
+    <your xllm serve command> --enable_online_profile=true --profile_backend=cuda
+```
+
+Drive the window with the same `/start_profile` and `/stop_profile` endpoints. When the server process exits, `nsys` writes the report to `xllm_profile.nsys-rep`.
+
+## Viewing traces
+
+For the `torch` backend, open the generated `.pt.trace.json` in [Perfetto](https://ui.perfetto.dev), `chrome://tracing`, or TensorBoard.
+
+For the `cuda` backend, open the generated `.nsys-rep` in the Nsight Systems GUI, or summarize it on the command line:
+
+```shell
+nsys stats xllm_profile.nsys-rep
+```
+
+## Notice
+- Profiling is currently supported on **CUDA only**. On other backends the endpoints return an error.
+- The two endpoints are only active when `--enable_online_profile=true`; otherwise they respond with an error explaining how to enable the feature.
+- With `--profile_backend=cuda`, `cudaProfilerStart`/`cudaProfilerStop` only have an effect when the server is running under a profiler such as `nsys` (or `ncu`) configured with `--capture-range=cudaProfilerApi`. Calling the endpoints without such a profiler attached is harmless but produces no trace. For multi-process / multi-GPU runs, `nsys` recommends launching with `--trace-fork-before-exec=true` so child worker processes are traced.
+- Profiling adds runtime overhead. Enable it only for diagnosis, not in steady-state production serving, and keep the capture window short.

--- a/docs/zh/features/online_profiling.md
+++ b/docs/zh/features/online_profiling.md
@@ -1,0 +1,98 @@
+# 在线性能采集 (Online Profiling)
+
+## 背景
+在线服务部署中，Timeline 性能采集对于定位性能瓶颈至关重要：它能展示时间究竟消耗在主机侧调度、设备侧算子还是通信上。vLLM 通过两个 HTTP 接口 `POST /start_profile` 与 `POST /stop_profile` 实现该能力，在每个 worker 上开启/关闭采集，从而无需重启即可在运行中的服务上采集 timeline。
+
+xLLM 提供等价的能力，并通过 `--profile_backend` 选择两种后端：
+
+- **`torch`（默认）** —— 通过 libtorch 的 Kineto profiler（即 `torch.profiler.profile` 的 C++ 等价实现）在进程内采集 CPU 与 CUDA 活动，并在 `/stop_profile` 时把 Chrome trace 直接写到磁盘。无需任何外部 profiler：正常启动服务、调用这两个接口即可。该方式与 vLLM 默认的 `TorchProfilerWrapper` 对齐。
+- **`cuda`** —— 仅开关 CUDA profiler 的 capture range（`cudaProfilerStart()` / `cudaProfilerStop()`）。它本身不记录任何内容，必须与 NVIDIA Nsight Systems（`nsys`）配合使用：服务在 `nsys profile` 下启动，并将 capture range 绑定到 CUDA Profiler API，这两个接口负责开启/关闭 `nsys` 实际记录的窗口。
+
+两种后端目前均仅支持 CUDA，其他芯片后续支持。
+
+## 原理介绍
+整体调用链复用了已有的 `sleep`/`wakeup` 广播路径：
+
+```
+HTTP POST /start_profile
+   -> APIService::StartProfileHttp        (xllm/api_service)
+   -> Master::start_profile               (xllm/core/distributed_runtime)
+   -> Engine::start_profile               (广播到所有 worker)
+        -> WorkerClient::start_profile_async   (进程内本地 worker)
+        -> RemoteWorker::start_profile_async   (通过 brpc 的远程 worker)
+             -> WorkerService::StartProfile     (worker 服务端处理)
+        -> WorkerImpl::start_profile
+             -> TorchProfiler::start            (Kineto，默认)
+                或 CudaProfiler::start          (cudaProfilerStart，--profile_backend=cuda)
+```
+
+Engine 会将请求并发广播到每个 worker，并等待全部确认。由于 xLLM 在单进程内为每个设备运行一个 worker 线程，而 Kineto/CUPTI 是进程级的，因此每个 profiler 都被封装为进程级、幂等的单例：首次 `start` 会为整个进程开启采集窗口，重复或并发的 `start`/`stop` 调用会被合并处理。`/stop_profile` 会关闭采集窗口。
+
+对于 `torch` 后端，profiler 在 worker 的计算线程（即执行 forward 的线程）上开启与关闭，从而能采集到主机侧的 CPU 算子。在 `/stop_profile` 时，由 libtorch 自行写出 Chrome trace，文件落到 `--profile_dir`（未设置时为当前工作目录）。对于 `cuda` 后端，trace 的输出位置由 `nsys` 控制（其 `-o` 参数），而非由 xLLM 管理。
+
+## 使用方式
+
+该功能默认关闭，需显式开启。启动服务时开启采集：
+
+```shell
+--enable_online_profile=true
+```
+
+`enable_online_profile`、`profile_backend` 与 `profile_dir` 也可以通过 JSON 配置文件设置。仅当 `--enable_online_profile=true` 时这两个接口才会生效；否则会返回错误并提示如何开启该功能。
+
+### 默认后端（`torch`，无需 nsys）
+
+正常启动服务，并指定 trace 的输出目录即可：
+
+```shell
+<你的 xllm serve 启动命令> \
+    --enable_online_profile=true \
+    --profile_dir=/path/to/traces   # 可选；默认为当前目录
+```
+
+随后，针对运行中的服务：
+
+```shell
+# 开始采集
+curl -X POST http://127.0.0.1:9977/start_profile
+
+# ... 发送需要采集的推理请求 ...
+
+# 停止采集（此时写出 trace）
+curl -X POST http://127.0.0.1:9977/stop_profile
+```
+
+（请将 host/port 替换为你的服务地址。）在 `/stop_profile` 时，每个 worker 会在 `--profile_dir` 下写出名为 `xllm_rank<rank>_<pid>_<timestamp>.pt.trace.json` 的 Chrome trace，其绝对路径会打印在服务日志中。
+
+### `cuda` 后端（仅 capture range，需要 nsys）
+
+若改用 capture range 方式，设置 `--profile_backend=cuda`，并在 `nsys` 下启动服务、将 capture range 绑定到 CUDA Profiler API：
+
+```shell
+# --capture-range=cudaProfilerApi 让 nsys 恰好在 cudaProfilerStart/Stop 被调用时
+# 开始/停止采集；--capture-range-end=repeat 允许在一次会话中进行多次 start/stop 循环。
+nsys profile \
+    --trace=cuda,nvtx,osrt \
+    --capture-range=cudaProfilerApi \
+    --capture-range-end=repeat \
+    -o xllm_profile \
+    <你的 xllm serve 启动命令> --enable_online_profile=true --profile_backend=cuda
+```
+
+用同样的 `/start_profile` 与 `/stop_profile` 接口控制采集窗口。当服务进程退出时，`nsys` 会将报告写入 `xllm_profile.nsys-rep`。
+
+## 查看 trace
+
+对于 `torch` 后端，在 [Perfetto](https://ui.perfetto.dev)、`chrome://tracing` 或 TensorBoard 中打开生成的 `.pt.trace.json`。
+
+对于 `cuda` 后端，在 Nsight Systems GUI 中打开生成的 `.nsys-rep`，或在命令行汇总：
+
+```shell
+nsys stats xllm_profile.nsys-rep
+```
+
+## 注意事项
+- 当前仅支持 **CUDA**。其他芯片上调用这两个接口会返回错误。
+- 仅当 `--enable_online_profile=true` 时这两个接口才会生效；否则会返回错误并提示如何开启该功能。
+- 使用 `--profile_backend=cuda` 时，`cudaProfilerStart`/`cudaProfilerStop` 只有在服务运行于 `nsys`（或 `ncu`）这类配置了 `--capture-range=cudaProfilerApi` 的 profiler 之下时才会生效。未挂载此类 profiler 时调用接口无害，但不会产生 trace。对于多进程 / 多 GPU 场景，`nsys` 推荐使用 `--trace-fork-before-exec=true` 启动，以便子 worker 进程也被采集。
+- 采集会带来运行时开销，仅建议在诊断时开启，不要在稳态生产服务中长期开启，且采集窗口应尽量短。

--- a/mkdocs_en.yml
+++ b/mkdocs_en.yml
@@ -222,6 +222,8 @@ nav:
       - MoE Optimization:
         - features/moe_params.md
         - features/eplb.md
+      - Profiling:
+        - features/online_profiling.md
       - Advanced Guides:
         - Speculative Inference: features/mtp.md
         - GraphMode: features/graph_mode.md

--- a/mkdocs_zh.yml
+++ b/mkdocs_zh.yml
@@ -224,6 +224,8 @@ nav:
       - MoE优化:
         - features/moe_params.md
         - features/eplb.md
+      - 性能采集:
+        - features/online_profiling.md
       - 进阶指南:
         - 投机推理: features/mtp.md
         - GraphMode: features/graph_mode.md

--- a/xllm/api_service/api_service.cpp
+++ b/xllm/api_service/api_service.cpp
@@ -37,6 +37,7 @@ limitations under the License.
 #include "core/distributed_runtime/rec_master.h"
 #include "core/distributed_runtime/vlm_master.h"
 #include "core/framework/config/distributed_config.h"
+#include "core/framework/config/profile_config.h"
 #include "core/util/closure_guard.h"
 #include "embedding.pb.h"
 #include "image_generation.pb.h"
@@ -1204,6 +1205,78 @@ void APIService::WakeupHttp(::google::protobuf::RpcController* controller,
   if (!do_wakeup(*req_pb, &error_message)) {
     ctrl->SetFailed(error_message);
   }
+  // Success: return HTTP 200 with empty body
+}
+
+void APIService::StartProfileHttp(::google::protobuf::RpcController* controller,
+                                  const proto::HttpRequest* request,
+                                  proto::HttpResponse* response,
+                                  ::google::protobuf::Closure* done) {
+  brpc::ClosureGuard done_guard(done);
+  if (!request || !response || !controller) {
+    LOG(ERROR) << "brpc request | respose | controller is null";
+    return;
+  }
+
+  auto ctrl = reinterpret_cast<brpc::Controller*>(controller);
+
+  if (!ProfileConfig::get_instance().enable_online_profile()) {
+    LOG(ERROR) << "Profiling is disabled. Start the server with "
+                  "--enable_online_profile=true to use /start_profile.";
+    ctrl->SetFailed(
+        "Profiling is disabled. Start the server with "
+        "--enable_online_profile=true.");
+    return;
+  }
+  if (master_ == nullptr) {
+    LOG(ERROR) << "No master available to start profiling.";
+    ctrl->SetFailed("No master available to start profiling.");
+    return;
+  }
+
+  LOG(INFO) << "Starting profiler.";
+  if (!master_->start_profile()) {
+    LOG(ERROR) << "Failed to start profiler.";
+    ctrl->SetFailed("Failed to start profiler.");
+    return;
+  }
+  LOG(INFO) << "Profiler started.";
+  // Success: return HTTP 200 with empty body
+}
+
+void APIService::StopProfileHttp(::google::protobuf::RpcController* controller,
+                                 const proto::HttpRequest* request,
+                                 proto::HttpResponse* response,
+                                 ::google::protobuf::Closure* done) {
+  brpc::ClosureGuard done_guard(done);
+  if (!request || !response || !controller) {
+    LOG(ERROR) << "brpc request | respose | controller is null";
+    return;
+  }
+
+  auto ctrl = reinterpret_cast<brpc::Controller*>(controller);
+
+  if (!ProfileConfig::get_instance().enable_online_profile()) {
+    LOG(ERROR) << "Profiling is disabled. Start the server with "
+                  "--enable_online_profile=true to use /stop_profile.";
+    ctrl->SetFailed(
+        "Profiling is disabled. Start the server with "
+        "--enable_online_profile=true.");
+    return;
+  }
+  if (master_ == nullptr) {
+    LOG(ERROR) << "No master available to stop profiling.";
+    ctrl->SetFailed("No master available to stop profiling.");
+    return;
+  }
+
+  LOG(INFO) << "Stopping profiler.";
+  if (!master_->stop_profile()) {
+    LOG(ERROR) << "Failed to stop profiler.";
+    ctrl->SetFailed("Failed to stop profiler.");
+    return;
+  }
+  LOG(INFO) << "Profiler stopped.";
   // Success: return HTTP 200 with empty body
 }
 

--- a/xllm/api_service/api_service.h
+++ b/xllm/api_service/api_service.h
@@ -178,6 +178,16 @@ class APIService : public proto::XllmAPIService {
                   proto::HttpResponse* response,
                   ::google::protobuf::Closure* done) override;
 
+  void StartProfileHttp(::google::protobuf::RpcController* controller,
+                        const proto::HttpRequest* request,
+                        proto::HttpResponse* response,
+                        ::google::protobuf::Closure* done) override;
+
+  void StopProfileHttp(::google::protobuf::RpcController* controller,
+                       const proto::HttpRequest* request,
+                       proto::HttpResponse* response,
+                       ::google::protobuf::Closure* done) override;
+
   void LinkD2D(::google::protobuf::RpcController* controller,
                const proto::D2DLinkRequest* request,
                proto::Status* response,

--- a/xllm/core/common/CMakeLists.txt
+++ b/xllm/core/common/CMakeLists.txt
@@ -31,6 +31,7 @@ cc_library(
     absl::strings
     torch
     $<$<BOOL:${USE_NPU}>:torch_npu>
+    $<$<BOOL:${USE_CUDA}>:CUDA::cudart>
     $<$<BOOL:${USE_MSPTI}>:mspti>
     $<$<BOOL:${USE_NPU}>:ms_tools_ext>
     Boost::serialization

--- a/xllm/core/common/global_flags.h
+++ b/xllm/core/common/global_flags.h
@@ -247,6 +247,12 @@ DECLARE_bool(disable_ttft_profiling);
 
 DECLARE_bool(enable_forward_interruption);
 
+DECLARE_bool(enable_online_profile);
+
+DECLARE_string(profile_backend);
+
+DECLARE_string(profile_dir);
+
 DECLARE_int32(max_global_ttft_ms);
 
 DECLARE_int32(max_global_tpot_ms);

--- a/xllm/core/distributed_runtime/comm_channel.cpp
+++ b/xllm/core/distributed_runtime/comm_channel.cpp
@@ -380,6 +380,32 @@ bool CommChannel::wakeup(const WakeupOptions& options) {
   return true;
 }
 
+bool CommChannel::start_profile() {
+  proto::Empty req;
+  proto::Status s;
+  brpc::Controller cntl;
+
+  stub_->StartProfile(&cntl, &req, &s, nullptr);
+  if (cntl.Failed() || !s.ok()) {
+    LOG(ERROR) << "StartProfile failed: " << cntl.ErrorText();
+    return false;
+  }
+  return true;
+}
+
+bool CommChannel::stop_profile() {
+  proto::Empty req;
+  proto::Status s;
+  brpc::Controller cntl;
+
+  stub_->StopProfile(&cntl, &req, &s, nullptr);
+  if (cntl.Failed() || !s.ok()) {
+    LOG(ERROR) << "StopProfile failed: " << cntl.ErrorText();
+    return false;
+  }
+  return true;
+}
+
 class ClientStreamReceiver : public brpc::StreamInputHandler {
  private:
   std::shared_ptr<std::atomic<int32_t>> termination_flag_;

--- a/xllm/core/distributed_runtime/comm_channel.h
+++ b/xllm/core/distributed_runtime/comm_channel.h
@@ -116,6 +116,10 @@ class CommChannel {
 
   virtual bool wakeup(const WakeupOptions& options);
 
+  virtual bool start_profile();
+
+  virtual bool stop_profile();
+
  protected:
   bool execute_model_with_brpc(
       const ForwardInput& input,

--- a/xllm/core/distributed_runtime/engine.h
+++ b/xllm/core/distributed_runtime/engine.h
@@ -155,6 +155,17 @@ class Engine {
     return false;
   };
 
+  // Start/stop online timeline profiling on all workers. CUDA only for now.
+  virtual bool start_profile() {
+    LOG(ERROR) << "start_profile is not implemented for this engine!";
+    return false;
+  };
+
+  virtual bool stop_profile() {
+    LOG(ERROR) << "stop_profile is not implemented for this engine!";
+    return false;
+  };
+
   // XTensor mode: get GlobalXTensor offsets for allocated blocks
   // Returns per-layer K/V offsets for each block
   // Output: offsets[layer_id] = {k_offsets, v_offsets}

--- a/xllm/core/distributed_runtime/llm_engine.cpp
+++ b/xllm/core/distributed_runtime/llm_engine.cpp
@@ -1187,6 +1187,54 @@ bool LLMEngine::sleep(MasterStatus master_status) {
   return true;
 }
 
+bool LLMEngine::start_profile() {
+  LOG(INFO) << "Starting profiler on " << worker_clients_num_ << " worker(s).";
+  if (worker_clients_.empty()) {
+    LOG(ERROR) << "No worker clients available to start profiling.";
+    return false;
+  }
+
+  std::vector<folly::SemiFuture<bool>> futures;
+  futures.reserve(worker_clients_num_);
+  for (auto& worker : worker_clients_) {
+    futures.push_back(worker->start_profile_async());
+  }
+
+  auto results = folly::collectAll(futures).get();
+  for (const auto& result : results) {
+    if (!result.value()) {
+      LOG(ERROR) << "Start profile failed on a worker.";
+      return false;
+    }
+  }
+
+  return true;
+}
+
+bool LLMEngine::stop_profile() {
+  LOG(INFO) << "Stopping profiler on " << worker_clients_num_ << " worker(s).";
+  if (worker_clients_.empty()) {
+    LOG(ERROR) << "No worker clients available to stop profiling.";
+    return false;
+  }
+
+  std::vector<folly::SemiFuture<bool>> futures;
+  futures.reserve(worker_clients_num_);
+  for (auto& worker : worker_clients_) {
+    futures.push_back(worker->stop_profile_async());
+  }
+
+  auto results = folly::collectAll(futures).get();
+  for (const auto& result : results) {
+    if (!result.value()) {
+      LOG(ERROR) << "Stop profile failed on a worker.";
+      return false;
+    }
+  }
+
+  return true;
+}
+
 bool LLMEngine::wakeup(const WakeupOptions& options) {
   // sleep/wakeup/fork_master requires
   // ::xllm::KVCacheConfig::get_instance().enable_xtensor()

--- a/xllm/core/distributed_runtime/llm_engine.h
+++ b/xllm/core/distributed_runtime/llm_engine.h
@@ -123,6 +123,10 @@ class LLMEngine : public Engine {
 
   bool wakeup(const WakeupOptions& options) override;
 
+  bool start_profile() override;
+
+  bool stop_profile() override;
+
   // XTensor mode: get GlobalXTensor offsets for allocated blocks via RPC
   // Calls worker in the specified DP group to compute offsets
   bool get_xtensor_offsets_for_blocks(

--- a/xllm/core/distributed_runtime/master.h
+++ b/xllm/core/distributed_runtime/master.h
@@ -47,6 +47,16 @@ class Master {
     return false;
   }
 
+  // Start/stop online timeline profiling on all workers. Forwards to the
+  // engine, which broadcasts to every worker. CUDA only for now.
+  virtual bool start_profile() {
+    return engine_ ? engine_->start_profile() : false;
+  }
+
+  virtual bool stop_profile() {
+    return engine_ ? engine_->stop_profile() : false;
+  }
+
   virtual bool unlink_d2d(const std::vector<std::string>& remote_addrs) {
     return false;
   }

--- a/xllm/core/distributed_runtime/remote_worker.cpp
+++ b/xllm/core/distributed_runtime/remote_worker.cpp
@@ -374,4 +374,32 @@ folly::SemiFuture<bool> RemoteWorker::wakeup_async(
   return future;
 }
 
+folly::SemiFuture<bool> RemoteWorker::start_profile_async() {
+  folly::Promise<bool> promise;
+  auto future = promise.getSemiFuture();
+  threadpool_.schedule([this, promise = std::move(promise)]() mutable {
+    if (!channel_->start_profile()) {
+      LOG(ERROR) << "StartProfile failed";
+      promise.setValue(false);
+    } else {
+      promise.setValue(true);
+    }
+  });
+  return future;
+}
+
+folly::SemiFuture<bool> RemoteWorker::stop_profile_async() {
+  folly::Promise<bool> promise;
+  auto future = promise.getSemiFuture();
+  threadpool_.schedule([this, promise = std::move(promise)]() mutable {
+    if (!channel_->stop_profile()) {
+      LOG(ERROR) << "StopProfile failed";
+      promise.setValue(false);
+    } else {
+      promise.setValue(true);
+    }
+  });
+  return future;
+}
+
 }  // namespace xllm

--- a/xllm/core/distributed_runtime/remote_worker.h
+++ b/xllm/core/distributed_runtime/remote_worker.h
@@ -150,6 +150,10 @@ class RemoteWorker : public WorkerClient {
   virtual folly::SemiFuture<bool> wakeup_async(
       const WakeupOptions& options) override;
 
+  virtual folly::SemiFuture<bool> start_profile_async() override;
+
+  virtual folly::SemiFuture<bool> stop_profile_async() override;
+
  private:
   DISALLOW_COPY_AND_ASSIGN(RemoteWorker);
 

--- a/xllm/core/distributed_runtime/worker_service.cpp
+++ b/xllm/core/distributed_runtime/worker_service.cpp
@@ -591,6 +591,32 @@ void WorkerService::Wakeup(::google::protobuf::RpcController* controller,
   return;
 }
 
+void WorkerService::StartProfile(::google::protobuf::RpcController* controller,
+                                 const proto::Empty* req,
+                                 proto::Status* resp,
+                                 ::google::protobuf::Closure* done) {
+  threadpool_->schedule([this, controller, req, resp, done]() mutable {
+    brpc::ClosureGuard done_guard(done);
+    bool status = worker_->start_profile();
+    resp->set_ok(status);
+  });
+
+  return;
+}
+
+void WorkerService::StopProfile(::google::protobuf::RpcController* controller,
+                                const proto::Empty* req,
+                                proto::Status* resp,
+                                ::google::protobuf::Closure* done) {
+  threadpool_->schedule([this, controller, req, resp, done]() mutable {
+    brpc::ClosureGuard done_guard(done);
+    bool status = worker_->stop_profile();
+    resp->set_ok(status);
+  });
+
+  return;
+}
+
 void WorkerService::ExecuteModel(::google::protobuf::RpcController* controller,
                                  const proto::ForwardInput* pb_forward_input,
                                  proto::ForwardOutput* pb_forward_output,

--- a/xllm/core/distributed_runtime/worker_service.h
+++ b/xllm/core/distributed_runtime/worker_service.h
@@ -135,6 +135,16 @@ class WorkerService : public proto::DistributeWorker {
               proto::Status* resp,
               ::google::protobuf::Closure* done) override;
 
+  void StartProfile(::google::protobuf::RpcController* controller,
+                    const proto::Empty* req,
+                    proto::Status* resp,
+                    ::google::protobuf::Closure* done) override;
+
+  void StopProfile(::google::protobuf::RpcController* controller,
+                   const proto::Empty* req,
+                   proto::Status* resp,
+                   ::google::protobuf::Closure* done) override;
+
  private:
   void step(ForwardInput& fwd_input,
             torch::Tensor& next_tokens,

--- a/xllm/core/framework/config/profile_config.cpp
+++ b/xllm/core/framework/config/profile_config.cpp
@@ -56,6 +56,27 @@ DEFINE_bool(enable_forward_interruption,
             false,
             "Whether to enable forward interruption.");
 
+DEFINE_bool(enable_online_profile,
+            false,
+            "Whether to enable the online timeline profiling endpoints "
+            "(/start_profile and /stop_profile). CUDA only for now; pair with "
+            "launching the server under nsys "
+            "--capture-range=cudaProfilerApi.");
+
+DEFINE_string(
+    profile_backend,
+    "torch",
+    "Online profiling backend: 1: 'torch' (default) records CPU+CUDA "
+    "activities in-process and writes a Chrome trace on "
+    "/stop_profile, no external profiler needed; 2: 'cuda' only toggles "
+    "the CUDA profiler capture range and requires launching under "
+    "nsys --capture-range=cudaProfilerApi.");
+
+DEFINE_string(profile_dir,
+              "",
+              "Directory the 'torch' online profiling backend writes timeline "
+              "traces to. Empty means the current working directory.");
+
 namespace xllm {
 
 void ProfileConfig::from_flags() {
@@ -68,6 +89,9 @@ void ProfileConfig::from_flags() {
   XLLM_CONFIG_ASSIGN_FROM_FLAG(enable_profile_kv_blocks);
   XLLM_CONFIG_ASSIGN_FROM_FLAG(disable_ttft_profiling);
   XLLM_CONFIG_ASSIGN_FROM_FLAG(enable_forward_interruption);
+  XLLM_CONFIG_ASSIGN_FROM_FLAG(enable_online_profile);
+  XLLM_CONFIG_ASSIGN_FROM_FLAG(profile_backend);
+  XLLM_CONFIG_ASSIGN_FROM_FLAG(profile_dir);
 }
 
 void ProfileConfig::from_json(const JsonReader& json) {
@@ -80,6 +104,9 @@ void ProfileConfig::from_json(const JsonReader& json) {
   XLLM_CONFIG_ASSIGN_FROM_JSON(enable_profile_kv_blocks);
   XLLM_CONFIG_ASSIGN_FROM_JSON(disable_ttft_profiling);
   XLLM_CONFIG_ASSIGN_FROM_JSON(enable_forward_interruption);
+  XLLM_CONFIG_ASSIGN_FROM_JSON(enable_online_profile);
+  XLLM_CONFIG_ASSIGN_FROM_JSON(profile_backend);
+  XLLM_CONFIG_ASSIGN_FROM_JSON(profile_dir);
 }
 
 void ProfileConfig::append_config_json(
@@ -103,6 +130,12 @@ void ProfileConfig::append_config_json(
       config_json, default_config, disable_ttft_profiling);
   APPEND_CONFIG_JSON_VALUE_IF_NOT_DEFAULT(
       config_json, default_config, enable_forward_interruption);
+  APPEND_CONFIG_JSON_VALUE_IF_NOT_DEFAULT(
+      config_json, default_config, enable_online_profile);
+  APPEND_CONFIG_JSON_VALUE_IF_NOT_DEFAULT(
+      config_json, default_config, profile_backend);
+  APPEND_CONFIG_JSON_VALUE_IF_NOT_DEFAULT(
+      config_json, default_config, profile_dir);
 }
 
 ProfileConfig& ProfileConfig::get_instance() {

--- a/xllm/core/framework/config/profile_config.h
+++ b/xllm/core/framework/config/profile_config.h
@@ -18,6 +18,7 @@ limitations under the License.
 #include <cstdint>
 #include <limits>
 #include <nlohmann/json_fwd.hpp>
+#include <string>
 
 #include "core/common/macros.h"
 #include "core/framework/config/option_category.h"
@@ -49,7 +50,10 @@ class ProfileConfig final {
          "max_global_tpot_ms",
          "enable_profile_kv_blocks",
          "disable_ttft_profiling",
-         "enable_forward_interruption"}};
+         "enable_forward_interruption",
+         "enable_online_profile",
+         "profile_backend",
+         "profile_dir"}};
     return kOptionCategory;
   }
 
@@ -70,6 +74,22 @@ class ProfileConfig final {
   PROPERTY(bool, disable_ttft_profiling) = false;
 
   PROPERTY(bool, enable_forward_interruption) = false;
+
+  // Whether to enable the online timeline profiling endpoints
+  // (/start_profile and /stop_profile). CUDA only for now.
+  PROPERTY(bool, enable_online_profile) = false;
+
+  // Online profiling backend. "torch" (default) records CPU+CUDA activities
+  // in-process via libtorch's Kineto profiler and writes a Chrome trace on
+  // /stop_profile, no external profiler required (mirrors vLLM's default).
+  // "cuda" only toggles the CUDA profiler capture range
+  // (cudaProfilerStart/Stop) and requires launching the server under nsys with
+  // --capture-range=cudaProfilerApi to record a trace.
+  PROPERTY(std::string, profile_backend) = "torch";
+
+  // Directory the "torch" backend writes timeline traces to. Empty means the
+  // current working directory. Mirrors vLLM's torch_profiler_dir.
+  PROPERTY(std::string, profile_dir) = "";
 };
 
 }  // namespace xllm

--- a/xllm/core/platform/CMakeLists.txt
+++ b/xllm/core/platform/CMakeLists.txt
@@ -16,6 +16,8 @@ cc_library(
     $<$<BOOL:${USE_MLU}>:mlu/mlu_layer_synchronizer.h>
     $<$<BOOL:${USE_MLU}>:mlu/mlu_tensor_alloc.h>
     $<$<BOOL:${USE_CUDA}>:cuda/cuda_utils.h>
+    $<$<BOOL:${USE_CUDA}>:cuda_profiler.h>
+    $<$<BOOL:${USE_CUDA}>:torch_profiler.h>
     $<$<OR:$<BOOL:${USE_CUDA}>,$<BOOL:${USE_MLU}>>:numa_utils.h>
   SRCS
     stream.cpp
@@ -24,6 +26,8 @@ cc_library(
     shared_vmm_allocator.cpp
     $<$<BOOL:${USE_MLU}>:mlu/mlu_layer_synchronizer.cpp>
     $<$<BOOL:${USE_MLU}>:mlu/mlu_tensor_alloc.cpp>
+    $<$<BOOL:${USE_CUDA}>:cuda_profiler.cpp>
+    $<$<BOOL:${USE_CUDA}>:torch_profiler.cpp>
     $<$<OR:$<BOOL:${USE_CUDA}>,$<BOOL:${USE_MLU}>>:numa_utils.cpp>
   DEPS
     torch

--- a/xllm/core/platform/cuda_profiler.cpp
+++ b/xllm/core/platform/cuda_profiler.cpp
@@ -1,0 +1,78 @@
+/* Copyright 2026 The xLLM Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://github.com/jd-opensource/xllm/blob/main/LICENSE
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include "platform/cuda_profiler.h"
+
+#include <cuda_profiler_api.h>
+#include <cuda_runtime_api.h>
+#include <glog/logging.h>
+
+namespace xllm {
+
+CudaProfiler& CudaProfiler::get_instance() {
+  static CudaProfiler instance;
+  return instance;
+}
+
+CudaProfiler::~CudaProfiler() {
+  if (running_) {
+    stop();
+  }
+}
+
+bool CudaProfiler::start() {
+  std::lock_guard<std::mutex> lock(mutex_);
+  if (running_) {
+    LOG(WARNING) << "CUDA profiler is already running, ignoring start request.";
+    return true;
+  }
+
+  cudaError_t ret = cudaProfilerStart();
+  if (ret != cudaSuccess) {
+    LOG(ERROR) << "cudaProfilerStart failed: " << cudaGetErrorString(ret);
+    return false;
+  }
+
+  running_ = true;
+  LOG(INFO) << "CUDA profiler started. Make sure the server was launched under "
+               "nsys with --capture-range=cudaProfilerApi for the trace to be "
+               "recorded.";
+  return true;
+}
+
+bool CudaProfiler::stop() {
+  std::lock_guard<std::mutex> lock(mutex_);
+  if (!running_) {
+    LOG(WARNING) << "CUDA profiler is not running, ignoring stop request.";
+    return true;
+  }
+
+  cudaError_t ret = cudaProfilerStop();
+  running_ = false;
+  if (ret != cudaSuccess) {
+    LOG(ERROR) << "cudaProfilerStop failed: " << cudaGetErrorString(ret);
+    return false;
+  }
+
+  LOG(INFO) << "CUDA profiler stopped.";
+  return true;
+}
+
+bool CudaProfiler::is_running() const {
+  std::lock_guard<std::mutex> lock(mutex_);
+  return running_;
+}
+
+}  // namespace xllm

--- a/xllm/core/platform/cuda_profiler.h
+++ b/xllm/core/platform/cuda_profiler.h
@@ -1,0 +1,59 @@
+/* Copyright 2026 The xLLM Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://github.com/jd-opensource/xllm/blob/main/LICENSE
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#pragma once
+
+#include <mutex>
+
+namespace xllm {
+
+// CudaProfiler drives online timeline collection on CUDA GPUs by toggling the
+// CUDA profiler capture range (cudaProfilerStart / cudaProfilerStop). This
+// mirrors vLLM's CudaProfilerWrapper and is meant to be used together with
+// NVIDIA Nsight Systems: the server is launched under
+//   nsys profile --capture-range=cudaProfilerApi --capture-range-end repeat ...
+// and /start_profile / /stop_profile open and close the capture range so that
+// nsys records exactly the window of interest. The trace output location is
+// controlled by nsys (its -o flag), not by xLLM.
+//
+// xLLM runs one worker thread per device inside a single process, so the CUDA
+// profiler (which is process-global) is wrapped in a process-wide singleton:
+// the first start() opens the capture range for the whole process and repeated
+// / overlapping start()/stop() calls are made idempotent under a mutex.
+class CudaProfiler {
+ public:
+  static CudaProfiler& get_instance();
+
+  // Open the CUDA profiler capture range. Repeated calls while already running
+  // are ignored. Returns true on success (or if already running).
+  bool start();
+
+  // Close the CUDA profiler capture range. Calling stop() while not running is
+  // a no-op that returns true.
+  bool stop();
+
+  bool is_running() const;
+
+ private:
+  CudaProfiler() = default;
+  ~CudaProfiler();
+  CudaProfiler(const CudaProfiler&) = delete;
+  CudaProfiler& operator=(const CudaProfiler&) = delete;
+
+  mutable std::mutex mutex_;
+  bool running_ = false;
+};
+
+}  // namespace xllm

--- a/xllm/core/platform/torch_profiler.cpp
+++ b/xllm/core/platform/torch_profiler.cpp
@@ -1,0 +1,137 @@
+/* Copyright 2026 The xLLM Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://github.com/jd-opensource/xllm/blob/main/LICENSE
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include "platform/torch_profiler.h"
+
+#include <glog/logging.h>
+#include <torch/csrc/autograd/profiler.h>
+#include <unistd.h>
+
+#include <chrono>
+#include <filesystem>
+#include <set>
+
+namespace xllm {
+namespace {
+
+namespace tp = torch::profiler::impl;
+namespace ap = torch::autograd::profiler;
+
+// Build the destination path for a worker's Chrome trace. Mirrors the
+// ".pt.trace.json" suffix produced by torch.profiler's tensorboard handler so
+// the file is recognized by the usual viewers (Perfetto, chrome://tracing,
+// TensorBoard).
+std::string make_trace_path(const std::string& profile_dir, int32_t rank) {
+  const auto now = std::chrono::system_clock::now().time_since_epoch();
+  const auto ts =
+      std::chrono::duration_cast<std::chrono::milliseconds>(now).count();
+  const std::string file_name = "xllm_rank" + std::to_string(rank) + "_" +
+                                std::to_string(::getpid()) + "_" +
+                                std::to_string(ts) + ".pt.trace.json";
+  if (profile_dir.empty()) {
+    return file_name;
+  }
+  return (std::filesystem::path(profile_dir) / file_name).string();
+}
+
+}  // namespace
+
+TorchProfiler& TorchProfiler::get_instance() {
+  static TorchProfiler instance;
+  return instance;
+}
+
+TorchProfiler::~TorchProfiler() {
+  if (running_) {
+    // Best-effort: drop the trace rather than write it during teardown.
+    try {
+      ap::disableProfiler();
+    } catch (const std::exception& e) {
+      LOG(WARNING) << "disableProfiler during shutdown failed: " << e.what();
+    }
+    running_ = false;
+  }
+}
+
+bool TorchProfiler::start() {
+  std::lock_guard<std::mutex> lock(mutex_);
+  if (running_) {
+    LOG(WARNING)
+        << "Torch profiler is already running, ignoring start request.";
+    return true;
+  }
+
+  try {
+    const std::set<tp::ActivityType> activities = {tp::ActivityType::CPU,
+                                                   tp::ActivityType::CUDA};
+    const tp::ProfilerConfig config(tp::ProfilerState::KINETO,
+                                    /*report_input_shapes=*/false,
+                                    /*profile_memory=*/false,
+                                    /*with_stack=*/false,
+                                    /*with_flops=*/false,
+                                    /*with_modules=*/false);
+    ap::prepareProfiler(config, activities);
+    ap::enableProfiler(config, activities);
+  } catch (const std::exception& e) {
+    LOG(ERROR) << "Failed to start torch profiler: " << e.what();
+    return false;
+  }
+
+  running_ = true;
+  LOG(INFO) << "Torch profiler started (in-process Kineto). The trace will be "
+               "written on /stop_profile; no external profiler is required.";
+  return true;
+}
+
+bool TorchProfiler::stop(const std::string& profile_dir, int32_t rank) {
+  std::lock_guard<std::mutex> lock(mutex_);
+  if (!running_) {
+    LOG(WARNING) << "Torch profiler is not running, ignoring stop request.";
+    return true;
+  }
+  running_ = false;
+
+  const std::string path = make_trace_path(profile_dir, rank);
+  try {
+    if (!profile_dir.empty()) {
+      std::error_code ec;
+      std::filesystem::create_directories(profile_dir, ec);
+      if (ec) {
+        LOG(WARNING) << "Failed to create profile dir '" << profile_dir
+                     << "': " << ec.message();
+      }
+    }
+    auto result = ap::disableProfiler();
+    if (result == nullptr) {
+      LOG(ERROR) << "disableProfiler returned no result; no trace written.";
+      return false;
+    }
+    result->save(path);
+  } catch (const std::exception& e) {
+    LOG(ERROR) << "Failed to stop torch profiler / save trace: " << e.what();
+    return false;
+  }
+
+  LOG(INFO) << "Torch profiler stopped. Trace written to: "
+            << std::filesystem::absolute(path).string();
+  return true;
+}
+
+bool TorchProfiler::is_running() const {
+  std::lock_guard<std::mutex> lock(mutex_);
+  return running_;
+}
+
+}  // namespace xllm

--- a/xllm/core/platform/torch_profiler.h
+++ b/xllm/core/platform/torch_profiler.h
@@ -1,0 +1,68 @@
+/* Copyright 2026 The xLLM Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://github.com/jd-opensource/xllm/blob/main/LICENSE
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#pragma once
+
+#include <mutex>
+#include <string>
+
+namespace xllm {
+
+// TorchProfiler drives online timeline collection through libtorch's in-process
+// Kineto profiler (the C++ equivalent of torch.profiler.profile). Unlike the
+// CUDA-profiler capture-range path (see CudaProfiler), this backend records CPU
+// and CUDA activities itself and, on stop(), writes a Chrome trace JSON to disk
+// without needing an external profiler such as nsys attached. This mirrors
+// vLLM's default TorchProfilerWrapper so that simply launching the server with
+// --enable_online_profile=true and driving /start_profile and /stop_profile
+// produces a timeline.
+//
+// xLLM runs one worker thread per device inside a single process and Kineto /
+// CUPTI is process-global, so the profiler is wrapped in a process-wide
+// singleton: the first start() opens the collection window for the whole
+// process and repeated / overlapping start()/stop() calls are made idempotent
+// under a mutex.
+//
+// IMPORTANT: Kineto captures CPU operators via thread-local RecordFunction
+// callbacks, so start() and stop() must be invoked on the same thread that runs
+// the model forward pass for the host-side timeline to be complete. CUDA kernel
+// activities are collected process-globally via CUPTI regardless of thread.
+class TorchProfiler {
+ public:
+  static TorchProfiler& get_instance();
+
+  // Open the Kineto collection window. Repeated calls while already running are
+  // ignored. Returns true on success (or if already running).
+  bool start();
+
+  // Close the collection window and write the Chrome trace to `profile_dir`
+  // (current directory when empty). `rank` is embedded in the file name so
+  // per-worker traces in a multi-device process do not collide. Calling stop()
+  // while not running is a no-op that returns true.
+  bool stop(const std::string& profile_dir, int32_t rank);
+
+  bool is_running() const;
+
+ private:
+  TorchProfiler() = default;
+  ~TorchProfiler();
+  TorchProfiler(const TorchProfiler&) = delete;
+  TorchProfiler& operator=(const TorchProfiler&) = delete;
+
+  mutable std::mutex mutex_;
+  bool running_ = false;
+};
+
+}  // namespace xllm

--- a/xllm/core/runtime/worker.cpp
+++ b/xllm/core/runtime/worker.cpp
@@ -229,4 +229,26 @@ folly::SemiFuture<bool> Worker::wakeup_async(const WakeupOptions& options) {
   });
   return future;
 }
+
+bool Worker::start_profile() { return impl_->start_profile(); }
+
+bool Worker::stop_profile() { return impl_->stop_profile(); }
+
+folly::SemiFuture<bool> Worker::start_profile_async() {
+  folly::Promise<bool> promise;
+  auto future = promise.getSemiFuture();
+  threadpool_.schedule([this, promise = std::move(promise)]() mutable {
+    promise.setValue(this->start_profile());
+  });
+  return future;
+}
+
+folly::SemiFuture<bool> Worker::stop_profile_async() {
+  folly::Promise<bool> promise;
+  auto future = promise.getSemiFuture();
+  threadpool_.schedule([this, promise = std::move(promise)]() mutable {
+    promise.setValue(this->stop_profile());
+  });
+  return future;
+}
 }  // namespace xllm

--- a/xllm/core/runtime/worker.h
+++ b/xllm/core/runtime/worker.h
@@ -54,6 +54,15 @@ class Worker {
 
   folly::SemiFuture<bool> wakeup_async(const WakeupOptions& options);
 
+  // Start/stop online timeline profiling on this worker's device.
+  bool start_profile();
+
+  bool stop_profile();
+
+  folly::SemiFuture<bool> start_profile_async();
+
+  folly::SemiFuture<bool> stop_profile_async();
+
   std::tuple<int64_t, int64_t> estimate_kv_cache_capacity();
 
   // allocate kv cache. blocking call

--- a/xllm/core/runtime/worker_client.cpp
+++ b/xllm/core/runtime/worker_client.cpp
@@ -181,6 +181,14 @@ folly::SemiFuture<bool> WorkerClient::wakeup_async(
   return worker_->wakeup_async(options);
 }
 
+folly::SemiFuture<bool> WorkerClient::start_profile_async() {
+  return worker_->start_profile_async();
+}
+
+folly::SemiFuture<bool> WorkerClient::stop_profile_async() {
+  return worker_->stop_profile_async();
+}
+
 const torch::Device& WorkerClient::device() const { return worker_->device(); }
 
 folly::SemiFuture<std::optional<RawForwardOutput>>

--- a/xllm/core/runtime/worker_client.h
+++ b/xllm/core/runtime/worker_client.h
@@ -49,6 +49,11 @@ class WorkerClient {
 
   virtual folly::SemiFuture<bool> wakeup_async(const WakeupOptions& options);
 
+  // Start/stop online timeline profiling on the underlying worker.
+  virtual folly::SemiFuture<bool> start_profile_async();
+
+  virtual folly::SemiFuture<bool> stop_profile_async();
+
   virtual std::tuple<int64_t, int64_t> estimate_kv_cache_capacity();
 
   // allocate kv cache. blocking call

--- a/xllm/core/runtime/worker_impl.cpp
+++ b/xllm/core/runtime/worker_impl.cpp
@@ -48,12 +48,15 @@ limitations under the License.
 #include "core/framework/config/execution_config.h"
 #include "core/framework/config/kv_cache_config.h"
 #include "core/framework/config/load_config.h"
+#include "core/framework/config/profile_config.h"
 #include "core/framework/config/scheduler_config.h"
 #include "core/framework/config/speculative_config.h"
 #if defined(USE_NPU)
 #include "platform/npu/device_capture_lock.h"
 #elif defined(USE_CUDA)
 #include "kernels/cuda/cuda_ops_api.h"
+#include "platform/cuda_profiler.h"
+#include "platform/torch_profiler.h"
 #endif
 #include "core/distributed_runtime/master.h"
 #include "core/runtime/worker_rendezvous.h"
@@ -1102,6 +1105,49 @@ bool WorkerImpl::sleep(MasterStatus master_status) {
   }
 
   return true;
+}
+
+bool WorkerImpl::start_profile() {
+#if defined(USE_CUDA)
+  const auto& cfg = ProfileConfig::get_instance();
+  if (cfg.profile_backend() == "cuda") {
+    // Capture-range only; requires the server to run under nsys.
+    return CudaProfiler::get_instance().start();
+  }
+  // Default "torch" backend records in-process via Kineto. CPU-op capture uses
+  // thread-local callbacks, so enable it on the compute thread that runs the
+  // forward pass rather than on the RPC handler thread.
+  folly::Promise<bool> promise;
+  auto future = promise.getSemiFuture();
+  threadpool_.schedule([promise = std::move(promise)]() mutable {
+    promise.setValue(TorchProfiler::get_instance().start());
+  });
+  return std::move(future).get();
+#else
+  LOG(ERROR) << "Online timeline profiling is only supported on CUDA.";
+  return false;
+#endif
+}
+
+bool WorkerImpl::stop_profile() {
+#if defined(USE_CUDA)
+  const auto& cfg = ProfileConfig::get_instance();
+  if (cfg.profile_backend() == "cuda") {
+    return CudaProfiler::get_instance().stop();
+  }
+  const std::string profile_dir = cfg.profile_dir();
+  const int32_t rank = parallel_args_.rank();
+  folly::Promise<bool> promise;
+  auto future = promise.getSemiFuture();
+  threadpool_.schedule(
+      [profile_dir, rank, promise = std::move(promise)]() mutable {
+        promise.setValue(TorchProfiler::get_instance().stop(profile_dir, rank));
+      });
+  return std::move(future).get();
+#else
+  LOG(ERROR) << "Online timeline profiling is only supported on CUDA.";
+  return false;
+#endif
 }
 
 bool WorkerImpl::wakeup(const WakeupOptions& options) {

--- a/xllm/core/runtime/worker_impl.h
+++ b/xllm/core/runtime/worker_impl.h
@@ -141,6 +141,12 @@ class WorkerImpl {
 
   virtual bool wakeup(const WakeupOptions& options);
 
+  // Start/stop online timeline profiling on this worker's device. CUDA only
+  // for now; on other backends these are no-ops returning false.
+  virtual bool start_profile();
+
+  virtual bool stop_profile();
+
   virtual folly::SemiFuture<bool> pull_kv_blocks_async(
       uint64_t src_cluster_id,
       const std::string& src_addr,

--- a/xllm/proto/worker.proto
+++ b/xllm/proto/worker.proto
@@ -351,4 +351,6 @@ service DistributeWorker {
   rpc PrefetchFromStorage(BlockTransferInfos) returns (Status) {}
   rpc Sleep (SleepRequest)  returns (Status);
   rpc Wakeup (WakeupRequest) returns (Status);
+  rpc StartProfile (Empty) returns (Status);
+  rpc StopProfile (Empty) returns (Status);
 }

--- a/xllm/proto/xllm_service.proto
+++ b/xllm/proto/xllm_service.proto
@@ -92,6 +92,9 @@ service XllmAPIService {
   rpc Wakeup (MasterInfos) returns (Status);
   rpc WakeupHttp (HttpRequest) returns (HttpResponse);
 
+  rpc StartProfileHttp (HttpRequest) returns (HttpResponse);
+  rpc StopProfileHttp (HttpRequest) returns (HttpResponse);
+
   rpc LinkD2D (D2DLinkRequest) returns (Status);
   rpc LinkD2DHttp (HttpRequest) returns (HttpResponse);
 

--- a/xllm/server/xllm_server.cpp
+++ b/xllm/server/xllm_server.cpp
@@ -51,6 +51,8 @@ constexpr const char* kApiServiceRoutes =
     "fork_master => ForkMasterHttp,"
     "sleep => SleepHttp,"
     "wakeup => WakeupHttp,"
+    "start_profile => StartProfileHttp,"
+    "stop_profile => StopProfileHttp,"
     "link_d2d => LinkD2DHttp,"
     "unlink_d2d => UnlinkD2DHttp";
 


### PR DESCRIPTION
  ## Description

  Adds vLLM-style online timeline profiling for the running server, exposed via two HTTP endpoints POST /start_profile and POST /stop_profile. This lets developers capture a
  timeline trace of a live serving deployment without restarting it, to diagnose where time goes across host scheduling, device kernels, and communication.

  The control request fans out through the existing sleep/wakeup broadcast path: APIService::*ProfileHttp → Master::start_profile/stop_profile → Engine::start_profile/stop_profile
  (broadcast to all workers) → WorkerClient/RemoteWorker (in-process or over brpc) → WorkerImpl → the device profiler backend. A new StartProfile/StopProfile RPC pair is added to
  the DistributeWorker service so the command reaches both in-process and remote workers.

  Two CUDA profiling backends are provided, selected by --profile_backend:
  - torch (default): in-process Kineto capture of CPU+CUDA activities; writes a per-rank Chrome trace (*.pt.trace.json) to --profile_dir on /stop_profile. No external profiler
  required.
  - cuda: toggles the CUDA profiler capture range (cudaProfilerStart/cudaProfilerStop), for use under nsys profile --capture-range=cudaProfilerApi --capture-range-end=repeat. nsys
  owns the output path.
  
  The feature is gated by --enable_online_profile (default false); both backends are compiled only under USE_CUDA and are no-ops returning an error on other devices. The profilers
  are process-global, idempotent singletons and are fully lazy — no instrumentation is added to the forward hot path, so there is no runtime cost unless a capture window is
  opened. Docs added under docs/{en,zh}/features/online_profiling.md with mkdocs nav entries.

  ## Related Issues

  N/A

  ## Change Type

  - [ ] Bug fix
  - [x] New feature
  - [ ] Performance improvement
  - [ ] Refactor
  - [x] Documentation
  - [ ] Test
  - [ ] Build or CI

  ## Pull Request Checklist

  Thank you for contributing to xLLM. Before requesting review, please make sure the following items are complete.

  ## PR Title and Commit Messages

  - [x] The PR title and each commit message follow the xLLM commit format: <type>: <subject>.

  ▎ Allowed types: feat, bugfix, docs, test, refactor, chore, style, revert, perf, model, build, release.
  ▎ The subject should use clear English, start with a verb, include at least 4 words, and end with ..

  Pre-commit Checks

  - [ ] I have installed pre-commit by running pip install pre-commit or an equivalent command.
  - [ ] I have installed the hooks with pre-commit install.
  - [ ] I have run pre-commit run --all-files and fixed any reported issues.

  ▎ If you are unsure how to set up pre-commit, see the pre-commit documentation (https://pre-commit.com/).

  ## Self Review

  - [x] I have self-reviewed the code according to .agents/skills/code-review/references/custom-code-style.md, especially code written or assisted by AI.
  - [ ] I have rebased this PR onto the latest main branch.

  ## Build and Test Coverage

  - [ ] Tests have been added or updated as needed.
  - [ ] CUDA: python setup.py build test has passed on a CUDA machine.
  - [ ] NPU: python setup.py build test has passed on an NPU machine.
  - [ ] MLU: python setup.py build test has passed on an MLU machine.

  ## Reviewer Notes

  - CUDA-only feature. All profiling code is gated behind USE_CUDA; on NPU/MLU the endpoints return an error. The shared plumbing (proto, engine/worker RPC chain, api_service)
  compiles and links cleanly on an NPU build, but the CUDA-gated backends (cuda_profiler.cpp, torch_profiler.cpp) have not been compiled on a CUDA machine in my environment (no
  CUDA toolchain available) — please verify python setup.py build test on CUDA before merge. The cudaProfilerStart/Stop and Kineto enable/disableProfiler usage was validated
  against the official API signatures only.
  - Two backends, torch is the default. Reviewers should confirm the default choice is intended: torch (in-process Kineto) carries higher in-window overhead and extra host/device
  memory than the cuda/nsys capture-range path. Neither has any cost outside a /start_profile→/stop_profile window.
  - Security: like the existing /sleep and /wakeup control endpoints, these are unauthenticated; they are only registered/active when --enable_online_profile=true.
  - No unit tests were added (the feature is I/O- and device-driven, exercised via the HTTP endpoints under a profiler); the test checkboxes are left unchecked accordingly.