### PR TITLE
feat: support CANN 9.0.0 toolkit for npu device.

### DIFF
--- a/cibuild/build_npu.sh
+++ b/cibuild/build_npu.sh
@@ -6,7 +6,7 @@ function error() {
   exit 1
 }
 
-IMAGE="quay.io/jd_xllm/xllm-ai:xllm-dev-a2-x86-20260429"
+IMAGE="quay.io/jd_xllm/xllm-ai:xllm-dev-a2-x86-cann9-20260605"
 
 XLLM_OPS_CACHE="/export/home/npu_xllm_ops_build_cache"
 mkdir -p "${XLLM_OPS_CACHE}"

--- a/docs/en/getting_started/quick_start.md
+++ b/docs/en/getting_started/quick_start.md
@@ -9,11 +9,11 @@ All images are stored [here](https://quay.io/repository/jd_xllm/xllm-ai?tab=tags
 Below are our pre-built dev image.
 ```bash
 # A2 x86
-docker pull quay.io/jd_xllm/xllm-ai:xllm-dev-a2-x86-20260429
+docker pull quay.io/jd_xllm/xllm-ai:xllm-dev-a2-x86-cann9-20260605
 # A2 arm
-docker pull quay.io/jd_xllm/xllm-ai:xllm-dev-a2-arm-20260429
+docker pull quay.io/jd_xllm/xllm-ai:xllm-dev-a2-arm-cann9-20260605
 # A3 arm
-docker pull quay.io/jd_xllm/xllm-ai:xllm-dev-a3-arm-20260429
+docker pull quay.io/jd_xllm/xllm-ai:xllm-dev-a3-arm-cann9-20260605
 ```
 
 Container startup command:

--- a/docs/zh/getting_started/quick_start.md
+++ b/docs/zh/getting_started/quick_start.md
@@ -9,11 +9,11 @@
 下面是我们构建好的开发镜像。
 ```bash
 # A2 x86
-docker pull quay.io/jd_xllm/xllm-ai:xllm-dev-a2-x86-20260429
+docker pull quay.io/jd_xllm/xllm-ai:xllm-dev-a2-x86-cann9-20260605
 # A2 arm
-docker pull quay.io/jd_xllm/xllm-ai:xllm-dev-a2-arm-20260429
+docker pull quay.io/jd_xllm/xllm-ai:xllm-dev-a2-arm-cann9-20260605
 # A3 arm
-docker pull quay.io/jd_xllm/xllm-ai:xllm-dev-a3-arm-20260429
+docker pull quay.io/jd_xllm/xllm-ai:xllm-dev-a3-arm-cann9-20260605
 ```
 
 容器启动命令如下：

--- a/docs/zh/getting_started/quick_start_GLM5.md
+++ b/docs/zh/getting_started/quick_start_GLM5.md
@@ -12,11 +12,11 @@
 
 ```bash
 # A2 x86
-docker pull quay.io/jd_xllm/xllm-ai:xllm-dev-a2-x86-20260429
+docker pull quay.io/jd_xllm/xllm-ai:xllm-dev-a2-x86-cann9-20260605
 # A2 arm
-docker pull quay.io/jd_xllm/xllm-ai:xllm-dev-a2-arm-20260429
+docker pull quay.io/jd_xllm/xllm-ai:xllm-dev-a2-arm-cann9-20260605
 # A3 arm
-docker pull quay.io/jd_xllm/xllm-ai:xllm-dev-a3-arm-20260429
+docker pull quay.io/jd_xllm/xllm-ai:xllm-dev-a3-arm-cann9-20260605
 ```
 
 **注意**: A2 机器性能未进行压测。

--- a/tests/core/framework/sampling/CMakeLists.txt
+++ b/tests/core/framework/sampling/CMakeLists.txt
@@ -20,6 +20,7 @@ target_link_libraries(sampler_test
                       PUBLIC
                       Python::Python
                       $<$<BOOL:${USE_NPU}>:ascendcl>
+                      $<$<BOOL:${USE_NPU}>:unified_dlog>
                       $<$<BOOL:${USE_NPU}>:hccl>
                       $<$<BOOL:${USE_NPU}>:c_sec>
                       $<$<BOOL:${USE_NPU}>:nnopbase>)

--- a/tests/core/kernels/npu/tilelang/CMakeLists.txt
+++ b/tests/core/kernels/npu/tilelang/CMakeLists.txt
@@ -10,6 +10,7 @@ cc_test(
     torch
     GTest::gtest_main
     glog::glog
+    unified_dlog
 )
 
 cc_test(
@@ -22,6 +23,7 @@ cc_test(
     torch
     GTest::gtest_main
     glog::glog
+    unified_dlog
 )
 
 cc_test(
@@ -34,4 +36,5 @@ cc_test(
     torch
     GTest::gtest_main
     glog::glog
+    unified_dlog
 )

--- a/third_party/CMakeLists.txt
+++ b/third_party/CMakeLists.txt
@@ -30,6 +30,11 @@ target_include_directories(mooncake_store PUBLIC
   ${CMAKE_CURRENT_SOURCE_DIR}/Mooncake/mooncake-transfer-engine/include
 )
 
+find_package(yalantinglibs CONFIG REQUIRED)
+if(TARGET ascend_transport)
+  target_link_libraries(ascend_transport PUBLIC yalantinglibs::yalantinglibs)
+endif()
+
 if(USE_ILU)
   if(TARGET cpprest)
       set_target_properties(cpprest PROPERTIES

--- a/xllm/CMakeLists.txt
+++ b/xllm/CMakeLists.txt
@@ -98,7 +98,7 @@ target_link_libraries(xllm PRIVATE glog::glog brpc leveldb::leveldb protobuf::li
 add_dependencies(xllm brpc-static)
 
 if(USE_NPU)
-  set(COMMON_LIBS torch_npu torch_python Python::Python ascendcl atb_customize hccl c_sec nnopbase ms_tools_ext)
+  set(COMMON_LIBS torch_npu torch_python Python::Python ascendcl atb_customize unified_dlog hccl c_sec nnopbase ms_tools_ext)
 elseif(USE_MLU)
   set(COMMON_LIBS Python::Python)
 endif()

--- a/xllm/compiler/tilelang/tilelang_ascend_install.py
+++ b/xllm/compiler/tilelang/tilelang_ascend_install.py
@@ -12,9 +12,9 @@ from .common.toolchain import find_installed_tilelang_root, prepare_tilelang_imp
 PREPARE_ASCEND_COMMAND = "python xllm/compiler/tilelang_launcher.py prepare-ascend --target-platform <a2|a3|a5> --arch <arm|x86>"
 
 TILELANG_ASCEND_WHEELS: dict[tuple[str, str], str] = {
-    ("a2", "arm"): "https://gitcode.com/xLLM-AI/tilelang-ascend/releases/download/v0.1.0-pre-release/tilelang-master.56d3f9b8.a2.cann850-cp311-cp311-linux_aarch64.whl",
-    ("a2", "x86"): "https://gitcode.com/xLLM-AI/tilelang-ascend/releases/download/v0.1.0-pre-release/tilelang-master.56d3f9b8.a2.cann850-cp311-cp311-linux_x86_64.whl",
-    ("a3", "arm"): "https://gitcode.com/xLLM-AI/tilelang-ascend/releases/download/v0.1.0-pre-release/tilelang-master.56d3f9b8.a3.cann850-cp311-cp311-linux_aarch64.whl",
+    ("a2", "arm"): "https://gitcode.com/xLLM-AI/tilelang-ascend/releases/download/v0.1.1.010-release/tilelang-0.1.0%2Bascendc_pto.56d3f9b8.a2.cann850-cp311-cp311-linux_aarch64.whl",
+    ("a2", "x86"): "https://gitcode.com/xLLM-AI/tilelang-ascend/releases/download/v0.1.1.010-release/tilelang-0.1.0%2Bascendc_pto.56d3f9b8.a2.cann850-cp311-cp311-linux_x86_64.whl",
+    ("a3", "arm"): "https://gitcode.com/xLLM-AI/tilelang-ascend/releases/download/v0.1.1.010-release/tilelang-0.1.0%2Bascendc_pto.56d3f9b8.a3.cann850-cp311-cp311-linux_aarch64.whl",
 }
 
 

--- a/xllm/core/distributed_runtime/CMakeLists.txt
+++ b/xllm/core/distributed_runtime/CMakeLists.txt
@@ -63,6 +63,7 @@ cc_library(
     absl::flat_hash_set
     :parallel_state
     $<$<BOOL:${USE_NPU}>:xllm_atb_layers>
+    $<$<BOOL:${USE_NPU}>:unified_dlog>
     :collective_service
     :xtensor
 )

--- a/xllm/core/kernels/npu/npu_grouped_matmul.cpp
+++ b/xllm/core/kernels/npu/npu_grouped_matmul.cpp
@@ -165,7 +165,11 @@ std::vector<torch::Tensor> apply_npu_grouped_matmul(
       resolved_group_list_type,
       resolved_act_type,
       resolved_tuning_config,
-      resolved_output_dtype);
+      ::std::optional<int64_t>{static_cast<int64_t>(resolved_output_dtype)},
+      c10::nullopt,
+      c10::nullopt,
+      c10::nullopt,
+      c10::nullopt);
 }
 
 }  // namespace xllm::kernel::npu


### PR DESCRIPTION
## Description
Upgrade xLLM to support CANN 9.0.0 (Ascend NPU toolkit).

### Build & CI
- Update CI Docker image to `cann9-20260605`
- Update all dev Docker image tags in docs (en/zh) to CANN 9 variants
- Update `torch_npu_ops` and `xllm_ops` submodules for CANN 9 compatibility

### NPU Linkage
- Add `unified_dlog` library linkage across NPU build targets (`xllm`, `distributed_runtime`, `sampler_test`, `tilelang` tests)
- Add `find_package(yalantinglibs)` and link `ascend_transport` in `third_party/CMakeLists.txt`

### API Compatibility
- Update `npu_grouped_matmul.cpp` to match CANN 9 grouped matmul API signature (additional optional parameters)

### TileLang
- Update tilelang-ascend wheel URLs to v0.1.1.010 release


## Related Issues

<!-- Link related issues here. Use "Fixes #123" when this PR closes an issue. -->

## Change Type

- [ ] Bug fix
- [x] New feature
- [ ] Performance improvement
- [ ] Refactor
- [ ] Documentation
- [ ] Test
- [ ] Build or CI

## Pull Request Checklist

Thank you for contributing to xLLM. Before requesting review, please make sure the following items are complete.

### PR Title and Commit Messages

- [x] The PR title and each commit message follow the xLLM commit format: `<type>: <subject>`.

> Allowed types: feat, bugfix, docs, test, refactor, chore, style, revert, perf, model, build, release.
> The subject should use clear English, start with a verb, include at least 4 words, and end with `.`.

### Pre-commit Checks

- [x] I have installed `pre-commit` by running `pip install pre-commit` or an equivalent command.
- [x] I have installed the hooks with `pre-commit install`.
- [x] I have run `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

### Self Review

- [x] I have self-reviewed the code according to `.agents/skills/code-review/references/custom-code-style.md`, especially code written or assisted by AI.
- [x] I have rebased this PR onto the latest `main` branch.

### Build and Test Coverage

- [ ] Tests have been added or updated as needed.
- [ ] CUDA: `python setup.py build test` has passed on a CUDA machine.
- [x] NPU: `python setup.py build test` has passed on an NPU machine.
- [ ] MLU: `python setup.py build test` has passed on an MLU machine.

## Reviewer Notes

<!-- Optional: anything reviewers should focus on, known risks, follow-ups, or validation gaps. -->
