### PR TITLE
build: clean submodule untracked files before ci build.

### DIFF
--- a/.github/workflows/build_x86_64_cuda.yaml
+++ b/.github/workflows/build_x86_64_cuda.yaml
@@ -114,6 +114,9 @@ jobs:
       with:
         submodules: true
 
+    - name: Clean submodules
+      run: git submodule foreach --recursive git clean -ffdx
+
     - name: Build
       if: ${{ success() }}
       timeout-minutes: 60

--- a/.github/workflows/build_x86_64_npu.yaml
+++ b/.github/workflows/build_x86_64_npu.yaml
@@ -125,6 +125,9 @@ jobs:
         clean: true
         submodules: recursive
 
+    - name: Clean submodules
+      run: git submodule foreach --recursive git clean -ffdx
+
     - name: Build
       if: ${{ success() }}
       timeout-minutes: 60

--- a/setup.py
+++ b/setup.py
@@ -85,16 +85,23 @@ def _stage_triton_npu_runtime_binaries(base_dir: str, extdir: str, device: str) 
     if device != "npu":
         return
 
-    source_dir = os.path.join(
-        base_dir,
-        "third_party",
-        "torch_npu_ops",
-        "triton_npu",
-        "binary",
-    )
+    env_path = os.environ.get("TRITON_BINARY_PATH")
+    if env_path and os.path.isdir(env_path):
+        source_dir = env_path
+    else:
+        source_dir = os.path.join(
+            get_cmake_dir(),
+            "third_party",
+            "torch_npu_ops",
+            "triton_npu",
+            "binary",
+        )
+
     if not os.path.isdir(source_dir):
         raise RuntimeError(
-            f"Triton NPU binary directory does not exist: {source_dir}"
+            f"Triton NPU binary directory does not exist: {source_dir}\n"
+            "Hint: Ensure the CMake build completed successfully, or set "
+            "TRITON_BINARY_PATH to a directory containing pre-built binaries."
         )
 
     dest_dir = os.path.join(extdir, "triton_npu", "binary")


### PR DESCRIPTION
## Description

在 NPU 和 CUDA CI workflow 的 Checkout 步骤后增加 `git submodule foreach --recursive git clean -ffdx`，清理子模块内残留的 untracked/ignored 文件。

同时修复 `torch_npu_ops` 的 Triton NPU binary 构建产物问题：将 binary 默认输出从 submodule 源码树迁移到 CMake build tree，使 `git submodule clean` 不再导致 NPU 构建失败。

### 问题

`actions/checkout@v4` 的 `git submodule update --init --recursive --force` 只重置 tracked 文件到 pinned commit，不清理 untracked/ignored 文件。当不同 PR 分支 pin 不同版本的 xllm_ops 子模块时，前一次构建在子模块源码树内留下的目录（如 `build/`、`output/`、`build_out/`、`vllm_ascend/`）会残留到下一次 run。xllm_ops cmake 的 `op_add_subdirectory` 使用 `file(GLOB)` 扫描算子目录，会将这些残留目录误识别为算子目录并尝试 `add_subdirectory`，因缺少 `CMakeLists.txt` 导致配置失败。

此外，`torch_npu_ops` 的 Triton NPU binary（`.npubin`/`.json`）原先生成到 `third_party/torch_npu_ops/triton_npu/binary/`（submodule 源码树内）。`git submodule clean` 会删除这些产物，导致后续 NPU 构建因找不到 binary 而失败。

### 根因追溯

以 [run 26954709149](https://github.com/jd-opensource/xllm/actions/runs/26954709149/job/79621195274) 为例：
1. PR #1624（fork `JC-ut0/xllm`，分支 `ds_pro_main_merge`）的 CI 先在 runner `xllm-a2-x86-cicd` 上执行，其 xllm_ops 子模块指向 `23972b09`（重构了编译框架）。构建过程中 `build_aclnn.sh` 和内层 `build.sh` 在 `xllm_ops/xllm_ops/` 下创建了 `build/`、`output/`、`build_out/`、`vllm_ascend/` 目录。
2. 后续 CI run checkout 到 main 分支的 xllm_ops（`6aa9361`），`git submodule update --force` 只重置 tracked 文件，上述 untracked/gitignored 目录未被清理。
3. xllm_ops cmake 配置时 `file(GLOB)` 扫到这些残留目录，`add_subdirectory` 失败，导致连续多个 CI run 报错。

### Triton binary 修复

- `torch_npu_ops` 侧（依赖 PR）：默认 binary 输出改为 `CMAKE_CURRENT_BINARY_DIR`；`POST_BUILD` 改为 stamp-based custom target；`setup.py` 增加 fingerprint 缓存。
- `xllm` 侧：`setup.py` staging 源路径从 submodule 源码树改为 CMake build tree。

## Dependencies

- **torch_npu_ops**: https://gitcode.com/xLLM-AI/torch_npu_ops/pull/34

## Related Issues

N/A

## Change Type

- [ ] Bug fix
- [ ] New feature
- [ ] Performance improvement
- [ ] Refactor
- [ ] Documentation
- [ ] Test
- [x] Build or CI

## Pull Request Checklist

### PR Title and Commit Messages

- [x] The PR title and each commit message follow the xLLM commit format: `<type>: <subject>`.

### Pre-commit Checks

- [x] I have installed `pre-commit` by running `pip install pre-commit` or an equivalent command.
- [x] I have installed the hooks with `pre-commit install`.
- [x] I have run `pre-commit run --all-files` and fixed any reported issues.

### Self Review

- [x] I have self-reviewed the code according to `.agents/skills/code-review/references/custom-code-style.md`, especially code written or assisted by AI.
- [x] I have rebased this PR onto the latest `main` branch.

### Build and Test Coverage

- [ ] Tests have been added or updated as needed.
- [x] CUDA: `python setup.py build test` has passed on a CUDA machine.
- [x] NPU: `python setup.py build test` has passed on an NPU machine.
- [ ] MLU: `python setup.py build test` has passed on an MLU machine.

## Reviewer Notes

- 改动仅影响 CI workflow 和构建路径，不涉及运行时逻辑。
- `git clean -ffdx` 会删除子模块内所有 untracked 文件（包括 gitignored 的），不影响 git tracked 文件和外部构建缓存（`/export/home/npu_xllm_ops_build_cache`）。
- Triton binary 修复需要 torch_npu_ops PR 先合入，xllm 侧再更新 submodule ref。