### PR TITLE
feat: support W8A8 dynamic quantization for DiT models qwen_image_edit and wan22.

### DIFF
--- a/xllm/core/framework/dit_model_loader.cpp
+++ b/xllm/core/framework/dit_model_loader.cpp
@@ -92,6 +92,11 @@ bool DiTFolderLoader::load_args(const std::string& model_weights_path) {
     return false;
   }
 
+  if (!load_quant_args(model_weights_path)) {
+    LOG(WARNING) << "Failed to load quant args from " << model_weights_path;
+    // Non-fatal: not all models have quantization configs.
+  }
+
   return true;
 }
 
@@ -421,6 +426,103 @@ bool DiTFolderLoader::load_tokenizer_args(
     tokenizer_args_.pad_token() = v.value();
   }
 
+  return true;
+}
+
+bool DiTFolderLoader::load_quant_args(const std::string& model_weights_path) {
+  // Search for a quant description JSON file by fuzzy name match
+  // (e.g. "quant_model_description.json", "quant_desc.json", etc.).
+  std::string quant_desc_file_path;
+  for (const auto& entry :
+       std::filesystem::directory_iterator(model_weights_path)) {
+    if (!entry.is_regular_file()) {
+      continue;
+    }
+    const auto& path = entry.path();
+    if (path.extension() == ".json") {
+      std::string stem = path.stem().string();
+      boost::algorithm::to_lower(stem);
+      if (stem.find("quant") != std::string::npos) {
+        quant_desc_file_path = path.string();
+        break;
+      }
+    }
+  }
+  if (quant_desc_file_path.empty()) {
+    return true;  // No quant config — not an error.
+  }
+
+  JsonReader quant_desc_reader;
+  if (!quant_desc_reader.parse(quant_desc_file_path)) {
+    LOG(WARNING) << "Failed to parse quant description file: "
+                 << quant_desc_file_path;
+    return true;
+  }
+
+  const auto quant_desc_data = quant_desc_reader.data();
+  if (!quant_desc_data.is_object()) {
+    LOG(WARNING) << "Quant description file is not a JSON object: "
+                 << quant_desc_file_path;
+    return true;
+  }
+
+  std::unordered_map<std::string, std::string> quant_descs;
+  bool desc_has_w8a8 = false;
+  bool desc_has_w4a8 = false;
+
+  for (auto it = quant_desc_data.begin(); it != quant_desc_data.end(); ++it) {
+    if (!it.value().is_string()) {
+      continue;
+    }
+    // Keep only tensor-like keys (contain '.') — skip metadata fields.
+    if (it.key().find('.') == std::string::npos) {
+      continue;
+    }
+    const std::string quant_type = it.value().get<std::string>();
+    std::string quant_type_lower = quant_type;
+    boost::algorithm::to_lower(quant_type_lower);
+    if (boost::algorithm::starts_with(quant_type_lower, "w4a8")) {
+      desc_has_w4a8 = true;
+    } else if (boost::algorithm::starts_with(quant_type_lower, "w8a8")) {
+      desc_has_w8a8 = true;
+    }
+    quant_descs.emplace(it.key(), quant_type);
+    // Map "weight_packed" keys to "weight" for compatibility.
+    const std::string packed_weight = "weight_packed";
+    std::string mapped_key = it.key();
+    if (const auto pos = mapped_key.find(packed_weight);
+        pos != std::string::npos) {
+      mapped_key.replace(pos, packed_weight.size(), "weight");
+      quant_descs.emplace(std::move(mapped_key), quant_type);
+    }
+  }
+
+  quant_args_.quant_descs() = std::move(quant_descs);
+  if (desc_has_w4a8) {
+    quant_args_.quant_method() = kQuantMethodAscendInt4;
+  } else if (desc_has_w8a8) {
+    quant_args_.quant_method() = kQuantMethodAscendInt8;
+  }
+
+  // Read model-level quant metadata.
+  if (auto v = quant_desc_reader.value<std::string>("model_quant_type")) {
+    auto quantize_type = v.value();
+    boost::algorithm::to_lower(quantize_type);
+    quant_args_.quantize_type() = quantize_type;
+  }
+  if (auto v = quant_desc_reader.value<int64_t>("group_size")) {
+    quant_args_.group_size() = v.value();
+  }
+  if (auto v = quant_desc_reader.value<std::string>("version")) {
+    quant_args_.quant_version() = v.value();
+  }
+
+  LOG(INFO) << "Loaded quant_model_description from " << quant_desc_file_path
+            << ", quant_desc_count=" << quant_args_.quant_descs().size()
+            << ", quant_method="
+            << (quant_args_.quant_method().empty()
+                    ? "<empty>"
+                    : quant_args_.quant_method());
   return true;
 }
 

--- a/xllm/core/framework/dit_model_loader.h
+++ b/xllm/core/framework/dit_model_loader.h
@@ -43,6 +43,7 @@ class DiTFolderLoader : public ModelLoader {
   bool load_model_args(const std::string& model_weights_path);
   bool load_image_preprocessor_args(const std::string& model_weights_path);
   bool load_tokenizer_args(const std::string& model_weights_path);
+  bool load_quant_args(const std::string& model_weights_path);
 
   std::string model_weights_path_;
 

--- a/xllm/core/framework/quant_args.h
+++ b/xllm/core/framework/quant_args.h
@@ -32,7 +32,31 @@ limitations under the License.
 
 namespace xllm {
 
-// Quantization method identifiers
+// ── Shared Utilities ───────────────────────────────────────────────────────
+
+inline std::string to_lower_copy(std::string value) {
+  std::transform(
+      value.begin(), value.end(), value.begin(), [](unsigned char c) {
+        return static_cast<char>(std::tolower(c));
+      });
+  return value;
+}
+
+// ── Quant Method Checks ─────────────────────────────────────────────────────
+
+inline bool is_w8a8_dynamic_quant(
+    const std::optional<std::string>& resolved_weight_quant_method) {
+  return resolved_weight_quant_method.has_value() &&
+         resolved_weight_quant_method.value() == "w8a8_dynamic";
+}
+
+inline bool is_w8a8_quant(
+    const std::optional<std::string>& resolved_weight_quant_method) {
+  return resolved_weight_quant_method.has_value() &&
+         resolved_weight_quant_method.value() == "w8a8";
+}
+
+// ── Quantization method identifiers ─────────────────────────────────────────
 static const std::string kQuantMethodFp8 = "fp8";
 static const std::string kQuantMethodSmoothquant = "smoothquant";
 static const std::string kQuantMethodAscendInt4 = "ascend_int4";
@@ -85,6 +109,20 @@ struct QuantArgs {
   // key: full tensor name, e.g. "layers.0.attn.wq_a.weight"
   // value: quant type, e.g. "W8A8_DYNAMIC"
   PROPERTY(QuantDescs, quant_descs) = {};
+
+  // ── Convenience helpers for weight-loading prefix resolution ──────────
+
+  bool is_quantized() const { return !quant_descs_.empty(); }
+
+  // Returns `quant_key` when the model is quantized (quant_descs is
+  // non-empty), otherwise returns `fallback`.  Use this to pick between
+  // checkpoint key names / prefixes at load time without repeated if/else.
+  std::string resolve_prefix(const std::string& quant_key,
+                             const std::string& fallback) const {
+    return quant_descs_.empty() ? fallback : quant_key;
+  }
+
+  // ── Module-level helpers ────────────────────────────────────────────────
 
   bool should_ignore_module(const std::string& module_name) const {
     for (const auto& pattern : ignored_modules()) {

--- a/xllm/core/layers/common/add_matmul.cpp
+++ b/xllm/core/layers/common/add_matmul.cpp
@@ -16,6 +16,8 @@ limitations under the License.
 #include "add_matmul.h"
 
 #include "core/framework/state_dict/utils.h"
+#include "core/layers/common/quant_utils.h"
+#include "kernels/ops_api.h"
 
 namespace xllm {
 namespace layer {
@@ -102,10 +104,35 @@ AddMatmulWeightTransposedImpl::AddMatmulWeightTransposedImpl(
     int64_t in,
     int64_t out,
     bool with_bias,
-    const torch::TensorOptions& options)
-    : AddMatmulImpl(in, out, with_bias, options) {}
+    const torch::TensorOptions& options,
+    const QuantArgs& quant_args)
+    : AddMatmulImpl(in, out, with_bias, options),
+      quant_args_(quant_args),
+      output_dtype_(c10::typeMetaToScalarType(options.dtype())) {
+  if (!quant_args_.quant_descs().empty()) {
+    weight_scale_ =
+        register_parameter("weight_scale",
+                           torch::empty({out}, options.dtype(torch::kFloat32)),
+                           /*requires_grad=*/false);
+    weight_offset_ =
+        register_parameter("weight_offset",
+                           torch::empty({out}, options.dtype(torch::kFloat32)),
+                           /*requires_grad=*/false);
+  }
+}
 
 torch::Tensor AddMatmulWeightTransposedImpl::forward(const torch::Tensor& x) {
+  if (is_w8a8_dynamic_quant(resolved_weight_quant_method_)) {
+    CHECK(weight_scale_is_loaded_ && weight_scale_.defined())
+        << "weight_scale is required for w8a8_dynamic quant matmul.";
+    auto bias = with_bias_ ? std::optional<torch::Tensor>(bias_) : std::nullopt;
+    // Offset only valid when out dtype is INT8 (NPU kernel requirement).
+    auto w_offset = (weight_offset_.defined() && output_dtype_ == torch::kInt8)
+                        ? std::optional<torch::Tensor>(weight_offset_)
+                        : std::nullopt;
+    return npu_w8a8_dynamic_linear_forward(
+        x, weight_, weight_scale_, bias, output_dtype_, w_offset);
+  }
   // use addmm when bias is provided
   if (with_bias_) {
     auto sizes = x.sizes();
@@ -123,15 +150,54 @@ torch::Tensor AddMatmulWeightTransposedImpl::forward(const torch::Tensor& x) {
 
 void AddMatmulWeightTransposedImpl::load_state_dict(
     const StateDict& state_dict) {
-  // only transpoes weights when state_dict has the key
-  // or it would be transposed multiple times when having
-  // multiple state dicts
-  if (state_dict.has("weight")) {
-    xllm::weight::load_weight(state_dict, "weight", weight_, weight_is_loaded_);
-    // weight need to be transposed when using addmm
-    if (with_bias_) {
-      torch::Tensor transposed = weight_.data().transpose(0, 1).contiguous();
-      weight_.set_data(transposed);
+  resolve_weight_quant_method_for_linear_load(
+      quant_args_, state_dict, nullptr, resolved_weight_quant_method_);
+
+  if (is_w8a8_dynamic_quant(resolved_weight_quant_method_)) {
+    std::vector<weight::LazyParameterSpec> specs;
+    specs.push_back(
+        weight::LazyParameterSpec{&weight_,
+                                  &weight_is_loaded_,
+                                  "weight",
+                                  {weight_.size(0), weight_.size(1)},
+                                  options_.dtype(torch::kInt8)});
+    weight::ensure_parameter_storage(this, specs);
+
+    std::vector<weight::LazyParameterSpec> scale_specs;
+    scale_specs.push_back(
+        weight::LazyParameterSpec{&weight_scale_,
+                                  &weight_scale_is_loaded_,
+                                  "weight_scale",
+                                  {weight_.size(0)},
+                                  options_.dtype(torch::kFloat32)});
+    scale_specs.push_back(
+        weight::LazyParameterSpec{&weight_offset_,
+                                  &weight_offset_is_loaded_,
+                                  "weight_offset",
+                                  {weight_.size(0)},
+                                  options_.dtype(torch::kFloat32)});
+    weight::ensure_parameter_storage(this, scale_specs);
+
+    if (state_dict.has("weight")) {
+      weight::load_weight(state_dict, "weight", weight_, weight_is_loaded_);
+    }
+    if (state_dict.has("weight_scale")) {
+      weight::load_weight(
+          state_dict, "weight_scale", weight_scale_, weight_scale_is_loaded_);
+    }
+    if (state_dict.has("weight_offset")) {
+      weight::load_weight(state_dict,
+                          "weight_offset",
+                          weight_offset_,
+                          weight_offset_is_loaded_);
+    }
+  } else {
+    if (state_dict.has("weight")) {
+      weight::load_weight(state_dict, "weight", weight_, weight_is_loaded_);
+      if (with_bias_) {
+        torch::Tensor transposed = weight_.data().transpose(0, 1).contiguous();
+        weight_.set_data(transposed);
+      }
     }
   }
   if (with_bias_) {

--- a/xllm/core/layers/common/add_matmul.h
+++ b/xllm/core/layers/common/add_matmul.h
@@ -17,6 +17,10 @@ limitations under the License.
 
 #include <torch/torch.h>
 
+#include <optional>
+#include <string>
+
+#include "core/framework/quant_args.h"
 #include "core/framework/state_dict/state_dict.h"
 
 namespace xllm {
@@ -64,13 +68,24 @@ class AddMatmulWeightTransposedImpl : public AddMatmulImpl {
   AddMatmulWeightTransposedImpl(int64_t in,
                                 int64_t out,
                                 bool with_bias,
-                                const torch::TensorOptions& options);
+                                const torch::TensorOptions& options,
+                                const QuantArgs& quant_args = QuantArgs());
 
   torch::Tensor forward(const torch::Tensor& x) override;
 
   void load_state_dict(const xllm::StateDict& state_dict) override;
+
+ protected:
+  QuantArgs quant_args_;
+  std::optional<std::string> resolved_weight_quant_method_;
+  torch::Tensor weight_scale_;
+  torch::Tensor weight_offset_;
+  bool weight_scale_is_loaded_ = false;
+  bool weight_offset_is_loaded_ = false;
+  at::ScalarType output_dtype_;
 };
 
 TORCH_MODULE(AddMatmulWeightTransposed);
+
 }  // namespace layer
 }  // namespace xllm

--- a/xllm/core/layers/common/linear.cpp
+++ b/xllm/core/layers/common/linear.cpp
@@ -21,6 +21,7 @@ limitations under the License.
 #include <algorithm>
 #include <cctype>
 
+#include "core/layers/common/quant_utils.h"
 #include "framework/parallel_state/parallel_args.h"
 #include "framework/parallel_state/parallel_state.h"
 #include "kernels/ops_api.h"
@@ -191,50 +192,6 @@ std::string to_lower_copy(std::string value) {
         return static_cast<char>(std::tolower(c));
       });
   return value;
-}
-
-void resolve_weight_quant_method_for_linear_load(
-    const QuantArgs& quant_args,
-    const StateDict& state_dict,
-    const std::vector<std::string>* local_prefixes,
-    std::optional<std::string>& resolved_weight_quant_method) {
-  const auto prefixes =
-      local_prefixes == nullptr ? std::vector<std::string>{} : *local_prefixes;
-  auto resolved =
-      quant_args.get_quant_method_from_prefixes(state_dict, prefixes);
-  if (resolved.has_value()) {
-    resolved_weight_quant_method = to_lower_copy(resolved.value());
-    return;
-  }
-  if (quant_args.is_compressed_tensors_w8a8_dynamic()) {
-    bool is_w8a8_dynamic = false;
-    if (prefixes.empty()) {
-      torch::Tensor weight = state_dict.get_tensor("weight");
-      is_w8a8_dynamic = state_dict.has("weight_scale") && weight.defined() &&
-                        weight.scalar_type() == torch::kInt8;
-    } else {
-      is_w8a8_dynamic = true;
-      for (const std::string& prefix : prefixes) {
-        torch::Tensor weight = state_dict.get_tensor(prefix + "weight");
-        if (!state_dict.has(prefix + "weight_scale") || !weight.defined() ||
-            weight.scalar_type() != torch::kInt8) {
-          is_w8a8_dynamic = false;
-          break;
-        }
-      }
-    }
-    if (is_w8a8_dynamic) {
-      resolved_weight_quant_method = "w8a8_dynamic";
-      return;
-    }
-  }
-  if (!quant_args.quant_descs().empty()) {
-    LOG(WARNING) << "[LinearLoad][QuantMethod] quant_descs is not empty but "
-                    "quant method was not resolved from state_dict prefixes. "
-                    "state_dict.prefix="
-                 << state_dict.prefix();
-  }
-  resolved_weight_quant_method = std::nullopt;
 }
 
 bool is_w8a8_dynamic_quant(
@@ -469,37 +426,6 @@ torch::Tensor npu_w8a8_linear_forward(
   quant_matmul_params.output_dtype = output_dtype;
 
   return xllm::kernel::quant_matmul(quant_matmul_params);
-}
-
-torch::Tensor npu_w8a8_dynamic_linear_forward(
-    const torch::Tensor& input,
-    const torch::Tensor& weight,
-    const torch::Tensor& weight_scale,
-    const std::optional<torch::Tensor>& bias,
-    at::ScalarType output_dtype) {
-  xllm::kernel::NpuQuantizeParams quant_params;
-  quant_params.input = input;
-  // quant_params.dst_type = at::kChar;
-
-  torch::Tensor quantized_input;
-  std::optional<torch::Tensor> pertoken_scale;
-  std::tie(quantized_input, pertoken_scale) =
-      xllm::kernel::dynamic_quant(quant_params);
-  CHECK(pertoken_scale.has_value() && pertoken_scale->defined())
-      << "dynamic_quant must return per-token scale for w8a8_dynamic.";
-
-  xllm::kernel::QuantMatmulParams quant_matmul_params;
-  quant_matmul_params.x1 = quantized_input;
-  quant_matmul_params.x2 = weight;
-  quant_matmul_params.transpose2 = true;
-  quant_matmul_params.scale = weight_scale;
-  quant_matmul_params.pertoken_scale = pertoken_scale;
-  quant_matmul_params.output_dtype = output_dtype;
-  if (bias.has_value() && bias->defined()) {
-    quant_matmul_params.bias = bias;
-  }
-  auto output = xllm::kernel::quant_matmul(quant_matmul_params);
-  return output;
 }
 
 #if defined(USE_DCU)

--- a/xllm/core/layers/common/quant_utils.h
+++ b/xllm/core/layers/common/quant_utils.h
@@ -1,0 +1,115 @@
+/* Copyright 2026 The xLLM Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://github.com/jd-opensource/xllm/blob/main/LICENSE
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#pragma once
+
+// Two shared quant helpers used by both LLM (linear.cpp) and DiT
+// (add_matmul.cpp, dit_parallel_linear.h).
+
+#include <glog/logging.h>
+#include <torch/torch.h>
+
+#include <optional>
+#include <string>
+#include <vector>
+
+#include "core/framework/quant_args.h"
+#include "core/framework/state_dict/state_dict.h"
+#include "kernels/ops_api.h"
+
+namespace xllm {
+namespace layer {
+
+inline void resolve_weight_quant_method_for_linear_load(
+    const QuantArgs& quant_args,
+    const StateDict& state_dict,
+    const std::vector<std::string>* local_prefixes,
+    std::optional<std::string>& resolved_weight_quant_method) {
+  const auto prefixes =
+      local_prefixes == nullptr ? std::vector<std::string>{} : *local_prefixes;
+  auto resolved =
+      quant_args.get_quant_method_from_prefixes(state_dict, prefixes);
+  if (resolved.has_value()) {
+    resolved_weight_quant_method = resolved.value();
+    return;
+  }
+  if (quant_args.is_compressed_tensors_w8a8_dynamic()) {
+    bool is_w8a8_dynamic = false;
+    if (prefixes.empty()) {
+      torch::Tensor weight = state_dict.get_tensor("weight");
+      is_w8a8_dynamic = state_dict.has("weight_scale") && weight.defined() &&
+                        weight.scalar_type() == torch::kInt8;
+    } else {
+      is_w8a8_dynamic = true;
+      for (const std::string& prefix : prefixes) {
+        torch::Tensor weight = state_dict.get_tensor(prefix + "weight");
+        if (!state_dict.has(prefix + "weight_scale") || !weight.defined() ||
+            weight.scalar_type() != torch::kInt8) {
+          is_w8a8_dynamic = false;
+          break;
+        }
+      }
+    }
+    if (is_w8a8_dynamic) {
+      resolved_weight_quant_method = "w8a8_dynamic";
+      return;
+    }
+  }
+  if (!quant_args.quant_descs().empty()) {
+    LOG(WARNING) << "[LinearLoad][QuantMethod] quant_descs is not empty but "
+                    "quant method was not resolved from state_dict prefixes. "
+                    "state_dict.prefix="
+                 << state_dict.prefix();
+  }
+  resolved_weight_quant_method = std::nullopt;
+}
+
+inline torch::Tensor npu_w8a8_dynamic_linear_forward(
+    const torch::Tensor& input,
+    const torch::Tensor& weight,
+    const torch::Tensor& weight_scale,
+    const std::optional<torch::Tensor>& bias,
+    at::ScalarType output_dtype,
+    const std::optional<torch::Tensor>& weight_offset = std::nullopt) {
+  kernel::NpuQuantizeParams quant_params;
+  quant_params.input = input;
+  // quant_params.dst_type = at::kChar;
+
+  torch::Tensor quantized_input;
+  std::optional<torch::Tensor> pertoken_scale;
+  std::tie(quantized_input, pertoken_scale) =
+      kernel::dynamic_quant(quant_params);
+  CHECK(pertoken_scale.has_value() && pertoken_scale->defined())
+      << "dynamic_quant must return per-token scale for w8a8_dynamic.";
+
+  kernel::QuantMatmulParams quant_matmul_params;
+  quant_matmul_params.x1 = quantized_input;
+  quant_matmul_params.x2 = weight;
+  quant_matmul_params.transpose2 = true;
+  quant_matmul_params.scale = weight_scale;
+  quant_matmul_params.pertoken_scale = pertoken_scale->reshape({-1});
+  quant_matmul_params.output_dtype = output_dtype;
+  if (weight_offset.has_value() && weight_offset->defined()) {
+    quant_matmul_params.offset = weight_offset;
+  }
+  if (bias.has_value() && bias->defined()) {
+    quant_matmul_params.bias = bias;
+  }
+  auto output = kernel::quant_matmul(quant_matmul_params);
+  return output;
+}
+
+}  // namespace layer
+}  // namespace xllm

--- a/xllm/models/dit/pipelines/pipeline_qwenimage_edit_plus.h
+++ b/xllm/models/dit/pipelines/pipeline_qwenimage_edit_plus.h
@@ -1189,7 +1189,7 @@ class QwenImageEditPlusPipelineImpl : public torch::nn::Module {
 
     LOG(INFO) << "QwenImageEditPlusPipeline loading transformer weights";
     transformer_->load_model(std::move(transformer_loader));
-    
+
     LOG(INFO) << "QwenImageEditPlusPipeline moving transformer to device";
     transformer_->to(options_.device());
     LOG(INFO) << "QwenImageEditPlusPipeline transformer loaded";

--- a/xllm/models/dit/pipelines/pipeline_qwenimage_edit_plus.h
+++ b/xllm/models/dit/pipelines/pipeline_qwenimage_edit_plus.h
@@ -1189,8 +1189,9 @@ class QwenImageEditPlusPipelineImpl : public torch::nn::Module {
 
     LOG(INFO) << "QwenImageEditPlusPipeline loading transformer weights";
     transformer_->load_model(std::move(transformer_loader));
+    
     LOG(INFO) << "QwenImageEditPlusPipeline moving transformer to device";
-    transformer_->to(options_.device(), dtype_);
+    transformer_->to(options_.device());
     LOG(INFO) << "QwenImageEditPlusPipeline transformer loaded";
 
 #if defined(USE_DCU)

--- a/xllm/models/dit/pipelines/pipeline_wan_i2v.h
+++ b/xllm/models/dit/pipelines/pipeline_wan_i2v.h
@@ -58,24 +58,24 @@ class WanImageToVideoPipelineImpl : public torch::nn::Module {
 
     // RainFusion config is static (derived from flags) — build it once here
     // and pass to the transformers via constructor. It never changes per
-    // request, unlike RainFusionState which is per-inference dynamic state.
+    // request, unlike SparseAttnState which is per-inference dynamic state.
     auto& dit_config = DiTConfig::get_instance();
-    rf_config_.enabled = dit_config.dit_sparse_attention_enabled();
-    rf_config_.sparsity =
+    sparse_attn_config_.enabled = dit_config.dit_sparse_attention_enabled();
+    sparse_attn_config_.sparsity =
         static_cast<float>(dit_config.dit_sparse_attention_sparsity());
-    rf_config_.pool_size = dit_config.dit_sparse_attention_pool_size();
-    rf_config_.sparse_start_step =
+    sparse_attn_config_.pool_size = dit_config.dit_sparse_attention_pool_size();
+    sparse_attn_config_.sparse_start_step =
         dit_config.dit_sparse_attention_sparse_start_step();
-    rf_config_.version = dit_config.dit_sparse_attention_version();
-    rf_config_.mask_refresh_steps =
+    sparse_attn_config_.version = dit_config.dit_sparse_attention_version();
+    sparse_attn_config_.mask_refresh_steps =
         dit_config.dit_sparse_attention_mask_refresh_steps();
 
     LOG(INFO) << "Initializing Wan2_2I2V pipeline...";
     vae_ = AutoencoderKLWan(context.get_model_context("vae"));
     transformer_ = WanTransformer3DModel(
-        context.get_model_context("transformer"), rf_config_);
+        context.get_model_context("transformer"), sparse_attn_config_);
     transformer_2_ = WanTransformer3DModel(
-        context.get_model_context("transformer_2"), rf_config_);
+        context.get_model_context("transformer_2"), sparse_attn_config_);
     umt5_ = UMT5EncoderModel(context.get_model_context("text_encoder"));
     scheduler_ =
         UniPCMultistepScheduler(context.get_model_context("scheduler"));
@@ -500,7 +500,7 @@ class WanImageToVideoPipelineImpl : public torch::nn::Module {
 
     // RainFusion config is static and already bound to the transformers in the
     // constructor. Only the per-inference dynamic state lives here.
-    xllm::dit::RainFusionState rf_state;
+    xllm::dit::SparseAttnState sparse_attn_state;
 
     for (int64_t i = 0; i < timesteps.numel(); ++i) {
       torch::Tensor t = timesteps[i];
@@ -517,7 +517,7 @@ class WanImageToVideoPipelineImpl : public torch::nn::Module {
         current_guidance = guidance_scale_2;
       }
 
-      rf_state.current_step = i;
+      sparse_attn_state.current_step = i;
       torch::Tensor latent_model_input;
       torch::Tensor timestep_input;
 
@@ -554,7 +554,7 @@ class WanImageToVideoPipelineImpl : public torch::nn::Module {
             timestep_input,
             embeds,
             torch::Tensor(),
-            rf_state,
+            sparse_attn_state,
             [&rolling](int32_t i) { rolling.wait_h2d(i); },
             [&rolling](int32_t i) { rolling.schedule_next_h2d(i); });
       };
@@ -577,7 +577,7 @@ class WanImageToVideoPipelineImpl : public torch::nn::Module {
                                            rank == 0 ? encoded_prompt_embeds
                                                      : encoded_negative_embeds,
                                            torch::Tensor(),
-                                           rf_state);
+                                           sparse_attn_state);
           auto gathered = xllm::parallel_state::gather(
               noise_pred, parallel_args_.dit_cfg_group_, /*dim=*/0);
           auto chunks = torch::chunk(gathered, 2, 0);
@@ -592,12 +592,12 @@ class WanImageToVideoPipelineImpl : public torch::nn::Module {
                                                 timestep_input,
                                                 encoded_prompt_embeds,
                                                 torch::Tensor(),
-                                                rf_state);
+                                                sparse_attn_state);
             noise_uncond = current_model->forward(latent_model_input,
                                                   timestep_input,
                                                   encoded_negative_embeds,
                                                   torch::Tensor(),
-                                                  rf_state);
+                                                  sparse_attn_state);
           }
         }
 
@@ -613,7 +613,7 @@ class WanImageToVideoPipelineImpl : public torch::nn::Module {
                                                   timestep_input,
                                                   encoded_prompt_embeds,
                                                   torch::Tensor(),
-                                                  rf_state);
+                                                  sparse_attn_state);
       }
       auto prev_latents = scheduler_->step(noise_pred, t, prepared_latents);
       prepared_latents = prev_latents.detach();
@@ -754,7 +754,7 @@ class WanImageToVideoPipelineImpl : public torch::nn::Module {
   std::vector<double> latents_std_;
   torch::TensorOptions options_;
   const ParallelArgs parallel_args_;
-  xllm::dit::RainFusionConfig rf_config_;
+  xllm::dit::SparseAttnConfig sparse_attn_config_;
 };
 TORCH_MODULE(WanImageToVideoPipeline);
 

--- a/xllm/models/dit/transformers/transformer_qwen_image.h
+++ b/xllm/models/dit/transformers/transformer_qwen_image.h
@@ -232,11 +232,15 @@ class AdaLayerNormContinuousImpl final : public torch::nn::Module {
                                       bool bias = true)
       : options_(context.get_tensor_options()) {
     ModelArgs model_args = context.get_model_args();
+    quant_args_ = context.get_quant_args();
     silu_ = register_module("silu", torch::nn::SiLU());
     linear_ = register_module(
         "linear",
-        layer::AddMatmulWeightTransposed(
-            conditioning_embedding_dim, 2 * embedding_dim, bias, options_));
+        layer::AddMatmulWeightTransposed(conditioning_embedding_dim,
+                                         2 * embedding_dim,
+                                         bias,
+                                         options_,
+                                         quant_args_));
     norm_ = register_module(
         "norm",
         torch::nn::LayerNorm(torch::nn::LayerNormOptions({embedding_dim})
@@ -272,6 +276,7 @@ class AdaLayerNormContinuousImpl final : public torch::nn::Module {
   layer::AddMatmulWeightTransposed linear_{nullptr};
   torch::nn::SiLU silu_{nullptr};
   torch::nn::LayerNorm norm_{nullptr};
+  QuantArgs quant_args_;
   double eps_;
   std::string norm_type_;
   bool elementwise_affine_;
@@ -370,26 +375,33 @@ class TimestepEmbeddingImpl final : public torch::nn::Module {
                         int64_t cond_proj_dim = -1,
                         bool sample_proj_bias = true)
       : options_(context.get_tensor_options()) {
-    linear_1_ = register_module(
-        "linear_1",
-        layer::AddMatmulWeightTransposed(
-            in_channels, time_embed_dim, sample_proj_bias, options_));
+    quant_args_ = context.get_quant_args();
+    linear_1_ =
+        register_module("linear_1",
+                        layer::AddMatmulWeightTransposed(in_channels,
+                                                         time_embed_dim,
+                                                         sample_proj_bias,
+                                                         options_,
+                                                         quant_args_));
 
     if (cond_proj_dim > 0) {
-      cond_proj_ =
-          register_module("cond_proj",
-                          layer::AddMatmulWeightTransposed(
-                              cond_proj_dim, in_channels, false, options_));
+      cond_proj_ = register_module(
+          "cond_proj",
+          layer::AddMatmulWeightTransposed(
+              cond_proj_dim, in_channels, false, options_, quant_args_));
     }
 
     act_fn_ = register_module("act_fn", torch::nn::SiLU());
 
     int64_t time_embed_dim_out = (out_dim > 0) ? out_dim : time_embed_dim;
 
-    linear_2_ = register_module(
-        "linear_2",
-        layer::AddMatmulWeightTransposed(
-            time_embed_dim, time_embed_dim_out, sample_proj_bias, options_));
+    linear_2_ =
+        register_module("linear_2",
+                        layer::AddMatmulWeightTransposed(time_embed_dim,
+                                                         time_embed_dim_out,
+                                                         sample_proj_bias,
+                                                         options_,
+                                                         quant_args_));
   }
 
   torch::Tensor forward(const torch::Tensor& sample,
@@ -420,6 +432,7 @@ class TimestepEmbeddingImpl final : public torch::nn::Module {
 
  private:
   torch::TensorOptions options_;
+  QuantArgs quant_args_;
   torch::nn::SiLU act_fn_{nullptr};
   layer::AddMatmulWeightTransposed linear_1_{nullptr};
   layer::AddMatmulWeightTransposed linear_2_{nullptr};
@@ -460,6 +473,7 @@ class AttentionImpl final : public torch::nn::Module {
                 bool is_causal = false,
                 ProcessGroup* sp_group = nullptr)
       : options_(context.get_tensor_options()),
+        quant_args_(context.get_quant_args()),
         heads_(heads),
         kv_heads_(kv_heads.has_value() ? kv_heads.value() : heads),
         dim_head_(dim_head),
@@ -559,12 +573,14 @@ class AttentionImpl final : public torch::nn::Module {
       linear_type = xllm::dit::LinearType::SequenceParallel;
     }
 
-    auto q_linear =
-        layer::AddMatmulWeightTransposed(query_dim, q_dim, bias, options_);
-
     to_q_ = register_module("q_linear",
-                            xllm::dit::DiTParallelLinear(
-                                query_dim, q_dim, bias, options_, q_sp_option));
+                            xllm::dit::DiTParallelLinear(query_dim,
+                                                         q_dim,
+                                                         bias,
+                                                         options_,
+                                                         q_sp_option,
+                                                         /*tp=*/std::nullopt,
+                                                         quant_args_));
 
     // Key-Value projections (if not only cross attention)
     if (!only_cross_attention) {
@@ -574,7 +590,9 @@ class AttentionImpl final : public torch::nn::Module {
                                        kv_dim,
                                        bias,
                                        options_,
-                                       kv_sp_option));
+                                       kv_sp_option,
+                                       /*tp=*/std::nullopt,
+                                       quant_args_));
 
       to_v_ = register_module(
           "v_linear",
@@ -582,7 +600,9 @@ class AttentionImpl final : public torch::nn::Module {
                                        kv_dim,
                                        bias,
                                        options_,
-                                       kv_sp_option));
+                                       kv_sp_option,
+                                       /*tp=*/std::nullopt,
+                                       quant_args_));
     }
 
     if (added_kv_proj_dim.has_value()) {
@@ -592,7 +612,9 @@ class AttentionImpl final : public torch::nn::Module {
                                        kv_dim,
                                        added_proj_bias,
                                        options_,
-                                       kv_sp_option));
+                                       kv_sp_option,
+                                       /*tp=*/std::nullopt,
+                                       quant_args_));
 
       add_v_proj_ = register_module(
           "add_v_linear",
@@ -600,7 +622,9 @@ class AttentionImpl final : public torch::nn::Module {
                                        kv_dim,
                                        added_proj_bias,
                                        options_,
-                                       kv_sp_option));
+                                       kv_sp_option,
+                                       /*tp=*/std::nullopt,
+                                       quant_args_));
       if (context_pre_only.has_value()) {
         add_q_proj_ = register_module(
             "add_q_linear",
@@ -608,7 +632,9 @@ class AttentionImpl final : public torch::nn::Module {
                                          q_dim,
                                          added_proj_bias,
                                          options_,
-                                         q_sp_option));
+                                         q_sp_option,
+                                         /*tp=*/std::nullopt,
+                                         quant_args_));
       }
     }
 
@@ -626,8 +652,13 @@ class AttentionImpl final : public torch::nn::Module {
     if (!pre_only) {
       to_out_ = register_module("to_out", torch::nn::Sequential());
 
-      to_out_->push_back(xllm::dit::DiTParallelLinear(
-          q_dim, out_dim.value(), out_bias, options_, out_sp_option));
+      to_out_->push_back(xllm::dit::DiTParallelLinear(q_dim,
+                                                      out_dim.value(),
+                                                      out_bias,
+                                                      options_,
+                                                      out_sp_option,
+                                                      /*tp=*/std::nullopt,
+                                                      quant_args_));
       to_out_->push_back(
           torch::nn::Dropout(torch::nn::DropoutOptions(dropout)));
     }
@@ -640,7 +671,9 @@ class AttentionImpl final : public torch::nn::Module {
                                                        out_context_dim.value(),
                                                        out_bias,
                                                        options_,
-                                                       out_sp_option));
+                                                       out_sp_option,
+                                                       /*tp=*/std::nullopt,
+                                                       quant_args_));
     }
 
     // Added QK normalization for added KV projections
@@ -722,6 +755,7 @@ class AttentionImpl final : public torch::nn::Module {
   ProcessGroup* sp_group_;
 
   torch::TensorOptions options_;
+  QuantArgs quant_args_;
   torch::nn::LayerNorm layer_norm_q_{nullptr}, layer_norm_k_{nullptr},
       norm_cross_{nullptr};
   xllm::dit::DiTParallelLinear to_q_{nullptr}, to_k_{nullptr}, to_v_{nullptr};
@@ -745,12 +779,14 @@ class FeedForwardImpl final : public torch::nn::Module {
                            double dropout = 0.0)
       : options_(context.get_tensor_options()) {
     auto model_args = context.get_model_args();
+    quant_args_ = context.get_quant_args();
     int64_t inner_dim = dim * 4;
 
     // linear1
-    linear1_ = register_module(
-        "linear1",
-        layer::AddMatmulWeightTransposed(dim, inner_dim, true, options_));
+    linear1_ =
+        register_module("linear1",
+                        layer::AddMatmulWeightTransposed(
+                            dim, inner_dim, true, options_, quant_args_));
 
     // activation
     activation_ =
@@ -762,9 +798,10 @@ class FeedForwardImpl final : public torch::nn::Module {
                                 })));
 
     // linear2
-    linear2_ = register_module(
-        "linear2",
-        layer::AddMatmulWeightTransposed(inner_dim, dim_out, true, options_));
+    linear2_ =
+        register_module("linear2",
+                        layer::AddMatmulWeightTransposed(
+                            inner_dim, dim_out, true, options_, quant_args_));
   }
 
   torch::Tensor forward(const torch::Tensor& hidden_states) {
@@ -790,6 +827,7 @@ class FeedForwardImpl final : public torch::nn::Module {
   layer::AddMatmulWeightTransposed linear1_{nullptr};
   layer::AddMatmulWeightTransposed linear2_{nullptr};
   torch::nn::Functional activation_{nullptr};
+  QuantArgs quant_args_;
   torch::TensorOptions options_;
 };
 TORCH_MODULE(FeedForward);
@@ -1662,7 +1700,7 @@ class QwenDoubleStreamAttnProcessor2_0Impl : public torch::nn::Module {
 
  protected:
   qwenimage::Attention attn_{nullptr};
-  const ParallelArgs parallel_args_;
+  ParallelArgs parallel_args_;
 };
 TORCH_MODULE(QwenDoubleStreamAttnProcessor2_0);
 
@@ -1885,12 +1923,13 @@ class QwenImageTransformerBlockImpl : public torch::nn::Module {
       : options_(context.get_tensor_options()),
         zero_cond_t_(zero_cond_t),
         parallel_args_(parallel_args) {
+    quant_args_ = context.get_quant_args();
     // Image processing modules
     img_mod_ = register_module(
         "img_mod",
-        torch::nn::Sequential(
-            torch::nn::SiLU(),
-            layer::AddMatmulWeightTransposed(dim, 6 * dim, true, options_)));
+        torch::nn::Sequential(torch::nn::SiLU(),
+                              layer::AddMatmulWeightTransposed(
+                                  dim, 6 * dim, true, options_, quant_args_)));
 
     // Image normalization
     img_norm1_ = register_module("img_norm1", AdaLayerNorm(context, dim, eps));
@@ -1941,9 +1980,9 @@ class QwenImageTransformerBlockImpl : public torch::nn::Module {
     // Text processing modules
     txt_mod_ = register_module(
         "txt_mod",
-        torch::nn::Sequential(
-            torch::nn::SiLU(),
-            layer::AddMatmulWeightTransposed(dim, 6 * dim, true, options_)));
+        torch::nn::Sequential(torch::nn::SiLU(),
+                              layer::AddMatmulWeightTransposed(
+                                  dim, 6 * dim, true, options_, quant_args_)));
 
     // Text normalization 1
     txt_norm1_ = register_module("txt_norm1", AdaLayerNorm(context, dim, eps));
@@ -2135,6 +2174,7 @@ class QwenImageTransformerBlockImpl : public torch::nn::Module {
 
  private:
   torch::TensorOptions options_;
+  QuantArgs quant_args_;
   torch::nn::Sequential img_mod_{nullptr};
   AdaLayerNorm img_norm1_{nullptr};
   AdaLayerNorm img_norm2_{nullptr};
@@ -2148,7 +2188,7 @@ class QwenImageTransformerBlockImpl : public torch::nn::Module {
   AdaLayerNorm txt_norm2_{nullptr};
   qwenimage::FeedForward txt_mlp_{nullptr};
   bool zero_cond_t_;
-  const ParallelArgs parallel_args_;
+  ParallelArgs parallel_args_;
 };
 
 TORCH_MODULE(QwenImageTransformerBlock);
@@ -2158,6 +2198,7 @@ class QwenImageTransformer2DModelImpl : public torch::nn::Module {
   QwenImageTransformer2DModelImpl(const ModelContext& context,
                                   const ParallelArgs& parallel_args)
       : options_(context.get_tensor_options()), parallel_args_(parallel_args) {
+    quant_args_ = context.get_quant_args();
     auto model_args = context.get_model_args();
     int64_t num_attention_heads = model_args.n_heads();
     int64_t attention_head_dim = model_args.head_dim();
@@ -2183,13 +2224,14 @@ class QwenImageTransformer2DModelImpl : public torch::nn::Module {
         "txt_norm", qwenimage::RMSNorm(joint_attention_dim, 1e-6, true, false));
 
     // Input projections
-    img_in_ = register_module("img_in",
-                              layer::AddMatmulWeightTransposed(
-                                  in_channels, inner_dim, true, options_));
-    txt_in_ =
-        register_module("txt_in",
-                        layer::AddMatmulWeightTransposed(
-                            joint_attention_dim, inner_dim, true, options_));
+    img_in_ = register_module(
+        "img_in",
+        layer::AddMatmulWeightTransposed(
+            in_channels, inner_dim, true, options_, quant_args_));
+    txt_in_ = register_module(
+        "txt_in",
+        layer::AddMatmulWeightTransposed(
+            joint_attention_dim, inner_dim, true, options_, quant_args_));
     // Transformer blocks
     transformer_blocks_ =
         register_module("transformer_blocks", torch::nn::ModuleList());
@@ -2210,8 +2252,11 @@ class QwenImageTransformer2DModelImpl : public torch::nn::Module {
                             context, inner_dim, inner_dim, false, 1e-6));
     proj_out_ = register_module(
         "proj_out",
-        layer::AddMatmulWeightTransposed(
-            inner_dim, patch_size * patch_size * out_channels, true, options_));
+        layer::AddMatmulWeightTransposed(inner_dim,
+                                         patch_size * patch_size * out_channels,
+                                         true,
+                                         options_,
+                                         quant_args_));
 
     // Cache for conditional and unconditional
     cache_cond_ = false;
@@ -2436,6 +2481,7 @@ class QwenImageTransformer2DModelImpl : public torch::nn::Module {
 
  private:
   torch::TensorOptions options_;
+  QuantArgs quant_args_;
   QwenTimestepProjEmbeddings time_text_embed_{nullptr};
   qwenimage::RMSNorm txt_norm_{nullptr};
   layer::AddMatmulWeightTransposed img_in_{nullptr};
@@ -2444,7 +2490,7 @@ class QwenImageTransformer2DModelImpl : public torch::nn::Module {
   qwenimage::AdaLayerNormContinuous norm_out_{nullptr};
   layer::AddMatmulWeightTransposed proj_out_{nullptr};
 
-  const ParallelArgs parallel_args_;
+  ParallelArgs parallel_args_;
 
   // Cache objects
   bool cache_cond_;

--- a/xllm/models/dit/transformers/transformer_wan.h
+++ b/xllm/models/dit/transformers/transformer_wan.h
@@ -560,10 +560,10 @@ class WanAttentionImpl : public torch::nn::Module {
       const ModelContext& context,
       const ParallelArgs& parallel_args,
       int64_t cross_attention_dim_head = -1,
-      const xllm::dit::RainFusionConfig& rainfusion_config = {})
+      const xllm::dit::SparseAttnConfig& sparse_attn_config = {})
       : options_(context.get_tensor_options()),
         parallel_args_(parallel_args),
-        rainfusion_config_(rainfusion_config) {
+        sparse_attn_config_(sparse_attn_config) {
     auto model_args = context.get_model_args();
     quant_args_ = context.get_quant_args();
     dim_ = model_args.head_dim() * model_args.n_heads();
@@ -669,17 +669,19 @@ class WanAttentionImpl : public torch::nn::Module {
     }
   }
 
-  torch::Tensor at_npu_attention(const torch::Tensor& q,
-                                 const torch::Tensor& k,
-                                 const torch::Tensor& v,
-                                 xllm::dit::RainFusionState& rf_state) {
+  torch::Tensor at_npu_attention(
+      const torch::Tensor& q,
+      const torch::Tensor& k,
+      const torch::Tensor& v,
+      xllm::dit::SparseAttnState& sparse_attn_state) {
     const auto q_t = q.transpose(1, 2);
     const auto k_t = k.transpose(1, 2);
     const auto v_t = v.transpose(1, 2);
 
 #if defined(USE_NPU)
-    if (rainfusion_config_.enabled &&
-        rf_state.current_step >= rainfusion_config_.sparse_start_step &&
+    if (sparse_attn_config_.enabled &&
+        sparse_attn_state.current_step >=
+            sparse_attn_config_.sparse_start_step &&
         q_t.size(2) == k_t.size(2)) {
       // Strip SP padding: latent_shape uses the unpadded seq_len,
       // but SP may have padded the sequence to be divisible by sp_size.
@@ -687,21 +689,22 @@ class WanAttentionImpl : public torch::nn::Module {
       auto k_use = k_t;
       auto v_use = v_t;
       int64_t pad_len = 0;
-      if (rf_state.seq_len > 0 && q_t.size(2) > rf_state.seq_len) {
-        pad_len = q_t.size(2) - rf_state.seq_len;
-        q_use = q_t.slice(2, 0, rf_state.seq_len);
-        k_use = k_t.slice(2, 0, rf_state.seq_len);
-        v_use = v_t.slice(2, 0, rf_state.seq_len);
+      if (sparse_attn_state.seq_len > 0 &&
+          q_t.size(2) > sparse_attn_state.seq_len) {
+        pad_len = q_t.size(2) - sparse_attn_state.seq_len;
+        q_use = q_t.slice(2, 0, sparse_attn_state.seq_len);
+        k_use = k_t.slice(2, 0, sparse_attn_state.seq_len);
+        v_use = v_t.slice(2, 0, sparse_attn_state.seq_len);
       }
       auto [out_bnsd, unused] = [&]() {
-        if (rainfusion_config_.version == "sparse_attention") {
+        if (sparse_attn_config_.version == "sparse_attention") {
           return xllm::dit::sparse_attention::attention(
-              q_use, k_use, v_use, rainfusion_config_, rf_state);
+              q_use, k_use, v_use, sparse_attn_config_, sparse_attn_state);
         }
         return xllm::dit::rain_fusion::attention(
-            q_use, k_use, v_use, rainfusion_config_, rf_state);
+            q_use, k_use, v_use, sparse_attn_config_, sparse_attn_state);
       }();
-      // RainFusionState cache (cached_select_idx/_num_idx) managed internally
+      // SparseAttnState cache (cached_select_idx/_num_idx) managed internally
       if (pad_len > 0) {
         out_bnsd = torch::nn::functional::pad(
             out_bnsd,
@@ -780,7 +783,7 @@ class WanAttentionImpl : public torch::nn::Module {
       const torch::Tensor& hidden_states_in,
       const torch::Tensor& encoder_hidden_states,
       std::optional<std::pair<torch::Tensor, torch::Tensor>> rotary_emb,
-      xllm::dit::RainFusionState& rf_state) {
+      xllm::dit::SparseAttnState& sparse_attn_state) {
     torch::Tensor hidden_states = hidden_states_in;
     bool is_self_attention =
         !encoder_hidden_states.defined() ||
@@ -887,9 +890,10 @@ class WanAttentionImpl : public torch::nn::Module {
 
       key_img = key_img.view({batch_size, -1, n_heads, dim_head_});
       value_img = value_img.view({batch_size, -1, n_heads, dim_head_});
-      hidden_states_img = at_npu_attention(query, key_img, value_img, rf_state);
+      hidden_states_img =
+          at_npu_attention(query, key_img, value_img, sparse_attn_state);
     }
-    hidden_states = at_npu_attention(query, key, value, rf_state);
+    hidden_states = at_npu_attention(query, key, value, sparse_attn_state);
     if (hidden_states_img.defined()) {
       hidden_states = hidden_states + hidden_states_img;
     }
@@ -962,7 +966,7 @@ class WanAttentionImpl : public torch::nn::Module {
   torch::TensorOptions options_;
 
   // RainFusionV3 configuration (static, same for all requests)
-  xllm::dit::RainFusionConfig rainfusion_config_;
+  xllm::dit::SparseAttnConfig sparse_attn_config_;
 };
 TORCH_MODULE(WanAttention);
 
@@ -1311,7 +1315,7 @@ class WanTransformerBlockImpl : public torch::nn::Module {
       const ModelContext& context,
       const ParallelArgs& parallel_args,
       int64_t block_idx = 0,
-      const xllm::dit::RainFusionConfig& rainfusion_config = {})
+      const xllm::dit::SparseAttnConfig& sparse_attn_config = {})
       : options_(context.get_tensor_options()),
         parallel_args_(parallel_args),
         block_idx_(block_idx) {
@@ -1330,12 +1334,11 @@ class WanTransformerBlockImpl : public torch::nn::Module {
         layer::AdaLayerNorm(
             dim_, eps_, /*elementwise_affine=*/false, options_));
     attn1_ = register_module(
-        "attn1", WanAttention(context, parallel_args, -1, rainfusion_config));
-
+        "attn1", WanAttention(context, parallel_args, -1, sparse_attn_config));
     attn2_ = register_module(
         "attn2",
         WanAttention(
-            context, parallel_args, dim_ / num_heads_, rainfusion_config));
+            context, parallel_args, dim_ / num_heads_, sparse_attn_config));
     if (cross_attn_norm_) {
       norm2_ =
           register_module("norm2", FP32LayerNorm(context, dim_, eps_, true));
@@ -1366,7 +1369,7 @@ class WanTransformerBlockImpl : public torch::nn::Module {
       const torch::Tensor& encoder_hidden_states,
       const torch::Tensor& timestep_proj,
       std::optional<std::pair<torch::Tensor, torch::Tensor>> rotary_emb,
-      xllm::dit::RainFusionState& rf_state) {
+      xllm::dit::SparseAttnState& sparse_attn_state) {
     torch::Tensor hidden_states = hidden_states_in;
     torch::Tensor shift_msa, scale_msa, gate_msa, c_shift_msa, c_scale_msa,
         c_gate_msa;
@@ -1401,8 +1404,7 @@ class WanTransformerBlockImpl : public torch::nn::Module {
     torch::Tensor norm_hidden_states =
         ada_norm1_->forward(hidden_states, scale_msa_2d, shift_msa_2d);
     torch::Tensor attn_output = attn1_->forward(
-        norm_hidden_states, norm_hidden_states, rotary_emb, rf_state);
-
+        norm_hidden_states, norm_hidden_states, rotary_emb, sparse_attn_state);
     hidden_states = hidden_states + attn_output * gate_msa;
 
     if (cross_attn_norm_) {
@@ -1411,8 +1413,10 @@ class WanTransformerBlockImpl : public torch::nn::Module {
       norm_hidden_states = hidden_states;
     }
 
-    attn_output = attn2_->forward(
-        norm_hidden_states, encoder_hidden_states, std::nullopt, rf_state);
+    attn_output = attn2_->forward(norm_hidden_states,
+                                  encoder_hidden_states,
+                                  std::nullopt,
+                                  sparse_attn_state);
     hidden_states = hidden_states + attn_output;
     auto c_scale_msa_2d =
         c_scale_msa.dim() == 3 ? c_scale_msa.select(1, 0) : c_scale_msa;
@@ -1504,7 +1508,7 @@ class WanTransformer3DModelImpl : public torch::nn::Module {
  public:
   explicit WanTransformer3DModelImpl(
       const ModelContext& context,
-      const xllm::dit::RainFusionConfig& rainfusion_config = {})
+      const xllm::dit::SparseAttnConfig& sparse_attn_config = {})
       : options_(context.get_tensor_options()) {
     auto model_args = context.get_model_args();
     auto parallel_args = context.get_parallel_args();
@@ -1548,7 +1552,7 @@ class WanTransformer3DModelImpl : public torch::nn::Module {
     transformer_layers_.reserve(num_layers_);
     for (int64_t i = 0; i < num_layers_; ++i) {
       auto block = WanTransformerBlock(
-          context, parallel_args, static_cast<int64_t>(i), rainfusion_config);
+          context, parallel_args, static_cast<int64_t>(i), sparse_attn_config);
       blocks_->push_back(block);
       transformer_layers_.push_back(block);
     }
@@ -1578,7 +1582,7 @@ class WanTransformer3DModelImpl : public torch::nn::Module {
                         const torch::Tensor& timestep,
                         const torch::Tensor& encoder_hidden_states,
                         const torch::Tensor& encoder_hidden_states_image,
-                        xllm::dit::RainFusionState& rf_state,
+                        xllm::dit::SparseAttnState& sparse_attn_state,
                         std::function<void(int32_t)> before_layer_cb = nullptr,
                         std::function<void(int32_t)> after_layer_cb = nullptr) {
     int64_t batch_size = hidden_states_in.size(0);
@@ -1610,8 +1614,8 @@ class WanTransformer3DModelImpl : public torch::nn::Module {
     int64_t pad_seq_len = sp_pad_sequence(
         hidden_states, freqs_cos, freqs_sin, rotary_emb, sp_group_);
 
-    rf_state.latent_shape = latent_shape;
-    rf_state.seq_len = seq_len;
+    sparse_attn_state.latent_shape = latent_shape;
+    sparse_attn_state.seq_len = seq_len;
 
     torch::Tensor timestep_input = timestep;
     int64_t ts_seq_len_val = hidden_states.size(1);
@@ -1662,7 +1666,7 @@ class WanTransformer3DModelImpl : public torch::nn::Module {
                                           encoder_hidden_states_embedded,
                                           timestep_proj,
                                           rotary_emb,
-                                          rf_state);
+                                          sparse_attn_state);
       if (after_layer_cb) {
         after_layer_cb(static_cast<int32_t>(i));
       }

--- a/xllm/models/dit/transformers/transformer_wan.h
+++ b/xllm/models/dit/transformers/transformer_wan.h
@@ -51,12 +51,11 @@ using xllm::dit::TpOptions;
 #include "models/dit/transformers/transformer_flux.h"
 #if defined(USE_NPU)
 #include "models/dit/utils/dit_block_weight_manager.h"
-#endif
-#include "models/model_registry.h"
-#if defined(USE_NPU)
 #include "core/kernels/npu/xllm_ops/xllm_ops_api.h"
 #include "torch_npu/csrc/aten/CustomFunctions.h"
 #endif
+#include "core/framework/quant_args.h"
+#include "models/model_registry.h"
 
 namespace xllm {
 
@@ -208,11 +207,13 @@ TORCH_MODULE(FP32LayerNorm);
 
 class WanTimestepEmbeddingImpl : public torch::nn::Module {
  public:
-  WanTimestepEmbeddingImpl(int64_t in_channels,
+  WanTimestepEmbeddingImpl(const ModelContext& context,
+                           int64_t in_channels,
                            int64_t time_embed_dim,
                            int64_t out_dim = -1,
                            bool sample_proj_bias = true)
       : options_(torch::dtype(torch::kFloat32)) {
+    quant_args_ = context.get_quant_args();
     linear_1_ = register_module(
         "linear_1",
         layer::AddMatmul(
@@ -241,16 +242,20 @@ class WanTimestepEmbeddingImpl : public torch::nn::Module {
   }
 
   void load_state_dict(const StateDict& state_dict) {
-    linear_1_->load_state_dict(state_dict.get_dict_with_prefix("linear_1."));
-    linear_2_->load_state_dict(state_dict.get_dict_with_prefix("linear_2."));
+    linear_1_->load_state_dict(state_dict.get_dict_with_prefix(
+        quant_args_.resolve_prefix("0.", "linear_1.")));
+    linear_2_->load_state_dict(state_dict.get_dict_with_prefix(
+        quant_args_.resolve_prefix("2.", "linear_2.")));
   }
-
   void verify_loaded_weights(const std::string& prefix) const {
-    linear_1_->verify_loaded_weights(prefix + "linear_1.");
-    linear_2_->verify_loaded_weights(prefix + "linear_2.");
+    linear_1_->verify_loaded_weights(
+        prefix + quant_args_.resolve_prefix("0.", "linear_1."));
+    linear_2_->verify_loaded_weights(
+        prefix + quant_args_.resolve_prefix("2.", "linear_2."));
   }
 
  private:
+  QuantArgs quant_args_;
   torch::TensorOptions options_;
   layer::AddMatmul linear_1_{nullptr};
   torch::nn::SiLU act_{nullptr};
@@ -330,6 +335,7 @@ class WanGELUImpl : public torch::nn::Module {
       : approximate_(approximate),
         options_(context.get_tensor_options()),
         parallel_args_(parallel_args) {
+    quant_args_ = context.get_quant_args();
     std::optional<TpOptions> tp = std::nullopt;
     if (::xllm::ParallelConfig::get_instance().tp_size() > 1) {
       tp = TpOptions::col(parallel_args_.dit_tp_group_,
@@ -340,7 +346,8 @@ class WanGELUImpl : public torch::nn::Module {
                                   with_bias,
                                   options_,
                                   /*sp=*/std::nullopt,
-                                  tp);
+                                  tp,
+                                  quant_args_);
     proj_ = register_module("proj", proj);
   }
 
@@ -355,15 +362,23 @@ class WanGELUImpl : public torch::nn::Module {
   }
 
   void load_state_dict(const StateDict& state_dict) {
-    proj_->as<DiTParallelLinear>()->load_state_dict(
-        state_dict.get_dict_with_prefix("proj."));
+    if (quant_args_.is_quantized()) {
+      // Quantized checkpoint stores weights directly under the module's
+      // own prefix — no additional sub-prefix wrapping.
+      proj_->as<DiTParallelLinear>()->load_state_dict(state_dict);
+    } else {
+      proj_->as<DiTParallelLinear>()->load_state_dict(
+          state_dict.get_dict_with_prefix("proj."));
+    }
   }
 
   void verify_loaded_weights(const std::string& prefix) const {
-    proj_->as<DiTParallelLinear>()->verify_loaded_weights(prefix + "proj.");
+    proj_->as<DiTParallelLinear>()->verify_loaded_weights(
+        prefix + quant_args_.resolve_prefix("", "proj."));
   }
 
  private:
+  QuantArgs quant_args_;
   bool approximate_;
   torch::TensorOptions options_;
   ParallelArgs parallel_args_;
@@ -387,6 +402,7 @@ class WanFeedForwardImpl : public torch::nn::Module {
     int64_t actual_inner_dim =
         (inner_dim > 0) ? inner_dim : static_cast<int64_t>(dim * mult);
     int64_t actual_dim_out = (dim_out > 0) ? dim_out : dim;
+    quant_args_ = context.get_quant_args();
 
     if (activation_fn == "gelu") {
       act_fn_ = register_module("act_fn",
@@ -423,7 +439,8 @@ class WanFeedForwardImpl : public torch::nn::Module {
                                       with_bias,
                                       options_,
                                       /*sp=*/std::nullopt,
-                                      tp_out);
+                                      tp_out,
+                                      quant_args_);
     proj_out_ = register_module("proj_out", proj_out);
 
     if (final_dropout) {
@@ -443,16 +460,21 @@ class WanFeedForwardImpl : public torch::nn::Module {
   }
 
   void load_state_dict(const StateDict& state_dict) {
-    act_fn_->load_state_dict(state_dict.get_dict_with_prefix("net.0."));
-    proj_out_->load_state_dict(state_dict.get_dict_with_prefix("net.2."));
+    act_fn_->load_state_dict(state_dict.get_dict_with_prefix(
+        quant_args_.resolve_prefix("0.", "net.0.")));
+    proj_out_->load_state_dict(state_dict.get_dict_with_prefix(
+        quant_args_.resolve_prefix("2.", "net.2.")));
   }
 
   void verify_loaded_weights(const std::string& prefix) const {
-    act_fn_->verify_loaded_weights(prefix + "net.0.");
-    proj_out_->verify_loaded_weights(prefix + "net.2.");
+    act_fn_->verify_loaded_weights(prefix +
+                                   quant_args_.resolve_prefix("0.", "net.0."));
+    proj_out_->verify_loaded_weights(
+        prefix + quant_args_.resolve_prefix("2.", "net.2."));
   }
 
  private:
+  QuantArgs quant_args_;
   torch::TensorOptions options_;
   ParallelArgs parallel_args_;
   WanGELU act_fn_{nullptr};
@@ -464,11 +486,13 @@ TORCH_MODULE(WanFeedForward);
 
 class WanPixArtAlphaTextProjectionImpl : public torch::nn::Module {
  public:
-  WanPixArtAlphaTextProjectionImpl(int64_t in_features,
+  WanPixArtAlphaTextProjectionImpl(const ModelContext& context,
+                                   int64_t in_features,
                                    int64_t hidden_size,
                                    int64_t out_features = -1,
                                    const std::string& act_fn = "gelu_tanh")
       : options_(torch::dtype(torch::kFloat32)) {
+    quant_args_ = context.get_quant_args();
     int64_t actual_out_features =
         (out_features > 0) ? out_features : hidden_size;
 
@@ -508,16 +532,21 @@ class WanPixArtAlphaTextProjectionImpl : public torch::nn::Module {
   }
 
   void load_state_dict(const StateDict& state_dict) {
-    linear_1_->load_state_dict(state_dict.get_dict_with_prefix("linear_1."));
-    linear_2_->load_state_dict(state_dict.get_dict_with_prefix("linear_2."));
+    linear_1_->load_state_dict(state_dict.get_dict_with_prefix(
+        quant_args_.resolve_prefix("0.", "linear_1.")));
+    linear_2_->load_state_dict(state_dict.get_dict_with_prefix(
+        quant_args_.resolve_prefix("2.", "linear_2.")));
   }
 
   void verify_loaded_weights(const std::string& prefix) const {
-    linear_1_->verify_loaded_weights(prefix + "linear_1.");
-    linear_2_->verify_loaded_weights(prefix + "linear_2.");
+    linear_1_->verify_loaded_weights(
+        prefix + quant_args_.resolve_prefix("0.", "linear_1."));
+    linear_2_->verify_loaded_weights(
+        prefix + quant_args_.resolve_prefix("2.", "linear_2."));
   }
 
  private:
+  QuantArgs quant_args_;
   torch::TensorOptions options_;
   layer::AddMatmul linear_1_{nullptr};
   torch::nn::AnyModule act_1_;
@@ -536,6 +565,7 @@ class WanAttentionImpl : public torch::nn::Module {
         parallel_args_(parallel_args),
         rainfusion_config_(rainfusion_config) {
     auto model_args = context.get_model_args();
+    quant_args_ = context.get_quant_args();
     dim_ = model_args.head_dim() * model_args.n_heads();
     heads_ = model_args.n_heads();
     dim_head_ = model_args.head_dim();
@@ -579,14 +609,16 @@ class WanAttentionImpl : public torch::nn::Module {
                                               true,
                                               options_,
                                               /*sp=*/std::nullopt,
-                                              tp_qk));
+                                              tp_qk,
+                                              quant_args_));
     to_k_ = register_module("to_k",
                             DiTParallelLinear(dim_,
                                               kv_inner_dim_,
                                               true,
                                               options_,
                                               /*sp=*/std::nullopt,
-                                              tp_qk));
+                                              tp_qk,
+                                              quant_args_));
 
     // V: TP+SP for self-attention, TP only for cross-attention
     bool is_self_attn = cross_attention_dim_head <= 0;
@@ -597,13 +629,18 @@ class WanAttentionImpl : public torch::nn::Module {
                           true,
                           options_,
                           is_self_attn ? sp_before : std::optional<SpOptions>{},
-                          tp_v));
+                          tp_v,
+                          quant_args_));
 
     // to_out: TP+SP row parallel
-    to_out_ = register_module(
-        "to_out",
-        DiTParallelLinear(
-            heads_ * dim_head_, dim_, true, options_, sp_after, tp_out));
+    to_out_ = register_module("to_out",
+                              DiTParallelLinear(heads_ * dim_head_,
+                                                dim_,
+                                                true,
+                                                options_,
+                                                sp_after,
+                                                tp_out,
+                                                quant_args_));
     norm_q_ = register_module(
         "norm_q", layer::RMSNorm(dim_head_ * heads_, eps_, options_));
     norm_k_ = register_module(
@@ -862,11 +899,14 @@ class WanAttentionImpl : public torch::nn::Module {
   }
 
   void load_state_dict(const StateDict& state_dict) {
-    to_q_->load_state_dict(state_dict.get_dict_with_prefix("to_q."));
-    to_k_->load_state_dict(state_dict.get_dict_with_prefix("to_k."));
-    to_v_->load_state_dict(state_dict.get_dict_with_prefix("to_v."));
-
-    to_out_->load_state_dict(state_dict.get_dict_with_prefix("to_out.0."));
+    to_q_->load_state_dict(state_dict.get_dict_with_prefix(
+        quant_args_.resolve_prefix("q.", "to_q.")));
+    to_k_->load_state_dict(state_dict.get_dict_with_prefix(
+        quant_args_.resolve_prefix("k.", "to_k.")));
+    to_v_->load_state_dict(state_dict.get_dict_with_prefix(
+        quant_args_.resolve_prefix("v.", "to_v.")));
+    to_out_->load_state_dict(state_dict.get_dict_with_prefix(
+        quant_args_.resolve_prefix("o.", "to_out.0.")));
 
     norm_q_->load_state_dict(state_dict.get_dict_with_prefix("norm_q."));
     norm_k_->load_state_dict(state_dict.get_dict_with_prefix("norm_k."));
@@ -882,12 +922,14 @@ class WanAttentionImpl : public torch::nn::Module {
   }
 
   void verify_loaded_weights(const std::string& prefix) const {
-    to_q_->verify_loaded_weights(prefix + "to_q.");
-    to_k_->verify_loaded_weights(prefix + "to_k.");
-    to_v_->verify_loaded_weights(prefix + "to_v.");
-
-    to_out_->verify_loaded_weights(prefix + "to_out.0.");
-
+    to_q_->verify_loaded_weights(prefix +
+                                 quant_args_.resolve_prefix("q.", "to_q."));
+    to_k_->verify_loaded_weights(prefix +
+                                 quant_args_.resolve_prefix("k.", "to_k."));
+    to_v_->verify_loaded_weights(prefix +
+                                 quant_args_.resolve_prefix("v.", "to_v."));
+    to_out_->verify_loaded_weights(
+        prefix + quant_args_.resolve_prefix("o.", "to_out.0."));
     if (add_k_proj_) {
       add_k_proj_->verify_loaded_weights(prefix + "add_k_proj.");
       add_v_proj_->verify_loaded_weights(prefix + "add_v_proj.");
@@ -895,6 +937,7 @@ class WanAttentionImpl : public torch::nn::Module {
   }
 
  private:
+  QuantArgs quant_args_;
   int64_t dim_;
   int64_t heads_;
   int64_t dim_head_;
@@ -1017,17 +1060,20 @@ class WanTimeTextImageEmbeddingImpl : public torch::nn::Module {
     image_embed_dim_ = model_args.image_embed_dim();
     pos_embed_seq_len_ = model_args.pos_embed_seq_len();
 
+    quant_args_ = context.get_quant_args();
     timesteps_proj_ = register_module(
         "timesteps_proj", WanTimesteps(time_freq_dim_, true, 0.0f, 1));
     time_embedder_ = register_module(
-        "time_embedder", WanTimestepEmbedding(time_freq_dim_, dim_, -1, true));
+        "time_embedder",
+        WanTimestepEmbedding(context, time_freq_dim_, dim_, -1, true));
     act_fn_ = register_module("act_fn", torch::nn::SiLU());
     time_proj_ = register_module(
         "time_proj", layer::AddMatmul(dim_, time_proj_dim_, true, options_));
 
-    text_embedder_ = register_module(
-        "text_embedder",
-        WanPixArtAlphaTextProjection(text_embed_dim_, dim_, dim_, "gelu_tanh"));
+    text_embedder_ =
+        register_module("text_embedder",
+                        WanPixArtAlphaTextProjection(
+                            context, text_embed_dim_, dim_, dim_, "gelu_tanh"));
 
     if (image_embed_dim_ > 0) {
       image_embedder_ =
@@ -1069,11 +1115,12 @@ class WanTimeTextImageEmbeddingImpl : public torch::nn::Module {
   }
 
   void load_state_dict(const StateDict& state_dict) {
-    time_embedder_->load_state_dict(
-        state_dict.get_dict_with_prefix("time_embedder."));
-    time_proj_->load_state_dict(state_dict.get_dict_with_prefix("time_proj."));
-    text_embedder_->load_state_dict(
-        state_dict.get_dict_with_prefix("text_embedder."));
+    time_embedder_->load_state_dict(state_dict.get_dict_with_prefix(
+        quant_args_.resolve_prefix("time_embedding.", "time_embedder.")));
+    time_proj_->load_state_dict(state_dict.get_dict_with_prefix(
+        quant_args_.resolve_prefix("time_projection.1.", "time_proj.")));
+    text_embedder_->load_state_dict(state_dict.get_dict_with_prefix(
+        quant_args_.resolve_prefix("text_embedding.", "text_embedder.")));
     if (image_embedder_) {
       image_embedder_->load_state_dict(
           state_dict.get_dict_with_prefix("image_embedder."));
@@ -1081,9 +1128,15 @@ class WanTimeTextImageEmbeddingImpl : public torch::nn::Module {
   }
 
   void verify_loaded_weights(const std::string& prefix) const {
-    time_embedder_->verify_loaded_weights(prefix + "time_embedder.");
-    time_proj_->verify_loaded_weights(prefix + "time_proj.");
-    text_embedder_->verify_loaded_weights(prefix + "text_embedder.");
+    time_embedder_->verify_loaded_weights(
+        prefix +
+        quant_args_.resolve_prefix("time_embedding.", "time_embedder."));
+    time_proj_->verify_loaded_weights(
+        prefix +
+        quant_args_.resolve_prefix("time_projection.1.", "time_proj."));
+    text_embedder_->verify_loaded_weights(
+        prefix +
+        quant_args_.resolve_prefix("text_embedding.", "text_embedder."));
     if (image_embedder_) {
       image_embedder_->verify_loaded_weights(prefix + "image_embedder.");
     }
@@ -1097,6 +1150,7 @@ class WanTimeTextImageEmbeddingImpl : public torch::nn::Module {
   int64_t image_embed_dim_;
   int64_t pos_embed_seq_len_;
 
+  QuantArgs quant_args_;
   WanTimesteps timesteps_proj_{nullptr};
   WanTimestepEmbedding time_embedder_{nullptr};
   torch::nn::SiLU act_fn_{nullptr};
@@ -1262,6 +1316,7 @@ class WanTransformerBlockImpl : public torch::nn::Module {
         parallel_args_(parallel_args),
         block_idx_(block_idx) {
     auto model_args = context.get_model_args();
+    quant_args_ = context.get_quant_args();
     dim_ = model_args.head_dim() * model_args.n_heads();
     ffn_dim_ = model_args.ffn_dim();
     num_heads_ = model_args.n_heads();
@@ -1372,27 +1427,38 @@ class WanTransformerBlockImpl : public torch::nn::Module {
   }
 
   void load_state_dict(const StateDict& state_dict) {
-    attn1_->load_state_dict(state_dict.get_dict_with_prefix("attn1."));
-    attn2_->load_state_dict(state_dict.get_dict_with_prefix("attn2."));
-    if (cross_attn_norm_) {
-      norm2_->load_state_dict(state_dict.get_dict_with_prefix("norm2."));
+    attn1_->load_state_dict(state_dict.get_dict_with_prefix(
+        quant_args_.resolve_prefix("self_attn.", "attn1.")));
+    attn2_->load_state_dict(state_dict.get_dict_with_prefix(
+        quant_args_.resolve_prefix("cross_attn.", "attn2.")));
+    if (cross_attn_norm_ && norm2_) {
+      norm2_->load_state_dict(state_dict.get_dict_with_prefix(
+          quant_args_.resolve_prefix("norm3.", "norm2.")));
     }
-    ff_->load_state_dict(state_dict.get_dict_with_prefix("ffn."));
-    weight::load_weight(state_dict,
-                        "scale_shift_table",
-                        scale_shift_table_,
-                        scale_shift_table_loaded_);
+    ff_->load_state_dict(state_dict.get_dict_with_prefix(
+        quant_args_.resolve_prefix("ffn.", "ffn.")));
+    weight::load_weight(
+        state_dict,
+        quant_args_.resolve_prefix("modulation", "scale_shift_table"),
+        scale_shift_table_,
+        scale_shift_table_loaded_);
   }
 
   void verify_loaded_weights(const std::string& prefix) const {
-    attn1_->verify_loaded_weights(prefix + "attn1.");
+    attn1_->verify_loaded_weights(
+        prefix + quant_args_.resolve_prefix("self_attn.", "attn1."));
     if (cross_attn_norm_) {
-      norm2_->verify_loaded_weights(prefix + "norm2.");
+      norm2_->verify_loaded_weights(
+          prefix + quant_args_.resolve_prefix("norm3.", "norm2."));
     }
-    attn2_->verify_loaded_weights(prefix + "attn2.");
-    ff_->verify_loaded_weights(prefix + "ffn.");
-    CHECK(scale_shift_table_loaded_) << "scale_shift_table is not loaded for "
-                                     << prefix + "scale_shift_table";
+    attn2_->verify_loaded_weights(
+        prefix + quant_args_.resolve_prefix("cross_attn.", "attn2."));
+    ff_->verify_loaded_weights(prefix +
+                               quant_args_.resolve_prefix("ffn.", "ffn."));
+    auto scale_key =
+        quant_args_.resolve_prefix("modulation", "scale_shift_table");
+    CHECK(scale_shift_table_loaded_)
+        << scale_key << " is not loaded for " << prefix + scale_key;
   }
 
 #if defined(USE_NPU)
@@ -1425,6 +1491,7 @@ class WanTransformerBlockImpl : public torch::nn::Module {
   torch::Tensor scale_shift_table_;
   bool scale_shift_table_loaded_{false};
 
+  QuantArgs quant_args_;
   torch::TensorOptions options_;
   ParallelArgs parallel_args_;
 #if defined(USE_NPU)
@@ -1462,6 +1529,7 @@ class WanTransformer3DModelImpl : public torch::nn::Module {
     if (out_channels_ <= 0) {
       out_channels_ = in_channels_;
     }
+    quant_args_ = context.get_quant_args();
     rope_ = register_module("rope", WanRotaryPosEmbed(context));
     patch_embedding_ = register_module(
         "patch_embedding",
@@ -1660,17 +1728,25 @@ class WanTransformer3DModelImpl : public torch::nn::Module {
                         patch_embedding_->bias,
                         pad_embedding_bias_loaded_);
 
-    condition_embedder_->load_state_dict(
-        state_dict.get_dict_with_prefix("condition_embedder."));
+    if (quant_args_.is_quantized()) {
+      // Quantized checkpoint stores condition_embedder weights directly
+      // under the top-level prefix — no "condition_embedder." wrapper.
+      condition_embedder_->load_state_dict(state_dict);
+      proj_out_->load_state_dict(state_dict.get_dict_with_prefix("head.head."));
+    } else {
+      condition_embedder_->load_state_dict(
+          state_dict.get_dict_with_prefix("condition_embedder."));
+      proj_out_->load_state_dict(state_dict.get_dict_with_prefix("proj_out."));
+    }
     for (int64_t i = 0; i < transformer_layers_.size(); ++i) {
       transformer_layers_[i]->load_state_dict(
           state_dict.get_dict_with_prefix("blocks." + std::to_string(i) + "."));
     }
-    proj_out_->load_state_dict(state_dict.get_dict_with_prefix("proj_out."));
-    weight::load_weight(state_dict,
-                        "scale_shift_table",
-                        scale_shift_table_,
-                        scale_shift_table_loaded_);
+    weight::load_weight(
+        state_dict,
+        quant_args_.resolve_prefix("head.modulation", "scale_shift_table"),
+        scale_shift_table_,
+        scale_shift_table_loaded_);
   }
 
   void verify_loaded_weights(const std::string& prefix) const {
@@ -1679,14 +1755,22 @@ class WanTransformer3DModelImpl : public torch::nn::Module {
     CHECK(pad_embedding_bias_loaded_) << "patch_embedding is not loaded for"
                                       << prefix << "pad_embedding.bias";
 
-    condition_embedder_->verify_loaded_weights(prefix + "condition_embedder.");
+    if (quant_args_.is_quantized()) {
+      condition_embedder_->verify_loaded_weights(prefix);
+      proj_out_->verify_loaded_weights(prefix + "head.head.");
+    } else {
+      condition_embedder_->verify_loaded_weights(prefix +
+                                                 "condition_embedder.");
+      proj_out_->verify_loaded_weights(prefix + "proj_out.");
+    }
     for (size_t i = 0; i < transformer_layers_.size(); ++i) {
       transformer_layers_[i]->verify_loaded_weights(prefix + "blocks." +
                                                     std::to_string(i) + ".");
     }
-    proj_out_->verify_loaded_weights(prefix + "proj_out.");
-    CHECK(scale_shift_table_loaded_) << "scale_shift_table is not loaded for "
-                                     << prefix + "scale_shift_table";
+    auto scale_key =
+        quant_args_.resolve_prefix("head.modulation", "scale_shift_table");
+    CHECK(scale_shift_table_loaded_)
+        << scale_key << " is not loaded for " << prefix + scale_key;
   }
 
   int64_t in_channels() const { return in_channels_; }
@@ -1695,15 +1779,15 @@ class WanTransformer3DModelImpl : public torch::nn::Module {
 
   void load_model(std::unique_ptr<DiTFolderLoader> loader,
                   bool rolling = false) {
+    auto freqs_cos_fp32 = rope_->get_freqs_cos().clone();
+    auto freqs_sin_fp32 = rope_->get_freqs_sin().clone();
+    this->to(rolling ? torch::kCPU : options_.device(), torch::kBFloat16);
     for (const auto& state_dict : loader->get_state_dicts()) {
       load_state_dict(*state_dict);
     }
     verify_loaded_weights("");
 
-    auto freqs_cos_fp32 = rope_->get_freqs_cos().clone();
-    auto freqs_sin_fp32 = rope_->get_freqs_sin().clone();
-
-    this->to(rolling ? torch::kCPU : options_.device(), torch::kBFloat16);
+    // Restore fp32 RoPE frequencies that were cloned before dtype conversion.
     rope_->set_freqs_cos(freqs_cos_fp32);
     rope_->set_freqs_sin(freqs_sin_fp32);
 
@@ -1757,6 +1841,7 @@ class WanTransformer3DModelImpl : public torch::nn::Module {
   int64_t inner_dim_;
   bool cross_attn_norm_;
   std::string qk_norm_;
+  QuantArgs quant_args_;
   ProcessGroup* sp_group_ = nullptr;
   torch::nn::Conv3d patch_embedding_{nullptr};
   WanTimeTextImageEmbedding condition_embedder_{nullptr};

--- a/xllm/models/dit/transformers/transformer_wan.h
+++ b/xllm/models/dit/transformers/transformer_wan.h
@@ -50,8 +50,8 @@ using xllm::dit::TpOptions;
 #include "framework/model_context.h"
 #include "models/dit/transformers/transformer_flux.h"
 #if defined(USE_NPU)
-#include "models/dit/utils/dit_block_weight_manager.h"
 #include "core/kernels/npu/xllm_ops/xllm_ops_api.h"
+#include "models/dit/utils/dit_block_weight_manager.h"
 #include "torch_npu/csrc/aten/CustomFunctions.h"
 #endif
 #include "core/framework/quant_args.h"

--- a/xllm/models/dit/utils/dit_parallel_linear.h
+++ b/xllm/models/dit/utils/dit_parallel_linear.h
@@ -22,6 +22,7 @@ limitations under the License.
 
 #include "core/framework/state_dict/utils.h"
 #include "core/layers/common/add_matmul.h"
+#include "core/layers/common/quant_utils.h"
 #include "core/layers/common/rms_norm.h"
 #include "framework/parallel_state/parallel_state.h"
 #include "kernels/ops_api.h"
@@ -145,14 +146,17 @@ class DiTParallelLinearImpl : public torch::nn::Module {
       bool bias,
       const torch::TensorOptions& options,
       const std::optional<SpOptions>& sp_options = std::nullopt,
-      const std::optional<TpOptions>& tp_options = std::nullopt)
+      const std::optional<TpOptions>& tp_options = std::nullopt,
+      const QuantArgs& quant_args = QuantArgs())
       : in_features_(in_features),
         out_features_(out_features),
         has_bias_(bias),
         tensor_options_(options),
         linear_type_(infer_linear_type(sp_options, tp_options)),
         sp_options_(sp_options.value_or(SpOptions())),
-        tp_options_(tp_options) {
+        tp_options_(tp_options),
+        quant_args_(quant_args),
+        output_dtype_(c10::typeMetaToScalarType(options.dtype())) {
     if (linear_type_ == LinearType::SequenceParallel ||
         linear_type_ == LinearType::TensorAndSequenceParallel) {
       sp_options_.validate();
@@ -163,9 +167,10 @@ class DiTParallelLinearImpl : public torch::nn::Module {
       tp_options_->validate();
       init_tp_weights();
     } else {
-      linear_ = register_module("linear",
-                                layer::AddMatmulWeightTransposed(
-                                    in_features, out_features, bias, options));
+      linear_ = register_module(
+          "linear",
+          layer::AddMatmulWeightTransposed(
+              in_features, out_features, bias, options, quant_args_));
     }
   }
 
@@ -198,6 +203,11 @@ class DiTParallelLinearImpl : public torch::nn::Module {
     if (has_tp_weights()) {
       CHECK(tp_weight_loaded_)
           << "DiTParallelLinear: weight not loaded for " << prefix << "weight";
+      if (is_w8a8_dynamic_quant(resolved_weight_quant_method_)) {
+        CHECK(tp_weight_scale_is_loaded_)
+            << "DiTParallelLinear: weight_scale not loaded for " << prefix
+            << "weight_scale";
+      }
       if (has_bias_) {
         CHECK(tp_bias_loaded_)
             << "DiTParallelLinear: bias not loaded for " << prefix << "bias";
@@ -272,6 +282,19 @@ class DiTParallelLinearImpl : public torch::nn::Module {
                                /*is_buffer=*/false);
       }
     }
+    // Pre-allocate 1D weight_scale and weight_offset for dynamic W8A8.
+    // Size is always out_features per partition (size(0) of tp_weight_).
+    if (!quant_args_.quant_descs().empty()) {
+      int64_t scale_size = tp_weight_.size(0);
+      tp_weight_scale_ = register_parameter(
+          "weight_scale",
+          torch::empty({scale_size}, tensor_options_.dtype(torch::kFloat32)),
+          /*is_buffer=*/false);
+      tp_weight_offset_ = register_parameter(
+          "weight_offset",
+          torch::empty({scale_size}, tensor_options_.dtype(torch::kFloat32)),
+          /*is_buffer=*/false);
+    }
   }
 
   torch::Tensor forward_tp(const torch::Tensor& input) {
@@ -285,14 +308,26 @@ class DiTParallelLinearImpl : public torch::nn::Module {
 
   torch::Tensor forward_tp_column(const torch::Tensor& input) {
     const auto& tp = tp_options_.value();
-
     auto bias =
         has_bias_ ? std::optional<torch::Tensor>(tp_bias_) : std::nullopt;
-    xllm::kernel::MatmulParams params;
-    params.a = input;
-    params.b = tp_weight_;
-    params.bias = bias;
-    auto output = xllm::kernel::matmul(params);
+
+    torch::Tensor output;
+    if (is_w8a8_dynamic_quant(resolved_weight_quant_method_)) {
+      CHECK(tp_weight_scale_is_loaded_ && tp_weight_scale_.defined())
+          << "tp_weight_scale is required for w8a8_dynamic TP column";
+      auto w_offset =
+          (tp_weight_offset_.defined() && output_dtype_ == torch::kInt8)
+              ? std::optional<torch::Tensor>(tp_weight_offset_)
+              : std::nullopt;
+      output = layer::npu_w8a8_dynamic_linear_forward(
+          input, tp_weight_, tp_weight_scale_, bias, output_dtype_, w_offset);
+    } else {
+      xllm::kernel::MatmulParams params;
+      params.a = input;
+      params.b = tp_weight_;
+      params.bias = bias;
+      output = xllm::kernel::matmul(params);
+    }
 
     if (tp.gather_output) {
       output = parallel_state::gather(output, tp.process_group, /*dim=*/-1);
@@ -308,12 +343,31 @@ class DiTParallelLinearImpl : public torch::nn::Module {
       x = parallel_state::scatter(input, tp.process_group, /*dim=*/-1);
     }
 
-    xllm::kernel::MatmulParams params;
-    params.a = x;
-    params.b = tp_weight_;
-    auto output = xllm::kernel::matmul(params);
+    // Bias must be added AFTER all-reduce for row-parallel; otherwise each
+    // rank adds the full bias and reduce-sum multiplies it by tp_size.
+    torch::Tensor output;
+    if (is_w8a8_dynamic_quant(resolved_weight_quant_method_)) {
+      CHECK(tp_weight_scale_is_loaded_ && tp_weight_scale_.defined())
+          << "tp_weight_scale is required for w8a8_dynamic TP row";
+      auto w_offset =
+          (tp_weight_offset_.defined() && output_dtype_ == torch::kInt8)
+              ? std::optional<torch::Tensor>(tp_weight_offset_)
+              : std::nullopt;
+      output = layer::npu_w8a8_dynamic_linear_forward(x,
+                                                      tp_weight_,
+                                                      tp_weight_scale_,
+                                                      /*bias=*/std::nullopt,
+                                                      output_dtype_,
+                                                      w_offset);
+    } else {
+      xllm::kernel::MatmulParams params;
+      params.a = x;
+      params.b = tp_weight_;
+      output = xllm::kernel::matmul(params);
+    }
 
     output = parallel_state::reduce(output, tp.process_group);
+
     if (has_bias_) {
       output = output + tp_bias_;
     }
@@ -395,15 +449,86 @@ class DiTParallelLinearImpl : public torch::nn::Module {
 
   void load_tp_weights(const StateDict& state_dict) {
     const auto& tp = tp_options_.value();
-    if (tp.column_parallel) {
+
+    layer::resolve_weight_quant_method_for_linear_load(
+        quant_args_, state_dict, nullptr, resolved_weight_quant_method_);
+
+    int64_t weight_axis = tp.column_parallel ? 0 : 1;
+    if (is_w8a8_dynamic_quant(resolved_weight_quant_method_)) {
+      // Convert tp_weight from original dtype to int8.
+      std::vector<weight::LazyParameterSpec> specs;
+      specs.push_back(
+          weight::LazyParameterSpec{&tp_weight_,
+                                    &tp_weight_loaded_,
+                                    "weight",
+                                    {tp_weight_.size(0), tp_weight_.size(1)},
+                                    tensor_options_.dtype(torch::kInt8)});
+      weight::ensure_parameter_storage(this, specs);
+
+      int64_t weight_scale_size = tp_weight_.size(0);
+      std::vector<weight::LazyParameterSpec> scale_specs;
+      scale_specs.push_back(
+          weight::LazyParameterSpec{&tp_weight_scale_,
+                                    &tp_weight_scale_is_loaded_,
+                                    "weight_scale",
+                                    {weight_scale_size},
+                                    tensor_options_.dtype(torch::kFloat32)});
+      scale_specs.push_back(
+          weight::LazyParameterSpec{&tp_weight_offset_,
+                                    &tp_weight_offset_is_loaded_,
+                                    "weight_offset",
+                                    {weight_scale_size},
+                                    tensor_options_.dtype(torch::kFloat32)});
+      weight::ensure_parameter_storage(this, scale_specs);
+
       weight::load_sharded_weight(state_dict,
                                   "weight",
-                                  /*axis=*/0,
+                                  /*axis=*/weight_axis,
                                   tp.tp_rank(),
                                   tp.tp_size(),
                                   tp_weight_,
                                   tp_weight_loaded_);
-      if (has_bias_) {
+      if (tp.column_parallel) {
+        weight::load_sharded_weight(state_dict,
+                                    "weight_scale",
+                                    /*axis=*/0,
+                                    tp.tp_rank(),
+                                    tp.tp_size(),
+                                    tp_weight_scale_,
+                                    tp_weight_scale_is_loaded_);
+        if (state_dict.has("weight_offset")) {
+          weight::load_sharded_weight(state_dict,
+                                      "weight_offset",
+                                      /*axis=*/0,
+                                      tp.tp_rank(),
+                                      tp.tp_size(),
+                                      tp_weight_offset_,
+                                      tp_weight_offset_is_loaded_);
+        }
+      } else {
+        weight::load_weight(state_dict,
+                            "weight_scale",
+                            tp_weight_scale_,
+                            tp_weight_scale_is_loaded_);
+        if (state_dict.has("weight_offset")) {
+          weight::load_weight(state_dict,
+                              "weight_offset",
+                              tp_weight_offset_,
+                              tp_weight_offset_is_loaded_);
+        }
+      }
+    } else {
+      weight::load_sharded_weight(state_dict,
+                                  "weight",
+                                  /*axis=*/weight_axis,
+                                  tp.tp_rank(),
+                                  tp.tp_size(),
+                                  tp_weight_,
+                                  tp_weight_loaded_);
+    }
+
+    if (has_bias_) {
+      if (tp.column_parallel) {
         weight::load_sharded_weight(state_dict,
                                     "bias",
                                     /*axis=*/0,
@@ -411,16 +536,7 @@ class DiTParallelLinearImpl : public torch::nn::Module {
                                     tp.tp_size(),
                                     tp_bias_,
                                     tp_bias_loaded_);
-      }
-    } else {
-      weight::load_sharded_weight(state_dict,
-                                  "weight",
-                                  /*axis=*/1,
-                                  tp.tp_rank(),
-                                  tp.tp_size(),
-                                  tp_weight_,
-                                  tp_weight_loaded_);
-      if (has_bias_) {
+      } else {
         weight::load_weight(state_dict, "bias", tp_bias_, tp_bias_loaded_);
       }
     }
@@ -436,8 +552,15 @@ class DiTParallelLinearImpl : public torch::nn::Module {
   std::optional<TpOptions> tp_options_;
   torch::Tensor tp_weight_;
   torch::Tensor tp_bias_;
+  torch::Tensor tp_weight_scale_;
+  torch::Tensor tp_weight_offset_;
   bool tp_weight_loaded_ = false;
   bool tp_bias_loaded_ = false;
+  bool tp_weight_scale_is_loaded_ = false;
+  bool tp_weight_offset_is_loaded_ = false;
+  QuantArgs quant_args_;
+  std::optional<std::string> resolved_weight_quant_method_;
+  at::ScalarType output_dtype_;
 };
 
 TORCH_MODULE(DiTParallelLinear);

--- a/xllm/models/dit/utils/sparse_attention.h
+++ b/xllm/models/dit/utils/sparse_attention.h
@@ -27,7 +27,7 @@ limitations under the License.
 
 namespace xllm::dit {
 
-struct RainFusionConfig {
+struct SparseAttnConfig {
   float sparsity = 0.5;
   int64_t pool_size = 128;
   int64_t sparse_start_step = 0;  // skip_timesteps
@@ -39,7 +39,7 @@ struct RainFusionConfig {
 };
 
 // Per-request dynamic state for sparse / RainFusion attention.
-struct RainFusionState {
+struct SparseAttnState {
   int64_t current_step = 0;
   std::vector<int64_t> latent_shape = {1, 1, 1};
   int64_t seq_len = -1;
@@ -360,8 +360,8 @@ inline std::tuple<torch::Tensor, torch::Tensor> attention(
     const torch::Tensor& query,
     const torch::Tensor& key,
     const torch::Tensor& value,
-    const RainFusionConfig& config,
-    RainFusionState& state) {
+    const SparseAttnConfig& config,
+    SparseAttnState& state) {
   CHECK(query.dim() == 4) << "query must be 4D [B, N, S, D]";
   CHECK(query.dtype() == torch::kHalf || query.dtype() == torch::kBFloat16)
       << "query must be fp16 or bf16";
@@ -722,8 +722,8 @@ inline std::tuple<torch::Tensor, torch::Tensor> attention(
     const torch::Tensor& query,
     const torch::Tensor& key,
     const torch::Tensor& value,
-    const RainFusionConfig& config,
-    RainFusionState& state) {
+    const SparseAttnConfig& config,
+    SparseAttnState& state) {
   CHECK(query.dim() == 4) << "query must be 4D [B, N, S, D]";
   int64_t tq = state.latent_shape[0], hq = state.latent_shape[1],
           wq = state.latent_shape[2];


### PR DESCRIPTION
Add dynamic W8A8 quantization infrastructure and integrate it into the Qwen Image Edit transformer pipeline and wan22 model. 

test case for qwen_image_edit:
cfg1 * sp4 + step 40 + one picture + (with torch save for percision)： before quant 27.86s, after quant 25.87s, benefit 7.14%, percison compare 98.60%

test case for wan2_2:
cfg2 * sp4 + step 40 + scale 1.5 + (with torch save for percision)： before quant 119.03s, after quant 108.42s, benefit 8.91%, percison compare 99.43%
cfg2 * sp4 + step 40 + scale 5.0 + (with torch save for percision)： before quant 119.56s, after quant 108.48s, benefit 9.27%, percison compare 87.01%
