### PR TITLE
bugfix: fix KV split communication group setup.

### DIFF
--- a/xllm/core/framework/parallel_state/mapping_npu.cpp
+++ b/xllm/core/framework/parallel_state/mapping_npu.cpp
@@ -209,12 +209,10 @@ void MappingNPU::parse_parallel_info() {
     attn_cp_.group_size(options_.cp_size());
   }
 
-  // kv split: fall back to cp_size when unset so that the kvSplit JSON group
-  // mirrors attnCp byte-for-byte (legacy behavior, no extra HCCL domain).
   const int32_t cp_group_size =
       attn_cp_.group_size() > 0 ? attn_cp_.group_size() : 1;
   const int32_t kv_split_group_size =
-      options_.kv_split_size() > 0 ? options_.kv_split_size() : cp_group_size;
+      options_.kv_split_size() > 0 ? options_.kv_split_size() : 1;
   attn_kv_split_.group_size(kv_split_group_size);
   attn_kv_split_.backend("hccl");
 

--- a/xllm/core/framework/parallel_state/parallel_args.h
+++ b/xllm/core/framework/parallel_state/parallel_args.h
@@ -141,18 +141,15 @@ struct ParallelArgs {
     return kv_split_size_ > 0 ? kv_split_size_ : cp_size_;
   }
 
-  // KV-split rank of the current process. Under the default round-robin
-  // contract documented in `cp_kv_split.md`, when kv_split_size matches
-  // cp_size this aliases `cp_rank()`. For kv_split_size != cp_size the actual
-  // mapping is filled in by S2 (mapping_npu kvSplit group); until then we
-  // conservatively project cp_rank into the smaller group via modulo so single-
-  // rank deployments stay correct (kv_split_size==1 → rank 0).
+  // KV-split rank: global rank block index over world_size / kv_split_size.
+  // Aligns with MappingNPU::get_kv_split_group (get_dp_group stride) and ATB
+  // kvSplitInfo.rankIds ordering used by the prefix AllGather.
   [[nodiscard]] int32_t kv_split_rank() const noexcept {
     const int32_t kv = kv_split_size_effective();
     if (kv <= 1) {
       return 0;
     }
-    return cp_rank() % kv;
+    return rank_ / (world_size_ / kv);
   }
 
   // tp size


### PR DESCRIPTION
## Description

Fix the mismatch between KV splitting and the communication group when the CP size does not equal the KV split size.

## Related Issues

<!-- Link related issues here. Use "Fixes #123" when this PR closes an issue. -->

## Change Type

- [x] Bug fix
- [ ] New feature
- [ ] Performance improvement
- [ ] Refactor
- [ ] Documentation
- [ ] Test
- [ ] Build or CI

## Pull Request Checklist

Thank you for contributing to xLLM. Before requesting review, please make sure the following items are complete.

### PR Title and Commit Messages

- [x] The PR title and each commit message follow the xLLM commit format: `<type>: <subject>`.

> Allowed types: feat, bugfix, docs, test, refactor, chore, style, revert, perf, model, build, release.
> The subject should use clear English, start with a verb, include at least 4 words, and end with `.`.

### Pre-commit Checks

- [x] I have installed `pre-commit` by running `pip install pre-commit` or an equivalent command.
- [x] I have installed the hooks with `pre-commit install`.
- [x] I have run `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

### Self Review

- [ ] I have self-reviewed the code according to `.agents/skills/code-review/references/custom-code-style.md`, especially code written or assisted by AI.
- [ ] I have rebased this PR onto the latest `main` branch.

### Build and Test Coverage

- [ ] Tests have been added or updated as needed.
- [x] CUDA: `python setup.py build test` has passed on a CUDA machine.
- [x] NPU: `python setup.py build test` has passed on an NPU machine.
- [ ] MLU: `python setup.py build test` has passed on an MLU machine.

## Reviewer Notes

<!-- Optional: anything reviewers should focus on, known risks, follow-ups, or validation gaps. -->
