### PR TITLE
perf: support aclnnsiwglu & aclnnmatmul for Atb layers on npu device.

### DIFF
--- a/xllm/core/common/global_flags.h
+++ b/xllm/core/common/global_flags.h
@@ -371,6 +371,10 @@ DECLARE_int32(enable_fused_mc2);
 DECLARE_bool(enable_interlayer_addnorm);
 
 DECLARE_bool(enable_split_rmsnorm_rope);
+
+DECLARE_bool(enable_aclnn_matmul);
+
+DECLARE_bool(enable_aclnn_swiglu);
 #endif
 
 // --- chat template config ---

--- a/xllm/core/framework/config/kernel_config.cpp
+++ b/xllm/core/framework/config/kernel_config.cpp
@@ -44,6 +44,14 @@ DEFINE_bool(enable_interlayer_addnorm,
 DEFINE_bool(enable_split_rmsnorm_rope,
             false,
             "enable fused split rmsnorm rope ops.");
+
+DEFINE_bool(enable_qwen3_dense_aclnn_matmul,
+            false,
+            "enable ACLNN matmul backend for Qwen3 dense ATB layers.");
+
+DEFINE_bool(enable_qwen3_dense_aclnn_swiglu,
+            false,
+            "enable ACLNN SwiGLU backend for Qwen3 dense ATB layers.");
 #endif
 
 namespace xllm {
@@ -74,6 +82,8 @@ void KernelConfig::from_flags() {
   XLLM_CONFIG_ASSIGN_FROM_FLAG(enable_fused_mc2);
   XLLM_CONFIG_ASSIGN_FROM_FLAG(enable_interlayer_addnorm);
   XLLM_CONFIG_ASSIGN_FROM_FLAG(enable_split_rmsnorm_rope);
+  XLLM_CONFIG_ASSIGN_FROM_FLAG(enable_qwen3_dense_aclnn_matmul);
+  XLLM_CONFIG_ASSIGN_FROM_FLAG(enable_qwen3_dense_aclnn_swiglu);
 #endif
 }
 
@@ -85,6 +95,8 @@ void KernelConfig::from_json(const JsonReader& json) {
   XLLM_CONFIG_ASSIGN_FROM_JSON(enable_fused_mc2);
   XLLM_CONFIG_ASSIGN_FROM_JSON(enable_interlayer_addnorm);
   XLLM_CONFIG_ASSIGN_FROM_JSON(enable_split_rmsnorm_rope);
+  XLLM_CONFIG_ASSIGN_FROM_JSON(enable_qwen3_dense_aclnn_matmul);
+  XLLM_CONFIG_ASSIGN_FROM_JSON(enable_qwen3_dense_aclnn_swiglu);
 #endif
 }
 
@@ -100,6 +112,14 @@ void KernelConfig::append_config_json(
       config_json, default_config, enable_intralayer_addnorm);
   APPEND_CONFIG_JSON_VALUE_IF_NOT_DEFAULT(
       config_json, default_config, enable_fused_mc2);
+  APPEND_CONFIG_JSON_VALUE_IF_NOT_DEFAULT(
+      config_json, default_config, enable_interlayer_addnorm);
+  APPEND_CONFIG_JSON_VALUE_IF_NOT_DEFAULT(
+      config_json, default_config, enable_split_rmsnorm_rope);
+  APPEND_CONFIG_JSON_VALUE_IF_NOT_DEFAULT(
+      config_json, default_config, enable_qwen3_dense_aclnn_matmul);
+  APPEND_CONFIG_JSON_VALUE_IF_NOT_DEFAULT(
+      config_json, default_config, enable_qwen3_dense_aclnn_swiglu);
 #endif
 }
 

--- a/xllm/core/framework/config/kernel_config.cpp
+++ b/xllm/core/framework/config/kernel_config.cpp
@@ -34,9 +34,10 @@ DEFINE_bool(enable_intralayer_addnorm,
 
 DEFINE_int32(enable_fused_mc2,
              -1,
-             "Fused MC2 mode for NPU EP MoE. -1 uses auto default, 0 "
-             "disables fused MC2, 1 uses DispatchFFNCombine, 2 uses "
-             "DispatchGmmCombineDecode.");
+             "Fused MC2 mode for NPU. -1 uses auto default, 0 disables fused "
+             "MC2, positive values enable dense matmul-allreduce, 1 uses "
+             "DispatchFFNCombine for MoE, 2 uses DispatchGmmCombineDecode for "
+             "MoE.");
 DEFINE_bool(enable_interlayer_addnorm,
             false,
             "enable fused interlayer addnorm ops.");
@@ -45,13 +46,13 @@ DEFINE_bool(enable_split_rmsnorm_rope,
             false,
             "enable fused split rmsnorm rope ops.");
 
-DEFINE_bool(enable_qwen3_dense_aclnn_matmul,
+DEFINE_bool(enable_aclnn_matmul,
             false,
-            "enable ACLNN matmul backend for Qwen3 dense ATB layers.");
+            "enable ACLNN matmul backend for supported NPU ATB layers.");
 
-DEFINE_bool(enable_qwen3_dense_aclnn_swiglu,
+DEFINE_bool(enable_aclnn_swiglu,
             false,
-            "enable ACLNN SwiGLU backend for Qwen3 dense ATB layers.");
+            "enable ACLNN SwiGLU backend for supported NPU ATB layers.");
 #endif
 
 namespace xllm {
@@ -82,8 +83,8 @@ void KernelConfig::from_flags() {
   XLLM_CONFIG_ASSIGN_FROM_FLAG(enable_fused_mc2);
   XLLM_CONFIG_ASSIGN_FROM_FLAG(enable_interlayer_addnorm);
   XLLM_CONFIG_ASSIGN_FROM_FLAG(enable_split_rmsnorm_rope);
-  XLLM_CONFIG_ASSIGN_FROM_FLAG(enable_qwen3_dense_aclnn_matmul);
-  XLLM_CONFIG_ASSIGN_FROM_FLAG(enable_qwen3_dense_aclnn_swiglu);
+  XLLM_CONFIG_ASSIGN_FROM_FLAG(enable_aclnn_matmul);
+  XLLM_CONFIG_ASSIGN_FROM_FLAG(enable_aclnn_swiglu);
 #endif
 }
 
@@ -95,8 +96,8 @@ void KernelConfig::from_json(const JsonReader& json) {
   XLLM_CONFIG_ASSIGN_FROM_JSON(enable_fused_mc2);
   XLLM_CONFIG_ASSIGN_FROM_JSON(enable_interlayer_addnorm);
   XLLM_CONFIG_ASSIGN_FROM_JSON(enable_split_rmsnorm_rope);
-  XLLM_CONFIG_ASSIGN_FROM_JSON(enable_qwen3_dense_aclnn_matmul);
-  XLLM_CONFIG_ASSIGN_FROM_JSON(enable_qwen3_dense_aclnn_swiglu);
+  XLLM_CONFIG_ASSIGN_FROM_JSON(enable_aclnn_matmul);
+  XLLM_CONFIG_ASSIGN_FROM_JSON(enable_aclnn_swiglu);
 #endif
 }
 
@@ -117,9 +118,9 @@ void KernelConfig::append_config_json(
   APPEND_CONFIG_JSON_VALUE_IF_NOT_DEFAULT(
       config_json, default_config, enable_split_rmsnorm_rope);
   APPEND_CONFIG_JSON_VALUE_IF_NOT_DEFAULT(
-      config_json, default_config, enable_qwen3_dense_aclnn_matmul);
+      config_json, default_config, enable_aclnn_matmul);
   APPEND_CONFIG_JSON_VALUE_IF_NOT_DEFAULT(
-      config_json, default_config, enable_qwen3_dense_aclnn_swiglu);
+      config_json, default_config, enable_aclnn_swiglu);
 #endif
 }
 

--- a/xllm/core/framework/config/kernel_config.h
+++ b/xllm/core/framework/config/kernel_config.h
@@ -45,7 +45,9 @@ class KernelConfig final {
          "enable_intralayer_addnorm",
          "enable_fused_mc2",
          "enable_interlayer_addnorm",
-         "enable_split_rmsnorm_rope"}};
+         "enable_split_rmsnorm_rope",
+         "enable_qwen3_dense_aclnn_matmul",
+         "enable_qwen3_dense_aclnn_swiglu"}};
     return kOptionCategory;
   }
 
@@ -61,6 +63,10 @@ class KernelConfig final {
   PROPERTY(bool, enable_interlayer_addnorm) = false;
 
   PROPERTY(bool, enable_split_rmsnorm_rope) = false;
+
+  PROPERTY(bool, enable_qwen3_dense_aclnn_matmul) = false;
+
+  PROPERTY(bool, enable_qwen3_dense_aclnn_swiglu) = false;
 #endif
 };
 

--- a/xllm/core/framework/config/kernel_config.h
+++ b/xllm/core/framework/config/kernel_config.h
@@ -46,8 +46,8 @@ class KernelConfig final {
          "enable_fused_mc2",
          "enable_interlayer_addnorm",
          "enable_split_rmsnorm_rope",
-         "enable_qwen3_dense_aclnn_matmul",
-         "enable_qwen3_dense_aclnn_swiglu"}};
+         "enable_aclnn_matmul",
+         "enable_aclnn_swiglu"}};
     return kOptionCategory;
   }
 
@@ -64,9 +64,9 @@ class KernelConfig final {
 
   PROPERTY(bool, enable_split_rmsnorm_rope) = false;
 
-  PROPERTY(bool, enable_qwen3_dense_aclnn_matmul) = false;
+  PROPERTY(bool, enable_aclnn_matmul) = false;
 
-  PROPERTY(bool, enable_qwen3_dense_aclnn_swiglu) = false;
+  PROPERTY(bool, enable_aclnn_swiglu) = false;
 #endif
 };
 

--- a/xllm/core/layers/npu/loader/qwen3_decoder_loader.cpp
+++ b/xllm/core/layers/npu/loader/qwen3_decoder_loader.cpp
@@ -15,6 +15,8 @@ limitations under the License.
 
 #include "qwen3_decoder_loader.h"
 
+#include "core/framework/config/kernel_config.h"
+#include "core/framework/config/parallel_config.h"
 #include "qwen_loader_constants.h"
 
 namespace xllm {
@@ -76,6 +78,11 @@ void Qwen3DecoderLoader::verify_loaded_weights() const {
 
 void Qwen3DecoderLoader::merge_host_at_weights() {
   auto& t = working_tensors();
+  const bool enable_mc2 =
+      ::xllm::KernelConfig::get_instance().enable_fused_mc2() > 0 &&
+      ::xllm::ParallelConfig::get_instance().communication_backend() ==
+          "hccl" &&
+      quantize_type_.empty();
 
   if (quantize_type_.compare("w8a8") == 0) {
     t[IN_ATTENTION_OUT_DEQSCALE] =
@@ -136,15 +143,19 @@ void Qwen3DecoderLoader::merge_host_at_weights() {
                   .transpose(0, 1),
               IN_Q_WEIGHT);
 
-  t[IN_ATTENTION_OUT_WEIGHT] = cast_nz(
-      t[IN_ATTENTION_OUT_WEIGHT].transpose(0, 1), IN_ATTENTION_OUT_WEIGHT);
+  t[IN_ATTENTION_OUT_WEIGHT] =
+      enable_mc2 ? t[IN_ATTENTION_OUT_WEIGHT].transpose(0, 1).contiguous()
+                 : cast_nz(t[IN_ATTENTION_OUT_WEIGHT].transpose(0, 1),
+                           IN_ATTENTION_OUT_WEIGHT);
 
   t[IN_MLP_W2_WEIGHT] = cast_nz(
       torch::cat({t[IN_MLP_W2_WEIGHT], t[IN_MLP_W1_WEIGHT]}, 0).transpose(0, 1),
       IN_MLP_W2_WEIGHT);
 
   t[IN_MLP_CPROJ_WEIGHT] =
-      cast_nz(t[IN_MLP_CPROJ_WEIGHT].transpose(0, 1), IN_MLP_CPROJ_WEIGHT);
+      enable_mc2 ? t[IN_MLP_CPROJ_WEIGHT].transpose(0, 1).contiguous()
+                 : cast_nz(t[IN_MLP_CPROJ_WEIGHT].transpose(0, 1),
+                           IN_MLP_CPROJ_WEIGHT);
 
   for (auto idx :
        {IN_MLP_W1_WEIGHT, IN_K_WEIGHT, IN_V_WEIGHT, IN_K_BIAS, IN_V_BIAS}) {

--- a/xllm/core/layers/npu/npu_qwen3_decoder_layer_impl.cpp
+++ b/xllm/core/layers/npu/npu_qwen3_decoder_layer_impl.cpp
@@ -95,6 +95,14 @@ void NpuQwen3DecoderLayerImpl::param_from_args(
       ::xllm::LoadConfig::get_instance().enable_prefetch_weight();
   param.enableAclGraphPagedAttention =
       ::xllm::ExecutionConfig::get_instance().enable_graph() && !isPrefill;
+  if (::xllm::KernelConfig::get_instance()
+          .enable_qwen3_dense_aclnn_matmul()) {
+    param.matmulBackend = atb_speed::common::OpBackend::ACLNN;
+  }
+  if (::xllm::KernelConfig::get_instance()
+          .enable_qwen3_dense_aclnn_swiglu()) {
+    param.swigluBackend = atb_speed::common::OpBackend::ACLNN;
+  }
   initialize_parallel_parameters(param, parallel_args);
   initialize_quantization_parameters(param);
 

--- a/xllm/core/layers/npu/npu_qwen3_decoder_layer_impl.cpp
+++ b/xllm/core/layers/npu/npu_qwen3_decoder_layer_impl.cpp
@@ -61,6 +61,7 @@ void NpuQwen3DecoderLayerImpl::param_from_args(
       isPrefill;
   param.loraEnableGMM = false;
   param.enableXattention = is_rec_multi_round_mode();
+  const auto& kernel_config = ::xllm::KernelConfig::get_instance();
 
   param.linearTransposeType = {static_cast<int>(TransposeType::NOT_TRANSPOSE),
                                static_cast<int>(TransposeType::INVALID),
@@ -78,6 +79,11 @@ void NpuQwen3DecoderLayerImpl::param_from_args(
       static_cast<int>(optionalValue.value()) / parallel_args.world_size();
   param.backend =
       ::xllm::ParallelConfig::get_instance().communication_backend();
+  param.enableMC2 = kernel_config.enable_fused_mc2() > 0 &&
+                    param.backend == "hccl" && quantize_type_.empty();
+  if (param.enableMC2) {
+    LOG(WARNING) << "currently A3 doesn't support MC2.";
+  }
   param.enableLogN = false;
   param.tensorParallelInfo = {
       parallel_args.rank(),
@@ -88,19 +94,17 @@ void NpuQwen3DecoderLayerImpl::param_from_args(
 
   param.numHiddenLayers = args.n_layers();
   param.enableIntraLayerAddNorm = true;
-  if (::xllm::KernelConfig::get_instance().enable_interlayer_addnorm()) {
+  if (kernel_config.enable_interlayer_addnorm()) {
     param.enableInterLayerAddNorm = true;
   }
   param.enablePreFetchWeight =
       ::xllm::LoadConfig::get_instance().enable_prefetch_weight();
   param.enableAclGraphPagedAttention =
       ::xllm::ExecutionConfig::get_instance().enable_graph() && !isPrefill;
-  if (::xllm::KernelConfig::get_instance()
-          .enable_qwen3_dense_aclnn_matmul()) {
+  if (kernel_config.enable_aclnn_matmul()) {
     param.matmulBackend = atb_speed::common::OpBackend::ACLNN;
   }
-  if (::xllm::KernelConfig::get_instance()
-          .enable_qwen3_dense_aclnn_swiglu()) {
+  if (kernel_config.enable_aclnn_swiglu()) {
     param.swigluBackend = atb_speed::common::OpBackend::ACLNN;
   }
   initialize_parallel_parameters(param, parallel_args);
@@ -124,7 +128,7 @@ void NpuQwen3DecoderLayerImpl::param_from_args(
         ::xllm::KVCacheConfig::get_instance().block_size() == 128;
   }
   num_hidden_layers_ = args.n_layers();
-  if (::xllm::KernelConfig::get_instance().enable_split_rmsnorm_rope()) {
+  if (kernel_config.enable_split_rmsnorm_rope()) {
     param.enableSplitRmsNormRope = true;
   }
 }


### PR DESCRIPTION
## Description
Support aclnnSwiglu and aclnnMatmul for qwen3 models， add gflags enable_aclnn_matmul and enable_aclnn_swiglu. add additional gflag enable_layer_optimization，which will open interlayer_addnorm and aclnn_swiglu and split_rmsnormrope by default.
<!-- What does this PR do? Briefly describe the changes and why they are needed. -->

## Related Issues

<!-- Link related issues here. Use "Fixes #123" when this PR closes an issue. -->

## Change Type

- [ ] Bug fix
- [ ] New feature
- [✅ ] Performance improvement
- [ ] Refactor
- [ ] Documentation
- [ ] Test
- [ ] Build or CI

## Pull Request Checklist

Thank you for contributing to xLLM. Before requesting review, please make sure the following items are complete.

### PR Title and Commit Messages

- [ ] The PR title and each commit message follow the xLLM commit format: `<type>: <subject>`.

> Allowed types: feat, bugfix, docs, test, refactor, chore, style, revert, perf, model, build, release.
> The subject should use clear English, start with a verb, include at least 4 words, and end with `.`.

### Pre-commit Checks

- [ ] I have installed `pre-commit` by running `pip install pre-commit` or an equivalent command.
- [ ] I have installed the hooks with `pre-commit install`.
- [ ] I have run `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

### Self Review

- [ ] I have self-reviewed the code according to `.agents/skills/code-review/references/custom-code-style.md`, especially code written or assisted by AI.
- [ ] I have rebased this PR onto the latest `main` branch.

### Build and Test Coverage

- [ ] Tests have been added or updated as needed.
- [ ] CUDA: `python setup.py build test` has passed on a CUDA machine.
- [ ] NPU: `python setup.py build test` has passed on an NPU machine.
- [ ] MLU: `python setup.py build test` has passed on an MLU machine.

## Reviewer Notes

<!-- Optional: anything reviewers should focus on, known risks, follow-ups, or validation gaps. -->
