### PR TITLE
build: add persistent triton npu binary cache.

### DIFF
--- a/cibuild/build_npu.sh
+++ b/cibuild/build_npu.sh
@@ -9,7 +9,8 @@ function error() {
 IMAGE="quay.io/jd_xllm/xllm-ai:xllm-dev-a2-x86-20260429"
 
 XLLM_OPS_CACHE="/export/home/npu_xllm_ops_build_cache"
-mkdir -p "${XLLM_OPS_CACHE}"
+TRITON_BINARY_CACHE="/export/home/npu_triton_binary_cache"
+mkdir -p "${XLLM_OPS_CACHE}" "${TRITON_BINARY_CACHE}"
 
 RUN_OPTS=(
   --rm
@@ -28,9 +29,11 @@ RUN_OPTS=(
   -v /export/home:/export/home
   -v /export/home/npu_vcpkg_cache_abi_1:/root/.cache/vcpkg # cached vcpkg installed dir
   -v "${XLLM_OPS_CACHE}":"${XLLM_OPS_CACHE}" # cached xllm_ops build dir
+  -v "${TRITON_BINARY_CACHE}":"${TRITON_BINARY_CACHE}" # cached triton_npu binary dir
   -v /etc/hccn.conf:/etc/hccn.conf
   -w /export/home
   -e XLLM_OPS_BUILD_DIR="${XLLM_OPS_CACHE}"
+  -e TRITON_BINARY_PATH="${TRITON_BINARY_CACHE}"
 )
 
 CMD="$*"


### PR DESCRIPTION
## Description

This PR fixes a missing piece from #1656. PR #1656 moved Triton NPU binary generation out of the `torch_npu_ops` submodule source tree and added `TRITON_BINARY_PATH` support, but the GitHub x86_64 NPU build CI did not pass a persistent Triton binary cache path into the CI container.

As a result, GitHub NPU CI could still regenerate Triton NPU binaries after clean checkouts instead of reusing a host-side cache.

This PR adds the missing CI wiring by:

- defining a fixed host-side Triton binary cache path in `cibuild/build_npu.sh`;
- creating and mounting that cache directory into the NPU CI container;
- passing `TRITON_BINARY_PATH` into the container so the existing `torch_npu_ops` cache logic is used during the CI build.

## Related PRs

- Follow-up fix for #1656

## Change Type

- [ ] Bug fix
- [ ] New feature
- [ ] Performance improvement
- [ ] Refactor
- [ ] Documentation
- [ ] Test
- [x] Build or CI

## Validation

- Locally simulated the GitHub NPU build CI cleanup flow by deleting `build/` and running `git submodule foreach --recursive git clean -ffdx` while preserving the external Triton binary cache.
- Verified the NPU wheel build succeeds with `TRITON_BINARY_PATH` pointing to the persistent cache.
- Verified the generated wheel still packages Triton binaries under `xllm/triton_npu/binary/`.