### PR TITLE
feat: send mtp bootstrap over pd handoff.

### DIFF
--- a/tests/core/framework/batch/batch_test.cpp
+++ b/tests/core/framework/batch/batch_test.cpp
@@ -29,6 +29,7 @@ limitations under the License.
 #include "core/framework/config/scheduler_config.h"
 #include "framework/block/block.h"
 #include "framework/block/block_manager_impl.h"
+#include "framework/block/block_manager_pool.h"
 #include "framework/config/beam_search_config.h"
 #include "framework/kv_cache/kv_cache.h"
 #include "framework/model/model_args.h"
@@ -341,6 +342,61 @@ TEST(BatchTest, ProcessRawOutputStoresMtpBootstrapEmbedding) {
   torch::Tensor stored = sequence.get_mtp_bootstrap_embedding();
   ASSERT_TRUE(stored.defined());
   EXPECT_TRUE(torch::equal(stored, torch::tensor({3.0f, 4.0f})));
+}
+
+TEST(BatchTest, DecodeForwardInputConsumesMtpBootstrap) {
+  BlockManagerPool::Options options;
+  options.num_blocks(8).block_size(4).enable_disagg_pd(true);
+  BlockManagerPool manager(options, /*dp_size=*/1);
+
+  Sequence sequence = make_basic_sequence({1, 2, 3});
+  ASSERT_TRUE(manager.allocate(&sequence));
+  ASSERT_GE(sequence.get_single_block_id(), 0);
+  sequence.kv_state().set_kv_cache_tokens_num(sequence.num_prompt_tokens());
+  sequence.append_token(Token(42));
+
+  torch::Tensor embedding = torch::tensor({3.0f, 4.0f});
+  sequence.update_mtp_bootstrap_embedding(embedding);
+
+  Batch batch(&sequence);
+  ForwardInput forward_input = batch.prepare_forward_input(
+      /*num_decoding_tokens=*/1, /*min_decoding_batch_size=*/0, ModelArgs());
+
+  const auto& embed_params = forward_input.input_params.embedding;
+  EXPECT_EQ(embed_params.mtp_bootstrap_row_idxes, std::vector<int32_t>{0});
+  ASSERT_TRUE(embed_params.mtp_bootstrap_embeddings.defined());
+  EXPECT_TRUE(torch::equal(embed_params.mtp_bootstrap_embeddings,
+                           embedding.unsqueeze(0)));
+  EXPECT_FALSE(sequence.get_mtp_bootstrap_embedding().defined());
+}
+
+TEST(BatchTest, DecodeForwardInputMapsSparseMtpBootstrapRows) {
+  BlockManagerPool::Options options;
+  options.num_blocks(8).block_size(4).enable_disagg_pd(true);
+  BlockManagerPool manager(options, /*dp_size=*/1);
+
+  Sequence first = make_basic_sequence({1, 2, 3});
+  ASSERT_TRUE(manager.allocate(&first));
+  first.kv_state().set_kv_cache_tokens_num(first.num_prompt_tokens());
+  first.append_token(Token(41));
+
+  Sequence second = make_basic_sequence({4, 5, 6});
+  ASSERT_TRUE(manager.allocate(&second));
+  second.kv_state().set_kv_cache_tokens_num(second.num_prompt_tokens());
+  second.append_token(Token(42));
+
+  torch::Tensor embedding = torch::tensor({3.0f, 4.0f});
+  second.update_mtp_bootstrap_embedding(embedding);
+
+  Batch batch({&first, &second});
+  ForwardInput forward_input = batch.prepare_forward_input(
+      /*num_decoding_tokens=*/1, /*min_decoding_batch_size=*/0, ModelArgs());
+
+  const auto& embed_params = forward_input.input_params.embedding;
+  EXPECT_EQ(embed_params.mtp_bootstrap_row_idxes, std::vector<int32_t>{1});
+  ASSERT_TRUE(embed_params.mtp_bootstrap_embeddings.defined());
+  EXPECT_TRUE(torch::equal(embed_params.mtp_bootstrap_embeddings,
+                           embedding.unsqueeze(0)));
 }
 
 TEST(BatchTest, Basic) {
@@ -820,6 +876,9 @@ TEST(BatchTest, ForwardInputPackedRoundTripPreservesTransportFields) {
   ForwardInput input =
       builder.build_forward_input(/*num_decoding_tokens=*/1,
                                   /*min_decoding_batch_size=*/0);
+  input.input_params.embedding.mtp_bootstrap_row_idxes = {0};
+  input.input_params.embedding.mtp_bootstrap_embeddings =
+      torch::tensor({{3.0f, 4.0f}});
   bool is_creator = false;
   auto shm_name =
       ForwardSharedMemoryManager::create_unique_name("batch_test_forward_input",
@@ -844,6 +903,11 @@ TEST(BatchTest, ForwardInputPackedRoundTripPreservesTransportFields) {
             (std::vector<uint64_t>{1}));
   EXPECT_EQ(round_trip.transfer_kv_infos[0].remote_blocks_ids,
             (std::vector<uint64_t>{100}));
+  EXPECT_EQ(round_trip.input_params.embedding.mtp_bootstrap_row_idxes,
+            std::vector<int32_t>{0});
+  EXPECT_TRUE(
+      torch::equal(round_trip.input_params.embedding.mtp_bootstrap_embeddings,
+                   torch::tensor({{3.0f, 4.0f}})));
 }
 
 TEST(BatchTest, ForwardInputBlockCopyKernelFieldsMatchExpectedLayout) {

--- a/tests/core/scheduler/disagg_pd_scheduler_test.cpp
+++ b/tests/core/scheduler/disagg_pd_scheduler_test.cpp
@@ -16,6 +16,7 @@ limitations under the License.
 #include "scheduler/disagg_pd_scheduler.h"
 
 #include <gtest/gtest.h>
+#include <torch/torch.h>
 
 #include <cstdint>
 #include <memory>
@@ -108,6 +109,10 @@ class TestDisaggPDScheduler final : public DisaggPDScheduler {
   void cache_prefill_blocks_for_test(Request* request) {
     cache_prefill_blocks(request);
   }
+
+  bool pop_decode_request_for_test(std::shared_ptr<Request>* request) {
+    return request_queue_.read(*request);
+  }
 };
 
 DisaggPDScheduler::Options make_options() {
@@ -120,6 +125,12 @@ DisaggPDScheduler::Options make_options() {
       .max_seqs_per_batch(4)
       .max_tokens_per_chunk_for_prefill(32)
       .dp_size(1);
+  return options;
+}
+
+DisaggPDScheduler::Options make_mtp_decode_options() {
+  DisaggPDScheduler::Options options = make_options();
+  options.instance_role(InstanceRole::DECODE).num_speculative_tokens(1);
   return options;
 }
 
@@ -182,6 +193,26 @@ void release_prefix_cache(BlockManagerPool* block_manager) {
   EXPECT_EQ(first_cache_size(*block_manager), 0u);
 }
 
+bool recv_first_generation(DisaggPDScheduler* scheduler,
+                           const torch::Tensor& mtp_embedding) {
+  return scheduler->decode_recv_first_generation(
+      "req",
+      /*token_id=*/42,
+      /*has_logprob=*/false,
+      /*logprob=*/0.0f,
+      /*time_to_first_token_latency_seconds=*/0.1,
+      /*top_tokens=*/{},
+      /*top_logprobs=*/{},
+      /*kv_cache_transfer_mode=*/"PUSH",
+      /*src_cluster_ids=*/{},
+      /*src_addrs=*/{},
+      /*src_block_ids=*/{},
+      /*src_linear_state_id=*/-1,
+      /*src_dp_size=*/1,
+      /*src_dp_rank=*/0,
+      mtp_embedding);
+}
+
 }  // namespace
 
 TEST(DisaggPDSchedulerTest, CachesPrefillBlocksBeforeRelease) {
@@ -237,6 +268,40 @@ TEST(DisaggPDSchedulerTest, CacheSkipsExistingSharedBlocks) {
   block_manager->deallocate(extended_request.get());
   EXPECT_EQ(first_cache_size(*block_manager), 3u);
   release_prefix_cache(block_manager);
+}
+
+TEST(DisaggPDSchedulerTest, MtpFirstGenerationRequiresBootstrapBeforeQueue) {
+  FakeEngine engine(/*num_blocks=*/8, /*block_size=*/2);
+  TestDisaggPDScheduler scheduler(&engine, make_mtp_decode_options());
+  std::shared_ptr<Request> request = make_request({1, 2, 3, 4});
+  ASSERT_TRUE(
+      engine.block_manager_pool()->allocate(request->sequences()[0].get()));
+  ASSERT_TRUE(scheduler.decode_schedule(request, "prefill"));
+
+  EXPECT_FALSE(recv_first_generation(&scheduler, torch::Tensor()));
+  std::shared_ptr<Request> queued;
+  EXPECT_FALSE(scheduler.pop_decode_request_for_test(&queued));
+}
+
+TEST(DisaggPDSchedulerTest, MtpFirstGenerationStoresBootstrapThenQueues) {
+  FakeEngine engine(/*num_blocks=*/8, /*block_size=*/2);
+  TestDisaggPDScheduler scheduler(&engine, make_mtp_decode_options());
+  std::shared_ptr<Request> request = make_request({1, 2, 3, 4});
+  Sequence* sequence = request->sequences()[0].get();
+  ASSERT_TRUE(engine.block_manager_pool()->allocate(sequence));
+  sequence->kv_state().set_kv_cache_tokens_num(sequence->num_prompt_tokens());
+  ASSERT_GE(sequence->get_single_block_id(), 0);
+  ASSERT_TRUE(scheduler.decode_schedule(request, "prefill"));
+
+  torch::Tensor embedding = torch::tensor({1.0f, 2.0f});
+  EXPECT_TRUE(recv_first_generation(&scheduler, embedding));
+
+  std::shared_ptr<Request> queued;
+  ASSERT_TRUE(scheduler.pop_decode_request_for_test(&queued));
+  EXPECT_EQ(queued->request_id(), "req");
+  EXPECT_EQ(queued->sequences()[0]->tokens().back(), 42);
+  EXPECT_TRUE(torch::equal(
+      queued->sequences()[0]->get_mtp_bootstrap_embedding(), embedding));
 }
 
 }  // namespace xllm

--- a/xllm/core/distributed_runtime/disagg_pd_service_impl.cpp
+++ b/xllm/core/distributed_runtime/disagg_pd_service_impl.cpp
@@ -23,6 +23,7 @@ limitations under the License.
 #include "distributed_runtime/llm_engine.h"
 #include "framework/request/request_output.h"
 #include "scheduler/disagg_pd_scheduler.h"
+#include "util/utils.h"
 
 namespace xllm {
 
@@ -241,6 +242,11 @@ void DisaggPDServiceImpl::decode_recv_first_generation(
     std::vector<uint64_t> block_ids(gen.block_ids().begin(),
                                     gen.block_ids().end());
     int32_t linear_state_id = gen.linear_state_id();
+    torch::Tensor mtp_bootstrap_embedding;
+    if (gen.has_mtp_bootstrap_embedding()) {
+      mtp_bootstrap_embedding =
+          util::proto_to_torch(gen.mtp_bootstrap_embedding());
+    }
 
     bool success = scheduler_->decode_recv_first_generation(
         gen.req_id(),
@@ -256,7 +262,8 @@ void DisaggPDServiceImpl::decode_recv_first_generation(
         std::move(block_ids),
         linear_state_id,
         gen.dp_size(),
-        gen.dp_rank());
+        gen.dp_rank(),
+        mtp_bootstrap_embedding);
     if (!success) {
       response->set_ok(false);
       return;

--- a/xllm/core/framework/batch/batch_input_builder.cpp
+++ b/xllm/core/framework/batch/batch_input_builder.cpp
@@ -168,18 +168,6 @@ torch::Tensor build_pinned_int_tensor(const std::vector<int32_t>& values) {
                            .pinned_memory(true));
 }
 
-torch::Tensor normalize_mtp_bootstrap(const torch::Tensor& embedding) {
-  CHECK(embedding.defined()) << "MTP bootstrap embedding is undefined";
-  if (embedding.dim() == 1) {
-    return embedding.unsqueeze(0);
-  }
-  CHECK_EQ(embedding.dim(), 2)
-      << "MTP bootstrap embedding should be [hidden] or [1, hidden]";
-  CHECK_EQ(embedding.size(0), 1)
-      << "MTP bootstrap embedding should contain one sequence";
-  return embedding;
-}
-
 }  // namespace
 
 BatchInputBuilder::BatchInputBuilder(
@@ -649,8 +637,13 @@ void BatchInputBuilder::extract_tokens_and_positions(Sequence* sequence,
       CHECK_GE(token_id, 0) << "MTP bootstrap token should be valid";
       state.mtp_bootstrap_row_idxes.emplace_back(
           static_cast<int32_t>(state.embedding_ids.size() - 1));
-      state.mtp_bootstrap_embeddings.emplace_back(
-          normalize_mtp_bootstrap(mtp_bootstrap));
+      if (mtp_bootstrap.dim() == 1) {
+        state.mtp_bootstrap_embeddings.emplace_back(mtp_bootstrap.unsqueeze(0));
+      } else {
+        CHECK(mtp_bootstrap.dim() == 2 && mtp_bootstrap.size(0) == 1)
+            << "MTP bootstrap embedding should be [hidden] or [1, hidden]";
+        state.mtp_bootstrap_embeddings.emplace_back(mtp_bootstrap);
+      }
     }
   } else {
     extra_token_id = token_ids[seq_len];

--- a/xllm/core/framework/batch/batch_input_builder.cpp
+++ b/xllm/core/framework/batch/batch_input_builder.cpp
@@ -200,6 +200,7 @@ BatchInputBuilder::BatchInputBuilder(
   state_.acc_logprob_vec.reserve(sequences.size());
   state_.mtp_shifted_token_ids.reserve(reserve_size);
   state_.mtp_bootstrap_embeddings.reserve(sequences.size());
+  state_.mtp_bootstrap_row_idxes.reserve(sequences.size());
   if (args_ != nullptr) {
     use_mrope_ = (args_->rope_scaling_rope_type() == "mrope");
   }

--- a/xllm/core/framework/batch/batch_input_builder.cpp
+++ b/xllm/core/framework/batch/batch_input_builder.cpp
@@ -168,6 +168,18 @@ torch::Tensor build_pinned_int_tensor(const std::vector<int32_t>& values) {
                            .pinned_memory(true));
 }
 
+torch::Tensor normalize_mtp_bootstrap(const torch::Tensor& embedding) {
+  CHECK(embedding.defined()) << "MTP bootstrap embedding is undefined";
+  if (embedding.dim() == 1) {
+    return embedding.unsqueeze(0);
+  }
+  CHECK_EQ(embedding.dim(), 2)
+      << "MTP bootstrap embedding should be [hidden] or [1, hidden]";
+  CHECK_EQ(embedding.size(0), 1)
+      << "MTP bootstrap embedding should contain one sequence";
+  return embedding;
+}
+
 }  // namespace
 
 BatchInputBuilder::BatchInputBuilder(
@@ -199,6 +211,7 @@ BatchInputBuilder::BatchInputBuilder(
   state_.block_tables_vec.reserve(sequences.size());
   state_.acc_logprob_vec.reserve(sequences.size());
   state_.mtp_shifted_token_ids.reserve(reserve_size);
+  state_.mtp_bootstrap_embeddings.reserve(sequences.size());
   if (args_ != nullptr) {
     use_mrope_ = (args_->rope_scaling_rope_type() == "mrope");
   }
@@ -420,6 +433,8 @@ void BatchInputBuilder::process_sequences_multithreaded() {
     state_.new_token_slot_ids.insert(state_.new_token_slot_ids.end(),
                                      state.new_token_slot_ids.begin(),
                                      state.new_token_slot_ids.end());
+    const int32_t row_offset =
+        static_cast<int32_t>(state_.embedding_ids.size());
     state_.embedding_ids.insert(state_.embedding_ids.end(),
                                 state.embedding_ids.begin(),
                                 state.embedding_ids.end());
@@ -435,6 +450,13 @@ void BatchInputBuilder::process_sequences_multithreaded() {
     state_.mtp_shifted_token_ids.insert(state_.mtp_shifted_token_ids.end(),
                                         state.mtp_shifted_token_ids.begin(),
                                         state.mtp_shifted_token_ids.end());
+    for (int32_t row_idx : state.mtp_bootstrap_row_idxes) {
+      state_.mtp_bootstrap_row_idxes.emplace_back(row_offset + row_idx);
+    }
+    state_.mtp_bootstrap_embeddings.insert(
+        state_.mtp_bootstrap_embeddings.end(),
+        state.mtp_bootstrap_embeddings.begin(),
+        state.mtp_bootstrap_embeddings.end());
     state_.transfer_kv_infos.insert(state_.transfer_kv_infos.end(),
                                     state.transfer_kv_infos.begin(),
                                     state.transfer_kv_infos.end());
@@ -619,6 +641,17 @@ void BatchInputBuilder::extract_tokens_and_positions(Sequence* sequence,
     state.extra_token_ids.emplace_back(-1);
     state.embedding_ids.emplace_back(sequence->get_single_block_id());
     state.request_ids.emplace_back(sequence->request_id());
+    torch::Tensor mtp_bootstrap = sequence->get_mtp_bootstrap_embedding();
+    if (state.batch_forward_type.is_decode() && mtp_bootstrap.defined()) {
+      CHECK_LT(n_kv_cache_tokens, seq_len)
+          << "MTP bootstrap decode input must contain current token";
+      const int32_t token_id = token_ids[n_kv_cache_tokens];
+      CHECK_GE(token_id, 0) << "MTP bootstrap token should be valid";
+      state.mtp_bootstrap_row_idxes.emplace_back(
+          static_cast<int32_t>(state.embedding_ids.size() - 1));
+      state.mtp_bootstrap_embeddings.emplace_back(
+          normalize_mtp_bootstrap(mtp_bootstrap));
+    }
   } else {
     extra_token_id = token_ids[seq_len];
     state.extra_token_ids.emplace_back(extra_token_id);
@@ -926,6 +959,17 @@ ForwardInput BatchInputBuilder::state_to_forward_input() {
     auto mtp_tensor = torch::tensor(state_.mtp_shifted_token_ids, torch::kInt);
     input_params.embedding.mtp_shifted_token_ids = mtp_tensor;
     input_params.mtp_shifted_token_ids = mtp_tensor;
+  }
+  if (!state_.mtp_bootstrap_embeddings.empty()) {
+    CHECK_EQ(state_.mtp_bootstrap_row_idxes.size(),
+             state_.mtp_bootstrap_embeddings.size());
+    input_params.embedding.mtp_bootstrap_row_idxes =
+        std::move(state_.mtp_bootstrap_row_idxes);
+    input_params.embedding.mtp_bootstrap_embeddings =
+        torch::cat(state_.mtp_bootstrap_embeddings, /*dim=*/0);
+    for (Sequence* sequence : sequences_) {
+      sequence->clear_mtp_bootstrap_embedding();
+    }
   }
   input_params.meta.batch_id = batch_id_;
 

--- a/xllm/core/framework/batch/batch_input_builder.h
+++ b/xllm/core/framework/batch/batch_input_builder.h
@@ -126,6 +126,8 @@ class BatchInputBuilder {
     std::vector<std::string> request_ids;
     std::vector<int32_t> extra_token_ids;
     std::vector<int32_t> mtp_shifted_token_ids;
+    std::vector<int32_t> mtp_bootstrap_row_idxes;
+    std::vector<torch::Tensor> mtp_bootstrap_embeddings;
     std::vector<TransferKVInfo> transfer_kv_infos;
 
     // for continuous kvcache

--- a/xllm/core/scheduler/continuous_scheduler.cpp
+++ b/xllm/core/scheduler/continuous_scheduler.cpp
@@ -356,6 +356,9 @@ void ContinuousScheduler::clear_mtp_bootstrap(Request* request) {
     return;
   }
   Sequence* sequence = request->sequences()[0].get();
+  if (sequence == nullptr) {
+    return;
+  }
   sequence->clear_mtp_bootstrap_embedding();
 }
 

--- a/xllm/core/scheduler/continuous_scheduler.cpp
+++ b/xllm/core/scheduler/continuous_scheduler.cpp
@@ -350,6 +350,15 @@ bool ContinuousScheduler::check_if_enough_to_evict(
   return false;
 }
 
+void ContinuousScheduler::clear_mtp_bootstrap(Request* request) {
+  if (!options_.enable_disagg_pd() || options_.num_speculative_tokens() <= 0 ||
+      request == nullptr || request->sequences().empty()) {
+    return;
+  }
+  Sequence* sequence = request->sequences()[0].get();
+  sequence->clear_mtp_bootstrap_embedding();
+}
+
 void ContinuousScheduler::handle_prefill_requests(
     double& latency_budget,
     double& estimate_latency,
@@ -387,6 +396,7 @@ void ContinuousScheduler::handle_prefill_requests(
 
     std::shared_ptr<Request> request(waiting_priority_queue->top());
     if (request->finished() || request->cancelled()) {
+      clear_mtp_bootstrap(request.get());
       kv_cache_manager_->deallocate(request.get());
       // release the ownership of the request
       finished_requests.emplace_back(request);
@@ -461,6 +471,7 @@ void ContinuousScheduler::handle_prefill_requests(
               std::shared_ptr<Request> request_to_preempt =
                   running_queue_offline_->back();
               ++num_online_prefill_preempt_offline_requests;
+              clear_mtp_bootstrap(request_to_preempt.get());
               kv_cache_manager_->deallocate(request_to_preempt.get());
               running_queue_offline_->pop_back();
               // add preemptable request to request priority queue
@@ -538,6 +549,7 @@ void ContinuousScheduler::handle_prefill_requests(
       running_queue_->empty()) {
     std::shared_ptr<Request> request(waiting_priority_queue->top());
     waiting_priority_queue->pop_top();
+    clear_mtp_bootstrap(request.get());
     kv_cache_manager_->deallocate(request.get());
     if (blocks_exhausted) {
       LOG(ERROR) << "Request prompt is too long, no enough memory to schedule "
@@ -684,6 +696,7 @@ void ContinuousScheduler::handle_decode_requests(
                      << ", beam=" << request->check_beam_search();
           // Fallback to full request deallocation to avoid inconsistent
           // per-sequence states.
+          clear_mtp_bootstrap(request.get());
           kv_cache_manager_->deallocate(request.get());
           running_queue->pop_top();
           request->set_preempted();
@@ -798,6 +811,7 @@ void ContinuousScheduler::handle_decode_requests(
       std::shared_ptr<Request> request_to_preempt =
           running_queue_offline_->back();
       ++num_online_decode_preempt_offline_requests;
+      clear_mtp_bootstrap(request_to_preempt.get());
       kv_cache_manager_->deallocate(request_to_preempt.get());
       running_queue_offline_->pop_back();
       // add preemptable request to waiting priority queue
@@ -808,6 +822,7 @@ void ContinuousScheduler::handle_decode_requests(
       std::shared_ptr<Request> request_to_preempt = running_queue->back();
       if (request_to_preempt.get() != request.get()) {
         // TO IMPROVE: kv cache offload to cpu
+        clear_mtp_bootstrap(request_to_preempt.get());
         kv_cache_manager_->deallocate(request_to_preempt.get());
         running_queue->pop_back();
         // add preemptable request to waiting priority queue
@@ -895,6 +910,7 @@ void ContinuousScheduler::handle_abnormal_request(
 
     // request is too long, budget or memory no enough.
     running_queue->pop_top();
+    clear_mtp_bootstrap(request.get());
     kv_cache_manager_->deallocate(request.get());
     response_processor_->process_failed_request(
         request,
@@ -977,6 +993,7 @@ std::vector<Batch> ContinuousScheduler::prepare_batch() {
     std::shared_ptr<Request> request = *it;
     request->update_connection_status();
     if (request->finished() || request->cancelled()) {
+      clear_mtp_bootstrap(request.get());
       kv_cache_manager_->deallocate(request.get());
       // release the ownership of the request
       finished_requests.emplace_back(request);
@@ -1670,6 +1687,7 @@ void ContinuousScheduler::preempt_all_running_requests() {
     }
 
     // Deallocate KV cache blocks (critical for RL weight updates)
+    clear_mtp_bootstrap(request.get());
     kv_cache_manager_->deallocate(request.get());
 
     // Mark as preempted
@@ -1735,6 +1753,7 @@ void ContinuousScheduler::abort_all_running_requests() {
       return;
     }
 
+    clear_mtp_bootstrap(request.get());
     kv_cache_manager_->deallocate(request.get());
     request->set_cancel();
     response_processor_->process_failed_request(

--- a/xllm/core/scheduler/continuous_scheduler.h
+++ b/xllm/core/scheduler/continuous_scheduler.h
@@ -238,6 +238,8 @@ class ContinuousScheduler : public Scheduler {
   // ABORT mode: cancel all running requests; they are not rescheduled.
   void abort_all_running_requests();
 
+  void clear_mtp_bootstrap(Request* request);
+
  protected:
   const Options options_;
 

--- a/xllm/core/scheduler/disagg_pd_scheduler.cpp
+++ b/xllm/core/scheduler/disagg_pd_scheduler.cpp
@@ -809,6 +809,16 @@ bool DisaggPDScheduler::decode_recv_first_generation(
       request_to_instance_map_.erase(inst_it);
     }
   }
+  auto& sequences = request->sequences();
+  if (sequences.empty() || sequences[0] == nullptr) {
+    LOG(ERROR) << "Request has no valid sequences, request_id: " << req_id;
+    for (auto& sequence : sequences) {
+      if (sequence != nullptr) {
+        kv_cache_manager_->deallocate(sequence.get());
+      }
+    }
+    return false;
+  }
   Sequence* sequence = request->sequences()[0].get();
   const bool need_mtp_bootstrap = options_.num_speculative_tokens() > 0;
   if (need_mtp_bootstrap) {

--- a/xllm/core/scheduler/disagg_pd_scheduler.cpp
+++ b/xllm/core/scheduler/disagg_pd_scheduler.cpp
@@ -21,6 +21,7 @@ limitations under the License.
 #include <brpc/server.h>
 #include <glog/logging.h>
 
+#include <limits>
 #include <random>
 
 #include "common/global_flags.h"
@@ -631,6 +632,16 @@ void DisaggPDScheduler::prefill_send_first_generation() {
                                 requests = std::move(requests)]() mutable {
     // send request first token to remote instance
     // TODO: here we only support one sequence for now.
+    auto fail_request = [this](const std::shared_ptr<Request>& request,
+                               Status status) {
+      response_processor_->process_failed_request(request, status);
+      {
+        std::lock_guard<std::mutex> lock(req_to_channel_map_mutex_);
+        req_to_channel_map_.erase(request->request_id());
+      }
+      response_processor_->wait_completion();
+      kv_cache_manager_->deallocate(request.get());
+    };
     for (auto& request : requests) {
       // TODO: support batch request later
       proto::DisaggGenerationsRequests gens;
@@ -680,6 +691,29 @@ void DisaggPDScheduler::prefill_send_first_generation() {
             request->sequences()[0]->get_single_block_id());
         gen->set_dp_size(instance_info_.dp_size);
         gen->set_dp_rank(request->sequences()[0]->dp_rank());
+      }
+      if (options_.num_speculative_tokens() > 0) {
+        torch::Tensor embedding =
+            request->sequences()[0]->get_mtp_bootstrap_embedding();
+        if (!embedding.defined()) {
+          LOG(ERROR) << "Missing MTP bootstrap embedding, request_id: "
+                     << request->request_id();
+          fail_request(
+              request,
+              {StatusCode::UNKNOWN, "Missing MTP bootstrap embedding"});
+          continue;
+        }
+        torch::Tensor embedding_cpu = safe_to(embedding, torch::kCPU);
+        if (!util::torch_to_proto(embedding_cpu,
+                                  gen->mutable_mtp_bootstrap_embedding())) {
+          LOG(ERROR) << "Failed to serialize MTP bootstrap embedding, "
+                     << "request_id: " << request->request_id();
+          fail_request(request,
+                       {StatusCode::UNKNOWN,
+                        "Failed to serialize MTP bootstrap embedding"});
+          continue;
+        }
+        request->sequences()[0]->clear_mtp_bootstrap_embedding();
       }
 
       // send first gens to remote instance
@@ -755,7 +789,8 @@ bool DisaggPDScheduler::decode_recv_first_generation(
     std::vector<uint64_t> src_block_ids,
     int32_t src_linear_state_id,
     int32_t src_dp_size,
-    int32_t src_dp_rank) {
+    int32_t src_dp_rank,
+    torch::Tensor mtp_bootstrap_embedding) {
   // push to request_queue_, and will be executed by engine.
   std::shared_ptr<Request> request = nullptr;
   {
@@ -774,6 +809,30 @@ bool DisaggPDScheduler::decode_recv_first_generation(
       request_to_instance_map_.erase(inst_it);
     }
   }
+  Sequence* sequence = request->sequences()[0].get();
+  const bool need_mtp_bootstrap = options_.num_speculative_tokens() > 0;
+  if (need_mtp_bootstrap) {
+    const int32_t slot_id = sequence->get_single_block_id();
+    if (slot_id < 0) {
+      LOG(ERROR) << "Invalid MTP bootstrap slot, request_id: " << req_id;
+      kv_cache_manager_->deallocate(request.get());
+      return false;
+    }
+    if (token_id < 0 ||
+        token_id > static_cast<int64_t>(std::numeric_limits<int32_t>::max())) {
+      LOG(ERROR) << "Invalid MTP bootstrap token, request_id: " << req_id
+                 << ", token_id: " << token_id;
+      kv_cache_manager_->deallocate(request.get());
+      return false;
+    }
+    if (!mtp_bootstrap_embedding.defined()) {
+      LOG(ERROR) << "Missing MTP bootstrap embedding, request_id: " << req_id;
+      kv_cache_manager_->deallocate(request.get());
+      return false;
+    }
+
+    sequence->update_mtp_bootstrap_embedding(mtp_bootstrap_embedding);
+  }
 
   Token first_token(token_id);
   if (has_logprob) {
@@ -787,29 +846,28 @@ bool DisaggPDScheduler::decode_recv_first_generation(
   }
   // Enable checking whether to skip the prefill token
   if (request->state().stream) {
-    request->sequences()[0]->enable_checking_prefill_token();
+    sequence->enable_checking_prefill_token();
   }
 
   // update latency metrics
-  request->sequences()[0]->set_time_to_first_token_latency_seconds(
+  sequence->set_time_to_first_token_latency_seconds(
       time_to_first_token_latency_seconds);
   // update latest_generate_time_ for sequence
-  request->sequences()[0]->tbt(
-      request->created_time() +
-      absl::Seconds(time_to_first_token_latency_seconds));
+  sequence->tbt(request->created_time() +
+                absl::Seconds(time_to_first_token_latency_seconds));
 
   // TODO: we only support one sequence for currently.
   if (enable_schedule_overlap()) {
     Token fake_token(-1);
-    request->sequences()[0]->append_token(fake_token);
-    request->sequences()[0]->update_last_step_token(first_token);
+    sequence->append_token(fake_token);
+    sequence->update_last_step_token(first_token);
   } else {
-    request->sequences()[0]->append_token(first_token);
+    sequence->append_token(first_token);
   }
 
   // pull kv cache
   if (kv_cache_transfer_mode == "PULL") {
-    const auto blocks = request->sequences()[0]->kv_state().kv_blocks();
+    const auto blocks = sequence->kv_state().kv_blocks();
     std::vector<uint64_t> dst_block_ids;
     dst_block_ids.reserve(blocks.size());
     for (const auto& block : blocks) {
@@ -817,26 +875,33 @@ bool DisaggPDScheduler::decode_recv_first_generation(
     }
     std::vector<uint64_t> src_linear_state_ids;
     std::vector<uint64_t> dst_linear_state_ids;
-    if (src_linear_state_id >= 0 &&
-        request->sequences()[0]->get_single_block_id() >= 0) {
+    if (src_linear_state_id >= 0 && sequence->get_single_block_id() >= 0) {
       src_linear_state_ids.emplace_back(src_linear_state_id);
-      dst_linear_state_ids.emplace_back(
-          request->sequences()[0]->get_single_block_id());
+      dst_linear_state_ids.emplace_back(sequence->get_single_block_id());
     }
 
-    int32_t dst_dp_rank = request->sequences()[0]->dp_rank();
-    engine_->pull_kv_blocks(src_dp_size,
-                            src_dp_rank,
-                            src_cluster_ids,
-                            src_addrs,
-                            src_block_ids,
-                            dst_dp_rank,
-                            dst_block_ids,
-                            src_linear_state_ids,
-                            dst_linear_state_ids);
+    int32_t dst_dp_rank = sequence->dp_rank();
+    const bool pulled = engine_->pull_kv_blocks(src_dp_size,
+                                                src_dp_rank,
+                                                src_cluster_ids,
+                                                src_addrs,
+                                                src_block_ids,
+                                                dst_dp_rank,
+                                                dst_block_ids,
+                                                src_linear_state_ids,
+                                                dst_linear_state_ids);
+    if (!pulled) {
+      LOG(ERROR) << "Failed to pull KV blocks, request_id: " << req_id;
+      kv_cache_manager_->deallocate(request.get());
+      return false;
+    }
   }
 
-  request_queue_.write(request);
+  if (!request_queue_.write(request)) {
+    LOG(ERROR) << "Failed to enqueue decode request, request_id: " << req_id;
+    kv_cache_manager_->deallocate(request.get());
+    return false;
+  }
   return true;
 }
 

--- a/xllm/core/scheduler/disagg_pd_scheduler.h
+++ b/xllm/core/scheduler/disagg_pd_scheduler.h
@@ -73,7 +73,8 @@ class DisaggPDScheduler : public ChunkedPrefillScheduler {
       std::vector<uint64_t> src_block_ids,
       int32_t src_linear_state_id,
       int32_t src_dp_size,
-      int32_t src_dp_rank);
+      int32_t src_dp_rank,
+      torch::Tensor mtp_bootstrap_embedding = torch::Tensor());
 
   // decode allocate blocks with prefix cache.
   bool try_allocate(Sequence* sequence);

--- a/xllm/proto/disagg_pd.proto
+++ b/xllm/proto/disagg_pd.proto
@@ -5,6 +5,7 @@ package xllm.proto;
 option cc_generic_services = true;
 
 import "common.proto";
+import "tensor.proto";
 
 message ClusterInfos {
   repeated uint64 cluster_ids = 1;
@@ -227,6 +228,8 @@ message DisaggGenerationsRequest {
   string x_request_time = 12;
   // Sequence-scoped cache row used by linear attention caches.
   int32 linear_state_id = 13;
+  // MTP bootstrap state for the first decode draft extend.
+  Tensor mtp_bootstrap_embedding = 14;
 }
 
 message DisaggGenerationsRequests {


### PR DESCRIPTION
## Description

This PR completes the PD MTP bootstrap handoff for speculative/MTP decode.

It serializes the MTP bootstrap embedding on the prefill side, sends it through `DisaggGenerationsRequest`, restores it on the decode side, and injects the bootstrap row indices and embedding tensor into decode `ForwardInput`. The bootstrap state is consumed after batch input construction to avoid reuse.

This PR also clears stale MTP bootstrap embeddings when requests are released, preempted, cancelled, or aborted, and adds validation/failure handling for missing bootstrap state, invalid first-token inputs, KV pull failures, anddecode queue enqueue failures.

  Unit tests cover:
  - decode `ForwardInput` consuming MTP bootstrap embeddings
  - sparse bootstrap row mapping
  - forward input shared-memory round trip
  - PD decode first-generation bootstrap gating

## Change Type

- [ ] Bug fix
- [x] New feature
- [ ] Performance improvement
- [x] Refactor
- [ ] Documentation
- [ ] Test
- [ ] Build or CI

## Pull Request Checklist

Thank you for contributing to xLLM. Before requesting review, please make sure the following items are complete.

### PR Title and Commit Messages

- [x] The PR title and each commit message follow the xLLM commit format: `<type>: <subject>`.

> Allowed types: feat, bugfix, docs, test, refactor, chore, style, revert, perf, model, build, release.
> The subject should use clear English, start with a verb, include at least 4 words, and end with `.`.

### Pre-commit Checks

- [x] I have installed `pre-commit` by running `pip install pre-commit` or an equivalent command.
- [x] I have installed the hooks with `pre-commit install`.
- [x] I have run `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

### Self Review

- [x] I have self-reviewed the code according to `.agents/skills/code-review/references/custom-code-style.md`, especially code written or assisted by AI.
- [x] I have rebased this PR onto the latest `main` branch.

### Build and Test Coverage

- [ ] Tests have been added or updated as needed.
- [ ] CUDA: `python setup.py build test` has passed on a CUDA machine.
- [x] NPU: `python setup.py build test` has passed on an NPU machine.
- [x] MLU: `python setup.py build test` has passed on an MLU machine.

## Reviewer Notes

<!-- Optional: anything reviewers should focus on, known risks, follow-ups, or validation gaps. -->
