### PR TITLE
bugfix: handle Qwen3.5 MTP graph inputs.

### DIFF
--- a/xllm/core/distributed_runtime/worker_service.cpp
+++ b/xllm/core/distributed_runtime/worker_service.cpp
@@ -114,6 +114,21 @@ void record_speculative_metrics_from_output(const torch::Tensor& next_tokens,
               num_draft_tokens - rejected_count);
 }
 
+torch::Tensor clone_cpu_tensor_view(const torch::Tensor& tensor) {
+  if (!tensor.defined()) {
+    return tensor;
+  }
+  CHECK(tensor.device().is_cpu()) << "expected a CPU tensor view";
+  return tensor.contiguous().clone();
+}
+
+void stabilize_schedule_overlap_host_views(ForwardInput& input) {
+  input.token_ids_host = clone_cpu_tensor_view(input.token_ids_host);
+  input.positions_host = clone_cpu_tensor_view(input.positions_host);
+  input.input_params.attention.host.block_tables =
+      clone_cpu_tensor_view(input.input_params.attention.host.block_tables);
+}
+
 }  // namespace
 
 WorkerService::WorkerService(runtime::Options options,
@@ -168,6 +183,9 @@ void WorkerService::step(ForwardInput& fwd_input,
                          torch::Tensor& out_logprobs) {
   const bool use_default_stream =
       !options_.enable_schedule_overlap() && options_.backend() == "llm";
+  if (options_.enable_schedule_overlap()) {
+    stabilize_schedule_overlap_host_views(fwd_input);
+  }
   // execute model
   auto future = worker_->step_async(fwd_input);
   if (!options_.enable_schedule_overlap()) {

--- a/xllm/core/runtime/acl_graph_persistent_param.cpp
+++ b/xllm/core/runtime/acl_graph_persistent_param.cpp
@@ -584,14 +584,18 @@ std::optional<ModelInputParams> GraphPersistentParam::update(
     bool return_capture_params) {
   CHECK_GT(padded_num_tokens, 0) << "padded_num_tokens must be > 0";
   const uint32_t actual_num_tokens = tokens.size(0);
-  CHECK(params.meta.batch_forward_type.is_decode())
-      << "ACL graph persistent param only supports decode";
   const bool is_decode = params.meta.batch_forward_type.is_decode();
+  const bool is_chunked_prefill =
+      params.meta.batch_forward_type.is_chunked_prefill();
+  const bool is_qwen3_5_spec_verify_chunked_prefill =
+      params.is_spec_verify && is_chunked_prefill &&
+      is_qwen3_5_model_type(args_.model_type());
+  CHECK(is_decode || is_qwen3_5_spec_verify_chunked_prefill)
+      << "ACL graph persistent param only supports decode or Qwen3.5 "
+         "spec-verify chunked prefill";
   const int64_t decode_tokens =
       is_decode ? std::max<int64_t>(options_.num_decoding_tokens(), 1) : 1;
   int64_t actual_batch_size = infer_actual_batch_size(params);
-  const bool is_chunked_prefill =
-      params.meta.batch_forward_type.is_chunked_prefill();
   if (is_chunked_prefill && params.meta.num_sequences > 0) {
     actual_batch_size = params.meta.num_sequences;
   } else if (is_decode) {
@@ -606,6 +610,8 @@ std::optional<ModelInputParams> GraphPersistentParam::update(
       is_chunked_prefill
           ? (padded_num_tokens + q_max_seq_len - 1) / q_max_seq_len
           : padded_num_tokens;
+  const int64_t actual_seq_len_rows =
+      is_chunked_prefill ? actual_batch_size : actual_num_tokens;
 
   // Copy data from input parameters to persistent graph tensors
   if (actual_num_tokens > 0) {
@@ -639,11 +645,11 @@ std::optional<ModelInputParams> GraphPersistentParam::update(
       q_seq_lens_default_.sizes() == q_seq_lens_.sizes()) {
     q_seq_lens_.copy_(q_seq_lens_default_, /*non_blocking=*/true);
   }
-  if (actual_num_tokens > 0 && params.attention.device.q_seq_lens.defined() &&
+  if (actual_seq_len_rows > 0 && params.attention.device.q_seq_lens.defined() &&
       params.attention.device.q_seq_lens.dim() >= 1 &&
       params.attention.device.q_seq_lens.numel() > 0) {
     const int64_t q_copy_len = std::min<int64_t>(
-        actual_num_tokens, params.attention.device.q_seq_lens.size(0));
+        actual_seq_len_rows, params.attention.device.q_seq_lens.size(0));
     if (q_copy_len > 0) {
       q_seq_lens_.slice(/*dim=*/0, /*start=*/0, /*end=*/q_copy_len)
           .copy_(params.attention.device.q_seq_lens.slice(/*dim=*/0,
@@ -656,11 +662,12 @@ std::optional<ModelInputParams> GraphPersistentParam::update(
       kv_seq_lens_default_.sizes() == kv_seq_lens_.sizes()) {
     kv_seq_lens_.copy_(kv_seq_lens_default_, /*non_blocking=*/true);
   }
-  if (actual_num_tokens > 0 && params.attention.device.kv_seq_lens.defined() &&
+  if (actual_seq_len_rows > 0 &&
+      params.attention.device.kv_seq_lens.defined() &&
       params.attention.device.kv_seq_lens.dim() >= 1 &&
       params.attention.device.kv_seq_lens.numel() > 0) {
     const int64_t kv_copy_len = std::min<int64_t>(
-        actual_num_tokens, params.attention.device.kv_seq_lens.size(0));
+        actual_seq_len_rows, params.attention.device.kv_seq_lens.size(0));
     if (kv_copy_len > 0) {
       kv_seq_lens_.slice(/*dim=*/0, /*start=*/0, /*end=*/kv_copy_len)
           .copy_(params.attention.device.kv_seq_lens.slice(/*dim=*/0,
@@ -669,16 +676,16 @@ std::optional<ModelInputParams> GraphPersistentParam::update(
                  /*non_blocking=*/true);
     }
   }
-  if (padded_batch_size > actual_num_tokens) {
+  if (padded_batch_size > actual_seq_len_rows) {
     const int32_t padding_q_len = is_chunked_prefill ? q_max_seq_len : 1;
     q_seq_lens_
         .slice(/*dim=*/0,
-               /*start=*/actual_num_tokens,
+               /*start=*/actual_seq_len_rows,
                /*end=*/padded_batch_size)
         .fill_(padding_q_len);
     kv_seq_lens_
         .slice(/*dim=*/0,
-               /*start=*/actual_num_tokens,
+               /*start=*/actual_seq_len_rows,
                /*end=*/padded_batch_size)
         .fill_(1);
   }
@@ -758,11 +765,12 @@ std::optional<ModelInputParams> GraphPersistentParam::update(
     persistent_block_tables_.copy_(persistent_block_tables_default_,
                                    /*non_blocking=*/true);
   }
-  if (actual_num_tokens > 0 && params.attention.device.block_tables.defined() &&
+  if (actual_seq_len_rows > 0 &&
+      params.attention.device.block_tables.defined() &&
       params.attention.device.block_tables.dim() >= 2 &&
       params.attention.device.block_tables.numel() > 0) {
     const int64_t block_rows_to_copy = std::min<int64_t>(
-        actual_num_tokens, params.attention.device.block_tables.size(0));
+        actual_seq_len_rows, params.attention.device.block_tables.size(0));
     const int64_t actual_block_table_len =
         params.attention.device.block_tables.size(1);
     if (block_rows_to_copy > 0 && actual_block_table_len > 0) {
@@ -776,9 +784,9 @@ std::optional<ModelInputParams> GraphPersistentParam::update(
           /*non_blocking=*/true);
     }
   }
-  if (actual_num_tokens < padded_batch_size) {
+  if (actual_seq_len_rows < padded_batch_size) {
     zero_tensor_tail(
-        persistent_block_tables_, actual_num_tokens, padded_batch_size);
+        persistent_block_tables_, actual_seq_len_rows, padded_batch_size);
   }
 
   // Update persistent embedding from input_embedding if available
@@ -817,16 +825,16 @@ std::optional<ModelInputParams> GraphPersistentParam::update(
     const bool input_has_leading_zero =
         params.is_spec_verify && use_qwen3_5_query_start_loc;
     const int64_t required_q_cu_seq_lens =
-        actual_num_tokens + (input_has_leading_zero ? 1 : 0);
+        actual_seq_len_rows + (input_has_leading_zero ? 1 : 0);
     CHECK_GE(params.attention.device.q_cu_seq_lens.numel(),
              required_q_cu_seq_lens)
         << "q_cu_seq_lens does not have enough entries for ACL graph execution";
     if (use_qwen3_5_query_start_loc && !input_has_leading_zero) {
       q_cu_seq_lens_.slice(/*dim=*/0, /*start=*/0, /*end=*/1).zero_();
       q_cu_seq_lens_
-          .slice(/*dim=*/0, /*start=*/1, /*end=*/actual_num_tokens + 1)
+          .slice(/*dim=*/0, /*start=*/1, /*end=*/actual_seq_len_rows + 1)
           .copy_(params.attention.device.q_cu_seq_lens.slice(
-                     /*dim=*/0, /*start=*/0, /*end=*/actual_num_tokens),
+                     /*dim=*/0, /*start=*/0, /*end=*/actual_seq_len_rows),
                  /*non_blocking=*/true);
     } else {
       q_cu_seq_lens_
@@ -837,17 +845,17 @@ std::optional<ModelInputParams> GraphPersistentParam::update(
                      /*dim=*/0, /*start=*/0, /*end=*/required_q_cu_seq_lens),
                  /*non_blocking=*/true);
     }
-    if (padded_batch_size > actual_num_tokens) {
+    if (padded_batch_size > actual_seq_len_rows) {
       int32_t offset = static_cast<int32_t>(actual_num_tokens);
       std::vector<int32_t> padded_q_cu_seq_lens;
-      padded_q_cu_seq_lens.reserve(padded_batch_size - actual_num_tokens);
+      padded_q_cu_seq_lens.reserve(padded_batch_size - actual_seq_len_rows);
       const int32_t padding_q_len = is_chunked_prefill ? q_max_seq_len : 1;
-      for (int64_t i = actual_num_tokens; i < padded_batch_size; ++i) {
+      for (int64_t i = actual_seq_len_rows; i < padded_batch_size; ++i) {
         offset += padding_q_len;
         padded_q_cu_seq_lens.emplace_back(offset);
       }
       const int64_t padding_start =
-          actual_num_tokens + (use_qwen3_5_query_start_loc ? 1 : 0);
+          actual_seq_len_rows + (use_qwen3_5_query_start_loc ? 1 : 0);
       const int64_t padding_end =
           padded_batch_size + (use_qwen3_5_query_start_loc ? 1 : 0);
       q_cu_seq_lens_
@@ -869,18 +877,18 @@ std::optional<ModelInputParams> GraphPersistentParam::update(
   std::vector<int32_t> padded_q_seq_lens_vec(
       static_cast<size_t>(padded_batch_size), 1);
   CHECK_GE(params.attention.host.kv_seq_lens.size(),
-           static_cast<size_t>(actual_num_tokens))
-      << "kv_seq_lens host size is smaller than actual num tokens";
+           static_cast<size_t>(actual_seq_len_rows))
+      << "kv_seq_lens host size is smaller than required graph rows";
   CHECK_GE(params.attention.host.q_seq_lens.size(),
-           static_cast<size_t>(actual_num_tokens))
-      << "q_seq_lens host size is smaller than actual num tokens";
-  for (int64_t i = 0; i < actual_num_tokens; ++i) {
+           static_cast<size_t>(actual_seq_len_rows))
+      << "q_seq_lens host size is smaller than required graph rows";
+  for (int64_t i = 0; i < actual_seq_len_rows; ++i) {
     padded_kv_seq_lens_vec[static_cast<size_t>(i)] =
         params.attention.host.kv_seq_lens[static_cast<size_t>(i)];
     padded_q_seq_lens_vec[static_cast<size_t>(i)] =
         params.attention.host.q_seq_lens[static_cast<size_t>(i)];
   }
-  for (int64_t i = actual_num_tokens; i < padded_batch_size; ++i) {
+  for (int64_t i = actual_seq_len_rows; i < padded_batch_size; ++i) {
     padded_q_seq_lens_vec[static_cast<size_t>(i)] =
         is_chunked_prefill ? q_max_seq_len : 1;
   }

--- a/xllm/core/runtime/mtp_worker_impl.cpp
+++ b/xllm/core/runtime/mtp_worker_impl.cpp
@@ -1212,8 +1212,7 @@ void MTPWorkerImpl::prepare_draft_extend_inputs(
 
   const bool dp_enabled = parallel_args_.dp_size() > 1;
   const bool use_chunked_prefill =
-      ::xllm::SpeculativeConfig::get_instance().enable_atb_spec_kernel() ||
-      use_qwen3_5_spec_verify_path();
+      ::xllm::SpeculativeConfig::get_instance().enable_atb_spec_kernel();
   CHECK_EQ(last_states.size(), static_cast<size_t>(num_sequences))
       << "draft extend state count mismatch";
 

--- a/xllm/core/runtime/mtp_worker_impl.cpp
+++ b/xllm/core/runtime/mtp_worker_impl.cpp
@@ -1143,9 +1143,7 @@ void MTPWorkerImpl::prepare_draft_extend_inputs(
 
   const bool dp_enabled = parallel_args_.dp_size() > 1;
   const bool use_chunked_prefill =
-      (::xllm::SpeculativeConfig::get_instance().enable_atb_spec_kernel() ||
-       use_qwen3_5_spec_verify_path()) &&
-      use_qwen3_5_spec_verify_path();
+      ::xllm::SpeculativeConfig::get_instance().enable_atb_spec_kernel();
   CHECK_EQ(last_states.size(), static_cast<size_t>(num_sequences))
       << "draft extend state count mismatch";
 
@@ -1194,6 +1192,7 @@ void MTPWorkerImpl::prepare_draft_extend_inputs(
       row.seq_id = seq_id;
       row.token_id = token_id >= 0 ? token_id : 0;
       row.position_offset = position_offset;
+      row.append_kv_len = !use_chunked_prefill;
       row.append_q_len_one = !use_chunked_prefill;
       row.append_block_table = !use_chunked_prefill;
       specBuilder::append_decode_row(row_ctx, row, block_size, buf);

--- a/xllm/core/runtime/mtp_worker_impl.cpp
+++ b/xllm/core/runtime/mtp_worker_impl.cpp
@@ -138,6 +138,24 @@ std::optional<ForwardOutput> run_llm_no_sync_impl(LLMWorkerImpl& worker,
   return worker.execute_no_sync_on_stream(processed_input, compute_stream);
 }
 
+torch::Tensor clone_host_tensor(const torch::Tensor& tensor) {
+  if (!tensor.defined()) {
+    return tensor;
+  }
+  CHECK(tensor.device().is_cpu()) << "expected a CPU host tensor";
+  return tensor.contiguous().clone();
+}
+
+void stabilize_decode_host_tensors(ForwardInput& input) {
+  input.token_ids_host = clone_host_tensor(input.token_ids_host);
+  input.positions_host = clone_host_tensor(input.positions_host);
+  input.input_params.attention.host.block_tables =
+      clone_host_tensor(input.input_params.attention.host.block_tables);
+  for (torch::Tensor& block_table : input.input_params.multi_block_tables) {
+    block_table = clone_host_tensor(block_table);
+  }
+}
+
 void set_token_ids_device_tensor(ForwardInput& input,
                                  const torch::Tensor& token_ids,
                                  const torch::TensorOptions& token_options,
@@ -765,6 +783,9 @@ void MTPWorkerImpl::prepare_prefill_inputs(const ForwardInput& input,
 std::optional<ForwardOutput> MTPWorkerImpl::step_decode(
     const ForwardInput& raw_input) {
   ForwardInput input = raw_input;
+  if (use_qwen3_5_spec_verify_path()) {
+    stabilize_decode_host_tensors(input);
+  }
   const int32_t num_speculative_tokens = options_.num_speculative_tokens();
 
   std::vector<ForwardOutput> draft_outputs;
@@ -967,11 +988,59 @@ void MTPWorkerImpl::update_decode_step_input(
         enable_cache_correction && input_is_fake_token && !state.valid;
     const int32_t position_offset =
         use_cache_correction ? state.position_offset : 0;
-    const int32_t current_position = input_positions[seq_id] + position_offset;
-    const int32_t current_kv_len = specBuilder::calc_kv_len(
+    int32_t current_position = input_positions[seq_id] + position_offset;
+    int32_t current_kv_len = specBuilder::calc_kv_len(
         input.input_params.attention.host.kv_seq_lens, seq_id, position_offset);
+    int32_t expected_kv_len = current_position + 1;
+    if (use_qwen3_5_spec_verify_path()) {
+      const torch::Tensor& block_tables =
+          input.input_params.attention.host.block_tables;
+      if (block_tables.defined() && block_tables.dim() == 2 &&
+          seq_id < block_tables.size(0)) {
+        const int32_t allocated_kv_len =
+            static_cast<int32_t>(block_tables.size(1)) * options_.block_size();
+        const int32_t validate_width = options_.num_speculative_tokens() + 1;
+        const int32_t max_valid_position = allocated_kv_len - validate_width;
+        if (current_position > max_valid_position) {
+          CHECK_GT(allocated_kv_len, 0)
+              << "decode context has empty block table, seq_id=" << seq_id;
+          CHECK_GE(max_valid_position, 0)
+              << "decode context block table is too small for validation, "
+              << "seq_id=" << seq_id
+              << ", allocated_kv_len=" << allocated_kv_len
+              << ", validate_width=" << validate_width;
+          CHECK_LE(current_position - max_valid_position,
+                   options_.num_speculative_tokens() + 1)
+              << "decode context position exceeds allocated blocks, seq_id="
+              << seq_id << ", current_position=" << current_position
+              << ", current_kv_len=" << current_kv_len
+              << ", allocated_kv_len=" << allocated_kv_len;
+          current_position = max_valid_position;
+          expected_kv_len = current_position + 1;
+          current_kv_len = std::min(current_kv_len, expected_kv_len);
+        }
+      }
+    }
+    if (use_qwen3_5_spec_verify_path() && current_kv_len < expected_kv_len) {
+      // Qwen3.5 MTP can receive a scheduler KV length that has not yet caught
+      // up with the speculative placeholder resolved into current_position.
+      // Normalize only the lag explainable by the current speculative step.
+      CHECK_LE(expected_kv_len - current_kv_len,
+               options_.num_speculative_tokens() + 1)
+          << "decode context kv_len lag is too large, seq_id=" << seq_id
+          << ", current_position=" << current_position
+          << ", current_kv_len=" << current_kv_len;
+      current_kv_len = expected_kv_len;
+    }
+    if (use_qwen3_5_spec_verify_path() && current_kv_len > expected_kv_len) {
+      // The first decode step can carry the prompt KV length while the decode
+      // position is still initialized to zero. Align the position to the KV
+      // context before building the MTP draft input.
+      current_position = current_kv_len - 1;
+      expected_kv_len = current_kv_len;
+    }
 
-    CHECK_EQ(current_position + 1, current_kv_len)
+    CHECK_EQ(expected_kv_len, current_kv_len)
         << "decode context position/kv_len mismatch, seq_id=" << seq_id
         << ", current_position=" << current_position
         << ", current_kv_len=" << current_kv_len;
@@ -1143,7 +1212,8 @@ void MTPWorkerImpl::prepare_draft_extend_inputs(
 
   const bool dp_enabled = parallel_args_.dp_size() > 1;
   const bool use_chunked_prefill =
-      ::xllm::SpeculativeConfig::get_instance().enable_atb_spec_kernel();
+      ::xllm::SpeculativeConfig::get_instance().enable_atb_spec_kernel() ||
+      use_qwen3_5_spec_verify_path();
   CHECK_EQ(last_states.size(), static_cast<size_t>(num_sequences))
       << "draft extend state count mismatch";
 


### PR DESCRIPTION
## Problem

Qwen3.5 MTP speculative decoding with graph mode can fail before or during request serving.

Observed failures include:

- Startup/warmup failure: `PagedAttentionOperation setup failed!`
- Graph persistent-param failure: `ACL graph persistent param only supports decode`
- Shape validation failure: `q_cu_seq_lens does not have enough entries for ACL graph execution`
- Concurrent request failure: `decode context position/kv_len mismatch` or `decode context position exceeds allocated blocks`

## Root Cause

This path has four input-layout/lifetime issues:

1. Qwen3.5 MTP draft extend may need chunked-prefill style inputs for the graph/spec-verify path, while the original logic only enabled that layout for `enable_atb_spec_kernel()`.
2. Spec-verify graph capture can receive chunked-prefill inputs where `tokens` is token-row based, but `q_seq_lens`, `kv_seq_lens`, `block_tables`, and `q_cu_seq_lens` are sequence-row based. The old persistent-param logic could treat those tensors as token-row based and over-copy/over-check rows.
3. NPU chunked-prefill attention selected the spec-verify paged-prefill path whenever speculative decoding was enabled. This also affected normal chunked-prefill warmup/capture inputs and could make `PagedAttentionOperation` setup fail before the service became ready.
4. With `enable_schedule_overlap=true`, `WorkerService::step()` can return before async worker execution finishes. Some CPU tensors decoded from shared memory, such as `token_ids_host`, `positions_host`, and `block_tables`, are `from_blob` views into shared memory. The next request can reuse that memory while MTP decode still reads the previous input, corrupting positions/KV metadata and causing MTP validation failures.

## Fix

- Allow Qwen3.5 spec-verify to use chunked-prefill draft extend inputs while preserving the existing `enable_atb_spec_kernel()` path.
- Avoid appending decode-row metadata in draft extend when the chunked path is used.
- Allow Qwen3.5 spec-verify chunked-prefill inputs in graph persistent params.
- Use sequence-row count, instead of token count, when copying seq-len tensors, block tables, and `q_cu_seq_lens` for chunked-prefill graph inputs.
- Restrict the NPU chunked-prefill paged-prefill attention path to real spec-verify inputs instead of all speculative-decoding runs.
- Clone CPU shared-memory tensor views at the `WorkerService` schedule-overlap boundary before dispatching async worker execution.
- Normalize Qwen3.5 MTP decode `position/kv_len` only within the current speculative window and fail fast on larger mismatches.

## Validation

- `git submodule update --init --recursive`
- `python setup.py build --device npu`: passed after the latest attention-path fix
- Qwen35-27B MTP graph-mode startup with `/home/g00510989/xllm/xllm-main/xllm.sh`: prefill warmup, decode warmup, and ACL graph buckets 4/8/16/32 completed without `PagedAttentionOperation setup failed`
- `/v1/models` returned normally on port 28150
- CEVAL-test:

| 进度 | 已完成/总量 | 正确数 | 准确率 |
|------|------------|--------|--------|
| 当前 | 573/1346 (42.6%) | 524 | **91.45%** |

**各科目明细：**

| 科目 | 正确/总数 | 准确率 |
|------|----------|--------|
| education_science | 5/12 | 41.67% |
| electrical_engineer | 26/37 | 70.27% |
| discrete_mathematics | 13/16 | 81.25% |
| middle_school_biology | 18/21 | 85.71% |
| college_economics | 48/55 | 87.27% |
| metrology_engineer | 21/24 | 87.50% |
| computer_network | 17/19 | 89.47% |
| business_administration | 30/33 | 90.91% |
| mao_zedong_thought | 22/24 | 91.67% |
| probability_and_statistics | 17/18 | 94.44% |
| high_school_mathematics | 17/18 | 94.44% |
| college_programming | 35/37 | 94.59% |
| college_physics | 18/19 | 94.74% |
| marxism | 18/19 | 94.74% |
| veterinary_medicine | 22/23 | 95.65% |
| college_chemistry | 23/24 | 95.83% |
| operating_system | 19/19 | 100% |
| computer_architecture | 21/21 | 100% |
| advanced_mathematics | 19/19 | 100% |
| high_school_physics | 19/19 | 100% |
| high_school_chemistry | 19/19 | 100% |
| high_school_biology | 19/19 | 100% |
| middle_school_mathematics | 19/19 | 100% |
| middle_school_physics | 19/19 | 100% |
| middle_school_chemistry | 20/20 | 100% |

- evalscope perf
```bash
curl -s http://127.0.0.1:28150/vars > /tmp/vars_before.txt
evalscope perf \
  --model Qwen35-27B \
  --api openai \
  --tokenizer-path /home/data/weights/Qwen35-27B \
  --url http://127.0.0.1:28150/v1/chat/completions \
  --connect-timeout 120 \
  --read-timeout 900 \
  --total-timeout 21600 \
  --number 5 \
  --parallel 1 \
  --warmup-num 5 \
  --outputs-dir ./output \
  --max-prompt-length 20000 \
  --min-prompt-length 20000 \
  --dataset random \
  --max-tokens 1000 \
  --min-tokens 1000 \
  --stream \
  --temperature 0.0 \
  --extra-args '{"ignore_eos": true}'
curl -s http://127.0.0.1:28150/vars > /tmp/vars_after.txt
```
spec decode accept rate: 65% (speculative_num_accepted_tokens_total/speculative_num_draft_tokens_total)

<img width="629" height="520" alt="image" src="https://github.com/user-attachments/assets/73df520a-8724-43ed-9596-3ef9a8712f83" />
