### PR TITLE
feat: add custom header for mm downloader.

### DIFF
--- a/tests/core/util/CMakeLists.txt
+++ b/tests/core/util/CMakeLists.txt
@@ -6,6 +6,7 @@ cc_test(
   SRCS
     blocking_counter_test.cpp
     device_name_utils_test.cpp
+    http_downloader_test.cpp
     suffix_decoding_cache_test.cpp
     threadpool_test.cpp
   DEPS

--- a/tests/core/util/http_downloader_test.cpp
+++ b/tests/core/util/http_downloader_test.cpp
@@ -15,9 +15,9 @@ limitations under the License.
 
 #include "core/util/http_downloader.h"
 
-#include "core/common/message.h"
-
 #include <gtest/gtest.h>
+
+#include "core/common/message.h"
 
 namespace xllm {
 

--- a/tests/core/util/http_downloader_test.cpp
+++ b/tests/core/util/http_downloader_test.cpp
@@ -1,0 +1,193 @@
+/* Copyright 2025 The xLLM Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://github.com/jd-opensource/xllm/blob/main/LICENSE
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include "core/util/http_downloader.h"
+
+#include "core/common/message.h"
+
+#include <gtest/gtest.h>
+
+namespace xllm {
+
+// ============================================================
+// parse_headers_json tests (pure function, no caching)
+// ============================================================
+
+TEST(ParseHeadersJsonTest, EmptyStringReturnsEmptyMap) {
+  auto result = parse_headers_json("");
+  EXPECT_TRUE(result.empty());
+}
+
+TEST(ParseHeadersJsonTest, ValidJsonParsesCorrectly) {
+  auto result = parse_headers_json(
+      R"({"Authorization":"Bearer token123","Referer":"https://example.com"})");
+  EXPECT_EQ(2, result.size());
+  EXPECT_EQ("Bearer token123", result["Authorization"]);
+  EXPECT_EQ("https://example.com", result["Referer"]);
+}
+
+TEST(ParseHeadersJsonTest, SingleHeader) {
+  auto result = parse_headers_json(R"({"X-Custom":"value"})");
+  EXPECT_EQ(1, result.size());
+  EXPECT_EQ("value", result["X-Custom"]);
+}
+
+TEST(ParseHeadersJsonTest, InvalidJsonReturnsEmptyMap) {
+  auto result = parse_headers_json("not-valid-json");
+  EXPECT_TRUE(result.empty());
+}
+
+TEST(ParseHeadersJsonTest, EmptyJsonObject) {
+  auto result = parse_headers_json("{}");
+  EXPECT_TRUE(result.empty());
+}
+
+TEST(ParseHeadersJsonTest, HeaderValueWithSpecialChars) {
+  auto result = parse_headers_json(
+      R"({"Authorization":"Bearer eyJhbGciOiJIUzI1NiJ9.abc.xyz"})");
+  EXPECT_EQ(1, result.size());
+  EXPECT_EQ("Bearer eyJhbGciOiJIUzI1NiJ9.abc.xyz", result["Authorization"]);
+}
+
+TEST(ParseHeadersJsonTest, MultipleCustomHeaders) {
+  auto result = parse_headers_json(
+      R"({"X-Key-1":"val1","X-Key-2":"val2","X-Key-3":"val3"})");
+  EXPECT_EQ(3, result.size());
+  EXPECT_EQ("val1", result["X-Key-1"]);
+  EXPECT_EQ("val2", result["X-Key-2"]);
+  EXPECT_EQ("val3", result["X-Key-3"]);
+}
+
+// ============================================================
+// ImageURL / VideoURL / AudioURL struct tests
+// ============================================================
+
+TEST(ImageUrlTest, DefaultHeadersEmpty) {
+  ImageURL url;
+  url.url = "http://example.com/img.jpg";
+  EXPECT_TRUE(url.headers.empty());
+  EXPECT_EQ("http://example.com/img.jpg", url.url);
+}
+
+TEST(ImageUrlTest, SetHeaders) {
+  ImageURL url;
+  url.url = "http://example.com/img.jpg";
+  url.headers["Authorization"] = "Bearer abc";
+  url.headers["Referer"] = "https://ref.com";
+  EXPECT_EQ(2, url.headers.size());
+  EXPECT_EQ("Bearer abc", url.headers["Authorization"]);
+  EXPECT_EQ("https://ref.com", url.headers["Referer"]);
+}
+
+TEST(VideoUrlTest, DefaultHeadersEmpty) {
+  VideoURL url;
+  url.url = "http://example.com/video.mp4";
+  EXPECT_TRUE(url.headers.empty());
+}
+
+TEST(AudioUrlTest, DefaultHeadersEmpty) {
+  AudioURL url;
+  url.url = "http://example.com/audio.mp3";
+  EXPECT_TRUE(url.headers.empty());
+}
+
+// ============================================================
+// MMContent struct with headers
+// ============================================================
+
+TEST(MMContentTest, ImageUrlWithHeaders) {
+  ImageURL img;
+  img.url = "http://example.com/img.jpg";
+  img.headers["Authorization"] = "Bearer test";
+
+  MMContent content("image_url", img);
+  EXPECT_EQ("image_url", content.type);
+  EXPECT_EQ("http://example.com/img.jpg", content.image_url.url);
+  EXPECT_EQ(1, content.image_url.headers.size());
+  EXPECT_EQ("Bearer test", content.image_url.headers["Authorization"]);
+}
+
+TEST(MMContentTest, ImageUrlWithoutHeaders) {
+  ImageURL img;
+  img.url = "http://example.com/img.jpg";
+
+  MMContent content("image_url", img);
+  EXPECT_TRUE(content.image_url.headers.empty());
+}
+
+// ============================================================
+// Header merge order: global < request
+// ============================================================
+
+TEST(HeaderMergeTest, RequestHeadersOverrideGlobal) {
+  // Simulate the merge order used in BRpcDownloader::download():
+  // 1) global defaults first
+  // 2) per-request headers second (SetHeader overrides)
+
+  std::unordered_map<std::string, std::string> global;
+  global["Authorization"] = "Bearer global";
+  global["Referer"] = "https://global-ref.com";
+
+  std::unordered_map<std::string, std::string> request;
+  request["Authorization"] = "Bearer specific";  // overrides global
+  request["X-Custom"] = "custom-value";          // request-only
+
+  // Merge: global first, then request
+  std::unordered_map<std::string, std::string> merged;
+  for (const auto& [k, v] : global) {
+    merged[k] = v;
+  }
+  for (const auto& [k, v] : request) {
+    merged[k] = v;  // request overrides
+  }
+
+  // Request value wins for shared key
+  EXPECT_EQ("Bearer specific", merged["Authorization"]);
+  // Global value preserved for non-overlapping key
+  EXPECT_EQ("https://global-ref.com", merged["Referer"]);
+  // Request-only key present
+  EXPECT_EQ("custom-value", merged["X-Custom"]);
+  EXPECT_EQ(3, merged.size());
+}
+
+TEST(HeaderMergeTest, EmptyRequestHeadersKeepsGlobal) {
+  std::unordered_map<std::string, std::string> global;
+  global["Authorization"] = "Bearer global";
+
+  std::unordered_map<std::string, std::string> request;  // empty
+
+  std::unordered_map<std::string, std::string> merged;
+  for (const auto& [k, v] : global) merged[k] = v;
+  for (const auto& [k, v] : request) merged[k] = v;
+
+  EXPECT_EQ(1, merged.size());
+  EXPECT_EQ("Bearer global", merged["Authorization"]);
+}
+
+TEST(HeaderMergeTest, EmptyGlobalHeadersKeepsRequest) {
+  std::unordered_map<std::string, std::string> global;  // empty
+
+  std::unordered_map<std::string, std::string> request;
+  request["Authorization"] = "Bearer request";
+
+  std::unordered_map<std::string, std::string> merged;
+  for (const auto& [k, v] : global) merged[k] = v;
+  for (const auto& [k, v] : request) merged[k] = v;
+
+  EXPECT_EQ(1, merged.size());
+  EXPECT_EQ("Bearer request", merged["Authorization"]);
+}
+
+}  // namespace xllm

--- a/xllm/api_service/mm_service_utils.h
+++ b/xllm/api_service/mm_service_utils.h
@@ -47,16 +47,25 @@ bool build_messages(const google::protobuf::RepeatedPtrField<
       } else if (item.type() == "image_url") {
         ImageURL image_url;
         image_url.url = std::move(*item.mutable_image_url()->release_url());
+        for (const auto& [k, v] : item.image_url().headers()) {
+          image_url.headers[k] = v;
+        }
         contents.emplace_back(item.type(), image_url);
 
       } else if (item.type() == "video_url") {
         VideoURL video_url;
         video_url.url = std::move(*item.mutable_video_url()->release_url());
+        for (const auto& [k, v] : item.video_url().headers()) {
+          video_url.headers[k] = v;
+        }
         contents.emplace_back(item.type(), video_url);
 
       } else if (item.type() == "audio_url") {
         AudioURL audio_url;
         audio_url.url = std::move(*item.mutable_audio_url()->release_url());
+        for (const auto& [k, v] : item.audio_url().headers()) {
+          audio_url.headers[k] = v;
+        }
         contents.emplace_back(item.type(), audio_url);
       } else if (item.type() == "image_embedding") {
         contents.emplace_back("image_embedding", item.image_embedding());

--- a/xllm/core/common/global_flags.h
+++ b/xllm/core/common/global_flags.h
@@ -45,6 +45,8 @@ DECLARE_int32(device_id);
 
 DECLARE_int32(limit_image_per_prompt);
 
+DECLARE_string(mm_download_headers);
+
 // --- kvcache config ---
 DECLARE_int32(block_size);
 DECLARE_int64(max_cache_size);

--- a/xllm/core/common/message.h
+++ b/xllm/core/common/message.h
@@ -19,6 +19,7 @@ limitations under the License.
 
 #include <optional>
 #include <string>
+#include <unordered_map>
 #include <variant>
 #include <vector>
 
@@ -29,14 +30,17 @@ using Embedding = xllm::proto::Embedding;
 
 struct ImageURL {
   std::string url;
+  std::unordered_map<std::string, std::string> headers;
 };
 
 struct VideoURL {
   std::string url;
+  std::unordered_map<std::string, std::string> headers;
 };
 
 struct AudioURL {
   std::string url;
+  std::unordered_map<std::string, std::string> headers;
 };
 
 struct MMContent {

--- a/xllm/core/framework/config/model_config.cpp
+++ b/xllm/core/framework/config/model_config.cpp
@@ -75,6 +75,12 @@ DEFINE_bool(enable_return_mm_full_embeddings,
             false,
             "return vit and sequence embeddings for vlm models");
 
+DEFINE_string(mm_download_headers,
+              "",
+              "Service-level default HTTP headers for multimodal downloads, "
+              "as a JSON object. Per-request headers take precedence. "
+              "Example: '{\"Authorization\":\"Bearer xxx\"}'");
+
 DEFINE_bool(
     use_audio_in_video,
     false,
@@ -121,6 +127,7 @@ void ModelConfig::from_flags() {
   XLLM_CONFIG_ASSIGN_FROM_FLAG(tool_call_parser);
   XLLM_CONFIG_ASSIGN_FROM_FLAG(enable_qwen3_reranker);
   XLLM_CONFIG_ASSIGN_FROM_FLAG(enable_return_mm_full_embeddings);
+  XLLM_CONFIG_ASSIGN_FROM_FLAG(mm_download_headers);
   XLLM_CONFIG_ASSIGN_FROM_FLAG(flashinfer_workspace_buffer_size);
   XLLM_CONFIG_ASSIGN_FROM_FLAG(use_audio_in_video);
   XLLM_CONFIG_ASSIGN_FROM_FLAG(use_cpp_chat_template);
@@ -154,6 +161,7 @@ void ModelConfig::from_json(const JsonReader& json) {
   XLLM_CONFIG_ASSIGN_FROM_JSON(tool_call_parser);
   XLLM_CONFIG_ASSIGN_FROM_JSON(enable_qwen3_reranker);
   XLLM_CONFIG_ASSIGN_FROM_JSON(enable_return_mm_full_embeddings);
+  XLLM_CONFIG_ASSIGN_FROM_JSON(mm_download_headers);
   XLLM_CONFIG_ASSIGN_FROM_JSON(flashinfer_workspace_buffer_size);
   XLLM_CONFIG_ASSIGN_FROM_JSON(use_audio_in_video);
   XLLM_CONFIG_ASSIGN_FROM_JSON(use_cpp_chat_template);
@@ -184,6 +192,8 @@ void ModelConfig::append_config_json(
       config_json, default_config, enable_qwen3_reranker);
   APPEND_CONFIG_JSON_VALUE_IF_NOT_DEFAULT(
       config_json, default_config, enable_return_mm_full_embeddings);
+  APPEND_CONFIG_JSON_VALUE_IF_NOT_DEFAULT(
+      config_json, default_config, mm_download_headers);
   APPEND_CONFIG_JSON_VALUE_IF_NOT_DEFAULT(
       config_json, default_config, flashinfer_workspace_buffer_size);
   APPEND_CONFIG_JSON_VALUE_IF_NOT_DEFAULT(

--- a/xllm/core/framework/config/model_config.h
+++ b/xllm/core/framework/config/model_config.h
@@ -54,6 +54,7 @@ class ModelConfig final {
          "tool_call_parser",
          "enable_qwen3_reranker",
          "enable_return_mm_full_embeddings",
+         "mm_download_headers",
          "flashinfer_workspace_buffer_size",
          "use_audio_in_video",
          "use_cpp_chat_template"}};
@@ -83,6 +84,8 @@ class ModelConfig final {
   PROPERTY(bool, enable_qwen3_reranker) = false;
 
   PROPERTY(bool, enable_return_mm_full_embeddings) = false;
+
+  PROPERTY(std::string, mm_download_headers) = "";
 
   PROPERTY(int32_t, flashinfer_workspace_buffer_size) = 128 * 1024 * 1024;
 

--- a/xllm/core/framework/multimodal/mm_handler.cpp
+++ b/xllm/core/framework/multimodal/mm_handler.cpp
@@ -98,10 +98,12 @@ MMErrCode MMHandlerBase::load_from_local(const std::string& url,
   return MMErrCode::SUCCESS;
 }
 
-MMErrCode MMHandlerBase::load_from_http(const std::string& url,
-                                        std::string& data) {
+MMErrCode MMHandlerBase::load_from_http(
+    const std::string& url,
+    std::string& data,
+    const std::unordered_map<std::string, std::string>& headers) {
   BRpcDownloader helper_;
-  if (!helper_.fetch_data(url, data)) {
+  if (!helper_.fetch_data(url, data, headers)) {
     return MMErrCode::LOAD_HTTP_ERR;
   }
   return MMErrCode::SUCCESS;
@@ -124,7 +126,7 @@ MMErrCode ImageHandler::load(const MMContent& content,
              0) {  // http url
 
     input.type = MMType::IMAGE;
-    return this->load_from_http(url, input.raw_data);
+    return this->load_from_http(url, input.raw_data, content.image_url.headers);
   } else {
     // treat as local path or file:// url
     input.type = MMType::IMAGE;
@@ -161,7 +163,7 @@ MMErrCode VideoHandler::load(const MMContent& content,
              0) {  // http url
 
     input.type = MMType::VIDEO;
-    return this->load_from_http(url, input.raw_data);
+    return this->load_from_http(url, input.raw_data, content.video_url.headers);
   } else {
     LOG(ERROR) << " video url is invalid, url is " << url;
     return MMErrCode::INVALID_URL_ERR;
@@ -204,7 +206,7 @@ MMErrCode AudioHandler::load(const MMContent& content,
              0) {  // http url
 
     input.type = MMType::AUDIO;
-    return this->load_from_http(url, input.raw_data);
+    return this->load_from_http(url, input.raw_data, content.audio_url.headers);
   } else {
     LOG(ERROR) << " audio url is invalid, url is " << url;
     return MMErrCode::INVALID_URL_ERR;

--- a/xllm/core/framework/multimodal/mm_handler.h
+++ b/xllm/core/framework/multimodal/mm_handler.h
@@ -50,7 +50,10 @@ class MMHandlerBase {
 
   MMErrCode load_from_local(const std::string& url, std::string& data);
 
-  MMErrCode load_from_http(const std::string& url, std::string& data);
+  MMErrCode load_from_http(
+      const std::string& url,
+      std::string& data,
+      const std::unordered_map<std::string, std::string>& headers = {});
 
  protected:
   std::string httpurl_prefix_{"http"};

--- a/xllm/core/util/http_downloader.cpp
+++ b/xllm/core/util/http_downloader.cpp
@@ -41,8 +41,7 @@ std::unordered_map<std::string, std::string> parse_headers_json(
 
 std::unordered_map<std::string, std::string> parse_global_headers() {
   static const std::unordered_map<std::string, std::string> cached =
-      parse_headers_json(
-          ModelConfig::get_instance().mm_download_headers());
+      parse_headers_json(ModelConfig::get_instance().mm_download_headers());
   return cached;
 }
 

--- a/xllm/core/util/http_downloader.cpp
+++ b/xllm/core/util/http_downloader.cpp
@@ -19,13 +19,16 @@ limitations under the License.
 
 namespace xllm {
 
-bool HttpDownloader::fetch_data(const std::string& url, std::string& data) {
+bool HttpDownloader::fetch_data(
+    const std::string& url,
+    std::string& data,
+    const std::unordered_map<std::string, std::string>& headers) {
   std::string host;
   if (!parse_url(url, host)) {
     return false;
   }
 
-  return download(host, url, data);
+  return download(host, url, data, headers);
 }
 
 bool HttpDownloader::parse_url(const std::string& url, std::string& host) {
@@ -77,11 +80,16 @@ std::shared_ptr<brpc::Channel> BRpcDownloader::get_channel(
   return channel;
 }
 
-bool BRpcDownloader::download(const std::string& host,
-                              const std::string& url,
-                              std::string& data) {
+bool BRpcDownloader::download(
+    const std::string& host,
+    const std::string& url,
+    std::string& data,
+    const std::unordered_map<std::string, std::string>& headers) {
   brpc::Controller cntl;
   cntl.http_request().uri() = url;
+  for (const auto& [k, v] : headers) {
+    cntl.http_request().SetHeader(k, v);
+  }
   cntl.set_timeout_ms(2000);
   auto channel = get_channel(host);
   if (!channel) {

--- a/xllm/core/util/http_downloader.cpp
+++ b/xllm/core/util/http_downloader.cpp
@@ -17,7 +17,38 @@ limitations under the License.
 
 #include <glog/logging.h>
 
+#include <nlohmann/json.hpp>
+
+#include "core/framework/config/model_config.h"
+
 namespace xllm {
+
+std::unordered_map<std::string, std::string> parse_headers_json(
+    const std::string& raw) {
+  std::unordered_map<std::string, std::string> result;
+  if (raw.empty()) return result;
+
+  try {
+    auto j = nlohmann::json::parse(raw);
+    for (auto& [k, v] : j.items()) {
+      result[k] = v.get<std::string>();
+    }
+  } catch (const std::exception& e) {
+    LOG(ERROR) << "Failed to parse mm_download_headers JSON: " << e.what();
+  }
+  return result;
+}
+
+std::unordered_map<std::string, std::string> parse_global_headers() {
+  static const std::unordered_map<std::string, std::string> cached =
+      parse_headers_json(
+          ModelConfig::get_instance().mm_download_headers());
+  if (!cached.empty()) {
+    LOG(INFO) << "Loaded " << cached.size()
+              << " mm_download_headers from config";
+  }
+  return cached;
+}
 
 bool HttpDownloader::fetch_data(
     const std::string& url,
@@ -87,6 +118,11 @@ bool BRpcDownloader::download(
     const std::unordered_map<std::string, std::string>& headers) {
   brpc::Controller cntl;
   cntl.http_request().uri() = url;
+  // 1) global defaults (lowest priority)
+  for (const auto& [k, v] : parse_global_headers()) {
+    cntl.http_request().SetHeader(k, v);
+  }
+  // 2) per-request headers (override global)
   for (const auto& [k, v] : headers) {
     cntl.http_request().SetHeader(k, v);
   }

--- a/xllm/core/util/http_downloader.cpp
+++ b/xllm/core/util/http_downloader.cpp
@@ -43,10 +43,6 @@ std::unordered_map<std::string, std::string> parse_global_headers() {
   static const std::unordered_map<std::string, std::string> cached =
       parse_headers_json(
           ModelConfig::get_instance().mm_download_headers());
-  if (!cached.empty()) {
-    LOG(INFO) << "Loaded " << cached.size()
-              << " mm_download_headers from config";
-  }
   return cached;
 }
 

--- a/xllm/core/util/http_downloader.h
+++ b/xllm/core/util/http_downloader.h
@@ -31,13 +31,18 @@ class HttpDownloader {
   HttpDownloader() = default;
   virtual ~HttpDownloader() {}
 
-  bool fetch_data(const std::string& url, std::string& data);
+  bool fetch_data(const std::string& url,
+                  std::string& data,
+                  const std::unordered_map<std::string, std::string>& headers =
+                      {});
 
  protected:
   bool parse_url(const std::string& url, std::string& host);
   virtual bool download(const std::string& host,
                         const std::string& url,
-                        std::string& data) = 0;
+                        std::string& data,
+                        const std::unordered_map<std::string, std::string>&
+                            headers = {}) = 0;
 };
 
 class BRpcDownloader : public HttpDownloader {
@@ -47,7 +52,9 @@ class BRpcDownloader : public HttpDownloader {
 
   bool download(const std::string& host,
                 const std::string& url,
-                std::string& data) override;
+                std::string& data,
+                const std::unordered_map<std::string, std::string>& headers =
+                    {}) override;
 
  private:
   std::shared_ptr<brpc::Channel> get_channel(const std::string& host);

--- a/xllm/core/util/http_downloader.h
+++ b/xllm/core/util/http_downloader.h
@@ -31,18 +31,18 @@ class HttpDownloader {
   HttpDownloader() = default;
   virtual ~HttpDownloader() {}
 
-  bool fetch_data(const std::string& url,
-                  std::string& data,
-                  const std::unordered_map<std::string, std::string>& headers =
-                      {});
+  bool fetch_data(
+      const std::string& url,
+      std::string& data,
+      const std::unordered_map<std::string, std::string>& headers = {});
 
  protected:
   bool parse_url(const std::string& url, std::string& host);
-  virtual bool download(const std::string& host,
-                        const std::string& url,
-                        std::string& data,
-                        const std::unordered_map<std::string, std::string>&
-                            headers = {}) = 0;
+  virtual bool download(
+      const std::string& host,
+      const std::string& url,
+      std::string& data,
+      const std::unordered_map<std::string, std::string>& headers = {}) = 0;
 };
 
 class BRpcDownloader : public HttpDownloader {

--- a/xllm/core/util/http_downloader.h
+++ b/xllm/core/util/http_downloader.h
@@ -65,4 +65,13 @@ class BRpcDownloader : public HttpDownloader {
       channels_;
 };
 
+// Parse a JSON string of headers into a key-value map.
+// Returns empty map on empty input or parse failure.
+// Exposed for testing.
+std::unordered_map<std::string, std::string> parse_headers_json(
+    const std::string& raw);
+
+// Parse the --mm_download_headers gflag. Cached after first call.
+std::unordered_map<std::string, std::string> parse_global_headers();
+
 }  // namespace xllm

--- a/xllm/proto/multimodal.proto
+++ b/xllm/proto/multimodal.proto
@@ -10,14 +10,17 @@ import "embedding_data.proto";
 
 message ImageURL {
   string url = 1;
+  map<string, string> headers = 2;
 }
 
 message VideoURL {
   string url = 1;
+  map<string, string> headers = 2;
 }
 
 message AudioURL {
   string url = 1;
+  map<string, string> headers = 2;
 }
 
 message MMInputData {


### PR DESCRIPTION
## Description

Allow callers to attach custom HTTP headers (e.g., Authorization, Referer) when downloading multimodal resources via image_url/video_url/audio_url. Headers can be set at two levels with clear precedence:

  1. Per-request headers via the API (highest priority)
  2. Service-level defaults via --mm_download_headers gflag (fallback)
  
When both are present, per-request headers override the global defaults on a per-key basis; non-overlapping keys from both levels are merged.

**1. Service-level gflag**
`--mm_download_headers (string, default: "")`  Global HTTP headers applied to all multimodal downloads. Accepts a JSON  object string. Parsed once at first use and cached for the process lifetime.

Example:
```shell
    --mm_download_headers={"Authorization":"Bearer global","Referer":"https://example.com"}
```

**2. Per-request API format**
```json
{
	"messages": [{
		"role": "user",
		"content": [{
			"type": "image_url",
			"image_url": {
				"url": "http://img.example.com/photo.jpg",
				"headers": {
					"Authorization": "token123"
				}
			}
		}]
	}]
}
```

**3. Merge behavior**
```text
--mm_download_headers={"Referer":"https://default.com"}
  +
  Request: {"headers": {"Authorization": "Bearer xxx"}}
  =
  Effective:  Authorization=Bearer xxx, Referer=https://default.com
```
### Changes:
proto:
    - multimodal.proto: add map<string, string> headers to ImageURL, VideoURL, and AudioURL messages

core:
    - message.h: add std::unordered_map<std::string, std::string> headers to ImageURL, VideoURL, and AudioURL structs
    - global_flags.h/cpp: declare and define --mm_download_headers gflag
    - http_downloader.h/cpp:
        - parse_headers_json() — parse JSON header string into map
        - parse_global_headers() — cached parser for the gflag
        - BRpcDownloader::download() — apply global defaults first, then per-request headers via cntl.http_request().SetHeader()
    - mm_handler.h/cpp: thread headers from MMContent through load_from_http() in ImageHandler, VideoHandler, and AudioHandler
    - mm_service_utils.h: parse headers from proto into C++ structs in build_messages()

tests:
    - http_downloader_test.cpp: unit tests covering parse_headers_json()
      (empty/valid/invalid/edge-case JSON), struct default & assignment,
      MMContent header plumbing, and header merge priority order


## Related Issues

<!-- Link related issues here. Use "Fixes #123" when this PR closes an issue. -->

## Change Type

- [ ] Bug fix
- [x] New feature
- [ ] Performance improvement
- [ ] Refactor
- [ ] Documentation
- [ ] Test
- [ ] Build or CI

## Pull Request Checklist

Thank you for contributing to xLLM. Before requesting review, please make sure the following items are complete.

### PR Title and Commit Messages

- [x] The PR title and each commit message follow the xLLM commit format: `<type>: <subject>`.

> Allowed types: feat, bugfix, docs, test, refactor, chore, style, revert, perf, model, build, release.
> The subject should use clear English, start with a verb, include at least 4 words, and end with `.`.

### Pre-commit Checks

- [x] I have installed `pre-commit` by running `pip install pre-commit` or an equivalent command.
- [x] I have installed the hooks with `pre-commit install`.
- [x] I have run `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

### Self Review

- [x] I have self-reviewed the code according to `.agents/skills/code-review/references/custom-code-style.md`, especially code written or assisted by AI.
- [x] I have rebased this PR onto the latest `main` branch.

### Build and Test Coverage

- [ ] Tests have been added or updated as needed.
- [x] CUDA: `python setup.py build test` has passed on a CUDA machine.
- [x] NPU: `python setup.py build test` has passed on an NPU machine.
- [x] MLU: `python setup.py build test` has passed on an MLU machine.

## Reviewer Notes

<!-- Optional: anything reviewers should focus on, known risks, follow-ups, or validation gaps. -->
