### PR TITLE
feat: support pause and resume for fully async-rl.

### DIFF
--- a/tests/core/scheduler/continuous_scheduler_test.cpp
+++ b/tests/core/scheduler/continuous_scheduler_test.cpp
@@ -875,6 +875,159 @@ TEST(ContinuousSchedulerTest, PDDecodeBestOfOneSkipsExpansionAndShares) {
   // prepare_batch may allocate extra decode blocks; release them before engine
   // teardown (BlockManagerImpl checks all blocks are on the free list).
   block_manager_pool->deallocate_without_cache(seq0);
+  (void)engine.release();
+}
+// ============== Async RL training: Pause/Resume tests ==============
+
+// TEST: pause()/resume() state transitions are correct and idempotent.
+TEST(ContinuousSchedulerTest, PauseResumeStateTransition) {
+  int block_num = 9;
+  int block_size = 32;
+  ContinuousScheduler::Options opt =
+      create_scheduler_options(10000, 256, 0, 1024, 1);
+  auto engine = std::make_unique<FakeEngine>(block_num, block_size);
+  auto scheduler = std::make_unique<ContinuousScheduler>(engine.get(), opt);
+
+  EXPECT_FALSE(scheduler->is_paused());
+  scheduler->pause();
+  EXPECT_TRUE(scheduler->is_paused());
+  scheduler->pause();  // idempotent
+  EXPECT_TRUE(scheduler->is_paused());
+  scheduler->resume();
+  EXPECT_FALSE(scheduler->is_paused());
+  scheduler->resume();  // idempotent
+  EXPECT_FALSE(scheduler->is_paused());
+
+  (void)engine.release();
+}
+
+// TEST: pause preempts all running requests, frees KV cache, moves them back
+// to the waiting queue (vLLM-compatible semantics for RL).
+TEST(ContinuousSchedulerTest, PausePreemptsRunningAndFreesKVCache) {
+  int block_num = 33;
+  int block_size = 32;
+  ContinuousScheduler::Options opt =
+      create_scheduler_options(10000, 256, 0, 1024, 1);
+  auto engine = std::make_unique<FakeEngine>(block_num, block_size);
+  auto scheduler = std::make_unique<ContinuousScheduler>(engine.get(), opt);
+  BlockManagerPool* block_manager_pool = engine->block_manager_pool();
+  ASSERT_TRUE(scheduler != nullptr);
+
+  auto requests = generate_request({127, 127},
+                                   {10, 10},
+                                   std::vector<bool>{false, false},
+                                   std::vector<int32_t>{2, 2},
+                                   std::nullopt,
+                                   std::nullopt,
+                                   30000);
+  std::vector<std::shared_ptr<Request>> running_requests = requests;
+  for (auto req : requests) {
+    scheduler->add_request(req);
+  }
+  auto batch = scheduler->prepare_batch_test();
+  EXPECT_EQ(batch.size(), 1);
+  EXPECT_EQ(batch[0].size(), 2);
+  update_requests(running_requests);
+
+  EXPECT_EQ(scheduler->get_running_requests().size(), 2);
+  int free_blocks_before = util::max(block_manager_pool->num_free_blocks());
+
+  scheduler->pause();
+  scheduler->preempt_all_running_requests_test();
+
+  int free_blocks_after = util::max(block_manager_pool->num_free_blocks());
+  EXPECT_GT(free_blocks_after, free_blocks_before);
+  EXPECT_EQ(scheduler->get_running_requests().size(), 0);
+  EXPECT_EQ(scheduler->get_waiting_requests_num(), 2);
+
+  (void)engine.release();
+}
+
+// TEST: after resume, preempted requests in the waiting queue get re-scheduled.
+TEST(ContinuousSchedulerTest, ResumeReschedulesPreemptedRequests) {
+  int block_num = 33;
+  int block_size = 32;
+  ContinuousScheduler::Options opt =
+      create_scheduler_options(10000, 256, 0, 1024, 1);
+  auto engine = std::make_unique<FakeEngine>(block_num, block_size);
+  auto scheduler = std::make_unique<ContinuousScheduler>(engine.get(), opt);
+  ASSERT_TRUE(scheduler != nullptr);
+
+  auto requests = generate_request({127, 127},
+                                   {10, 10},
+                                   std::vector<bool>{false, false},
+                                   std::vector<int32_t>{2, 2},
+                                   std::nullopt,
+                                   std::nullopt,
+                                   30000);
+  std::vector<std::shared_ptr<Request>> running_requests = requests;
+  for (auto req : requests) {
+    scheduler->add_request(req);
+  }
+  (void)scheduler->prepare_batch_test();
+  update_requests(running_requests);
+  EXPECT_EQ(scheduler->get_running_requests().size(), 2);
+
+  scheduler->pause();
+  scheduler->preempt_all_running_requests_test();
+  EXPECT_EQ(scheduler->get_running_requests().size(), 0);
+  EXPECT_EQ(scheduler->get_waiting_requests_num(), 2);
+
+  scheduler->resume();
+  EXPECT_FALSE(scheduler->is_paused());
+
+  auto batch = scheduler->prepare_batch_test();
+  EXPECT_EQ(batch.size(), 1);
+  EXPECT_EQ(batch[0].size(), 2);
+  EXPECT_EQ(scheduler->get_running_requests().size(), 2);
+  EXPECT_EQ(scheduler->get_waiting_requests_num(), 0);
+
+  (void)engine.release();
+}
+
+// TEST: ABORT mode cancels running requests, frees KV cache, and does NOT
+// push them back to the waiting queue (clients must retry).
+TEST(ContinuousSchedulerTest, PauseAbortCancelsRunningRequests) {
+  int block_num = 33;
+  int block_size = 32;
+  ContinuousScheduler::Options opt =
+      create_scheduler_options(10000, 256, 0, 1024, 1);
+  auto engine = std::make_unique<FakeEngine>(block_num, block_size);
+  auto scheduler = std::make_unique<ContinuousScheduler>(engine.get(), opt);
+  BlockManagerPool* block_manager_pool = engine->block_manager_pool();
+  ASSERT_TRUE(scheduler != nullptr);
+
+  auto requests = generate_request({127, 127},
+                                   {10, 10},
+                                   std::vector<bool>{false, false},
+                                   std::vector<int32_t>{2, 2},
+                                   std::nullopt,
+                                   std::nullopt,
+                                   30000);
+  std::vector<std::shared_ptr<Request>> running_requests = requests;
+  for (auto req : requests) {
+    // process_failed_request invokes the requests output callback; give it a
+    // no-op so ABORT can notify completion without a real client.
+    req->state().output_func = [](const RequestOutput&) { return true; };
+    scheduler->add_request(req);
+  }
+  auto batch = scheduler->prepare_batch_test();
+  EXPECT_EQ(batch.size(), 1);
+  EXPECT_EQ(batch[0].size(), 2);
+  update_requests(running_requests);
+
+  EXPECT_EQ(scheduler->get_running_requests().size(), 2);
+  int free_blocks_before = util::max(block_manager_pool->num_free_blocks());
+
+  scheduler->abort_all_running_requests_test();
+
+  int free_blocks_after = util::max(block_manager_pool->num_free_blocks());
+  EXPECT_GT(free_blocks_after, free_blocks_before);        // KV cache freed
+  EXPECT_EQ(scheduler->get_running_requests().size(), 0);  // running cleared
+  EXPECT_EQ(scheduler->get_waiting_requests_num(), 0);     // NOT requeued
+
+  (void)engine.release();
+
 }
 
 }  // namespace xllm

--- a/xllm/api_service/api_service.cpp
+++ b/xllm/api_service/api_service.cpp
@@ -1280,8 +1280,8 @@ void APIService::StopProfileHttp(::google::protobuf::RpcController* controller,
   // Success: return HTTP 200 with empty body
 }
 
-void APIService::LinkD2D(::google::protobuf::RpcController* controller,
-                         const proto::D2DLinkRequest* request,
+void APIService::LinkP2P(::google::protobuf::RpcController* controller,
+                         const proto::P2PLinkRequest* request,
                          proto::Status* response,
                          ::google::protobuf::Closure* done) {
   brpc::ClosureGuard done_guard(done);
@@ -1296,12 +1296,12 @@ void APIService::LinkD2D(::google::protobuf::RpcController* controller,
     response->set_ok(false);
     return;
   }
-  bool status = master->link_d2d(
+  bool status = master->link_p2p(
       {request->remote_addrs().begin(), request->remote_addrs().end()});
   response->set_ok(status);
 }
 
-void APIService::LinkD2DHttp(::google::protobuf::RpcController* controller,
+void APIService::LinkP2PHttp(::google::protobuf::RpcController* controller,
                              const proto::HttpRequest* request,
                              proto::HttpResponse* response,
                              ::google::protobuf::Closure* done) {
@@ -1313,7 +1313,7 @@ void APIService::LinkD2DHttp(::google::protobuf::RpcController* controller,
 
   auto arena = response->GetArena();
   auto req_pb =
-      google::protobuf::Arena::CreateMessage<proto::D2DLinkRequest>(arena);
+      google::protobuf::Arena::CreateMessage<proto::P2PLinkRequest>(arena);
   auto resp_pb = google::protobuf::Arena::CreateMessage<proto::Status>(arena);
 
   auto ctrl = reinterpret_cast<brpc::Controller*>(controller);
@@ -1335,7 +1335,7 @@ void APIService::LinkD2DHttp(::google::protobuf::RpcController* controller,
     ctrl->SetFailed("Master for model not found");
     return;
   }
-  bool status = master->link_d2d(
+  bool status = master->link_p2p(
       {req_pb->remote_addrs().begin(), req_pb->remote_addrs().end()});
   resp_pb->set_ok(status);
 
@@ -1350,8 +1350,8 @@ void APIService::LinkD2DHttp(::google::protobuf::RpcController* controller,
   }
 }
 
-void APIService::UnlinkD2D(::google::protobuf::RpcController* controller,
-                           const proto::D2DLinkRequest* request,
+void APIService::UnlinkP2P(::google::protobuf::RpcController* controller,
+                           const proto::P2PLinkRequest* request,
                            proto::Status* response,
                            ::google::protobuf::Closure* done) {
   brpc::ClosureGuard done_guard(done);
@@ -1366,12 +1366,12 @@ void APIService::UnlinkD2D(::google::protobuf::RpcController* controller,
     response->set_ok(false);
     return;
   }
-  bool status = master->unlink_d2d(
+  bool status = master->unlink_p2p(
       {request->remote_addrs().begin(), request->remote_addrs().end()});
   response->set_ok(status);
 }
 
-void APIService::UnlinkD2DHttp(::google::protobuf::RpcController* controller,
+void APIService::UnlinkP2PHttp(::google::protobuf::RpcController* controller,
                                const proto::HttpRequest* request,
                                proto::HttpResponse* response,
                                ::google::protobuf::Closure* done) {
@@ -1383,7 +1383,7 @@ void APIService::UnlinkD2DHttp(::google::protobuf::RpcController* controller,
 
   auto arena = response->GetArena();
   auto req_pb =
-      google::protobuf::Arena::CreateMessage<proto::D2DLinkRequest>(arena);
+      google::protobuf::Arena::CreateMessage<proto::P2PLinkRequest>(arena);
   auto resp_pb = google::protobuf::Arena::CreateMessage<proto::Status>(arena);
 
   auto ctrl = reinterpret_cast<brpc::Controller*>(controller);
@@ -1405,7 +1405,7 @@ void APIService::UnlinkD2DHttp(::google::protobuf::RpcController* controller,
     ctrl->SetFailed("Master for model not found");
     return;
   }
-  bool status = master->unlink_d2d(
+  bool status = master->unlink_p2p(
       {req_pb->remote_addrs().begin(), req_pb->remote_addrs().end()});
   resp_pb->set_ok(status);
 
@@ -1418,6 +1418,128 @@ void APIService::UnlinkD2DHttp(::google::protobuf::RpcController* controller,
     LOG(ERROR) << "proto to json failed: " << err_msg;
     return;
   }
+}
+
+// ============== Async RL training support: Pause/Resume ==============
+void APIService::Pause(::google::protobuf::RpcController* controller,
+                       const proto::PauseRequest* request,
+                       proto::PauseResponse* response,
+                       ::google::protobuf::Closure* done) {
+  brpc::ClosureGuard done_guard(done);
+
+  if (!request || !response || !controller) {
+    LOG(ERROR) << "Pause: request/response/controller is null";
+    return;
+  }
+
+  auto* llm_master = dynamic_cast<LLMMaster*>(master_);
+  if (!llm_master) {
+    LOG(ERROR) << "Master is not an LLMMaster";
+    response->set_status("error: not an LLMMaster");
+    return;
+  }
+
+  const std::string& mode = request->mode();
+  llm_master->pause_scheduler(mode);
+
+  response->set_status("paused");
+  LOG(INFO) << "Pause completed successfully (mode="
+            << (mode.empty() ? "keep" : mode) << ")";
+}
+
+void APIService::PauseHttp(::google::protobuf::RpcController* controller,
+                           const proto::HttpRequest* request,
+                           proto::HttpResponse* response,
+                           ::google::protobuf::Closure* done) {
+  brpc::ClosureGuard done_guard(done);
+
+  if (!request || !response || !controller) {
+    LOG(ERROR) << "PauseHttp: request/response/controller is null";
+    return;
+  }
+
+  auto arena = response->GetArena();
+  auto req_pb =
+      google::protobuf::Arena::CreateMessage<proto::PauseRequest>(arena);
+  auto resp_pb =
+      google::protobuf::Arena::CreateMessage<proto::PauseResponse>(arena);
+
+  auto ctrl = reinterpret_cast<brpc::Controller*>(controller);
+
+  // Parse JSON request (if body provided, otherwise use defaults)
+  if (ctrl->request_attachment().size() > 0) {
+    std::string error;
+    json2pb::Json2PbOptions options;
+    butil::IOBuf& buf = ctrl->request_attachment();
+    butil::IOBufAsZeroCopyInputStream iobuf_stream(buf);
+    auto st =
+        json2pb::JsonToProtoMessage(&iobuf_stream, req_pb, options, &error);
+    if (!st) {
+      ctrl->SetFailed(error);
+      LOG(ERROR) << "PauseHttp: parse json to proto failed: " << error;
+      return;
+    }
+  }
+
+  // Call Pause
+  Pause(controller, req_pb, resp_pb, nullptr);
+
+  // Convert response to JSON
+  std::string json_output;
+  json2pb::ProtoMessageToJson(*resp_pb, &json_output, nullptr);
+  ctrl->response_attachment().append(json_output);
+}
+
+void APIService::Resume(::google::protobuf::RpcController* controller,
+                        const proto::ResumeRequest* request,
+                        proto::ResumeResponse* response,
+                        ::google::protobuf::Closure* done) {
+  brpc::ClosureGuard done_guard(done);
+
+  if (!request || !response || !controller) {
+    LOG(ERROR) << "Resume: request/response/controller is null";
+    return;
+  }
+
+  auto* llm_master = dynamic_cast<LLMMaster*>(master_);
+  if (!llm_master) {
+    LOG(ERROR) << "Master is not an LLMMaster";
+    response->set_status("error: not an LLMMaster");
+    return;
+  }
+
+  llm_master->resume_scheduler();
+
+  response->set_status("running");
+  LOG(INFO) << "Resume completed successfully";
+}
+
+void APIService::ResumeHttp(::google::protobuf::RpcController* controller,
+                            const proto::HttpRequest* request,
+                            proto::HttpResponse* response,
+                            ::google::protobuf::Closure* done) {
+  brpc::ClosureGuard done_guard(done);
+
+  if (!request || !response || !controller) {
+    LOG(ERROR) << "ResumeHttp: request/response/controller is null";
+    return;
+  }
+
+  auto arena = response->GetArena();
+  auto req_pb =
+      google::protobuf::Arena::CreateMessage<proto::ResumeRequest>(arena);
+  auto resp_pb =
+      google::protobuf::Arena::CreateMessage<proto::ResumeResponse>(arena);
+
+  auto ctrl = reinterpret_cast<brpc::Controller*>(controller);
+
+  // Call Resume (no request body needed)
+  Resume(controller, req_pb, resp_pb, nullptr);
+
+  // Convert response to JSON
+  std::string json_output;
+  json2pb::ProtoMessageToJson(*resp_pb, &json_output, nullptr);
+  ctrl->response_attachment().append(json_output);
 }
 
 }  // namespace xllm

--- a/xllm/api_service/api_service.h
+++ b/xllm/api_service/api_service.h
@@ -188,25 +188,46 @@ class APIService : public proto::XllmAPIService {
                        proto::HttpResponse* response,
                        ::google::protobuf::Closure* done) override;
 
-  void LinkD2D(::google::protobuf::RpcController* controller,
-               const proto::D2DLinkRequest* request,
+  void LinkP2P(::google::protobuf::RpcController* controller,
+               const proto::P2PLinkRequest* request,
                proto::Status* response,
                ::google::protobuf::Closure* done) override;
 
-  void LinkD2DHttp(::google::protobuf::RpcController* controller,
+  void LinkP2PHttp(::google::protobuf::RpcController* controller,
                    const proto::HttpRequest* request,
                    proto::HttpResponse* response,
                    ::google::protobuf::Closure* done) override;
 
-  void UnlinkD2D(::google::protobuf::RpcController* controller,
-                 const proto::D2DLinkRequest* request,
+  void UnlinkP2P(::google::protobuf::RpcController* controller,
+                 const proto::P2PLinkRequest* request,
                  proto::Status* response,
                  ::google::protobuf::Closure* done) override;
 
-  void UnlinkD2DHttp(::google::protobuf::RpcController* controller,
+  void UnlinkP2PHttp(::google::protobuf::RpcController* controller,
                      const proto::HttpRequest* request,
                      proto::HttpResponse* response,
                      ::google::protobuf::Closure* done) override;
+
+  // Async RL training support: pause/resume
+  void Pause(::google::protobuf::RpcController* controller,
+             const proto::PauseRequest* request,
+             proto::PauseResponse* response,
+             ::google::protobuf::Closure* done) override;
+
+  void PauseHttp(::google::protobuf::RpcController* controller,
+                 const proto::HttpRequest* request,
+                 proto::HttpResponse* response,
+                 ::google::protobuf::Closure* done) override;
+
+  void Resume(::google::protobuf::RpcController* controller,
+              const proto::ResumeRequest* request,
+              proto::ResumeResponse* response,
+              ::google::protobuf::Closure* done) override;
+
+  void ResumeHttp(::google::protobuf::RpcController* controller,
+                  const proto::HttpRequest* request,
+                  proto::HttpResponse* response,
+                  ::google::protobuf::Closure* done) override;
 
  private:
   using ChatHttpHandler = std::function<void(ClosureGuard&,

--- a/xllm/core/common/types.h
+++ b/xllm/core/common/types.h
@@ -209,7 +209,7 @@ struct RecItemInfo {
   std::string type;
 };
 
-// Weight segment info for D2D transfer (supports non-contiguous allocation)
+// Weight segment info for P2P transfer (supports non-contiguous allocation)
 // Forward declaration needed by InstanceInfo
 struct WeightSegment {
   uint64_t offset;  // Offset from GlobalXTensor base address

--- a/xllm/core/distributed_runtime/comm_channel.cpp
+++ b/xllm/core/distributed_runtime/comm_channel.cpp
@@ -160,31 +160,31 @@ bool CommChannel::unlink_cluster(const std::vector<uint64_t>& cluster_ids,
   return true;
 }
 
-bool CommChannel::link_d2d(const std::string& remote_addr) {
-  proto::D2DLinkWorkerRequest req;
+bool CommChannel::link_p2p(const std::string& remote_addr) {
+  proto::P2PLinkWorkerRequest req;
   req.set_remote_addr(remote_addr);
 
   proto::Status s;
   brpc::Controller cntl;
-  stub_->LinkD2D(&cntl, &req, &s, nullptr);
+  stub_->LinkP2P(&cntl, &req, &s, nullptr);
 
   if (cntl.Failed() || !s.ok()) {
-    LOG(ERROR) << "LinkD2D failed: " << cntl.ErrorText();
+    LOG(ERROR) << "LinkP2P failed: " << cntl.ErrorText();
     return false;
   }
   return true;
 }
 
-bool CommChannel::unlink_d2d(const std::string& remote_addr) {
-  proto::D2DLinkWorkerRequest req;
+bool CommChannel::unlink_p2p(const std::string& remote_addr) {
+  proto::P2PLinkWorkerRequest req;
   req.set_remote_addr(remote_addr);
 
   proto::Status s;
   brpc::Controller cntl;
-  stub_->UnlinkD2D(&cntl, &req, &s, nullptr);
+  stub_->UnlinkP2P(&cntl, &req, &s, nullptr);
 
   if (cntl.Failed() || !s.ok()) {
-    LOG(ERROR) << "UnlinkD2D failed: " << cntl.ErrorText();
+    LOG(ERROR) << "UnlinkP2P failed: " << cntl.ErrorText();
     return false;
   }
   return true;

--- a/xllm/core/distributed_runtime/comm_channel.h
+++ b/xllm/core/distributed_runtime/comm_channel.h
@@ -55,9 +55,9 @@ class CommChannel {
                               const std::vector<std::string>& addrs,
                               const std::vector<uint16_t>& ports);
 
-  // D2D link for weight transfer
-  virtual bool link_d2d(const std::string& remote_addr);
-  virtual bool unlink_d2d(const std::string& remote_addr);
+  // P2P link for weight transfer
+  virtual bool link_p2p(const std::string& remote_addr);
+  virtual bool unlink_p2p(const std::string& remote_addr);
 
   virtual bool init_model(const std::string& model_weights_path,
                           int32_t random_seed,

--- a/xllm/core/distributed_runtime/engine.h
+++ b/xllm/core/distributed_runtime/engine.h
@@ -134,13 +134,13 @@ class Engine {
     return false;
   };
 
-  // D2D link for weight transfer - each worker links to one remote addr.
-  virtual bool link_d2d(const std::vector<std::string>& remote_addrs) {
+  // P2P link for weight transfer - each worker links to one remote addr.
+  virtual bool link_p2p(const std::vector<std::string>& remote_addrs) {
     NOT_IMPLEMENTED();
     return false;
   };
 
-  virtual bool unlink_d2d(const std::vector<std::string>& remote_addrs) {
+  virtual bool unlink_p2p(const std::vector<std::string>& remote_addrs) {
     NOT_IMPLEMENTED();
     return false;
   };

--- a/xllm/core/distributed_runtime/llm_engine.cpp
+++ b/xllm/core/distributed_runtime/llm_engine.cpp
@@ -835,7 +835,7 @@ bool LLMEngine::unlink_cluster(const std::vector<uint64_t>& cluster_ids,
   return true;
 }
 
-bool LLMEngine::link_d2d(const std::vector<std::string>& remote_addrs) {
+bool LLMEngine::link_p2p(const std::vector<std::string>& remote_addrs) {
   if (remote_addrs.size() != worker_clients_num_) {
     LOG(ERROR) << "remote_addrs size " << remote_addrs.size()
                << " != worker_clients_num " << worker_clients_num_;
@@ -854,7 +854,7 @@ bool LLMEngine::link_d2d(const std::vector<std::string>& remote_addrs) {
                                 promise = std::move(promise),
                                 worker_rank,
                                 remote_addr]() mutable {
-      promise.setValue(worker_clients_[worker_rank]->link_d2d(remote_addr));
+      promise.setValue(worker_clients_[worker_rank]->link_p2p(remote_addr));
     });
     futures.emplace_back(std::move(future));
   }
@@ -862,14 +862,14 @@ bool LLMEngine::link_d2d(const std::vector<std::string>& remote_addrs) {
   auto results = folly::collectAll(futures).get();
   for (const auto& result : results) {
     if (!result.value()) {
-      LOG(ERROR) << "Link D2D failed.";
+      LOG(ERROR) << "Link P2P failed.";
       return false;
     }
   }
   return true;
 }
 
-bool LLMEngine::unlink_d2d(const std::vector<std::string>& remote_addrs) {
+bool LLMEngine::unlink_p2p(const std::vector<std::string>& remote_addrs) {
   if (remote_addrs.size() != worker_clients_num_) {
     LOG(ERROR) << "remote_addrs size " << remote_addrs.size()
                << " != worker_clients_num " << worker_clients_num_;
@@ -888,7 +888,7 @@ bool LLMEngine::unlink_d2d(const std::vector<std::string>& remote_addrs) {
                                 promise = std::move(promise),
                                 worker_rank,
                                 remote_addr]() mutable {
-      promise.setValue(worker_clients_[worker_rank]->unlink_d2d(remote_addr));
+      promise.setValue(worker_clients_[worker_rank]->unlink_p2p(remote_addr));
     });
     futures.emplace_back(std::move(future));
   }
@@ -896,7 +896,7 @@ bool LLMEngine::unlink_d2d(const std::vector<std::string>& remote_addrs) {
   auto results = folly::collectAll(futures).get();
   for (const auto& result : results) {
     if (!result.value()) {
-      LOG(ERROR) << "Unlink D2D failed.";
+      LOG(ERROR) << "Unlink P2P failed.";
       return false;
     }
   }
@@ -1266,7 +1266,7 @@ bool LLMEngine::wakeup(const WakeupOptions& options) {
 
   if (!options.remote_addrs.empty() &&
       options.remote_addrs.size() == worker_clients_num_) {
-    // D2D mode with TP: each worker pulls only from its corresponding source
+    // P2P mode with TP: each worker pulls only from its corresponding source
     for (size_t i = 0; i < worker_clients_num_; ++i) {
       WakeupOptions per_worker_options;
       per_worker_options.master_status = options.master_status;

--- a/xllm/core/distributed_runtime/llm_engine.h
+++ b/xllm/core/distributed_runtime/llm_engine.h
@@ -112,10 +112,10 @@ class LLMEngine : public Engine {
                       const int32_t src_dp_size,
                       const int32_t src_kv_split_size = 1) override;
 
-  // D2D link for weight transfer - each worker links to one remote addr
-  bool link_d2d(const std::vector<std::string>& remote_addrs) override;
+  // P2P link for weight transfer - each worker links to one remote addr
+  bool link_p2p(const std::vector<std::string>& remote_addrs) override;
 
-  bool unlink_d2d(const std::vector<std::string>& remote_addrs) override;
+  bool unlink_p2p(const std::vector<std::string>& remote_addrs) override;
 
   std::shared_ptr<DistManager> get_dist_manager() { return dist_manager_; };
 

--- a/xllm/core/distributed_runtime/llm_master.cpp
+++ b/xllm/core/distributed_runtime/llm_master.cpp
@@ -552,12 +552,12 @@ bool LLMMaster::wakeup(const WakeupOptions& options) {
   return engine_->wakeup(opts);
 }
 
-bool LLMMaster::link_d2d(const std::vector<std::string>& remote_addrs) {
-  return engine_->link_d2d(remote_addrs);
+bool LLMMaster::link_p2p(const std::vector<std::string>& remote_addrs) {
+  return engine_->link_p2p(remote_addrs);
 }
 
-bool LLMMaster::unlink_d2d(const std::vector<std::string>& remote_addrs) {
-  return engine_->unlink_d2d(remote_addrs);
+bool LLMMaster::unlink_p2p(const std::vector<std::string>& remote_addrs) {
+  return engine_->unlink_p2p(remote_addrs);
 }
 
 LLMAssistantMaster::LLMAssistantMaster(const Options& options)
@@ -592,6 +592,59 @@ void LLMAssistantMaster::run() {
       std::this_thread::sleep_for(std::chrono::seconds(5));
     }
   });
+}
+
+// ============== Async RL training support: Pause/Resume ==============
+void LLMMaster::pause_scheduler(const std::string& mode) {
+  LOG(INFO) << "LLMMaster: pausing scheduler (mode=" << mode << ")";
+
+  auto* continuous_scheduler =
+      dynamic_cast<ContinuousScheduler*>(scheduler_.get());
+  if (!continuous_scheduler) {
+    LOG(ERROR) << "Scheduler is not a ContinuousScheduler";
+    return;
+  }
+
+  ContinuousScheduler::PauseMode pause_mode =
+      ContinuousScheduler::PauseMode::KEEP;
+  if (mode == "abort") {
+    pause_mode = ContinuousScheduler::PauseMode::ABORT;
+  } else if (mode == "wait") {
+    pause_mode = ContinuousScheduler::PauseMode::WAIT;
+  } else if (mode != "keep" && !mode.empty()) {
+    LOG(WARNING) << "Unknown pause mode '" << mode << "', defaulting to keep";
+  }
+
+  continuous_scheduler->pause(pause_mode);
+
+  // Block until the scheduler loop thread has actually reached PAUSED, so that
+  // when this call returns it is safe to update weights (KEEP/ABORT: running
+  // requests handled and KV cache freed; WAIT: all in-flight requests done).
+  continuous_scheduler->wait_until_paused();
+  LOG(INFO) << "LLMMaster: scheduler fully paused (mode=" << mode << ")";
+}
+
+void LLMMaster::resume_scheduler() {
+  LOG(INFO) << "LLMMaster: resuming scheduler";
+
+  auto* continuous_scheduler =
+      dynamic_cast<ContinuousScheduler*>(scheduler_.get());
+  if (!continuous_scheduler) {
+    LOG(ERROR) << "Scheduler is not a ContinuousScheduler";
+    return;
+  }
+
+  continuous_scheduler->resume();
+}
+
+bool LLMMaster::is_scheduler_paused() const {
+  auto* continuous_scheduler =
+      dynamic_cast<ContinuousScheduler*>(scheduler_.get());
+  if (!continuous_scheduler) {
+    return false;
+  }
+
+  return continuous_scheduler->is_paused();
 }
 
 }  // namespace xllm

--- a/xllm/core/distributed_runtime/llm_master.h
+++ b/xllm/core/distributed_runtime/llm_master.h
@@ -88,9 +88,15 @@ class LLMMaster : public Master {
 
   bool wakeup(const WakeupOptions& options) override;
 
-  bool link_d2d(const std::vector<std::string>& remote_addrs) override;
+  bool link_p2p(const std::vector<std::string>& remote_addrs) override;
 
-  bool unlink_d2d(const std::vector<std::string>& remote_addrs) override;
+  bool unlink_p2p(const std::vector<std::string>& remote_addrs) override;
+
+  // Async RL training support: pause/resume.
+  // mode: "keep" (default), "abort", or "wait" — see ContinuousScheduler.
+  void pause_scheduler(const std::string& mode = "keep");
+  void resume_scheduler();
+  bool is_scheduler_paused() const;
 
  private:
   std::shared_ptr<Request> generate_request(

--- a/xllm/core/distributed_runtime/master.h
+++ b/xllm/core/distributed_runtime/master.h
@@ -43,7 +43,7 @@ class Master {
 
   virtual bool wakeup(const WakeupOptions& options) { return false; }
 
-  virtual bool link_d2d(const std::vector<std::string>& remote_addrs) {
+  virtual bool link_p2p(const std::vector<std::string>& remote_addrs) {
     return false;
   }
 
@@ -57,7 +57,7 @@ class Master {
     return engine_ ? engine_->stop_profile() : false;
   }
 
-  virtual bool unlink_d2d(const std::vector<std::string>& remote_addrs) {
+  virtual bool unlink_p2p(const std::vector<std::string>& remote_addrs) {
     return false;
   }
 

--- a/xllm/core/distributed_runtime/remote_worker.cpp
+++ b/xllm/core/distributed_runtime/remote_worker.cpp
@@ -96,12 +96,12 @@ bool RemoteWorker::unlink_cluster(const std::vector<uint64_t>& cluster_ids,
   return channel_->unlink_cluster(cluster_ids, addrs, ports);
 }
 
-bool RemoteWorker::link_d2d(const std::string& remote_addr) {
-  return channel_->link_d2d(remote_addr);
+bool RemoteWorker::link_p2p(const std::string& remote_addr) {
+  return channel_->link_p2p(remote_addr);
 }
 
-bool RemoteWorker::unlink_d2d(const std::string& remote_addr) {
-  return channel_->unlink_d2d(remote_addr);
+bool RemoteWorker::unlink_p2p(const std::string& remote_addr) {
+  return channel_->unlink_p2p(remote_addr);
 }
 
 bool RemoteWorker::init_model(const std::string& model_weights_path,

--- a/xllm/core/distributed_runtime/remote_worker.h
+++ b/xllm/core/distributed_runtime/remote_worker.h
@@ -67,9 +67,9 @@ class RemoteWorker : public WorkerClient {
                               const std::vector<std::string>& addrs,
                               const std::vector<uint16_t>& ports) override;
 
-  // D2D link for weight transfer
-  virtual bool link_d2d(const std::string& remote_addr) override;
-  virtual bool unlink_d2d(const std::string& remote_addr) override;
+  // P2P link for weight transfer
+  virtual bool link_p2p(const std::string& remote_addr) override;
+  virtual bool unlink_p2p(const std::string& remote_addr) override;
 
   virtual bool pull_kv_blocks(
       const uint64_t src_cluster_id,

--- a/xllm/core/distributed_runtime/worker_service.cpp
+++ b/xllm/core/distributed_runtime/worker_service.cpp
@@ -528,25 +528,25 @@ void WorkerService::UnlinkCluster(::google::protobuf::RpcController* controller,
   return;
 }
 
-void WorkerService::LinkD2D(::google::protobuf::RpcController* controller,
-                            const proto::D2DLinkWorkerRequest* req,
+void WorkerService::LinkP2P(::google::protobuf::RpcController* controller,
+                            const proto::P2PLinkWorkerRequest* req,
                             proto::Status* resp,
                             ::google::protobuf::Closure* done) {
   threadpool_->schedule([this, controller, req, resp, done]() mutable {
     brpc::ClosureGuard done_guard(done);
-    bool status = worker_->link_d2d(req->remote_addr());
+    bool status = worker_->link_p2p(req->remote_addr());
     resp->set_ok(status);
   });
   return;
 }
 
-void WorkerService::UnlinkD2D(::google::protobuf::RpcController* controller,
-                              const proto::D2DLinkWorkerRequest* req,
+void WorkerService::UnlinkP2P(::google::protobuf::RpcController* controller,
+                              const proto::P2PLinkWorkerRequest* req,
                               proto::Status* resp,
                               ::google::protobuf::Closure* done) {
   threadpool_->schedule([this, controller, req, resp, done]() mutable {
     brpc::ClosureGuard done_guard(done);
-    bool status = worker_->unlink_d2d(req->remote_addr());
+    bool status = worker_->unlink_p2p(req->remote_addr());
     resp->set_ok(status);
   });
   return;

--- a/xllm/core/distributed_runtime/worker_service.h
+++ b/xllm/core/distributed_runtime/worker_service.h
@@ -100,13 +100,13 @@ class WorkerService : public proto::DistributeWorker {
                      proto::Status* resp,
                      ::google::protobuf::Closure* done) override;
 
-  void LinkD2D(::google::protobuf::RpcController* controller,
-               const proto::D2DLinkWorkerRequest* req,
+  void LinkP2P(::google::protobuf::RpcController* controller,
+               const proto::P2PLinkWorkerRequest* req,
                proto::Status* resp,
                ::google::protobuf::Closure* done) override;
 
-  void UnlinkD2D(::google::protobuf::RpcController* controller,
-                 const proto::D2DLinkWorkerRequest* req,
+  void UnlinkP2P(::google::protobuf::RpcController* controller,
+                 const proto::P2PLinkWorkerRequest* req,
                  proto::Status* resp,
                  ::google::protobuf::Closure* done) override;
 

--- a/xllm/core/framework/kv_cache_transfer/mooncake_weight_transfer.cpp
+++ b/xllm/core/framework/kv_cache_transfer/mooncake_weight_transfer.cpp
@@ -67,46 +67,46 @@ bool MooncakeWeightTransfer::register_global_xtensor() {
   return true;
 }
 
-bool MooncakeWeightTransfer::link_d2d(const std::string& remote_addr) {
+bool MooncakeWeightTransfer::link_p2p(const std::string& remote_addr) {
   std::string host;
   int port = 0;
   net::parse_host_port_from_addr(remote_addr, host, port);
   auto remote_cluster_id =
       net::convert_ip_port_to_uint64(host, static_cast<uint16_t>(port));
 
-  LOG(INFO) << "MooncakeWeightTransfer::link_d2d, remote_addr=" << remote_addr
+  LOG(INFO) << "MooncakeWeightTransfer::link_p2p, remote_addr=" << remote_addr
             << ", remote_cluster_id=" << remote_cluster_id;
 
   return mooncake_te_->open_session(remote_cluster_id, remote_addr);
 }
 
-bool MooncakeWeightTransfer::link_d2d(
+bool MooncakeWeightTransfer::link_p2p(
     const std::vector<std::string>& remote_addrs) {
   for (const auto& remote_addr : remote_addrs) {
-    if (!link_d2d(remote_addr)) {
+    if (!link_p2p(remote_addr)) {
       return false;
     }
   }
   return true;
 }
 
-bool MooncakeWeightTransfer::unlink_d2d(const std::string& remote_addr) {
+bool MooncakeWeightTransfer::unlink_p2p(const std::string& remote_addr) {
   std::string host;
   int port = 0;
   net::parse_host_port_from_addr(remote_addr, host, port);
   auto remote_cluster_id =
       net::convert_ip_port_to_uint64(host, static_cast<uint16_t>(port));
 
-  LOG(INFO) << "MooncakeWeightTransfer::unlink_d2d, remote_addr=" << remote_addr
+  LOG(INFO) << "MooncakeWeightTransfer::unlink_p2p, remote_addr=" << remote_addr
             << ", remote_cluster_id=" << remote_cluster_id;
 
   return mooncake_te_->close_session(remote_cluster_id, remote_addr);
 }
 
-bool MooncakeWeightTransfer::unlink_d2d(
+bool MooncakeWeightTransfer::unlink_p2p(
     const std::vector<std::string>& remote_addrs) {
   for (const auto& remote_addr : remote_addrs) {
-    if (!unlink_d2d(remote_addr)) {
+    if (!unlink_p2p(remote_addr)) {
       return false;
     }
   }

--- a/xllm/core/framework/kv_cache_transfer/mooncake_weight_transfer.h
+++ b/xllm/core/framework/kv_cache_transfer/mooncake_weight_transfer.h
@@ -37,10 +37,10 @@ class MooncakeWeightTransfer {
 
   bool register_global_xtensor();
 
-  bool link_d2d(const std::string& remote_addr);
-  bool link_d2d(const std::vector<std::string>& remote_addrs);
-  bool unlink_d2d(const std::string& remote_addr);
-  bool unlink_d2d(const std::vector<std::string>& remote_addrs);
+  bool link_p2p(const std::string& remote_addr);
+  bool link_p2p(const std::vector<std::string>& remote_addrs);
+  bool unlink_p2p(const std::string& remote_addr);
+  bool unlink_p2p(const std::vector<std::string>& remote_addrs);
 
   bool pull_weights(const std::string& remote_addr,
                     uint64_t src_offset,

--- a/xllm/core/framework/xtensor/xtensor_allocator.cpp
+++ b/xllm/core/framework/xtensor/xtensor_allocator.cpp
@@ -638,7 +638,7 @@ void XTensorAllocator::record_weight_allocation(const std::string& model_id,
   tensors.using_weight_xtensor = false;
   tensors.weight_xtensor.reset();
 
-  // Populate weight_segments for D2D transfer support
+  // Populate weight_segments for P2P transfer support
   size_t page_size = global_xtensor.page_size();
   tensors.weight_segments.clear();
   tensors.weight_segments.push_back(
@@ -676,7 +676,7 @@ void XTensorAllocator::record_weight_fallback_allocation(
   tensors.weight_current_offset = 0;
   tensors.weight_start_page_id = -1;  // Not applicable for non-contiguous
 
-  // Populate weight_segments for D2D transfer support
+  // Populate weight_segments for P2P transfer support
   // Merge adjacent page_ids into contiguous segments
   size_t page_size = GlobalXTensor::get_instance().page_size();
   tensors.weight_segments.clear();

--- a/xllm/core/framework/xtensor/xtensor_allocator.h
+++ b/xllm/core/framework/xtensor/xtensor_allocator.h
@@ -63,7 +63,7 @@ struct ModelTensors {
   int32_t dp_size = 0;
   int32_t tp_size = 0;
 
-  // ============== Weight Segments (for D2D transfer) ==============
+  // ============== Weight Segments (for P2P transfer) ==============
   // Ordered list of weight segments in GlobalXTensor.
   // For contiguous allocation: single segment.
   // For fallback (XTensor): multiple segments from non-contiguous pages.

--- a/xllm/core/layers/npu/loader/base_loader.cpp
+++ b/xllm/core/layers/npu/loader/base_loader.cpp
@@ -384,7 +384,7 @@ void BaseLoader::reload_weights() {
 void BaseLoader::reload_weights_from_device() {
   CHECK(mode_ == LoadMode::kManual)
       << "reload_weights_from_device is only valid in manual loader mode";
-  // D2D path: weights already transferred to GlobalXTensor weight region.
+  // P2P path: weights already transferred to GlobalXTensor weight region.
   // Call allocate_weight to get the pointer into the pre-allocated region.
   allocate_device_storage();
   init_device_at_weights();

--- a/xllm/core/layers/npu/loader/base_loader.h
+++ b/xllm/core/layers/npu/loader/base_loader.h
@@ -78,7 +78,7 @@ class BaseLoader {
   // Manual-mode: re-allocate device storage, async H2D copy, rebuild views.
   virtual void reload_weights();
 
-  // Manual-mode D2D path: device buffer already filled (e.g. by xtensor
+  // Manual-mode P2P path: device buffer already filled (e.g. by xtensor
   // allocator or rolling load), just rebuild views.
   virtual void reload_weights_from_device();
 

--- a/xllm/core/runtime/worker.cpp
+++ b/xllm/core/runtime/worker.cpp
@@ -106,12 +106,12 @@ bool Worker::unlink_cluster(const std::vector<uint64_t>& cluster_ids,
   return impl_->unlink_cluster(cluster_ids, addrs, ports);
 }
 
-bool Worker::link_d2d(const std::string& remote_addr) {
-  return impl_->link_d2d(remote_addr);
+bool Worker::link_p2p(const std::string& remote_addr) {
+  return impl_->link_p2p(remote_addr);
 }
 
-bool Worker::unlink_d2d(const std::string& remote_addr) {
-  return impl_->unlink_d2d(remote_addr);
+bool Worker::unlink_p2p(const std::string& remote_addr) {
+  return impl_->unlink_p2p(remote_addr);
 }
 
 std::tuple<int64_t, int64_t> Worker::estimate_kv_cache_capacity() {

--- a/xllm/core/runtime/worker.h
+++ b/xllm/core/runtime/worker.h
@@ -78,9 +78,9 @@ class Worker {
                       const std::vector<std::string>& addrs,
                       const std::vector<uint16_t>& ports);
 
-  // D2D link for weight transfer
-  bool link_d2d(const std::string& remote_addr);
-  bool unlink_d2d(const std::string& remote_addr);
+  // P2P link for weight transfer
+  bool link_p2p(const std::string& remote_addr);
+  bool unlink_p2p(const std::string& remote_addr);
 
   const bool is_driver();
 

--- a/xllm/core/runtime/worker_client.cpp
+++ b/xllm/core/runtime/worker_client.cpp
@@ -60,12 +60,12 @@ bool WorkerClient::unlink_cluster(const std::vector<uint64_t>& cluster_ids,
   return worker_->unlink_cluster(cluster_ids, addrs, ports);
 }
 
-bool WorkerClient::link_d2d(const std::string& remote_addr) {
-  return worker_->link_d2d(remote_addr);
+bool WorkerClient::link_p2p(const std::string& remote_addr) {
+  return worker_->link_p2p(remote_addr);
 }
 
-bool WorkerClient::unlink_d2d(const std::string& remote_addr) {
-  return worker_->unlink_d2d(remote_addr);
+bool WorkerClient::unlink_p2p(const std::string& remote_addr) {
+  return worker_->unlink_p2p(remote_addr);
 }
 
 std::tuple<int64_t, int64_t> WorkerClient::estimate_kv_cache_capacity() {

--- a/xllm/core/runtime/worker_client.h
+++ b/xllm/core/runtime/worker_client.h
@@ -71,9 +71,9 @@ class WorkerClient {
                               const std::vector<std::string>& addrs,
                               const std::vector<uint16_t>& ports);
 
-  // D2D link for weight transfer
-  virtual bool link_d2d(const std::string& remote_addr);
-  virtual bool unlink_d2d(const std::string& remote_addr);
+  // P2P link for weight transfer
+  virtual bool link_p2p(const std::string& remote_addr);
+  virtual bool unlink_p2p(const std::string& remote_addr);
 
   virtual bool pull_kv_blocks(
       const uint64_t src_cluster_id,

--- a/xllm/core/runtime/worker_impl.cpp
+++ b/xllm/core/runtime/worker_impl.cpp
@@ -444,12 +444,12 @@ bool WorkerImpl::unlink_cluster(const std::vector<uint64_t>& cluster_ids,
   return worker_rendezvous_->unlink_cluster(cluster_ids, addrs, ports);
 }
 
-bool WorkerImpl::link_d2d(const std::string& remote_addr) {
-  return worker_rendezvous_->link_d2d(remote_addr);
+bool WorkerImpl::link_p2p(const std::string& remote_addr) {
+  return worker_rendezvous_->link_p2p(remote_addr);
 }
 
-bool WorkerImpl::unlink_d2d(const std::string& remote_addr) {
-  return worker_rendezvous_->unlink_d2d(remote_addr);
+bool WorkerImpl::unlink_p2p(const std::string& remote_addr) {
+  return worker_rendezvous_->unlink_p2p(remote_addr);
 }
 
 std::tuple<int64_t, int64_t> WorkerImpl::estimate_kv_cache_capacity() {

--- a/xllm/core/runtime/worker_impl.h
+++ b/xllm/core/runtime/worker_impl.h
@@ -101,9 +101,9 @@ class WorkerImpl {
                               const std::vector<std::string>& addrs,
                               const std::vector<uint16_t>& ports);
 
-  // D2D link for weight transfer
-  virtual bool link_d2d(const std::string& remote_addr);
-  virtual bool unlink_d2d(const std::string& remote_addr);
+  // P2P link for weight transfer
+  virtual bool link_p2p(const std::string& remote_addr);
+  virtual bool unlink_p2p(const std::string& remote_addr);
 
   // prepare input for execution
   virtual ForwardInput prepare_inputs(Batch& batch);

--- a/xllm/core/runtime/worker_rendezvous.cpp
+++ b/xllm/core/runtime/worker_rendezvous.cpp
@@ -83,28 +83,28 @@ bool WorkerRendezvous::unlink_cluster(const std::vector<uint64_t>& cluster_ids,
   return true;
 }
 
-bool WorkerRendezvous::link_d2d(const std::string& remote_addr) {
+bool WorkerRendezvous::link_p2p(const std::string& remote_addr) {
 #if defined(USE_NPU)
   if (!weight_transfer_) {
     LOG(ERROR) << "MooncakeWeightTransfer not initialized";
     return false;
   }
-  return weight_transfer_->link_d2d(remote_addr);
+  return weight_transfer_->link_p2p(remote_addr);
 #else
-  LOG(ERROR) << "link_d2d requires USE_NPU build";
+  LOG(ERROR) << "link_p2p requires USE_NPU build";
   return false;
 #endif
 }
 
-bool WorkerRendezvous::unlink_d2d(const std::string& remote_addr) {
+bool WorkerRendezvous::unlink_p2p(const std::string& remote_addr) {
 #if defined(USE_NPU)
   if (!weight_transfer_) {
     LOG(ERROR) << "MooncakeWeightTransfer not initialized";
     return false;
   }
-  return weight_transfer_->unlink_d2d(remote_addr);
+  return weight_transfer_->unlink_p2p(remote_addr);
 #else
-  LOG(ERROR) << "unlink_d2d requires USE_NPU build";
+  LOG(ERROR) << "unlink_p2p requires USE_NPU build";
   return false;
 #endif
 }

--- a/xllm/core/runtime/worker_rendezvous.h
+++ b/xllm/core/runtime/worker_rendezvous.h
@@ -47,8 +47,8 @@ class WorkerRendezvous final {
                       const std::vector<std::string>& addrs,
                       const std::vector<uint16_t>& ports);
 
-  bool link_d2d(const std::string& remote_addr);
-  bool unlink_d2d(const std::string& remote_addr);
+  bool link_p2p(const std::string& remote_addr);
+  bool unlink_p2p(const std::string& remote_addr);
 
  private:
   bool validate_cluster_endpoints(const std::vector<uint64_t>& cluster_ids,

--- a/xllm/core/scheduler/continuous_scheduler.cpp
+++ b/xllm/core/scheduler/continuous_scheduler.cpp
@@ -1190,6 +1190,31 @@ std::vector<Batch> ContinuousScheduler::schedule_request(
 // step the scheduler forward by one step
 // may get blocked if there are no requests to process
 void ContinuousScheduler::step(const absl::Duration& timeout) {
+  if (try_complete_pause()) {
+    return;
+  }
+
+  // Check if paused - block instead of busy-waiting.
+  //
+  // step() is called in a tight loop by LLMMaster::run() with no sleep, so a
+  // bare `return` here would spin a CPU core at 100% while paused. Block on
+  // pause_cv_ until resume() flips the state. resume() holds pause_mutex_ when
+  // storing RUNNING and then notifies, so there is no lost-wakeup window.
+  //
+  // We use wait_for with a bounded timeout rather than an unbounded wait: the
+  // owning LLMMaster signals shutdown via its own `stoped_` flag (not visible
+  // here) and joins this loop thread WITHOUT calling resume() (see
+  // ~LLMMaster). An unbounded wait would therefore deadlock shutdown if the
+  // engine is destroyed while paused. The timeout lets the loop periodically
+  // fall through so the `stoped_` check in LLMMaster::run() can break the loop.
+  if (pause_state_.load(std::memory_order_acquire) == PauseState::PAUSED) {
+    std::unique_lock<std::mutex> lock(pause_mutex_);
+    pause_cv_.wait_for(lock, std::chrono::milliseconds(100), [this] {
+      return pause_state_.load(std::memory_order_acquire) != PauseState::PAUSED;
+    });
+    return;  // Stay paused (or fall through to shutdown check on next loop)
+  }
+
   if (!options_.enable_schedule_overlap()) {
     // get a new batch of requests
     last_batch_lengths_.clear();
@@ -1462,4 +1487,285 @@ void ContinuousScheduler::step_with_pd_ooc(std::vector<Batch>& batch) {
   VLOG(1) << "PERF - " << ss.str() << " - " << std::fixed
           << std::setprecision(3) << duration_ms << " ms";
 }
+
+bool ContinuousScheduler::try_complete_pause() {
+  if (pause_state_.load(std::memory_order_acquire) != PauseState::PAUSING) {
+    return false;
+  }
+
+  const PauseMode mode = pause_mode_.load(std::memory_order_acquire);
+
+  // WAIT mode: do not preempt. Let already-running requests finish naturally,
+  // and only transition to PAUSED once nothing is left running/in-flight. We
+  // return false here so step() proceeds with normal scheduling to drain them.
+  // (Matches vLLM "wait": ongoing requests complete before the engine pauses.)
+  if (mode == PauseMode::WAIT) {
+    const bool last_batch_in_flight =
+        options_.enable_schedule_overlap() && !is_first_step_ &&
+        !std::all_of(last_batch_.begin(),
+                     last_batch_.end(),
+                     [](const Batch& b) { return b.empty(); });
+    if (!running_requests_.empty() || last_batch_in_flight) {
+      return false;  // still draining; keep stepping normally
+    }
+    {
+      std::lock_guard<std::mutex> lock(pause_mutex_);
+      pause_state_.store(PauseState::PAUSED, std::memory_order_release);
+    }
+    pause_cv_.notify_all();
+    LOG(INFO) << "Scheduler paused (WAIT mode: all in-flight requests drained, "
+                 "KV cache preserved)";
+    return true;
+  }
+
+  // KEEP / ABORT: drain the in-flight overlap pipeline first.
+  //
+  // With enable_schedule_overlap, a forward batch may still be in flight on the
+  // device (tracked by last_batch_). We must collect its results and let the
+  // sequence/KV state settle BEFORE deallocating KV cache, otherwise we would
+  // free blocks that the in-flight forward still reads/writes, corrupting the
+  // recomputation after resume (garbled output).
+  if (options_.enable_schedule_overlap() && !is_first_step_) {
+    const bool last_batch_all_empty = std::all_of(
+        last_batch_.begin(), last_batch_.end(), [](const Batch& one_batch) {
+          return one_batch.empty();
+        });
+    if (!last_batch_all_empty) {
+      // Drain the one in-flight step scheduled in advance.
+      engine_->update_last_step_result(last_batch_);
+      process_batch_output(true);
+    }
+    // Reset overlap pipeline bookkeeping so resume starts clean.
+    last_batch_.clear();
+    last_batch_.resize(options_.dp_size());
+    last_running_requests_.clear();
+    last_running_sequences_.clear();
+    is_first_step_ = true;
+  }
+
+  // Now the pipeline is drained; handle running requests per mode.
+  if (mode == PauseMode::ABORT) {
+    abort_all_running_requests();
+    {
+      std::lock_guard<std::mutex> lock(pause_mutex_);
+      pause_state_.store(PauseState::PAUSED, std::memory_order_release);
+    }
+    pause_cv_.notify_all();
+    LOG(INFO)
+        << "Scheduler paused (ABORT mode: all running requests cancelled)";
+  } else {  // KEEP
+    preempt_all_running_requests();
+    {
+      std::lock_guard<std::mutex> lock(pause_mutex_);
+      pause_state_.store(PauseState::PAUSED, std::memory_order_release);
+    }
+    pause_cv_.notify_all();
+    LOG(INFO) << "Scheduler paused (KEEP mode: requests preempted to waiting "
+                 "queue, KV cache freed, will re-prefill on resume)";
+  }
+  return true;
+}
+
+// ============== Async RL training support: Pause/Resume ==============
+void ContinuousScheduler::pause(PauseMode mode) {
+  const char* mode_str = mode == PauseMode::KEEP    ? "KEEP"
+                         : mode == PauseMode::ABORT ? "ABORT"
+                                                    : "WAIT";
+  LOG(INFO) << "Pausing scheduler (mode=" << mode_str << ")";
+
+  // Publish the mode before the state so the loop thread, upon observing
+  // PAUSING, reads a consistent mode.
+  pause_mode_.store(mode, std::memory_order_relaxed);
+
+  PauseState expected = PauseState::RUNNING;
+  if (!pause_state_.compare_exchange_strong(expected,
+                                            PauseState::PAUSING,
+                                            std::memory_order_release,
+                                            std::memory_order_relaxed)) {
+    LOG(WARNING) << "Scheduler already paused or pausing";
+    return;
+  }
+
+  LOG(INFO) << "Scheduler pause requested (mode=" << mode_str
+            << "). Running requests: " << running_requests_.size();
+}
+
+bool ContinuousScheduler::wait_until_paused(int64_t timeout_ms) {
+  std::unique_lock<std::mutex> lock(pause_mutex_);
+  // Wait until the transition settles: either fully PAUSED, or no longer
+  // pausing at all (e.g. a concurrent resume() moved it back to RUNNING).
+  // This avoids hanging forever if pause() was a no-op or resume() raced in.
+  auto settled = [this] {
+    return pause_state_.load(std::memory_order_acquire) != PauseState::PAUSING;
+  };
+  bool ok;
+  if (timeout_ms < 0) {
+    pause_cv_.wait(lock, settled);
+    ok = true;
+  } else {
+    ok = pause_cv_.wait_for(
+        lock, std::chrono::milliseconds(timeout_ms), settled);
+  }
+  // Only report "paused" if we actually ended up PAUSED.
+  return ok &&
+         pause_state_.load(std::memory_order_acquire) == PauseState::PAUSED;
+}
+
+void ContinuousScheduler::resume() {
+  LOG(INFO) << "Resuming scheduler";
+
+  // Resume from either PAUSING or PAUSED. Using exchange() unconditionally sets
+  // RUNNING and returns the previous state, so a resume() issued before step()
+  // has advanced PAUSING -> PAUSED still works. Hold the lock and notify so any
+  // thread blocked in wait_until_paused() is released.
+  PauseState prev;
+  {
+    std::lock_guard<std::mutex> lock(pause_mutex_);
+    prev =
+        pause_state_.exchange(PauseState::RUNNING, std::memory_order_acq_rel);
+  }
+  pause_cv_.notify_all();
+  if (prev == PauseState::RUNNING) {
+    LOG(WARNING) << "Scheduler was not paused; resume() is a no-op";
+    return;
+  }
+
+  LOG(INFO) << "Scheduler resumed. Preempted requests in waiting queue: "
+            << get_waiting_requests_num()
+            << " (will need re-prefill with new weights)";
+}
+
+bool ContinuousScheduler::is_paused() const {
+  auto state = pause_state_.load(std::memory_order_acquire);
+  return state == PauseState::PAUSED || state == PauseState::PAUSING;
+}
+
+void ContinuousScheduler::preempt_all_running_requests() {
+  const size_t total_to_preempt = running_requests_.size() +
+                                  running_queue_->size() +
+                                  running_queue_offline_->size();
+  if (total_to_preempt == 0) {
+    return;
+  }
+
+  LOG(INFO) << "Preempting " << total_to_preempt
+            << " running requests for pause";
+
+  size_t preempted_count = 0;
+
+  // Preempt a single request: free its KV cache and move it back to the
+  // matching waiting queue so it will be re-prefilled on resume.
+  auto preempt_one = [&](const std::shared_ptr<Request>& request) {
+    if (!request) {
+      return;
+    }
+
+    // Skip already finished requests
+    if (request->finished()) {
+      return;
+    }
+
+    // Deallocate KV cache blocks (critical for RL weight updates)
+    kv_cache_manager_->deallocate(request.get());
+
+    // Mark as preempted
+    request->set_preempted();
+
+    // Push back to waiting queue (will need re-prefill on resume)
+    if (request->offline()) {
+      waiting_priority_queue_offline_->push(request);
+    } else {
+      waiting_priority_queue_->push(request);
+    }
+
+    preempted_count++;
+  };
+
+  // 1. Requests selected into the current batch.
+  for (auto& request : running_requests_) {
+    preempt_one(request);
+  }
+
+  // 2. Active decoding requests still waiting in the running queues. These were
+  // pushed back to running_queue_/running_queue_offline_ at the start of the
+  // step but were not selected into running_requests_ (e.g. budget exhausted,
+  // or this step scheduled prefill so decode was skipped). They still hold KV
+  // cache and must be preempted as well.
+  while (!running_queue_->empty()) {
+    preempt_one(running_queue_->top());
+    running_queue_->pop_top();
+  }
+  while (!running_queue_offline_->empty()) {
+    preempt_one(running_queue_offline_->top());
+    running_queue_offline_->pop_top();
+  }
+
+  // Clear running state
+  running_requests_.clear();
+  running_sequences_.clear();
+  running_sequences_budgets_.clear();
+
+  LOG(INFO) << "Preempted " << preempted_count
+            << " requests, KV cache freed, moved to waiting queue";
+}
+
+void ContinuousScheduler::abort_all_running_requests() {
+  const size_t total_to_abort = running_requests_.size() +
+                                running_queue_->size() +
+                                running_queue_offline_->size();
+  if (total_to_abort == 0) {
+    return;
+  }
+
+  LOG(INFO) << "Aborting " << total_to_abort << " running requests";
+
+  size_t aborted_count = 0;
+
+  // Abort a single request: free its KV cache and notify the client. Unlike
+  // KEEP, aborted requests are NOT pushed back to the waiting queue.
+  auto abort_one = [&](const std::shared_ptr<Request>& request) {
+    if (!request) {
+      return;
+    }
+    if (request->finished()) {
+      return;
+    }
+
+    kv_cache_manager_->deallocate(request.get());
+    request->set_cancel();
+    response_processor_->process_failed_request(
+        request,
+        {StatusCode::CANCELLED, "Request aborted due to scheduler pause"});
+    aborted_count++;
+  };
+
+  // 1. Requests selected into the current batch.
+  for (auto& request : running_requests_) {
+    abort_one(request);
+  }
+
+  // 2. Active decoding requests still waiting in the running queues. These were
+  // pushed back to running_queue_/running_queue_offline_ at the start of the
+  // step but were not selected into running_requests_ (e.g. budget exhausted,
+  // or this step scheduled prefill so decode was skipped). They still hold KV
+  // cache and must be aborted as well, otherwise their blocks leak and the
+  // client never receives a cancellation.
+  while (!running_queue_->empty()) {
+    abort_one(running_queue_->top());
+    running_queue_->pop_top();
+  }
+  while (!running_queue_offline_->empty()) {
+    abort_one(running_queue_offline_->top());
+    running_queue_offline_->pop_top();
+  }
+
+  // Clear running state.
+  running_requests_.clear();
+  running_sequences_.clear();
+  running_sequences_budgets_.clear();
+
+  LOG(INFO) << "Aborted " << aborted_count
+            << " requests, KV cache freed (not rescheduled)";
+}
+
 }  // namespace xllm

--- a/xllm/core/scheduler/continuous_scheduler.h
+++ b/xllm/core/scheduler/continuous_scheduler.h
@@ -19,8 +19,11 @@ limitations under the License.
 #include <folly/MPMCQueue.h>
 #include <folly/futures/Future.h>
 
+#include <atomic>
+#include <condition_variable>
 #include <limits>
 #include <memory>
+#include <mutex>
 #include <unordered_map>
 
 #include "async_response_processor.h"
@@ -189,6 +192,52 @@ class ContinuousScheduler : public Scheduler {
 
   std::vector<int> last_batch_lengths_;
 
+  // Async RL training support: pause/resume
+  enum class PauseState {
+    RUNNING = 0,  // Normal operation
+    PAUSING = 1,  // Requested pause, transitioning to PAUSED
+    PAUSED = 2    // Fully paused
+  };
+
+  // How to handle in-flight requests when pausing (vLLM-compatible).
+  enum class PauseMode {
+    KEEP = 0,   // Preempt running requests, free KV cache, push back to waiting
+                // queue; recomputed (re-prefill) on resume. Default for RL.
+    ABORT = 1,  // Cancel all running requests; clients must retry.
+    WAIT = 2    // Stop admitting new requests; let running requests finish
+                // naturally, then pause. KV cache is not discarded.
+  };
+
+  // Pause the scheduler. See PauseMode for in-flight request handling.
+  void pause(PauseMode mode = PauseMode::KEEP);
+
+  // Block until the scheduler has fully transitioned to PAUSED (i.e. running
+  // requests have been handled per mode and it is safe to update weights).
+  // Returns true if paused, false if it timed out first.
+  bool wait_until_paused(int64_t timeout_ms = -1);
+
+  // Resume the scheduler.
+  void resume();
+
+  // Check if scheduler is paused or pausing
+  bool is_paused() const;
+
+  // for test only: directly trigger the preemption that step() performs when
+  // transitioning to PAUSED, without needing a real engine to drive step().
+  void preempt_all_running_requests_test() { preempt_all_running_requests(); }
+  void abort_all_running_requests_test() { abort_all_running_requests(); }
+
+ private:
+  // Drive the PAUSING -> PAUSED transition from within step(). Returns true if
+  // the scheduler is paused (caller should skip normal scheduling).
+  bool try_complete_pause();
+
+  // KEEP mode: preempt all running requests, free KV cache, push to waiting.
+  void preempt_all_running_requests();
+
+  // ABORT mode: cancel all running requests; they are not rescheduled.
+  void abort_all_running_requests();
+
  protected:
   const Options options_;
 
@@ -310,6 +359,16 @@ class ContinuousScheduler : public Scheduler {
   std::vector<std::shared_ptr<Request>> last_running_requests_;
   std::vector<Sequence*> last_running_sequences_;
   bool is_first_step_ = true;
+
+  // Pause state (atomic for thread-safe access)
+  std::atomic<PauseState> pause_state_{PauseState::RUNNING};
+  // How to handle in-flight requests for the current pause. Only read while
+  // pause_state_ != RUNNING; written by pause() before publishing the state.
+  std::atomic<PauseMode> pause_mode_{PauseMode::KEEP};
+  // Signals the PAUSING -> PAUSED transition to callers blocked in
+  // wait_until_paused(). Notified by the scheduler loop thread.
+  std::mutex pause_mutex_;
+  std::condition_variable pause_cv_;
 
  private:
   std::vector<Batch> schedule_request(const absl::Duration& timeout);

--- a/xllm/proto/worker.proto
+++ b/xllm/proto/worker.proto
@@ -53,7 +53,7 @@ message WakeupRequest {
   repeated WakeupWeightSegmentList src_weight_segments = 3;
 }
 
-// A single weight segment for D2D transfer
+// A single weight segment for P2P transfer
 message WakeupWeightSegment {
   uint64 offset = 1;  // Byte offset from source GlobalXTensor base
   uint64 size = 2;    // Segment size in bytes
@@ -64,7 +64,7 @@ message WakeupWeightSegmentList {
   repeated WakeupWeightSegment segments = 1;
 }
 
-message D2DLinkWorkerRequest {
+message P2PLinkWorkerRequest {
   string remote_addr = 1; 
 }
 
@@ -342,8 +342,8 @@ service DistributeWorker {
   rpc GetCacheInfo(Empty) returns (CacheInfo) {}
   rpc LinkCluster(ClusterInfo) returns (Status) {}
   rpc UnlinkCluster(ClusterInfo) returns (Status) {}
-  rpc LinkD2D(D2DLinkWorkerRequest) returns (Status) {}
-  rpc UnlinkD2D(D2DLinkWorkerRequest) returns (Status) {}
+  rpc LinkP2P(P2PLinkWorkerRequest) returns (Status) {}
+  rpc UnlinkP2P(P2PLinkWorkerRequest) returns (Status) {}
   rpc ExecuteModel (ForwardInput) returns (ForwardOutput);
   rpc GetLastStepResult (Empty) returns (ForwardOutput);
   rpc GetActiveActivationMemory (Empty) returns (ActivationMemory);

--- a/xllm/proto/xllm_service.proto
+++ b/xllm/proto/xllm_service.proto
@@ -46,9 +46,30 @@ message MasterWeightSegmentList {
   repeated MasterWeightSegment segments = 1;
 }
 
-message D2DLinkRequest {
+message P2PLinkRequest {
   string model_id = 1;
   repeated string remote_addrs = 2;
+}
+
+// Async RL training support: pause/resume
+message PauseRequest {
+  // How to handle in-flight requests: "keep" (default), "abort", or "wait".
+  //  - keep:  preempt running requests, free KV cache, re-prefill on resume.
+  //  - abort: cancel running requests; clients must retry.
+  //  - wait:  let running requests finish naturally, then pause.
+  string mode = 1;
+}
+
+message PauseResponse {
+  string status = 1;  // "paused" or "error: ..."
+}
+
+message ResumeRequest {
+  // Empty for now - simple resume semantics
+}
+
+message ResumeResponse {
+  string status = 1;  // "running" or "error: ..."
 }
 
 service XllmAPIService {
@@ -95,9 +116,15 @@ service XllmAPIService {
   rpc StartProfileHttp (HttpRequest) returns (HttpResponse);
   rpc StopProfileHttp (HttpRequest) returns (HttpResponse);
 
-  rpc LinkD2D (D2DLinkRequest) returns (Status);
-  rpc LinkD2DHttp (HttpRequest) returns (HttpResponse);
+  rpc LinkP2P (P2PLinkRequest) returns (Status);
+  rpc LinkP2PHttp (HttpRequest) returns (HttpResponse);
 
-  rpc UnlinkD2D (D2DLinkRequest) returns (Status);
-  rpc UnlinkD2DHttp (HttpRequest) returns (HttpResponse);
+  rpc UnlinkP2P (P2PLinkRequest) returns (Status);
+  rpc UnlinkP2PHttp (HttpRequest) returns (HttpResponse);
+
+  // Async RL training support: pause/resume
+  rpc Pause (PauseRequest) returns (PauseResponse);
+  rpc PauseHttp (HttpRequest) returns (HttpResponse);
+  rpc Resume (ResumeRequest) returns (ResumeResponse);
+  rpc ResumeHttp (HttpRequest) returns (HttpResponse);
 }; 

--- a/xllm/server/xllm_server.cpp
+++ b/xllm/server/xllm_server.cpp
@@ -53,8 +53,10 @@ constexpr const char* kApiServiceRoutes =
     "wakeup => WakeupHttp,"
     "start_profile => StartProfileHttp,"
     "stop_profile => StopProfileHttp,"
-    "link_d2d => LinkD2DHttp,"
-    "unlink_d2d => UnlinkD2DHttp";
+    "pause => PauseHttp,"
+    "resume => ResumeHttp,"
+    "link_p2p => LinkP2PHttp,"
+    "unlink_p2p => UnlinkP2PHttp";
 
 constexpr const char* kForkOnlyRoute = "fork_master => ForkMasterHttp";
 


### PR DESCRIPTION
## Description

Add native pause/resume APIs to support fully asynchronous RL training, and
rename the existing weight-transfer "D2D" naming to "P2P" to better reflect its
cross-node/cross-process nature.

### 1. Pause / Resume for async RL (vLLM-compatible)

In async RL, the inference engine must periodically stop generation so the
trainer can sync updated weights, then resume. This PR adds `pause`/`resume` to
the scheduler, exposed both as engine-level methods and as HTTP endpoints
(`POST /pause`, `POST /resume`).

Three pause modes are supported, matching vLLM semantics:

| Mode | In-flight requests | KV cache | Client impact |
|------|--------------------|----------|---------------|
| `keep` (default) | preempted and pushed back to the waiting queue; re-prefilled on resume | freed | none, requests continue after resume |
| `abort` | cancelled and returned to the client | freed | client must retry |
| `wait` | allowed to finish naturally before pausing | preserved | none |

Key implementation points:
- Pause state is tracked in the scheduler (`pause_state_`, atomic) and the pause
  check sits at the very top of `ContinuousScheduler::step()`, so it is
  inherited by all schedulers that delegate to it (ChunkedPrefill, PrefillOnly,
  Mix, ZeroEviction, and the PD schedulers that call `ContinuousScheduler::step`).
- The `PAUSING -> PAUSED` transition is driven from inside the scheduler loop
  thread (`try_complete_pause`). For `enable_schedule_overlap`, the in-flight
  forward batch (`last_batch_`) is drained first so KV cache is not freed while
  a forward is still reading/writing it — this prevents garbled output after
  resume.
- `POST /pause` blocks until the scheduler has actually reached `PAUSED`
  (`wait_until_paused`, condition-variable based), so when it returns it is safe
  to update weights. This matches vLLM's behaviour where the API server only
  returns once the engine is truly paused.

### 2. Rename D2D -> P2P

The weight-transfer link APIs (`link_d2d`/`unlink_d2d`, `LinkD2D`/`UnlinkD2D`,
`D2DLinkRequest`, etc.) are renamed to the `P2P` equivalents across the proto
definitions, RPC services, scheduler, engine, worker, and HTTP routes. This is a
pure rename with no behavioural change.

> Note: this changes the HTTP routes `/link_d2d` -> `/link_p2p` and
> `/unlink_d2d` -> `/unlink_p2p`.

## Related Issues

<!-- Link related issues here. Use "Fixes #123" when this PR closes an issue. -->

## Change Type

- [ ] Bug fix
- [x] New feature
- [ ] Performance improvement
- [x] Refactor
- [ ] Documentation
- [x] Test
- [ ] Build or CI

## Pull Request Checklist

Thank you for contributing to xLLM. Before requesting review, please make sure the following items are complete.

### PR Title and Commit Messages

- [x] The PR title and each commit message follow the xLLM commit format: `<type>: <subject>`.

> Allowed types: feat, bugfix, docs, test, refactor, chore, style, revert, perf, model, build, release.
> The subject should use clear English, start with a verb, include at least 4 words, and end with `.`.

### Pre-commit Checks

- [ ] I have installed `pre-commit` by running `pip install pre-commit` or an equivalent command.
- [ ] I have installed the hooks with `pre-commit install`.
- [ ] I have run `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

### Self Review

- [x] I have self-reviewed the code according to `.agents/skills/code-review/references/custom-code-style.md`, especially code written or assisted by AI.
- [ ] I have rebased this PR onto the latest `main` branch.

### Build and Test Coverage

- [x] Tests have been added or updated as needed.
- [ ] CUDA: `python setup.py build test` has passed on a CUDA machine.
- [x] NPU: `python setup.py build test` has passed on an NPU machine.
- [ ] MLU: `python setup.py build test` has passed on an MLU machine.

## Reviewer Notes

- **Scope of pause/resume:** verified to take effect for single-instance
  deployments (including TP/DP/EP multi-rank within one engine, which is driven
  by a single scheduler). PD-disaggregated deployments are **not** covered yet —
  in P/D mode a `keep` preempt on the decode side can strand requests (decode
  cannot self-prefill, and prefill no longer re-sends), similar to the DPEP
  deadlock vLLM describes. Cross-instance two-phase coordination for P/D is left
  as a follow-up.
- **Tests:** unit tests cover `keep`/`abort` preemption (KV freed, requests
  re-queued / cancelled), pause/resume state-machine transitions and
  idempotency, and re-scheduling of preempted requests. They run via
  `prepare_batch_test` and therefore do not exercise the `enable_schedule_overlap`
  drain path or the blocking `/pause` HTTP path — those were validated manually
  on NPU (Qwen3-8B): KEEP pause/resume mid-decode produces coherent output
  (earlier garbled-output bug fixed by draining the in-flight pipeline first).
- **Schedulers with a custom `step()`** (`DisaggPDScheduler`, `PDOOCScheduler`)
  still delegate to `ContinuousScheduler::step()`, so the pause check applies;
  `FixedStepsScheduler` does not delegate and is not covered.

