### PR TITLE
bugfix: fix chunked prefill graph alignment and DSV4 SWA reuse.

### DIFF
--- a/xllm/core/distributed_runtime/llm_engine.cpp
+++ b/xllm/core/distributed_runtime/llm_engine.cpp
@@ -1126,6 +1126,19 @@ std::vector<ForwardInput> LLMEngine::prepare_inputs(std::vector<Batch>& batch) {
     eplb_info = eplb_manager_->get_eplb_info();
   }
 
+  // Empty DP ranks inherit decode below and use fake inputs in WorkerImpl.
+  if (::xllm::ExecutionConfig::get_instance().enable_graph() &&
+      util::is_deepseek_v4_model_type(args_.model_type()) &&
+      batch_forward_type.is_decode()) {
+    for (int32_t dp_rank = 0; dp_rank < dp_size_; ++dp_rank) {
+      if (batched_inputs[dp_rank]
+              .input_params.meta.batch_forward_type.is_empty() &&
+          dp_global_token_nums[dp_rank] == 0) {
+        dp_is_decode[dp_rank] = 1;
+      }
+    }
+  }
+
   // update dp_global_token_nums and batch_forward_type
   for (auto dp_rank = 0; dp_rank < dp_size_; ++dp_rank) {
     batched_inputs[dp_rank].input_params.parallel.dp_global_token_nums =

--- a/xllm/core/distributed_runtime/llm_engine.cpp
+++ b/xllm/core/distributed_runtime/llm_engine.cpp
@@ -1111,9 +1111,6 @@ std::vector<ForwardInput> LLMEngine::prepare_inputs(std::vector<Batch>& batch) {
     if (batch_forward_type.is_empty() &&
         !current_batch_forward_type.is_empty()) {
       batch_forward_type = current_batch_forward_type;
-      if (batch_forward_type.is_chunked_prefill()) {
-        batch_forward_type = BatchForwardType::PREFILL;
-      }
     }
     dp_is_decode[dp_rank] =
         current_batch_forward_type.is_decode() &&
@@ -1128,7 +1125,6 @@ std::vector<ForwardInput> LLMEngine::prepare_inputs(std::vector<Batch>& batch) {
 
   // Empty DP ranks inherit decode below and use fake inputs in WorkerImpl.
   if (::xllm::ExecutionConfig::get_instance().enable_graph() &&
-      util::is_deepseek_v4_model_type(args_.model_type()) &&
       batch_forward_type.is_decode()) {
     for (int32_t dp_rank = 0; dp_rank < dp_size_; ++dp_rank) {
       if (batched_inputs[dp_rank]

--- a/xllm/core/framework/block/composite_block_manager.cpp
+++ b/xllm/core/framework/block/composite_block_manager.cpp
@@ -131,6 +131,22 @@ bool CompositeBlockManager::allocate_for_sequence(Sequence* seq,
     release_blocks = std::min(skipped_blocks, swa_blocks.size());
   }
 
+  if (release_blocks > 0) {
+    std::vector<Block> blocks_to_release;
+    blocks_to_release.reserve(release_blocks);
+    for (size_t j = 0; j < release_blocks; ++j) {
+      if (swa_blocks[j].is_valid()) {
+        blocks_to_release.emplace_back(std::move(swa_blocks[j]));
+      }
+    }
+    if (!blocks_to_release.empty()) {
+      sub_managers_[0]->deallocate(blocks_to_release);
+      // Drop the last Block references so released ids re-enter the pool
+      // before this allocation grows the next chunk.
+      blocks_to_release.clear();
+    }
+  }
+
   const size_t swa_blocks_needed = (num_tokens + block_size - 1) / block_size;
   if (swa_blocks.size() < swa_blocks_needed) {
     const size_t old_size = swa_blocks.size();
@@ -163,18 +179,6 @@ bool CompositeBlockManager::allocate_for_sequence(Sequence* seq,
 
     composite->at(i).insert(
         composite->at(i).end(), blocks.begin(), blocks.end());
-  }
-  if (release_blocks > 0) {
-    std::vector<Block> blocks_to_release;
-    blocks_to_release.reserve(release_blocks);
-    for (size_t j = 0; j < release_blocks; ++j) {
-      if (swa_blocks[j].is_valid()) {
-        blocks_to_release.emplace_back(std::move(swa_blocks[j]));
-      }
-    }
-    if (!blocks_to_release.empty()) {
-      sub_managers_[0]->deallocate(blocks_to_release);
-    }
   }
   return true;
 }

--- a/xllm/core/runtime/acl_graph_persistent_param.cpp
+++ b/xllm/core/runtime/acl_graph_persistent_param.cpp
@@ -610,8 +610,15 @@ std::optional<ModelInputParams> GraphPersistentParam::update(
       is_chunked_prefill
           ? (padded_num_tokens + q_max_seq_len - 1) / q_max_seq_len
           : padded_num_tokens;
+  const bool is_empty_dp_decode_rank =
+      is_decode && params.meta.num_sequences == 0 && actual_num_tokens > 0 &&
+      params.parallel.dp_global_token_nums.size() > 1 &&
+      params.attention.host.kv_seq_lens.empty() &&
+      params.attention.host.q_seq_lens.empty();
   const int64_t actual_seq_len_rows =
-      is_chunked_prefill ? actual_batch_size : actual_num_tokens;
+      is_empty_dp_decode_rank
+          ? 0
+          : (is_chunked_prefill ? actual_batch_size : actual_num_tokens);
 
   // Copy data from input parameters to persistent graph tensors
   if (actual_num_tokens > 0) {
@@ -846,7 +853,8 @@ std::optional<ModelInputParams> GraphPersistentParam::update(
                  /*non_blocking=*/true);
     }
     if (padded_batch_size > actual_seq_len_rows) {
-      int32_t offset = static_cast<int32_t>(actual_num_tokens);
+      int32_t offset =
+          is_empty_dp_decode_rank ? 0 : static_cast<int32_t>(actual_num_tokens);
       std::vector<int32_t> padded_q_cu_seq_lens;
       padded_q_cu_seq_lens.reserve(padded_batch_size - actual_seq_len_rows);
       const int32_t padding_q_len = is_chunked_prefill ? q_max_seq_len : 1;
@@ -962,7 +970,7 @@ std::optional<ModelInputParams> GraphPersistentParam::update(
     params_for_capture->attention.device.q_seq_lens =
         q_seq_lens(static_cast<uint32_t>(padded_batch_size));
     params_for_capture->meta.actual_num_sequences =
-        static_cast<int32_t>(actual_num_tokens);
+        is_empty_dp_decode_rank ? 0 : static_cast<int32_t>(actual_num_tokens);
     params_for_capture->attention.host.kv_seq_lens = padded_kv_seq_lens_vec;
     params_for_capture->attention.host.q_seq_lens = padded_q_seq_lens_vec;
     params_for_capture->meta.num_sequences =

--- a/xllm/models/llm/deepseek_v4.h
+++ b/xllm/models/llm/deepseek_v4.h
@@ -1044,6 +1044,8 @@ class DeepseekV4ModelImpl
   void fill_empty_dp_rank_input_params(
       ModelInputParams& params,
       const std::vector<KVCache>* kv_caches = nullptr) const {
+    const bool is_chunked_prefill =
+        params.meta.batch_forward_type.is_chunked_prefill();
     params.attn_metadata = nullptr;
     auto cpu_int_options = torch::TensorOptions()
                                .dtype(torch::kInt32)
@@ -1062,7 +1064,9 @@ class DeepseekV4ModelImpl
     params.meta.kv_max_seq_len =
         std::max<int32_t>(params.meta.kv_max_seq_len, dummy_kv_len);
     params.meta.q_max_seq_len = 1;
-    params.meta.batch_forward_type = BatchForwardType::DECODE;
+    params.meta.batch_forward_type =
+        is_chunked_prefill ? BatchForwardType::CHUNKED_PREFILL
+                           : BatchForwardType::DECODE;
     params.attention.host.kv_seq_lens = {dummy_kv_len};
     params.attention.host.q_seq_lens = {1};
     params.attention.host.q_cu_seq_lens = {1};

--- a/xllm/models/llm/deepseek_v4.h
+++ b/xllm/models/llm/deepseek_v4.h
@@ -1064,9 +1064,9 @@ class DeepseekV4ModelImpl
     params.meta.kv_max_seq_len =
         std::max<int32_t>(params.meta.kv_max_seq_len, dummy_kv_len);
     params.meta.q_max_seq_len = 1;
-    params.meta.batch_forward_type =
-        is_chunked_prefill ? BatchForwardType::CHUNKED_PREFILL
-                           : BatchForwardType::DECODE;
+    params.meta.batch_forward_type = is_chunked_prefill
+                                         ? BatchForwardType::CHUNKED_PREFILL
+                                         : BatchForwardType::DECODE;
     params.attention.host.kv_seq_lens = {dummy_kv_len};
     params.attention.host.q_seq_lens = {1};
     params.attention.host.q_cu_seq_lens = {1};


### PR DESCRIPTION
## Description

### Summary

This PR fixes two chunked-prefill issues exposed by DeepSeek V4 NPU inference:

- Keeps empty DP ranks aligned with the real batch phase so decode can still enter the ACL graph path when some DP ranks receive no active sequence.
- Preserves `CHUNKED_PREFILL` semantics for empty-rank fallback inputs instead of downgrading them to regular prefill.
- Releases stale sliding-window attention blocks before growing the next chunk, preventing long chunked-prefill requests from getting stuck when `max_seqs_per_batch` is small.

### Motivation

With `dp > 1`, a single request can leave some DP ranks empty. Those empty ranks still need phase metadata consistent with non-empty ranks; otherwise decode graph capture/execution can diverge.

For long prompts with chunked prefill, DSV4 SWA block allocation previously expanded the cumulative block table before returning blocks that had already moved out of the sliding window. This created a temporary block demand spike and could make scheduling repeatedly fail even though enough reusable SWA blocks existed.

## Related Issues

<!-- Link related issues here. Use "Fixes #123" when this PR closes an issue. -->

## Change Type

- [x] Bug fix
- [ ] New feature
- [ ] Performance improvement
- [ ] Refactor
- [ ] Documentation
- [ ] Test
- [ ] Build or CI

## Pull Request Checklist

Thank you for contributing to xLLM. Before requesting review, please make sure the following items are complete.

### PR Title and Commit Messages

- [ ] The PR title and each commit message follow the xLLM commit format: `<type>: <subject>`.

> Allowed types: feat, bugfix, docs, test, refactor, chore, style, revert, perf, model, build, release.
> The subject should use clear English, start with a verb, include at least 4 words, and end with `.`.

### Pre-commit Checks

- [ ] I have installed `pre-commit` by running `pip install pre-commit` or an equivalent command.
- [ ] I have installed the hooks with `pre-commit install`.
- [ ] I have run `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

### Self Review

- [ ] I have self-reviewed the code according to `.agents/skills/code-review/references/custom-code-style.md`, especially code written or assisted by AI.
- [ ] I have rebased this PR onto the latest `main` branch.

### Build and Test Coverage

- [ ] Tests have been added or updated as needed.
- [ ] CUDA: `python setup.py build test` has passed on a CUDA machine.
- [ ] NPU: `python setup.py build test` has passed on an NPU machine.
- [ ] MLU: `python setup.py build test` has passed on an MLU machine.

## Reviewer Notes

<!-- Optional: anything reviewers should focus on, known risks, follow-ups, or validation gaps. -->
