### PR TITLE
feat: add mtp bootstrap embedding context.

### DIFF
--- a/tests/core/framework/batch/batch_test.cpp
+++ b/tests/core/framework/batch/batch_test.cpp
@@ -78,12 +78,14 @@ bool equal(const torch::Tensor& t, const std::vector<T>& d) {
 RawSampleOutput make_raw_sample_output(int64_t token_id,
                                        std::optional<float> logprob,
                                        std::vector<int64_t> top_tokens = {},
-                                       std::vector<float> top_logprobs = {}) {
+                                       std::vector<float> top_logprobs = {},
+                                       std::vector<float> embeddings = {}) {
   RawToken raw_token;
   raw_token.id = token_id;
   raw_token.logprob = logprob;
   raw_token.top_tokens = std::move(top_tokens);
   raw_token.top_logprobs = std::move(top_logprobs);
+  raw_token.embeddings = std::move(embeddings);
 
   RawSampleOutput raw_output;
   raw_output.tokens.push_back(std::move(raw_token));
@@ -115,6 +117,31 @@ void expect_blocks(const TransferKVInfo& info,
   EXPECT_EQ(info.remote_blocks_ids, remote_block_ids);
   EXPECT_EQ(info.request_id, "req_0");
   EXPECT_EQ(info.dp_rank, 3);
+}
+
+Sequence make_basic_sequence(const std::vector<int32_t>& prompt_token_ids) {
+  static RequestSamplingParam sampling_param;
+  static StoppingChecker stopping_checker;
+
+  SequenceParams seq_params;
+  seq_params.seq_capacity = prompt_token_ids.size() + 8;
+  seq_params.stopping_checker = &stopping_checker;
+  seq_params.sampling_param = &sampling_param;
+  seq_params.skip_special_tokens = true;
+  seq_params.echo = false;
+  seq_params.logprobs = false;
+  seq_params.enable_schedule_overlap = false;
+
+  IncrementalDecoder decoder(/*prompt=*/"",
+                             /*num_prompt_tokens=*/prompt_token_ids.size(),
+                             /*echo=*/false,
+                             /*skip_special_tokens=*/true);
+  return Sequence(/*index=*/0,
+                  prompt_token_ids,
+                  /*input_embedding=*/torch::Tensor(),
+                  /*mm_data=*/MMData(),
+                  decoder,
+                  seq_params);
 }
 
 }  // namespace
@@ -264,6 +291,56 @@ TEST(BatchInputBuilderTest, RemoteCoverageShortageDies) {
         (void)info;
       },
       "remote");
+}
+
+TEST(BatchTest, ProcessSampleOutputStoresMtpBootstrapEmbedding) {
+  BlockManager::Options options;
+  options.num_blocks(8).block_size(4);
+  BlockManagerImpl manager(options);
+
+  Sequence sequence = make_basic_sequence({1, 2, 3});
+  sequence.add_kv_blocks(manager.allocate(1));
+
+  Batch batch(&sequence);
+  (void)batch.prepare_forward_input(
+      /*num_decoding_tokens=*/1, /*min_decoding_batch_size=*/0, ModelArgs());
+
+  SampleOutput output;
+  output.next_tokens = torch::tensor({42}, torch::kInt);
+  output.embeddings = torch::tensor({{3.0f, 4.0f}});
+
+  batch.process_sample_output(output, /*replace_fake_token=*/false);
+
+  torch::Tensor stored = sequence.get_mtp_bootstrap_embedding();
+  ASSERT_TRUE(stored.defined());
+  EXPECT_TRUE(torch::equal(stored, output.embeddings[0]));
+
+  output.embeddings.fill_(9.0f);
+  EXPECT_TRUE(torch::equal(sequence.get_mtp_bootstrap_embedding(),
+                           torch::tensor({3.0f, 4.0f})));
+}
+
+TEST(BatchTest, ProcessRawOutputStoresMtpBootstrapEmbedding) {
+  BlockManager::Options options;
+  options.num_blocks(8).block_size(4);
+  BlockManagerImpl manager(options);
+
+  Sequence sequence = make_basic_sequence({1, 2, 3});
+  sequence.add_kv_blocks(manager.allocate(1));
+
+  Batch batch(&sequence);
+  (void)batch.prepare_forward_input(
+      /*num_decoding_tokens=*/1, /*min_decoding_batch_size=*/0, ModelArgs());
+
+  RawForwardOutput raw_output;
+  raw_output.outputs.push_back(make_raw_sample_output(
+      42, std::nullopt, {}, {}, /*embeddings=*/{3.0f, 4.0f}));
+
+  batch.process_sample_output(raw_output, /*replace_fake_token=*/false);
+
+  torch::Tensor stored = sequence.get_mtp_bootstrap_embedding();
+  ASSERT_TRUE(stored.defined());
+  EXPECT_TRUE(torch::equal(stored, torch::tensor({3.0f, 4.0f})));
 }
 
 TEST(BatchTest, Basic) {

--- a/tests/core/framework/kv_cache/embedding_cache_test.cpp
+++ b/tests/core/framework/kv_cache/embedding_cache_test.cpp
@@ -159,11 +159,6 @@ TEST(EmbeddingCacheTest, WriteMtpBootstrapContextStoresExactDecodeState) {
   EXPECT_FALSE(states[0].all_draft_accepted);
   EXPECT_TRUE(tensor_equal(states[0].embedding, embedding));
 
-  embedding.fill_(9.0f);
-  states = cache.read_decode_states({1}, {"req_bootstrap"});
-  EXPECT_TRUE(
-      tensor_equal(states[0].embedding, torch::tensor({1.0f, 2.0f, 3.0f})));
-
   cache.clear({1});
   states = cache.read_decode_states({1}, {"req_bootstrap"});
   EXPECT_FALSE(states[0].valid);

--- a/tests/core/framework/kv_cache/embedding_cache_test.cpp
+++ b/tests/core/framework/kv_cache/embedding_cache_test.cpp
@@ -142,4 +142,32 @@ TEST(EmbeddingCacheTest, RequestMismatchMaterializesMissingState) {
   EXPECT_FALSE(states[0].embedding.defined());
 }
 
+TEST(EmbeddingCacheTest, WriteMtpBootstrapContextStoresExactDecodeState) {
+  EmbeddingCache cache(/*total_nums=*/2);
+  torch::Tensor embedding = torch::tensor({1.0f, 2.0f, 3.0f});
+
+  cache.write_mtp_bootstrap_context(
+      /*embedding_id=*/1, "req_bootstrap", /*token_id=*/17, embedding);
+
+  std::vector<EmbeddingCache::DecodeState> states =
+      cache.read_decode_states({1}, {"req_bootstrap"});
+  ASSERT_EQ(states.size(), 1u);
+  EXPECT_TRUE(states[0].valid);
+  EXPECT_EQ(states[0].request_id, "req_bootstrap");
+  EXPECT_EQ(states[0].token_id, 17);
+  EXPECT_EQ(states[0].position_offset, 0);
+  EXPECT_FALSE(states[0].all_draft_accepted);
+  EXPECT_TRUE(tensor_equal(states[0].embedding, embedding));
+
+  embedding.fill_(9.0f);
+  states = cache.read_decode_states({1}, {"req_bootstrap"});
+  EXPECT_TRUE(
+      tensor_equal(states[0].embedding, torch::tensor({1.0f, 2.0f, 3.0f})));
+
+  cache.clear({1});
+  states = cache.read_decode_states({1}, {"req_bootstrap"});
+  EXPECT_FALSE(states[0].valid);
+  EXPECT_FALSE(states[0].embedding.defined());
+}
+
 }  // namespace xllm

--- a/tests/core/framework/request/CMakeLists.txt
+++ b/tests/core/framework/request/CMakeLists.txt
@@ -65,3 +65,25 @@ target_link_libraries(sequence_kv_state_test
 target_link_options(sequence_kv_state_test
                     PRIVATE
                     $<$<BOOL:${USE_MLU}>:-Wl,--no-as-needed>)
+
+cc_test(
+  NAME
+    sequence_mtp_bootstrap_test
+  SRCS
+    sequence_mtp_bootstrap_test.cpp
+  DEPS
+    :request
+    $<$<BOOL:${USE_MLU}>:torch_mlu>
+    $<$<BOOL:${USE_NPU}>:torch_npu>
+    GTest::gtest_main
+)
+target_link_libraries(sequence_mtp_bootstrap_test
+                      PUBLIC
+                      Python::Python
+                      $<$<BOOL:${USE_NPU}>:ascendcl>
+                      $<$<BOOL:${USE_NPU}>:hccl>
+                      $<$<BOOL:${USE_NPU}>:c_sec>
+                      $<$<BOOL:${USE_NPU}>:nnopbase>)
+target_link_options(sequence_mtp_bootstrap_test
+                    PRIVATE
+                    $<$<BOOL:${USE_MLU}>:-Wl,--no-as-needed>)

--- a/tests/core/framework/request/sequence_mtp_bootstrap_test.cpp
+++ b/tests/core/framework/request/sequence_mtp_bootstrap_test.cpp
@@ -1,0 +1,78 @@
+/* Copyright 2026 The xLLM Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://github.com/jd-opensource/xllm/blob/main/LICENSE
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include <gtest/gtest.h>
+
+#include <cstddef>
+#include <cstdint>
+#include <vector>
+
+#include "framework/request/incremental_decoder.h"
+#include "framework/request/sequence.h"
+
+namespace xllm {
+namespace {
+
+Sequence make_sequence() {
+  static RequestSamplingParam sampling_param;
+  static StoppingChecker stopping_checker;
+
+  SequenceParams params;
+  params.seq_capacity = 8;
+  params.echo = false;
+  params.skip_special_tokens = true;
+  params.streaming = false;
+  params.enable_schedule_overlap = false;
+  params.rec_type = RecType::kNone;
+  params.bos_token_id = 0;
+  params.request_id = "mtp_bootstrap_req";
+  params.sampling_param = &sampling_param;
+  params.stopping_checker = &stopping_checker;
+
+  std::vector<int32_t> prompt_token_ids = {1, 2, 3};
+  IncrementalDecoder decoder(
+      /*prompt=*/"prompt",
+      /*num_prompt_tokens=*/prompt_token_ids.size(),
+      /*echo=*/params.echo,
+      /*skip_special_tokens=*/params.skip_special_tokens);
+  return Sequence(/*index=*/0,
+                  prompt_token_ids,
+                  /*input_embedding=*/torch::Tensor(),
+                  /*mm_data=*/MMData(),
+                  decoder,
+                  params);
+}
+
+}  // namespace
+
+TEST(SequenceMtpBootstrapTest, StoresAndClearsBootstrapEmbedding) {
+  Sequence sequence = make_sequence();
+  torch::Tensor embedding = torch::tensor({1.0f, 2.0f});
+
+  sequence.update_mtp_bootstrap_embedding(embedding);
+
+  torch::Tensor stored = sequence.get_mtp_bootstrap_embedding();
+  ASSERT_TRUE(stored.defined());
+  EXPECT_TRUE(torch::equal(stored, embedding));
+
+  embedding.fill_(9.0f);
+  EXPECT_TRUE(torch::equal(sequence.get_mtp_bootstrap_embedding(),
+                           torch::tensor({1.0f, 2.0f})));
+
+  sequence.clear_mtp_bootstrap_embedding();
+  EXPECT_FALSE(sequence.get_mtp_bootstrap_embedding().defined());
+}
+
+}  // namespace xllm

--- a/xllm/core/framework/batch/batch.cpp
+++ b/xllm/core/framework/batch/batch.cpp
@@ -540,6 +540,7 @@ void Batch::process_sample_output(const RawForwardOutput& raw_output,
       if (!raw_token.embeddings.empty()) {
         torch::Tensor embeddings = torch::tensor(raw_token.embeddings);
         seq->update_embeddings(embeddings);
+        seq->update_mtp_bootstrap_embedding(embeddings);
       }
       // Speculative decoding may append an EOS token at the beginning,
       // followed by bonus tokens, causing the sequence stopping check to fail.
@@ -640,6 +641,7 @@ void Batch::process_sample_output(const SampleOutput& sample_output,
       auto cur_seq_embed =
           safe_to(sample_output.embeddings[output_idx++], torch::kFloat32);
       seq->update_embeddings(cur_seq_embed);
+      seq->update_mtp_bootstrap_embedding(cur_seq_embed);
     }
   }
 

--- a/xllm/core/framework/kv_cache/embedding_cache.cpp
+++ b/xllm/core/framework/kv_cache/embedding_cache.cpp
@@ -110,7 +110,7 @@ void EmbeddingCache::write_mtp_bootstrap_context(
   state.all_draft_accepted = false;
   state.token_id = token_id;
   state.position_offset = 0;
-  state.embedding = embedding.detach().clone();
+  state.embedding = embedding.detach();
 
   DecodeState& tail = mutable_tail(embedding_id);
   tail = std::move(state);

--- a/xllm/core/framework/kv_cache/embedding_cache.cpp
+++ b/xllm/core/framework/kv_cache/embedding_cache.cpp
@@ -96,6 +96,26 @@ void EmbeddingCache::write_prefill_target_context(
   }
 }
 
+void EmbeddingCache::write_mtp_bootstrap_context(
+    int32_t embedding_id,
+    const std::string& request_id,
+    int32_t token_id,
+    const torch::Tensor& embedding) {
+  CHECK(embedding.defined()) << "MTP bootstrap embedding is undefined";
+  CHECK_GE(token_id, 0) << "MTP bootstrap token should be valid";
+
+  DecodeState state;
+  state.valid = true;
+  state.request_id = request_id;
+  state.all_draft_accepted = false;
+  state.token_id = token_id;
+  state.position_offset = 0;
+  state.embedding = embedding.detach().clone();
+
+  DecodeState& tail = mutable_tail(embedding_id);
+  tail = std::move(state);
+}
+
 void EmbeddingCache::write_target_context(
     const std::vector<int32_t>& ids,
     const std::vector<std::string>& request_ids,

--- a/xllm/core/framework/kv_cache/embedding_cache.h
+++ b/xllm/core/framework/kv_cache/embedding_cache.h
@@ -74,6 +74,12 @@ class EmbeddingCache final {
       const torch::Tensor& embeddings,
       const torch::Tensor& selected_token_idxes = torch::Tensor());
 
+  // Writes PD handoff bootstrap target context for the first MTP decode step.
+  void write_mtp_bootstrap_context(int32_t embedding_id,
+                                   const std::string& request_id,
+                                   int32_t token_id,
+                                   const torch::Tensor& embedding);
+
   // Writes target validate output after rejection sampling. accepted_tokens is
   // a contiguous accepted prefix padded by -1; accepted_embeddings keeps the
   // corresponding target hidden states for the next draft extend input.

--- a/xllm/core/framework/model/model_input_params.h
+++ b/xllm/core/framework/model/model_input_params.h
@@ -723,6 +723,10 @@ struct ModelEmbeddingInput {
   // Precomputed shifted token ids for MTP prefill, aligned with tokens.
   torch::Tensor mtp_shifted_token_ids;
 
+  // Pending PD handoff bootstrap rows for the first MTP decode step.
+  std::vector<int32_t> mtp_bootstrap_row_idxes;
+  torch::Tensor mtp_bootstrap_embeddings;
+
   ModelEmbeddingInput to(const torch::Device& device) const {
     ModelEmbeddingInput out;
     out.input_embedding = safe_to(input_embedding, device);
@@ -732,6 +736,9 @@ struct ModelEmbeddingInput {
     out.request_ids = request_ids;
     out.extra_token_ids = extra_token_ids;
     out.mtp_shifted_token_ids = safe_to(mtp_shifted_token_ids, device, true);
+    out.mtp_bootstrap_row_idxes = mtp_bootstrap_row_idxes;
+    out.mtp_bootstrap_embeddings =
+        safe_to(mtp_bootstrap_embeddings, device, true);
     return out;
   }
 };

--- a/xllm/core/framework/request/sequence.cpp
+++ b/xllm/core/framework/request/sequence.cpp
@@ -287,6 +287,7 @@ Sequence::Sequence(const Sequence& other)
       mm_data_(other.mm_data_),
       mrope_position_delta_(other.mrope_position_delta_),
       output_embedding_(other.output_embedding_),
+      mtp_bootstrap_embedding_(other.mtp_bootstrap_embedding_),
       num_tokens_(other.num_tokens_),
       token_to_count_map_(other.token_to_count_map_),
       num_prompt_tokens_(other.num_prompt_tokens_),
@@ -459,6 +460,12 @@ void Sequence::update_embeddings(const torch::Tensor& embeddings) {
     if (output_embedding_.dim() == 1) {
       output_embedding_ = output_embedding_.unsqueeze(0);
     }
+  }
+}
+
+void Sequence::update_mtp_bootstrap_embedding(const torch::Tensor& embedding) {
+  if (embedding.defined()) {
+    mtp_bootstrap_embedding_ = embedding.detach().clone();
   }
 }
 

--- a/xllm/core/framework/request/sequence.h
+++ b/xllm/core/framework/request/sequence.h
@@ -192,6 +192,13 @@ class Sequence final {
   void update_mm_embeddings(const std::vector<torch::Tensor>& mm_embeddings);
   // update embeddings to the sequence
   void update_embeddings(const torch::Tensor& embedding);
+  void update_mtp_bootstrap_embedding(const torch::Tensor& embedding);
+  torch::Tensor get_mtp_bootstrap_embedding() const {
+    return mtp_bootstrap_embedding_;
+  }
+  void clear_mtp_bootstrap_embedding() {
+    mtp_bootstrap_embedding_ = torch::Tensor();
+  }
   bool has_single_block_id() const { return single_block_.is_valid(); }
   int32_t get_single_block_id() const {
     return has_single_block_id() ? single_block_.id() : -1;
@@ -473,6 +480,9 @@ class Sequence final {
 
   // embeddings of the sequence
   torch::Tensor output_embedding_;
+
+  // temporary PD handoff bootstrap hidden state for first MTP decode.
+  torch::Tensor mtp_bootstrap_embedding_;
 
   // number of tokens in the sequence
   size_t num_tokens_ = 0;

--- a/xllm/core/runtime/forward_params.h
+++ b/xllm/core/runtime/forward_params.h
@@ -217,6 +217,7 @@ inline void clear_contiguous_input_buffer_tensor_targets(
     ModelInputParams& params) {
   params.embedding.input_embedding = torch::Tensor();
   params.embedding.linear_state_indices = torch::Tensor();
+  params.embedding.mtp_bootstrap_embeddings = torch::Tensor();
   params.block_copy.src_block_indices = torch::Tensor();
   params.block_copy.dst_block_indices = torch::Tensor();
   params.block_copy.cum_sum = torch::Tensor();
@@ -262,6 +263,8 @@ inline bool add_model_tensors_to_plan(const ModelInputParams& source,
                   &target.embedding.input_embedding) &&
          plan.add(source.embedding.linear_state_indices,
                   &target.embedding.linear_state_indices) &&
+         plan.add(source.embedding.mtp_bootstrap_embeddings,
+                  &target.embedding.mtp_bootstrap_embeddings) &&
          plan.add(source.block_copy.src_block_indices,
                   &target.block_copy.src_block_indices) &&
          plan.add(source.block_copy.dst_block_indices,

--- a/xllm/core/runtime/forward_shared_memory_manager.cpp
+++ b/xllm/core/runtime/forward_shared_memory_manager.cpp
@@ -2196,6 +2196,8 @@ inline void deserialize_forward_input_payload(
   // dropped by the CP polish commit (no live worker consumer).
   read_tensor(context, input_params.mtp_shifted_token_ids, stream);
   read_tensor(context, input_params.embedding.mtp_shifted_token_ids, stream);
+  read_vector(context, input_params.embedding.mtp_bootstrap_row_idxes);
+  read_tensor(context, input_params.embedding.mtp_bootstrap_embeddings, stream);
   read_swap_blocks(context, input_params.block_copy.swap_blocks);
   read_tensor(context, input_params.block_copy.src_block_indices, stream);
   read_tensor(context, input_params.block_copy.dst_block_indices, stream);
@@ -2521,6 +2523,9 @@ inline void serialize_forward_input_sections(
   // deserializer sees both fields. Order MUST match the read_* sequence.
   write_tensor(context, input_params.mtp_shifted_token_ids);
   write_tensor(context, input_params.embedding.mtp_shifted_token_ids);
+  write_vector(context.descriptor,
+               input_params.embedding.mtp_bootstrap_row_idxes);
+  write_tensor(context, input_params.embedding.mtp_bootstrap_embeddings);
   write_swap_blocks(context, input_params.block_copy.swap_blocks);
   write_tensor(context, input_params.block_copy.src_block_indices);
   write_tensor(context, input_params.block_copy.dst_block_indices);

--- a/xllm/core/runtime/mtp_worker_impl.cpp
+++ b/xllm/core/runtime/mtp_worker_impl.cpp
@@ -119,9 +119,17 @@ void wait_metadata_ready_event(const ForwardInput& input, Stream& stream) {
       << "failed to wait speculative metadata ready event";
 }
 
-void clear_output_embeddings(ForwardOutput& output) {
+void clear_sample_embeddings(ForwardOutput& output) {
   output.sample_output.embeddings = torch::Tensor();
+}
+
+void clear_selected_embeddings(ForwardOutput& output) {
   output.sample_output.selected_embeddings = torch::Tensor();
+}
+
+void clear_all_output_embeddings(ForwardOutput& output) {
+  clear_sample_embeddings(output);
+  clear_selected_embeddings(output);
 }
 
 void clear_ready_events(ForwardInput& input) {
@@ -186,6 +194,35 @@ bool has_mtp_prefill_placeholder_extra_token(
   return std::find(extra_token_ids.begin(),
                    extra_token_ids.end(),
                    placeholder) != extra_token_ids.end();
+}
+
+void check_mtp_decode_states(
+    const std::vector<EmbeddingCache::DecodeState>& states,
+    const std::vector<std::string>& request_ids,
+    const torch::Tensor& token_ids_host) {
+  CHECK(!request_ids.empty())
+      << "MTP decode requires request ids for bootstrap state validation";
+  CHECK_EQ(states.size(), request_ids.size())
+      << "MTP decode request/state count mismatch";
+  CHECK_GE(token_ids_host.numel(), static_cast<int64_t>(states.size()))
+      << "MTP decode token/state count mismatch";
+
+  Slice<int32_t> token_ids = {token_ids_host.data_ptr<int32_t>(),
+                              static_cast<size_t>(token_ids_host.numel())};
+  for (int32_t i = 0; i < static_cast<int32_t>(states.size()); ++i) {
+    const EmbeddingCache::DecodeState& state = states[i];
+    const int32_t token_id = token_ids[i];
+    CHECK(state.valid) << "MTP decode missing target state, request_id="
+                       << request_ids[i];
+    CHECK_EQ(state.request_id, request_ids[i])
+        << "MTP decode target state request mismatch";
+    CHECK_EQ(state.token_id, token_id)
+        << "MTP decode target state token mismatch, request_id="
+        << request_ids[i];
+    CHECK(state.embedding.defined())
+        << "MTP decode target state embedding is undefined, request_id="
+        << request_ids[i];
+  }
 }
 
 // CP partition keeps the final -1 placeholder on exactly one rank's shard.
@@ -619,7 +656,7 @@ std::optional<ForwardOutput> MTPWorkerImpl::step_empty(
     auto draft_output = run_llm_no_sync_impl(
         *draft_impl_, input, *prepare_stream_, *compute_stream_);
     (void)draft_output;
-    clear_output_embeddings(*output);
+    clear_all_output_embeddings(*output);
     return output;
   } else {
     ForwardInput new_input = input;
@@ -650,7 +687,7 @@ std::optional<ForwardOutput> MTPWorkerImpl::step_empty(
         run_llm_no_sync_impl(
             *impl_, new_input, *prepare_stream_, *compute_stream_)
             .value();
-    clear_output_embeddings(output);
+    clear_all_output_embeddings(output);
     return output;
   }
 }
@@ -715,14 +752,27 @@ std::optional<ForwardOutput> MTPWorkerImpl::step_prefill(
         output.sample_output.selected_embeddings.defined()
             ? output.sample_output.selected_embeddings
             : embeddings;
+    torch::Tensor bootstrap_embeddings = target_hidden;
+    if (bootstrap_embeddings.size(0) !=
+        static_cast<int64_t>(
+            input.input_params.embedding.embedding_ids.size())) {
+      torch::Tensor bootstrap_idxes =
+          input.sampling_params.selected_token_idxes.to(
+              torch::dtype(torch::kLong).device(bootstrap_embeddings.device()));
+      bootstrap_embeddings =
+          bootstrap_embeddings.index_select(/*dim=*/0, bootstrap_idxes);
+    }
+    output.sample_output.embeddings = bootstrap_embeddings.detach().clone();
     embedding_cache_->write_prefill_target_context(
         input.input_params.embedding.embedding_ids,
         input.input_params.embedding.request_ids,
         output.sample_output.next_tokens,
         target_hidden,
         input.sampling_params.selected_token_idxes);
+    clear_selected_embeddings(output);
+  } else {
+    clear_all_output_embeddings(output);
   }
-  clear_output_embeddings(output);
 
   if (!enable_schedule_overlap() && !driver_ && !dp_driver_) {
     return std::nullopt;
@@ -800,6 +850,9 @@ std::optional<ForwardOutput> MTPWorkerImpl::step_decode(
   CHECK_EQ(last_states.size(),
            input.input_params.embedding.embedding_ids.size())
       << "decode target state count mismatch";
+  check_mtp_decode_states(last_states,
+                          input.input_params.embedding.request_ids,
+                          input.token_ids_host);
   update_decode_step_input(input, last_states);
   prepare_draft_extend_inputs(input, last_states, current_draft_input);
   draft_outputs.reserve(num_speculative_tokens);
@@ -909,7 +962,7 @@ std::optional<ForwardOutput> MTPWorkerImpl::run_validate(
   if (!enable_schedule_overlap() && !driver_ && !dp_driver_) {
     return std::nullopt;
   }
-  clear_output_embeddings(target_output);
+  clear_all_output_embeddings(target_output);
   val_output.embeddings = torch::Tensor();
   target_output.sample_output = val_output;
   return target_output;

--- a/xllm/core/runtime/mtp_worker_impl.cpp
+++ b/xllm/core/runtime/mtp_worker_impl.cpp
@@ -762,7 +762,7 @@ std::optional<ForwardOutput> MTPWorkerImpl::step_prefill(
       bootstrap_embeddings =
           bootstrap_embeddings.index_select(/*dim=*/0, bootstrap_idxes);
     }
-    output.sample_output.embeddings = bootstrap_embeddings.detach().clone();
+    output.sample_output.embeddings = bootstrap_embeddings.detach();
     embedding_cache_->write_prefill_target_context(
         input.input_params.embedding.embedding_ids,
         input.input_params.embedding.request_ids,

--- a/xllm/core/runtime/mtp_worker_impl.cpp
+++ b/xllm/core/runtime/mtp_worker_impl.cpp
@@ -842,6 +842,46 @@ std::optional<ForwardOutput> MTPWorkerImpl::step_decode(
   ForwardInput current_draft_input, validate_input, next_step_input;
   Timer timer;
 
+  CHECK(embedding_cache_ != nullptr) << "MTP embedding cache is not allocated";
+
+  const auto& embedding = input.input_params.embedding;
+  if (embedding.mtp_bootstrap_embeddings.defined()) {
+    CHECK(input.token_ids_host.defined())
+        << "MTP bootstrap requires host token ids";
+    CHECK(input.token_ids_host.device().is_cpu())
+        << "MTP bootstrap host token ids must be on CPU";
+    CHECK_EQ(input.token_ids_host.scalar_type(), torch::kInt)
+        << "MTP bootstrap host token ids must be int32";
+
+    torch::Tensor bootstrap_embeddings =
+        safe_to(embedding.mtp_bootstrap_embeddings,
+                torch::dtype(dtype_).device(device_));
+    CHECK_EQ(bootstrap_embeddings.size(0),
+             static_cast<int64_t>(embedding.mtp_bootstrap_row_idxes.size()))
+        << "MTP bootstrap row count mismatch";
+
+    Slice<int32_t> token_ids = {
+        input.token_ids_host.data_ptr<int32_t>(),
+        static_cast<size_t>(input.token_ids_host.numel())};
+    for (int32_t i = 0;
+         i < static_cast<int32_t>(embedding.mtp_bootstrap_row_idxes.size());
+         ++i) {
+      const int32_t row_idx = embedding.mtp_bootstrap_row_idxes[i];
+      CHECK_GE(row_idx, 0) << "MTP bootstrap row index should be valid";
+      CHECK_LT(row_idx, static_cast<int32_t>(embedding.embedding_ids.size()))
+          << "MTP bootstrap row index exceeds embedding ids";
+      CHECK_LT(row_idx, static_cast<int32_t>(embedding.request_ids.size()))
+          << "MTP bootstrap row index exceeds request ids";
+      CHECK_LT(static_cast<int64_t>(row_idx), input.token_ids_host.numel())
+          << "MTP bootstrap row index exceeds token ids";
+      embedding_cache_->write_mtp_bootstrap_context(
+          embedding.embedding_ids[row_idx],
+          embedding.request_ids[row_idx],
+          token_ids[row_idx],
+          bootstrap_embeddings[i]);
+    }
+  }
+
   // Get decode state of last step
   std::vector<EmbeddingCache::DecodeState> last_states =
       embedding_cache_->read_decode_states(


### PR DESCRIPTION
## Description

This PR adds the first part of MTP bootstrap support for disaggregated PD handoff.

In PD mode, the decode side needs the target hidden state for the handoff token before the first MTP decode step can follow the normal draft-extend path. This change introduces bootstrap embedding storage and transport plumbing so that the handoff embedding can be preserved, passed through `ForwardInput`, and written into the MTP embedding cache before decode validation.

Main changes:
  - Store temporary MTP bootstrap embeddings on `Sequence` and capture them from sample outputs.
  - Add `EmbeddingCache::write_mtp_bootstrap_context` to materialize a valid decode state for the first MTP decode step.
  - Extend `ModelEmbeddingInput`, contiguous input buffering, and shared-memory serialization with bootstrap row indices and embeddings.
  - Update `MTPWorkerImpl` to preserve selected prefill embeddings for handoff and seed the embedding cache from bootstrap inputs during decode.
  - Add regression coverage for `Sequence`, `Batch`, and `EmbeddingCache` bootstrap storage behavior.



## Change Type

- [ ] Bug fix
- [x] New feature
- [ ] Performance improvement
- [x] Refactor
- [ ] Documentation
- [ ] Test
- [ ] Build or CI

## Pull Request Checklist

Thank you for contributing to xLLM. Before requesting review, please make sure the following items are complete.

### PR Title and Commit Messages

- [x] The PR title and each commit message follow the xLLM commit format: `<type>: <subject>`.

> Allowed types: feat, bugfix, docs, test, refactor, chore, style, revert, perf, model, build, release.
> The subject should use clear English, start with a verb, include at least 4 words, and end with `.`.

### Pre-commit Checks

- [x] I have installed `pre-commit` by running `pip install pre-commit` or an equivalent command.
- [x] I have installed the hooks with `pre-commit install`.
- [x] I have run `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

### Self Review

- [x] I have self-reviewed the code according to `.agents/skills/code-review/references/custom-code-style.md`, especially code written or assisted by AI.
- [x] I have rebased this PR onto the latest `main` branch.

### Build and Test Coverage

- [x] Tests have been added or updated as needed.
- [ ] CUDA: `python setup.py build test` has passed on a CUDA machine.
- [ ] NPU: `python setup.py build test` has passed on an NPU machine.
- [x] MLU: `python setup.py build test` has passed on an MLU machine.
