### PR TITLE
feat: add DCU Mooncake disaggregated PD support.

### DIFF
--- a/xllm/core/framework/config/disagg_pd_config.cpp
+++ b/xllm/core/framework/config/disagg_pd_config.cpp
@@ -155,4 +155,30 @@ void DisaggPDConfig::normalize_mlu(KVCacheConfig& kv_cache_config,
   }
 }
 
+void DisaggPDConfig::normalize_dcu(SchedulerConfig& scheduler_config) {
+  if (kv_cache_transfer_type() != "Mooncake") {
+    LOG(WARNING) << "DCU disaggregated PD requires "
+                 << "kv_cache_transfer_type=Mooncake; forcing from "
+                 << kv_cache_transfer_type() << " to Mooncake.";
+    kv_cache_transfer_type("Mooncake");
+  }
+  if (kv_cache_transfer_mode() != "PUSH" &&
+      kv_cache_transfer_mode() != "PULL") {
+    LOG(WARNING) << "DCU disaggregated PD supports "
+                 << "kv_cache_transfer_mode=PUSH or PULL; forcing from "
+                 << kv_cache_transfer_mode() << " to PUSH.";
+    kv_cache_transfer_mode("PUSH");
+  }
+  if (scheduler_config.enable_schedule_overlap()) {
+    LOG(WARNING) << "DCU disaggregated PD does not support schedule overlap; "
+                 << "forcing enable_schedule_overlap=false.";
+    scheduler_config.enable_schedule_overlap(false);
+  }
+  if (enable_pd_ooc()) {
+    LOG(WARNING) << "DCU disaggregated PD does not support pd_ooc; "
+                 << "forcing enable_pd_ooc=false.";
+    enable_pd_ooc(false);
+  }
+}
+
 }  // namespace xllm

--- a/xllm/core/framework/config/disagg_pd_config.h
+++ b/xllm/core/framework/config/disagg_pd_config.h
@@ -41,6 +41,7 @@ class DisaggPDConfig final {
   void initialize();
   void normalize_mlu(KVCacheConfig& kv_cache_config,
                      SchedulerConfig& scheduler_config);
+  void normalize_dcu(SchedulerConfig& scheduler_config);
 
   [[nodiscard]] static const OptionCategory& option_category() {
     static const OptionCategory kOptionCategory = {

--- a/xllm/core/framework/kv_cache_transfer/CMakeLists.txt
+++ b/xllm/core/framework/kv_cache_transfer/CMakeLists.txt
@@ -30,8 +30,8 @@ cc_library(
     $<$<BOOL:${USE_NPU}>:spec_kv_cache_transfer.h>
     kv_cache_store.h
     hierarchy_kv_cache_transfer.h
-    $<$<OR:$<BOOL:${USE_NPU}>,$<BOOL:${USE_MLU}>>:mooncake_transfer_engine.h>
-    $<$<OR:$<BOOL:${USE_NPU}>,$<BOOL:${USE_MLU}>>:mooncake_kv_cache_transfer.h>
+    $<$<OR:$<BOOL:${USE_NPU}>,$<BOOL:${USE_MLU}>,$<BOOL:${USE_DCU}>>:mooncake_transfer_engine.h>
+    $<$<OR:$<BOOL:${USE_NPU}>,$<BOOL:${USE_MLU}>,$<BOOL:${USE_DCU}>>:mooncake_kv_cache_transfer.h>
     $<$<BOOL:${USE_NPU}>:mooncake_weight_transfer.h>
   SRCS
     kv_cache_transfer.cpp
@@ -39,8 +39,8 @@ cc_library(
     $<$<BOOL:${USE_NPU}>:spec_kv_cache_transfer.cpp>
     kv_cache_store.cpp
     hierarchy_kv_cache_transfer.cpp
-    $<$<OR:$<BOOL:${USE_NPU}>,$<BOOL:${USE_MLU}>>:mooncake_transfer_engine.cpp>
-    $<$<OR:$<BOOL:${USE_NPU}>,$<BOOL:${USE_MLU}>>:mooncake_kv_cache_transfer.cpp>
+    $<$<OR:$<BOOL:${USE_NPU}>,$<BOOL:${USE_MLU}>,$<BOOL:${USE_DCU}>>:mooncake_transfer_engine.cpp>
+    $<$<OR:$<BOOL:${USE_NPU}>,$<BOOL:${USE_MLU}>,$<BOOL:${USE_DCU}>>:mooncake_kv_cache_transfer.cpp>
     $<$<BOOL:${USE_NPU}>:mooncake_weight_transfer.cpp>
   DEPS
     :common
@@ -56,4 +56,5 @@ cc_library(
     mooncake_store
     proto::xllm_proto
     $<$<BOOL:${USE_NPU}>:platform_npu>
+    $<$<BOOL:${USE_DCU}>:hip::host>
 )

--- a/xllm/core/framework/kv_cache_transfer/kv_cache_transfer.cpp
+++ b/xllm/core/framework/kv_cache_transfer/kv_cache_transfer.cpp
@@ -31,7 +31,7 @@ limitations under the License.
 #include "framework/kv_cache_transfer/llm_data_dist_transfer.h"
 #endif
 
-#if defined(USE_NPU) || defined(USE_MLU)
+#if defined(USE_NPU) || defined(USE_MLU) || defined(USE_DCU)
 #include "framework/kv_cache_transfer/mooncake_kv_cache_transfer.h"
 #endif
 
@@ -128,7 +128,7 @@ std::vector<std::string> KVCacheTransfer::rotate_dst_rank(
   return rotated_keys;
 }
 
-#if defined(USE_NPU) || defined(USE_MLU)
+#if defined(USE_NPU) || defined(USE_MLU) || defined(USE_DCU)
 folly::SemiFuture<bool> KVCacheTransfer::push_kv_blocks_async(
     const std::vector<TransferKVInfo>& transfer_kv_infos,
     const ParallelArgs& parallel_args,
@@ -349,7 +349,7 @@ std::shared_ptr<KVCacheTransfer> KVCacheTransferFactory::create(
 
   int32_t device_id = device.index();
 
-#if defined(USE_NPU) || defined(USE_MLU)
+#if defined(USE_NPU) || defined(USE_MLU) || defined(USE_DCU)
   LOG(INFO) << "Create KVCacheTransfer for " << transfer_type << "flag"
             << ::xllm::DisaggPDConfig::get_instance().kv_cache_transfer_type();
   if (transfer_type == "LlmDataDist") {
@@ -365,7 +365,7 @@ std::shared_ptr<KVCacheTransfer> KVCacheTransferFactory::create(
         << "Allocate KV cache failed.";
     transfer->register_kv_cache(kv_caches, kv_cache_shape, dtype);
 #else
-    LOG(FATAL) << "LlmDataDist is not supported on MLU backend.";
+    LOG(FATAL) << "LlmDataDist is not supported on this backend.";
 #endif
   } else if (transfer_type == "Mooncake") {
     std::shared_ptr<MooncakeKVCacheTransferBase> mooncake_transfer;

--- a/xllm/core/framework/kv_cache_transfer/kv_cache_transfer.h
+++ b/xllm/core/framework/kv_cache_transfer/kv_cache_transfer.h
@@ -25,6 +25,9 @@ limitations under the License.
 #if defined(USE_MLU)
 #include "platform/mlu/mlu_layer_synchronizer.h"
 #endif
+#if defined(USE_DCU)
+#include "platform/dcu/dcu_layer_synchronizer.h"
+#endif
 #include "framework/parallel_state/parallel_args.h"
 #include "platform/device.h"
 #include "util/threadpool.h"
@@ -35,6 +38,8 @@ namespace xllm {
 using KVPushSynchronizerImpl = NPULayerSynchronizerImpl;
 #elif defined(USE_MLU)
 using KVPushSynchronizerImpl = MLULayerSynchronizerImpl;
+#elif defined(USE_DCU)
+using KVPushSynchronizerImpl = DCULayerSynchronizerImpl;
 #endif
 
 // In KV-split mode, filters and remaps remote_blocks_ids so that each KV-split
@@ -128,7 +133,7 @@ class KVCacheTransfer {
       const std::vector<uint64_t>& src_linear_state_ids,
       const std::vector<uint64_t>& dst_linear_state_ids);
 
-#if defined(USE_NPU) || defined(USE_MLU)
+#if defined(USE_NPU) || defined(USE_MLU) || defined(USE_DCU)
   virtual folly::SemiFuture<bool> push_kv_blocks_async(
       const std::vector<TransferKVInfo>& transfer_kv_infos,
       const ParallelArgs& parallel_args,
@@ -141,7 +146,7 @@ class KVCacheTransfer {
       const std::vector<TransferKVInfo>& transfer_kv_infos,
       const ParallelArgs& parallel_args);
 
-#if defined(USE_NPU) || defined(USE_MLU)
+#if defined(USE_NPU) || defined(USE_MLU) || defined(USE_DCU)
   virtual bool push_kv_blocks(
       std::unordered_map<std::string, KVCacheInfo>& merged_kv_infos,
       std::shared_ptr<KVPushSynchronizerImpl>& layer_synchronizer,

--- a/xllm/core/framework/kv_cache_transfer/mooncake_kv_cache_transfer.cpp
+++ b/xllm/core/framework/kv_cache_transfer/mooncake_kv_cache_transfer.cpp
@@ -40,12 +40,11 @@ limitations under the License.
 #include "framework/kv_cache_transfer/push_route.h"
 #include "framework/xtensor/global_xtensor.h"
 #include "framework/xtensor/xtensor_allocator.h"
+#if defined(USE_DCU)
+#include "platform/dcu/dcu_tensor_alloc.h"
+#endif
 #include "platform/mlu/mlu_tensor_alloc.h"
 #include "util/net.h"
-
-#if defined(USE_DCU)
-#include <hip/hip_runtime.h>
-#endif
 
 namespace xllm {
 
@@ -300,62 +299,11 @@ void MooncakeKVCacheTransferDefault::allocate_kv_cache_impl(
   CHECK(!kv_cache_shape.has_index_cache_shape())
       << "DCU Mooncake KV transfer does not support index cache yet.";
 
-  int64_t data_size = static_cast<int64_t>(torch::elementSize(dtype));
-  int64_t k_cache_size_per_layer = data_size;
-  for (int64_t dim : key_cache_shape) {
-    k_cache_size_per_layer *= dim;
-  }
-  int64_t v_cache_size_per_layer = data_size;
-  for (int64_t dim : value_cache_shape) {
-    v_cache_size_per_layer *= dim;
-  }
-
-  torch::TensorOptions options =
-      torch::TensorOptions().dtype(dtype).device(device_);
   for (int64_t i = 0; i < num_layers; ++i) {
-    void* k_cache_buffer = nullptr;
-    void* v_cache_buffer = nullptr;
-    hipError_t hip_ret =
-        hipMalloc(&k_cache_buffer, static_cast<size_t>(k_cache_size_per_layer));
-    CHECK(hip_ret == hipSuccess)
-        << "hipMalloc k cache failed: " << hipGetErrorString(hip_ret);
-    hip_ret =
-        hipMalloc(&v_cache_buffer, static_cast<size_t>(v_cache_size_per_layer));
-    CHECK(hip_ret == hipSuccess)
-        << "hipMalloc v cache failed: " << hipGetErrorString(hip_ret);
-
-    auto k_data_ptr = c10::DataPtr(
-        k_cache_buffer,
-        k_cache_buffer,
-        [](void* ptr) { hipFree(ptr); },
-        device_);
-    auto k_storage_impl = c10::make_intrusive<c10::StorageImpl>(
-        c10::StorageImpl::use_byte_size_t(),
-        c10::SymInt(k_cache_size_per_layer),
-        std::move(k_data_ptr),
-        /*allocator=*/nullptr,
-        /*resizable=*/false);
-    torch::Tensor key_cache = torch::empty({/*size=*/0}, options);
-    key_cache.set_(c10::Storage(std::move(k_storage_impl)),
-                   /*storage_offset=*/0,
-                   c10::IntArrayRef(key_cache_shape));
-
-    auto v_data_ptr = c10::DataPtr(
-        v_cache_buffer,
-        v_cache_buffer,
-        [](void* ptr) { hipFree(ptr); },
-        device_);
-    auto v_storage_impl = c10::make_intrusive<c10::StorageImpl>(
-        c10::StorageImpl::use_byte_size_t(),
-        c10::SymInt(v_cache_size_per_layer),
-        std::move(v_data_ptr),
-        /*allocator=*/nullptr,
-        /*resizable=*/false);
-    torch::Tensor value_cache = torch::empty({/*size=*/0}, options);
-    value_cache.set_(c10::Storage(std::move(v_storage_impl)),
-                     /*storage_offset=*/0,
-                     c10::IntArrayRef(value_cache_shape));
-
+    torch::Tensor key_cache =
+        dcu::alloc_zero_tensor(key_cache_shape, dtype, device_);
+    torch::Tensor value_cache =
+        dcu::alloc_zero_tensor(value_cache_shape, dtype, device_);
     kv_caches.emplace_back(KVCacheTensors{key_cache, value_cache});
   }
 #else

--- a/xllm/core/framework/kv_cache_transfer/mooncake_kv_cache_transfer.cpp
+++ b/xllm/core/framework/kv_cache_transfer/mooncake_kv_cache_transfer.cpp
@@ -43,6 +43,10 @@ limitations under the License.
 #include "platform/mlu/mlu_tensor_alloc.h"
 #include "util/net.h"
 
+#if defined(USE_DCU)
+#include <hip/hip_runtime.h>
+#endif
+
 namespace xllm {
 
 namespace {
@@ -129,7 +133,7 @@ void merge_kv_info(
 
 MooncakeKVCacheTransferBase::MooncakeKVCacheTransferBase(
     const int32_t device_id,
-    const int16_t listen_port,
+    const uint16_t listen_port,
     const torch::Device& device,
     std::unique_ptr<MooncakeTransferEngine> engine)
     : device_id_(device_id),
@@ -179,7 +183,7 @@ bool MooncakeKVCacheTransferBase::unlink_cluster(const uint64_t& cluster_id,
 
 MooncakeKVCacheTransferDefault::MooncakeKVCacheTransferDefault(
     const int32_t device_id,
-    const int16_t listen_port,
+    const uint16_t listen_port,
     const torch::Device& device,
     const std::string& model_type)
     : MooncakeKVCacheTransferBase(
@@ -289,6 +293,70 @@ void MooncakeKVCacheTransferDefault::allocate_kv_cache_impl(
     } else {
       kv_caches.emplace_back(KVCacheTensors{key_cache, value_cache});
     }
+  }
+#elif defined(USE_DCU)
+  CHECK(kv_cache_shape.has_value_cache_shape())
+      << "DCU Mooncake KV transfer requires a value cache shape.";
+  CHECK(!kv_cache_shape.has_index_cache_shape())
+      << "DCU Mooncake KV transfer does not support index cache yet.";
+
+  int64_t data_size = static_cast<int64_t>(torch::elementSize(dtype));
+  int64_t k_cache_size_per_layer = data_size;
+  for (int64_t dim : key_cache_shape) {
+    k_cache_size_per_layer *= dim;
+  }
+  int64_t v_cache_size_per_layer = data_size;
+  for (int64_t dim : value_cache_shape) {
+    v_cache_size_per_layer *= dim;
+  }
+
+  torch::TensorOptions options =
+      torch::TensorOptions().dtype(dtype).device(device_);
+  for (int64_t i = 0; i < num_layers; ++i) {
+    void* k_cache_buffer = nullptr;
+    void* v_cache_buffer = nullptr;
+    hipError_t hip_ret =
+        hipMalloc(&k_cache_buffer, static_cast<size_t>(k_cache_size_per_layer));
+    CHECK(hip_ret == hipSuccess)
+        << "hipMalloc k cache failed: " << hipGetErrorString(hip_ret);
+    hip_ret =
+        hipMalloc(&v_cache_buffer, static_cast<size_t>(v_cache_size_per_layer));
+    CHECK(hip_ret == hipSuccess)
+        << "hipMalloc v cache failed: " << hipGetErrorString(hip_ret);
+
+    auto k_data_ptr = c10::DataPtr(
+        k_cache_buffer,
+        k_cache_buffer,
+        [](void* ptr) { hipFree(ptr); },
+        device_);
+    auto k_storage_impl = c10::make_intrusive<c10::StorageImpl>(
+        c10::StorageImpl::use_byte_size_t(),
+        c10::SymInt(k_cache_size_per_layer),
+        std::move(k_data_ptr),
+        /*allocator=*/nullptr,
+        /*resizable=*/false);
+    torch::Tensor key_cache = torch::empty({/*size=*/0}, options);
+    key_cache.set_(c10::Storage(std::move(k_storage_impl)),
+                   /*storage_offset=*/0,
+                   c10::IntArrayRef(key_cache_shape));
+
+    auto v_data_ptr = c10::DataPtr(
+        v_cache_buffer,
+        v_cache_buffer,
+        [](void* ptr) { hipFree(ptr); },
+        device_);
+    auto v_storage_impl = c10::make_intrusive<c10::StorageImpl>(
+        c10::StorageImpl::use_byte_size_t(),
+        c10::SymInt(v_cache_size_per_layer),
+        std::move(v_data_ptr),
+        /*allocator=*/nullptr,
+        /*resizable=*/false);
+    torch::Tensor value_cache = torch::empty({/*size=*/0}, options);
+    value_cache.set_(c10::Storage(std::move(v_storage_impl)),
+                     /*storage_offset=*/0,
+                     c10::IntArrayRef(value_cache_shape));
+
+    kv_caches.emplace_back(KVCacheTensors{key_cache, value_cache});
   }
 #else
   // Original mode: allocate device memory using aclrtMalloc
@@ -540,7 +608,7 @@ bool MooncakeKVCacheTransferDefault::push_kv_blocks(
 
 MooncakeKVCacheTransferXTensor::MooncakeKVCacheTransferXTensor(
     const int32_t device_id,
-    const int16_t listen_port,
+    const uint16_t listen_port,
     const torch::Device& device)
     : MooncakeKVCacheTransferBase(
           device_id,

--- a/xllm/core/framework/kv_cache_transfer/mooncake_kv_cache_transfer.h
+++ b/xllm/core/framework/kv_cache_transfer/mooncake_kv_cache_transfer.h
@@ -25,7 +25,7 @@ namespace xllm {
 class MooncakeKVCacheTransferBase : public KVCacheTransfer {
  public:
   MooncakeKVCacheTransferBase(const int32_t device_id,
-                              const int16_t listen_port,
+                              const uint16_t listen_port,
                               const torch::Device& device,
                               std::unique_ptr<MooncakeTransferEngine> engine);
   ~MooncakeKVCacheTransferBase() override = default;
@@ -46,7 +46,7 @@ class MooncakeKVCacheTransferBase : public KVCacheTransfer {
  protected:
   std::string addr_;
   uint64_t cluster_id_;
-  int16_t listen_port_;
+  uint16_t listen_port_;
   int32_t device_id_;
   torch::Device device_;
   int64_t num_layers_ = 0;
@@ -59,7 +59,7 @@ class MooncakeKVCacheTransferDefault final
     : public MooncakeKVCacheTransferBase {
  public:
   MooncakeKVCacheTransferDefault(const int32_t device_id,
-                                 const int16_t listen_port,
+                                 const uint16_t listen_port,
                                  const torch::Device& device,
                                  const std::string& model_type);
 
@@ -138,7 +138,7 @@ class MooncakeKVCacheTransferXTensor final
     : public MooncakeKVCacheTransferBase {
  public:
   MooncakeKVCacheTransferXTensor(const int32_t device_id,
-                                 const int16_t listen_port,
+                                 const uint16_t listen_port,
                                  const torch::Device& device);
 
   void set_model_id(const std::string& model_id) { model_id_ = model_id; }

--- a/xllm/core/framework/kv_cache_transfer/mooncake_transfer_engine.cpp
+++ b/xllm/core/framework/kv_cache_transfer/mooncake_transfer_engine.cpp
@@ -93,7 +93,7 @@ MooncakeTransferEngineCore::~MooncakeTransferEngineCore() {
   }
 }
 
-bool MooncakeTransferEngineCore::initialize(int16_t listen_port,
+bool MooncakeTransferEngineCore::initialize(uint16_t listen_port,
                                             const torch::Device& device) {
   std::lock_guard<std::mutex> lock(mutex_);
 
@@ -178,7 +178,9 @@ bool MooncakeTransferEngineCore::open_session(const uint64_t cluster_id,
 
     LOG(INFO) << "OpenSession RPC to " << remote_addr
               << ", local_addr=" << addr_;
+#if !defined(USE_DCU)
     return true;
+#endif
   }
 
   Transport::SegmentHandle handle = engine_->openSegment(remote_addr);
@@ -214,7 +216,21 @@ bool MooncakeTransferEngineCore::close_session(const uint64_t cluster_id,
         return true;
       }
     }
+#if defined(USE_DCU)
+    if (!close_remote_session(this, cluster_id)) {
+      return false;
+    }
+    if (it != handles_.end()) {
+      Transport::SegmentHandle handle = it->second.handle;
+      if (handle != static_cast<Transport::SegmentHandle>(-1)) {
+        engine_->closeSegment(handle);
+      }
+      handles_.erase(it);
+    }
+    return true;
+#else
     return close_remote_session(this, cluster_id);
+#endif
   }
 
   if (it == handles_.end()) {
@@ -287,7 +303,7 @@ MooncakeTransferEngineCore::get_or_create_stub_locked(uint64_t cluster_id) {
 // MooncakeTransferEngine
 // ============================================================================
 
-MooncakeTransferEngine::MooncakeTransferEngine(const int16_t listen_port,
+MooncakeTransferEngine::MooncakeTransferEngine(const uint16_t listen_port,
                                                const torch::Device& device)
     : listen_port_(listen_port),
       device_(device),
@@ -484,23 +500,34 @@ bool MooncakeTransferEngine::move_memory_blocks(
       uint64_t src_block_id = merged_src_blocks[i];
       uint64_t dst_block_id = merged_dst_blocks[i];
       uint64_t block_length = block_lengths[i];
+      uint64_t local_block_id = src_block_id;
+      uint64_t remote_block_id = dst_block_id;
+#if defined(USE_DCU)
+      if (move_opcode == MoveOpcode::READ) {
+        local_block_id = dst_block_id;
+        remote_block_id = src_block_id;
+      }
+#endif
       if (!check_buf_range(
-              local_buf_len, buf_bytes, src_block_id, block_length, buf_id) ||
-          !check_buf_range(
-              remote_buf_len, buf_bytes, dst_block_id, block_length, buf_id)) {
+              local_buf_len, buf_bytes, local_block_id, block_length, buf_id) ||
+          !check_buf_range(remote_buf_len,
+                           buf_bytes,
+                           remote_block_id,
+                           block_length,
+                           buf_id)) {
         return false;
       }
 
-      uint64_t src_bias = src_block_id * buf_bytes;
-      uint64_t dst_bias = dst_block_id * buf_bytes;
+      uint64_t local_bias = local_block_id * buf_bytes;
+      uint64_t remote_bias = remote_block_id * buf_bytes;
       uint64_t len = block_length * buf_bytes;
 
       TransferRequest entry;
       entry.opcode = opcode;
       entry.length = len;
-      entry.source = reinterpret_cast<void*>(local_base + src_bias);
+      entry.source = reinterpret_cast<void*>(local_base + local_bias);
       entry.target_id = remote_handle;
-      entry.target_offset = remote_base + dst_bias;
+      entry.target_offset = remote_base + remote_bias;
       entry.advise_retry_cnt = 0;
       entries.push_back(entry);
     }
@@ -521,10 +548,16 @@ bool MooncakeTransferEngine::move_memory_blocks(
 
   TransferStatus status;
   bool completed = false;
+#if defined(USE_DCU)
+  bool transfer_success = true;
+#endif
   while (!completed) {
     s = engine->getBatchTransferStatus(batch_id, status);
     if (!s.ok()) {
       LOG(ERROR) << "getBatchTransferStatus not ok";
+#if defined(USE_DCU)
+      transfer_success = false;
+#endif
       completed = true;
     }
 
@@ -532,9 +565,15 @@ bool MooncakeTransferEngine::move_memory_blocks(
       completed = true;
     } else if (status.s == TransferStatusEnum::FAILED) {
       LOG(ERROR) << "getBatchTransferStatus failed";
+#if defined(USE_DCU)
+      transfer_success = false;
+#endif
       completed = true;
     } else if (status.s == TransferStatusEnum::TIMEOUT) {
       LOG(ERROR) << "Sync data transfer timeout";
+#if defined(USE_DCU)
+      transfer_success = false;
+#endif
       completed = true;
     }
   }
@@ -545,7 +584,11 @@ bool MooncakeTransferEngine::move_memory_blocks(
     return false;
   }
 
+#if defined(USE_DCU)
+  return transfer_success;
+#else
   return true;
+#endif
 }
 
 bool MooncakeTransferEngine::move_memory_by_global_offsets(

--- a/xllm/core/framework/kv_cache_transfer/mooncake_transfer_engine.cpp
+++ b/xllm/core/framework/kv_cache_transfer/mooncake_transfer_engine.cpp
@@ -502,12 +502,10 @@ bool MooncakeTransferEngine::move_memory_blocks(
       uint64_t block_length = block_lengths[i];
       uint64_t local_block_id = src_block_id;
       uint64_t remote_block_id = dst_block_id;
-#if defined(USE_DCU)
       if (move_opcode == MoveOpcode::READ) {
         local_block_id = dst_block_id;
         remote_block_id = src_block_id;
       }
-#endif
       if (!check_buf_range(
               local_buf_len, buf_bytes, local_block_id, block_length, buf_id) ||
           !check_buf_range(remote_buf_len,

--- a/xllm/core/framework/kv_cache_transfer/mooncake_transfer_engine.h
+++ b/xllm/core/framework/kv_cache_transfer/mooncake_transfer_engine.h
@@ -44,7 +44,7 @@ class MooncakeTransferEngineCore {
   }
 
   // Initialize the shared core. Only the first call takes effect.
-  bool initialize(int16_t listen_port, const torch::Device& device);
+  bool initialize(uint16_t listen_port, const torch::Device& device);
 
   TransferEngine* engine() { return engine_.get(); }
 
@@ -78,7 +78,7 @@ class MooncakeTransferEngineCore {
   std::string addr_;
   std::string host_ip_;
   int32_t rpc_port_ = 0;
-  int16_t listen_port_ = 0;
+  uint16_t listen_port_ = 0;
 
   std::unique_ptr<TransferEngine> engine_;
   brpc::Server server_;
@@ -98,7 +98,7 @@ class MooncakeTransferEngine final {
  public:
   enum class MoveOpcode { READ = 0, WRITE = 1 };
 
-  MooncakeTransferEngine(const int16_t listen_port,
+  MooncakeTransferEngine(const uint16_t listen_port,
                          const torch::Device& device);
   virtual ~MooncakeTransferEngine() = default;
 
@@ -139,7 +139,7 @@ class MooncakeTransferEngine final {
       uint64_t cluster_id);
 
  private:
-  int16_t listen_port_;
+  uint16_t listen_port_;
   std::vector<uint64_t> buf_bytes_;
   Device device_;
   MooncakeTransferEngineCore& core_;

--- a/xllm/core/framework/kv_cache_transfer/mooncake_weight_transfer.cpp
+++ b/xllm/core/framework/kv_cache_transfer/mooncake_weight_transfer.cpp
@@ -22,7 +22,7 @@ limitations under the License.
 
 namespace xllm {
 
-MooncakeWeightTransfer::MooncakeWeightTransfer(int16_t listen_port,
+MooncakeWeightTransfer::MooncakeWeightTransfer(uint16_t listen_port,
                                                const torch::Device& device)
     : listen_port_(listen_port), device_id_(device.index()) {
   std::string instance_ip = net::get_local_ip_addr();

--- a/xllm/core/framework/kv_cache_transfer/mooncake_weight_transfer.h
+++ b/xllm/core/framework/kv_cache_transfer/mooncake_weight_transfer.h
@@ -30,7 +30,7 @@ namespace xllm {
 // Weight transfer using Mooncake transfer engine for remote weight loading
 class MooncakeWeightTransfer {
  public:
-  MooncakeWeightTransfer(int16_t listen_port, const torch::Device& device);
+  MooncakeWeightTransfer(uint16_t listen_port, const torch::Device& device);
   ~MooncakeWeightTransfer() = default;
 
   bool initialize();
@@ -53,7 +53,7 @@ class MooncakeWeightTransfer {
                     size_t size);
 
  private:
-  int16_t listen_port_;
+  uint16_t listen_port_;
   int32_t device_id_;
   std::string addr_;
   uint64_t cluster_id_ = 0;

--- a/xllm/core/framework/model/model_input_params.h
+++ b/xllm/core/framework/model/model_input_params.h
@@ -32,6 +32,10 @@ limitations under the License.
 #if defined(USE_MLU)
 #include "platform/mlu/mlu_layer_synchronizer.h"
 #endif
+#if defined(USE_DCU)
+#include "platform/dcu/dcu_layer_synchronizer.h"
+#endif
+
 #include "core/framework/multimodal/mm_batch_data.h"
 #include "framework/batch/batch_forward_type.h"
 #include "framework/parallel_state/npu_cp_ep_padding.h"
@@ -789,6 +793,8 @@ struct ParallelInput {
 
 #if defined(USE_MLU)
   std::shared_ptr<MLULayerSynchronizerImpl> layer_synchronizer = nullptr;
+#elif defined(USE_DCU)
+  std::shared_ptr<DCULayerSynchronizerImpl> layer_synchronizer = nullptr;
 #elif defined(USE_NPU)
   std::shared_ptr<NPULayerSynchronizerImpl> layer_synchronizer = nullptr;
   uint32_t layers_per_bacth_copy = std::numeric_limits<uint32_t>::max();
@@ -826,7 +832,7 @@ struct ParallelInput {
         .moe_idx(safe_to(cp_ep_padding_data.moe_idx(), device, true))
         .expert_array(safe_to(cp_ep_padding_data.expert_array(), device, true));
     out.cp_prefill_inputs = cp_prefill_inputs.to(device);
-#if defined(USE_NPU) || defined(USE_MLU)
+#if defined(USE_NPU) || defined(USE_MLU) || defined(USE_DCU)
     out.layer_synchronizer = layer_synchronizer;
 #endif
 #if defined(USE_NPU)
@@ -987,7 +993,7 @@ struct ModelInputParams {
   }
 
   bool record_layer(uint32_t layer_idx, const torch::Device& device) const {
-#if defined(USE_MLU)
+#if defined(USE_MLU) || defined(USE_DCU)
     if (parallel.layer_synchronizer != nullptr) {
       return parallel.layer_synchronizer->record_current(layer_idx,
                                                          device.index());

--- a/xllm/core/platform/CMakeLists.txt
+++ b/xllm/core/platform/CMakeLists.txt
@@ -16,6 +16,7 @@ cc_library(
     vmm_torch_allocator.h
     $<$<BOOL:${USE_MLU}>:mlu/mlu_layer_synchronizer.h>
     $<$<BOOL:${USE_MLU}>:mlu/mlu_tensor_alloc.h>
+    $<$<BOOL:${USE_DCU}>:dcu/dcu_layer_synchronizer.h>
     $<$<BOOL:${USE_CUDA}>:cuda/cuda_utils.h>
     $<$<BOOL:${USE_CUDA}>:cuda_profiler.h>
     $<$<BOOL:${USE_CUDA}>:torch_profiler.h>
@@ -30,6 +31,7 @@ cc_library(
     $<$<BOOL:${USE_MLU}>:mlu/mlu_tensor_alloc.cpp>
     $<$<BOOL:${USE_CUDA}>:cuda_profiler.cpp>
     $<$<BOOL:${USE_CUDA}>:torch_profiler.cpp>
+    $<$<BOOL:${USE_DCU}>:dcu/dcu_layer_synchronizer.cpp>
     $<$<OR:$<BOOL:${USE_CUDA}>,$<BOOL:${USE_MLU}>,$<BOOL:${USE_DCU}>>:numa_utils.cpp>
   DEPS
     :config

--- a/xllm/core/platform/CMakeLists.txt
+++ b/xllm/core/platform/CMakeLists.txt
@@ -17,6 +17,7 @@ cc_library(
     $<$<BOOL:${USE_MLU}>:mlu/mlu_layer_synchronizer.h>
     $<$<BOOL:${USE_MLU}>:mlu/mlu_tensor_alloc.h>
     $<$<BOOL:${USE_DCU}>:dcu/dcu_layer_synchronizer.h>
+    $<$<BOOL:${USE_DCU}>:dcu/dcu_tensor_alloc.h>
     $<$<BOOL:${USE_CUDA}>:cuda/cuda_utils.h>
     $<$<BOOL:${USE_CUDA}>:cuda_profiler.h>
     $<$<BOOL:${USE_CUDA}>:torch_profiler.h>
@@ -32,6 +33,7 @@ cc_library(
     $<$<BOOL:${USE_CUDA}>:cuda_profiler.cpp>
     $<$<BOOL:${USE_CUDA}>:torch_profiler.cpp>
     $<$<BOOL:${USE_DCU}>:dcu/dcu_layer_synchronizer.cpp>
+    $<$<BOOL:${USE_DCU}>:dcu/dcu_tensor_alloc.cpp>
     $<$<OR:$<BOOL:${USE_CUDA}>,$<BOOL:${USE_MLU}>,$<BOOL:${USE_DCU}>>:numa_utils.cpp>
   DEPS
     :config

--- a/xllm/core/platform/dcu/dcu_layer_synchronizer.cpp
+++ b/xllm/core/platform/dcu/dcu_layer_synchronizer.cpp
@@ -1,0 +1,100 @@
+/* Copyright 2026 The xLLM Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://github.com/jd-opensource/xllm/blob/main/LICENSE
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include "platform/dcu/dcu_layer_synchronizer.h"
+
+#include <c10/hip/HIPStream.h>
+#include <glog/logging.h>
+
+#include <chrono>
+#include <cstddef>
+#include <thread>
+
+namespace xllm {
+namespace {
+
+constexpr int32_t kDefaultSynchronizeTimeoutMs = 300000;
+
+}  // namespace
+
+DCULayerSynchronizerImpl::DCULayerSynchronizerImpl(int64_t num_layers,
+                                                   int32_t timeout_ms)
+    : events_(static_cast<size_t>(num_layers)),
+      event_record_flags_(static_cast<size_t>(num_layers)),
+      timeout_ms_(timeout_ms) {
+  size_t num_layers_size = static_cast<size_t>(num_layers);
+  for (size_t i = 0; i < num_layers_size; ++i) {
+    event_record_flags_[i].store(false, std::memory_order_relaxed);
+    hipError_t ret =
+        hipEventCreateWithFlags(&events_[i], hipEventDisableTiming);
+    CHECK(ret == hipSuccess)
+        << "hipEventCreateWithFlags failed: " << hipGetErrorString(ret);
+  }
+}
+
+DCULayerSynchronizerImpl::~DCULayerSynchronizerImpl() {
+  for (hipEvent_t& event : events_) {
+    hipEventDestroy(event);
+  }
+}
+
+bool DCULayerSynchronizerImpl::synchronize_layer(int64_t layer_index) {
+  size_t layer = static_cast<size_t>(layer_index);
+  while (!event_record_flags_[layer].load(std::memory_order_acquire)) {
+    std::this_thread::yield();
+  }
+
+  auto deadline =
+      std::chrono::steady_clock::now() +
+      std::chrono::milliseconds(timeout_ms_ > 0 ? timeout_ms_
+                                                : kDefaultSynchronizeTimeoutMs);
+
+  while (true) {
+    hipError_t ret = hipEventQuery(events_[layer]);
+    if (ret == hipSuccess) {
+      return true;
+    }
+    if (ret != hipErrorNotReady) {
+      LOG(ERROR) << "hipEventQuery failed for layer " << layer_index << ": "
+                 << hipGetErrorString(ret);
+      return false;
+    }
+    if (timeout_ms_ > 0 && std::chrono::steady_clock::now() > deadline) {
+      LOG(ERROR) << "synchronize_layer timed out for layer " << layer_index;
+      return false;
+    }
+    std::this_thread::yield();
+  }
+}
+
+bool DCULayerSynchronizerImpl::record_current(int64_t layer_index,
+                                              int32_t device_index) {
+  size_t layer = static_cast<size_t>(layer_index);
+  c10::hip::HIPStream stream = c10::hip::getCurrentHIPStream(device_index);
+  hipError_t ret = hipEventRecord(events_[layer], stream.stream());
+  if (ret != hipSuccess) {
+    LOG(ERROR) << "hipEventRecord failed for layer " << layer_index << ": "
+               << hipGetErrorString(ret);
+    return false;
+  }
+  event_record_flags_[layer].store(true, std::memory_order_release);
+  return true;
+}
+
+uint32_t DCULayerSynchronizerImpl::get_event_size() const {
+  return static_cast<uint32_t>(events_.size());
+}
+
+}  // namespace xllm

--- a/xllm/core/platform/dcu/dcu_layer_synchronizer.cpp
+++ b/xllm/core/platform/dcu/dcu_layer_synchronizer.cpp
@@ -51,6 +51,9 @@ DCULayerSynchronizerImpl::~DCULayerSynchronizerImpl() {
 }
 
 bool DCULayerSynchronizerImpl::synchronize_layer(int64_t layer_index) {
+  CHECK_GE(layer_index, 0) << "layer_index must be non-negative.";
+  CHECK_LT(static_cast<size_t>(layer_index), events_.size())
+      << "layer_index out of bounds.";
   size_t layer = static_cast<size_t>(layer_index);
   while (!event_record_flags_[layer].load(std::memory_order_acquire)) {
     std::this_thread::yield();
@@ -81,6 +84,9 @@ bool DCULayerSynchronizerImpl::synchronize_layer(int64_t layer_index) {
 
 bool DCULayerSynchronizerImpl::record_current(int64_t layer_index,
                                               int32_t device_index) {
+  CHECK_GE(layer_index, 0) << "layer_index must be non-negative.";
+  CHECK_LT(static_cast<size_t>(layer_index), events_.size())
+      << "layer_index out of bounds.";
   size_t layer = static_cast<size_t>(layer_index);
   c10::hip::HIPStream stream = c10::hip::getCurrentHIPStream(device_index);
   hipError_t ret = hipEventRecord(events_[layer], stream.stream());

--- a/xllm/core/platform/dcu/dcu_layer_synchronizer.h
+++ b/xllm/core/platform/dcu/dcu_layer_synchronizer.h
@@ -1,0 +1,42 @@
+/* Copyright 2026 The xLLM Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://github.com/jd-opensource/xllm/blob/main/LICENSE
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#pragma once
+
+#include <hip/hip_runtime.h>
+
+#include <atomic>
+#include <cstdint>
+#include <vector>
+
+namespace xllm {
+
+class DCULayerSynchronizerImpl final {
+ public:
+  explicit DCULayerSynchronizerImpl(int64_t num_layers,
+                                    int32_t timeout_ms = -1);
+  ~DCULayerSynchronizerImpl();
+
+  bool synchronize_layer(int64_t layer_index);
+  bool record_current(int64_t layer_index, int32_t device_index);
+  uint32_t get_event_size() const;
+
+ private:
+  std::vector<hipEvent_t> events_;
+  std::vector<std::atomic<bool>> event_record_flags_;
+  int32_t timeout_ms_;
+};
+
+}  // namespace xllm

--- a/xllm/core/platform/dcu/dcu_tensor_alloc.cpp
+++ b/xllm/core/platform/dcu/dcu_tensor_alloc.cpp
@@ -1,0 +1,86 @@
+/* Copyright 2026 The xLLM Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://github.com/jd-opensource/xllm/blob/main/LICENSE
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include "platform/dcu/dcu_tensor_alloc.h"
+
+#include <glog/logging.h>
+#include <hip/hip_runtime.h>
+
+#include <limits>
+
+namespace xllm::dcu {
+namespace {
+
+size_t get_nbytes(const std::vector<int64_t>& dims,
+                  const torch::ScalarType dtype) {
+  size_t count = 1;
+  for (int64_t dim : dims) {
+    CHECK_GE(dim, 0) << "tensor dim must be non-negative";
+    size_t dim_size = static_cast<size_t>(dim);
+    if (dim_size > static_cast<size_t>(0)) {
+      CHECK_LE(count, std::numeric_limits<size_t>::max() / dim_size)
+          << "tensor element count overflow";
+    }
+    count *= dim_size;
+  }
+  size_t elem_size = static_cast<size_t>(torch::elementSize(dtype));
+  CHECK_GT(elem_size, static_cast<size_t>(0)) << "tensor dtype size is zero";
+  CHECK_LE(count, std::numeric_limits<size_t>::max() / elem_size)
+      << "tensor byte size overflow";
+  return count * elem_size;
+}
+
+void free_tensor(void* ptr, int32_t device_id) {
+  if (ptr == nullptr) {
+    return;
+  }
+
+  hipError_t ret = hipSetDevice(device_id);
+  CHECK(ret == hipSuccess) << "hipSetDevice failed: " << hipGetErrorString(ret)
+                           << ", device_id=" << device_id;
+  ret = hipFree(ptr);
+  CHECK(ret == hipSuccess) << "hipFree failed: " << hipGetErrorString(ret)
+                           << ", ptr=" << ptr;
+}
+
+}  // namespace
+
+torch::Tensor alloc_zero_tensor(const std::vector<int64_t>& dims,
+                                torch::ScalarType dtype,
+                                const torch::Device& device) {
+  CHECK(device.has_index()) << "DCU device index is required";
+  int32_t device_id = static_cast<int32_t>(device.index());
+
+  hipError_t ret = hipSetDevice(device_id);
+  CHECK(ret == hipSuccess) << "hipSetDevice failed: " << hipGetErrorString(ret)
+                           << ", device_id=" << device_id;
+
+  size_t nbytes = get_nbytes(dims, dtype);
+  void* ptr = nullptr;
+  ret = hipMalloc(&ptr, nbytes);
+  CHECK(ret == hipSuccess) << "hipMalloc failed: " << hipGetErrorString(ret)
+                           << ", nbytes=" << nbytes;
+  ret = hipMemset(ptr, 0, nbytes);
+  CHECK(ret == hipSuccess) << "hipMemset failed: " << hipGetErrorString(ret)
+                           << ", nbytes=" << nbytes;
+
+  auto deleter = [device_id](void* data) { free_tensor(data, device_id); };
+  torch::TensorOptions options =
+      torch::TensorOptions().dtype(dtype).device(device).requires_grad(
+          /*requires_grad=*/false);
+  return torch::from_blob(ptr, dims, deleter, options);
+}
+
+}  // namespace xllm::dcu

--- a/xllm/core/platform/dcu/dcu_tensor_alloc.h
+++ b/xllm/core/platform/dcu/dcu_tensor_alloc.h
@@ -1,0 +1,29 @@
+/* Copyright 2026 The xLLM Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://github.com/jd-opensource/xllm/blob/main/LICENSE
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#pragma once
+
+#include <torch/torch.h>
+
+#include <cstdint>
+#include <vector>
+
+namespace xllm::dcu {
+
+torch::Tensor alloc_zero_tensor(const std::vector<int64_t>& dims,
+                                torch::ScalarType dtype,
+                                const torch::Device& device);
+
+}  // namespace xllm::dcu

--- a/xllm/core/runtime/llm_worker_impl.cpp
+++ b/xllm/core/runtime/llm_worker_impl.cpp
@@ -220,8 +220,12 @@ std::optional<ForwardOutput> LLMWorkerImpl::step_internal(
     std::shared_ptr<MLULayerSynchronizerImpl> layer_synchronizer =
         std::make_shared<MLULayerSynchronizerImpl>(
             context_.get_model_args().n_layers());
+#elif defined(USE_DCU)
+    std::shared_ptr<DCULayerSynchronizerImpl> layer_synchronizer =
+        std::make_shared<DCULayerSynchronizerImpl>(
+            context_.get_model_args().n_layers());
 #endif
-#if defined(USE_NPU) || defined(USE_MLU)
+#if defined(USE_NPU) || defined(USE_MLU) || defined(USE_DCU)
     const_cast<ModelInputParams*>(&(input.input_params))
         ->parallel.layer_synchronizer = layer_synchronizer;
 

--- a/xllm/core/runtime/worker_impl.cpp
+++ b/xllm/core/runtime/worker_impl.cpp
@@ -388,7 +388,7 @@ bool WorkerImpl::allocate_kv_cache_with_transfer(
   return true;
 }
 
-#if defined(USE_NPU) || defined(USE_MLU)
+#if defined(USE_NPU) || defined(USE_MLU) || defined(USE_DCU)
 bool WorkerImpl::allocate_kv_cache_with_transfer(
     std::shared_ptr<KVCacheTransfer> kv_cache_transfer,
     const KVCacheShape& kv_cache_shape) {
@@ -425,7 +425,7 @@ void WorkerImpl::get_cache_info(uint64_t& cluster_id,
                                 uint16_t& port) {
   cluster_id = 0;
   addr.clear();
-#if defined(USE_NPU) || defined(USE_MLU)
+#if defined(USE_NPU) || defined(USE_MLU) || defined(USE_DCU)
   if (kv_cache_transfer_) {
     kv_cache_transfer_->get_cache_info(cluster_id, addr);
   }
@@ -1485,7 +1485,7 @@ folly::SemiFuture<bool> WorkerImpl::pull_kv_blocks_async(
     const std::vector<uint64_t>& dst_blocks,
     const std::vector<uint64_t>& src_linear_state_ids,
     const std::vector<uint64_t>& dst_linear_state_ids) {
-#if defined(USE_NPU)
+#if defined(USE_NPU) || defined(USE_DCU)
   return kv_cache_transfer_->pull_kv_blocks_async(src_cluster_id,
                                                   src_addr,
                                                   src_blocks,

--- a/xllm/core/runtime/worker_impl.h
+++ b/xllm/core/runtime/worker_impl.h
@@ -83,7 +83,7 @@ class WorkerImpl {
   virtual bool allocate_kv_cache_with_transfer(
       const KVCacheShape& kv_cache_shape);
 
-#if defined(USE_NPU) || defined(USE_MLU)
+#if defined(USE_NPU) || defined(USE_MLU) || defined(USE_DCU)
   virtual bool allocate_kv_cache_with_transfer(
       std::shared_ptr<KVCacheTransfer> kv_cache_transfer,
       const KVCacheShape& kv_cache_shape);

--- a/xllm/core/runtime/worker_rendezvous.cpp
+++ b/xllm/core/runtime/worker_rendezvous.cpp
@@ -41,7 +41,7 @@ WorkerRendezvous::WorkerRendezvous(
 bool WorkerRendezvous::link_cluster(const std::vector<uint64_t>& cluster_ids,
                                     const std::vector<std::string>& addrs,
                                     const std::vector<uint16_t>& ports) {
-#if defined(USE_NPU) || defined(USE_MLU)
+#if defined(USE_NPU) || defined(USE_MLU) || defined(USE_DCU)
   if (!kv_cache_transfer_) {
     LOG(ERROR) << "KVCacheTransfer not initialized";
     return false;
@@ -63,7 +63,7 @@ bool WorkerRendezvous::link_cluster(const std::vector<uint64_t>& cluster_ids,
 bool WorkerRendezvous::unlink_cluster(const std::vector<uint64_t>& cluster_ids,
                                       const std::vector<std::string>& addrs,
                                       const std::vector<uint16_t>& ports) {
-#if defined(USE_NPU) || defined(USE_MLU)
+#if defined(USE_NPU) || defined(USE_MLU) || defined(USE_DCU)
   if (!kv_cache_transfer_) {
     LOG(ERROR) << "KVCacheTransfer not initialized";
     return false;

--- a/xllm/xllm.cpp
+++ b/xllm/xllm.cpp
@@ -288,6 +288,21 @@ void validate_config(const std::string& model_type) {
   }
 #endif
 
+#if defined(USE_DCU)
+  if (disagg_pd_config.enable_disagg_pd()) {
+    if (scheduler_config.enable_schedule_overlap()) {
+      LOG(WARNING) << "enable_schedule_overlap is not supported for "
+                      "disaggregated PD on DCU backend. "
+                   << "Disabling enable_schedule_overlap.";
+      scheduler_config.enable_schedule_overlap(false);
+    }
+    if (model_config.backend() != "llm") {
+      LOG(FATAL) << "DCU disaggregated PD only supports backend=llm.";
+    }
+    disagg_pd_config.normalize_dcu(scheduler_config);
+  }
+#endif
+
 #if defined(USE_NPU)
   // enable_xtensor / enable_rolling_load imply enable_manual_loader
   if ((kv_cache_config.enable_xtensor() || load_config.enable_rolling_load()) &&


### PR DESCRIPTION
## Description

<!-- What does this PR do? Briefly describe the changes and why they are needed. -->

- Adds DCU support for Mooncake-based disaggregated PD.
- Enables DCU KV cache transfer, worker/rendezvous integration, and DCU layer synchronization.
- Supports DCU Mooncake PUSH and PULL.
- Changes Mooncake listen ports to uint16_t to avoid port overflow.
- Keeps unsupported DCU PD features like pd_ooc and schedule_overlap disabled.

## Related Issues

<!-- Link related issues here. Use "Fixes #123" when this PR closes an issue. -->

## Change Type

- [ ] Bug fix
- [x] New feature
- [ ] Performance improvement
- [ ] Refactor
- [ ] Documentation
- [ ] Test
- [ ] Build or CI

## Pull Request Checklist

Thank you for contributing to xLLM. Before requesting review, please make sure the following items are complete.

### PR Title and Commit Messages

- [x] The PR title and each commit message follow the xLLM commit format: `<type>: <subject>`.

> Allowed types: feat, bugfix, docs, test, refactor, chore, style, revert, perf, model, build, release.
> The subject should use clear English, start with a verb, include at least 4 words, and end with `.`.

### Pre-commit Checks

- [x] I have installed `pre-commit` by running `pip install pre-commit` or an equivalent command.
- [x] I have installed the hooks with `pre-commit install`.
- [x] I have run `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

### Self Review

- [x] I have self-reviewed the code according to `.agents/skills/code-review/references/custom-code-style.md`, especially code written or assisted by AI.
- [x] I have rebased this PR onto the latest `main` branch.

### Build and Test Coverage

- [ ] Tests have been added or updated as needed.
- [x] CUDA: `python setup.py build test` has passed on a CUDA machine.
- [ ] NPU: `python setup.py build test` has passed on an NPU machine.
- [ ] MLU: `python setup.py build test` has passed on an MLU machine.

## Reviewer Notes

<!-- Optional: anything reviewers should focus on, known risks, follow-ups, or validation gaps. -->
