### PR TITLE
feat: optimize DeepSeek V4 NPU decode metadata.

### DIFF
--- a/xllm/core/kernels/npu/xllm_ops/hc_pre.cpp
+++ b/xllm/core/kernels/npu/xllm_ops/hc_pre.cpp
@@ -19,11 +19,11 @@ limitations under the License.
 
 namespace xllm::kernel::npu {
 
-std::tuple<at::Tensor, at::Tensor, at::Tensor> hc_pre(
-    const at::Tensor& x,
-    const at::Tensor& hc_fn,
-    const at::Tensor& hc_scale,
-    const at::Tensor& hc_base,
+std::tuple<torch::Tensor, torch::Tensor, torch::Tensor> hc_pre(
+    const torch::Tensor& x,
+    const torch::Tensor& hc_fn,
+    const torch::Tensor& hc_scale,
+    const torch::Tensor& hc_base,
     int64_t hc_mult,
     int64_t hc_sinkhorn_iters,
     double norm_eps,
@@ -33,17 +33,26 @@ std::tuple<at::Tensor, at::Tensor, at::Tensor> hc_pre(
               x.dim(),
               ".");
 
-  auto original_type = x.dtype();
-  auto x_bf16 = x;
-  if (x_bf16.dtype() != at::kBFloat16) {
-    x_bf16 = x_bf16.to(at::kBFloat16);
+  c10::ScalarType original_type = x.dtype();
+  torch::Tensor x_bf16 = x;
+  if (x_bf16.dtype() != torch::kBFloat16) {
+    x_bf16 = x_bf16.to(torch::kBFloat16);
   }
 
-  auto rsqrt = hc_pre_inv_rms(x_bf16, norm_eps);
-  at::Tensor x_float = x_bf16.to(at::kFloat);
-  at::Tensor x_flattened =
-      x.dim() == 4 ? x_float.flatten(2, -1) : x_float.flatten(1, -1);
-  auto mixes = at::linear(x_flattened, hc_fn);
+  torch::Tensor rsqrt = hc_pre_inv_rms(x_bf16, norm_eps);
+  // Run the gating projection on the BF16 cube (the cube accumulates in FP32
+  // internally), then cast the result back to FP32 which hc_pre_sinkhorn
+  // requires. The original FP32 cube path was the single largest decode
+  // hotspot (~8% of device time); the K=16384 reduction is safe in BF16
+  // because the accumulator stays FP32 and the downstream sinkhorn
+  // renormalizes the logits.
+  torch::Tensor hc_fn_bf16 = hc_fn.scalar_type() == torch::kBFloat16
+                                 ? hc_fn
+                                 : hc_fn.to(torch::kBFloat16);
+  torch::Tensor x_flattened =
+      x.dim() == 4 ? x_bf16.flatten(2, -1) : x_bf16.flatten(1, -1);
+  torch::Tensor mixes =
+      torch::linear(x_flattened, hc_fn_bf16).to(torch::kFloat);
 
   auto output = hc_pre_sinkhorn(mixes,
                                 rsqrt,
@@ -54,7 +63,7 @@ std::tuple<at::Tensor, at::Tensor, at::Tensor> hc_pre(
                                 hc_sinkhorn_iters,
                                 hc_eps);
 
-  at::Tensor y = std::get<0>(output).to(original_type);
+  torch::Tensor y = std::get<0>(output).to(original_type);
   return std::make_tuple(y, std::get<1>(output), std::get<2>(output));
 }
 

--- a/xllm/core/layers/common/dsa_metadata.h
+++ b/xllm/core/layers/common/dsa_metadata.h
@@ -117,6 +117,11 @@ struct DSAMetadata {
   //   prefill: pad(cumsum(context_length), (1,0), 0)
   //   decode:  pad(cumsum(ones(batch_size)), (1,0), 0)
   torch::Tensor actual_seq_lengths_query;
+  // kv_cu_seq_lens: (batch_size+1,) — pad(cumsum(actual_seq_lengths_kv),
+  // (1,0)). Built once per forward and reused by all layers so the per-layer
+  // indexer metadata builder does not recompute a host-side cumsum on every DSA
+  // layer.
+  torch::Tensor kv_cu_seq_lens;
   // max_seqlen_kv / max_seqlen_q: max sequence lengths
   torch::Tensor max_seqlen_kv;
   torch::Tensor max_seqlen_q;

--- a/xllm/core/layers/common/dsa_metadata_builder.cpp
+++ b/xllm/core/layers/common/dsa_metadata_builder.cpp
@@ -628,6 +628,18 @@ void DSAMetadataBuilder::build_seq_lengths(const ModelInputParams& params,
       torch::cat({torch::zeros({1}, int_options), cumsum});
   dsa_metadata.seq_lens_q = q_lens;
 
+  // Precompute the kv cumulative sequence lengths once per forward so the
+  // per-layer indexer metadata builder can reuse it instead of running a
+  // host-side cumsum on every DSA layer (kv_lens is identical across layers
+  // within one forward).
+  if (kv_lens.numel() > 0) {
+    torch::Tensor kv_lens_i32 = kv_lens.to(torch::kInt32);
+    torch::Tensor kv_cumsum =
+        torch::cumsum(kv_lens_i32, /*dim=*/0, /*dtype=*/torch::kInt32);
+    dsa_metadata.kv_cu_seq_lens =
+        torch::cat({torch::zeros({1}, int_options), kv_cumsum});
+  }
+
   if (kv_lens.numel() > 0) {
     dsa_metadata.max_seqlen_kv = torch::max(kv_lens).to(torch::kInt32);
   } else {

--- a/xllm/core/layers/npu_torch/deepseek_sparse_attention.cpp
+++ b/xllm/core/layers/npu_torch/deepseek_sparse_attention.cpp
@@ -424,7 +424,13 @@ AttentionMetadata build_indexer_attention_metadata(
     metadata.q_seq_lens = attn_metadata.seq_lens_q;
   }
 
-  if (metadata.kv_seq_lens.defined()) {
+  if (attn_metadata.kv_cu_seq_lens.defined() &&
+      attn_metadata.kv_cu_seq_lens.numel() > 0) {
+    // Reuse the kv cumulative sequence lengths computed once per forward in
+    // DSAMetadataBuilder, avoiding a redundant host-side cumsum on every DSA
+    // layer.
+    metadata.kv_cu_seq_lens = attn_metadata.kv_cu_seq_lens;
+  } else if (metadata.kv_seq_lens.defined()) {
     auto kv_seq_lens = metadata.kv_seq_lens.to(torch::kInt32);
     auto kv_cumsum = torch::cumsum(kv_seq_lens, /*dim=*/0);
     metadata.kv_cu_seq_lens =

--- a/xllm/models/llm/deepseek_v4.h
+++ b/xllm/models/llm/deepseek_v4.h
@@ -159,6 +159,7 @@ inline void deepseek_v4_collect_cpu_metadata_tensors(
       dsa.actual_seq_lengths_query, runtime_device, specs);
   deepseek_v4_add_packed_tensor(
       dsa.actual_seq_lengths_kv, runtime_device, specs);
+  deepseek_v4_add_packed_tensor(dsa.kv_cu_seq_lens, runtime_device, specs);
   deepseek_v4_add_packed_tensor(dsa.max_seqlen_q, runtime_device, specs);
   deepseek_v4_add_packed_tensor(dsa.max_seqlen_kv, runtime_device, specs);
   deepseek_v4_add_packed_tensor(dsa.input_positions, runtime_device, specs);
@@ -239,6 +240,7 @@ inline void deepseek_v4_move_dsa_metadata_to_device(
       maybe_to_device(dsa.actual_seq_lengths_query, runtime_device);
   dsa.actual_seq_lengths_kv =
       maybe_to_device(dsa.actual_seq_lengths_kv, runtime_device);
+  dsa.kv_cu_seq_lens = maybe_to_device(dsa.kv_cu_seq_lens, runtime_device);
   dsa.max_seqlen_q = maybe_to_device(dsa.max_seqlen_q, runtime_device);
   dsa.max_seqlen_kv = maybe_to_device(dsa.max_seqlen_kv, runtime_device);
   dsa.input_positions = maybe_to_device(dsa.input_positions, runtime_device);
@@ -1047,13 +1049,21 @@ class DeepseekV4ModelImpl
                                .dtype(torch::kInt32)
                                .device(torch::kCPU)
                                .pinned_memory(true);
+    // The DSA sparse-attention/indexer metadata kernels are configured with a
+    // fixed sparse top-k (index_topk_) and sliding-window size. A dummy/empty
+    // DP rank that reports a kv length of 1 makes cmp_topk/sparse_count far
+    // exceed the kv length, which the SparseAttnSharedkvMetadata /
+    // QuantLightningIndexer AICPU kernels reject as invalid parameters. Pad the
+    // dummy kv length so it can hold the configured sparse top-k and window.
+    const int32_t dummy_kv_len =
+        static_cast<int32_t>(std::max<int64_t>({index_topk_, window_size_, 1}));
     params.meta.num_sequences = 1;
     params.meta.actual_num_sequences = 1;
     params.meta.kv_max_seq_len =
-        std::max<int32_t>(params.meta.kv_max_seq_len, 1);
+        std::max<int32_t>(params.meta.kv_max_seq_len, dummy_kv_len);
     params.meta.q_max_seq_len = 1;
     params.meta.batch_forward_type = BatchForwardType::DECODE;
-    params.attention.host.kv_seq_lens = {1};
+    params.attention.host.kv_seq_lens = {dummy_kv_len};
     params.attention.host.q_seq_lens = {1};
     params.attention.host.q_cu_seq_lens = {1};
     params.attention.device.kv_seq_lens =
@@ -1093,20 +1103,26 @@ class DeepseekV4ModelImpl
     params.attn_metadata = nullptr;
     const int64_t metadata_batch_size =
         std::max<int64_t>(params.meta.num_sequences, 1);
+    // See fill_empty_dp_rank_input_params: the dummy kv length must be able to
+    // hold the configured sparse top-k / sliding window, otherwise the DSA
+    // metadata AICPU kernels reject cmp_topk/sparse_count > kv_len.
+    const int32_t dummy_kv_len =
+        static_cast<int32_t>(std::max<int64_t>({index_topk_, window_size_, 1}));
     params.meta.num_sequences = static_cast<int32_t>(metadata_batch_size);
     params.meta.kv_max_seq_len =
-        std::max<int32_t>(params.meta.kv_max_seq_len, 1);
+        std::max<int32_t>(params.meta.kv_max_seq_len, dummy_kv_len);
     params.meta.q_max_seq_len = 1;
     params.meta.batch_forward_type = BatchForwardType::DECODE;
 
-    auto pad_lens_vec = [metadata_batch_size](std::vector<int32_t>& lens) {
-      lens.resize(static_cast<size_t>(metadata_batch_size), 1);
-      for (auto& len : lens) {
-        len = std::max<int32_t>(len, 1);
+    auto pad_lens_vec = [metadata_batch_size](std::vector<int32_t>& lens,
+                                              int32_t fill_value) {
+      lens.resize(static_cast<size_t>(metadata_batch_size), fill_value);
+      for (int32_t& len : lens) {
+        len = std::max<int32_t>(len, fill_value);
       }
     };
-    pad_lens_vec(params.attention.host.kv_seq_lens);
-    pad_lens_vec(params.attention.host.q_seq_lens);
+    pad_lens_vec(params.attention.host.kv_seq_lens, dummy_kv_len);
+    pad_lens_vec(params.attention.host.q_seq_lens, 1);
 
     const int32_t manager_num = static_cast<int32_t>(group_infos_.size());
     bool has_full_multi_block_tables =
@@ -1311,6 +1327,7 @@ class DeepseekV4ModelImpl
         maybe_to_device(dsa.actual_seq_lengths_query, metadata_device);
     dsa.actual_seq_lengths_kv =
         maybe_to_device(dsa.actual_seq_lengths_kv, metadata_device);
+    dsa.kv_cu_seq_lens = maybe_to_device(dsa.kv_cu_seq_lens, metadata_device);
     dsa.seq_lens_q = maybe_to_device(dsa.seq_lens_q, metadata_device);
     dsa.seq_lens = maybe_to_device(dsa.seq_lens, metadata_device);
     dsa.max_seqlen_q = maybe_to_device(dsa.max_seqlen_q, metadata_device);


### PR DESCRIPTION
Use BF16 gating projection in hc_pre and reuse DSA KV cumulative sequence lengths across sparse-attention layers.

Pad empty DP rank dummy KV lengths for DSA sparse metadata and keep the new KV cumsum metadata on the same runtime device path as the other DSA tensors.

## Description

<!-- What does this PR do? Briefly describe the changes and why they are needed. -->

## Related Issues

<!-- Link related issues here. Use "Fixes #123" when this PR closes an issue. -->

## Change Type

- [ ] Bug fix
- [ ] New feature
- [ ] Performance improvement
- [ ] Refactor
- [ ] Documentation
- [ ] Test
- [ ] Build or CI

## Pull Request Checklist

Thank you for contributing to xLLM. Before requesting review, please make sure the following items are complete.

### PR Title and Commit Messages

- [ ] The PR title and each commit message follow the xLLM commit format: `<type>: <subject>`.

> Allowed types: feat, bugfix, docs, test, refactor, chore, style, revert, perf, model, build, release.
> The subject should use clear English, start with a verb, include at least 4 words, and end with `.`.

### Pre-commit Checks

- [ ] I have installed `pre-commit` by running `pip install pre-commit` or an equivalent command.
- [ ] I have installed the hooks with `pre-commit install`.
- [ ] I have run `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

### Self Review

- [ ] I have self-reviewed the code according to `.agents/skills/code-review/references/custom-code-style.md`, especially code written or assisted by AI.
- [ ] I have rebased this PR onto the latest `main` branch.

### Build and Test Coverage

- [ ] Tests have been added or updated as needed.
- [ ] CUDA: `python setup.py build test` has passed on a CUDA machine.
- [ ] NPU: `python setup.py build test` has passed on an NPU machine.
- [ ] MLU: `python setup.py build test` has passed on an MLU machine.

## Reviewer Notes

<!-- Optional: anything reviewers should focus on, known risks, follow-ups, or validation gaps. -->
