### PR TITLE
bugfix: fix anthropic tool call compatibility and eos issues.

### DIFF
--- a/tests/api_service/CMakeLists.txt
+++ b/tests/api_service/CMakeLists.txt
@@ -54,6 +54,17 @@ cc_test(
 
 cc_test(
   NAME
+    anthropic_stream_utils_test
+  SRCS
+    anthropic_stream_utils_test.cpp
+    ../../xllm/api_service/anthropic_stream_utils.cpp
+  DEPS
+    proto::xllm_proto
+    GTest::gtest_main
+)
+
+cc_test(
+  NAME
     usage_json_test
   SRCS
     usage_json_test.cpp

--- a/tests/api_service/CMakeLists.txt
+++ b/tests/api_service/CMakeLists.txt
@@ -43,6 +43,17 @@ cc_test(
 
 cc_test(
   NAME
+    anthropic_json_test
+  SRCS
+    anthropic_json_test.cpp
+  DEPS
+    api_service
+    GTest::gtest_main
+    nlohmann_json::nlohmann_json
+)
+
+cc_test(
+  NAME
     usage_json_test
   SRCS
     usage_json_test.cpp

--- a/tests/api_service/anthropic_json_test.cpp
+++ b/tests/api_service/anthropic_json_test.cpp
@@ -1,0 +1,119 @@
+/* Copyright 2026 The xLLM Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://github.com/jd-opensource/xllm/blob/main/LICENSE
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include "api_service/anthropic_json.h"
+
+#include <google/protobuf/util/json_util.h>
+#include <gtest/gtest.h>
+#include <json2pb/pb_to_json.h>
+
+#include <nlohmann/json.hpp>
+#include <string>
+
+#include "anthropic.pb.h"
+
+namespace xllm {
+namespace {
+
+google::protobuf::Struct json_to_struct(const nlohmann::json& value) {
+  google::protobuf::Struct pb_struct;
+  std::string json_str = value.dump();
+  google::protobuf::util::JsonStringToMessage(json_str, &pb_struct);
+  return pb_struct;
+}
+
+json2pb::Pb2JsonOptions json_options() {
+  json2pb::Pb2JsonOptions options;
+  options.bytes_to_base64 = false;
+  options.jsonify_empty_array = true;
+  return options;
+}
+
+TEST(AnthropicJsonTest, ExpandsToolUseInputStruct) {
+  proto::AnthropicMessagesResponse response;
+  response.set_id("msg_123");
+  response.set_type("message");
+  response.set_role("assistant");
+  response.set_model("test_model");
+  response.set_stop_reason("tool_use");
+
+  auto* tool_block = response.add_content();
+  tool_block->set_type("tool_use");
+  tool_block->set_id("call_123");
+  tool_block->set_name("get_weather");
+  *tool_block->mutable_input() =
+      json_to_struct({{"city", "San Francisco"}, {"unit", "celsius"}});
+
+  std::string json;
+  std::string err_msg;
+  ASSERT_TRUE(api_service::proto_to_anthropic_json(
+      response, json_options(), &json, &err_msg))
+      << err_msg;
+
+  nlohmann::json parsed = nlohmann::json::parse(json);
+  ASSERT_TRUE(parsed["content"].is_array());
+  ASSERT_EQ(parsed["content"].size(), 1);
+  const nlohmann::json& input = parsed["content"][0]["input"];
+  ASSERT_TRUE(input.is_object());
+  EXPECT_FALSE(input.contains("fields"));
+  EXPECT_EQ(input["city"], "San Francisco");
+  EXPECT_EQ(input["unit"], "celsius");
+  EXPECT_EQ(parsed["stop_reason"], "tool_use");
+}
+
+TEST(AnthropicJsonTest, KeepsEmptyContentArray) {
+  proto::AnthropicMessagesResponse response;
+  response.set_id("msg_123");
+  response.set_type("message");
+  response.set_role("assistant");
+  response.set_model("test_model");
+
+  std::string json;
+  std::string err_msg;
+  ASSERT_TRUE(api_service::proto_to_anthropic_json(
+      response, json_options(), &json, &err_msg))
+      << err_msg;
+
+  nlohmann::json parsed = nlohmann::json::parse(json);
+  ASSERT_TRUE(parsed.contains("content"));
+  EXPECT_TRUE(parsed["content"].is_array());
+  EXPECT_TRUE(parsed["content"].empty());
+}
+
+TEST(AnthropicJsonTest, KeepsEmptyToolUseInputObject) {
+  proto::AnthropicStreamEvent event;
+  event.set_type("content_block_start");
+  event.set_index(0);
+  auto* content_block = event.mutable_content_block();
+  content_block->set_type("tool_use");
+  content_block->set_id("call_123");
+  content_block->set_name("Bash");
+  content_block->mutable_input();
+
+  std::string json;
+  std::string err_msg;
+  ASSERT_TRUE(api_service::proto_to_anthropic_json(
+      event, json_options(), &json, &err_msg))
+      << err_msg;
+
+  nlohmann::json parsed = nlohmann::json::parse(json);
+  const nlohmann::json& input = parsed["content_block"]["input"];
+  ASSERT_TRUE(input.is_object());
+  EXPECT_TRUE(input.empty());
+  EXPECT_FALSE(input.contains("fields"));
+}
+
+}  // namespace
+}  // namespace xllm

--- a/tests/api_service/anthropic_json_test.cpp
+++ b/tests/api_service/anthropic_json_test.cpp
@@ -155,7 +155,6 @@ TEST(AnthropicJsonTest, KeepsEmptyToolUseInputObject) {
   const nlohmann::json& input = parsed["content_block"]["input"];
   ASSERT_TRUE(input.is_object());
   EXPECT_TRUE(input.empty());
-  EXPECT_FALSE(input.contains("fields"));
 }
 
 }  // namespace

--- a/tests/api_service/anthropic_json_test.cpp
+++ b/tests/api_service/anthropic_json_test.cpp
@@ -73,6 +73,49 @@ TEST(AnthropicJsonTest, ExpandsToolUseInputStruct) {
   EXPECT_EQ(parsed["stop_reason"], "tool_use");
 }
 
+TEST(AnthropicJsonTest, ExpandsNestedToolInputStruct) {
+  proto::AnthropicMessagesResponse response;
+  response.set_id("msg_123");
+  response.set_type("message");
+  response.set_role("assistant");
+  response.set_model("test_model");
+  response.set_stop_reason("tool_use");
+
+  auto* tool_block = response.add_content();
+  tool_block->set_type("tool_use");
+  tool_block->set_id("call_123");
+  tool_block->set_name("search");
+  *tool_block->mutable_input() = json_to_struct({
+      {"query", "error budget"},
+      {"limit", 3},
+      {"filters",
+       {{"regions", {"us-east-1", "eu-west-1"}}, {"archived", nullptr}}},
+      {"flags", {true, false}},
+  });
+
+  std::string json;
+  std::string err_msg;
+  ASSERT_TRUE(api_service::proto_to_anthropic_json(
+      response, json_options(), &json, &err_msg))
+      << err_msg;
+
+  nlohmann::json parsed = nlohmann::json::parse(json);
+  const nlohmann::json& input = parsed["content"][0]["input"];
+  ASSERT_TRUE(input.is_object());
+  EXPECT_FALSE(input.contains("fields"));
+  EXPECT_EQ(input["query"], "error budget");
+  EXPECT_EQ(input["limit"].get<double>(), 3.0);
+  ASSERT_TRUE(input["filters"].is_object());
+  EXPECT_FALSE(input["filters"].contains("fields"));
+  ASSERT_TRUE(input["filters"]["regions"].is_array());
+  EXPECT_EQ(input["filters"]["regions"][0], "us-east-1");
+  EXPECT_EQ(input["filters"]["regions"][1], "eu-west-1");
+  EXPECT_TRUE(input["filters"]["archived"].is_null());
+  ASSERT_TRUE(input["flags"].is_array());
+  EXPECT_EQ(input["flags"][0], true);
+  EXPECT_EQ(input["flags"][1], false);
+}
+
 TEST(AnthropicJsonTest, KeepsEmptyContentArray) {
   proto::AnthropicMessagesResponse response;
   response.set_id("msg_123");

--- a/tests/api_service/anthropic_stream_utils_test.cpp
+++ b/tests/api_service/anthropic_stream_utils_test.cpp
@@ -1,0 +1,83 @@
+/* Copyright 2026 The xLLM Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://github.com/jd-opensource/xllm/blob/main/LICENSE
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include "api_service/anthropic_stream_utils.h"
+
+#include <gtest/gtest.h>
+
+#include <optional>
+#include <string>
+
+namespace xllm {
+namespace {
+
+TEST(AnthropicStreamUtilsTest, MapsToolFinishReasonsToToolUse) {
+  EXPECT_EQ(api_service::convert_finish_reason_to_anthropic("tool_calls"),
+            "tool_use");
+  EXPECT_EQ(api_service::convert_finish_reason_to_anthropic("function_call"),
+            "tool_use");
+}
+
+TEST(AnthropicStreamUtilsTest, MapsTextFinishReasons) {
+  EXPECT_EQ(api_service::convert_finish_reason_to_anthropic("stop"),
+            "end_turn");
+  EXPECT_EQ(api_service::convert_finish_reason_to_anthropic("length"),
+            "max_tokens");
+  EXPECT_EQ(api_service::convert_finish_reason_to_anthropic("unknown"),
+            "end_turn");
+}
+
+TEST(AnthropicStreamUtilsTest, ToolCallOverridesStreamStopReason) {
+  EXPECT_EQ(api_service::get_stream_stop_reason(true, true, "stop"),
+            "tool_use");
+  EXPECT_EQ(api_service::get_stream_stop_reason(true, true, "length"),
+            "tool_use");
+  EXPECT_EQ(api_service::get_stream_stop_reason(true, true, ""), "tool_use");
+}
+
+TEST(AnthropicStreamUtilsTest, TextStreamKeepsMappedStopReason) {
+  EXPECT_EQ(api_service::get_stream_stop_reason(true, false, "stop"),
+            "end_turn");
+  EXPECT_EQ(api_service::get_stream_stop_reason(true, false, "length"),
+            "max_tokens");
+}
+
+TEST(AnthropicStreamUtilsTest, CancelledStreamUsesStop) {
+  EXPECT_EQ(api_service::get_stream_stop_reason(false, true, "length"), "stop");
+  EXPECT_EQ(api_service::get_stream_stop_reason(false, false, "stop"), "stop");
+}
+
+TEST(AnthropicStreamUtilsTest, EmptyToolArgsDoNotCreateInputDelta) {
+  std::optional<proto::AnthropicStreamEvent> event =
+      api_service::make_input_json_delta_event(2, "");
+
+  EXPECT_FALSE(event.has_value());
+}
+
+TEST(AnthropicStreamUtilsTest, NonEmptyToolArgsCreateInputDelta) {
+  std::optional<proto::AnthropicStreamEvent> event =
+      api_service::make_input_json_delta_event(2, "{\"city\":\"Paris\"}");
+
+  ASSERT_TRUE(event.has_value());
+  EXPECT_EQ(event->type(), "content_block_delta");
+  ASSERT_TRUE(event->has_index());
+  EXPECT_EQ(event->index(), 2);
+  ASSERT_TRUE(event->has_delta());
+  EXPECT_EQ(event->delta().type(), "input_json_delta");
+  EXPECT_EQ(event->delta().partial_json(), "{\"city\":\"Paris\"}");
+}
+
+}  // namespace
+}  // namespace xllm

--- a/tests/api_service/chat_json_parser_test.cpp
+++ b/tests/api_service/chat_json_parser_test.cpp
@@ -15,9 +15,12 @@ limitations under the License.
 
 #include "api_service/chat_json_parser.h"
 
+#include <google/protobuf/util/json_util.h>
 #include <gtest/gtest.h>
 
 #include <nlohmann/json.hpp>
+
+#include "anthropic.pb.h"
 
 namespace xllm {
 
@@ -383,6 +386,31 @@ TEST_F(PreprocessChatJsonTest, AnthropicPreservesOtherFields) {
   })";
   AnthropicChatJsonParser parser;
   expect_success(input, parser, expected);
+}
+
+TEST_F(PreprocessChatJsonTest, AnthropicIgnoreEosParsedAfterRemap) {
+  std::string input = R"({
+    "model": "claude-3",
+    "max_tokens": 1024,
+    "ignore_eos": true,
+    "messages": [{"role": "user", "content": "Hello"}]
+  })";
+
+  AnthropicChatJsonParser parser;
+  auto [status, processed_json] = parser.preprocess(input);
+  ASSERT_TRUE(status.ok()) << "Unexpected error: " << status.message();
+
+  proto::AnthropicMessagesRequest request;
+  google::protobuf::util::JsonParseOptions options;
+  options.ignore_unknown_fields = true;
+  auto parse_status = google::protobuf::util::JsonStringToMessage(
+      processed_json, &request, options);
+  ASSERT_TRUE(parse_status.ok()) << parse_status.ToString();
+
+  EXPECT_TRUE(request.has_ignore_eos());
+  EXPECT_TRUE(request.ignore_eos());
+  ASSERT_EQ(request.messages_size(), 1);
+  EXPECT_EQ(request.messages(0).content_string(), "Hello");
 }
 
 }  // namespace xllm

--- a/tests/api_service/chat_json_parser_test.cpp
+++ b/tests/api_service/chat_json_parser_test.cpp
@@ -368,6 +368,53 @@ TEST_F(PreprocessChatJsonTest, AnthropicToolResultRemapped) {
   EXPECT_EQ(blocks[0].content_string(), "total 1\nfile.txt");
 }
 
+TEST_F(PreprocessChatJsonTest, AnthropicToolResultListRemapped) {
+  std::string input = R"({
+    "messages": [{
+      "role": "user",
+      "content": [{
+        "type": "tool_result",
+        "tool_use_id": "call_123",
+        "content": [
+          {"type": "text", "text": "total 1"},
+          {"type": "text", "text": "file.txt"}
+        ]
+      }]
+    }]
+  })";
+
+  AnthropicChatJsonParser parser;
+  auto [status, processed_json] = parser.preprocess(input);
+  ASSERT_TRUE(status.ok()) << "Unexpected error: " << status.message();
+
+  nlohmann::json processed = nlohmann::json::parse(processed_json);
+  const nlohmann::json& block =
+      processed["messages"][0]["content_blocks"]["blocks"][0];
+  const nlohmann::json& items = block["content_list"]["items"];
+  ASSERT_TRUE(items.is_array());
+  ASSERT_EQ(items.size(), 2);
+  EXPECT_EQ(items[0]["type"], "text");
+  EXPECT_EQ(items[0]["text"], "total 1");
+  EXPECT_EQ(items[1]["type"], "text");
+  EXPECT_EQ(items[1]["text"], "file.txt");
+
+  proto::AnthropicMessagesRequest request;
+  google::protobuf::util::JsonParseOptions options;
+  options.ignore_unknown_fields = true;
+  auto parse_status = google::protobuf::util::JsonStringToMessage(
+      processed_json, &request, options);
+  ASSERT_TRUE(parse_status.ok()) << parse_status.ToString();
+
+  ASSERT_EQ(request.messages_size(), 1);
+  const auto& blocks = request.messages(0).content_blocks().blocks();
+  ASSERT_EQ(blocks.size(), 1);
+  EXPECT_EQ(blocks[0].type(), "tool_result");
+  ASSERT_TRUE(blocks[0].has_id());
+  EXPECT_EQ(blocks[0].id(), "call_123");
+  ASSERT_TRUE(blocks[0].has_content_list());
+  ASSERT_EQ(blocks[0].content_list().items_size(), 2);
+}
+
 TEST_F(PreprocessChatJsonTest, AnthropicSystemStringRemapped) {
   std::string input = R"({
     "system": "You are helpful.",

--- a/tests/api_service/chat_json_parser_test.cpp
+++ b/tests/api_service/chat_json_parser_test.cpp
@@ -335,6 +335,39 @@ TEST_F(PreprocessChatJsonTest, AnthropicArrayContentRemapped) {
   expect_success(input, parser, expected);
 }
 
+TEST_F(PreprocessChatJsonTest, AnthropicToolResultRemapped) {
+  std::string input = R"({
+    "messages": [{
+      "role": "user",
+      "content": [{
+        "type": "tool_result",
+        "tool_use_id": "call_123",
+        "content": "total 1\nfile.txt"
+      }]
+    }]
+  })";
+
+  AnthropicChatJsonParser parser;
+  auto [status, processed_json] = parser.preprocess(input);
+  ASSERT_TRUE(status.ok()) << "Unexpected error: " << status.message();
+
+  proto::AnthropicMessagesRequest request;
+  google::protobuf::util::JsonParseOptions options;
+  options.ignore_unknown_fields = true;
+  auto parse_status = google::protobuf::util::JsonStringToMessage(
+      processed_json, &request, options);
+  ASSERT_TRUE(parse_status.ok()) << parse_status.ToString();
+
+  ASSERT_EQ(request.messages_size(), 1);
+  const auto& blocks = request.messages(0).content_blocks().blocks();
+  ASSERT_EQ(blocks.size(), 1);
+  EXPECT_EQ(blocks[0].type(), "tool_result");
+  ASSERT_TRUE(blocks[0].has_id());
+  EXPECT_EQ(blocks[0].id(), "call_123");
+  ASSERT_TRUE(blocks[0].has_content_string());
+  EXPECT_EQ(blocks[0].content_string(), "total 1\nfile.txt");
+}
+
 TEST_F(PreprocessChatJsonTest, AnthropicSystemStringRemapped) {
   std::string input = R"({
     "system": "You are helpful.",

--- a/tests/core/framework/request/CMakeLists.txt
+++ b/tests/core/framework/request/CMakeLists.txt
@@ -24,6 +24,16 @@ cc_test(
 
 cc_test(
   NAME
+    stopping_checker_test
+  SRCS
+    stopping_checker_test.cpp
+  DEPS
+    :request
+    GTest::gtest_main
+)
+
+cc_test(
+  NAME
     request_prefix_cache_tokens_test
   SRCS
     request_prefix_cache_tokens_test.cpp

--- a/tests/core/framework/request/request_params_test.cpp
+++ b/tests/core/framework/request/request_params_test.cpp
@@ -113,6 +113,49 @@ TEST(RequestParamsTest, AnthropicPreservesIgnoreEos) {
   EXPECT_TRUE(params.ignore_eos);
 }
 
+TEST(RequestParamsTest, AnthropicToolChoiceDefaults) {
+  proto::AnthropicMessagesRequest request;
+  request.set_model("claude-3");
+  request.set_max_tokens(16);
+
+  RequestParams no_tool_params(request, "", "");
+  EXPECT_EQ(no_tool_params.tool_choice, "");
+
+  auto* tool = request.add_tools();
+  tool->set_name("list_files");
+
+  RequestParams auto_params(request, "", "");
+  EXPECT_EQ(auto_params.tool_choice, "auto");
+
+  request.mutable_tool_choice()->set_type("any");
+  RequestParams required_params(request, "", "");
+  EXPECT_EQ(required_params.tool_choice, "required");
+
+  request.mutable_tool_choice()->set_type("tool");
+  request.mutable_tool_choice()->clear_name();
+  RequestParams fallback_params(request, "", "");
+  EXPECT_EQ(fallback_params.tool_choice, "auto");
+
+  request.mutable_tool_choice()->set_type("unknown");
+  RequestParams unknown_params(request, "", "");
+  EXPECT_EQ(unknown_params.tool_choice, "auto");
+}
+
+TEST(RequestParamsTest, AnthropicToolWithoutSchemaUsesEmptyJson) {
+  proto::AnthropicMessagesRequest request;
+  request.set_model("claude-3");
+  request.set_max_tokens(16);
+
+  auto* tool = request.add_tools();
+  tool->set_name("list_files");
+
+  RequestParams params(request, "", "");
+
+  ASSERT_EQ(params.tools.size(), 1);
+  EXPECT_TRUE(params.tools[0].function.parameters.is_object());
+  EXPECT_TRUE(params.tools[0].function.parameters.empty());
+}
+
 TEST(RequestParamsTest, AnthropicToolSchemaUsesPlainJson) {
   proto::AnthropicMessagesRequest request;
   request.set_model("claude-3");

--- a/tests/core/framework/request/request_params_test.cpp
+++ b/tests/core/framework/request/request_params_test.cpp
@@ -15,6 +15,7 @@ limitations under the License.
 
 #include "core/framework/request/request_params.h"
 
+#include <google/protobuf/util/json_util.h>
 #include <gtest/gtest.h>
 
 #include "anthropic.pb.h"
@@ -110,6 +111,61 @@ TEST(RequestParamsTest, AnthropicPreservesIgnoreEos) {
   RequestParams params(request, "", "");
 
   EXPECT_TRUE(params.ignore_eos);
+}
+
+TEST(RequestParamsTest, AnthropicToolSchemaUsesPlainJson) {
+  proto::AnthropicMessagesRequest request;
+  request.set_model("claude-3");
+  request.set_max_tokens(16);
+
+  auto* tool = request.add_tools();
+  tool->set_name("list_files");
+  tool->set_description("List files under a folder");
+  const std::string schema = R"({
+    "type": "object",
+    "properties": {
+      "path": {
+        "type": "string",
+        "description": "Folder path"
+      },
+      "recursive": {
+        "type": "boolean",
+        "default": false
+      }
+    },
+    "required": ["path"]
+  })";
+  auto status = google::protobuf::util::JsonStringToMessage(
+      schema, tool->mutable_input_schema());
+  ASSERT_TRUE(status.ok()) << status.ToString();
+
+  auto* tool_choice = request.mutable_tool_choice();
+  tool_choice->set_type("tool");
+  tool_choice->set_name("list_files");
+
+  RequestParams params(request, "", "");
+
+  ASSERT_EQ(params.tools.size(), 1);
+  const auto& parsed_tool = params.tools[0];
+  EXPECT_EQ(parsed_tool.type, "function");
+  EXPECT_EQ(parsed_tool.function.name, "list_files");
+  EXPECT_EQ(parsed_tool.function.description, "List files under a folder");
+
+  const nlohmann::json& params_schema = parsed_tool.function.parameters;
+  ASSERT_TRUE(params_schema.is_object());
+  EXPECT_FALSE(params_schema.contains("fields"));
+  EXPECT_EQ(params_schema.at("type"), "object");
+  EXPECT_EQ(params_schema.at("properties").at("path").at("type"), "string");
+  EXPECT_EQ(params_schema.at("properties").at("recursive").at("type"),
+            "boolean");
+  EXPECT_EQ(params_schema.at("properties").at("recursive").at("default"),
+            false);
+  ASSERT_TRUE(params_schema.at("required").is_array());
+  EXPECT_EQ(params_schema.at("required").at(0), "path");
+
+  nlohmann::json expected_tool_choice = {
+      {"type", "function"}, {"function", {{"name", "list_files"}}}};
+  EXPECT_EQ(nlohmann::json::parse(params.tool_choice), expected_tool_choice);
 }
 
 }  // namespace

--- a/tests/core/framework/request/request_params_test.cpp
+++ b/tests/core/framework/request/request_params_test.cpp
@@ -17,6 +17,7 @@ limitations under the License.
 
 #include <gtest/gtest.h>
 
+#include "anthropic.pb.h"
 #include "chat.pb.h"
 #include "completion.pb.h"
 
@@ -98,6 +99,17 @@ TEST(RequestParamsTest, ChatBeamSearchKeepsExplicitZeroTopLogprobs) {
 
   EXPECT_TRUE(params.logprobs);
   EXPECT_EQ(params.top_logprobs, 0);
+}
+
+TEST(RequestParamsTest, AnthropicPreservesIgnoreEos) {
+  proto::AnthropicMessagesRequest request;
+  request.set_model("claude-3");
+  request.set_max_tokens(16);
+  request.set_ignore_eos(true);
+
+  RequestParams params(request, "", "");
+
+  EXPECT_TRUE(params.ignore_eos);
 }
 
 }  // namespace

--- a/tests/core/framework/request/stopping_checker_test.cpp
+++ b/tests/core/framework/request/stopping_checker_test.cpp
@@ -1,0 +1,70 @@
+/* Copyright 2026 The xLLM Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://github.com/jd-opensource/xllm/blob/main/LICENSE
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include "core/framework/request/stopping_checker.h"
+
+#include <gtest/gtest.h>
+
+#include <cstdint>
+#include <unordered_set>
+#include <vector>
+
+namespace xllm {
+namespace {
+
+TEST(StoppingCheckerTest, IgnoreEosSkipsOnlyEosToken) {
+  StoppingChecker checker(
+      /*max_generated_tokens=*/10,
+      /*max_context_len=*/0,
+      /*eos_token=*/2,
+      /*ignore_eos=*/true,
+      /*stop_tokens=*/std::unordered_set<int32_t>{},
+      /*stop_sequences=*/std::vector<std::vector<int32_t>>{});
+  const std::vector<int32_t> token_ids = {1, 2};
+
+  EXPECT_EQ(checker.check(token_ids, /*num_prompt_tokens=*/1),
+            FinishReason::NONE);
+}
+
+TEST(StoppingCheckerTest, IgnoreEosStillStopsOnStopToken) {
+  StoppingChecker checker(
+      /*max_generated_tokens=*/10,
+      /*max_context_len=*/0,
+      /*eos_token=*/2,
+      /*ignore_eos=*/true,
+      /*stop_tokens=*/std::unordered_set<int32_t>{7},
+      /*stop_sequences=*/std::vector<std::vector<int32_t>>{});
+  const std::vector<int32_t> token_ids = {1, 7};
+
+  EXPECT_EQ(checker.check(token_ids, /*num_prompt_tokens=*/1),
+            FinishReason::STOP);
+}
+
+TEST(StoppingCheckerTest, IgnoreEosStillStopsOnStopSequence) {
+  StoppingChecker checker(
+      /*max_generated_tokens=*/10,
+      /*max_context_len=*/0,
+      /*eos_token=*/2,
+      /*ignore_eos=*/true,
+      /*stop_tokens=*/std::unordered_set<int32_t>{},
+      /*stop_sequences=*/std::vector<std::vector<int32_t>>{{4, 5}});
+  const std::vector<int32_t> token_ids = {1, 4, 5};
+
+  EXPECT_EQ(checker.check(token_ids, /*num_prompt_tokens=*/1),
+            FinishReason::STOP);
+}
+
+}  // namespace
+}  // namespace xllm

--- a/xllm/api_service/CMakeLists.txt
+++ b/xllm/api_service/CMakeLists.txt
@@ -12,6 +12,7 @@ cc_library(
     rec_completion_service_impl.h
     chat_service_impl.h
     anthropic_service_impl.h
+    anthropic_stream_utils.h
     sample_service_impl.h
     embedding_service_impl.h
     audio_generation_service_impl.h
@@ -37,6 +38,7 @@ cc_library(
     rec_completion_service_impl.cpp
     chat_service_impl.cpp
     anthropic_service_impl.cpp
+    anthropic_stream_utils.cpp
     sample_service_impl.cpp
     embedding_service_impl.cpp
     audio_generation_service_impl.cpp

--- a/xllm/api_service/anthropic_json.h
+++ b/xllm/api_service/anthropic_json.h
@@ -1,0 +1,140 @@
+/* Copyright 2026 The xLLM Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://github.com/jd-opensource/xllm/blob/main/LICENSE
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#pragma once
+
+#include <butil/iobuf.h>
+#include <google/protobuf/message.h>
+#include <json2pb/pb_to_json.h>
+
+#include <exception>
+#include <nlohmann/json.hpp>
+#include <string>
+
+namespace xllm {
+namespace api_service {
+namespace detail {
+
+inline bool has_only_key(const nlohmann::json& value, const char* key) {
+  return value.is_object() && value.size() == 1 && value.contains(key);
+}
+
+inline nlohmann::json normalize_json(const nlohmann::json& value);
+
+inline nlohmann::json normalize_struct(const nlohmann::json& value) {
+  nlohmann::json result = nlohmann::json::object();
+  if (!value.is_object() || !value.contains("fields") ||
+      !value["fields"].is_object()) {
+    return result;
+  }
+
+  for (auto it = value["fields"].begin(); it != value["fields"].end(); ++it) {
+    result[it.key()] = normalize_json(it.value());
+  }
+  return result;
+}
+
+inline nlohmann::json normalize_list(const nlohmann::json& value) {
+  nlohmann::json result = nlohmann::json::array();
+  if (!value.is_object() || !value.contains("values") ||
+      !value["values"].is_array()) {
+    return result;
+  }
+
+  for (const nlohmann::json& item : value["values"]) {
+    result.push_back(normalize_json(item));
+  }
+  return result;
+}
+
+inline bool is_value_wrapper(const nlohmann::json& value) {
+  return has_only_key(value, "null_value") ||
+         has_only_key(value, "number_value") ||
+         has_only_key(value, "string_value") ||
+         has_only_key(value, "bool_value") ||
+         has_only_key(value, "struct_value") ||
+         has_only_key(value, "list_value");
+}
+
+inline nlohmann::json normalize_value(const nlohmann::json& value) {
+  if (has_only_key(value, "null_value")) {
+    return nullptr;
+  }
+  if (has_only_key(value, "number_value")) {
+    return value["number_value"];
+  }
+  if (has_only_key(value, "string_value")) {
+    return value["string_value"];
+  }
+  if (has_only_key(value, "bool_value")) {
+    return value["bool_value"];
+  }
+  if (has_only_key(value, "struct_value")) {
+    return normalize_struct(value["struct_value"]);
+  }
+  if (has_only_key(value, "list_value")) {
+    return normalize_list(value["list_value"]);
+  }
+  return value;
+}
+
+inline nlohmann::json normalize_json(const nlohmann::json& value) {
+  if (has_only_key(value, "fields")) {
+    return normalize_struct(value);
+  }
+  if (is_value_wrapper(value)) {
+    return normalize_value(value);
+  }
+  if (value.is_array()) {
+    nlohmann::json result = nlohmann::json::array();
+    for (const nlohmann::json& item : value) {
+      result.push_back(normalize_json(item));
+    }
+    return result;
+  }
+  if (value.is_object()) {
+    nlohmann::json result = nlohmann::json::object();
+    for (auto it = value.begin(); it != value.end(); ++it) {
+      result[it.key()] = normalize_json(it.value());
+    }
+    return result;
+  }
+  return value;
+}
+
+}  // namespace detail
+
+inline bool proto_to_anthropic_json(const google::protobuf::Message& message,
+                                    const json2pb::Pb2JsonOptions& options,
+                                    std::string* json,
+                                    std::string* err_msg) {
+  butil::IOBuf raw_buf;
+  butil::IOBufAsZeroCopyOutputStream json_output(&raw_buf);
+  if (!json2pb::ProtoMessageToJson(message, &json_output, options, err_msg)) {
+    return false;
+  }
+
+  try {
+    nlohmann::json parsed = nlohmann::json::parse(raw_buf.to_string());
+    *json = detail::normalize_json(parsed).dump();
+  } catch (const std::exception& e) {
+    *err_msg = e.what();
+    return false;
+  }
+  return true;
+}
+
+}  // namespace api_service
+}  // namespace xllm

--- a/xllm/api_service/anthropic_service_impl.cpp
+++ b/xllm/api_service/anthropic_service_impl.cpp
@@ -21,9 +21,11 @@ limitations under the License.
 #include <google/protobuf/util/json_util.h>
 
 #include <cstdint>
+#include <optional>
 #include <string>
 #include <unordered_set>
 
+#include "api_service/anthropic_stream_utils.h"
 #include "api_service/stream_output_parser.h"
 #include "api_service/utils.h"
 #include "core/common/types.h"
@@ -45,19 +47,6 @@ struct ContentBlockInfo {
   std::string normal_text = "";
   std::vector<FunctionCallInfo> function_calls;
 };
-
-std::string convert_finish_reason_to_anthropic(
-    const std::string& finish_reason) {
-  if (finish_reason == "stop") {
-    return "end_turn";
-  } else if (finish_reason == "length") {
-    return "max_tokens";
-  } else if (finish_reason == "function_call" ||
-             finish_reason == "tool_calls") {
-    return "tool_use";
-  }
-  return "end_turn";
-}
 
 // Build messages from Anthropic protobuf request
 std::vector<Message> build_messages(
@@ -283,8 +272,9 @@ bool send_result_to_client(std::shared_ptr<AnthropicCall> call,
 
     // set stop_reason
     if (choice.has_finish_reason()) {
-      anthropic_response.set_stop_reason(std::move(
-          convert_finish_reason_to_anthropic(choice.finish_reason())));
+      anthropic_response.set_stop_reason(
+          std::move(api_service::convert_finish_reason_to_anthropic(
+              choice.finish_reason())));
     }
 
     // Add text content block
@@ -392,12 +382,21 @@ bool send_content_block_delta(std::shared_ptr<AnthropicCall> call,
     delta->set_type("text_delta");
     delta->set_text(content_block_info.normal_text);
   } else if (delta_type == "tool_use_delta") {
-    if (content_block_info.function_calls.empty() ||
-        content_block_info.function_calls[0].arguments.empty()) {
+    if (content_block_info.function_calls.empty()) {
       return true;
     }
-    delta->set_type("input_json_delta");
-    delta->set_partial_json(content_block_info.function_calls[0].arguments);
+    std::optional<proto::AnthropicStreamEvent> event =
+        api_service::make_input_json_delta_event(
+            static_cast<int32_t>(content_block_index),
+            content_block_info.function_calls[0].arguments);
+    if (!event.has_value()) {
+      return true;
+    }
+    if (!call->write(event->type(), event.value())) {
+      LOG(ERROR) << "Failed to send content_block_delta event";
+      return false;
+    }
+    return true;
   } else {
     LOG(FATAL) << "Unknown delta type: " << delta_type;
   }
@@ -571,13 +570,8 @@ bool send_delta_to_client(
   // 4) finish request, we need to send the
   // last `content_block_stop` and `message_delta` event
   if (output.finished || output.cancelled) {
-    if (output.finished) {
-      finish_reason = has_tool_call
-                          ? "tool_use"
-                          : convert_finish_reason_to_anthropic(finish_reason);
-    } else {
-      finish_reason = "stop";
-    }
+    finish_reason = api_service::get_stream_stop_reason(
+        output.finished, has_tool_call, finish_reason);
 
     // if content_block_index < 0, means no content block started
     // so we don't need to send content_block_stop event

--- a/xllm/api_service/anthropic_service_impl.cpp
+++ b/xllm/api_service/anthropic_service_impl.cpp
@@ -37,6 +37,11 @@ limitations under the License.
 namespace xllm {
 namespace {
 
+LLMMaster* check_master(LLMMaster* master) {
+  CHECK(master != nullptr);
+  return master;
+}
+
 struct FunctionCallInfo {
   std::string id = "";
   std::string name = "";
@@ -359,10 +364,15 @@ bool send_content_block_delta(std::shared_ptr<AnthropicCall> call,
                               const std::string& delta_type,
                               const ContentBlockInfo& content_block_info,
                               int& content_block_index) {
+  bool is_tool_use_delta = delta_type == "tool_use_delta";
+  if (is_tool_use_delta && content_block_info.function_calls.empty()) {
+    return true;
+  }
+
   // counter new block or tool function call, we need a new content block
   // <content_block_start> ... <content_block_stop>
   if (last_content_block_type != curr_content_block_type ||
-      (delta_type == "tool_use_delta" &&
+      (is_tool_use_delta &&
        !content_block_info.function_calls[0].name.empty())) {
     // try to create new content block
     if (!start_new_content_block(call,
@@ -381,10 +391,7 @@ bool send_content_block_delta(std::shared_ptr<AnthropicCall> call,
   if (delta_type == "text_delta") {
     delta->set_type("text_delta");
     delta->set_text(content_block_info.normal_text);
-  } else if (delta_type == "tool_use_delta") {
-    if (content_block_info.function_calls.empty()) {
-      return true;
-    }
+  } else if (is_tool_use_delta) {
     std::optional<proto::AnthropicStreamEvent> event =
         api_service::make_input_json_delta_event(
             static_cast<int32_t>(content_block_index),
@@ -625,13 +632,11 @@ AnthropicServiceImpl::AnthropicServiceImpl(
     LLMMaster* master,
     const std::vector<std::string>& models)
     : APIServiceImpl(models),
-      master_(master),
+      master_(check_master(master)),
       tool_call_parser_format_(
           master_->options().tool_call_parser().value_or("")),
       reasoning_parser_format_(
-          master_->options().reasoning_parser().value_or("")) {
-  CHECK(master_ != nullptr);
-}
+          master_->options().reasoning_parser().value_or("")) {}
 
 void AnthropicServiceImpl::process_async_impl(
     std::shared_ptr<AnthropicCall> call) {
@@ -643,7 +648,6 @@ void AnthropicServiceImpl::process_async_impl(
     return;
   }
 
-  CHECK(master_ != nullptr);
   // Check rate limit
   if (master_->get_rate_limiter()->is_limited()) {
     call->finish_with_error(
@@ -668,7 +672,6 @@ void AnthropicServiceImpl::process_async_impl(
                                              tool_call_parser_format_,
                                              reasoning_parser_format_,
                                              false /*is_force_reasoning_*/);
-    CHECK(stream_parser != nullptr) << "create StreamOutputParser failed!";
   }
 
   auto saved_streaming = request_params.streaming;

--- a/xllm/api_service/anthropic_service_impl.cpp
+++ b/xllm/api_service/anthropic_service_impl.cpp
@@ -52,7 +52,8 @@ std::string convert_finish_reason_to_anthropic(
     return "end_turn";
   } else if (finish_reason == "length") {
     return "max_tokens";
-  } else if (finish_reason == "function_call") {
+  } else if (finish_reason == "function_call" ||
+             finish_reason == "tool_calls") {
     return "tool_use";
   }
   return "end_turn";
@@ -349,6 +350,7 @@ bool start_new_content_block(std::shared_ptr<AnthropicCall> call,
   } else if (curr_content_block_type == "tool_use") {
     content_block->set_id(content_block_info.function_calls[0].id);
     content_block->set_name(content_block_info.function_calls[0].name);
+    content_block->mutable_input();
   } else {
     LOG(FATAL) << "Unknown content block type: " << curr_content_block_type;
   }
@@ -390,11 +392,12 @@ bool send_content_block_delta(std::shared_ptr<AnthropicCall> call,
     delta->set_type("text_delta");
     delta->set_text(content_block_info.normal_text);
   } else if (delta_type == "tool_use_delta") {
-    delta->set_type("input_json_delta");
-    if (!content_block_info.function_calls.empty() &&
-        !content_block_info.function_calls[0].arguments.empty()) {
-      delta->set_partial_json(content_block_info.function_calls[0].arguments);
+    if (content_block_info.function_calls.empty() ||
+        content_block_info.function_calls[0].arguments.empty()) {
+      return true;
     }
+    delta->set_type("input_json_delta");
+    delta->set_partial_json(content_block_info.function_calls[0].arguments);
   } else {
     LOG(FATAL) << "Unknown delta type: " << delta_type;
   }
@@ -480,6 +483,7 @@ bool send_delta_to_client(
   }
 
   std::string finish_reason = "";
+  bool has_tool_call = false;
   for (const auto& seq_output : output.outputs) {
     const auto& index = seq_output.index;
     std::string cur_text = seq_output.text;
@@ -533,6 +537,10 @@ bool send_delta_to_client(
       }
     }
 
+    if (stream_parser && stream_parser->get_has_tool_call(index)) {
+      has_tool_call = true;
+    }
+
     // Handle finish reason
     if (seq_output.finish_reason.has_value()) {
       // Check for unstreamed tool args before sending finish reason
@@ -564,7 +572,9 @@ bool send_delta_to_client(
   // last `content_block_stop` and `message_delta` event
   if (output.finished || output.cancelled) {
     if (output.finished) {
-      finish_reason = convert_finish_reason_to_anthropic(finish_reason);
+      finish_reason = has_tool_call
+                          ? "tool_use"
+                          : convert_finish_reason_to_anthropic(finish_reason);
     } else {
       finish_reason = "stop";
     }

--- a/xllm/api_service/anthropic_service_impl.cpp
+++ b/xllm/api_service/anthropic_service_impl.cpp
@@ -634,9 +634,9 @@ AnthropicServiceImpl::AnthropicServiceImpl(
     : APIServiceImpl(models),
       master_(check_master(master)),
       tool_call_parser_format_(
-          master_->options().tool_call_parser().value_or("")),
+          master->options().tool_call_parser().value_or("")),
       reasoning_parser_format_(
-          master_->options().reasoning_parser().value_or("")) {}
+          master->options().reasoning_parser().value_or("")) {}
 
 void AnthropicServiceImpl::process_async_impl(
     std::shared_ptr<AnthropicCall> call) {

--- a/xllm/api_service/anthropic_stream_utils.cpp
+++ b/xllm/api_service/anthropic_stream_utils.cpp
@@ -1,0 +1,64 @@
+/* Copyright 2026 The xLLM Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://github.com/jd-opensource/xllm/blob/main/LICENSE
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include "api_service/anthropic_stream_utils.h"
+
+namespace xllm {
+namespace api_service {
+
+std::string convert_finish_reason_to_anthropic(
+    const std::string& finish_reason) {
+  if (finish_reason == "stop") {
+    return "end_turn";
+  }
+  if (finish_reason == "length") {
+    return "max_tokens";
+  }
+  if (finish_reason == "function_call" || finish_reason == "tool_calls") {
+    return "tool_use";
+  }
+  return "end_turn";
+}
+
+std::string get_stream_stop_reason(bool finished,
+                                   bool has_tool_call,
+                                   const std::string& finish_reason) {
+  if (!finished) {
+    return "stop";
+  }
+  if (has_tool_call) {
+    return "tool_use";
+  }
+  return convert_finish_reason_to_anthropic(finish_reason);
+}
+
+std::optional<proto::AnthropicStreamEvent> make_input_json_delta_event(
+    int32_t content_block_index,
+    const std::string& partial_json) {
+  if (partial_json.empty()) {
+    return std::nullopt;
+  }
+
+  proto::AnthropicStreamEvent chunk;
+  chunk.set_index(content_block_index);
+  chunk.set_type("content_block_delta");
+  auto* delta = chunk.mutable_delta();
+  delta->set_type("input_json_delta");
+  delta->set_partial_json(partial_json);
+  return chunk;
+}
+
+}  // namespace api_service
+}  // namespace xllm

--- a/xllm/api_service/anthropic_stream_utils.h
+++ b/xllm/api_service/anthropic_stream_utils.h
@@ -1,0 +1,39 @@
+/* Copyright 2026 The xLLM Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://github.com/jd-opensource/xllm/blob/main/LICENSE
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#pragma once
+
+#include <cstdint>
+#include <optional>
+#include <string>
+
+#include "anthropic.pb.h"
+
+namespace xllm {
+namespace api_service {
+
+std::string convert_finish_reason_to_anthropic(
+    const std::string& finish_reason);
+
+std::string get_stream_stop_reason(bool finished,
+                                   bool has_tool_call,
+                                   const std::string& finish_reason);
+
+std::optional<proto::AnthropicStreamEvent> make_input_json_delta_event(
+    int32_t content_block_index,
+    const std::string& partial_json);
+
+}  // namespace api_service
+}  // namespace xllm

--- a/xllm/api_service/chat_json_parser.cpp
+++ b/xllm/api_service/chat_json_parser.cpp
@@ -161,6 +161,27 @@ std::pair<Status, std::string> AnthropicChatJsonParser::preprocess(
           msg["content_string"] = content.get<std::string>();
           msg.erase("content");
         } else if (content.is_array()) {
+          for (auto& block : content) {
+            if (!block.is_object() ||
+                block.value("type", "") != "tool_result") {
+              continue;
+            }
+            if (block.contains("tool_use_id") && !block.contains("id")) {
+              block["id"] = block["tool_use_id"];
+            }
+            block.erase("tool_use_id");
+            if (!block.contains("content")) {
+              continue;
+            }
+            auto& tool_content = block["content"];
+            if (tool_content.is_string()) {
+              block["content_string"] = tool_content.get<std::string>();
+              block.erase("content");
+            } else if (tool_content.is_array()) {
+              block["content_list"] = {{"items", tool_content}};
+              block.erase("content");
+            }
+          }
           nlohmann::json content_blocks;
           content_blocks["blocks"] = content;
           msg["content_blocks"] = content_blocks;

--- a/xllm/api_service/chat_json_parser.h
+++ b/xllm/api_service/chat_json_parser.h
@@ -57,8 +57,9 @@ class VlmChatJsonParser final : public ChatJsonParser {
 };
 
 // Anthropic Messages API: remaps "content" (string|array) to
-// "content_string"/"content_blocks" and "system" (string|array) to
-// "system_string"/"system_blocks" for protobuf compatibility.
+// "content_string"/"content_blocks", tool_result fields to protobuf names,
+// and "system" (string|array) to "system_string"/"system_blocks" for
+// protobuf compatibility.
 class AnthropicChatJsonParser final : public ChatJsonParser {
  public:
   std::pair<Status, std::string> preprocess(

--- a/xllm/api_service/stream_call.h
+++ b/xllm/api_service/stream_call.h
@@ -25,6 +25,8 @@ limitations under the License.
 #include <optional>
 #include <string>
 
+#include "anthropic.pb.h"
+#include "api_service/anthropic_json.h"
 #include "api_service/call.h"
 #include "core/common/types.h"
 
@@ -178,6 +180,17 @@ class AnthropicCall : public StreamCall<proto::AnthropicMessagesRequest,
 
   ~AnthropicCall() {}
 
+  bool write_and_finish(proto::AnthropicMessagesResponse& response) {
+    std::string json;
+    std::string err_msg;
+    if (!api_service::proto_to_anthropic_json(
+            response, this->json_options_, &json, &err_msg)) {
+      return this->finish_with_error(StatusCode::UNKNOWN, err_msg);
+    }
+    this->controller_->response_attachment().append(json);
+    return true;
+  }
+
   // Write SSE event with Anthropic format: event: <type>\ndata: <json>\n\n
   bool write(const std::string& event_type, const std::string& json_data) {
     this->io_buf_.clear();
@@ -198,13 +211,14 @@ class AnthropicCall : public StreamCall<proto::AnthropicMessagesRequest,
     this->io_buf_.append("event: ");
     this->io_buf_.append(event_type);
     this->io_buf_.append("\ndata: ");
-    butil::IOBufAsZeroCopyOutputStream json_output(&this->io_buf_);
+    std::string json;
     std::string err_msg;
-    if (!json2pb::ProtoMessageToJson(
-            message, &json_output, this->json_options_, &err_msg)) {
+    if (!api_service::proto_to_anthropic_json(
+            message, this->json_options_, &json, &err_msg)) {
       LOG(ERROR) << "Failed to convert proto to json: " << err_msg;
       return false;
     }
+    this->io_buf_.append(json);
     this->io_buf_.append("\n\n");
     this->connection_status_ |= this->pa_->Write(this->io_buf_);
     return this->connection_status_ == 0;

--- a/xllm/core/framework/request/request_params.cpp
+++ b/xllm/core/framework/request/request_params.cpp
@@ -549,6 +549,9 @@ RequestParams::RequestParams(const proto::AnthropicMessagesRequest& request,
     stop = std::vector<std::string>(request.stop_sequences().begin(),
                                     request.stop_sequences().end());
   }
+  if (request.has_ignore_eos()) {
+    ignore_eos = request.ignore_eos();
+  }
   tool_choice = std::move(handle_tool_choice(request));
   tools = std::move(handle_tools(request));
 }

--- a/xllm/core/framework/request/request_params.cpp
+++ b/xllm/core/framework/request/request_params.cpp
@@ -16,8 +16,6 @@ limitations under the License.
 
 #include "request_params.h"
 
-#include <google/protobuf/util/json_util.h>
-
 #include "core/common/global_flags.h"
 #include "core/common/instance_name.h"
 #include "core/framework/config/model_config.h"
@@ -61,6 +59,8 @@ void apply_beam_search_logprobs_default(
     params.top_logprobs = static_cast<int64_t>(params.beam_width);
   }
 }
+
+nlohmann::json proto_struct_to_json(const google::protobuf::Struct& pb_struct);
 
 // Handle tool_choice conversion from Anthropic format to internal format
 std::string handle_tool_choice(
@@ -111,10 +111,9 @@ std::vector<JsonTool> handle_tools(
 
     // Convert input_schema to JSON
     if (tool.has_input_schema()) {
-      std::string json_str;
-      google::protobuf::util::MessageToJsonString(tool.input_schema(),
-                                                  &json_str);
-      json_tool.function.parameters = nlohmann::json::parse(json_str);
+      json_tool.function.parameters = proto_struct_to_json(tool.input_schema());
+    } else {
+      json_tool.function.parameters = nlohmann::json::object();
     }
 
     tools.push_back(std::move(json_tool));

--- a/xllm/core/framework/request/stopping_checker.cpp
+++ b/xllm/core/framework/request/stopping_checker.cpp
@@ -68,12 +68,8 @@ FinishReason StoppingChecker::check(const Slice<int32_t>& token_ids,
     return FinishReason::LENGTH;
   }
 
-  if (ignore_eos_) {
-    return FinishReason::NONE;
-  }
-
   // check eos token
-  if (last_token_id == eos_token_) {
+  if (!ignore_eos_ && last_token_id == eos_token_) {
     return FinishReason::STOP;
   }
 

--- a/xllm/proto/anthropic.proto
+++ b/xllm/proto/anthropic.proto
@@ -144,6 +144,9 @@ message AnthropicMessagesRequest {
 
   // Top-P (nucleus) sampling (optional)
   optional float top_p = 13;
+
+  // Whether to ignore the end of sequence token. xLLM extension.
+  optional bool ignore_eos = 14;
 }
 
 message AnthropicDelta {


### PR DESCRIPTION
## Description

<!-- What does this PR do? Briefly describe the changes and why they are needed. -->

This PR fixes Anthropic Messages API compatibility issues around `ignore_eos`, tool calls, and streaming tool-use responses.

Changes include:
  - Preserve Anthropic `ignore_eos` in request params, while still honoring explicit stop tokens and stop sequences.
  - Normalize protobuf `Struct` / `Value` JSON output into plain Anthropic-compatible JSON for tool inputs, nested schemas, lists, nulls, and empty objects.
  - Improve Anthropic tool request parsing, including `tool_result.tool_use_id`, string/list tool result content, tool schema conversion, and tool choice defaults.
  - Fix streaming tool-call behavior by mapping tool finish reasons to `tool_use`, emitting `input_json_delta` only when arguments exist, and guarding empty tool deltas before access.
  - Add regression coverage for Anthropic JSON conversion, stream utilities, tool result parsing, request params, and stopping checker behavior.


<!-- Link related issues here. Use "Fixes #123" when this PR closes an issue. -->

## Change Type

- [x] Bug fix
- [ ] New feature
- [ ] Performance improvement
- [ ] Refactor
- [ ] Documentation
- [ ] Test
- [ ] Build or CI

## Pull Request Checklist

Thank you for contributing to xLLM. Before requesting review, please make sure the following items are complete.

### PR Title and Commit Messages

- [x] The PR title and each commit message follow the xLLM commit format: `<type>: <subject>`.

> Allowed types: feat, bugfix, docs, test, refactor, chore, style, revert, perf, model, build, release.
> The subject should use clear English, start with a verb, include at least 4 words, and end with `.`.

### Pre-commit Checks

- [x] I have installed `pre-commit` by running `pip install pre-commit` or an equivalent command.
- [x] I have installed the hooks with `pre-commit install`.
- [x] I have run `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

### Self Review

- [x] I have self-reviewed the code according to `.agents/skills/code-review/references/custom-code-style.md`, especially code written or assisted by AI.
- [x] I have rebased this PR onto the latest `main` branch.

### Build and Test Coverage

- [x] Tests have been added or updated as needed.
- [ ] CUDA: `python setup.py build test` has passed on a CUDA machine.
- [x] NPU: `python setup.py build test` has passed on an NPU machine.
- [x] MLU: `python setup.py build test` has passed on an MLU machine.

## Reviewer Notes

<!-- Optional: anything reviewers should focus on, known risks, follow-ups, or validation gaps. -->
