### PR TITLE
bugfix: fix pipeline_longcat_image_edit.h compile fail on cuda device.

### DIFF
--- a/xllm/models/dit/pipelines/pipeline_longcat_image_edit.h
+++ b/xllm/models/dit/pipelines/pipeline_longcat_image_edit.h
@@ -401,11 +401,16 @@ class LongCatImageEditPipelineImpl : public torch::nn::Module {
     }
     std::vector<torch::Tensor> pixel_values_list;
     std::vector<torch::Tensor> image_grid_thw_list;
-    CHECK(vl_image_processor_.process_image(
-        {img}, pixel_values_list, image_grid_thw_list))
+
+    std::vector<MMDataItem> mm_items;
+
+    CHECK(vl_image_processor_.process({img}, mm_items))
         << "VL image processor failed";
-    torch::Tensor pixel_values = pixel_values_list[0];
-    torch::Tensor image_grid_thw = image_grid_thw_list[0];
+
+    torch::Tensor pixel_values =
+        mm_items[0].get<torch::Tensor>("pixel_values").value();
+    torch::Tensor image_grid_thw =
+        mm_items[0].get<torch::Tensor>("image_grid_thw").value();
 
     int64_t num_image_tokens =
         image_grid_thw.prod().item<int64_t>() / merge_length;
@@ -528,11 +533,13 @@ class LongCatImageEditPipelineImpl : public torch::nn::Module {
 
     torch::Tensor tokens_flat = input_ids.view({-1});
     torch::Tensor positions_2d = build_qwen2_5_vl_mrope_positions(
-        input_ids, attention_mask, *image_grid_thw);
+        input_ids, attention_mask, image_grid_thw);
     torch::Tensor positions_3d =
         positions_2d.view({3, batch_size, total_seq_len}).to(torch::kLong);
 
     std::vector<KVCache> kv_caches(text_encoder_args.n_layers());
+    MMData mm_data;
+    mm_data.set(MMType::IMAGE, std::move(mm_items));
     std::vector<MMData> mm_data_list(static_cast<size_t>(batch_size), mm_data);
     MMBatchData mm_batch(std::move(mm_data_list));
     ModelInputParams input_params = build_longcat_input_params(


### PR DESCRIPTION
## Description

 fix pipeline_longcat_image_edit.h compile fail on cuda device.

## Related Issues

<!-- Link related issues here. Use "Fixes #123" when this PR closes an issue. -->

## Change Type

- [x] Bug fix
- [ ] New feature
- [ ] Performance improvement
- [ ] Refactor
- [ ] Documentation
- [ ] Test
- [ ] Build or CI

## Pull Request Checklist

Thank you for contributing to xLLM. Before requesting review, please make sure the following items are complete.

### PR Title and Commit Messages

- [ ] The PR title and each commit message follow the xLLM commit format: `<type>: <subject>`.

> Allowed types: feat, bugfix, docs, test, refactor, chore, style, revert, perf, model, build, release.
> The subject should use clear English, start with a verb, include at least 4 words, and end with `.`.

### Pre-commit Checks

- [x] I have installed `pre-commit` by running `pip install pre-commit` or an equivalent command.
- [x] I have installed the hooks with `pre-commit install`.
- [x] I have run `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

### Self Review

- [x] I have self-reviewed the code according to `.agents/skills/code-review/references/custom-code-style.md`, especially code written or assisted by AI.
- [x] I have rebased this PR onto the latest `main` branch.

### Build and Test Coverage

- [ ] Tests have been added or updated as needed.
- [ ] CUDA: `python setup.py build test` has passed on a CUDA machine.
- [x] NPU: `python setup.py build test` has passed on an NPU machine.
- [ ] MLU: `python setup.py build test` has passed on an MLU machine.

## Reviewer Notes

<!-- Optional: anything reviewers should focus on, known risks, follow-ups, or validation gaps. -->
