### PR TITLE
bugfix: enable prefill batching with prefix cache by matching shared blocks before budget calculation.

### DIFF
--- a/xllm/core/scheduler/prefill_only_scheduler.cpp
+++ b/xllm/core/scheduler/prefill_only_scheduler.cpp
@@ -109,14 +109,15 @@ void PrefillOnlyScheduler::handle_prefill_requests(
         continue;
       }
 
-      // FIXME: use actual num_tokens to handle
-      // Currently overestimating the number of tokens actually processed when
-      // enable prefix cache
-      // size_t num_tokens = prefill_sequence->num_need_compute_tokens();
-      size_t num_tokens = std::min(prefill_sequence->num_need_compute_tokens(),
-                                   remaining_token_budget);
+      // Match prefix cache first so that num_need_compute_tokens() reflects
+      // the cached prefix length.
+      kv_cache_manager_->allocate_shared(prefill_sequence.get());
+      size_t num_need_compute = prefill_sequence->num_need_compute_tokens();
+      size_t num_tokens = std::min(num_need_compute, remaining_token_budget);
       if (remaining_token_budget < allocated_tokens + num_tokens ||
           remaining_seq_budget < allocated_seqs + 1) {
+        // release shared prefix blocks allocated above
+        kv_cache_manager_->deallocate(prefill_sequence.get());
         can_schedule = false;
         budget_exhausted = true;
         break;
@@ -125,7 +126,9 @@ void PrefillOnlyScheduler::handle_prefill_requests(
       // preempt offline decode
       const size_t kv_cache_tokens_num =
           prefill_sequence->kv_state().kv_cache_tokens_num();
-      if (!kv_cache_manager_->allocate(prefill_sequence.get())) {
+      const size_t max_handle_num_tokens = kv_cache_tokens_num + num_tokens;
+      if (!kv_cache_manager_->allocate(prefill_sequence.get(),
+                                       max_handle_num_tokens)) {
         can_schedule = false;
         if (options_.enable_online_preempt_offline() && !request->offline() &&
             !running_queue_offline_->empty()) {
@@ -433,6 +436,7 @@ void PrefillOnlyScheduler::handle_last_step_prefill_requests(
 
 std::vector<Batch> PrefillOnlyScheduler::prepare_batch() {
   Timer timer;
+
   // propogate new requests to waiting_priority_queue_
   // Include those requests that are preempted by others.
   std::shared_ptr<Request> request;


### PR DESCRIPTION
## Description
Problem:
When multiple concurrent requests share the same prefix, prefix cache hits many blocks but each request's prefill is still scheduled serially, one at a time. This causes unnecessarily high TTFT under concurrent load.

Root cause:
In PrefillOnlyScheduler::handle_prefill_requests(), num_need_compute_tokens() was called before prefix cache matching (allocate_shared). Since kv_cache_tokens was still 0 at that point, it returned the full prompt length (e.g., 17052) instead of the actual tokens to compute (e.g., 668). The min() with remaining_token_budget then consumed the entire budget (8192) for a single request, leaving no room for subsequent prefill requests in the same batch.

Fix:
Call kv_cache_manager_->allocate_shared() before num_need_compute_tokens() so that prefix cache blocks are matched first. This makes kv_cache_tokens reflect the cached prefix length, and num_need_compute_tokens() returns only the tokens that actually need computation. With the corrected token budget consumption, multiple prefill requests can now share a single batch.

Results (qwen3.5 27B tp4, 4 concurrent requests, 17k tokens each, prefix cache enabled):
- Before: prefill serial, TTFT 650-3000ms
- After:  prefill batched (4 seqs in one forward), TTFT 620-1070ms

## Change Type

- [x] Bug fix
- [ ] New feature
- [ ] Performance improvement
- [ ] Refactor
- [ ] Documentation
- [ ] Test
- [ ] Build or CI

### Build and Test Coverage

- [x] Tests have been added or updated as needed.
- [ ] CUDA: `python setup.py build test` has passed on a CUDA machine.
- [x] NPU: `python setup.py build test` has passed on an NPU machine.
- [ ] MLU: `python setup.py build test` has passed on an MLU machine.
<img width="618" height="376" alt="image" src="https://github.com/user-attachments/assets/41cbea5c-f8be-4018-a0b1-949561793512" />
