### PR TITLE
docs: fix Chinese README license link

### DIFF
--- a/docs/project/README_zh.md
+++ b/docs/project/README_zh.md
@@ -140,7 +140,7 @@ xLLM 提供了强大的智能计算能力，通过硬件系统的算力优化与
 
 ## 许可证
 
-[Apache License](LICENSE)
+[Apache License](../../LICENSE)
 
 #### xLLM 由 JD.com 提供 
 #### 感谢您对xLLM的关心与贡献!


### PR DESCRIPTION
## Summary
- Fix the Apache License link in `docs/project/README_zh.md` so it resolves to the repository-level `LICENSE` file.

## Why
- The previous relative link pointed to `docs/project/LICENSE`, which does not exist.

## Validation
- Ran a local Markdown relative-link check across repository Markdown files; it now reports no missing local links.
- Ran `git diff --check`.