### PR TITLE
feat: add support for DSA topk sharing on NPU devices for v0.10.0.

### DIFF
--- a/xllm/core/framework/model/model_args.h
+++ b/xllm/core/framework/model/model_args.h
@@ -148,6 +148,9 @@ struct ModelArgs {
   PROPERTY(int32_t, index_n_heads) = 0;
   PROPERTY(int32_t, index_topk) = 0;
   PROPERTY(bool, indexer_rope_interleave) = false;
+  PROPERTY(int32_t, index_topk_freq) = 1;
+  PROPERTY(std::string, index_topk_pattern);
+  PROPERTY(int32_t, index_skip_topk_offset) = 0;
 
   // deepseek v4
   PROPERTY(int32_t, rope_head_dim) = 0;

--- a/xllm/core/framework/model/model_args.h
+++ b/xllm/core/framework/model/model_args.h
@@ -148,6 +148,7 @@ struct ModelArgs {
   PROPERTY(int32_t, index_n_heads) = 0;
   PROPERTY(int32_t, index_topk) = 0;
   PROPERTY(bool, indexer_rope_interleave) = false;
+  // IndexCache: https://arxiv.org/abs/2603.12201
   PROPERTY(int32_t, index_topk_freq) = 1;
   PROPERTY(std::string, index_topk_pattern);
   PROPERTY(int32_t, index_skip_topk_offset) = 0;

--- a/xllm/core/framework/model/model_args.h
+++ b/xllm/core/framework/model/model_args.h
@@ -151,6 +151,7 @@ struct ModelArgs {
   PROPERTY(int32_t, index_topk_freq) = 1;
   PROPERTY(std::string, index_topk_pattern);
   PROPERTY(int32_t, index_skip_topk_offset) = 0;
+  PROPERTY(bool, index_share_for_mtp_iteration) = false;
 
   // deepseek v4
   PROPERTY(int32_t, rope_head_dim) = 0;

--- a/xllm/core/framework/model/model_input_params.h
+++ b/xllm/core/framework/model/model_input_params.h
@@ -890,6 +890,7 @@ struct ModelInputParams {
     params.dit_forward_input = dit_forward_input.to(device);
     params.is_spec_verify = is_spec_verify;
     params.num_accepted_tokens = safe_to(num_accepted_tokens, device, true);
+    params.dsa_topk_indices = safe_to(dsa_topk_indices, device, true);
     for (const auto& table : multi_block_tables) {
       params.multi_block_tables.push_back(
           safe_to(table, table.options().device(torch::kCPU), true));
@@ -1015,6 +1016,7 @@ struct ModelInputParams {
   torch::Tensor mtp_shifted_token_ids;
   bool is_spec_verify = false;
   torch::Tensor num_accepted_tokens;
+  torch::Tensor dsa_topk_indices;
 
   RecModelInputParams rec_params;
 

--- a/xllm/core/framework/model/model_output.h
+++ b/xllm/core/framework/model/model_output.h
@@ -28,6 +28,8 @@ struct ModelOutput {
   torch::Tensor residual;
   // [num_tokens, ...]
   torch::Tensor aux_hidden_states;
+  // DSA top-k indices reused across MTP draft forwards.
+  torch::Tensor dsa_topk_indices;
 
   ModelOutput() = default;
 

--- a/xllm/core/layers/common/CMakeLists.txt
+++ b/xllm/core/layers/common/CMakeLists.txt
@@ -23,6 +23,7 @@ cc_library(
     attention_metadata_builder.h
     dsa_metadata.h
     dsa_metadata_builder.h
+    dsa_topk_share_plan.h
     dp_utils.h
     add_matmul.h
     moe_fused_topk.h

--- a/xllm/core/layers/common/dsa_topk_share_plan.h
+++ b/xllm/core/layers/common/dsa_topk_share_plan.h
@@ -15,6 +15,7 @@ limitations under the License.
 
 #pragma once
 
+#include <algorithm>
 #include <cctype>
 #include <cstdint>
 #include <string>
@@ -35,8 +36,8 @@ inline bool has_dsa_indexer(const ModelArgs& args) {
          args.index_topk() > 0;
 }
 
-inline bool should_compute_topk_from_pattern(const std::string& pattern,
-                                             int32_t layer_id) {
+inline bool should_skip_topk_from_pattern(const std::string& pattern,
+                                          int32_t layer_id) {
   CHECK_GE(layer_id, 0) << "DSA top-k sharing layer id must be non-negative.";
   CHECK_LT(layer_id, static_cast<int32_t>(pattern.size()))
       << "DSA top-k sharing pattern is shorter than num_hidden_layers.";
@@ -45,7 +46,29 @@ inline bool should_compute_topk_from_pattern(const std::string& pattern,
           pattern[static_cast<size_t>(layer_id)])));
   CHECK(symbol == 'F' || symbol == 'S')
       << "DSA top-k sharing pattern only supports F/S, got " << symbol;
-  return symbol == 'F';
+  return symbol == 'S';
+}
+
+inline bool should_skip_topk_from_freq(int32_t freq,
+                                       int32_t offset,
+                                       int32_t layer_id) {
+  CHECK_GT(freq, 1) << "DSA top-k sharing freq must be greater than 1.";
+  CHECK_GE(offset, 0) << "DSA top-k sharing offset must be non-negative.";
+  if (offset > 0) {
+    return std::max(layer_id - offset + 1, 0) % freq != 0;
+  }
+  return std::max(layer_id - 1, 0) % freq != 0;
+}
+
+inline bool should_next_layer_skip_topk_from_freq(int32_t freq,
+                                                  int32_t offset,
+                                                  int32_t layer_id) {
+  CHECK_GT(freq, 1) << "DSA top-k sharing freq must be greater than 1.";
+  CHECK_GE(offset, 0) << "DSA top-k sharing offset must be non-negative.";
+  if (offset > 0) {
+    return std::max(layer_id - offset + 2, 0) % freq != 0;
+  }
+  return layer_id % freq != 0;
 }
 
 inline DsaTopkShareDecision get_dsa_topk_share_decision(
@@ -59,20 +82,24 @@ inline DsaTopkShareDecision get_dsa_topk_share_decision(
     return decision;
   }
 
-  bool compute_topk = true;
+  bool skip_topk = false;
+  bool next_skip_topk = false;
   if (!args.index_topk_pattern().empty()) {
-    compute_topk =
-        should_compute_topk_from_pattern(args.index_topk_pattern(), layer_id);
+    const std::string& pattern = args.index_topk_pattern();
+    skip_topk = should_skip_topk_from_pattern(pattern, layer_id);
+    if (layer_id + 1 < static_cast<int32_t>(pattern.size())) {
+      next_skip_topk = should_skip_topk_from_pattern(pattern, layer_id + 1);
+    }
   } else {
     const int32_t freq = args.index_topk_freq();
-    CHECK_GT(freq, 1) << "DSA top-k sharing freq must be greater than 1.";
     const int32_t offset = args.index_skip_topk_offset();
-    CHECK_GE(offset, 0) << "DSA top-k sharing offset must be non-negative.";
-    compute_topk = layer_id <= offset || (layer_id - offset) % freq == 0;
+    skip_topk = should_skip_topk_from_freq(freq, offset, layer_id);
+    next_skip_topk =
+        should_next_layer_skip_topk_from_freq(freq, offset, layer_id);
   }
 
-  decision.reuse_topk = !compute_topk;
-  decision.output_topk = compute_topk;
+  decision.reuse_topk = skip_topk;
+  decision.output_topk = !skip_topk && next_skip_topk;
   return decision;
 }
 

--- a/xllm/core/layers/common/dsa_topk_share_plan.h
+++ b/xllm/core/layers/common/dsa_topk_share_plan.h
@@ -1,0 +1,79 @@
+/* Copyright 2026 The xLLM Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://github.com/jd-opensource/xllm/blob/main/LICENSE
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#pragma once
+
+#include <cctype>
+#include <cstdint>
+#include <string>
+
+#include <glog/logging.h>
+
+#include "core/framework/model/model_args.h"
+
+namespace xllm::layer {
+
+struct DsaTopkShareDecision {
+  bool reuse_topk = false;
+  bool output_topk = false;
+};
+
+inline bool has_dsa_indexer(const ModelArgs& args) {
+  return args.index_n_heads() > 0 && args.index_head_dim() > 0 &&
+         args.index_topk() > 0;
+}
+
+inline bool should_compute_topk_from_pattern(const std::string& pattern,
+                                             int32_t layer_id) {
+  CHECK_GE(layer_id, 0) << "DSA top-k sharing layer id must be non-negative.";
+  CHECK_LT(layer_id, static_cast<int32_t>(pattern.size()))
+      << "DSA top-k sharing pattern is shorter than num_hidden_layers.";
+  const char symbol =
+      static_cast<char>(std::toupper(static_cast<unsigned char>(
+          pattern[static_cast<size_t>(layer_id)])));
+  CHECK(symbol == 'F' || symbol == 'S')
+      << "DSA top-k sharing pattern only supports F/S, got " << symbol;
+  return symbol == 'F';
+}
+
+inline DsaTopkShareDecision get_dsa_topk_share_decision(
+    const ModelArgs& args,
+    int32_t layer_id) {
+  DsaTopkShareDecision decision;
+  if (!has_dsa_indexer(args)) {
+    return decision;
+  }
+  if (args.index_topk_pattern().empty() && args.index_topk_freq() <= 1) {
+    return decision;
+  }
+
+  bool compute_topk = true;
+  if (!args.index_topk_pattern().empty()) {
+    compute_topk =
+        should_compute_topk_from_pattern(args.index_topk_pattern(), layer_id);
+  } else {
+    const int32_t freq = args.index_topk_freq();
+    CHECK_GT(freq, 1) << "DSA top-k sharing freq must be greater than 1.";
+    const int32_t offset = args.index_skip_topk_offset();
+    CHECK_GE(offset, 0) << "DSA top-k sharing offset must be non-negative.";
+    compute_topk = layer_id <= offset || (layer_id - offset) % freq == 0;
+  }
+
+  decision.reuse_topk = !compute_topk;
+  decision.output_topk = compute_topk;
+  return decision;
+}
+
+}  // namespace xllm::layer

--- a/xllm/core/layers/common/dsa_topk_share_plan.h
+++ b/xllm/core/layers/common/dsa_topk_share_plan.h
@@ -55,9 +55,9 @@ inline bool should_skip_topk_from_freq(int32_t freq,
   CHECK_GT(freq, 1) << "DSA top-k sharing freq must be greater than 1.";
   CHECK_GE(offset, 0) << "DSA top-k sharing offset must be non-negative.";
   if (offset > 0) {
-    return std::max(layer_id - offset + 1, 0) % freq != 0;
+    return std::max<int32_t>(layer_id - offset + 1, 0) % freq != 0;
   }
-  return std::max(layer_id - 1, 0) % freq != 0;
+  return std::max<int32_t>(layer_id - 1, 0) % freq != 0;
 }
 
 inline bool should_next_layer_skip_topk_from_freq(int32_t freq,
@@ -66,7 +66,7 @@ inline bool should_next_layer_skip_topk_from_freq(int32_t freq,
   CHECK_GT(freq, 1) << "DSA top-k sharing freq must be greater than 1.";
   CHECK_GE(offset, 0) << "DSA top-k sharing offset must be non-negative.";
   if (offset > 0) {
-    return std::max(layer_id - offset + 2, 0) % freq != 0;
+    return std::max<int32_t>(layer_id - offset + 2, 0) % freq != 0;
   }
   return layer_id % freq != 0;
 }

--- a/xllm/core/layers/common/dsa_topk_share_plan.h
+++ b/xllm/core/layers/common/dsa_topk_share_plan.h
@@ -15,12 +15,12 @@ limitations under the License.
 
 #pragma once
 
+#include <glog/logging.h>
+
 #include <algorithm>
 #include <cctype>
 #include <cstdint>
 #include <string>
-
-#include <glog/logging.h>
 
 #include "core/framework/model/model_args.h"
 
@@ -41,9 +41,8 @@ inline bool should_skip_topk_from_pattern(const std::string& pattern,
   CHECK_GE(layer_id, 0) << "DSA top-k sharing layer id must be non-negative.";
   CHECK_LT(layer_id, static_cast<int32_t>(pattern.size()))
       << "DSA top-k sharing pattern is shorter than num_hidden_layers.";
-  const char symbol =
-      static_cast<char>(std::toupper(static_cast<unsigned char>(
-          pattern[static_cast<size_t>(layer_id)])));
+  const char symbol = static_cast<char>(std::toupper(
+      static_cast<unsigned char>(pattern[static_cast<size_t>(layer_id)])));
   CHECK(symbol == 'F' || symbol == 'S')
       << "DSA top-k sharing pattern only supports F/S, got " << symbol;
   return symbol == 'S';
@@ -71,9 +70,8 @@ inline bool should_next_layer_skip_topk_from_freq(int32_t freq,
   return layer_id % freq != 0;
 }
 
-inline DsaTopkShareDecision get_dsa_topk_share_decision(
-    const ModelArgs& args,
-    int32_t layer_id) {
+inline DsaTopkShareDecision get_dsa_topk_share_decision(const ModelArgs& args,
+                                                        int32_t layer_id) {
   DsaTopkShareDecision decision;
   if (!has_dsa_indexer(args)) {
     return decision;

--- a/xllm/core/layers/npu/npu_deepseek_v32_decoder_layer_impl.cpp
+++ b/xllm/core/layers/npu/npu_deepseek_v32_decoder_layer_impl.cpp
@@ -30,6 +30,7 @@ limitations under the License.
 #include "core/framework/config/load_config.h"
 #include "core/framework/config/parallel_config.h"
 #include "core/framework/config/scheduler_config.h"
+#include "core/layers/common/dsa_topk_share_plan.h"
 #include "framework/parallel_state/npu_cp_prepare.h"
 #include "layers/common/rotary_embedding_util.h"
 #include "loader/deepseek_v32_decoder_loader.h"
@@ -199,6 +200,10 @@ NpuDeepseekV32DecoderLayerImpl::NpuDeepseekV32DecoderLayerImpl(
   auto parallel_args = context.get_parallel_args();
   auto model_args = context.get_model_args();
   auto options = context.get_tensor_options();
+  const DsaTopkShareDecision topk_decision =
+      get_dsa_topk_share_decision(model_args, layer_id_);
+  skip_topk_ = topk_decision.reuse_topk;
+  output_topk_ = topk_decision.output_topk;
 
   rank_ = parallel_args.rank();
   first_k_dense_replace_ = model_args.first_k_dense_replace();
@@ -397,6 +402,8 @@ void NpuDeepseekV32DecoderLayerImpl::initialize_attention_parameters(
   param.index_head_dim = args.index_head_dim();
   param.index_n_heads = args.index_n_heads();
   param.index_topk = args.index_topk();
+  param.skipTopk = skip_topk_;
+  param.outputTopk = output_topk_;
 }
 
 void NpuDeepseekV32DecoderLayerImpl::initialize_mlp_parameters(
@@ -772,11 +779,14 @@ int64_t NpuDeepseekV32DecoderLayerImpl::init_node(
   }
   node.inTensors.resize(node.operation->GetInputNum());
 
+  size_t out_tensor_num = 1;
   if (eplb_enabled) {
-    node.outTensors.resize(2);
-  } else {
-    node.outTensors.resize(1);
+    ++out_tensor_num;
   }
+  if (param.outputTopk) {
+    ++out_tensor_num;
+  }
+  node.outTensors.resize(out_tensor_num);
 
   size_t inTensorId = 1;
 
@@ -788,15 +798,8 @@ int64_t NpuDeepseekV32DecoderLayerImpl::init_node(
   node.variantPack.inTensors.reserve(node.inTensors.size());
   node.variantPack.inTensors.resize(node.inTensors.size());
 
-  // eplb used in decode stage, while multi stream parallel used in prefill
-  // stage
-  if (eplb_enabled) {
-    node.variantPack.outTensors.reserve(2);
-    node.variantPack.outTensors.resize(2);  // TODO
-  } else {
-    node.variantPack.outTensors.reserve(1);
-    node.variantPack.outTensors.resize(1);
-  }
+  node.variantPack.outTensors.reserve(out_tensor_num);
+  node.variantPack.outTensors.resize(out_tensor_num);
   return atb::NO_ERROR;
 }
 
@@ -807,6 +810,33 @@ torch::Tensor NpuDeepseekV32DecoderLayerImpl::forward(
     torch::Tensor& attn_mask,
     KVCache& kv_cache,
     const ModelInputParams& input_params,
+    aclrtEvent* event,
+    std::atomic<bool>* event_flag,
+    int node_id) {
+  CHECK(!is_topk_sharing_enabled())
+      << "DSA top-k sharing layer requires forward_with_topk.";
+  return forward_with_topk(x,
+                           cos_pos,
+                           sin_pos,
+                           attn_mask,
+                           kv_cache,
+                           input_params,
+                           torch::Tensor(),
+                           nullptr,
+                           event,
+                           event_flag,
+                           node_id);
+}
+
+torch::Tensor NpuDeepseekV32DecoderLayerImpl::forward_with_topk(
+    torch::Tensor& x,
+    torch::Tensor& cos_pos,
+    torch::Tensor& sin_pos,
+    torch::Tensor& attn_mask,
+    KVCache& kv_cache,
+    const ModelInputParams& input_params,
+    const torch::Tensor& shared_topk_indices,
+    torch::Tensor* output_topk_indices,
     aclrtEvent* event,
     std::atomic<bool>* event_flag,
     int node_id) {
@@ -821,7 +851,9 @@ torch::Tensor NpuDeepseekV32DecoderLayerImpl::forward(
                             attn_mask,
                             kv_cache,
                             input_params_new,
-                            false);
+                            false,
+                            shared_topk_indices,
+                            output_topk_indices);
     st = execute_node(decode_node_, node_id, event, event_flag);
     LOG_IF(FATAL, st != 0) << model_name_
                            << "execute prefill layer fail, error code: " << st;
@@ -833,7 +865,9 @@ torch::Tensor NpuDeepseekV32DecoderLayerImpl::forward(
                             attn_mask,
                             kv_cache,
                             input_params_new,
-                            true);
+                            true,
+                            shared_topk_indices,
+                            output_topk_indices);
     st = execute_node(prefill_node_, node_id, event, event_flag);
     LOG_IF(FATAL, st != 0) << model_name_
                            << "execute prefill layer fail, error code: " << st;
@@ -849,7 +883,9 @@ void NpuDeepseekV32DecoderLayerImpl::build_node_variant_pack(
     torch::Tensor& attn_mask,
     KVCache& kv_cache,
     ModelInputParams& input_params,
-    bool is_prefill) {
+    bool is_prefill,
+    const torch::Tensor& shared_topk_indices,
+    torch::Tensor* output_topk_indices) {
   internal_tensor_ = atb_speed::Utils::AtTensor2Tensor(x);
   // final_hidden_states_ = torch::zeros_like(x);
   int32_t input_idx = 0;
@@ -1023,6 +1059,18 @@ void NpuDeepseekV32DecoderLayerImpl::build_node_variant_pack(
         atb_speed::Utils::AtTensor2Tensor(int_tensor_placeholder_);
   }
 
+  if (skip_topk_ || output_topk_) {
+    // TODO: support DSA top-k sharing for CP prefill.
+    CHECK(!(cp_size_ > 1 && is_prefill))
+        << "DSA top-k sharing does not support CP prefill yet.";
+    if (skip_topk_) {
+      CHECK(shared_topk_indices.defined())
+          << "DSA top-k sharing requires previous top-k indices.";
+      node.variantPack.inTensors.at(WEIGHT_COUNT_PER_LAYER + 32) =
+          atb_speed::Utils::AtTensor2Tensor(shared_topk_indices);
+    }
+  }
+
   if (cp_size_ > 1 && is_prefill) {
     node.variantPack.inTensors.at(WEIGHT_COUNT_PER_LAYER + 32) =
         atb_speed::Utils::AtTensor2Tensor(cp_inputs.cp_o_recover_idx);
@@ -1055,6 +1103,12 @@ void NpuDeepseekV32DecoderLayerImpl::build_node_variant_pack(
   }
 
   node.variantPack.outTensors.at(0) = internal_tensor_;
+  if (output_topk_) {
+    CHECK(output_topk_indices != nullptr && output_topk_indices->defined())
+        << "DSA top-k sharing output tensor is not initialized.";
+    node.variantPack.outTensors.at(node.variantPack.outTensors.size() - 1) =
+        atb_speed::Utils::AtTensor2Tensor(*output_topk_indices);
+  }
 }
 
 }  // namespace layer

--- a/xllm/core/layers/npu/npu_deepseek_v32_decoder_layer_impl.h
+++ b/xllm/core/layers/npu/npu_deepseek_v32_decoder_layer_impl.h
@@ -62,6 +62,22 @@ class NpuDeepseekV32DecoderLayerImpl : public BaseLayer {
                         std::atomic<bool>* event_flag = nullptr,
                         int node_id = 0);
 
+  torch::Tensor forward_with_topk(torch::Tensor& x,
+                                  torch::Tensor& cos_pos,
+                                  torch::Tensor& sin_pos,
+                                  torch::Tensor& attn_mask,
+                                  KVCache& kv_cache,
+                                  const ModelInputParams& input_params,
+                                  const torch::Tensor& shared_topk_indices,
+                                  torch::Tensor* output_topk_indices,
+                                  aclrtEvent* event = nullptr,
+                                  std::atomic<bool>* event_flag = nullptr,
+                                  int node_id = 0);
+
+  bool is_topk_sharing_enabled() const { return skip_topk_ || output_topk_; }
+  bool skip_topk() const { return skip_topk_; }
+  bool output_topk() const { return output_topk_; }
+
  private:
   struct ShardingConfig {
     bool is_sharded;
@@ -126,7 +142,9 @@ class NpuDeepseekV32DecoderLayerImpl : public BaseLayer {
                                torch::Tensor& attn_mask,
                                KVCache& kv_cache,
                                ModelInputParams& input_params,
-                               bool is_prefill);
+                               bool is_prefill,
+                               const torch::Tensor& shared_topk_indices,
+                               torch::Tensor* output_topk_indices);
 
   torch::Tensor block_tables_placeholder_;
   std::string model_name_;
@@ -138,6 +156,8 @@ class NpuDeepseekV32DecoderLayerImpl : public BaseLayer {
   int32_t v_head_dim_;
   int32_t kv_lora_rank_;
   int32_t qk_rope_head_dim_;
+  bool skip_topk_ = false;
+  bool output_topk_ = false;
 
   int32_t rank_;
   int32_t first_k_dense_replace_;

--- a/xllm/core/runtime/forward_params.h
+++ b/xllm/core/runtime/forward_params.h
@@ -913,6 +913,7 @@ struct ForwardOutput {
   StreamEventPtr ready_event;
   torch::Tensor logits;
   torch::Tensor embedding;
+  torch::Tensor dsa_topk_indices;
 
   // for eplb, collect the tokens load of experts on each worker.
   torch::Tensor expert_load_data;

--- a/xllm/core/runtime/llm_worker_impl.cpp
+++ b/xllm/core/runtime/llm_worker_impl.cpp
@@ -264,6 +264,7 @@ std::optional<ForwardOutput> LLMWorkerImpl::step_internal(
   }
 
   ForwardOutput output;
+  output.dsa_topk_indices = model_output.dsa_topk_indices;
   if (::xllm::EPLBConfig::get_instance().enable_eplb()) {
     output.expert_load_data = expert_load_data_;
     output.prepared_layer_id = eplb_executor_->get_ready_layer_id();

--- a/xllm/core/runtime/mtp_worker_impl.cpp
+++ b/xllm/core/runtime/mtp_worker_impl.cpp
@@ -136,6 +136,11 @@ void clear_ready_events(ForwardInput& input) {
   input.metadata_ready_event.reset();
 }
 
+bool should_reuse_mtp_topk_indices(const ModelArgs& model_args) {
+  return model_args.index_share_for_mtp_iteration() &&
+         model_args.index_n_heads() > 0 && model_args.index_topk() > 0;
+}
+
 std::optional<ForwardOutput> run_llm_no_sync_impl(LLMWorkerImpl& worker,
                                                   const ForwardInput& input,
                                                   Stream& prepare_stream,
@@ -907,7 +912,13 @@ std::optional<ForwardOutput> MTPWorkerImpl::step_decode(
   update_decode_step_input(input, last_states);
   prepare_draft_extend_inputs(input, last_states, current_draft_input);
   draft_outputs.reserve(num_speculative_tokens);
+  const bool reuse_mtp_topk_indices =
+      should_reuse_mtp_topk_indices(draft_impl_->context_.get_model_args());
+  torch::Tensor mtp_topk_indices;
   for (int32_t draft_idx = 0; draft_idx < num_speculative_tokens; ++draft_idx) {
+    if (reuse_mtp_topk_indices) {
+      current_draft_input.input_params.dsa_topk_indices = mtp_topk_indices;
+    }
     std::optional<ForwardOutput> draft_output_opt = run_llm_no_sync_impl(
         *draft_impl_, current_draft_input, *prepare_stream_, *compute_stream_);
 
@@ -922,6 +933,9 @@ std::optional<ForwardOutput> MTPWorkerImpl::step_decode(
         << "draft output is empty in speculative step";
 
     draft_outputs.emplace_back(std::move(draft_output_opt.value()));
+    if (reuse_mtp_topk_indices) {
+      mtp_topk_indices = draft_outputs.back().dsa_topk_indices;
+    }
     process_draft_sample_output(draft_outputs.back().sample_output);
     if (draft_idx == num_speculative_tokens - 1) {
       continue;

--- a/xllm/models/llm/deepseek_v32.h
+++ b/xllm/models/llm/deepseek_v32.h
@@ -224,6 +224,9 @@ REGISTER_MODEL_ARGS(deepseek_v32, [&] {
   LOAD_ARG_OR(index_head_dim, "index_head_dim", 128);
   LOAD_ARG_OR(index_n_heads, "index_n_heads", 64);
   LOAD_ARG_OR(index_topk, "index_topk", 2048);
+  LOAD_ARG_OR(index_topk_freq, "index_topk_freq", 1);
+  LOAD_ARG_OR(index_topk_pattern, "index_topk_pattern", "");
+  LOAD_ARG_OR(index_skip_topk_offset, "index_skip_topk_offset", 0);
 
   // extra parameters to adopt with other models
   SET_ARG(indexer_rope_interleave, false);

--- a/xllm/models/llm/glm5.h
+++ b/xllm/models/llm/glm5.h
@@ -92,6 +92,9 @@ REGISTER_MODEL_ARGS(
       LOAD_ARG_OR(index_head_dim, "index_head_dim", 128);
       LOAD_ARG_OR(index_n_heads, "index_n_heads", 32);
       LOAD_ARG_OR(index_topk, "index_topk", 2048);
+      LOAD_ARG_OR(index_topk_freq, "index_topk_freq", 1);
+      LOAD_ARG_OR(index_topk_pattern, "index_topk_pattern", "");
+      LOAD_ARG_OR(index_skip_topk_offset, "index_skip_topk_offset", 0);
 
       // Computed parameters
       // the original head_dim in glm5 config seem useless

--- a/xllm/models/llm/npu/deepseek_v32.h
+++ b/xllm/models/llm/npu/deepseek_v32.h
@@ -54,6 +54,36 @@ class DeepseekV32DecoderLayerImpl : public torch::nn::Module {
                           event_flag);
   }
 
+  torch::Tensor forward_with_topk(torch::Tensor& x,
+                                  torch::Tensor& cos_pos,
+                                  torch::Tensor& sin_pos,
+                                  torch::Tensor& attn_mask,
+                                  KVCache& kv_cache,
+                                  const ModelInputParams& input_params,
+                                  const torch::Tensor& shared_topk_indices,
+                                  torch::Tensor* output_topk_indices,
+                                  aclrtEvent* event,
+                                  std::atomic<bool>* event_flag) {
+    return decoder_layer_->forward_with_topk(x,
+                                             cos_pos,
+                                             sin_pos,
+                                             attn_mask,
+                                             kv_cache,
+                                             input_params,
+                                             shared_topk_indices,
+                                             output_topk_indices,
+                                             event,
+                                             event_flag);
+  }
+
+  bool is_topk_sharing_enabled() const {
+    return decoder_layer_->is_topk_sharing_enabled();
+  }
+
+  bool skip_topk() const { return decoder_layer_->skip_topk(); }
+
+  bool output_topk() const { return decoder_layer_->output_topk(); }
+
   void load_state_dict(const StateDict& state_dict) {
     decoder_layer_->load_state_dict(state_dict);
   }
@@ -177,6 +207,7 @@ class DeepseekV32ModelImpl : public torch::nn::Module {
           num_speculative_tokens_ + 1, dtype_, device_);
     }
 
+    torch::Tensor prev_topk_indices;
     RollingLayerGuard rolling_guard(rolling_mgr_);
     for (size_t i = 0; i < layers_.size(); i++) {
       aclrtEvent* event = nullptr;
@@ -191,16 +222,56 @@ class DeepseekV32ModelImpl : public torch::nn::Module {
       }
 
       auto& layer = layers_[i];
-      const int32_t layer_index = i;
+      const int32_t layer_index = static_cast<int32_t>(i);
+      const bool topk_sharing_enabled = layer->is_topk_sharing_enabled();
+      const bool skip_topk = layer->skip_topk();
+      const bool output_topk = layer->output_topk();
+      torch::Tensor current_topk_indices;
+      torch::Tensor shared_topk_indices;
+      torch::Tensor* output_topk_indices = nullptr;
+      if (topk_sharing_enabled) {
+        if (skip_topk) {
+          CHECK(prev_topk_indices.defined())
+              << "DSA top-k sharing requires previous top-k indices at layer "
+              << layer_index;
+          shared_topk_indices = prev_topk_indices;
+        }
+        if (output_topk) {
+          torch::Tensor index_cache = kv_caches[i].get_index_cache();
+          CHECK(index_cache.defined())
+              << "DSA top-k sharing requires index cache at layer "
+              << layer_index;
+          current_topk_indices = torch::empty(
+              {h.size(0), index_cache.size(2), model_args.index_topk()},
+              torch::TensorOptions().device(device_).dtype(torch::kInt32));
+          output_topk_indices = &current_topk_indices;
+        }
+      }
       rolling_guard.before_layer(layer_index);
-      layer(h,
-            cos_pos,
-            sin_pos,
-            attn_mask,
-            kv_caches[i],
-            input_params,
-            event,
-            event_flag);
+      if (topk_sharing_enabled) {
+        layer->forward_with_topk(h,
+                                 cos_pos,
+                                 sin_pos,
+                                 attn_mask,
+                                 kv_caches[i],
+                                 input_params,
+                                 shared_topk_indices,
+                                 output_topk_indices,
+                                 event,
+                                 event_flag);
+      } else {
+        layer(h,
+              cos_pos,
+              sin_pos,
+              attn_mask,
+              kv_caches[i],
+              input_params,
+              event,
+              event_flag);
+      }
+      if (output_topk) {
+        prev_topk_indices = current_topk_indices;
+      }
       rolling_guard.after_layer(layer_index);
     }
     auto hidden_states = norm_(h, 0);
@@ -393,6 +464,9 @@ REGISTER_MODEL_ARGS(deepseek_v32, [&] {
   LOAD_ARG_OR(index_head_dim, "index_head_dim", 128);
   LOAD_ARG_OR(index_n_heads, "index_n_heads", 0);
   LOAD_ARG_OR(index_topk, "index_topk", 2048);
+  LOAD_ARG_OR(index_topk_freq, "index_topk_freq", 1);
+  LOAD_ARG_OR(index_topk_pattern, "index_topk_pattern", "");
+  LOAD_ARG_OR(index_skip_topk_offset, "index_skip_topk_offset", 0);
 
   LOAD_ARG_OR_FUNC(head_dim, "head_dim", [&] {
     return 256;  // args->qk_nope_head_dim() + args->qk_rope_head_dim();

--- a/xllm/models/llm/npu/deepseek_v32.h
+++ b/xllm/models/llm/npu/deepseek_v32.h
@@ -76,6 +76,70 @@ class DeepseekV32DecoderLayerImpl : public torch::nn::Module {
                                              event_flag);
   }
 
+  void forward_with_mtp_topk(torch::Tensor& x,
+                             torch::Tensor& cos_pos,
+                             torch::Tensor& sin_pos,
+                             torch::Tensor& attn_mask,
+                             KVCache& kv_cache,
+                             const ModelInputParams& input_params,
+                             torch::Tensor& topk_indices,
+                             int32_t index_topk,
+                             const torch::Device& device,
+                             int32_t layer_index,
+                             aclrtEvent* event,
+                             std::atomic<bool>* event_flag) {
+    const bool topk_sharing_enabled = is_topk_sharing_enabled();
+    const bool should_skip_topk = skip_topk();
+    const bool should_output_topk = output_topk();
+    torch::Tensor current_topk_indices;
+    torch::Tensor shared_topk_indices;
+    torch::Tensor* output_topk_indices = nullptr;
+    if (topk_sharing_enabled) {
+      if (should_skip_topk) {
+        CHECK(topk_indices.defined())
+            << "DSA top-k sharing requires previous top-k indices at MTP layer "
+            << layer_index;
+        shared_topk_indices = topk_indices;
+      }
+      if (should_output_topk) {
+        torch::Tensor index_cache = kv_cache.get_index_cache();
+        CHECK(index_cache.defined())
+            << "DSA top-k sharing requires index cache at MTP layer "
+            << layer_index;
+        current_topk_indices = torch::empty(
+            std::vector<int64_t>{x.size(0),
+                                 index_cache.size(2),
+                                 static_cast<int64_t>(index_topk)},
+            torch::TensorOptions().device(device).dtype(torch::kInt32));
+        output_topk_indices = &current_topk_indices;
+      }
+    }
+    if (topk_sharing_enabled) {
+      forward_with_topk(x,
+                        cos_pos,
+                        sin_pos,
+                        attn_mask,
+                        kv_cache,
+                        input_params,
+                        shared_topk_indices,
+                        output_topk_indices,
+                        event,
+                        event_flag);
+    } else {
+      forward(x,
+              cos_pos,
+              sin_pos,
+              attn_mask,
+              kv_cache,
+              input_params,
+              event,
+              event_flag);
+    }
+    if (should_output_topk) {
+      topk_indices = current_topk_indices;
+    }
+  }
+
   bool is_topk_sharing_enabled() const {
     return decoder_layer_->is_topk_sharing_enabled();
   }
@@ -243,10 +307,9 @@ class DeepseekV32ModelImpl : public torch::nn::Module {
               << "DSA top-k sharing requires index cache at layer "
               << layer_index;
           current_topk_indices = torch::empty(
-              std::vector<int64_t>{
-                  h.size(0),
-                  index_cache.size(2),
-                  static_cast<int64_t>(index_topk_)},
+              std::vector<int64_t>{h.size(0),
+                                   index_cache.size(2),
+                                   static_cast<int64_t>(index_topk_)},
               torch::TensorOptions().device(device_).dtype(torch::kInt32));
           output_topk_indices = &current_topk_indices;
         }

--- a/xllm/models/llm/npu/deepseek_v32.h
+++ b/xllm/models/llm/npu/deepseek_v32.h
@@ -135,6 +135,7 @@ class DeepseekV32ModelImpl : public torch::nn::Module {
     device_ = options.device();
     dtype_ = options.dtype().toScalarType();
     num_speculative_tokens_ = model_args.num_speculative_tokens();
+    index_topk_ = model_args.index_topk();
 
     npu_embed_tokens_ =
         register_module("npu_embed_tokens", layer::NpuWordEmbedding(context));
@@ -242,7 +243,10 @@ class DeepseekV32ModelImpl : public torch::nn::Module {
               << "DSA top-k sharing requires index cache at layer "
               << layer_index;
           current_topk_indices = torch::empty(
-              {h.size(0), index_cache.size(2), model_args.index_topk()},
+              std::vector<int64_t>{
+                  h.size(0),
+                  index_cache.size(2),
+                  static_cast<int64_t>(index_topk_)},
               torch::TensorOptions().device(device_).dtype(torch::kInt32));
           output_topk_indices = &current_topk_indices;
         }
@@ -387,6 +391,7 @@ class DeepseekV32ModelImpl : public torch::nn::Module {
   nlohmann::json mapping_data_;
   int32_t num_experts_per_tok_;
   int32_t num_speculative_tokens_ = 0;
+  int32_t index_topk_ = 0;
   at::Device device_;
   torch::Dtype dtype_;
   layer::NpuWordEmbedding npu_embed_tokens_{nullptr};

--- a/xllm/models/llm/npu/deepseek_v32_mtp.h
+++ b/xllm/models/llm/npu/deepseek_v32_mtp.h
@@ -52,6 +52,32 @@ class DeepseekV32MtpModelImpl
         model_args.rope_scaling_mscale_all_dim(),
         options);
   }
+
+ protected:
+  void forward_layer(DeepseekV32DecoderLayer& layer,
+                     torch::Tensor& h,
+                     torch::Tensor& cos_pos,
+                     torch::Tensor& sin_pos,
+                     torch::Tensor& attn_mask,
+                     KVCache& kv_cache,
+                     const ModelInputParams& input_params,
+                     torch::Tensor& topk_indices,
+                     int32_t layer_index,
+                     aclrtEvent* event,
+                     std::atomic<bool>* event_flag) override {
+    layer->forward_with_mtp_topk(h,
+                                 cos_pos,
+                                 sin_pos,
+                                 attn_mask,
+                                 kv_cache,
+                                 input_params,
+                                 topk_indices,
+                                 index_topk_,
+                                 device_,
+                                 layer_index,
+                                 event,
+                                 event_flag);
+  }
 };
 TORCH_MODULE(DeepseekV32MtpModel);
 
@@ -104,6 +130,11 @@ REGISTER_MODEL_ARGS(deepseek_v32_mtp, [&] {
   LOAD_ARG_OR(index_head_dim, "index_head_dim", 128);
   LOAD_ARG_OR(index_n_heads, "index_n_heads", 64);
   LOAD_ARG_OR(index_topk, "index_topk", 2048);
+  LOAD_ARG_OR(index_topk_freq, "index_topk_freq", 1);
+  LOAD_ARG_OR(index_topk_pattern, "index_topk_pattern", "");
+  LOAD_ARG_OR(index_skip_topk_offset, "index_skip_topk_offset", 0);
+  LOAD_ARG_OR(
+      index_share_for_mtp_iteration, "index_share_for_mtp_iteration", false);
 
   LOAD_ARG_OR_FUNC(head_dim, "head_dim", [&] {
     return 256;  // args->qk_nope_head_dim() + args->qk_rope_head_dim();

--- a/xllm/models/llm/npu/glm5_moe.h
+++ b/xllm/models/llm/npu/glm5_moe.h
@@ -37,6 +37,7 @@ class GlmMoeDsaModelImpl : public torch::nn::Module {
     device_ = options.device();
     dtype_ = options.dtype().toScalarType();
     num_speculative_tokens_ = model_args.num_speculative_tokens();
+    index_topk_ = model_args.index_topk();
 
     npu_embed_tokens_ =
         register_module("npu_embed_tokens", layer::NpuWordEmbedding(context));
@@ -133,7 +134,10 @@ class GlmMoeDsaModelImpl : public torch::nn::Module {
               << "DSA top-k sharing requires index cache at layer "
               << layer_index;
           current_topk_indices = torch::empty(
-              {h.size(0), index_cache.size(2), model_args.index_topk()},
+              std::vector<int64_t>{
+                  h.size(0),
+                  index_cache.size(2),
+                  static_cast<int64_t>(index_topk_)},
               torch::TensorOptions().device(device_).dtype(torch::kInt32));
           output_topk_indices = &current_topk_indices;
         }
@@ -277,6 +281,7 @@ class GlmMoeDsaModelImpl : public torch::nn::Module {
   nlohmann::json mapping_data_;
   int32_t num_experts_per_tok_;
   int32_t num_speculative_tokens_ = 0;
+  int32_t index_topk_ = 0;
   at::Device device_;
   torch::Dtype dtype_;
   layer::NpuWordEmbedding npu_embed_tokens_{nullptr};

--- a/xllm/models/llm/npu/glm5_moe.h
+++ b/xllm/models/llm/npu/glm5_moe.h
@@ -134,10 +134,9 @@ class GlmMoeDsaModelImpl : public torch::nn::Module {
               << "DSA top-k sharing requires index cache at layer "
               << layer_index;
           current_topk_indices = torch::empty(
-              std::vector<int64_t>{
-                  h.size(0),
-                  index_cache.size(2),
-                  static_cast<int64_t>(index_topk_)},
+              std::vector<int64_t>{h.size(0),
+                                   index_cache.size(2),
+                                   static_cast<int64_t>(index_topk_)},
               torch::TensorOptions().device(device_).dtype(torch::kInt32));
           output_topk_indices = &current_topk_indices;
         }

--- a/xllm/models/llm/npu/glm5_moe.h
+++ b/xllm/models/llm/npu/glm5_moe.h
@@ -98,6 +98,7 @@ class GlmMoeDsaModelImpl : public torch::nn::Module {
           num_speculative_tokens_ + 1, dtype_, device_);
     }
 
+    torch::Tensor prev_topk_indices;
     RollingLayerGuard rolling_guard(rolling_mgr_);
     for (size_t i = 0; i < layers_.size(); i++) {
       aclrtEvent* event = nullptr;
@@ -112,16 +113,56 @@ class GlmMoeDsaModelImpl : public torch::nn::Module {
       }
 
       auto& layer = layers_[i];
-      const int32_t layer_index = i;
+      const int32_t layer_index = static_cast<int32_t>(i);
+      const bool topk_sharing_enabled = layer->is_topk_sharing_enabled();
+      const bool skip_topk = layer->skip_topk();
+      const bool output_topk = layer->output_topk();
+      torch::Tensor current_topk_indices;
+      torch::Tensor shared_topk_indices;
+      torch::Tensor* output_topk_indices = nullptr;
+      if (topk_sharing_enabled) {
+        if (skip_topk) {
+          CHECK(prev_topk_indices.defined())
+              << "DSA top-k sharing requires previous top-k indices at layer "
+              << layer_index;
+          shared_topk_indices = prev_topk_indices;
+        }
+        if (output_topk) {
+          torch::Tensor index_cache = kv_caches[i].get_index_cache();
+          CHECK(index_cache.defined())
+              << "DSA top-k sharing requires index cache at layer "
+              << layer_index;
+          current_topk_indices = torch::empty(
+              {h.size(0), index_cache.size(2), model_args.index_topk()},
+              torch::TensorOptions().device(device_).dtype(torch::kInt32));
+          output_topk_indices = &current_topk_indices;
+        }
+      }
       rolling_guard.before_layer(layer_index);
-      layer(h,
-            cos_pos,
-            sin_pos,
-            attn_mask,
-            kv_caches[i],
-            input_params,
-            event,
-            event_flag);
+      if (topk_sharing_enabled) {
+        layer->forward_with_topk(h,
+                                 cos_pos,
+                                 sin_pos,
+                                 attn_mask,
+                                 kv_caches[i],
+                                 input_params,
+                                 shared_topk_indices,
+                                 output_topk_indices,
+                                 event,
+                                 event_flag);
+      } else {
+        layer(h,
+              cos_pos,
+              sin_pos,
+              attn_mask,
+              kv_caches[i],
+              input_params,
+              event,
+              event_flag);
+      }
+      if (output_topk) {
+        prev_topk_indices = current_topk_indices;
+      }
       rolling_guard.after_layer(layer_index);
     }
     return ModelOutput(norm_(h, 0));
@@ -313,6 +354,9 @@ REGISTER_MODEL_ARGS(glm_moe_dsa, [&] {
   LOAD_ARG_OR(index_head_dim, "index_head_dim", 128);
   LOAD_ARG_OR(index_n_heads, "index_n_heads", 0);
   LOAD_ARG_OR(index_topk, "index_topk", 2048);
+  LOAD_ARG_OR(index_topk_freq, "index_topk_freq", 1);
+  LOAD_ARG_OR(index_topk_pattern, "index_topk_pattern", "");
+  LOAD_ARG_OR(index_skip_topk_offset, "index_skip_topk_offset", 0);
 
   LOAD_ARG_OR(use_qk_norm, "use_qk_norm", true);
   LOAD_ARG_OR(rope_theta, "rope_theta", 1000000.0f);

--- a/xllm/models/llm/npu/glm5_moe_mtp.h
+++ b/xllm/models/llm/npu/glm5_moe_mtp.h
@@ -42,6 +42,32 @@ class GlmMoeDsaMtpModelImpl
         model_args.rope_theta(),
         options);
   }
+
+ protected:
+  void forward_layer(DeepseekV32DecoderLayer& layer,
+                     torch::Tensor& h,
+                     torch::Tensor& cos_pos,
+                     torch::Tensor& sin_pos,
+                     torch::Tensor& attn_mask,
+                     KVCache& kv_cache,
+                     const ModelInputParams& input_params,
+                     torch::Tensor& topk_indices,
+                     int32_t layer_index,
+                     aclrtEvent* event,
+                     std::atomic<bool>* event_flag) override {
+    layer->forward_with_mtp_topk(h,
+                                 cos_pos,
+                                 sin_pos,
+                                 attn_mask,
+                                 kv_cache,
+                                 input_params,
+                                 topk_indices,
+                                 index_topk_,
+                                 device_,
+                                 layer_index,
+                                 event,
+                                 event_flag);
+  }
 };
 TORCH_MODULE(GlmMoeDsaMtpModel);
 
@@ -96,6 +122,11 @@ REGISTER_MODEL_ARGS(glm_moe_dsa_mtp, [&] {
   LOAD_ARG_OR(index_head_dim, "index_head_dim", 128);
   LOAD_ARG_OR(index_n_heads, "index_n_heads", 0);
   LOAD_ARG_OR(index_topk, "index_topk", 2048);
+  LOAD_ARG_OR(index_topk_freq, "index_topk_freq", 1);
+  LOAD_ARG_OR(index_topk_pattern, "index_topk_pattern", "");
+  LOAD_ARG_OR(index_skip_topk_offset, "index_skip_topk_offset", 0);
+  LOAD_ARG_OR(
+      index_share_for_mtp_iteration, "index_share_for_mtp_iteration", false);
 
   LOAD_ARG_OR(use_qk_norm, "use_qk_norm", true);
   LOAD_ARG_OR(rope_theta, "rope_theta", 1000000.0f);

--- a/xllm/models/llm/npu/mtp_model_base.h
+++ b/xllm/models/llm/npu/mtp_model_base.h
@@ -62,6 +62,7 @@ class MtpModelImplBase : public torch::nn::Module {
     dp_rank_ = parallel_args.rank() / dp_local_tp_size_;
     rank_ = parallel_args.rank();
     num_experts_per_tok_ = model_args.num_experts_per_tok();
+    index_topk_ = model_args.index_topk();
 
     embed_tokens_ =
         register_module("embed_tokens", layer::NpuWordEmbedding(context));
@@ -174,6 +175,7 @@ class MtpModelImplBase : public torch::nn::Module {
         const_cast<ModelInputParams&>(input_params);
     input_params_new.expert.expert_array = expert_array;
 
+    torch::Tensor prev_topk_indices = input_params_new.dsa_topk_indices;
     for (size_t i = 0; i < layers_.size(); i++) {
       aclrtEvent* event = nullptr;
       std::atomic<bool>* event_flag = nullptr;
@@ -187,24 +189,30 @@ class MtpModelImplBase : public torch::nn::Module {
       }
 
       auto& layer = layers_[i];
+      const int32_t layer_index = static_cast<int32_t>(i);
 
       if (layer_forward_interrupted_) {
         LOG(INFO) << "Forward interrupted at layer: " << i;
         return ModelOutput();
       }
 
-      layer(h,
-            cos_pos,
-            sin_pos,
-            attn_mask,
-            kv_caches[i],
-            input_params_new,
-            event,
-            event_flag);
+      forward_layer(layer,
+                    h,
+                    cos_pos,
+                    sin_pos,
+                    attn_mask,
+                    kv_caches[i],
+                    input_params_new,
+                    prev_topk_indices,
+                    layer_index,
+                    event,
+                    event_flag);
     }
 
     auto hidden_states = final_norm_(h, 0);
-    return ModelOutput(hidden_states);
+    ModelOutput output(hidden_states);
+    output.dsa_topk_indices = prev_topk_indices;
+    return output;
   }
 
   // load the weight from the checkpoint
@@ -266,6 +274,27 @@ class MtpModelImplBase : public torch::nn::Module {
   }
 
  protected:
+  virtual void forward_layer(DecoderLayerType& layer,
+                             torch::Tensor& h,
+                             torch::Tensor& cos_pos,
+                             torch::Tensor& sin_pos,
+                             torch::Tensor& attn_mask,
+                             KVCache& kv_cache,
+                             const ModelInputParams& input_params,
+                             torch::Tensor&,
+                             int32_t,
+                             aclrtEvent* event,
+                             std::atomic<bool>* event_flag) {
+    layer(h,
+          cos_pos,
+          sin_pos,
+          attn_mask,
+          kv_cache,
+          input_params,
+          event,
+          event_flag);
+  }
+
   int32_t dp_rank_;
   int32_t rank_;
   int32_t dp_size_;
@@ -289,10 +318,11 @@ class MtpModelImplBase : public torch::nn::Module {
 
   bool layer_forward_interrupted_ = false;
   bool enable_rot_ = false;
+  torch::Device device_;
+  int32_t index_topk_ = 0;
 
  private:
   std::string model_type_;
-  torch::Device device_;
 };
 
 template <typename MtpModelType>


### PR DESCRIPTION
## Description

This PR adds **top-k sharing** support for xLLM’s NPU DSA models.

Main changes:
- Adds layer-to-layer DSA top-k reuse, allowing selected DSA layers to skip indexer/top-k computation and reuse `topk_indices` produced by an earlier layer.
- Adds MTP draft-iteration top-k reuse, allowing DSA `topk_indices` from one MTP draft forward to be passed into the next draft forward.
- Adds related config fields:
  - `index_topk_freq`
  - `index_topk_pattern`
  - `index_skip_topk_offset`
  - `index_share_for_mtp_iteration`
- Covers the following NPU model paths:
  - `deepseek_v32 / deepseek_v32_mtp`
  - `glm_moe_dsa / glm_moe_dsa_mtp`
- Updates the ATB graph path to support `skipTopk` / `outputTopk`, so DSA attention can consume shared top-k indices or export newly computed ones.

When top-k sharing is not enabled, the existing inference path remains unchanged.

Current limitations:
- Only supported for DSA indexer scenarios, requiring `index_n_heads > 0` and `index_topk > 0`.
- CP prefill with top-k sharing is not supported yet.
- A single layer cannot enable both `skipTopk` and `outputTopk`.
- Regular attention and non-DSA models do not use this top-k sharing IO path.

## Related Issues

<!-- Link related issues here. Use "Fixes #123" when this PR closes an issue. -->

## Change Type

- [ ] Bug fix
- [ ] New feature
- [ ] Performance improvement
- [ ] Refactor
- [ ] Documentation
- [ ] Test
- [ ] Build or CI

## Pull Request Checklist

Thank you for contributing to xLLM. Before requesting review, please make sure the following items are complete.

### PR Title and Commit Messages

- [ ] The PR title and each commit message follow the xLLM commit format: `<type>: <subject>`.

> Allowed types: feat, bugfix, docs, test, refactor, chore, style, revert, perf, model, build, release.
> The subject should use clear English, start with a verb, include at least 4 words, and end with `.`.

### Pre-commit Checks

- [ ] I have installed `pre-commit` by running `pip install pre-commit` or an equivalent command.
- [ ] I have installed the hooks with `pre-commit install`.
- [ ] I have run `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

### Self Review

- [ ] I have self-reviewed the code according to `.agents/skills/code-review/references/custom-code-style.md`, especially code written or assisted by AI.
- [ ] I have rebased this PR onto the latest `main` branch.

### Build and Test Coverage

- [ ] Tests have been added or updated as needed.
- [ ] CUDA: `python setup.py build test` has passed on a CUDA machine.
- [ ] NPU: `python setup.py build test` has passed on an NPU machine.
- [ ] MLU: `python setup.py build test` has passed on an MLU machine.

## Reviewer Notes

<!-- Optional: anything reviewers should focus on, known risks, follow-ups, or validation gaps. -->
