### PR TITLE
refactor: precompute per-sequence block hashes to avoid recomputation.

### DIFF
--- a/tests/core/framework/block/block_manager_test.cpp
+++ b/tests/core/framework/block/block_manager_test.cpp
@@ -354,4 +354,96 @@ TEST(BlockManagerPoolTest, SequenceCopyDoesNotReuseSingleBlockSlot) {
   EXPECT_NE(GetSingleBlockIdOrFail(clone), GetSingleBlockIdOrFail(src));
 }
 
+namespace {
+
+// Independently compute the chained block hashes for `tokens`, mirroring
+// xxh3_128bits_hash() so we can check Sequence::update_block_hashes().
+std::vector<XXH3Key> ExpectedChain(const std::vector<int32_t>& tokens,
+                                   uint32_t block_size) {
+  const size_t n_blocks = tokens.size() / block_size;
+  std::vector<XXH3Key> hashes;
+  hashes.reserve(n_blocks);
+  const Slice<int32_t> slice(tokens);
+  for (size_t b = 0; b < n_blocks; ++b) {
+    XXH3Key key;
+    const uint8_t* pre = (b == 0) ? nullptr : hashes.back().data;
+    xxh3_128bits_hash(
+        pre, slice.slice(b * block_size, (b + 1) * block_size), key.data);
+    hashes.emplace_back(key);
+  }
+  return hashes;
+}
+
+}  // namespace
+
+// Validates the production hash builder Sequence::update_block_hashes():
+// correct chain, idempotency, and invalidation after a token rewrite.
+TEST(BlockManagerPoolTest, SequenceUpdateBlockHashes) {
+  const uint32_t block_size = 4;
+  const uint32_t n_blocks = 5;
+  std::vector<int32_t> prompt;
+  prompt.reserve(n_blocks * block_size);
+  for (uint32_t i = 0; i < n_blocks * block_size; ++i) {
+    prompt.push_back(static_cast<int32_t>(i * 7 + 1));
+  }
+
+  // Build the Sequence in-test so the sampling/stopping params outlive it.
+  RequestSamplingParam sampling_param;
+  sampling_param.beam_width = 0;
+  sampling_param.is_embeddings = false;
+  StoppingChecker stopping_checker;
+  SequenceParams params;
+  params.seq_capacity = prompt.size() + 8;
+  params.bos_token_id = 0;
+  params.request_id = "seq_block_hash_test";
+  params.sampling_param = &sampling_param;
+  params.stopping_checker = &stopping_checker;
+  IncrementalDecoder decoder(/*prompt=*/"prompt",
+                             /*num_prompt_tokens=*/prompt.size(),
+                             /*echo=*/false,
+                             /*skip_special_tokens=*/true);
+  Sequence seq(/*index=*/0,
+               prompt,
+               /*input_embedding=*/torch::Tensor(),
+               /*mm_data=*/MMData(),
+               decoder,
+               params);
+
+  const std::vector<XXH3Key> expected = ExpectedChain(prompt, block_size);
+
+  seq.update_block_hashes(block_size, BlockHasherType::TEXT);
+  ASSERT_EQ(seq.block_hashes().size(), n_blocks);
+  for (uint32_t i = 0; i < n_blocks; ++i) {
+    EXPECT_EQ(std::memcmp(seq.block_hashes()[i].data,
+                          expected[i].data,
+                          XXH3_128BITS_HASH_VALUE_LEN),
+              0);
+  }
+
+  // Idempotent: no new full block -> nothing recomputed/appended.
+  seq.update_block_hashes(block_size, BlockHasherType::TEXT);
+  EXPECT_EQ(seq.block_hashes().size(), n_blocks);
+
+  // Rewriting a token in block index 2 invalidates block 2 and everything
+  // after it; blocks 0 and 1 survive.
+  seq.update_token(2 * block_size + 1, Token(/*id=*/999999));
+  EXPECT_EQ(seq.block_hashes().size(), 2u);
+
+  // Recompute: blocks 0/1 unchanged, block 2 differs from the old chain.
+  seq.update_block_hashes(block_size, BlockHasherType::TEXT);
+  ASSERT_EQ(seq.block_hashes().size(), n_blocks);
+  EXPECT_EQ(std::memcmp(seq.block_hashes()[0].data,
+                        expected[0].data,
+                        XXH3_128BITS_HASH_VALUE_LEN),
+            0);
+  EXPECT_EQ(std::memcmp(seq.block_hashes()[1].data,
+                        expected[1].data,
+                        XXH3_128BITS_HASH_VALUE_LEN),
+            0);
+  EXPECT_NE(std::memcmp(seq.block_hashes()[2].data,
+                        expected[2].data,
+                        XXH3_128BITS_HASH_VALUE_LEN),
+            0);
+}
+
 }  // namespace xllm

--- a/tests/core/framework/prefix_cache/prefix_cache_test.cpp
+++ b/tests/core/framework/prefix_cache/prefix_cache_test.cpp
@@ -5,9 +5,45 @@
 #include <string.h>
 
 #include <iostream>
+#include <random>
+#include <unordered_map>
+#include <vector>
 
 #include "framework/block/block_manager_impl.h"
+#include "util/hash_util.h"
 namespace xllm {
+
+namespace {
+
+// Build the chained block hashes for `tokens`, matching the chain produced by
+// xxh3_128bits_hash() inside PrefixCache and Sequence::update_block_hashes().
+std::vector<XXH3Key> build_chained_hashes(const std::vector<int32_t>& tokens,
+                                          uint32_t block_size) {
+  const size_t n_blocks = tokens.size() / block_size;
+  std::vector<XXH3Key> hashes;
+  hashes.reserve(n_blocks);
+  const Slice<int32_t> slice(tokens);
+  for (size_t b = 0; b < n_blocks; ++b) {
+    XXH3Key key;
+    const uint8_t* pre = (b == 0) ? nullptr : hashes.back().data;
+    xxh3_128bits_hash(
+        pre, slice.slice(b * block_size, (b + 1) * block_size), key.data);
+    hashes.emplace_back(key);
+  }
+  return hashes;
+}
+
+std::vector<int32_t> make_random_tokens(size_t count, uint32_t seed) {
+  std::mt19937 gen(seed);
+  std::uniform_int_distribution<int32_t> dist(0, 65535);
+  std::vector<int32_t> tokens(count);
+  for (int32_t& t : tokens) {
+    t = dist(gen);
+  }
+  return tokens;
+}
+
+}  // namespace
 
 void test_basic_operation(BlockManagerImpl* block_manager,
                           PrefixCache* prefix_cache,
@@ -370,6 +406,162 @@ TEST(HashUtilTest, XXHash3) {
     EXPECT_NE(
         std::memcmp(hash_value_1, hash_value_2, XXH3_128BITS_HASH_VALUE_LEN),
         0);
+  }
+}
+
+// Validates the precompute change: match() must return identical blocks whether
+// the chained hash is precomputed (passed in) or computed on the fly. Uses a
+// long sequence and both full-hit and partial-hit (after eviction) cases.
+TEST(PrefixCacheTest, PrecomputedHashMatchesComputedMatch) {
+  const uint32_t block_size = 4;
+  const uint32_t n_blocks = 200;
+  BlockManager::Options options;
+  options.num_blocks(n_blocks + 1).block_size(block_size);
+  BlockManagerImpl block_manager(options);
+  PrefixCache prefix_cache(block_size);
+
+  std::vector<int32_t> token_ids =
+      make_random_tokens(n_blocks * block_size, /*seed=*/2025);
+  const Slice<int32_t> tokens(token_ids);
+  const std::vector<XXH3Key> hashes =
+      build_chained_hashes(token_ids, block_size);
+  const Slice<XXH3Key> hash_slice(hashes);
+
+  // Populate the cache with all blocks via the on-the-fly compute path. Scope
+  // the allocated blocks so only the prefix cache holds a reference afterwards
+  // (otherwise the blocks stay `is_shared()` and cannot be evicted below).
+  {
+    std::vector<Block> blocks = block_manager.allocate(n_blocks);
+    prefix_cache.insert(tokens, blocks);
+  }
+
+  // Full hit: precomputed and computed paths must agree. Scope the matched
+  // results too, so they do not pin the blocks as shared before eviction.
+  {
+    auto full_computed = prefix_cache.match(tokens);
+    auto full_precomputed =
+        prefix_cache.match(tokens, {}, MMData(), hash_slice);
+    ASSERT_EQ(full_computed.size(), n_blocks);
+    ASSERT_EQ(full_precomputed.size(), full_computed.size());
+    for (size_t i = 0; i < full_computed.size(); ++i) {
+      EXPECT_EQ(full_computed[i].id(), full_precomputed[i].id());
+    }
+  }
+
+  // Partial hit: evict part of the cache (suffix-first under LRU), then both
+  // paths must still agree (they early-break at the same first miss regardless
+  // of hashing strategy).
+  prefix_cache.evict(120);
+  auto partial_computed = prefix_cache.match(tokens);
+  auto partial_precomputed =
+      prefix_cache.match(tokens, {}, MMData(), hash_slice);
+  EXPECT_LT(partial_computed.size(), n_blocks);
+  EXPECT_GT(partial_computed.size(), 0u);
+  ASSERT_EQ(partial_precomputed.size(), partial_computed.size());
+  for (size_t i = 0; i < partial_computed.size(); ++i) {
+    EXPECT_EQ(partial_computed[i].id(), partial_precomputed[i].id());
+  }
+}
+
+// Validates the precompute change on the insert path: inserting with
+// precomputed hashes must populate the cache identically to inserting with
+// on-the-fly hashing (same block count, same per-block hash value, same chain).
+TEST(PrefixCacheTest, PrecomputedHashInsertMatchesComputedInsert) {
+  const uint32_t block_size = 4;
+  const uint32_t n_blocks = 50;
+  BlockManager::Options options;
+  options.num_blocks(2 * n_blocks + 2).block_size(block_size);
+  BlockManagerImpl block_manager(options);
+
+  std::vector<int32_t> token_ids =
+      make_random_tokens(n_blocks * block_size, /*seed=*/99);
+  const Slice<int32_t> tokens(token_ids);
+  const std::vector<XXH3Key> hashes =
+      build_chained_hashes(token_ids, block_size);
+  const Slice<XXH3Key> hash_slice(hashes);
+
+  // Cache A: insert via the on-the-fly compute path.
+  PrefixCache cache_compute(block_size);
+  std::vector<Block> blocks_a = block_manager.allocate(n_blocks);
+  cache_compute.insert(tokens, blocks_a);
+
+  // Cache B: insert via the precomputed path.
+  PrefixCache cache_precomputed(block_size);
+  std::vector<Block> blocks_b = block_manager.allocate(n_blocks);
+  cache_precomputed.insert(
+      tokens, blocks_b, /*existed=*/0, MMData(), hash_slice);
+
+  EXPECT_EQ(cache_compute.num_blocks(), n_blocks);
+  EXPECT_EQ(cache_precomputed.num_blocks(), n_blocks);
+
+  for (size_t i = 0; i < n_blocks; ++i) {
+    // Both insert paths must stamp the same hash onto each block ...
+    EXPECT_EQ(std::memcmp(blocks_a[i].get_immutable_hash_value(),
+                          blocks_b[i].get_immutable_hash_value(),
+                          XXH3_128BITS_HASH_VALUE_LEN),
+              0);
+    // ... and it must equal the independently computed chain.
+    EXPECT_EQ(std::memcmp(blocks_b[i].get_immutable_hash_value(),
+                          hashes[i].data,
+                          XXH3_128BITS_HASH_VALUE_LEN),
+              0);
+  }
+
+  // A full match against the precomputed-built cache hits every block.
+  auto matched = cache_precomputed.match(tokens, {}, MMData(), hash_slice);
+  EXPECT_EQ(matched.size(), n_blocks);
+}
+
+// Validates the binary-search boundary equals the linear (early-break) boundary
+// over a prefix-closed cache, across hit ratios on a long sequence. This is the
+// correctness prerequisite for the linear-vs-binary probe benchmark.
+TEST(PrefixCacheTest, BinaryProbeMatchesLinearProbe) {
+  using HitMap = std::
+      unordered_map<XXH3Key, int32_t, FixedStringKeyHash, FixedStringKeyEqual>;
+
+  const uint32_t block_size = 16;
+  const size_t n_blocks = 1024;
+  const std::vector<int32_t> token_ids =
+      make_random_tokens(n_blocks * block_size, /*seed=*/7);
+  const std::vector<XXH3Key> hashes =
+      build_chained_hashes(token_ids, block_size);
+
+  auto linear_hit_len = [&](const HitMap& cache) -> size_t {
+    size_t k = 0;
+    for (; k < hashes.size(); ++k) {
+      if (cache.find(hashes[k]) == cache.end()) {
+        break;
+      }
+    }
+    return k;
+  };
+  auto binary_hit_len = [&](const HitMap& cache) -> size_t {
+    if (hashes.empty() || cache.find(hashes[0]) == cache.end()) {
+      return 0;
+    }
+    size_t lo = 0;
+    size_t hi = hashes.size() - 1;
+    while (lo < hi) {
+      const size_t mid = (lo + hi + 1) / 2;
+      if (cache.find(hashes[mid]) != cache.end()) {
+        lo = mid;
+      } else {
+        hi = mid - 1;
+      }
+    }
+    return lo + 1;
+  };
+
+  for (size_t hit_len :
+       {size_t{0}, size_t{1}, size_t{7}, size_t{512}, size_t{1023}, n_blocks}) {
+    HitMap cache;
+    cache.reserve(hit_len * 2 + 1);
+    for (size_t i = 0; i < hit_len; ++i) {
+      cache.emplace(hashes[i], 1);
+    }
+    EXPECT_EQ(linear_hit_len(cache), hit_len);
+    EXPECT_EQ(binary_hit_len(cache), hit_len);
+    EXPECT_EQ(binary_hit_len(cache), linear_hit_len(cache));
   }
 }
 

--- a/xllm/core/framework/block/block_manager.h
+++ b/xllm/core/framework/block/block_manager.h
@@ -71,12 +71,14 @@ class BlockManager {
   virtual std::vector<Block> allocate_shared(
       const Slice<int32_t>& token_ids,
       const Slice<Block>& existed_shared_blocks = {},
-      const MMData& mm_data = MMData()) = 0;
+      const MMData& mm_data = MMData(),
+      const Slice<XXH3Key>& block_hashes = {}) = 0;
 
   virtual void cache(const Slice<int32_t>& token_ids,
                      std::vector<Block>& blocks,
                      size_t existed_shared_blocks_num = 0,
-                     const MMData& mm_data = MMData()) = 0;
+                     const MMData& mm_data = MMData(),
+                     const Slice<XXH3Key>& block_hashes = {}) = 0;
   virtual void cache(const std::vector<Block>& blocks) = 0;
 
   // get merged all dp rank KVCacheEvent

--- a/xllm/core/framework/block/block_manager_impl.cpp
+++ b/xllm/core/framework/block/block_manager_impl.cpp
@@ -159,13 +159,14 @@ bool BlockManagerImpl::has_enough_blocks(uint32_t num_blocks) {
 std::vector<Block> BlockManagerImpl::allocate_shared(
     const Slice<int32_t>& token_ids,
     const Slice<Block>& existed_shared_blocks,
-    const MMData& mm_data) {
+    const MMData& mm_data,
+    const Slice<XXH3Key>& block_hashes) {
   // only allocate shared blocks for prefill sequences
   if (options_.enable_prefix_cache()) {
     AUTO_COUNTER(prefix_cache_latency_seconds_match);
 
-    std::vector<Block> shared_blocks =
-        prefix_cache_->match(token_ids, existed_shared_blocks, mm_data);
+    std::vector<Block> shared_blocks = prefix_cache_->match(
+        token_ids, existed_shared_blocks, mm_data, block_hashes);
 
     const size_t prefix_length =
         shared_blocks.empty() ? 0
@@ -186,12 +187,13 @@ std::vector<Block> BlockManagerImpl::allocate_shared(
 void BlockManagerImpl::cache(const Slice<int32_t>& token_ids,
                              std::vector<Block>& blocks,
                              size_t existed_shared_blocks_num,
-                             const MMData& mm_data) {
+                             const MMData& mm_data,
+                             const Slice<XXH3Key>& block_hashes) {
   if (options_.enable_prefix_cache()) {
     AUTO_COUNTER(prefix_cache_latency_seconds_insert);
     // Add the kv cache to the prefix cache
     prefix_cache_->insert(
-        token_ids, blocks, existed_shared_blocks_num, mm_data);
+        token_ids, blocks, existed_shared_blocks_num, mm_data, block_hashes);
   }
 }
 

--- a/xllm/core/framework/block/block_manager_impl.h
+++ b/xllm/core/framework/block/block_manager_impl.h
@@ -39,13 +39,15 @@ class BlockManagerImpl : public BlockManager {
   std::vector<Block> allocate_shared(
       const Slice<int32_t>& token_ids,
       const Slice<Block>& existed_shared_blocks = {},
-      const MMData& mm_data = MMData()) override;
+      const MMData& mm_data = MMData(),
+      const Slice<XXH3Key>& block_hashes = {}) override;
 
   // cache blocks when enable prefix cache
   void cache(const Slice<int32_t>& token_ids,
              std::vector<Block>& blocks,
              size_t existed_shared_blocks_num = 0,
-             const MMData& mm_data = MMData()) override;
+             const MMData& mm_data = MMData(),
+             const Slice<XXH3Key>& block_hashes = {}) override;
   void cache(const std::vector<Block>& blocks) override;
 
   void get_merged_kvcache_event(KvCacheEvent* event) const override;

--- a/xllm/core/framework/block/block_manager_pool.cpp
+++ b/xllm/core/framework/block/block_manager_pool.cpp
@@ -318,12 +318,17 @@ bool BlockManagerPool::try_allocate(Sequence* sequence) {
   std::vector<Block> shared_blocks;
   size_t shared_num = 0;
   if (options_.enable_prefix_cache()) {
+    sequence->update_block_hashes(static_cast<uint32_t>(options_.block_size()),
+                                  options_.hasher_type());
     const auto& existed_shared_blocks = sequence->kv_state().kv_blocks().slice(
         0, sequence->kv_state().shared_kv_blocks_num());
     // If the sequence holds shared_blocks, the hash values of these blocks do
     // not need to be recalculated and can be reused directly.
-    shared_blocks = block_managers_[dp_rank]->allocate_shared(
-        sequence->tokens(), existed_shared_blocks, sequence->mm_data());
+    shared_blocks =
+        block_managers_[dp_rank]->allocate_shared(sequence->tokens(),
+                                                  existed_shared_blocks,
+                                                  sequence->mm_data(),
+                                                  sequence->block_hashes());
 
     if (!shared_blocks.empty()) {
       sequence->add_kv_blocks(shared_blocks);
@@ -387,13 +392,17 @@ void BlockManagerPool::allocate_shared(Sequence* sequence) {
   // only allocate shared blocks for prefill sequences
   if (options_.enable_prefix_cache()) {
     int32_t dp_rank = get_dp_rank(sequence);
+    sequence->update_block_hashes(static_cast<uint32_t>(options_.block_size()),
+                                  options_.hasher_type());
     const auto& existed_shared_blocks = sequence->kv_state().kv_blocks().slice(
         0, sequence->kv_state().shared_kv_blocks_num());
     // If the sequence holds shared_blocks, the hash values of these blocks do
     // not need to be recalculated and can be reused directly.
     std::vector<Block> shared_blocks =
-        block_managers_[dp_rank]->allocate_shared(
-            sequence->tokens(), existed_shared_blocks, sequence->mm_data());
+        block_managers_[dp_rank]->allocate_shared(sequence->tokens(),
+                                                  existed_shared_blocks,
+                                                  sequence->mm_data(),
+                                                  sequence->block_hashes());
     sequence->add_shared_kv_blocks(std::move(shared_blocks));
   }
 }
@@ -404,11 +413,16 @@ void BlockManagerPool::cache(Sequence* sequence) {
     // Prefix cache is not supported for CompositeBlockManager yet.
     return;
   }
+  sequence->update_block_hashes(static_cast<uint32_t>(options_.block_size()),
+                                options_.hasher_type());
   const auto token_ids = sequence->cached_tokens();
   auto* blocks = sequence->kv_state().mutable_kv_blocks();
   auto existed_shared_blocks_num = sequence->kv_state().shared_kv_blocks_num();
-  block_managers_[dp_rank]->cache(
-      token_ids, *blocks, existed_shared_blocks_num, sequence->mm_data());
+  block_managers_[dp_rank]->cache(token_ids,
+                                  *blocks,
+                                  existed_shared_blocks_num,
+                                  sequence->mm_data(),
+                                  sequence->block_hashes());
 }
 
 void BlockManagerPool::get_merged_kvcache_event(KvCacheEvent* event) const {

--- a/xllm/core/framework/block/composite_block_manager.cpp
+++ b/xllm/core/framework/block/composite_block_manager.cpp
@@ -245,7 +245,8 @@ std::vector<Block> CompositeBlockManager::allocate(size_t /*num_blocks*/) {
 std::vector<Block> CompositeBlockManager::allocate_shared(
     const Slice<int32_t>& /*tokens_ids*/,
     const Slice<Block>& /*existed_shared_blocks*/,
-    const MMData& /*mm_data*/) {
+    const MMData& /*mm_data*/,
+    const Slice<XXH3Key>& /*block_hashes*/) {
   NOT_IMPLEMENTED();
   return {};
 }
@@ -253,7 +254,8 @@ std::vector<Block> CompositeBlockManager::allocate_shared(
 void CompositeBlockManager::cache(const Slice<int32_t>& /*token_ids*/,
                                   std::vector<Block>& /*blocks*/,
                                   size_t /*existed_shared_blocks_num*/,
-                                  const MMData& /*mm_data*/) {
+                                  const MMData& /*mm_data*/,
+                                  const Slice<XXH3Key>& /*block_hashes*/) {
   // Prefix cache is not supported for CompositeBlockManager yet.
   // Keep cache() as a no-op so scheduler-side prefill cache hooks
   // do not crash when composite manager is enabled (e.g. DeepSeek V4).

--- a/xllm/core/framework/block/composite_block_manager.h
+++ b/xllm/core/framework/block/composite_block_manager.h
@@ -40,11 +40,13 @@ class CompositeBlockManager : public BlockManager {
   std::vector<Block> allocate_shared(
       const Slice<int32_t>& tokens_ids,
       const Slice<Block>& existed_shared_blocks = {},
-      const MMData& mm_data = MMData()) override;
+      const MMData& mm_data = MMData(),
+      const Slice<XXH3Key>& block_hashes = {}) override;
   void cache(const Slice<int32_t>& token_ids,
              std::vector<Block>& blocks,
              size_t existed_shared_blocks_num = 0,
-             const MMData& mm_data = MMData()) override;
+             const MMData& mm_data = MMData(),
+             const Slice<XXH3Key>& block_hashes = {}) override;
   void cache(const std::vector<Block>& blocks) override;
   void get_merged_kvcache_event(KvCacheEvent* event) const override;
   size_t num_blocks_in_prefix_cache() const override;

--- a/xllm/core/framework/block/concurrent_block_manager_impl.cpp
+++ b/xllm/core/framework/block/concurrent_block_manager_impl.cpp
@@ -33,19 +33,21 @@ void ConcurrentBlockManagerImpl::deallocate(const Slice<Block>& blocks) {
 std::vector<Block> ConcurrentBlockManagerImpl::allocate_shared(
     const Slice<int32_t>& token_ids,
     const Slice<Block>& existed_shared_blocks,
-    const MMData& mm_data) {
+    const MMData& mm_data,
+    const Slice<XXH3Key>& block_hashes) {
   std::lock_guard<std::recursive_mutex> lock(mutex_);
   return BlockManagerImpl::allocate_shared(
-      token_ids, existed_shared_blocks, mm_data);
+      token_ids, existed_shared_blocks, mm_data, block_hashes);
 }
 
 void ConcurrentBlockManagerImpl::cache(const Slice<int32_t>& token_ids,
                                        std::vector<Block>& blocks,
                                        size_t existed_shared_blocks_num,
-                                       const MMData& mm_data) {
+                                       const MMData& mm_data,
+                                       const Slice<XXH3Key>& block_hashes) {
   std::lock_guard<std::recursive_mutex> lock(mutex_);
   BlockManagerImpl::cache(
-      token_ids, blocks, existed_shared_blocks_num, mm_data);
+      token_ids, blocks, existed_shared_blocks_num, mm_data, block_hashes);
 }
 
 void ConcurrentBlockManagerImpl::cache(const std::vector<Block>& blocks) {

--- a/xllm/core/framework/block/concurrent_block_manager_impl.h
+++ b/xllm/core/framework/block/concurrent_block_manager_impl.h
@@ -34,13 +34,15 @@ class ConcurrentBlockManagerImpl : public BlockManagerImpl {
   std::vector<Block> allocate_shared(
       const Slice<int32_t>& token_ids,
       const Slice<Block>& existed_shared_blocks = {},
-      const MMData& mm_data = MMData()) override;
+      const MMData& mm_data = MMData(),
+      const Slice<XXH3Key>& block_hashes = {}) override;
 
   // cache the blocks
   void cache(const Slice<int32_t>& token_ids,
              std::vector<Block>& blocks,
              size_t existed_shared_blocks_num = 0,
-             const MMData& mm_data = MMData()) override;
+             const MMData& mm_data = MMData(),
+             const Slice<XXH3Key>& block_hashes = {}) override;
   void cache(const std::vector<Block>& blocks) override;
 
   // get the number of blocks in the prefix cache

--- a/xllm/core/framework/block/single_block_manager.cpp
+++ b/xllm/core/framework/block/single_block_manager.cpp
@@ -139,7 +139,8 @@ void SingleBlockManager::deallocate(const Slice<Block>& blocks) {
 std::vector<Block> SingleBlockManager::allocate_shared(
     const Slice<int32_t>& /*token_ids*/,
     const Slice<Block>& /*existed_shared_blocks*/,
-    const MMData& /*mm_data*/) {
+    const MMData& /*mm_data*/,
+    const Slice<XXH3Key>& /*block_hashes*/) {
   // Prefix cache is disabled in this manager. Keep it substitutable with
   // BlockManager behavior under enable_prefix_cache=false.
   return {};
@@ -148,7 +149,8 @@ std::vector<Block> SingleBlockManager::allocate_shared(
 void SingleBlockManager::cache(const Slice<int32_t>& /*token_ids*/,
                                std::vector<Block>& /*blocks*/,
                                size_t /*existed_shared_blocks_num*/,
-                               const MMData& /*mm_data*/) {
+                               const MMData& /*mm_data*/,
+                               const Slice<XXH3Key>& /*block_hashes*/) {
   // Prefix cache is disabled in this manager: no-op.
 }
 

--- a/xllm/core/framework/block/single_block_manager.h
+++ b/xllm/core/framework/block/single_block_manager.h
@@ -39,12 +39,14 @@ class SingleBlockManager final : public BlockManager {
   std::vector<Block> allocate_shared(
       const Slice<int32_t>& token_ids,
       const Slice<Block>& existed_shared_blocks = {},
-      const MMData& mm_data = MMData()) override;
+      const MMData& mm_data = MMData(),
+      const Slice<XXH3Key>& block_hashes = {}) override;
 
   void cache(const Slice<int32_t>& token_ids,
              std::vector<Block>& blocks,
              size_t existed_shared_blocks_num = 0,
-             const MMData& mm_data = MMData()) override;
+             const MMData& mm_data = MMData(),
+             const Slice<XXH3Key>& block_hashes = {}) override;
   void cache(const std::vector<Block>& blocks) override;
 
   void get_merged_kvcache_event(KvCacheEvent* event) const override;

--- a/xllm/core/framework/prefix_cache/prefix_cache.cpp
+++ b/xllm/core/framework/prefix_cache/prefix_cache.cpp
@@ -28,14 +28,15 @@ namespace xllm {
 
 std::vector<Block> PrefixCache::match(const Slice<int32_t>& token_ids,
                                       const Slice<Block>& existed_shared_blocks,
-                                      const MMData& mm_data) {
+                                      const MMData& mm_data,
+                                      const Slice<XXH3Key>& block_hashes) {
   // allign tokens to block boundary
   const size_t n_tokens = round_down(token_ids.size(), block_size_);
   if (n_tokens == 0) {
     return std::vector<Block>();
   }
 
-  size_t n_blocks = n_tokens / block_size_;
+  const size_t n_blocks = n_tokens / block_size_;
   total_blocks_.fetch_add(n_blocks);
 
   std::vector<Block> blocks;
@@ -44,27 +45,45 @@ std::vector<Block> PrefixCache::match(const Slice<int32_t>& token_ids,
       blocks.end(), existed_shared_blocks.begin(), existed_shared_blocks.end());
 
   DNodeList node_list;
+  const size_t start_block = existed_shared_blocks.size();
 
-  size_t start_index = existed_shared_blocks.size() * block_size_;
-  XXH3Key token_hash_key =
-      existed_shared_blocks.empty()
-          ? XXH3Key{}
-          : XXH3Key{existed_shared_blocks.back().get_immutable_hash_value()};
-
-  auto hasher = BlockHasher::create(hasher_type_, mm_data, start_index);
-
-  for (size_t i = start_index; i < n_tokens; i += block_size_) {
-    const uint8_t* pre_hash_value = (i == 0) ? nullptr : token_hash_key.data;
-    hasher->compute(
-        token_ids, i, i + block_size_, pre_hash_value, token_hash_key);
-
+  // Look up one block by its chained hash; on hit, record the block and move
+  // its LRU node to the front of the working list. Returns false on miss.
+  auto match_block = [&](const XXH3Key& token_hash_key) -> bool {
     auto iter = cached_blocks_.find(token_hash_key);
-    if (iter != cached_blocks_.end()) {
-      blocks.push_back(iter->second->block);
-      lru_lst_.remove_node(iter->second);
-      node_list.push_front(iter->second);
-    } else {
-      break;
+    if (iter == cached_blocks_.end()) {
+      return false;
+    }
+    blocks.push_back(iter->second->block);
+    lru_lst_.remove_node(iter->second);
+    node_list.push_front(iter->second);
+    return true;
+  };
+
+  // Fast path: precomputed chained hash covers every matchable block, so we
+  // only do hash-table lookups and never recompute a hash.
+  if (block_hashes.size() >= n_blocks) {
+    for (size_t b = start_block; b < n_blocks; ++b) {
+      if (!match_block(block_hashes[b])) {
+        break;
+      }
+    }
+  } else {
+    // Fallback: compute the chained hash on the fly.
+    XXH3Key token_hash_key =
+        existed_shared_blocks.empty()
+            ? XXH3Key{}
+            : XXH3Key{existed_shared_blocks.back().get_immutable_hash_value()};
+    auto hasher =
+        BlockHasher::create(hasher_type_, mm_data, start_block * block_size_);
+    for (size_t b = start_block; b < n_blocks; ++b) {
+      const size_t i = b * block_size_;
+      const uint8_t* pre_hash_value = (b == 0) ? nullptr : token_hash_key.data;
+      hasher->compute(
+          token_ids, i, i + block_size_, pre_hash_value, token_hash_key);
+      if (!match_block(token_hash_key)) {
+        break;
+      }
     }
   }
 
@@ -87,10 +106,15 @@ std::vector<Block> PrefixCache::match(const Slice<int32_t>& token_ids,
 size_t PrefixCache::insert(const Slice<int32_t>& token_ids,
                            std::vector<Block>& blocks,
                            size_t existed_shared_blocks_num,
-                           const MMData& mm_data) {
+                           const MMData& mm_data,
+                           const Slice<XXH3Key>& block_hashes) {
   std::vector<XXH3Key> insert_keys;
-  return insert(
-      token_ids, blocks, existed_shared_blocks_num, mm_data, &insert_keys);
+  return insert(token_ids,
+                blocks,
+                existed_shared_blocks_num,
+                mm_data,
+                block_hashes,
+                &insert_keys);
 }
 
 size_t PrefixCache::insert(const std::vector<Block>& blocks) {
@@ -112,12 +136,12 @@ size_t PrefixCache::insert(const Slice<int32_t>& token_ids,
                            std::vector<Block>& blocks,
                            size_t existed_shared_blocks_num,
                            const MMData& mm_data,
+                           const Slice<XXH3Key>& block_hashes,
                            std::vector<XXH3Key>* insert_keys) {
   const int64_t now = absl::ToUnixMicros(absl::Now());
   // allign tokens to block boundary
   const size_t n_blocks =
       std::min(token_ids.size() / block_size_, blocks.size());
-  const size_t n_tokens = n_blocks * block_size_;
 
   if (n_blocks == 0) {
     return 0;
@@ -126,21 +150,35 @@ size_t PrefixCache::insert(const Slice<int32_t>& token_ids,
   // truncate the token ids and blocks to boundary
 
   DNodeList node_list;
+
+  // Fill `token_hash_key` with the chained hash of block `block_idx`, reusing
+  // the precomputed hash when it covers all blocks, otherwise computing it.
+  const bool use_precomputed = block_hashes.size() >= n_blocks;
   XXH3Key token_hash_key = existed_shared_blocks_num == 0
                                ? XXH3Key{}
                                : XXH3Key{blocks[existed_shared_blocks_num - 1]
                                              .get_immutable_hash_value()};
-
-  auto hasher = BlockHasher::create(
-      hasher_type_, mm_data, existed_shared_blocks_num * block_size_);
-
-  uint32_t block_idx = existed_shared_blocks_num;
-  insert_keys->reserve(n_blocks);
-  for (size_t i = existed_shared_blocks_num * block_size_; i < n_tokens;
-       i += block_size_) {
-    const uint8_t* pre_hash_value = (i == 0) ? nullptr : token_hash_key.data;
+  std::unique_ptr<BlockHasher> hasher;
+  if (!use_precomputed) {
+    hasher = BlockHasher::create(
+        hasher_type_, mm_data, existed_shared_blocks_num * block_size_);
+  }
+  auto fill_block_hash = [&](size_t block_idx) {
+    if (use_precomputed) {
+      token_hash_key = block_hashes[block_idx];
+      return;
+    }
+    const size_t i = block_idx * block_size_;
+    const uint8_t* pre_hash_value =
+        (block_idx == 0) ? nullptr : token_hash_key.data;
     hasher->compute(
         token_ids, i, i + block_size_, pre_hash_value, token_hash_key);
+  };
+
+  insert_keys->reserve(n_blocks);
+  for (size_t block_idx = existed_shared_blocks_num; block_idx < n_blocks;
+       ++block_idx) {
+    fill_block_hash(block_idx);
     blocks[block_idx].set_hash_value(token_hash_key.data);
 
     auto iter = cached_blocks_.find(token_hash_key);
@@ -163,10 +201,9 @@ size_t PrefixCache::insert(const Slice<int32_t>& token_ids,
 
       insert_keys->emplace_back(token_hash_key.data);
     }
-
-    ++block_idx;
   }
 
+  const size_t n_tokens = n_blocks * block_size_;
   while (!node_list.is_empty()) {
     Node* node = node_list.pop_front();
     lru_lst_.push_back(node);

--- a/xllm/core/framework/prefix_cache/prefix_cache.cpp
+++ b/xllm/core/framework/prefix_cache/prefix_cache.cpp
@@ -54,7 +54,7 @@ std::vector<Block> PrefixCache::match(const Slice<int32_t>& token_ids,
     if (iter == cached_blocks_.end()) {
       return false;
     }
-    blocks.push_back(iter->second->block);
+    blocks.emplace_back(iter->second->block);
     lru_lst_.remove_node(iter->second);
     node_list.push_front(iter->second);
     return true;

--- a/xllm/core/framework/prefix_cache/prefix_cache.h
+++ b/xllm/core/framework/prefix_cache/prefix_cache.h
@@ -64,18 +64,25 @@ class PrefixCache {
     sleep(2);
   };
 
+  // When `block_hashes` covers all matchable blocks, the chained hash is reused
+  // directly and no hash is recomputed; otherwise it is computed on the fly
+  // from `token_ids`/`mm_data` (backward-compatible fallback).
   virtual std::vector<Block> match(
       const Slice<int32_t>& token_ids,
       const Slice<Block>& existed_shared_blocks = {},
-      const MMData& mm_data = MMData());
+      const MMData& mm_data = MMData(),
+      const Slice<XXH3Key>& block_hashes = {});
 
   // insert the token ids and blocks into the prefix tree
   // and set hash key to the corresponding block
-  // return the length of new inserted tokens
+  // return the length of new inserted tokens.
+  // `block_hashes` carries the precomputed chained hash and is reused when it
+  // covers all inserted blocks; otherwise the hash is computed on the fly.
   virtual size_t insert(const Slice<int32_t>& token_ids,
                         std::vector<Block>& blocks,
                         size_t existed_shared_blocks_num = 0,
-                        const MMData& mm_data = MMData());
+                        const MMData& mm_data = MMData(),
+                        const Slice<XXH3Key>& block_hashes = {});
 
   // insert the blocks with hash key into the prefix tree
   virtual size_t insert(Slice<Block>& blocks);
@@ -111,6 +118,7 @@ class PrefixCache {
                         std::vector<Block>& blocks,
                         size_t existed_shared_blocks_num,
                         const MMData& mm_data,
+                        const Slice<XXH3Key>& block_hashes,
                         std::vector<XXH3Key>* insert_keys);
 
   size_t insert(Slice<Block>& blocks, std::vector<XXH3Key>* insert_keys);

--- a/xllm/core/framework/prefix_cache/prefix_cache_benchmark.cpp
+++ b/xllm/core/framework/prefix_cache/prefix_cache_benchmark.cpp
@@ -24,11 +24,92 @@ limitations under the License.
 #include <iostream>
 #include <iterator>
 #include <random>
+#include <unordered_map>
 #include <vector>
 
 #include "framework/block/block_manager_impl.h"
 #include "prefix_cache.h"
+#include "util/hash_util.h"
 using namespace xllm;
+
+// ============================================================================
+// Helpers shared by the linear-vs-binary prefix-match probe benchmarks.
+//
+// `match` already early-breaks on the first miss, so the linear path does
+// exactly `hit_len + 1` hash-table probes while binary search does O(log n).
+// Both must still collect `hit_len` blocks afterwards, so the ONLY thing that
+// differs between the two strategies is the boundary-finding probes isolated
+// below. These helpers therefore measure just the probe cost.
+// ============================================================================
+
+namespace {
+
+using HitMap = std::
+    unordered_map<XXH3Key, int32_t, FixedStringKeyHash, FixedStringKeyEqual>;
+
+// Build the chained block hashes for `tokens`, identical to the chain produced
+// by xxh3_128bits_hash() in prefix_cache.cpp.
+std::vector<XXH3Key> build_chained_hashes(const std::vector<int32_t>& tokens,
+                                          uint32_t block_size) {
+  const size_t n_blocks = tokens.size() / block_size;
+  std::vector<XXH3Key> hashes;
+  hashes.reserve(n_blocks);
+  const Slice<int32_t> slice(tokens);
+  for (size_t b = 0; b < n_blocks; ++b) {
+    XXH3Key key;
+    const uint8_t* pre = (b == 0) ? nullptr : hashes.back().data;
+    xxh3_128bits_hash(
+        pre, slice.slice(b * block_size, (b + 1) * block_size), key.data);
+    hashes.emplace_back(key);
+  }
+  return hashes;
+}
+
+// Populate a cache that holds the first `hit_len` blocks of the chain. This
+// models the prefix-closed invariant guaranteed by the LRU (suffix-first)
+// eviction: if block i is cached, every block < i is cached too.
+HitMap make_cache(const std::vector<XXH3Key>& hashes, size_t hit_len) {
+  HitMap cache;
+  cache.reserve(hit_len * 2);
+  for (size_t i = 0; i < hit_len; ++i) {
+    cache.emplace(hashes[i], 1);
+  }
+  return cache;
+}
+
+// Current strategy: probe from the front, stop at the first miss.
+size_t find_hit_len_linear(const HitMap& cache,
+                           const std::vector<XXH3Key>& hashes) {
+  size_t k = 0;
+  for (; k < hashes.size(); ++k) {
+    if (cache.find(hashes[k]) == cache.end()) {
+      break;
+    }
+  }
+  return k;
+}
+
+// Binary search for the longest hit, relying on the prefix-closed invariant.
+size_t find_hit_len_binary(const HitMap& cache,
+                           const std::vector<XXH3Key>& hashes) {
+  if (hashes.empty() || cache.find(hashes[0]) == cache.end()) {
+    return 0;
+  }
+  // Invariant: hashes[lo] is present, hashes[hi + 1] is absent.
+  size_t lo = 0;
+  size_t hi = hashes.size() - 1;
+  while (lo < hi) {
+    const size_t mid = (lo + hi + 1) / 2;
+    if (cache.find(hashes[mid]) != cache.end()) {
+      lo = mid;
+    } else {
+      hi = mid - 1;
+    }
+  }
+  return lo + 1;
+}
+
+}  // namespace
 
 // ============================================================================
 // Existing prefix-cache benchmark
@@ -237,6 +318,82 @@ BENCHMARK(BM_XXH3_128_Chain)
     ->Args({16, 32})
     ->Args({16, 128})
     ->Args({16, 512})
+    ->Unit(benchmark::TimeUnit::kNanosecond);
+
+// ============================================================================
+// Linear vs binary prefix-match probing.
+// Args: {n_blocks, hit_percent}  (hit_len = n_blocks * hit_percent / 100)
+//
+// Reading the numbers:
+//   - hit_percent = 100 (full hit): linear does n_blocks probes, binary does
+//     ~log2(n_blocks); binary should win and the gap grows with n_blocks.
+//   - hit_percent small: linear early-breaks after hit_len+1 probes, so binary
+//     (always ~log2(n_blocks)) can be equal or SLOWER. This is the case that
+//     shows binary is not a free win.
+// ============================================================================
+
+namespace {
+
+struct ProbeFixture {
+  std::vector<int32_t> tokens;
+  std::vector<XXH3Key> hashes;
+  HitMap cache;
+};
+
+ProbeFixture make_probe_fixture(size_t n_blocks, int64_t hit_percent) {
+  constexpr uint32_t kBlockSize = 16;
+  const size_t hit_len = n_blocks * static_cast<size_t>(hit_percent) / 100;
+
+  std::mt19937 gen(12345);
+  std::uniform_int_distribution<int32_t> dist(0, 65535);
+  ProbeFixture fixture;
+  fixture.tokens.resize(n_blocks * kBlockSize);
+  std::generate(fixture.tokens.begin(), fixture.tokens.end(), [&]() {
+    return dist(gen);
+  });
+  fixture.hashes = build_chained_hashes(fixture.tokens, kBlockSize);
+  fixture.cache = make_cache(fixture.hashes, hit_len);
+  return fixture;
+}
+
+}  // namespace
+
+static void BM_MatchProbe_Linear(benchmark::State& state) {
+  const ProbeFixture fixture =
+      make_probe_fixture(state.range(0), state.range(1));
+  for (auto _ : state) {
+    benchmark::DoNotOptimize(
+        find_hit_len_linear(fixture.cache, fixture.hashes));
+  }
+}
+
+static void BM_MatchProbe_Binary(benchmark::State& state) {
+  const ProbeFixture fixture =
+      make_probe_fixture(state.range(0), state.range(1));
+  for (auto _ : state) {
+    benchmark::DoNotOptimize(
+        find_hit_len_binary(fixture.cache, fixture.hashes));
+  }
+}
+
+// Sweep sequence length (n_blocks) at full / half / short / zero hit ratios.
+// At block_size=16, n_blocks=1024 ~= 16K-token sequence.
+BENCHMARK(BM_MatchProbe_Linear)
+    ->Args({64, 100})
+    ->Args({256, 100})
+    ->Args({1024, 100})
+    ->Args({1024, 50})
+    ->Args({1024, 10})
+    ->Args({1024, 0})
+    ->Unit(benchmark::TimeUnit::kNanosecond);
+
+BENCHMARK(BM_MatchProbe_Binary)
+    ->Args({64, 100})
+    ->Args({256, 100})
+    ->Args({1024, 100})
+    ->Args({1024, 50})
+    ->Args({1024, 10})
+    ->Args({1024, 0})
     ->Unit(benchmark::TimeUnit::kNanosecond);
 
 BENCHMARK_MAIN();

--- a/xllm/core/framework/prefix_cache/prefix_cache_with_upload.cpp
+++ b/xllm/core/framework/prefix_cache/prefix_cache_with_upload.cpp
@@ -38,7 +38,7 @@ size_t PrefixCacheWithUpload::insert(const Slice<int32_t>& token_ids,
                                      const MMData& mm_data,
                                      const Slice<XXH3Key>& block_hashes) {
   std::vector<XXH3Key> insert_keys;
-  auto n_tokens = PrefixCache::insert(token_ids,
+  size_t n_tokens = PrefixCache::insert(token_ids,
                                       blocks,
                                       existed_shared_blocks_num,
                                       mm_data,

--- a/xllm/core/framework/prefix_cache/prefix_cache_with_upload.cpp
+++ b/xllm/core/framework/prefix_cache/prefix_cache_with_upload.cpp
@@ -35,10 +35,15 @@ PrefixCacheWithUpload::~PrefixCacheWithUpload() {
 size_t PrefixCacheWithUpload::insert(const Slice<int32_t>& token_ids,
                                      std::vector<Block>& blocks,
                                      size_t existed_shared_blocks_num,
-                                     const MMData& mm_data) {
+                                     const MMData& mm_data,
+                                     const Slice<XXH3Key>& block_hashes) {
   std::vector<XXH3Key> insert_keys;
-  auto n_tokens = PrefixCache::insert(
-      token_ids, blocks, existed_shared_blocks_num, mm_data, &insert_keys);
+  auto n_tokens = PrefixCache::insert(token_ids,
+                                      blocks,
+                                      existed_shared_blocks_num,
+                                      mm_data,
+                                      block_hashes,
+                                      &insert_keys);
   save_event_async(true, insert_keys);
   return n_tokens;
 }

--- a/xllm/core/framework/prefix_cache/prefix_cache_with_upload.h
+++ b/xllm/core/framework/prefix_cache/prefix_cache_with_upload.h
@@ -20,7 +20,8 @@ class PrefixCacheWithUpload final : public PrefixCache {
   size_t insert(const Slice<int32_t>& token_ids,
                 std::vector<Block>& blocks,
                 size_t existed_shared_blocks_num = 0,
-                const MMData& mm_data = MMData()) override;
+                const MMData& mm_data = MMData(),
+                const Slice<XXH3Key>& block_hashes = {}) override;
 
   // insert the blocks with hash key into the prefix tree
   size_t insert(const std::vector<Block>& blocks) override;

--- a/xllm/core/framework/request/sequence.cpp
+++ b/xllm/core/framework/request/sequence.cpp
@@ -289,6 +289,8 @@ Sequence::Sequence(const Sequence& other)
       num_tokens_(other.num_tokens_),
       token_to_count_map_(other.token_to_count_map_),
       num_prompt_tokens_(other.num_prompt_tokens_),
+      block_hashes_(other.block_hashes_),
+      hash_block_size_(other.hash_block_size_),
       onerec_state_(other.onerec_state_),
       volatile_num_prompt_tokens_(other.volatile_num_prompt_tokens_),
       request_id_(other.request_id_),
@@ -392,6 +394,9 @@ void Sequence::update_last_step_token(const Token& token, size_t token_offset) {
 
   const int32_t token_id = static_cast<int32_t>(token.id);
   tokens_[cur_generated_token_idx_] = token_id;
+  // Overlap/MTP may rewrite tokens at decode positions; drop any cached block
+  // hash from this position onward so it is recomputed when next needed.
+  invalidate_block_hashes_from(cur_generated_token_idx_);
   if (need_unique_tokens_) {
     token_to_count_map_[token_id]++;
   }
@@ -414,6 +419,9 @@ void Sequence::update_token(size_t index, const Token& token) {
   const int32_t origin_token_id = tokens_[index];
   const int32_t token_id = static_cast<int32_t>(token.id);
   tokens_[index] = token_id;
+  // A rewritten token invalidates the cached hash of its block and all
+  // subsequent blocks; recompute lazily on the next update_block_hashes().
+  invalidate_block_hashes_from(index);
   if (need_unique_tokens_) {
     --token_to_count_map_[origin_token_id];
     ++token_to_count_map_[token_id];
@@ -706,6 +714,47 @@ void Sequence::add_shared_kv_blocks(std::vector<Block>&& blocks) {
 
 void Sequence::add_shared_host_kv_blocks(std::vector<Block>&& blocks) {
   host_kv_state_.add_shared_kv_blocks(std::move(blocks), num_tokens_);
+}
+
+void Sequence::update_block_hashes(uint32_t block_size,
+                                   BlockHasherType hasher_type) {
+  if (block_size == 0) {
+    return;
+  }
+  hash_block_size_ = block_size;
+
+  const size_t n_full_blocks = num_tokens_ / block_size;
+  if (n_full_blocks <= block_hashes_.size()) {
+    return;
+  }
+
+  const Slice<int32_t> tokens = this->tokens();
+  const size_t start_block = block_hashes_.size();
+  // Resume the chain from the last already-hashed block (its hash is the
+  // parent of the next block).
+  XXH3Key prev_key = start_block == 0 ? XXH3Key{} : block_hashes_.back();
+  auto hasher =
+      BlockHasher::create(hasher_type, mm_data_, start_block * block_size);
+
+  block_hashes_.reserve(n_full_blocks);
+  for (size_t b = start_block; b < n_full_blocks; ++b) {
+    const size_t i = b * block_size;
+    const uint8_t* pre_hash_value = (b == 0) ? nullptr : prev_key.data;
+    XXH3Key key;
+    hasher->compute(tokens, i, i + block_size, pre_hash_value, key);
+    block_hashes_.emplace_back(key);
+    prev_key = key;
+  }
+}
+
+void Sequence::invalidate_block_hashes_from(size_t token_index) {
+  if (block_hashes_.empty() || hash_block_size_ == 0) {
+    return;
+  }
+  const size_t first_stale_block = token_index / hash_block_size_;
+  if (first_stale_block < block_hashes_.size()) {
+    block_hashes_.resize(first_stale_block);
+  }
 }
 
 bool Sequence::finished() const {

--- a/xllm/core/framework/request/sequence.h
+++ b/xllm/core/framework/request/sequence.h
@@ -28,6 +28,7 @@ limitations under the License.
 
 #include "core/common/types.h"
 #include "core/framework/multimodal/mm_data.h"
+#include "core/framework/prefix_cache/block_hasher.h"
 #include "core/framework/sampling/sampling_params.h"
 #include "core/framework/tokenizer/tokenizer.h"
 #include "core/util/slice.h"
@@ -206,6 +207,16 @@ class Sequence final {
   void add_host_kv_blocks(const std::vector<Block>& blocks);
   void add_shared_kv_blocks(std::vector<Block>&& blocks);
   void add_shared_host_kv_blocks(std::vector<Block>&& blocks);
+
+  // Precomputed chained block hashes used by the prefix cache. Covers all full
+  // blocks of the current tokens; reused by match()/insert() so the hash is
+  // computed once per sequence instead of recomputed on every call.
+  Slice<XXH3Key> block_hashes() const { return block_hashes_; }
+
+  // Extend `block_hashes_` to cover any newly completed full blocks. Cheap
+  // (no-op) when no new full block is available, so it is safe to call before
+  // every match()/cache().
+  void update_block_hashes(uint32_t block_size, BlockHasherType hasher_type);
 
   // whether the prefill stage has been cached.
   bool if_cache_block_for_prefill() {
@@ -408,6 +419,10 @@ class Sequence final {
  private:
   void record_first_token(const Token& token);
 
+  // Drop cached block hashes that may be stale after the token at
+  // `token_index` was rewritten (beam search / speculative / disagg PD).
+  void invalidate_block_hashes_from(size_t token_index);
+
   SequenceOutputType output_type();
   void generate_embeddings_output(SequenceOutput& output);
   void generate_mm_embeddings_output(SequenceOutput& output);
@@ -481,6 +496,13 @@ class Sequence final {
 
   // the length of the prompt tokens
   size_t num_prompt_tokens_ = 0;
+
+  // Precomputed chained block hashes covering all full blocks of `tokens_`.
+  // Extended incrementally; consumed by the prefix cache.
+  std::vector<XXH3Key> block_hashes_;
+
+  // Block size used to compute `block_hashes_` (0 until first computed).
+  uint32_t hash_block_size_ = 0;
 
   std::optional<OneRecState> onerec_state_;
 

--- a/xllm/core/framework/xtensor/xtensor_block_manager_impl.cpp
+++ b/xllm/core/framework/xtensor/xtensor_block_manager_impl.cpp
@@ -245,7 +245,8 @@ void XTensorBlockManagerImpl::free(int32_t block_id) {
 std::vector<Block> XTensorBlockManagerImpl::allocate_shared(
     const Slice<int32_t>& /*token_ids*/,
     const Slice<Block>& /*existed_shared_blocks*/,
-    const MMData& /*mm_data*/) {
+    const MMData& /*mm_data*/,
+    const Slice<XXH3Key>& /*block_hashes*/) {
   // Prefix cache not supported
   VLOG(1) << "allocate_shared called but prefix cache is not supported";
   return {};
@@ -254,7 +255,8 @@ std::vector<Block> XTensorBlockManagerImpl::allocate_shared(
 void XTensorBlockManagerImpl::cache(const Slice<int32_t>& /*token_ids*/,
                                     std::vector<Block>& /*blocks*/,
                                     size_t /*existed_shared_blocks_num*/,
-                                    const MMData& /*mm_data*/) {
+                                    const MMData& /*mm_data*/,
+                                    const Slice<XXH3Key>& /*block_hashes*/) {
   // Prefix cache not supported
   VLOG(1) << "cache called but prefix cache is not supported";
   return;

--- a/xllm/core/framework/xtensor/xtensor_block_manager_impl.h
+++ b/xllm/core/framework/xtensor/xtensor_block_manager_impl.h
@@ -65,13 +65,15 @@ class XTensorBlockManagerImpl : public BlockManager {
   std::vector<Block> allocate_shared(
       const Slice<int32_t>& token_ids,
       const Slice<Block>& existed_shared_blocks = {},
-      const MMData& mm_data = MMData()) override;
+      const MMData& mm_data = MMData(),
+      const Slice<XXH3Key>& block_hashes = {}) override;
 
   // Cache blocks (prefix cache not supported)
   void cache(const Slice<int32_t>& token_ids,
              std::vector<Block>& blocks,
              size_t existed_shared_blocks_num = 0,
-             const MMData& mm_data = MMData()) override;
+             const MMData& mm_data = MMData(),
+             const Slice<XXH3Key>& block_hashes = {}) override;
   void cache(const std::vector<Block>& blocks) override;
 
   // Get merged KV cache event


### PR DESCRIPTION
## Description

Precompute the chained per-block XXH3 hashes once on the `Sequence` and reuse them across `match()`/`insert()`/`cache()`, instead of re-hashing the whole prefix on every scheduler step.

- `Sequence` now holds `block_hashes_` (+ `hash_block_size_`) and extends it incrementally via `update_block_hashes()`. Token rewrites (`update_token` / `update_last_step_token`, i.e. overlap / MTP / disagg-PD) call `invalidate_block_hashes_from()` to drop the affected block onward, keeping the hashes consistent. The copy constructor copies both new fields.
- `PrefixCache::match()/insert()` and `BlockManager::allocate_shared()/cache()` (all impls: impl/concurrent/single/composite/xtensor/with_upload) take an optional precomputed `block_hashes`. When it covers all matchable blocks, only hash-table lookups are done; otherwise it falls back to the original on-the-fly hashing. The new arg defaults to `{}`, so it is fully backward compatible.
- `BlockManagerPool` wires the precomputed hashes through `try_allocate()`, `allocate_shared()` and `cache()`.

The precomputed chain is byte-identical to the on-the-fly chain (same `block_size` and `hasher_type` from the shared options), so cache-hit behavior is unchanged.

## Related Issues

<!-- e.g. Fixes #123 -->

## Change Type

- [ ] Bug fix
- [ ] New feature
- [x] Performance improvement
- [ ] Refactor
- [ ] Documentation
- [x] Test
- [ ] Build or CI

## Pull Request Checklist

Thank you for contributing to xLLM. Before requesting review, please make sure the following items are complete.

### PR Title and Commit Messages

- [x] The PR title and each commit message follow the xLLM commit format: `<type>: <subject>`.

> Title: `perf: precompute per-sequence block hashes for prefix cache.`

### Pre-commit Checks

- [ ] I have installed `pre-commit` by running `pip install pre-commit` or an equivalent command.
- [ ] I have installed the hooks with `pre-commit install`.
- [ ] I have run `pre-commit run --all-files` and fixed any reported issues.

### Self Review

- [x] I have self-reviewed the code according to `.agents/skills/code-review/references/custom-code-style.md`, especially code written or assisted by AI.
- [ ] I have rebased this PR onto the latest `main` branch.

### Build and Test Coverage

- [x] Tests have been added or updated as needed.
- [ ] CUDA: `python setup.py build test` has passed on a CUDA machine.
- [ ] NPU: `python setup.py build test` has passed on an NPU machine.
- [ ] MLU: `python setup.py build test` has passed on an MLU machine.

## Reviewer Notes

- Correctness hinges on the precomputed chain matching the on-the-fly chain. This holds because `update_block_hashes()` uses the same `hasher_type` / `block_size` the prefix cache receives via the factory (`block_manager_impl.cpp` -> `prefix_cache_factory`). Tests `PrecomputedHashMatchesComputedMatch/Insert` assert this equivalence (full hit + partial hit after eviction).
- Invalidation: all `tokens_` rewrite paths invalidate from the lowest changed index (the MTP shift in `update_last_step_token` writes `cur+1/cur+2` but invalidates from `cur`, which covers them). `append_token` only grows the sequence, so no invalidation is needed there.
- `HierarchyBlockManagerPool` host-side `allocate_shared/cache` intentionally keep the compute fallback (no behavior change, just no speedup on that path).
- Tests added: `SequenceUpdateBlockHashes`, `PrecomputedHashMatches{Computed,Insert}`, `BinaryProbeMatchesLinearProbe`, plus a linear-vs-binary probe micro-benchmark.
