### PR TITLE
[wip]perf: reduce greedy decode host overhead.

### DIFF
--- a/xllm/core/distributed_runtime/worker_service.cpp
+++ b/xllm/core/distributed_runtime/worker_service.cpp
@@ -21,9 +21,16 @@ limitations under the License.
 
 #include <algorithm>
 #include <boost/algorithm/string.hpp>
+#include <cstdlib>
+#include <string>
 #include <vector>
 
+#if defined(USE_NPU)
+#include <acl/acl.h>
+#endif
+
 #include "common/global_flags.h"
+#include "common/macros.h"
 #include "common/metrics.h"
 #include "common/types.h"
 #include "core/distributed_runtime/comm_channel.h"
@@ -38,6 +45,111 @@ limitations under the License.
 
 namespace xllm {
 namespace {
+
+bool direct_next_token_d2h_enabled() {
+  const char* env = std::getenv("XLLM_ENABLE_DIRECT_NEXT_TOKEN_D2H");
+  return env != nullptr && std::string(env) == "1";
+}
+
+bool is_empty_tensor(const torch::Tensor& tensor) {
+  return !tensor.defined() || tensor.numel() == 0;
+}
+
+bool can_use_direct_next_token_d2h(const ForwardOutput& output) {
+#if defined(USE_NPU)
+  const auto& sample_output = output.sample_output;
+  const auto& beam_output = output.beam_search_output;
+  return sample_output.next_tokens.defined() &&
+         sample_output.next_tokens.is_contiguous() &&
+         sample_output.next_tokens.device().is_privateuseone() &&
+         (sample_output.next_tokens.scalar_type() == torch::kInt64 ||
+          sample_output.next_tokens.scalar_type() == torch::kInt32) &&
+         is_empty_tensor(sample_output.logprobs) &&
+         is_empty_tensor(sample_output.top_tokens) &&
+         is_empty_tensor(sample_output.top_logprobs) &&
+         is_empty_tensor(sample_output.embeddings) &&
+         sample_output.mm_embeddings.empty() &&
+         output.dit_forward_output.tensors.empty() &&
+         is_empty_tensor(output.expert_load_data) &&
+         is_empty_tensor(beam_output.src_seq_idxes) &&
+         is_empty_tensor(beam_output.out_tokens) &&
+         is_empty_tensor(beam_output.out_logprobs) &&
+         !::xllm::EPLBConfig::get_instance().enable_eplb();
+#else
+  UNUSED_PARAMETER(output);
+  return false;
+#endif
+}
+
+template <typename T>
+void fill_token_only_proto_from_cpu(const torch::Tensor& cpu_tokens,
+                                    proto::ForwardOutput* pb_forward_output) {
+  const T* tokens = cpu_tokens.const_data_ptr<T>();
+  const int64_t dim = cpu_tokens.dim();
+  const int64_t num_seqs = dim == 2 ? cpu_tokens.size(0) : cpu_tokens.numel();
+  const int64_t token_width = dim == 2 ? cpu_tokens.size(1) : 1;
+  pb_forward_output->mutable_outputs()->Reserve(num_seqs);
+  for (int64_t seq_idx = 0; seq_idx < num_seqs; ++seq_idx) {
+    proto::SquenceOutput pb_seq_out;
+    pb_seq_out.mutable_tokens()->Reserve(token_width);
+    for (int64_t token_idx = 0; token_idx < token_width; ++token_idx) {
+      const int64_t flat_idx = seq_idx * token_width + token_idx;
+      const int64_t token_id = static_cast<int64_t>(tokens[flat_idx]);
+      if (token_id == -1) {
+        break;
+      }
+      proto::Token pb_token;
+      pb_token.set_id(token_id);
+      pb_token.set_empty(true);
+      *pb_seq_out.mutable_tokens()->Add() = pb_token;
+    }
+    *pb_forward_output->mutable_outputs()->Add() = pb_seq_out;
+  }
+}
+
+bool fill_async_host_next_token_to_proto(
+    const ForwardOutput& output,
+    proto::ForwardOutput* pb_forward_output,
+    torch::Tensor* copied_host_tokens = nullptr) {
+#if defined(USE_NPU)
+  const torch::Tensor& host_tokens = output.async_host_next_tokens;
+  if (!host_tokens.defined() || host_tokens.numel() == 0 ||
+      !host_tokens.device().is_cpu() ||
+      (output.async_host_next_tokens_ready_event == nullptr &&
+       output.ready_event == nullptr)) {
+    return false;
+  }
+  if (output.async_host_next_tokens_ready_event != nullptr) {
+    CHECK_ACL_SUCCESS(
+        aclrtSynchronizeEvent(
+            output.async_host_next_tokens_ready_event->npu_event()),
+        "aclrtSynchronizeEvent for async schedule-overlap next_tokens D2H");
+  } else {
+    CHECK_ACL_SUCCESS(
+        aclrtSynchronizeEvent(output.ready_event->npu_event()),
+        "aclrtSynchronizeEvent for compute-stream schedule-overlap "
+        "next_tokens D2H");
+  }
+  if (host_tokens.scalar_type() == torch::kInt64) {
+    fill_token_only_proto_from_cpu<int64_t>(host_tokens, pb_forward_output);
+  } else if (host_tokens.scalar_type() == torch::kInt32) {
+    fill_token_only_proto_from_cpu<int32_t>(host_tokens, pb_forward_output);
+  } else {
+    return false;
+  }
+  if (copied_host_tokens != nullptr) {
+    *copied_host_tokens = host_tokens;
+  }
+  LOG_FIRST_N(WARNING, 1)
+      << "XLLM_ENABLE_ASYNC_DIRECT_NEXT_TOKEN_D2H enabled: using pre-copied "
+         "host next_tokens for schedule-overlap output";
+  return true;
+#else
+  UNUSED_PARAMETER(output);
+  UNUSED_PARAMETER(pb_forward_output);
+  return false;
+#endif
+}
 
 int32_t get_num_decode_seqs_for_schedule_overlap(const ForwardInput& input) {
   if (input.sampling_params.sample_idxes.defined()) {
@@ -785,6 +897,17 @@ void WorkerService::GetLastStepResult(
           const auto& sample_output = forward_output.sample_output;
           int32_t prepared_layer_id = forward_output.prepared_layer_id;
           const auto& beam_search_output = forward_output.beam_search_output;
+          if (options_.enable_schedule_overlap() &&
+              direct_next_token_d2h_enabled() &&
+              can_use_direct_next_token_d2h(forward_output)) {
+            torch::Tensor host_next_tokens;
+            if (fill_async_host_next_token_to_proto(
+                    forward_output, pb_forward_output, &host_next_tokens)) {
+              record_speculative_metrics_from_output(host_next_tokens,
+                                                     options_);
+              return;
+            }
+          }
           torch::Tensor expert_load_data;
           torch::Tensor embeddings;
           torch::Tensor next_tokens;

--- a/xllm/core/framework/model/model_input_params.h
+++ b/xllm/core/framework/model/model_input_params.h
@@ -849,6 +849,7 @@ struct GraphInput {
   torch::Tensor attn_mask;
   torch::Tensor tiling_data;
   bool use_expanded_decode_for_spec_verify_attention = false;
+  bool persistent_tokens_already_updated = false;
   torch::Tensor expanded_kv_seq_lens;
   torch::Tensor expanded_block_tables;
   torch::Tensor expanded_tiling_data;
@@ -860,6 +861,7 @@ struct GraphInput {
     out.tiling_data = safe_to(tiling_data, device, true);
     out.use_expanded_decode_for_spec_verify_attention =
         use_expanded_decode_for_spec_verify_attention;
+    out.persistent_tokens_already_updated = persistent_tokens_already_updated;
     out.expanded_kv_seq_lens = safe_to(expanded_kv_seq_lens, device, true);
     out.expanded_block_tables = safe_to(expanded_block_tables, device, true);
     out.expanded_tiling_data = safe_to(expanded_tiling_data, device, true);

--- a/xllm/core/framework/sampling/sampler.cpp
+++ b/xllm/core/framework/sampling/sampler.cpp
@@ -19,12 +19,27 @@ limitations under the License.
 #include <glog/logging.h>
 #include <torch/torch.h>
 
+#include <cstdlib>
+#include <string>
+
 #include "common/global_flags.h"
 #include "core/framework/config/model_config.h"
+#include "core/framework/config/speculative_config.h"
+#if defined(USE_NPU)
+#include "core/kernels/npu/npu_ops_api.h"
+#endif
 #include "logits_utils.h"
 #include "sampling_params.h"
 
 namespace xllm {
+namespace {
+
+bool enable_npu_greedy_argmax_int32() {
+  const char* env = std::getenv("XLLM_ENABLE_NPU_GREEDY_ARGMAX_INT32");
+  return env != nullptr && std::string(env) == "1";
+}
+
+}  // namespace
 
 SampleOutput Sampler::forward(torch::Tensor& logits,
                               const SamplingParameters& params,
@@ -77,6 +92,23 @@ SampleOutput Sampler::forward(torch::Tensor& logits,
         << filter_mask.size(1)
         << ", sample_logits.size(1)=" << sample_logits.size(1);
     sample_logits = sample_logits + filter_mask;
+  }
+
+  const bool can_greedy_from_logits =
+      params.all_greedy_sample && !params.logprobs &&
+      ::xllm::SpeculativeConfig::get_instance().num_speculative_tokens() == 0;
+  if (can_greedy_from_logits) {
+#if defined(USE_NPU)
+    if (enable_npu_greedy_argmax_int32() &&
+        sample_logits.device().is_privateuseone() &&
+        sample_logits.is_contiguous()) {
+      output.next_tokens =
+          xllm::kernel::npu::argmax_int32(sample_logits, /*dim=*/-1);
+      return output;
+    }
+#endif
+    output.next_tokens = sample_logits.argmax(/*dim=*/-1);
+    return output;
   }
 
   // apply temperatures, top-k and top-p

--- a/xllm/core/kernels/npu/CMakeLists.txt
+++ b/xllm/core/kernels/npu/CMakeLists.txt
@@ -13,6 +13,7 @@ cc_library(
   SRCS
     active.cpp
     attention.cpp
+    argmax.cpp
     fused_layernorm.cpp
     matmul.cpp
     npu_causal_conv1d.cpp

--- a/xllm/core/kernels/npu/argmax.cpp
+++ b/xllm/core/kernels/npu/argmax.cpp
@@ -1,0 +1,80 @@
+/* Copyright 2026 The xLLM Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://github.com/jd-opensource/xllm/blob/main/LICENSE
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include <c10/core/Device.h>
+#include <glog/logging.h>
+#include <torch/torch.h>
+#include <torch_npu/torch_npu.h>
+
+#include <vector>
+
+#include "acl/acl.h"
+#include "aclnnop/aclnn_argmax.h"
+#include "core/common/macros.h"
+#include "npu_ops_api.h"
+#include "utils.h"
+
+namespace xllm::kernel::npu {
+torch::Tensor argmax_int32(const torch::Tensor& input, int64_t dim) {
+  check_tensor(input, "input", "argmax_int32");
+  CHECK(input.device().is_privateuseone())
+      << "argmax_int32 expects an NPU tensor";
+  CHECK(input.is_contiguous()) << "argmax_int32 expects contiguous input";
+  if (dim < 0) {
+    dim += input.dim();
+  }
+  CHECK_GE(dim, 0);
+  CHECK_LT(dim, input.dim());
+
+  std::vector<int64_t> out_shape = input.sizes().vec();
+  out_shape.erase(out_shape.begin() + dim);
+  if (out_shape.empty()) {
+    out_shape.push_back(1);
+  }
+  torch::Tensor output =
+      torch::empty(out_shape, input.options().dtype(torch::kInt32));
+
+  aclTensor* input_acl = nullptr;
+  aclTensor* output_acl = nullptr;
+  create_acltensor(&input_acl, input);
+  create_acltensor(&output_acl, output);
+
+  uint64_t workspace_size = 0;
+  aclOpExecutor* executor = nullptr;
+  CHECK_ACL_SUCCESS(aclnnArgMaxGetWorkspaceSize(input_acl,
+                                                dim,
+                                                /*keepdim=*/false,
+                                                output_acl,
+                                                &workspace_size,
+                                                &executor),
+                    "argmax_int32: failed to get workspace size");
+  at::DataPtr workspace_holder;
+  void* workspace = nullptr;
+  if (workspace_size > 0) {
+    workspace_holder =
+        c10_npu::NPUCachingAllocator::get()->allocate(workspace_size);
+    workspace = workspace_holder.get();
+  }
+  const int32_t device_id = input.device().index();
+  aclrtStream stream = c10_npu::getCurrentNPUStream(device_id).stream();
+  CHECK_ACL_SUCCESS(aclnnArgMax(workspace, workspace_size, executor, stream),
+                    "argmax_int32: failed to run aclnnArgMax");
+
+  aclDestroyTensor(input_acl);
+  aclDestroyTensor(output_acl);
+  return output;
+}
+
+}  // namespace xllm::kernel::npu

--- a/xllm/core/kernels/npu/npu_ops_api.h
+++ b/xllm/core/kernels/npu/npu_ops_api.h
@@ -91,6 +91,8 @@ torch::Tensor matmul(const torch::Tensor& a,
 
 torch::Tensor active(const torch::Tensor& input, const std::string& act_mode);
 
+torch::Tensor argmax_int32(const torch::Tensor& input, int64_t dim);
+
 torch::Tensor rms_norm(const torch::Tensor& input,
                        const torch::Tensor& weight,
                        double eps,

--- a/xllm/core/kernels/npu/xllm_ops/replace_token.cpp
+++ b/xllm/core/kernels/npu/xllm_ops/replace_token.cpp
@@ -29,6 +29,7 @@ limitations under the License.
 
 #include "acl/acl.h"
 #include "aclnn_replace_token.h"
+#include "aclnnop/aclnn_cast.h"
 #include "core/common/macros.h"
 #include "core/kernels/npu/utils.h"
 #include "xllm_ops_api.h"
@@ -49,8 +50,43 @@ void replace_token(torch::Tensor& dst, torch::Tensor& src) {
   aclTensor* src_ids = nullptr;
   int32_t device_id = dst.device().index();
   aclrtStream stream = c10_npu::getCurrentNPUStream(device_id).stream();
+  if (dst.numel() == src.numel() && dst.scalar_type() == src.scalar_type() &&
+      dst.is_contiguous() && src.is_contiguous() &&
+      dst.device() == src.device()) {
+    const size_t bytes = static_cast<size_t>(dst.numel()) * dst.element_size();
+    CHECK_ACL_SUCCESS(aclrtMemcpyAsync(dst.data_ptr(),
+                                       bytes,
+                                       src.data_ptr(),
+                                       bytes,
+                                       ACL_MEMCPY_DEVICE_TO_DEVICE,
+                                       stream),
+                      "replace_token: failed to copy token");
+    return;
+  }
+  if (dst.numel() == src.numel() && dst.scalar_type() == torch::kInt &&
+      src.scalar_type() == torch::kLong && dst.is_contiguous() &&
+      src.is_contiguous() && dst.device() == src.device()) {
+    create_acltensor(&dst_ids, dst);
+    create_acltensor(&src_ids, src);
+    uint64_t workspace_size = 0;
+    aclOpExecutor* executor = nullptr;
+    CHECK_ACL_SUCCESS(
+        aclnnCastGetWorkspaceSize(
+            src_ids, ACL_INT32, dst_ids, &workspace_size, &executor),
+        "replace_token: failed to get cast workspace size");
+    CHECK_ACL_SUCCESS(aclnnCast(nullptr, workspace_size, executor, stream),
+                      "replace_token: failed to cast token");
+    aclDestroyTensor(dst_ids);
+    aclDestroyTensor(src_ids);
+    return;
+  }
+  torch::Tensor src_for_replace = src;
+  if (dst.scalar_type() == torch::kInt && src.scalar_type() == torch::kInt &&
+      dst.device() == src.device()) {
+    src_for_replace = src.to(torch::kLong);
+  }
   create_acltensor(&dst_ids, dst);
-  create_acltensor(&src_ids, src);
+  create_acltensor(&src_ids, src_for_replace);
   uint64_t workspace_size = 0;
   aclOpExecutor* executor;
   CHECK_ACL_SUCCESS(aclnnReplaceTokenGetWorkspaceSize(

--- a/xllm/core/layers/npu/npu_lm_head_impl.cpp
+++ b/xllm/core/layers/npu/npu_lm_head_impl.cpp
@@ -17,11 +17,34 @@ limitations under the License.
 
 #include <glog/logging.h>
 
+#include <cstdlib>
+#include <string>
+
 #include "core/framework/config/load_config.h"
 #include "core/framework/config/parallel_config.h"
 
 namespace xllm {
 namespace layer {
+namespace {
+
+bool enable_lmhead_decode_node() {
+  const char* env = std::getenv("XLLM_ENABLE_NPU_LMHEAD_DECODE_NODE");
+  return env != nullptr && std::string(env) == "1";
+}
+
+bool enable_lmhead_decode_setup_cache() {
+  const char* env = std::getenv("XLLM_ENABLE_NPU_LMHEAD_DECODE_SETUP_CACHE");
+  return env != nullptr && std::string(env) == "1";
+}
+
+bool looks_like_decode_lmhead(const torch::Tensor& hidden_states,
+                              const torch::Tensor& selected_idxes) {
+  return hidden_states.defined() && selected_idxes.defined() &&
+         hidden_states.dim() >= 2 && selected_idxes.dim() == 1 &&
+         hidden_states.size(0) == selected_idxes.size(0);
+}
+
+}  // namespace
 
 void NpuLmHeadImpl::param_from_args(atb_speed::common::LmHeadParam& param,
                                     const ModelArgs& args,
@@ -172,8 +195,26 @@ torch::Tensor NpuLmHeadImpl::forward_with_hidden(
     torch::Tensor& out_hidden,
     int nodeId) {
   atb::Status st;
-  build_node_variant_pack(lm_head_node_prefill_, hidden_states, seleted_idxes);
-  st = execute_node(lm_head_node_prefill_, nodeId);
+  atb_speed::Model::Node& node =
+      enable_lmhead_decode_node() &&
+              looks_like_decode_lmhead(hidden_states, seleted_idxes)
+          ? lm_head_node_decode_
+          : lm_head_node_prefill_;
+  const bool use_decode_setup_cache =
+      enable_lmhead_decode_setup_cache() && (&node == &lm_head_node_decode_);
+  build_node_variant_pack(node, hidden_states, seleted_idxes);
+  if (use_decode_setup_cache &&
+      can_reuse_decode_setup(hidden_states, seleted_idxes)) {
+    st = execute_node_without_setup(node, nodeId);
+  } else {
+    st = execute_node(node, nodeId);
+    if (st == atb::NO_ERROR && use_decode_setup_cache) {
+      update_decode_setup_cache(hidden_states, seleted_idxes);
+      LOG_FIRST_N(WARNING, 1)
+          << "XLLM_ENABLE_NPU_LMHEAD_DECODE_SETUP_CACHE enabled: reusing "
+             "LmHead decode setup for stable shapes";
+    }
+  }
   LOG_IF(FATAL, st != 0) << model_name_
                          << "execute lmhead node fail, error code: " << st;
   torch::Tensor output = atOutTensors_[0];
@@ -239,6 +280,34 @@ void NpuLmHeadImpl::build_node_variant_pack(
     node.variantPack.outTensors.at(i) =
         atb_speed::Utils::AtTensor2Tensor(atOutTensors_.at(i));
   }
+}
+
+bool NpuLmHeadImpl::can_reuse_decode_setup(
+    const torch::Tensor& hidden_states,
+    const torch::Tensor& seleted_idxes) const {
+  return decode_setup_cache_valid_ &&
+         hidden_states.sizes().vec() == decode_hidden_shape_ &&
+         seleted_idxes.sizes().vec() == decode_selected_shape_;
+}
+
+void NpuLmHeadImpl::update_decode_setup_cache(
+    const torch::Tensor& hidden_states,
+    const torch::Tensor& seleted_idxes) {
+  decode_setup_cache_valid_ = true;
+  decode_hidden_shape_ = hidden_states.sizes().vec();
+  decode_selected_shape_ = seleted_idxes.sizes().vec();
+}
+
+atb::Status NpuLmHeadImpl::execute_node_without_setup(
+    atb_speed::Model::Node& node,
+    int nodeId) {
+  if (node.workspaceSize > 0 && node.workspace == nullptr) {
+    node.workspace = work_space_->get_workspace_buffer(node.workspaceSize);
+  }
+  run_task_func_(name_ + std::to_string(nodeId), [=, this]() {
+    return execute_plan(node, name_ + std::to_string(nodeId), nullptr, nullptr);
+  });
+  return atb::NO_ERROR;
 }
 
 }  // namespace layer

--- a/xllm/core/layers/npu/npu_lm_head_impl.h
+++ b/xllm/core/layers/npu/npu_lm_head_impl.h
@@ -75,6 +75,13 @@ class NpuLmHeadImpl : public BaseLayer {
                                const torch::Tensor& hidden_states,
                                const torch::Tensor& seleted_idxes);
 
+  bool can_reuse_decode_setup(const torch::Tensor& hidden_states,
+                              const torch::Tensor& seleted_idxes) const;
+  void update_decode_setup_cache(const torch::Tensor& hidden_states,
+                                 const torch::Tensor& seleted_idxes);
+  atb::Status execute_node_without_setup(atb_speed::Model::Node& node,
+                                         int nodeId);
+
   atb_speed::Model::Node lm_head_node_prefill_;
   atb_speed::Model::Node lm_head_node_decode_;
 
@@ -93,6 +100,9 @@ class NpuLmHeadImpl : public BaseLayer {
 
   int64_t vocab_size_ = -1;
   int64_t padded_vocab_size_ = -1;
+  bool decode_setup_cache_valid_ = false;
+  std::vector<int64_t> decode_hidden_shape_;
+  std::vector<int64_t> decode_selected_shape_;
 };
 TORCH_MODULE(NpuLmHead);
 

--- a/xllm/core/platform/stream.cpp
+++ b/xllm/core/platform/stream.cpp
@@ -17,9 +17,13 @@ limitations under the License.
 
 #include <glog/logging.h>
 
+#include <atomic>
+#include <cstdlib>
 #include <exception>
 #include <memory>
 #include <ostream>
+#include <string>
+#include <vector>
 
 namespace xllm {
 
@@ -30,6 +34,50 @@ c10::Stream to_c10_stream(const PlatformStream& stream) {
 }
 
 #if defined(USE_NPU)
+bool enable_stream_event_ring() {
+  const char* env = std::getenv("XLLM_ENABLE_STREAM_EVENT_RING");
+  return env != nullptr && std::string(env) == "1";
+}
+
+class StreamEventRing {
+ public:
+  StreamEventRing() {
+    events_.resize(kPoolSize, nullptr);
+    for (auto& event : events_) {
+      aclError ret = aclrtCreateEventWithFlag(&event, ACL_EVENT_SYNC);
+      if (ret != ACL_SUCCESS) {
+        ret = aclrtCreateEvent(&event);
+      }
+      CHECK_EQ(ret, ACL_SUCCESS) << "Failed to create stream event ring event";
+    }
+  }
+
+  ~StreamEventRing() {
+    for (auto event : events_) {
+      if (event != nullptr) {
+        aclrtDestroyEvent(event);
+      }
+    }
+  }
+
+  aclrtEvent next() {
+    const size_t index =
+        next_index_.fetch_add(1, std::memory_order_relaxed) % events_.size();
+    return events_[index];
+  }
+
+ private:
+  static constexpr size_t kPoolSize = 8192;
+
+  std::atomic<size_t> next_index_{0};
+  std::vector<aclrtEvent> events_;
+};
+
+StreamEventRing& stream_event_ring() {
+  static StreamEventRing ring;
+  return ring;
+}
+
 PlatformStream get_stream_from_pool() {
   return c10_npu::getNPUStreamFromPool();
 }
@@ -76,6 +124,16 @@ void Stream::wait_stream(const Stream& other_stream) {
 
 StreamEventPtr Stream::record_event() const {
 #if defined(USE_NPU)
+  if (enable_stream_event_ring()) {
+    aclrtEvent event = stream_event_ring().next();
+    aclError ret = aclrtRecordEvent(event, stream_.stream());
+    if (ret != ACL_SUCCESS) {
+      LOG(ERROR) << "Failed to record NPU stream ring event: " << ret;
+      return nullptr;
+    }
+    return std::make_shared<StreamEvent>(event, /*owns_event=*/false);
+  }
+
   aclrtEvent event = nullptr;
   aclError ret = aclrtCreateEventWithFlag(&event, ACL_EVENT_SYNC);
   if (ret != ACL_SUCCESS) {

--- a/xllm/core/platform/stream_event.h
+++ b/xllm/core/platform/stream_event.h
@@ -30,10 +30,11 @@ namespace xllm {
 class StreamEvent final {
  public:
 #if defined(USE_NPU)
-  explicit StreamEvent(aclrtEvent event) : npu_event_(event) {}
+  explicit StreamEvent(aclrtEvent event, bool owns_event = true)
+      : npu_event_(event), owns_event_(owns_event) {}
 
   ~StreamEvent() {
-    if (npu_event_ != nullptr) {
+    if (owns_event_ && npu_event_ != nullptr) {
       aclrtDestroyEvent(npu_event_);
     }
   }
@@ -50,6 +51,7 @@ class StreamEvent final {
  private:
 #if defined(USE_NPU)
   aclrtEvent npu_event_ = nullptr;
+  bool owns_event_ = true;
 #else
   c10::Event c10_event_;
 #endif

--- a/xllm/core/runtime/acl_graph_executor_impl.cpp
+++ b/xllm/core/runtime/acl_graph_executor_impl.cpp
@@ -23,6 +23,8 @@ limitations under the License.
 #include <torch_npu/torch_npu.h>
 
 #include <algorithm>
+#include <cstdlib>
+#include <string>
 
 #include "core/common/global_flags.h"
 #include "core/framework/config/execution_config.h"
@@ -42,6 +44,10 @@ namespace xllm::npu {
 namespace {
 constexpr uint64_t kSpecVerifyGraphKeyMask = 1ull << 63;
 constexpr uint64_t kSpecVerifyQMaxSeqLenShift = 32;
+bool graph_direct_next_token_input_enabled() {
+  const char* env = std::getenv("XLLM_ENABLE_GRAPH_DIRECT_NEXT_TOKEN_INPUT");
+  return env != nullptr && std::string(env) == "1";
+}
 
 std::pair<torch::Tensor, torch::Tensor> find_attention_plan_kv_cache(
     const std::vector<KVCache>& kv_caches) {
@@ -166,7 +172,6 @@ bool AclGraph::capture(CausalLM* model,
   // Synchronize and test replay to verify graph capture
   aclrtSynchronizeStream(graph_stream_);
   aclrtSynchronizeStream(stream);
-
   graph_.replay();
 
   make_current_stream_wait_for_graph(stream);
@@ -204,13 +209,14 @@ void AclGraph::make_current_stream_wait_for_graph(aclrtStream current_stream) {
   CHECK_NE(graph_stream_, nullptr) << "graph_stream is not initialized";
   CHECK_NE(replay_done_event_, nullptr)
       << "replay_done_event is not initialized";
+  if (current_stream == graph_stream_) {
+    return;
+  }
   CHECK_EQ(aclrtRecordEvent(replay_done_event_, graph_stream_), ACL_SUCCESS)
       << "aclrtRecordEvent(replay_done_event) failed";
-  if (current_stream != graph_stream_) {
-    CHECK_EQ(aclrtStreamWaitEvent(current_stream, replay_done_event_),
-             ACL_SUCCESS)
-        << "aclrtStreamWaitEvent(current_stream, replay_done_event) failed";
-  }
+  CHECK_EQ(aclrtStreamWaitEvent(current_stream, replay_done_event_),
+           ACL_SUCCESS)
+      << "aclrtStreamWaitEvent(current_stream, replay_done_event) failed";
 }
 
 void AclGraph::prepare_model_graph_metadata(CausalLM* model,
@@ -293,6 +299,50 @@ ForwardInput AclGraphExecutorImpl::prepare_inputs(Batch& batch) {
   // Prepare inputs for workers
   return batch.prepare_forward_input(
       options_.num_decoding_tokens(), 0, args_, options_.cp_size());
+}
+
+bool AclGraphExecutorImpl::try_update_graph_input_tokens(
+    ForwardInput& input,
+    const torch::Tensor& next_tokens) {
+  if (!graph_direct_next_token_input_enabled() ||
+      !input.input_params.meta.batch_forward_type.is_decode() ||
+      !next_tokens.defined() || !next_tokens.is_contiguous() ||
+      !next_tokens.device().is_privateuseone() || !input.token_ids.defined() ||
+      input.token_ids.numel() != next_tokens.numel()) {
+    return false;
+  }
+
+  auto& params = input.input_params;
+  uint32_t graph_num_tokens = static_cast<uint32_t>(input.token_ids.size(0));
+  if (params.parallel.dp_global_token_nums.size() > 1) {
+    graph_num_tokens = util::max(params.parallel.dp_global_token_nums);
+  }
+  const uint32_t global_batch_size =
+      graph_num_tokens / options_.num_decoding_tokens();
+  const uint32_t decode_batch_size_limit = static_cast<uint32_t>(
+      std::max<int32_t>(1,
+                        ::xllm::ExecutionConfig::get_instance()
+                            .acl_graph_decode_batch_size_limit()));
+  if (global_batch_size > decode_batch_size_limit ||
+      params.meta.kv_max_seq_len > args_.max_position_embeddings()) {
+    return false;
+  }
+
+  const uint32_t bucket_num_tokens = get_bucket_num_tokens(graph_num_tokens);
+  const uint64_t graph_key = get_graph_key(bucket_num_tokens, params);
+  if (graphs_.find(graph_key) == graphs_.end()) {
+    return false;
+  }
+
+  if (!persistent_param_->update_persistent_tokens_direct(next_tokens)) {
+    return false;
+  }
+  params.graph.persistent_tokens_already_updated = true;
+  LOG_FIRST_N(WARNING, 1)
+      << "XLLM_ENABLE_GRAPH_DIRECT_NEXT_TOKEN_INPUT enabled: write "
+         "schedule-overlap next_tokens directly into ACL graph persistent "
+         "tokens";
+  return true;
 }
 
 // Main execution method with graph optimization for decode phase

--- a/xllm/core/runtime/acl_graph_executor_impl.h
+++ b/xllm/core/runtime/acl_graph_executor_impl.h
@@ -90,7 +90,6 @@ class AclGraph {
   void prepare_model_graph_metadata(CausalLM* model,
                                     const torch::Tensor& positions,
                                     ModelInputParams& params);
-
   // NPUGraph with mempool for managing temporary tensors during forward pass
   c10_npu::NPUGraph graph_;
   uint32_t num_tokens_;
@@ -125,6 +124,9 @@ class AclGraphExecutorImpl : public ExecutorImpl {
                   const torch::Tensor& positions,
                   std::vector<KVCache>& kv_caches,
                   const ModelInputParams& params) override;
+
+  bool try_update_graph_input_tokens(ForwardInput& input,
+                                     const torch::Tensor& next_tokens) override;
 
  private:
   // not own

--- a/xllm/core/runtime/acl_graph_persistent_param.cpp
+++ b/xllm/core/runtime/acl_graph_persistent_param.cpp
@@ -21,9 +21,11 @@ limitations under the License.
 
 #include <algorithm>
 #include <cmath>
+#include <cstdlib>
 #include <cstring>
 #include <limits>
 #include <numeric>
+#include <string>
 #include <utility>
 #include <vector>
 
@@ -129,6 +131,88 @@ int64_t infer_actual_batch_size(const ModelInputParams& params) {
 bool is_qwen3_5_model_type(const std::string& model_type) {
   return model_type == "qwen3_5" || model_type == "qwen3_5_moe" ||
          model_type == "qwen3_5_text" || model_type.rfind("qwen3_5_", 0) == 0;
+}
+
+bool graph_incremental_metadata_enabled() {
+  const char* env = std::getenv("XLLM_ENABLE_GRAPH_INCREMENTAL_METADATA");
+  return env != nullptr && std::string(env) == "1";
+}
+
+bool graph_decode_scalar_raw_metadata_copy_enabled() {
+  const char* env =
+      std::getenv("XLLM_ENABLE_GRAPH_DECODE_SCALAR_RAW_METADATA_COPY");
+  return env != nullptr && std::string(env) == "1";
+}
+
+bool graph_decode_raw_tokens_enabled() {
+  const char* env = std::getenv("XLLM_ENABLE_GRAPH_DECODE_RAW_TOKENS");
+  return env != nullptr && std::string(env) == "1";
+}
+
+bool graph_raw_padding_copy_enabled() {
+  const char* env = std::getenv("XLLM_ENABLE_GRAPH_RAW_PADDING_COPY");
+  return env != nullptr && std::string(env) == "1";
+}
+
+bool graph_stable_decode_metadata_enabled() {
+  const char* env = std::getenv("XLLM_ENABLE_GRAPH_STABLE_DECODE_METADATA");
+  return env != nullptr && std::string(env) == "1";
+}
+
+bool graph_block_table_cache_enabled() {
+  const char* env = std::getenv("XLLM_ENABLE_GRAPH_BLOCK_TABLE_CACHE");
+  return env != nullptr && std::string(env) == "1";
+}
+
+bool graph_pa_tiling_shape_cache_enabled() {
+  const char* env = std::getenv("XLLM_ENABLE_GRAPH_PA_TILING_SHAPE_CACHE");
+  return env != nullptr && std::string(env) == "1";
+}
+
+bool graph_decode_seq_len_tail_fill_skip_enabled() {
+  const char* env = std::getenv("XLLM_SKIP_GRAPH_DECODE_SEQ_LEN_TAIL_FILL");
+  return env != nullptr && std::string(env) == "1";
+}
+
+bool graph_decode_padding_tail_cache_enabled() {
+  const char* env = std::getenv("XLLM_ENABLE_GRAPH_DECODE_PADDING_TAIL_CACHE");
+  return env != nullptr && std::string(env) == "1";
+}
+
+bool graph_decode_token_tail_cache_enabled() {
+  const char* env = std::getenv("XLLM_ENABLE_GRAPH_DECODE_TOKEN_TAIL_CACHE");
+  return env != nullptr && std::string(env) == "1";
+}
+
+bool raw_copy_tensor_async(const torch::Tensor& dst,
+                           const torch::Tensor& src,
+                           aclrtStream stream) {
+  if (!dst.defined() || !src.defined() || dst.numel() == 0 ||
+      src.numel() == 0 || dst.device().is_cpu() || src.device().is_cpu() ||
+      !dst.is_contiguous() || !src.is_contiguous() ||
+      dst.scalar_type() != src.scalar_type() || dst.numel() < src.numel()) {
+    return false;
+  }
+  const size_t bytes = static_cast<size_t>(src.numel()) *
+                       static_cast<size_t>(src.element_size());
+  const aclError status = aclrtMemcpyAsync(dst.data_ptr(),
+                                           bytes,
+                                           src.data_ptr(),
+                                           bytes,
+                                           ACL_MEMCPY_DEVICE_TO_DEVICE,
+                                           stream);
+  CHECK_EQ(status, ACL_SUCCESS) << "Failed to raw-copy ACL graph metadata";
+  return true;
+}
+
+void copy_tensor_async(const torch::Tensor& dst,
+                       const torch::Tensor& src,
+                       aclrtStream stream,
+                       bool use_raw_copy) {
+  if (use_raw_copy && raw_copy_tensor_async(dst, src, stream)) {
+    return;
+  }
+  dst.copy_(src, /*non_blocking=*/true);
 }
 
 }  // namespace
@@ -301,8 +385,14 @@ void copy_into_persistent(torch::Tensor& persistent, const torch::Tensor& src) {
   CHECK_LE(src.size(0), persistent.size(0))
       << "dp_ep_padding persistent buffer overflow: src size " << src.size(0)
       << " exceeds pre-allocated capacity " << persistent.size(0);
-  persistent.slice(/*dim=*/0, /*start=*/0, /*end=*/src.size(0))
-      .copy_(src, /*non_blocking=*/true);
+  torch::Tensor dst =
+      persistent.slice(/*dim=*/0, /*start=*/0, /*end=*/src.size(0));
+  if (graph_raw_padding_copy_enabled() &&
+      raw_copy_tensor_async(
+          dst, src, c10_npu::getCurrentNPUStream().stream())) {
+    return;
+  }
+  dst.copy_(src, /*non_blocking=*/true);
 }
 
 torch::Tensor slice_like_source(const torch::Tensor& persistent,
@@ -468,6 +558,21 @@ GraphPersistentParam::~GraphPersistentParam() {
   }
 }
 
+bool GraphPersistentParam::update_persistent_tokens_direct(
+    const torch::Tensor& tokens) {
+  if (!tokens.defined() || tokens.numel() == 0 ||
+      !persistent_tokens_.defined() ||
+      tokens.numel() > persistent_tokens_.numel()) {
+    return false;
+  }
+  torch::Tensor dst = persistent_tokens_.slice(/*dim=*/0,
+                                               /*start=*/0,
+                                               /*end=*/tokens.numel());
+  aclrtStream stream = c10_npu::getCurrentNPUStream().stream();
+  copy_tensor_async(dst, tokens, stream, /*use_raw_copy=*/true);
+  return true;
+}
+
 void GraphPersistentParam::set_aux_hidden_states(const torch::Tensor& value) {
   if (!value.defined()) {
     return;
@@ -612,13 +717,92 @@ std::optional<ModelInputParams> GraphPersistentParam::update(
           : padded_num_tokens;
   const int64_t actual_seq_len_rows =
       is_chunked_prefill ? actual_batch_size : actual_num_tokens;
-
-  // Copy data from input parameters to persistent graph tensors
-  if (actual_num_tokens > 0) {
-    persistent_tokens_.slice(/*dim=*/0, /*start=*/0, /*end=*/actual_num_tokens)
-        .copy_(tokens, /*non_blocking=*/true);
+  const bool incremental_metadata =
+      !return_capture_params && graph_incremental_metadata_enabled();
+  const bool decode_scalar_raw_metadata_copy =
+      is_decode && !return_capture_params &&
+      graph_decode_scalar_raw_metadata_copy_enabled();
+  const bool decode_raw_tokens =
+      decode_scalar_raw_metadata_copy || (is_decode && !return_capture_params &&
+                                          graph_decode_raw_tokens_enabled());
+  const bool decode_raw_positions = decode_scalar_raw_metadata_copy;
+  const bool decode_raw_q_seq_lens = decode_scalar_raw_metadata_copy;
+  const bool decode_raw_kv_seq_lens = decode_scalar_raw_metadata_copy;
+  const bool decode_raw_new_cache_slots = decode_scalar_raw_metadata_copy;
+  const bool stable_decode_metadata = is_decode && !return_capture_params &&
+                                      graph_stable_decode_metadata_enabled();
+  const bool cache_decode_padding_tail =
+      is_decode && !return_capture_params && !is_chunked_prefill &&
+      graph_decode_padding_tail_cache_enabled();
+  const bool cache_decode_token_tail = is_decode && !return_capture_params &&
+                                       !is_chunked_prefill &&
+                                       graph_decode_token_tail_cache_enabled();
+  aclrtStream metadata_stream = nullptr;
+  if (decode_raw_tokens || decode_raw_positions || decode_raw_q_seq_lens ||
+      decode_raw_kv_seq_lens || decode_raw_new_cache_slots) {
+    metadata_stream = c10_npu::getCurrentNPUStream().stream();
   }
-  if (padded_num_tokens > actual_num_tokens) {
+  if (decode_scalar_raw_metadata_copy) {
+    LOG_FIRST_N(INFO, 1)
+        << "XLLM_ENABLE_GRAPH_DECODE_SCALAR_RAW_METADATA_COPY enabled: use "
+           "raw D2D copy for replay-time 1D decode scalar metadata";
+  }
+  if (incremental_metadata) {
+    LOG_FIRST_N(INFO, 1)
+        << "XLLM_ENABLE_GRAPH_INCREMENTAL_METADATA enabled: skip replay-time "
+           "full default tensor copies for ACL graph metadata";
+  }
+  if (stable_decode_metadata) {
+    LOG_FIRST_N(INFO, 1)
+        << "XLLM_ENABLE_GRAPH_STABLE_DECODE_METADATA enabled: skip stable "
+           "decode q_seq_lens/q_cu_seq_lens metadata when safe";
+  }
+  if (cache_decode_padding_tail) {
+    LOG_FIRST_N(INFO, 1)
+        << "XLLM_ENABLE_GRAPH_DECODE_PADDING_TAIL_CACHE enabled: cache stable "
+           "decode padding tails for linear_state_indices and "
+           "num_accepted_tokens";
+  }
+  if (cache_decode_token_tail) {
+    LOG_FIRST_N(INFO, 1)
+        << "XLLM_ENABLE_GRAPH_DECODE_TOKEN_TAIL_CACHE enabled: repair only "
+           "stale decode padding tails for tokens, positions and cache slots";
+  }
+  auto copy_decode_metadata = [&](const torch::Tensor& dst,
+                                  const torch::Tensor& src,
+                                  bool use_raw_copy) {
+    copy_tensor_async(dst, src, metadata_stream, use_raw_copy);
+  };
+
+  const bool persistent_tokens_already_updated =
+      is_decode && !return_capture_params &&
+      params.graph.persistent_tokens_already_updated;
+  // Copy data from input parameters to persistent graph tensors
+  if (actual_num_tokens > 0 && !persistent_tokens_already_updated) {
+    copy_decode_metadata(persistent_tokens_.slice(/*dim=*/0,
+                                                  /*start=*/0,
+                                                  /*end=*/actual_num_tokens),
+                         tokens,
+                         decode_raw_tokens);
+  } else if (persistent_tokens_already_updated) {
+    LOG_FIRST_N(INFO, 1)
+        << "Graph persistent tokens were updated directly from last-step "
+           "next_tokens; skip replay-time token copy";
+  }
+  if (cache_decode_token_tail && padded_num_tokens > actual_num_tokens) {
+    const int64_t tail_end =
+        std::min<int64_t>(cached_token_active_tokens_, padded_num_tokens);
+    if (tail_end > actual_num_tokens) {
+      zero_tensor_tail(persistent_tokens_,
+                       actual_num_tokens,
+                       tail_end,
+                       /*dim=*/0);
+    }
+  }
+  if (cache_decode_token_tail) {
+    cached_token_active_tokens_ = actual_num_tokens;
+  }
+  if (!cache_decode_token_tail && padded_num_tokens > actual_num_tokens) {
     zero_tensor_tail(persistent_tokens_,
                      actual_num_tokens,
                      static_cast<int64_t>(padded_num_tokens));
@@ -626,22 +810,38 @@ std::optional<ModelInputParams> GraphPersistentParam::update(
   // mRoPE positions have shape [3, num_tokens], slice on dim 1
   if (actual_num_tokens > 0) {
     if (use_mrope_) {
-      persistent_positions_
-          .slice(/*dim=*/1, /*start=*/0, /*end=*/actual_num_tokens)
-          .copy_(positions, /*non_blocking=*/true);
+      copy_tensor_async(persistent_positions_.slice(/*dim=*/1,
+                                                    /*start=*/0,
+                                                    /*end=*/actual_num_tokens),
+                        positions,
+                        metadata_stream,
+                        /*use_raw_copy=*/false);
     } else {
-      persistent_positions_
-          .slice(/*dim=*/0, /*start=*/0, /*end=*/actual_num_tokens)
-          .copy_(positions, /*non_blocking=*/true);
+      copy_decode_metadata(persistent_positions_.slice(
+                               /*dim=*/0,
+                               /*start=*/0,
+                               /*end=*/actual_num_tokens),
+                           positions,
+                           decode_raw_positions);
     }
   }
   if (padded_num_tokens > actual_num_tokens) {
-    zero_tensor_tail(persistent_positions_,
-                     actual_num_tokens,
-                     static_cast<int64_t>(padded_num_tokens),
-                     use_mrope_ ? 1 : 0);
+    const int64_t tail_end =
+        cache_decode_token_tail
+            ? std::min<int64_t>(cached_position_active_tokens_,
+                                padded_num_tokens)
+            : static_cast<int64_t>(padded_num_tokens);
+    if (tail_end > actual_num_tokens) {
+      zero_tensor_tail(persistent_positions_,
+                       actual_num_tokens,
+                       tail_end,
+                       use_mrope_ ? 1 : 0);
+    }
   }
-  if (q_seq_lens_default_.defined() &&
+  if (cache_decode_token_tail) {
+    cached_position_active_tokens_ = actual_num_tokens;
+  }
+  if (!incremental_metadata && q_seq_lens_default_.defined() &&
       q_seq_lens_default_.sizes() == q_seq_lens_.sizes()) {
     q_seq_lens_.copy_(q_seq_lens_default_, /*non_blocking=*/true);
   }
@@ -650,15 +850,28 @@ std::optional<ModelInputParams> GraphPersistentParam::update(
       params.attention.device.q_seq_lens.numel() > 0) {
     const int64_t q_copy_len = std::min<int64_t>(
         actual_seq_len_rows, params.attention.device.q_seq_lens.size(0));
-    if (q_copy_len > 0) {
-      q_seq_lens_.slice(/*dim=*/0, /*start=*/0, /*end=*/q_copy_len)
-          .copy_(params.attention.device.q_seq_lens.slice(/*dim=*/0,
-                                                          /*start=*/0,
-                                                          /*end=*/q_copy_len),
-                 /*non_blocking=*/true);
+    bool skip_q_seq_lens_copy = false;
+    if (stable_decode_metadata && q_copy_len > 0 &&
+        params.attention.host.q_seq_lens.size() >=
+            static_cast<size_t>(q_copy_len)) {
+      skip_q_seq_lens_copy = true;
+      for (int64_t i = 0; i < q_copy_len; ++i) {
+        if (params.attention.host.q_seq_lens[static_cast<size_t>(i)] != 1) {
+          skip_q_seq_lens_copy = false;
+          break;
+        }
+      }
+    }
+    if (q_copy_len > 0 && !skip_q_seq_lens_copy) {
+      copy_decode_metadata(q_seq_lens_.slice(/*dim=*/0,
+                                             /*start=*/0,
+                                             /*end=*/q_copy_len),
+                           params.attention.device.q_seq_lens.slice(
+                               /*dim=*/0, /*start=*/0, /*end=*/q_copy_len),
+                           decode_raw_q_seq_lens);
     }
   }
-  if (kv_seq_lens_default_.defined() &&
+  if (!incremental_metadata && kv_seq_lens_default_.defined() &&
       kv_seq_lens_default_.sizes() == kv_seq_lens_.sizes()) {
     kv_seq_lens_.copy_(kv_seq_lens_default_, /*non_blocking=*/true);
   }
@@ -669,14 +882,19 @@ std::optional<ModelInputParams> GraphPersistentParam::update(
     const int64_t kv_copy_len = std::min<int64_t>(
         actual_seq_len_rows, params.attention.device.kv_seq_lens.size(0));
     if (kv_copy_len > 0) {
-      kv_seq_lens_.slice(/*dim=*/0, /*start=*/0, /*end=*/kv_copy_len)
-          .copy_(params.attention.device.kv_seq_lens.slice(/*dim=*/0,
-                                                           /*start=*/0,
-                                                           /*end=*/kv_copy_len),
-                 /*non_blocking=*/true);
+      copy_decode_metadata(kv_seq_lens_.slice(/*dim=*/0,
+                                              /*start=*/0,
+                                              /*end=*/kv_copy_len),
+                           params.attention.device.kv_seq_lens.slice(
+                               /*dim=*/0, /*start=*/0, /*end=*/kv_copy_len),
+                           decode_raw_kv_seq_lens);
     }
   }
-  if (padded_batch_size > actual_seq_len_rows) {
+  const bool skip_decode_seq_len_tail_fill =
+      is_decode && !return_capture_params && !is_chunked_prefill &&
+      graph_decode_seq_len_tail_fill_skip_enabled();
+  if (padded_batch_size > actual_seq_len_rows &&
+      !skip_decode_seq_len_tail_fill) {
     const int32_t padding_q_len = is_chunked_prefill ? q_max_seq_len : 1;
     q_seq_lens_
         .slice(/*dim=*/0,
@@ -688,9 +906,13 @@ std::optional<ModelInputParams> GraphPersistentParam::update(
                /*start=*/actual_seq_len_rows,
                /*end=*/padded_batch_size)
         .fill_(1);
+  } else if (skip_decode_seq_len_tail_fill) {
+    LOG_FIRST_N(INFO, 1)
+        << "XLLM_SKIP_GRAPH_DECODE_SEQ_LEN_TAIL_FILL enabled: skip stable "
+           "decode q_seq_lens/kv_seq_lens padding tail fill";
   }
 
-  if (persistent_new_cache_slots_default_.defined() &&
+  if (!incremental_metadata && persistent_new_cache_slots_default_.defined() &&
       persistent_new_cache_slots_default_.sizes() ==
           persistent_new_cache_slots_.sizes()) {
     persistent_new_cache_slots_.copy_(persistent_new_cache_slots_default_,
@@ -704,30 +926,59 @@ std::optional<ModelInputParams> GraphPersistentParam::update(
         std::min<int64_t>(static_cast<int64_t>(actual_num_tokens),
                           params.attention.device.new_cache_slots.size(0));
     if (slot_copy_len > 0) {
-      persistent_new_cache_slots_
-          .slice(/*dim=*/0, /*start=*/0, /*end=*/slot_copy_len)
-          .copy_(params.attention.device.new_cache_slots.slice(
-                     /*dim=*/0, /*start=*/0, /*end=*/slot_copy_len),
-                 /*non_blocking=*/true);
+      copy_decode_metadata(persistent_new_cache_slots_.slice(
+                               /*dim=*/0, /*start=*/0, /*end=*/slot_copy_len),
+                           params.attention.device.new_cache_slots.slice(
+                               /*dim=*/0, /*start=*/0, /*end=*/slot_copy_len),
+                           decode_raw_new_cache_slots);
     }
   }
   if (actual_num_tokens < padded_num_tokens) {
-    zero_tensor_tail(persistent_new_cache_slots_,
-                     actual_num_tokens,
-                     static_cast<int64_t>(padded_num_tokens));
+    const int64_t tail_end =
+        cache_decode_token_tail
+            ? std::min<int64_t>(cached_new_cache_slot_active_tokens_,
+                                padded_num_tokens)
+            : static_cast<int64_t>(padded_num_tokens);
+    if (tail_end > actual_num_tokens) {
+      zero_tensor_tail(
+          persistent_new_cache_slots_, actual_num_tokens, tail_end);
+    }
+  }
+  if (cache_decode_token_tail) {
+    cached_new_cache_slot_active_tokens_ = actual_num_tokens;
   }
   if (!params.embedding.linear_state_ids.empty()) {
     const int64_t linear_copy_len = std::min<int64_t>(
         actual_batch_size,
         static_cast<int64_t>(params.embedding.linear_state_ids.size()));
     if (linear_copy_len > 0) {
-      if (params.embedding.linear_state_indices.defined()) {
-        persistent_linear_state_indices_
-            .slice(/*dim=*/0, /*start=*/0, /*end=*/linear_copy_len)
-            .copy_(params.embedding.linear_state_indices.slice(
-                       /*dim=*/0, /*start=*/0, /*end=*/linear_copy_len),
-                   /*non_blocking=*/true);
-      } else {
+      bool skip_linear_state_copy = false;
+      if (stable_decode_metadata &&
+          cached_linear_state_active_rows_ == linear_copy_len &&
+          cached_linear_state_values_.size() >=
+              static_cast<size_t>(linear_copy_len)) {
+        skip_linear_state_copy = true;
+        for (int64_t i = 0; i < linear_copy_len; ++i) {
+          if (cached_linear_state_values_[static_cast<size_t>(i)] !=
+              params.embedding.linear_state_ids[static_cast<size_t>(i)]) {
+            skip_linear_state_copy = false;
+            break;
+          }
+        }
+      }
+      if (!skip_linear_state_copy &&
+          params.embedding.linear_state_indices.defined()) {
+        copy_tensor_async(persistent_linear_state_indices_.slice(
+                              /*dim=*/0,
+                              /*start=*/0,
+                              /*end=*/linear_copy_len),
+                          params.embedding.linear_state_indices.slice(
+                              /*dim=*/0,
+                              /*start=*/0,
+                              /*end=*/linear_copy_len),
+                          metadata_stream,
+                          decode_scalar_raw_metadata_copy);
+      } else if (!skip_linear_state_copy) {
         persistent_linear_state_indices_
             .slice(/*dim=*/0, /*start=*/0, /*end=*/linear_copy_len)
             .copy_(torch::tensor(params.embedding.linear_state_ids, torch::kInt)
@@ -735,31 +986,109 @@ std::optional<ModelInputParams> GraphPersistentParam::update(
                        .slice(/*dim=*/0, /*start=*/0, /*end=*/linear_copy_len),
                    /*non_blocking=*/true);
       }
+      if (!skip_linear_state_copy && stable_decode_metadata) {
+        cached_linear_state_values_.assign(
+            params.embedding.linear_state_ids.begin(),
+            params.embedding.linear_state_ids.begin() + linear_copy_len);
+      }
     }
     if (padded_batch_size > actual_batch_size) {
-      persistent_linear_state_indices_
-          .slice(/*dim=*/0,
-                 /*start=*/actual_batch_size,
-                 /*end=*/padded_batch_size)
-          .fill_(kPaddingLinearStateId);
+      if (cache_decode_padding_tail) {
+        const int64_t repair_end = std::min<int64_t>(
+            cached_linear_state_active_rows_, padded_batch_size);
+        if (repair_end > actual_batch_size) {
+          persistent_linear_state_indices_
+              .slice(/*dim=*/0, /*start=*/actual_batch_size, /*end=*/repair_end)
+              .fill_(kPaddingLinearStateId);
+        }
+      } else {
+        persistent_linear_state_indices_
+            .slice(/*dim=*/0,
+                   /*start=*/actual_batch_size,
+                   /*end=*/padded_batch_size)
+            .fill_(kPaddingLinearStateId);
+      }
+    }
+    if (cache_decode_padding_tail) {
+      cached_linear_state_active_rows_ = linear_copy_len;
     }
   }
   if (params.num_accepted_tokens.defined()) {
-    persistent_num_accepted_tokens_
-        .slice(/*dim=*/0, /*start=*/0, /*end=*/actual_batch_size)
-        .copy_(params.num_accepted_tokens.slice(
-                   /*dim=*/0, /*start=*/0, /*end=*/actual_batch_size),
-               /*non_blocking=*/true);
+    const bool skip_num_accepted_copy =
+        stable_decode_metadata && is_decode && !params.is_spec_verify &&
+        cached_num_accepted_active_rows_ == actual_batch_size;
+    if (!skip_num_accepted_copy) {
+      copy_tensor_async(persistent_num_accepted_tokens_.slice(
+                            /*dim=*/0,
+                            /*start=*/0,
+                            /*end=*/actual_batch_size),
+                        params.num_accepted_tokens.slice(
+                            /*dim=*/0, /*start=*/0, /*end=*/actual_batch_size),
+                        metadata_stream,
+                        decode_scalar_raw_metadata_copy);
+    }
     if (padded_batch_size > actual_batch_size) {
-      persistent_num_accepted_tokens_
-          .slice(/*dim=*/0,
-                 /*start=*/actual_batch_size,
-                 /*end=*/padded_batch_size)
-          .fill_(1);
+      if (cache_decode_padding_tail) {
+        const int64_t repair_end = std::min<int64_t>(
+            cached_num_accepted_active_rows_, padded_batch_size);
+        if (repair_end > actual_batch_size) {
+          persistent_num_accepted_tokens_
+              .slice(/*dim=*/0, /*start=*/actual_batch_size, /*end=*/repair_end)
+              .fill_(1);
+        }
+      } else {
+        persistent_num_accepted_tokens_
+            .slice(/*dim=*/0,
+                   /*start=*/actual_batch_size,
+                   /*end=*/padded_batch_size)
+            .fill_(1);
+      }
+    }
+    if (cache_decode_padding_tail) {
+      cached_num_accepted_active_rows_ = actual_batch_size;
     }
   }
 
-  if (persistent_block_tables_default_.defined() &&
+  torch::Tensor block_table_host_for_cache;
+  bool block_table_cache_hit = false;
+  const bool can_use_block_table_cache =
+      is_decode && !return_capture_params &&
+      graph_block_table_cache_enabled() &&
+      params.attention.host.block_tables.defined() &&
+      params.attention.host.block_tables.device().is_cpu() &&
+      params.attention.host.block_tables.dim() == 2 &&
+      params.attention.host.block_tables.scalar_type() == torch::kInt &&
+      actual_seq_len_rows > 0;
+  if (can_use_block_table_cache) {
+    block_table_host_for_cache =
+        params.attention.host.block_tables.contiguous();
+    const int64_t host_rows = block_table_host_for_cache.size(0);
+    const int64_t host_cols = block_table_host_for_cache.size(1);
+    const int64_t cache_rows =
+        std::min<int64_t>(actual_seq_len_rows, host_rows);
+    const int64_t value_count = cache_rows * host_cols;
+    if (cache_rows == cached_block_table_rows_ &&
+        host_cols == cached_block_table_cols_ &&
+        padded_batch_size == cached_block_table_padded_rows_ &&
+        value_count ==
+            static_cast<int64_t>(cached_block_table_values_.size()) &&
+        value_count > 0) {
+      const auto* current_values =
+          block_table_host_for_cache.data_ptr<int32_t>();
+      block_table_cache_hit =
+          std::memcmp(current_values,
+                      cached_block_table_values_.data(),
+                      static_cast<size_t>(value_count) * sizeof(int32_t)) == 0;
+    }
+  }
+  const bool can_skip_block_table_default =
+      block_table_cache_hit ||
+      (incremental_metadata && params.attention.device.block_tables.defined() &&
+       params.attention.device.block_tables.dim() >= 2 &&
+       params.attention.device.block_tables.size(1) ==
+           persistent_block_tables_.size(1));
+  if (!can_skip_block_table_default &&
+      persistent_block_tables_default_.defined() &&
       persistent_block_tables_default_.sizes() ==
           persistent_block_tables_.sizes()) {
     persistent_block_tables_.copy_(persistent_block_tables_default_,
@@ -773,18 +1102,32 @@ std::optional<ModelInputParams> GraphPersistentParam::update(
         actual_seq_len_rows, params.attention.device.block_tables.size(0));
     const int64_t actual_block_table_len =
         params.attention.device.block_tables.size(1);
-    if (block_rows_to_copy > 0 && actual_block_table_len > 0) {
+    if (block_rows_to_copy > 0 && actual_block_table_len > 0 &&
+        !block_table_cache_hit) {
       auto slice_persistent_block_tables =
           persistent_block_tables_
               .slice(/*dim=*/0, /*start=*/0, /*end=*/block_rows_to_copy)
               .slice(/*dim=*/1, /*start=*/0, /*end=*/actual_block_table_len);
-      slice_persistent_block_tables.copy_(
-          params.attention.device.block_tables.slice(
-              /*dim=*/0, /*start=*/0, /*end=*/block_rows_to_copy),
-          /*non_blocking=*/true);
+      copy_tensor_async(slice_persistent_block_tables,
+                        params.attention.device.block_tables.slice(
+                            /*dim=*/0,
+                            /*start=*/0,
+                            /*end=*/block_rows_to_copy),
+                        metadata_stream,
+                        /*use_raw_copy=*/false);
+      if (can_use_block_table_cache && block_table_host_for_cache.defined() &&
+          block_table_host_for_cache.size(0) >= block_rows_to_copy &&
+          block_table_host_for_cache.size(1) == actual_block_table_len) {
+        const int64_t value_count = block_rows_to_copy * actual_block_table_len;
+        const auto* values = block_table_host_for_cache.data_ptr<int32_t>();
+        cached_block_table_values_.assign(values, values + value_count);
+        cached_block_table_rows_ = block_rows_to_copy;
+        cached_block_table_cols_ = actual_block_table_len;
+        cached_block_table_padded_rows_ = padded_batch_size;
+      }
     }
   }
-  if (actual_seq_len_rows < padded_batch_size) {
+  if (actual_seq_len_rows < padded_batch_size && !block_table_cache_hit) {
     zero_tensor_tail(
         persistent_block_tables_, actual_seq_len_rows, padded_batch_size);
   }
@@ -809,17 +1152,37 @@ std::optional<ModelInputParams> GraphPersistentParam::update(
         .slice(/*dim=*/0, /*start=*/0, /*end=*/embedding_tokens)
         .copy_(embedding, /*non_blocking=*/true);
   }
-  if (q_cu_seq_lens_default_.defined() &&
-      q_cu_seq_lens_default_.sizes() == q_cu_seq_lens_.sizes()) {
-    q_cu_seq_lens_.copy_(q_cu_seq_lens_default_, /*non_blocking=*/true);
-  }
+  bool skip_q_cu_seq_lens_copy = false;
   const bool has_q_cu = params.attention.device.q_cu_seq_lens.defined() &&
                         params.attention.device.q_cu_seq_lens.dim() >= 1;
   const int64_t q_cu_size =
       (has_q_cu && params.attention.device.q_cu_seq_lens.numel() > 0)
           ? params.attention.device.q_cu_seq_lens.size(0)
           : 0;
-  if (has_q_cu && q_cu_size > 0) {
+  if (stable_decode_metadata && has_q_cu && q_cu_size > 0 &&
+      params.attention.host.q_cu_seq_lens.size() >=
+          static_cast<size_t>(q_cu_size)) {
+    skip_q_cu_seq_lens_copy = true;
+    const bool decode_leading_zero_q_cu =
+        is_decode && !is_chunked_prefill &&
+        q_cu_size == actual_seq_len_rows + 1 &&
+        params.attention.host.q_cu_seq_lens[0] == 0;
+    for (int64_t i = 0; i < q_cu_size; ++i) {
+      const int32_t expected = decode_leading_zero_q_cu
+                                   ? static_cast<int32_t>(i)
+                                   : static_cast<int32_t>(i + 1);
+      if (params.attention.host.q_cu_seq_lens[static_cast<size_t>(i)] !=
+          expected) {
+        skip_q_cu_seq_lens_copy = false;
+        break;
+      }
+    }
+  }
+  if (!skip_q_cu_seq_lens_copy && q_cu_seq_lens_default_.defined() &&
+      q_cu_seq_lens_default_.sizes() == q_cu_seq_lens_.sizes()) {
+    q_cu_seq_lens_.copy_(q_cu_seq_lens_default_, /*non_blocking=*/true);
+  }
+  if (has_q_cu && q_cu_size > 0 && !skip_q_cu_seq_lens_copy) {
     const bool use_qwen3_5_query_start_loc =
         is_qwen3_5_model_type(args_.model_type());
     const bool input_has_leading_zero =
@@ -831,19 +1194,27 @@ std::optional<ModelInputParams> GraphPersistentParam::update(
         << "q_cu_seq_lens does not have enough entries for ACL graph execution";
     if (use_qwen3_5_query_start_loc && !input_has_leading_zero) {
       q_cu_seq_lens_.slice(/*dim=*/0, /*start=*/0, /*end=*/1).zero_();
-      q_cu_seq_lens_
-          .slice(/*dim=*/0, /*start=*/1, /*end=*/actual_seq_len_rows + 1)
-          .copy_(params.attention.device.q_cu_seq_lens.slice(
-                     /*dim=*/0, /*start=*/0, /*end=*/actual_seq_len_rows),
-                 /*non_blocking=*/true);
+      copy_tensor_async(q_cu_seq_lens_.slice(
+                            /*dim=*/0,
+                            /*start=*/1,
+                            /*end=*/actual_seq_len_rows + 1),
+                        params.attention.device.q_cu_seq_lens.slice(
+                            /*dim=*/0,
+                            /*start=*/0,
+                            /*end=*/actual_seq_len_rows),
+                        metadata_stream,
+                        decode_scalar_raw_metadata_copy);
     } else {
-      q_cu_seq_lens_
-          .slice(/*dim=*/0,
-                 /*start=*/0,
-                 /*end=*/required_q_cu_seq_lens)
-          .copy_(params.attention.device.q_cu_seq_lens.slice(
-                     /*dim=*/0, /*start=*/0, /*end=*/required_q_cu_seq_lens),
-                 /*non_blocking=*/true);
+      copy_tensor_async(q_cu_seq_lens_.slice(
+                            /*dim=*/0,
+                            /*start=*/0,
+                            /*end=*/required_q_cu_seq_lens),
+                        params.attention.device.q_cu_seq_lens.slice(
+                            /*dim=*/0,
+                            /*start=*/0,
+                            /*end=*/required_q_cu_seq_lens),
+                        metadata_stream,
+                        decode_scalar_raw_metadata_copy);
     }
     if (padded_batch_size > actual_seq_len_rows) {
       int32_t offset = static_cast<int32_t>(actual_num_tokens);
@@ -935,12 +1306,27 @@ std::optional<ModelInputParams> GraphPersistentParam::update(
             persistent_block_tables(static_cast<uint32_t>(padded_batch_size));
         plan_params.attention.device.block_tables = plan_block_tables;
       }
-      plan_paged_attention_tiling(persistent_tokens(padded_num_tokens),
-                                  k_cache,
-                                  v_cache,
-                                  plan_block_tables,
-                                  plan_params,
-                                  stream);
+      const int64_t block_table_cols =
+          plan_block_tables.defined() && plan_block_tables.dim() >= 2
+              ? plan_block_tables.size(1)
+              : 0;
+      const bool cache_hit =
+          is_decode && !return_capture_params &&
+          !use_expanded_spec_decode_attention &&
+          try_replay_cached_paged_attention_tiling(padded_batch_size,
+                                                   padded_num_tokens,
+                                                   block_table_cols,
+                                                   padded_kv_seq_lens_vec,
+                                                   padded_q_seq_lens_vec,
+                                                   stream);
+      if (!cache_hit) {
+        plan_paged_attention_tiling(persistent_tokens(padded_num_tokens),
+                                    k_cache,
+                                    v_cache,
+                                    plan_block_tables,
+                                    plan_params,
+                                    stream);
+      }
     }
   }
 
@@ -1380,6 +1766,16 @@ void GraphPersistentParam::plan_paged_attention_tiling(
     parse_pa_host_tiling_buffer(tiling_buffer_info.tilingBuffer,
                                 tiling_buffer_info.tilingBufferSize);
   }
+  const int64_t block_table_cols =
+      block_tables.defined() && block_tables.dim() >= 2 ? block_tables.size(1)
+                                                        : 0;
+  update_paged_attention_tiling_cache(input_params.meta.num_sequences,
+                                      tokens.size(0),
+                                      block_table_cols,
+                                      input_params.attention.host.kv_seq_lens,
+                                      input_params.attention.host.q_seq_lens,
+                                      tiling_buffer_info.tilingBuffer,
+                                      tiling_buffer_info.tilingBufferSize);
   aclError acl_status =
       aclrtMemcpyAsync(tiling_data_.data_ptr(),
                        tiling_data_.numel() * sizeof(uint32_t),
@@ -1388,6 +1784,77 @@ void GraphPersistentParam::plan_paged_attention_tiling(
                        ACL_MEMCPY_HOST_TO_DEVICE,
                        stream);
   CHECK_EQ(acl_status, ACL_SUCCESS) << "Failed to copy tiling buffer to device";
+}
+
+bool GraphPersistentParam::try_replay_cached_paged_attention_tiling(
+    int64_t padded_batch_size,
+    int64_t padded_num_tokens,
+    int64_t block_table_cols,
+    const std::vector<int32_t>& kv_seq_lens,
+    const std::vector<int32_t>& q_seq_lens,
+    aclrtStream stream) {
+  if (!graph_pa_tiling_shape_cache_enabled() || tiling_cache_entries_.empty()) {
+    return false;
+  }
+  for (const auto& entry : tiling_cache_entries_) {
+    if (padded_batch_size != entry.batch_size ||
+        padded_num_tokens != entry.num_tokens ||
+        block_table_cols != entry.block_table_cols ||
+        kv_seq_lens != entry.kv_seq_lens || q_seq_lens != entry.q_seq_lens) {
+      continue;
+    }
+    CHECK_LE(entry.buffer.size(),
+             static_cast<size_t>(tiling_data_.numel()) * sizeof(uint32_t))
+        << "cached paged attention tiling buffer is larger than device buffer";
+    const aclError status =
+        aclrtMemcpyAsync(tiling_data_.data_ptr(),
+                         tiling_data_.numel() * sizeof(uint32_t),
+                         entry.buffer.data(),
+                         entry.buffer.size(),
+                         ACL_MEMCPY_HOST_TO_DEVICE,
+                         stream);
+    CHECK_EQ(status, ACL_SUCCESS)
+        << "Failed to copy cached paged attention tiling buffer to device";
+    return true;
+  }
+  return false;
+}
+
+void GraphPersistentParam::update_paged_attention_tiling_cache(
+    int64_t padded_batch_size,
+    int64_t padded_num_tokens,
+    int64_t block_table_cols,
+    const std::vector<int32_t>& kv_seq_lens,
+    const std::vector<int32_t>& q_seq_lens,
+    const void* tiling_buffer,
+    size_t tiling_buffer_size) {
+  if (!graph_pa_tiling_shape_cache_enabled() || tiling_buffer == nullptr ||
+      tiling_buffer_size == 0) {
+    return;
+  }
+  for (auto& entry : tiling_cache_entries_) {
+    if (padded_batch_size == entry.batch_size &&
+        padded_num_tokens == entry.num_tokens &&
+        block_table_cols == entry.block_table_cols &&
+        kv_seq_lens == entry.kv_seq_lens && q_seq_lens == entry.q_seq_lens) {
+      const auto* begin = static_cast<const uint8_t*>(tiling_buffer);
+      entry.buffer.assign(begin, begin + tiling_buffer_size);
+      return;
+    }
+  }
+  constexpr size_t kMaxTilingCacheEntries = 128;
+  if (tiling_cache_entries_.size() >= kMaxTilingCacheEntries) {
+    tiling_cache_entries_.erase(tiling_cache_entries_.begin());
+  }
+  const auto* begin = static_cast<const uint8_t*>(tiling_buffer);
+  PagedAttentionTilingCacheEntry entry;
+  entry.buffer.assign(begin, begin + tiling_buffer_size);
+  entry.kv_seq_lens = kv_seq_lens;
+  entry.q_seq_lens = q_seq_lens;
+  entry.batch_size = padded_batch_size;
+  entry.num_tokens = padded_num_tokens;
+  entry.block_table_cols = block_table_cols;
+  tiling_cache_entries_.emplace_back(std::move(entry));
 }
 
 void GraphPersistentParam::update_attention_mask(

--- a/xllm/core/runtime/acl_graph_persistent_param.h
+++ b/xllm/core/runtime/acl_graph_persistent_param.h
@@ -70,6 +70,7 @@ class GraphPersistentParam final {
     }
     return persistent_tokens_;
   }
+  bool update_persistent_tokens_direct(const torch::Tensor& tokens);
   torch::Tensor persistent_positions(uint32_t actual_tokens = 0) const {
     if (actual_tokens > 0) {
       int32_t slice_dim = use_mrope_ ? 1 : 0;
@@ -189,6 +190,21 @@ class GraphPersistentParam final {
                                    const torch::Tensor& block_tables,
                                    const ModelInputParams& input_params,
                                    aclrtStream stream);
+  bool try_replay_cached_paged_attention_tiling(
+      int64_t padded_batch_size,
+      int64_t padded_num_tokens,
+      int64_t block_table_cols,
+      const std::vector<int32_t>& kv_seq_lens,
+      const std::vector<int32_t>& q_seq_lens,
+      aclrtStream stream);
+  void update_paged_attention_tiling_cache(
+      int64_t padded_batch_size,
+      int64_t padded_num_tokens,
+      int64_t block_table_cols,
+      const std::vector<int32_t>& kv_seq_lens,
+      const std::vector<int32_t>& q_seq_lens,
+      const void* tiling_buffer,
+      size_t tiling_buffer_size);
 
   std::vector<int32_t> update_expanded_spec_decode_attention(
       const ModelInputParams& input_params,
@@ -207,6 +223,13 @@ class GraphPersistentParam final {
   torch::Tensor persistent_block_tables_;
   torch::Tensor persistent_new_cache_slots_default_;
   torch::Tensor persistent_block_tables_default_;
+  int64_t cached_token_active_tokens_ = 0;
+  int64_t cached_position_active_tokens_ = 0;
+  int64_t cached_new_cache_slot_active_tokens_ = 0;
+  std::vector<int32_t> cached_block_table_values_;
+  int64_t cached_block_table_rows_ = 0;
+  int64_t cached_block_table_cols_ = 0;
+  int64_t cached_block_table_padded_rows_ = 0;
   torch::Tensor persistent_expanded_block_tables_;
   // When q_seq_lens contains values greater than 1(chunked prefill mode or
   // speculative decode mode), the mask needs to be passed to the attention
@@ -230,6 +253,9 @@ class GraphPersistentParam final {
   torch::Tensor persistent_embedding_;
   torch::Tensor persistent_linear_state_indices_;
   torch::Tensor persistent_num_accepted_tokens_;
+  std::vector<int32_t> cached_linear_state_values_;
+  int64_t cached_linear_state_active_rows_ = 0;
+  int64_t cached_num_accepted_active_rows_ = 0;
 
   // for mrope (multimodal rotary position embedding)
   bool use_mrope_ = false;
@@ -244,6 +270,15 @@ class GraphPersistentParam final {
 
   // Persistent paged attention tiling tensor on device
   torch::Tensor tiling_data_;
+  struct PagedAttentionTilingCacheEntry {
+    std::vector<uint8_t> buffer;
+    std::vector<int32_t> kv_seq_lens;
+    std::vector<int32_t> q_seq_lens;
+    int64_t batch_size = 0;
+    int64_t num_tokens = 0;
+    int64_t block_table_cols = 0;
+  };
+  std::vector<PagedAttentionTilingCacheEntry> tiling_cache_entries_;
 
   // Cached attention parameters
   int32_t num_head_;

--- a/xllm/core/runtime/executor.cpp
+++ b/xllm/core/runtime/executor.cpp
@@ -43,4 +43,9 @@ ModelOutput Executor::forward(const torch::Tensor& tokens,
   return impl_->run(tokens, positions, kv_caches, params);
 }
 
+bool Executor::try_update_graph_input_tokens(ForwardInput& input,
+                                             const torch::Tensor& next_tokens) {
+  return impl_->try_update_graph_input_tokens(input, next_tokens);
+}
+
 }  // namespace xllm

--- a/xllm/core/runtime/executor.h
+++ b/xllm/core/runtime/executor.h
@@ -46,6 +46,9 @@ class Executor final {
                       std::vector<KVCache>& kv_caches,
                       const ModelInputParams& params);
 
+  bool try_update_graph_input_tokens(ForwardInput& input,
+                                     const torch::Tensor& next_tokens);
+
  private:
   std::unique_ptr<ExecutorImpl> impl_;
 };

--- a/xllm/core/runtime/executor_impl.h
+++ b/xllm/core/runtime/executor_impl.h
@@ -43,6 +43,13 @@ class ExecutorImpl {
                           const torch::Tensor& positions,
                           std::vector<KVCache>& kv_caches,
                           const ModelInputParams& params) = 0;
+
+  virtual bool try_update_graph_input_tokens(ForwardInput& input,
+                                             const torch::Tensor& next_tokens) {
+    UNUSED_PARAMETER(input);
+    UNUSED_PARAMETER(next_tokens);
+    return false;
+  }
 };
 
 }  // namespace xllm

--- a/xllm/core/runtime/forward_params.h
+++ b/xllm/core/runtime/forward_params.h
@@ -908,6 +908,10 @@ struct ForwardOutput {
   // Device-side readiness dependency for no-sync outputs. This local runtime
   // handle is intentionally not included in proto or shared-memory transport.
   StreamEventPtr ready_event;
+  // Optional schedule-overlap fast path: next_tokens copied to pinned host
+  // memory on a side stream before GetLastStepResult asks for host output.
+  torch::Tensor async_host_next_tokens;
+  StreamEventPtr async_host_next_tokens_ready_event;
   torch::Tensor logits;
   torch::Tensor embedding;
 

--- a/xllm/core/runtime/llm_worker_impl.cpp
+++ b/xllm/core/runtime/llm_worker_impl.cpp
@@ -21,11 +21,20 @@ limitations under the License.
 #include <glog/logging.h>
 #include <torch/torch.h>
 
+#include <cstdlib>
 #include <memory>
 #include <optional>
+#include <string>
 #include <utility>
+#include <vector>
+
+#if defined(USE_NPU)
+#include <acl/acl.h>
+#include <torch_npu/torch_npu.h>
+#endif
 
 #include "common/device_monitor.h"
+#include "common/macros.h"
 #include "common/metrics.h"
 #include "common/types.h"
 #include "core/common/global_flags.h"
@@ -52,6 +61,50 @@ void wait_input_ready_events(const ForwardInput& input, const Stream& stream) {
       << "failed to wait ForwardInput metadata ready event";
 }
 
+bool async_direct_next_token_d2h_enabled() {
+  const char* env = std::getenv("XLLM_ENABLE_ASYNC_DIRECT_NEXT_TOKEN_D2H");
+  return env != nullptr && std::string(env) == "1";
+}
+
+#if defined(USE_NPU)
+class AsyncNextTokenD2HCopyStream {
+ public:
+  AsyncNextTokenD2HCopyStream() {
+    CHECK_ACL_SUCCESS(aclrtCreateStream(&stream_),
+                      "aclrtCreateStream for async next-token D2H");
+    events_.resize(kRingSize, nullptr);
+    for (auto& event : events_) {
+      CHECK_ACL_SUCCESS(aclrtCreateEventWithFlag(&event, ACL_EVENT_SYNC),
+                        "aclrtCreateEventWithFlag for async next-token D2H");
+    }
+  }
+
+  ~AsyncNextTokenD2HCopyStream() {
+    for (auto event : events_) {
+      if (event != nullptr) {
+        aclrtDestroyEvent(event);
+      }
+    }
+    if (stream_ != nullptr) {
+      aclrtDestroyStream(stream_);
+    }
+  }
+
+  aclrtStream get() const { return stream_; }
+
+  aclrtEvent next_event() {
+    const size_t index = next_event_index_++ % events_.size();
+    return events_[index];
+  }
+
+ private:
+  static constexpr size_t kRingSize = 64;
+  aclrtStream stream_ = nullptr;
+  size_t next_event_index_ = 0;
+  std::vector<aclrtEvent> events_;
+};
+#endif
+
 StreamEventPtr record_current_stream_event(const Device& device) {
   std::unique_ptr<Stream> stream = device.current_stream();
   StreamEventPtr event = stream->record_event();
@@ -60,6 +113,91 @@ StreamEventPtr record_current_stream_event(const Device& device) {
   }
   return event;
 }
+
+#if defined(USE_NPU)
+bool can_async_copy_next_tokens_to_host(const ForwardOutput& output) {
+  const auto& sample_output = output.sample_output;
+  const auto& beam_output = output.beam_search_output;
+  return async_direct_next_token_d2h_enabled() &&
+         sample_output.next_tokens.defined() &&
+         sample_output.next_tokens.is_contiguous() &&
+         sample_output.next_tokens.device().is_privateuseone() &&
+         (sample_output.next_tokens.scalar_type() == torch::kInt64 ||
+          sample_output.next_tokens.scalar_type() == torch::kInt32) &&
+         (!sample_output.logprobs.defined() ||
+          sample_output.logprobs.numel() == 0) &&
+         (!sample_output.top_tokens.defined() ||
+          sample_output.top_tokens.numel() == 0) &&
+         (!sample_output.top_logprobs.defined() ||
+          sample_output.top_logprobs.numel() == 0) &&
+         sample_output.embeddings.numel() == 0 &&
+         sample_output.mm_embeddings.empty() &&
+         output.dit_forward_output.tensors.empty() &&
+         (!output.expert_load_data.defined() ||
+          output.expert_load_data.numel() == 0) &&
+         (!beam_output.src_seq_idxes.defined() ||
+          beam_output.src_seq_idxes.numel() == 0) &&
+         (!beam_output.out_tokens.defined() ||
+          beam_output.out_tokens.numel() == 0) &&
+         (!beam_output.out_logprobs.defined() ||
+          beam_output.out_logprobs.numel() == 0) &&
+         !::xllm::EPLBConfig::get_instance().enable_eplb();
+}
+
+torch::Tensor allocate_async_host_next_tokens(
+    const torch::Tensor& device_tokens) {
+  static thread_local std::vector<torch::Tensor> host_token_ring;
+  static thread_local size_t next_host_token_index = 0;
+  constexpr size_t kHostTokenRingSize = 64;
+  if (host_token_ring.empty()) {
+    host_token_ring.resize(kHostTokenRingSize);
+  }
+  torch::Tensor& host_tokens =
+      host_token_ring[next_host_token_index++ % host_token_ring.size()];
+  if (!host_tokens.defined() || host_tokens.sizes() != device_tokens.sizes() ||
+      host_tokens.scalar_type() != device_tokens.scalar_type()) {
+    host_tokens = torch::empty(device_tokens.sizes(),
+                               torch::TensorOptions()
+                                   .device(torch::kCPU)
+                                   .dtype(device_tokens.scalar_type())
+                                   .pinned_memory(true));
+  }
+  return host_tokens;
+}
+
+void maybe_start_async_next_token_d2h(ForwardOutput& output) {
+  if (!can_async_copy_next_tokens_to_host(output) ||
+      output.ready_event == nullptr) {
+    return;
+  }
+  const torch::Tensor& device_tokens = output.sample_output.next_tokens;
+  torch::Tensor host_tokens = allocate_async_host_next_tokens(device_tokens);
+
+  static thread_local AsyncNextTokenD2HCopyStream copy_stream;
+  aclrtStream stream = copy_stream.get();
+  CHECK_ACL_SUCCESS(
+      aclrtStreamWaitEvent(stream, output.ready_event->npu_event()),
+      "aclrtStreamWaitEvent for async next-token D2H");
+  const size_t bytes = static_cast<size_t>(device_tokens.numel()) *
+                       static_cast<size_t>(device_tokens.element_size());
+  CHECK_ACL_SUCCESS(aclrtMemcpyAsync(host_tokens.data_ptr(),
+                                     bytes,
+                                     device_tokens.const_data_ptr(),
+                                     bytes,
+                                     ACL_MEMCPY_DEVICE_TO_HOST,
+                                     stream),
+                    "aclrtMemcpyAsync for async next-token D2H");
+  output.async_host_next_tokens = host_tokens;
+  aclrtEvent done_event = copy_stream.next_event();
+  CHECK_ACL_SUCCESS(aclrtRecordEvent(done_event, stream),
+                    "aclrtRecordEvent for async next-token D2H");
+  output.async_host_next_tokens_ready_event =
+      std::make_shared<StreamEvent>(done_event, /*owns_event=*/false);
+  LOG_FIRST_N(WARNING, 1)
+      << "XLLM_ENABLE_ASYNC_DIRECT_NEXT_TOKEN_D2H enabled: pre-copy "
+         "schedule-overlap next_tokens to pinned host memory";
+}
+#endif
 
 }  // namespace
 
@@ -195,8 +333,10 @@ ForwardInput
 LLMWorkerImpl::update_input_by_last_step_output_for_schedule_overlap(
     ForwardInput& input) {
   c10::StreamGuard stream_guard = compute_stream_->set_stream_guard();
-  CHECK(compute_stream_->wait_event(last_step_output_.ready_event))
-      << "failed to wait last step output ready event";
+  // step_for_schedule_overlap records last_step_output_.ready_event on this
+  // same compute_stream_.  The stream order already guarantees that the token
+  // replacement below is queued after the previous step's sampling kernels, so
+  // an extra StreamWaitEvent here only adds host/runtime overhead.
   return update_input_by_last_step_output(input);
 }
 
@@ -362,7 +502,12 @@ std::optional<ForwardOutput> LLMWorkerImpl::step_internal(
   if (sync_policy == ForwardSyncPolicy::NO_SYNC) {
     output.retained_input = std::make_shared<ForwardInput>(input);
     if (enable_schedule_overlap()) {
+#if defined(USE_NPU)
       output.ready_event = record_current_stream_event(device_);
+      maybe_start_async_next_token_d2h(output);
+#else
+      output.ready_event = record_current_stream_event(device_);
+#endif
     }
     return output;
   }

--- a/xllm/core/runtime/worker_impl.cpp
+++ b/xllm/core/runtime/worker_impl.cpp
@@ -515,8 +515,11 @@ void WorkerImpl::update_last_step_output(
 ForwardInput WorkerImpl::update_input_by_last_step_output(
     ForwardInput& inputs) {
 #if defined(USE_NPU)
-  xllm::kernel::npu::replace_token(inputs.token_ids,
-                                   last_step_output_.sample_output.next_tokens);
+  auto& next_tokens = last_step_output_.sample_output.next_tokens;
+  if (model_executor_->try_update_graph_input_tokens(inputs, next_tokens)) {
+    return inputs;
+  }
+  xllm::kernel::npu::replace_token(inputs.token_ids, next_tokens);
 #else
   auto& flatten_tokens = inputs.token_ids;
   auto neg_mask = (flatten_tokens < 0);


### PR DESCRIPTION
### What
This PR reduces decode-side host/runtime overhead for greedy generation on NPU.

Changes:
- Add a greedy fast path in `Sampler::forward` for `temperature=0`, no `logprobs`, and no speculative decoding. This directly uses `argmax` and skips unnecessary top-k/top-p/softmax post-processing.
- Add fast paths in `replace_token`:
  - same shape/dtype/device/contiguous tensors use async D2D copy;
  - int64 source to int32 destination uses `aclnnCast`.
  These avoid the heavier generic replace-token path for common decode token updates.
- Remove a redundant same-stream wait in schedule-overlap decode. The previous step output event is recorded on the same compute stream, so stream ordering already guarantees correctness before token replacement.

### Why
For Qwen3-1.7B greedy decode, profiling showed decode token post-processing and token replacement still introduce repeated host/runtime work between decode steps. These changes keep the same semantics while reducing unnecessary kernel/API scheduling overhead.

### Validation
Workload: Qwen3-1.7B, single NPU, input about 5k tokens, output 50 tokens, `temperature=0`, `top_p=1`, streaming, concurrency 1, evalscope with warmup.

Performance:
- Baseline TPOT: 6.00 ms, decode TPS: 166.11 tok/s
- This PR TPOT: 5.69 ms, decode TPS: 175.75 tok/s
- TPOT improvement: about 5.2%
- Decode TPS improvement: about 5.8%

Profiling:
- Greedy path no longer shows TopK/TopP/Softmax as post-processing hotspots.
- Remaining main costs are model compute and paged attention setup.
- Profiling output: `/home/g00510989/xllm/runs/20260604_qwen3_1_7b_single_npu/profiling/qwen3_1_7b_decode_5k_50_opt_v30_common_only_card15_dynamic_20260604_193411/PROF_000001_20260604193428376_GPCDCNMINPKERAGC/mindstudio_profiler_output`

Correctness:
- Greedy smoke request returned normal Chinese output without garbled text.
- Profiling warmup + 3 formal 5k/50 requests all completed successfully.

Build:
- `python setup.py build --device npu` completed successfully locally.