### PR TITLE
feat: add deepseek v4 mlu moe support.

### DIFF
--- a/tests/core/layers/mlu/CMakeLists.txt
+++ b/tests/core/layers/mlu/CMakeLists.txt
@@ -52,6 +52,25 @@ cc_test(
 
 cc_test(
   NAME
+    deepseek_v4_hyper_connection_test
+  SRCS
+    deepseek_v4_hyper_connection_test.cpp
+    tests_utils.cpp
+  DEPS
+    :mlu_layers
+    :common_layers
+    :block
+    :parallel_state
+    :model
+    :model_context
+    :state_dict
+    glog::glog
+    torch
+    GTest::gtest_main
+)
+
+cc_test(
+  NAME
     deepseek_v4_dsa_metadata_builder_test
   SRCS
     dsa_metadata_builder_mlu_test.cpp
@@ -76,6 +95,7 @@ cc_test(
     :config
     :common_layers
     :mlu_layers
+    :block
     :parallel_state
     :model
     :model_context

--- a/tests/core/layers/mlu/deepseek_v4_hyper_connection_test.cpp
+++ b/tests/core/layers/mlu/deepseek_v4_hyper_connection_test.cpp
@@ -1,0 +1,331 @@
+/* Copyright 2026 The xLLM Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://github.com/jd-opensource/xllm/blob/main/LICENSE
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include <gtest/gtest.h>
+#include <torch/torch.h>
+
+#include <string>
+#include <tuple>
+#include <unordered_map>
+#include <vector>
+
+#include "framework/state_dict/state_dict.h"
+#include "layers/mlu/deepseek_v4/hyper_connection.h"
+#include "layers/mlu/tests_utils.h"
+#include "platform/device.h"
+
+namespace xllm {
+namespace layer {
+namespace {
+
+struct HCConfig {
+  int64_t hc_mult = 4;
+  int64_t dim = 4096;
+  int64_t sinkhorn_iters = 20;
+  double hc_eps = 1e-6;
+  double norm_eps = 1e-6;
+};
+
+struct HCPreRefOut {
+  torch::Tensor output;
+  torch::Tensor post;
+  torch::Tensor comb;
+};
+
+torch::Tensor seeded(const std::string& key,
+                     torch::IntArrayRef shape,
+                     torch::ScalarType dtype,
+                     const torch::Device& device) {
+  return (test::seeded_tensor(key, shape, dtype, device) - 0.5) * 0.05;
+}
+
+torch::Tensor linear_ref(const torch::Tensor& input,
+                         const torch::Tensor& weight) {
+  return torch::nn::functional::linear(
+      input.to(torch::kFloat32), weight.to(input.device()).to(torch::kFloat32));
+}
+
+std::tuple<torch::Tensor, torch::Tensor, torch::Tensor> split_ref(
+    const torch::Tensor& mixes,
+    const torch::Tensor& hc_scale,
+    const torch::Tensor& hc_base,
+    int64_t hc_mult,
+    int64_t sinkhorn_iters,
+    double eps) {
+  torch::Tensor mixes_flat = mixes.reshape({-1, (2 + hc_mult) * hc_mult});
+  torch::Tensor scale = hc_scale.to(mixes.device()).to(torch::kFloat32);
+  torch::Tensor base = hc_base.to(mixes.device()).to(torch::kFloat32);
+
+  torch::Tensor pre_logits = mixes_flat.slice(-1, 0, hc_mult);
+  torch::Tensor post_logits = mixes_flat.slice(-1, hc_mult, 2 * hc_mult);
+  torch::Tensor comb_logits =
+      mixes_flat.slice(-1, 2 * hc_mult).reshape({-1, hc_mult, hc_mult});
+
+  torch::Tensor pre =
+      torch::sigmoid(pre_logits * scale[0] + base.slice(0, 0, hc_mult)) + eps;
+  torch::Tensor post =
+      2.0 * torch::sigmoid(post_logits * scale[1] +
+                           base.slice(0, hc_mult, 2 * hc_mult));
+  torch::Tensor comb = comb_logits * scale[2] +
+                       base.slice(0, 2 * hc_mult).reshape({hc_mult, hc_mult});
+
+  comb = torch::softmax(comb, -1) + eps;
+  comb = comb / (comb.sum(-2, true) + eps);
+  for (int64_t iter = 1; iter < sinkhorn_iters; ++iter) {
+    comb = comb / (comb.sum(-1, true) + eps);
+    comb = comb / (comb.sum(-2, true) + eps);
+  }
+  return {pre, post, comb};
+}
+
+HCPreRefOut hc_pre_ref(const torch::Tensor& x,
+                       const torch::Tensor& hc_fn,
+                       const torch::Tensor& hc_scale,
+                       const torch::Tensor& hc_base,
+                       const HCConfig& config) {
+  std::vector<int64_t> leading;
+  for (int64_t dim_idx = 0; dim_idx < x.dim() - 2; ++dim_idx) {
+    leading.emplace_back(x.size(dim_idx));
+  }
+  torch::Tensor x_hc = x.reshape({-1, config.hc_mult, config.dim}).contiguous();
+  torch::Tensor x_flat =
+      x_hc.reshape({x_hc.size(0), config.hc_mult * config.dim});
+  torch::Tensor rsqrt = torch::rsqrt(
+      x_flat.to(torch::kFloat32).square().mean(-1, true) + config.norm_eps);
+  torch::Tensor mixes = linear_ref(x_flat, hc_fn) * rsqrt;
+  torch::Tensor pre;
+  torch::Tensor post;
+  torch::Tensor comb;
+  std::tie(pre, post, comb) = split_ref(mixes,
+                                        hc_scale,
+                                        hc_base,
+                                        config.hc_mult,
+                                        config.sinkhorn_iters,
+                                        config.hc_eps);
+  torch::Tensor output =
+      (pre.unsqueeze(-1) * x_hc.to(torch::kFloat32)).sum(1).to(x.scalar_type());
+
+  std::vector<int64_t> out_shape = leading;
+  out_shape.emplace_back(config.dim);
+  std::vector<int64_t> post_shape = leading;
+  post_shape.emplace_back(config.hc_mult);
+  std::vector<int64_t> comb_shape = leading;
+  comb_shape.emplace_back(config.hc_mult);
+  comb_shape.emplace_back(config.hc_mult);
+  return {output.reshape(out_shape),
+          post.reshape(post_shape),
+          comb.reshape(comb_shape)};
+}
+
+std::tuple<torch::Tensor, torch::Tensor> hc_post_ref(
+    const torch::Tensor& x,
+    const torch::Tensor& residual,
+    const torch::Tensor& post,
+    const torch::Tensor& comb,
+    bool compute_rms,
+    double norm_eps) {
+  torch::Tensor output = post.unsqueeze(-1).to(torch::kFloat32) *
+                             x.unsqueeze(-2).to(torch::kFloat32) +
+                         (comb.unsqueeze(-1).to(torch::kFloat32) *
+                          residual.unsqueeze(-2).to(torch::kFloat32))
+                             .sum(-3);
+  output = output.to(x.scalar_type());
+  torch::Tensor rsqrt;
+  if (compute_rms) {
+    rsqrt = torch::rsqrt(
+        output.flatten(-2).to(torch::kFloat32).square().mean(-1, true) +
+        norm_eps);
+  }
+  return {output, rsqrt};
+}
+
+torch::Tensor hc_head_ref(const torch::Tensor& x,
+                          const torch::Tensor& hc_fn,
+                          const torch::Tensor& hc_scale,
+                          const torch::Tensor& hc_base,
+                          const HCConfig& config) {
+  std::vector<int64_t> leading;
+  for (int64_t dim_idx = 0; dim_idx < x.dim() - 2; ++dim_idx) {
+    leading.emplace_back(x.size(dim_idx));
+  }
+  torch::Tensor x_hc = x.reshape({-1, config.hc_mult, config.dim}).contiguous();
+  torch::Tensor x_flat =
+      x_hc.reshape({x_hc.size(0), config.hc_mult * config.dim});
+  torch::Tensor rsqrt = torch::rsqrt(
+      x_flat.to(torch::kFloat32).square().mean(-1, true) + config.norm_eps);
+  torch::Tensor mixes = linear_ref(x_flat, hc_fn) * rsqrt;
+  torch::Tensor pre =
+      torch::sigmoid(mixes * hc_scale.to(mixes.device()).to(torch::kFloat32) +
+                     hc_base.to(mixes.device()).to(torch::kFloat32)) +
+      config.hc_eps;
+  torch::Tensor output =
+      (pre.unsqueeze(-1) * x_hc.to(torch::kFloat32)).sum(1).to(x.scalar_type());
+  std::vector<int64_t> out_shape = leading;
+  out_shape.emplace_back(config.dim);
+  return output.reshape(out_shape);
+}
+
+}  // namespace
+
+class DeepseekV4HyperConnectionTest : public ::testing::Test {
+ protected:
+  void SetUp() override {
+    torch::Device torch_device(Device::type_torch(), 0);
+    Device device(torch_device);
+    device.set_seed();
+    options_ = torch::TensorOptions()
+                   .dtype(torch::kBFloat16)
+                   .device(torch_device)
+                   .requires_grad(false);
+  }
+
+  std::unordered_map<std::string, torch::Tensor> pre_weights() {
+    const int64_t mix_hc = (2 + config_.hc_mult) * config_.hc_mult;
+    const int64_t hc_dim = config_.hc_mult * config_.dim;
+    return {
+        {"hc_fn",
+         seeded("deepseek_v4_hc.pre.fn",
+                {mix_hc, hc_dim},
+                torch::kFloat32,
+                options_.device())},
+        {"hc_base",
+         seeded("deepseek_v4_hc.pre.base",
+                {mix_hc},
+                torch::kFloat32,
+                options_.device())},
+        {"hc_scale",
+         torch::tensor({0.1f, 0.2f, 0.15f}, options_.dtype(torch::kFloat32))}};
+  }
+
+  std::unordered_map<std::string, torch::Tensor> head_weights() {
+    const int64_t hc_dim = config_.hc_mult * config_.dim;
+    return {{"hc_head_fn",
+             seeded("deepseek_v4_hc.head.fn",
+                    {config_.hc_mult, hc_dim},
+                    torch::kFloat32,
+                    options_.device())},
+            {"hc_head_base",
+             seeded("deepseek_v4_hc.head.base",
+                    {config_.hc_mult},
+                    torch::kFloat32,
+                    options_.device())},
+            {"hc_head_scale",
+             torch::tensor({0.1f}, options_.dtype(torch::kFloat32))}};
+  }
+
+  HCConfig config_;
+  torch::TensorOptions options_;
+};
+
+TEST_F(DeepseekV4HyperConnectionTest, HCPreMatchesOfficialReference) {
+  const int64_t batch_size = 1;
+  const int64_t seq_len = 2;
+  torch::Tensor x = seeded("deepseek_v4_hc.pre.x",
+                           {batch_size, seq_len, config_.hc_mult, config_.dim},
+                           torch::kBFloat16,
+                           options_.device());
+  std::unordered_map<std::string, torch::Tensor> weights = pre_weights();
+
+  DeepseekV4HCPre hc_pre(config_.hc_mult,
+                         config_.dim,
+                         config_.sinkhorn_iters,
+                         config_.hc_eps,
+                         config_.norm_eps,
+                         options_);
+  hc_pre->load_state_dict(StateDict(weights));
+  DeepseekV4HCPreOutput actual = hc_pre->forward(x);
+  HCPreRefOut expected = hc_pre_ref(x,
+                                    weights.at("hc_fn"),
+                                    weights.at("hc_scale"),
+                                    weights.at("hc_base"),
+                                    config_);
+
+  EXPECT_EQ(actual.output.sizes(), expected.output.sizes());
+  EXPECT_EQ(actual.post.sizes(), expected.post.sizes());
+  EXPECT_EQ(actual.comb.sizes(), expected.comb.sizes());
+  test::verify_tensor_close(
+      actual.output.cpu(), expected.output.cpu(), 1e-2, 1e-2);
+  test::verify_tensor_close(actual.post.cpu(), expected.post.cpu(), 1e-4, 1e-4);
+  test::verify_tensor_close(actual.comb.cpu(), expected.comb.cpu(), 1e-4, 1e-4);
+}
+
+TEST_F(DeepseekV4HyperConnectionTest, HCPostMatchesOfficialReference) {
+  const int64_t tokens = 2;
+  torch::Tensor x = seeded("deepseek_v4_hc.post.x",
+                           {tokens, config_.dim},
+                           torch::kBFloat16,
+                           options_.device());
+  torch::Tensor residual = seeded("deepseek_v4_hc.post.residual",
+                                  {tokens, config_.hc_mult, config_.dim},
+                                  torch::kBFloat16,
+                                  options_.device());
+  torch::Tensor post = seeded("deepseek_v4_hc.post.post",
+                              {tokens, config_.hc_mult},
+                              torch::kFloat32,
+                              options_.device()) +
+                       0.5;
+  torch::Tensor comb =
+      torch::softmax(seeded("deepseek_v4_hc.post.comb",
+                            {tokens, config_.hc_mult, config_.hc_mult},
+                            torch::kFloat32,
+                            options_.device()),
+                     -1);
+
+  DeepseekV4HCPost hc_post(config_.norm_eps);
+  torch::Tensor actual;
+  torch::Tensor actual_rsqrt;
+  std::tie(actual, actual_rsqrt) =
+      hc_post->forward(x, residual, post, comb, /*compute_rms=*/true);
+  torch::Tensor expected;
+  torch::Tensor expected_rsqrt;
+  std::tie(expected, expected_rsqrt) = hc_post_ref(x,
+                                                   residual,
+                                                   post,
+                                                   comb,
+                                                   /*compute_rms=*/true,
+                                                   config_.norm_eps);
+
+  EXPECT_EQ(actual.sizes(), expected.sizes());
+  EXPECT_EQ(actual_rsqrt.sizes(), expected_rsqrt.sizes());
+  test::verify_tensor_close(actual.cpu(), expected.cpu(), 1e-2, 1e-2);
+  test::verify_tensor_close(
+      actual_rsqrt.cpu(), expected_rsqrt.cpu(), 1e-4, 1e-4);
+}
+
+TEST_F(DeepseekV4HyperConnectionTest, HCHeadMatchesOfficialReference) {
+  const int64_t batch_size = 1;
+  const int64_t seq_len = 2;
+  torch::Tensor x = seeded("deepseek_v4_hc.head.x",
+                           {batch_size, seq_len, config_.hc_mult, config_.dim},
+                           torch::kBFloat16,
+                           options_.device());
+  std::unordered_map<std::string, torch::Tensor> weights = head_weights();
+
+  DeepseekV4HCHead hc_head(
+      config_.hc_mult, config_.dim, config_.hc_eps, config_.norm_eps, options_);
+  hc_head->load_state_dict(StateDict(weights));
+  torch::Tensor actual = hc_head->forward(x);
+  torch::Tensor expected = hc_head_ref(x,
+                                       weights.at("hc_head_fn"),
+                                       weights.at("hc_head_scale"),
+                                       weights.at("hc_head_base"),
+                                       config_);
+
+  EXPECT_EQ(actual.sizes(), expected.sizes());
+  test::verify_tensor_close(actual.cpu(), expected.cpu(), 1e-2, 1e-2);
+}
+
+}  // namespace layer
+}  // namespace xllm

--- a/tests/core/layers/mlu/deepseek_v4_hyper_connection_test.cpp
+++ b/tests/core/layers/mlu/deepseek_v4_hyper_connection_test.cpp
@@ -96,6 +96,7 @@ HCPreRefOut hc_pre_ref(const torch::Tensor& x,
                        const torch::Tensor& hc_base,
                        const HCConfig& config) {
   std::vector<int64_t> leading;
+  leading.reserve(x.dim() - 2);
   for (int64_t dim_idx = 0; dim_idx < x.dim() - 2; ++dim_idx) {
     leading.emplace_back(x.size(dim_idx));
   }
@@ -157,6 +158,7 @@ torch::Tensor hc_head_ref(const torch::Tensor& x,
                           const torch::Tensor& hc_base,
                           const HCConfig& config) {
   std::vector<int64_t> leading;
+  leading.reserve(x.dim() - 2);
   for (int64_t dim_idx = 0; dim_idx < x.dim() - 2; ++dim_idx) {
     leading.emplace_back(x.size(dim_idx));
   }

--- a/tests/core/layers/mlu/fused_moe_test.cpp
+++ b/tests/core/layers/mlu/fused_moe_test.cpp
@@ -628,5 +628,130 @@ TEST_F(FusedMoETest, NoReductionModeMatchesExternalReduce) {
   verify_tensor_close(actual, expected, 1e-3, 1e-4);
 }
 
+TEST_F(FusedMoETest, DeepSeekV4MoETest) {
+  const int64_t batch_size = 2;
+  const int64_t seq_len = 4;
+  const int64_t hidden_size = 256;
+  const int64_t intermediate_size = 128;
+  const int64_t num_experts = 4;
+  const int64_t num_expert_group = 2;
+  const int64_t topk_group = 2;
+  const int64_t top_k = 2;
+  const double route_scale = 1.0;
+  const float swiglu_limit = 10.0f;
+
+  ModelArgs args = model_args_;
+  args.n_routed_experts() = static_cast<int32_t>(num_experts);
+  args.num_experts_per_tok() = static_cast<int32_t>(top_k);
+  args.n_group() = static_cast<int32_t>(num_expert_group);
+  args.topk_group() = static_cast<int32_t>(topk_group);
+  args.routed_scaling_factor() = static_cast<float>(route_scale);
+  args.hidden_size() = hidden_size;
+  args.moe_intermediate_size() = static_cast<int32_t>(intermediate_size);
+  args.n_shared_experts() = 1;
+  args.hidden_act() = "silu";
+  args.model_type() = "deepseek_v4";
+  args.scoring_func() = "sqrtsoftplus";
+  args.swiglu_limit() = swiglu_limit;
+
+  const FusedMoEArgs moe_args{
+      .is_gated = true, .enable_result_reduction = true, .use_hash = false};
+
+  auto fused_moe = FusedMoE(
+      FusedMoEImpl(args, moe_args, quant_args_, parallel_args_, options_));
+
+  auto weight_dict =
+      create_test_weights(num_experts, hidden_size, intermediate_size);
+  StateDict state_dict(weight_dict);
+  fused_moe->load_state_dict(state_dict);
+
+  auto hidden_states = create_custom_input(
+      {batch_size * seq_len, hidden_size},
+      std::vector<float>(batch_size * seq_len * hidden_size, 1.0f));
+
+  auto output = fused_moe->forward_experts(
+      hidden_states, /*enable_all2all_communication=*/false);
+
+  xllm::Device device(options_.device());
+  device.synchronize_default_stream();
+
+  ASSERT_EQ(output.dim(), 2);
+  ASSERT_EQ(output.size(0), batch_size * seq_len);
+  ASSERT_EQ(output.size(1), hidden_size);
+
+  auto output_sum = torch::sum(output).item<float>();
+  ASSERT_TRUE(std::isfinite(output_sum))
+      << "Output should be finite with swiglu_limit";
+
+  LOG(INFO) << "DeepSeek V4 MoE forward test passed, output sum: "
+            << output_sum;
+}
+
+TEST_F(FusedMoETest, DeepSeekV4HashMoETest) {
+  const int64_t batch_size = 2;
+  const int64_t seq_len = 4;
+  const int64_t hidden_size = 256;
+  const int64_t intermediate_size = 128;
+  const int64_t num_experts = 4;
+  const int64_t num_expert_group = 2;
+  const int64_t topk_group = 2;
+  const int64_t top_k = 2;
+  const int64_t vocab_size = 1024;
+  const double route_scale = 1.0;
+  const float swiglu_limit = 10.0f;
+
+  ModelArgs args = model_args_;
+  args.n_routed_experts() = static_cast<int32_t>(num_experts);
+  args.num_experts_per_tok() = static_cast<int32_t>(top_k);
+  args.n_group() = static_cast<int32_t>(num_expert_group);
+  args.topk_group() = static_cast<int32_t>(topk_group);
+  args.routed_scaling_factor() = static_cast<float>(route_scale);
+  args.hidden_size() = hidden_size;
+  args.moe_intermediate_size() = static_cast<int32_t>(intermediate_size);
+  args.n_shared_experts() = 1;
+  args.hidden_act() = "silu";
+  args.model_type() = "deepseek_v4";
+  args.scoring_func() = "sqrtsoftplus";
+  args.swiglu_limit() = swiglu_limit;
+  args.vocab_size() = vocab_size;
+
+  const FusedMoEArgs moe_args{
+      .is_gated = true, .enable_result_reduction = true, .use_hash = true};
+
+  auto fused_moe = FusedMoE(
+      FusedMoEImpl(args, moe_args, quant_args_, parallel_args_, options_));
+
+  auto weight_dict =
+      create_test_weights(num_experts, hidden_size, intermediate_size);
+  weight_dict["gate.tid2eid"] =
+      torch::full({vocab_size, top_k}, 0.1f, options_);
+  StateDict state_dict(weight_dict);
+  fused_moe->load_state_dict(state_dict);
+
+  auto hidden_states = create_custom_input(
+      {batch_size * seq_len, hidden_size},
+      std::vector<float>(batch_size * seq_len * hidden_size, 1.0f));
+  auto input_ids = torch::randint(
+      0, vocab_size, {batch_size * seq_len}, options_.dtype(torch::kInt32));
+  auto output =
+      fused_moe->forward_experts(hidden_states,
+                                 /*enable_all2all_communication=*/false,
+                                 /*route_info=*/std::nullopt,
+                                 input_ids);
+
+  xllm::Device device(options_.device());
+  device.synchronize_default_stream();
+
+  ASSERT_EQ(output.dim(), 2);
+  ASSERT_EQ(output.size(0), batch_size * seq_len);
+  ASSERT_EQ(output.size(1), hidden_size);
+
+  auto output_sum = torch::sum(output).item<float>();
+  ASSERT_TRUE(std::isfinite(output_sum))
+      << "Output should be finite with swiglu_limit";
+
+  LOG(INFO) << "DeepSeek V4 hash MoE forward test passed, output sum: "
+            << output_sum;
+}
 }  // namespace layer
 }  // namespace xllm

--- a/xllm/core/layers/common/dense_mlp.h
+++ b/xllm/core/layers/common/dense_mlp.h
@@ -17,6 +17,8 @@ limitations under the License.
 
 #include <torch/torch.h>
 
+#include <optional>
+
 #include "activation.h"
 #include "framework/model/model_args.h"
 #include "framework/parallel_state/parallel_args.h"

--- a/xllm/core/layers/common/fused_moe_base.h
+++ b/xllm/core/layers/common/fused_moe_base.h
@@ -22,6 +22,7 @@ struct FusedMoEArgs {
   bool is_gated = true;
   bool enable_result_reduction = true;
   bool skip_gate_load = false;
+  bool use_hash = false;
 };
 
 }  // namespace layer

--- a/xllm/core/layers/mlu/CMakeLists.txt
+++ b/xllm/core/layers/mlu/CMakeLists.txt
@@ -14,6 +14,7 @@ cc_library(
     deepseek_v4/dsa_metadata_builder_mlu.h
     deepseek_v4/deepseek_v4_indexer.h
     deepseek_v4/deepseek_v4_attention.h
+    deepseek_v4/hyper_connection.h
     deepseek_v32_sp_context.h
     deepseek_v32_sp_plan.h
     moe_gate.h
@@ -21,6 +22,7 @@ cc_library(
     qwen3_5_fused_moe.h
     qwen3_5_attention.h
     qwen3_5_decoder_layer.h
+    moe_softplus_topk.h
   SRCS
     attention.cpp
     deepseek_v2_attention.cpp
@@ -32,6 +34,7 @@ cc_library(
     deepseek_v4/dsa_metadata_builder_mlu.cpp
     deepseek_v4/deepseek_v4_indexer.cpp
     deepseek_v4/deepseek_v4_attention.cpp
+    deepseek_v4/hyper_connection.cpp
     moe_gate.cpp
     fused_moe.cpp
     fused_moe_base.cpp
@@ -39,6 +42,7 @@ cc_library(
     qwen3_5_fused_moe.cpp
     qwen3_5_attention.cpp
     qwen3_5_decoder_layer.cpp
+    moe_softplus_topk.cpp
   DEPS
     :common_layers
     :util

--- a/xllm/core/layers/mlu/deepseek_v4/hyper_connection.cpp
+++ b/xllm/core/layers/mlu/deepseek_v4/hyper_connection.cpp
@@ -15,8 +15,6 @@ limitations under the License.
 
 #include "layers/mlu/deepseek_v4/hyper_connection.h"
 
-#include <glog/logging.h>
-
 #include <tuple>
 #include <vector>
 
@@ -45,27 +43,6 @@ torch::Tensor flat_hidden(const torch::Tensor& x, int64_t dim) {
 
 torch::Tensor flat_matrix(const torch::Tensor& x, int64_t rows, int64_t cols) {
   return x.reshape({-1, rows, cols}).contiguous();
-}
-
-torch::Tensor fused_norm(const torch::Tensor& x, double norm_eps) {
-  torch::Tensor output = torch::empty_like(x);
-  const std::string mode = "rmsnorm";
-  xllm::kernel::mlu::fused_layernorm(x,
-                                     output,
-                                     std::nullopt,
-                                     std::nullopt,
-                                     std::nullopt,
-                                     std::nullopt,
-                                     std::nullopt,
-                                     std::nullopt,
-                                     std::nullopt,
-                                     std::nullopt,
-                                     mode,
-                                     norm_eps,
-                                     false,
-                                     false,
-                                     false);
-  return output;
 }
 
 }  // namespace

--- a/xllm/core/layers/mlu/deepseek_v4/hyper_connection.cpp
+++ b/xllm/core/layers/mlu/deepseek_v4/hyper_connection.cpp
@@ -1,0 +1,229 @@
+/* Copyright 2026 The xLLM Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://github.com/jd-opensource/xllm/blob/main/LICENSE
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include "layers/mlu/deepseek_v4/hyper_connection.h"
+
+#include <glog/logging.h>
+
+#include <tuple>
+#include <vector>
+
+#include "kernels/mlu/mlu_ops_api.h"
+
+namespace {
+
+std::vector<int64_t> leading_shape(const torch::Tensor& tensor,
+                                   int64_t tail_dims) {
+  std::vector<int64_t> shape;
+  const int64_t leading_dims = tensor.dim() - tail_dims;
+  shape.reserve(static_cast<size_t>(leading_dims + 1));
+  for (int64_t dim_idx = 0; dim_idx < leading_dims; ++dim_idx) {
+    shape.emplace_back(tensor.size(dim_idx));
+  }
+  return shape;
+}
+
+torch::Tensor flat_hc(const torch::Tensor& x, int64_t hc_mult, int64_t dim) {
+  return x.reshape({-1, hc_mult, dim}).contiguous();
+}
+
+torch::Tensor flat_hidden(const torch::Tensor& x, int64_t dim) {
+  return x.reshape({-1, dim}).contiguous();
+}
+
+torch::Tensor flat_matrix(const torch::Tensor& x, int64_t rows, int64_t cols) {
+  return x.reshape({-1, rows, cols}).contiguous();
+}
+
+torch::Tensor fused_norm(const torch::Tensor& x, double norm_eps) {
+  torch::Tensor output = torch::empty_like(x);
+  const std::string mode = "rmsnorm";
+  xllm::kernel::mlu::fused_layernorm(x,
+                                     output,
+                                     std::nullopt,
+                                     std::nullopt,
+                                     std::nullopt,
+                                     std::nullopt,
+                                     std::nullopt,
+                                     std::nullopt,
+                                     std::nullopt,
+                                     std::nullopt,
+                                     mode,
+                                     norm_eps,
+                                     false,
+                                     false,
+                                     false);
+  return output;
+}
+
+}  // namespace
+
+namespace xllm {
+namespace layer {
+
+DeepseekV4HCPreImpl::DeepseekV4HCPreImpl(int64_t hc_mult,
+                                         int64_t dim,
+                                         int64_t sinkhorn_iters,
+                                         double hc_eps,
+                                         double norm_eps,
+                                         const torch::TensorOptions& options)
+    : hc_mult_(hc_mult),
+      dim_(dim),
+      sinkhorn_iters_(sinkhorn_iters),
+      hc_eps_(hc_eps),
+      norm_eps_(norm_eps) {
+  const int64_t mix_hc = (2 + hc_mult_) * hc_mult_;
+  const int64_t hc_dim = hc_mult_ * dim_;
+  torch::TensorOptions param_options =
+      options.dtype(torch::kFloat32).requires_grad(false);
+  hc_fn_ = register_parameter("hc_fn",
+                              torch::empty({mix_hc, hc_dim}, param_options),
+                              /*requires_grad=*/false);
+  hc_base_ = register_parameter("hc_base",
+                                torch::empty({mix_hc}, param_options),
+                                /*requires_grad=*/false);
+  hc_scale_ = register_parameter(
+      "hc_scale", torch::empty({3}, param_options), /*requires_grad=*/false);
+}
+
+DeepseekV4HCPreOutput DeepseekV4HCPreImpl::forward(
+    const torch::Tensor& x,
+    const std::optional<torch::Tensor>& rsqrt) {
+  torch::Tensor x_hc = flat_hc(x, hc_mult_, dim_);
+  torch::Tensor x_flat = x_hc.reshape({x_hc.size(0), hc_mult_ * dim_});
+
+  torch::Tensor pre_scale;
+  if (rsqrt.has_value()) {
+    pre_scale = rsqrt.value().reshape({-1}).contiguous();
+  } else {
+    pre_scale =
+        torch::rsqrt(x_flat.to(torch::kFloat32).square().mean(-1, false) +
+                     norm_eps_)
+            .contiguous();
+  }
+
+  torch::Tensor mixes =
+      torch::nn::functional::linear(x_flat.to(torch::kFloat32), hc_fn_);
+  torch::Tensor pre;
+  torch::Tensor post;
+  torch::Tensor comb;
+  std::tie(pre, post, comb) = kernel::mlu::hc_split_sinkhorn(mixes,
+                                                             hc_scale_,
+                                                             hc_base_,
+                                                             pre_scale,
+                                                             hc_mult_,
+                                                             sinkhorn_iters_,
+                                                             hc_eps_);
+
+  torch::Tensor output = kernel::mlu::fused_mul_reduce_sum(x_hc, pre);
+  std::vector<int64_t> out_shape = leading_shape(x, /*tail_dims=*/2);
+  out_shape.emplace_back(dim_);
+  output = output.reshape(out_shape);
+
+  out_shape.back() = hc_mult_;
+  post = post.reshape(out_shape);
+
+  out_shape.emplace_back(hc_mult_);
+  comb = comb.reshape(out_shape);
+  return {output, post, comb};
+}
+
+void DeepseekV4HCPreImpl::load_state_dict(const StateDict& state_dict) {
+  if (state_dict.size() == 0) {
+    return;
+  }
+  LOAD_WEIGHT(hc_fn);
+  LOAD_WEIGHT(hc_base);
+  LOAD_WEIGHT(hc_scale);
+}
+
+DeepseekV4HCPostImpl::DeepseekV4HCPostImpl(double norm_eps)
+    : norm_eps_(norm_eps) {}
+
+std::tuple<torch::Tensor, torch::Tensor> DeepseekV4HCPostImpl::forward(
+    const torch::Tensor& x,
+    const torch::Tensor& residual,
+    const torch::Tensor& post,
+    const torch::Tensor& comb,
+    bool compute_rms) {
+  const int64_t hc_mult = residual.size(-2);
+  const int64_t dim = residual.size(-1);
+  torch::Tensor x_flat = flat_hidden(x, dim);
+  torch::Tensor residual_flat = flat_hc(residual, hc_mult, dim);
+  torch::Tensor post_flat = post.reshape({-1, hc_mult}).contiguous();
+  torch::Tensor comb_flat = flat_matrix(comb, hc_mult, hc_mult);
+
+  torch::Tensor output;
+  torch::Tensor output_rms;
+  std::tie(output, output_rms) = kernel::mlu::fused_mhc_post(
+      x_flat, residual_flat, post_flat, comb_flat, compute_rms, norm_eps_);
+
+  std::vector<int64_t> out_shape = residual.sizes().vec();
+  if (output_rms.defined()) {
+    std::vector<int64_t> rms_shape = leading_shape(x, /*tail_dims=*/1);
+    rms_shape.emplace_back(1);
+    output_rms = output_rms.reshape(rms_shape);
+  }
+  return {output.reshape(out_shape), output_rms};
+}
+
+DeepseekV4HCHeadImpl::DeepseekV4HCHeadImpl(int64_t hc_mult,
+                                           int64_t dim,
+                                           double hc_eps,
+                                           double norm_eps,
+                                           const torch::TensorOptions& options)
+    : hc_mult_(hc_mult), dim_(dim), hc_eps_(hc_eps), norm_eps_(norm_eps) {
+  const int64_t hc_dim = hc_mult_ * dim_;
+  torch::TensorOptions param_options =
+      options.dtype(torch::kFloat32).requires_grad(false);
+  hc_head_fn_ =
+      register_parameter("hc_head_fn",
+                         torch::empty({hc_mult_, hc_dim}, param_options),
+                         /*requires_grad=*/false);
+  hc_head_base_ = register_parameter("hc_head_base",
+                                     torch::empty({hc_mult_}, param_options),
+                                     /*requires_grad=*/false);
+  hc_head_scale_ = register_parameter("hc_head_scale",
+                                      torch::empty({1}, param_options),
+                                      /*requires_grad=*/false);
+}
+
+torch::Tensor DeepseekV4HCHeadImpl::forward(const torch::Tensor& x) {
+  torch::Tensor x_hc = flat_hc(x, hc_mult_, dim_);
+  torch::Tensor x_flat = x_hc.reshape({x_hc.size(0), hc_mult_ * dim_});
+  torch::Tensor x_fp32 = x_flat.to(torch::kFloat32);
+  torch::Tensor rsqrt =
+      torch::rsqrt(x_fp32.square().mean(-1, true) + norm_eps_);
+  torch::Tensor mixes =
+      torch::nn::functional::linear(x_fp32, hc_head_fn_) * rsqrt;
+  torch::Tensor pre =
+      torch::sigmoid(mixes * hc_head_scale_ + hc_head_base_) + hc_eps_;
+  torch::Tensor output = kernel::mlu::fused_mul_reduce_sum(x_hc, pre);
+  std::vector<int64_t> out_shape = leading_shape(x, /*tail_dims=*/2);
+  out_shape.emplace_back(dim_);
+  return output.reshape(out_shape);
+}
+
+void DeepseekV4HCHeadImpl::load_state_dict(const StateDict& state_dict) {
+  if (state_dict.size() == 0) {
+    return;
+  }
+  LOAD_WEIGHT(hc_head_fn);
+  LOAD_WEIGHT(hc_head_base);
+  LOAD_WEIGHT(hc_head_scale);
+}
+
+}  // namespace layer
+}  // namespace xllm

--- a/xllm/core/layers/mlu/deepseek_v4/hyper_connection.h
+++ b/xllm/core/layers/mlu/deepseek_v4/hyper_connection.h
@@ -33,7 +33,7 @@ struct DeepseekV4HCPreOutput {
   torch::Tensor comb;
 };
 
-class DeepseekV4HCPreImpl : public torch::nn::Module {
+class DeepseekV4HCPreImpl final : public torch::nn::Module {
  public:
   DeepseekV4HCPreImpl() = default;
 
@@ -64,7 +64,7 @@ class DeepseekV4HCPreImpl : public torch::nn::Module {
   DEFINE_WEIGHT(hc_scale);
 };
 
-class DeepseekV4HCPostImpl : public torch::nn::Module {
+class DeepseekV4HCPostImpl final : public torch::nn::Module {
  public:
   DeepseekV4HCPostImpl() = default;
 
@@ -81,7 +81,7 @@ class DeepseekV4HCPostImpl : public torch::nn::Module {
   double norm_eps_ = 1e-6;
 };
 
-class DeepseekV4HCHeadImpl : public torch::nn::Module {
+class DeepseekV4HCHeadImpl final : public torch::nn::Module {
  public:
   DeepseekV4HCHeadImpl() = default;
 

--- a/xllm/core/layers/mlu/deepseek_v4/hyper_connection.h
+++ b/xllm/core/layers/mlu/deepseek_v4/hyper_connection.h
@@ -1,0 +1,116 @@
+/* Copyright 2026 The xLLM Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://github.com/jd-opensource/xllm/blob/main/LICENSE
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#pragma once
+
+#include <torch/torch.h>
+
+#include <cstdint>
+#include <optional>
+#include <tuple>
+
+#include "framework/state_dict/state_dict.h"
+#include "framework/state_dict/utils.h"
+
+namespace xllm {
+namespace layer {
+
+struct DeepseekV4HCPreOutput {
+  torch::Tensor output;
+  torch::Tensor post;
+  torch::Tensor comb;
+};
+
+class DeepseekV4HCPreImpl : public torch::nn::Module {
+ public:
+  DeepseekV4HCPreImpl() = default;
+
+  DeepseekV4HCPreImpl(
+      int64_t hc_mult,
+      int64_t dim,
+      int64_t sinkhorn_iters,
+      double hc_eps,
+      double norm_eps,
+      const torch::TensorOptions& options =
+          torch::TensorOptions().dtype(torch::kBFloat16).device(torch::kCPU));
+
+  DeepseekV4HCPreOutput forward(
+      const torch::Tensor& x,
+      const std::optional<torch::Tensor>& rsqrt = std::nullopt);
+
+  void load_state_dict(const StateDict& state_dict);
+
+ private:
+  int64_t hc_mult_ = 0;
+  int64_t dim_ = 0;
+  int64_t sinkhorn_iters_ = 20;
+  double hc_eps_ = 1e-6;
+  double norm_eps_ = 1e-6;
+
+  DEFINE_WEIGHT(hc_fn);
+  DEFINE_WEIGHT(hc_base);
+  DEFINE_WEIGHT(hc_scale);
+};
+
+class DeepseekV4HCPostImpl : public torch::nn::Module {
+ public:
+  DeepseekV4HCPostImpl() = default;
+
+  explicit DeepseekV4HCPostImpl(double norm_eps);
+
+  std::tuple<torch::Tensor, torch::Tensor> forward(
+      const torch::Tensor& x,
+      const torch::Tensor& residual,
+      const torch::Tensor& post,
+      const torch::Tensor& comb,
+      bool compute_rms = false);
+
+ private:
+  double norm_eps_ = 1e-6;
+};
+
+class DeepseekV4HCHeadImpl : public torch::nn::Module {
+ public:
+  DeepseekV4HCHeadImpl() = default;
+
+  DeepseekV4HCHeadImpl(
+      int64_t hc_mult,
+      int64_t dim,
+      double hc_eps,
+      double norm_eps,
+      const torch::TensorOptions& options =
+          torch::TensorOptions().dtype(torch::kBFloat16).device(torch::kCPU));
+
+  torch::Tensor forward(const torch::Tensor& x);
+
+  void load_state_dict(const StateDict& state_dict);
+
+ private:
+  int64_t hc_mult_ = 0;
+  int64_t dim_ = 0;
+  double hc_eps_ = 1e-6;
+  double norm_eps_ = 1e-6;
+
+  DEFINE_WEIGHT(hc_head_fn);
+  DEFINE_WEIGHT(hc_head_base);
+  DEFINE_WEIGHT(hc_head_scale);
+};
+
+TORCH_MODULE(DeepseekV4HCPre);
+TORCH_MODULE(DeepseekV4HCPost);
+TORCH_MODULE(DeepseekV4HCHead);
+
+}  // namespace layer
+}  // namespace xllm

--- a/xllm/core/layers/mlu/fused_moe.cpp
+++ b/xllm/core/layers/mlu/fused_moe.cpp
@@ -17,6 +17,9 @@ limitations under the License.
 
 #include <glog/logging.h>
 
+#include <optional>
+#include <vector>
+
 #include "common/global_flags.h"
 #include "core/framework/config/eplb_config.h"
 #include "core/framework/config/scheduler_config.h"
@@ -41,6 +44,10 @@ FusedMoEImpl::FusedMoEImpl(const ModelArgs& model_args,
       is_gated_(moe_args.is_gated),
       enable_result_reduction_(moe_args.enable_result_reduction),
       hidden_act_(model_args.hidden_act()),
+      swiglu_limit_(model_args.model_type() == "deepseek_v4"
+                        ? std::make_optional(model_args.swiglu_limit())
+                        : std::nullopt),
+      use_hash_(moe_args.use_hash),
       quant_args_(quant_args),
       parallel_args_(parallel_args),
       options_(options),
@@ -152,24 +159,27 @@ FusedMoEImpl::FusedMoEImpl(const ModelArgs& model_args,
   num_experts_per_rank_ = num_experts / ep_size;
   start_expert_id_ = ep_rank * num_experts_per_rank_;
 
-  gate_ = register_module("gate", MoEGate(model_args, quant_args, options));
+  gate_ = register_module("gate",
+                          MoEGate(model_args, quant_args, options, use_hash_));
   if (n_shared_experts_ > 0) {
     CHECK(parallel_args.single_rank_group_ != nullptr)
         << "shared experts require single_rank_group_";
     // Shared experts always run with full weights on the local rank. This
     // keeps the shared path independent from TP/EP sharding.
     shared_pg_ = parallel_args.single_rank_group_;
-    shared_experts_ =
-        register_module("shared_experts",
-                        DenseMLP(hidden_size_,
-                                 intermediate_size * n_shared_experts_,
-                                 is_gated_,
-                                 false,
-                                 hidden_act_,
-                                 enable_result_reduction_,
-                                 quant_args,
-                                 shared_pg_,
-                                 options));
+    shared_experts_ = register_module(
+        "shared_experts",
+        DenseMLP(hidden_size_,
+                 intermediate_size * n_shared_experts_,
+                 is_gated_,
+                 false,
+                 hidden_act_,
+                 enable_result_reduction_,
+                 quant_args,
+                 shared_pg_,
+                 options,
+                 "",
+                 static_cast<double>(swiglu_limit_.value_or(0.0f))));
   }
 
   // create weight buffer
@@ -384,6 +394,15 @@ torch::Tensor FusedMoEImpl::compute_routed_experts(
     gemm1_out = xllm::kernel::group_gemm(group_gemm_params);
   }
 
+  if (swiglu_limit_.has_value()) {
+    const float limit = swiglu_limit_.value();
+    std::vector<torch::Tensor> gate_up_chunks = gemm1_out.chunk(2, -1);
+    torch::Tensor gate = torch::clamp_max(gate_up_chunks[0], /*max=*/limit);
+    torch::Tensor up =
+        torch::clamp(gate_up_chunks[1], /*min=*/-limit, /*max=*/limit);
+    gemm1_out = torch::cat({gate, up}, -1);
+  }
+
   torch::Tensor act_out;
   torch::Tensor act_out_scale;
   if (is_smoothquant_) {
@@ -452,13 +471,15 @@ torch::Tensor FusedMoEImpl::compute_routed_experts(
   return gemm2_out;
 }
 
-FusedMoEImpl::RouteInfo FusedMoEImpl::prep_route(torch::Tensor& hidden_states) {
+FusedMoEImpl::RouteInfo FusedMoEImpl::prep_route(
+    torch::Tensor& hidden_states,
+    const std::optional<torch::Tensor>& input_ids) {
   torch::Tensor hidden_states_2d =
       hidden_states.reshape({-1, hidden_states.size(-1)});
 
   RouteInfo route_info;
   std::tie(route_info.reduce_weight, route_info.expert_id) =
-      gate_->forward(hidden_states_2d);
+      gate_->forward(hidden_states_2d, input_ids);
   return route_info;
 }
 
@@ -498,9 +519,10 @@ void FusedMoEImpl::check_route(const torch::Tensor& hidden_states_2d,
 FusedMoEImpl::RouteInfo FusedMoEImpl::get_route(
     torch::Tensor& hidden_states_2d,
     bool enable_all2all_communication,
-    const std::optional<RouteInfo>& route_info) {
+    const std::optional<RouteInfo>& route_info,
+    const std::optional<torch::Tensor>& input_ids) {
   if (!route_info.has_value()) {
-    return prep_route(hidden_states_2d);
+    return prep_route(hidden_states_2d, input_ids);
   }
 
   CHECK(!enable_all2all_communication)
@@ -512,12 +534,13 @@ FusedMoEImpl::RouteInfo FusedMoEImpl::get_route(
 torch::Tensor FusedMoEImpl::forward_experts(
     const torch::Tensor& hidden_states,
     bool enable_all2all_communication,
-    const std::optional<RouteInfo>& route_info) {
+    const std::optional<RouteInfo>& route_info,
+    const std::optional<torch::Tensor>& input_ids) {
   // Dispatcher: route to the appropriate path based on communication mode
   if (enable_all2all_communication) {
-    return forward_experts_all2all(hidden_states, route_info);
+    return forward_experts_all2all(hidden_states, route_info, input_ids);
   } else {
-    return forward_experts_base(hidden_states, route_info);
+    return forward_experts_base(hidden_states, route_info, input_ids);
   }
 }
 

--- a/xllm/core/layers/mlu/fused_moe.h
+++ b/xllm/core/layers/mlu/fused_moe.h
@@ -50,11 +50,14 @@ class FusedMoEImpl : public torch::nn::Module {
                const ParallelArgs& parallel_args,
                const torch::TensorOptions& options);
 
-  RouteInfo prep_route(torch::Tensor& hidden_states);
+  RouteInfo prep_route(
+      torch::Tensor& hidden_states,
+      const std::optional<torch::Tensor>& input_ids = std::nullopt);
   torch::Tensor forward_experts(
       const torch::Tensor& hidden_states,
       bool enable_all2all_communication,
-      const std::optional<RouteInfo>& route_info = std::nullopt);
+      const std::optional<RouteInfo>& route_info = std::nullopt,
+      const std::optional<torch::Tensor>& input_ids = std::nullopt);
   torch::Tensor forward_shared(const torch::Tensor& hidden_states);
   torch::Tensor forward(const torch::Tensor& hidden_states,
                         const ModelInputParams& input_params);
@@ -86,7 +89,8 @@ class FusedMoEImpl : public torch::nn::Module {
 
   torch::Tensor forward_experts_base(
       const torch::Tensor& hidden_states,
-      const std::optional<RouteInfo>& route_info);
+      const std::optional<RouteInfo>& route_info,
+      const std::optional<torch::Tensor>& input_ids);
 
   virtual void final_comm_allreduce(torch::Tensor& final_hidden_states,
                                     const torch::Tensor& hidden_states,
@@ -100,7 +104,8 @@ class FusedMoEImpl : public torch::nn::Module {
 
   torch::Tensor forward_experts_all2all(
       const torch::Tensor& hidden_states,
-      const std::optional<RouteInfo>& route_info);
+      const std::optional<RouteInfo>& route_info,
+      const std::optional<torch::Tensor>& input_ids);
 
   // Result structure for combine_step
   struct CombineResult {
@@ -118,7 +123,8 @@ class FusedMoEImpl : public torch::nn::Module {
   prepare_group_gemm_weight_scale(const torch::Tensor& b_scale) const;
   RouteInfo get_route(torch::Tensor& hidden_states_2d,
                       bool enable_all2all_communication,
-                      const std::optional<RouteInfo>& route_info);
+                      const std::optional<RouteInfo>& route_info,
+                      const std::optional<torch::Tensor>& input_ids);
   void check_route(const torch::Tensor& hidden_states_2d,
                    const RouteInfo& route_info) const;
   void init_streams(const torch::Tensor& hidden_states);
@@ -156,8 +162,10 @@ class FusedMoEImpl : public torch::nn::Module {
   std::unique_ptr<Stream> routed_stream_;
   xllm::Device device_;
   bool stream_initialized_ = false;
+  bool use_hash_ = false;
 
   MoEGate gate_{nullptr};
+  std::optional<float> swiglu_limit_;
   DenseMLP shared_experts_{nullptr};
   DeepEP deep_ep_{nullptr};
 

--- a/xllm/core/layers/mlu/fused_moe_all2all.cpp
+++ b/xllm/core/layers/mlu/fused_moe_all2all.cpp
@@ -157,7 +157,8 @@ FusedMoEImpl::CombineResult FusedMoEImpl::combine_step(
 
 torch::Tensor FusedMoEImpl::forward_experts_all2all(
     const torch::Tensor& hidden_states,
-    const std::optional<RouteInfo>& route_info) {
+    const std::optional<RouteInfo>& route_info,
+    const std::optional<torch::Tensor>& input_ids) {
   init_streams(hidden_states);
 
   torch::Tensor shared_expert_output;
@@ -166,8 +167,10 @@ torch::Tensor FusedMoEImpl::forward_experts_all2all(
   torch::Tensor hidden_states_2d =
       hidden_states.reshape({-1, hidden_states.size(-1)});
 
-  RouteInfo route = get_route(
-      hidden_states_2d, /*enable_all2all_communication=*/true, route_info);
+  RouteInfo route = get_route(hidden_states_2d,
+                              /*enable_all2all_communication=*/true,
+                              route_info,
+                              input_ids);
 
   int64_t group_gemm_max_dim = deep_ep_params_.max_num_tokens_recv / topk_;
   int64_t expert_size = w13_.size(0);

--- a/xllm/core/layers/mlu/fused_moe_base.cpp
+++ b/xllm/core/layers/mlu/fused_moe_base.cpp
@@ -137,14 +137,17 @@ void FusedMoEImpl::final_comm_allreduce(torch::Tensor& final_hidden_states,
 
 torch::Tensor FusedMoEImpl::forward_experts_base(
     const torch::Tensor& hidden_states,
-    const std::optional<RouteInfo>& route_info) {
+    const std::optional<RouteInfo>& route_info,
+    const std::optional<torch::Tensor>& input_ids) {
   torch::IntArrayRef hidden_states_shape = hidden_states.sizes();
   torch::ScalarType hidden_states_dtype = hidden_states.dtype().toScalarType();
   torch::Tensor hidden_states_2d =
       hidden_states.reshape({-1, hidden_states.size(-1)});
 
-  RouteInfo route = get_route(
-      hidden_states_2d, /*enable_all2all_communication=*/false, route_info);
+  RouteInfo route = get_route(hidden_states_2d,
+                              /*enable_all2all_communication=*/false,
+                              route_info,
+                              input_ids);
 
   int64_t group_gemm_max_dim = hidden_states_2d.size(0);
   int64_t expert_size = w13_.size(0);

--- a/xllm/core/layers/mlu/moe_gate.cpp
+++ b/xllm/core/layers/mlu/moe_gate.cpp
@@ -22,7 +22,8 @@ namespace layer {
 
 MoEGateImpl::MoEGateImpl(const ModelArgs& model_args,
                          const QuantArgs& quant_args,
-                         const torch::TensorOptions& options)
+                         const torch::TensorOptions& options,
+                         bool use_hash)
     : num_experts_(model_args.n_routed_experts()),
       topk_(model_args.num_experts_per_tok()),
       num_expert_group_(model_args.n_group()),
@@ -39,6 +40,17 @@ MoEGateImpl::MoEGateImpl(const ModelArgs& model_args,
         false);
   }
 
+  if (scoring_func_ == "sqrtsoftplus") {
+    moe_softplus_topk_ =
+        register_module("moe_softplus_topk",
+                        MOESoftPlusTopK(model_args.n_routed_experts(),
+                                        model_args.num_experts_per_tok(),
+                                        model_args.routed_scaling_factor(),
+                                        model_args.vocab_size(),
+                                        use_hash,
+                                        options));
+  }
+
   gate_ = register_module("gate_proj",
                           ReplicatedLinear(model_args.hidden_size(),
                                            model_args.n_routed_experts(),
@@ -48,10 +60,15 @@ MoEGateImpl::MoEGateImpl(const ModelArgs& model_args,
 }
 
 std::tuple<torch::Tensor, torch::Tensor> MoEGateImpl::forward(
-    torch::Tensor& hidden_states) {
+    torch::Tensor& hidden_states,
+    const std::optional<torch::Tensor>& input_ids) {
   torch::Tensor router_logits = gate_->forward(hidden_states);
   torch::Tensor router_logits_2d =
       router_logits.reshape({-1, router_logits.size(-1)});
+
+  if (moe_softplus_topk_) {
+    return moe_softplus_topk_->forward(router_logits_2d, input_ids);
+  }
 
   std::optional<torch::Tensor> e_score_correction_bias = std::nullopt;
   if (e_score_correction_bias_.defined()) {
@@ -77,6 +94,9 @@ void MoEGateImpl::load_state_dict(const StateDict& state_dict) {
   if (e_score_correction_bias_.defined() &&
       !e_score_correction_bias_is_loaded_) {
     LOAD_WEIGHT(e_score_correction_bias);
+  }
+  if (moe_softplus_topk_) {
+    moe_softplus_topk_->load_state_dict(state_dict);
   }
 }
 

--- a/xllm/core/layers/mlu/moe_gate.h
+++ b/xllm/core/layers/mlu/moe_gate.h
@@ -17,11 +17,14 @@ limitations under the License.
 
 #include <torch/torch.h>
 
+#include <optional>
+
 #include "framework/model/model_args.h"
 #include "framework/quant_args.h"
 #include "framework/state_dict/state_dict.h"
 #include "framework/state_dict/utils.h"
 #include "layers/common/linear.h"
+#include "layers/mlu/moe_softplus_topk.h"
 
 namespace xllm {
 namespace layer {
@@ -36,12 +39,14 @@ class MoEGateImpl : public torch::nn::Module {
   // hidden_size, norm_topk_prob, scoring_func, topk_method).
   MoEGateImpl(const ModelArgs& model_args,
               const QuantArgs& quant_args,
-              const torch::TensorOptions& options);
+              const torch::TensorOptions& options,
+              bool use_hash = false);
 
   // Forward: hidden_states -> (reduce_weight, expert_id).
   // Reshapes hidden_states to 2D, runs gate projection, then moe_active_topk.
   std::tuple<torch::Tensor, torch::Tensor> forward(
-      torch::Tensor& hidden_states);
+      torch::Tensor& hidden_states,
+      const std::optional<torch::Tensor>& input_ids = std::nullopt);
 
   // Load state dict. Gate and e_score_correction_bias
   void load_state_dict(const StateDict& state_dict);
@@ -57,6 +62,7 @@ class MoEGateImpl : public torch::nn::Module {
   std::string scoring_func_;
 
   ReplicatedLinear gate_{nullptr};
+  MOESoftPlusTopK moe_softplus_topk_{nullptr};
   DEFINE_WEIGHT(e_score_correction_bias);
 };
 

--- a/xllm/core/layers/mlu/moe_softplus_topk.cpp
+++ b/xllm/core/layers/mlu/moe_softplus_topk.cpp
@@ -15,8 +15,6 @@ limitations under the License.
 
 #include "layers/mlu/moe_softplus_topk.h"
 
-#include <glog/logging.h>
-
 #include <tuple>
 
 #include "kernels/mlu/mlu_ops_api.h"

--- a/xllm/core/layers/mlu/moe_softplus_topk.cpp
+++ b/xllm/core/layers/mlu/moe_softplus_topk.cpp
@@ -1,0 +1,71 @@
+/* Copyright 2026 The xLLM Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://github.com/jd-opensource/xllm/blob/main/LICENSE
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include "layers/mlu/moe_softplus_topk.h"
+
+#include <glog/logging.h>
+
+#include <tuple>
+
+#include "kernels/mlu/mlu_ops_api.h"
+namespace xllm {
+namespace layer {
+
+MOESoftPlusTopKImpl::MOESoftPlusTopKImpl(int64_t n_routed_experts,
+                                         int64_t n_activated_experts,
+                                         float route_scale,
+                                         int64_t vocab_size,
+                                         bool use_hash,
+                                         const torch::TensorOptions& options)
+    : n_routed_experts_(n_routed_experts),
+      topk_(n_activated_experts),
+      route_scale_(route_scale),
+      vocab_size_(vocab_size),
+      use_hash_(use_hash) {
+  if (use_hash_) {
+    tid2eid_ = register_parameter(
+        "tid2eid",
+        torch::empty({vocab_size_, topk_}, options.dtype(torch::kInt32)),
+        /*requires_grad=*/false);
+    tid2eid_opt_ = tid2eid_;
+  } else {
+    bias_ = register_parameter(
+        "bias",
+        torch::empty({n_routed_experts_}, options.dtype(torch::kFloat32)),
+        /*requires_grad=*/false);
+    bias_opt_ = bias_;
+  }
+}
+
+std::tuple<torch::Tensor, torch::Tensor> MOESoftPlusTopKImpl::forward(
+    const torch::Tensor& scores,
+    const std::optional<torch::Tensor>& input_ids) {
+  auto [weights, indices] = xllm::kernel::mlu::moe_softplus_topk(
+      scores, topk_, input_ids, tid2eid_opt_, bias_opt_, route_scale_);
+  return {weights, indices};
+}
+
+void MOESoftPlusTopKImpl::load_state_dict(const StateDict& state_dict) {
+  if (use_hash_) {
+    LOAD_WEIGHT(tid2eid);
+    tid2eid_opt_ = tid2eid_;
+  } else {
+    LOAD_WEIGHT(bias);
+    bias_opt_ = bias_;
+  }
+}
+
+}  // namespace layer
+}  // namespace xllm

--- a/xllm/core/layers/mlu/moe_softplus_topk.h
+++ b/xllm/core/layers/mlu/moe_softplus_topk.h
@@ -1,0 +1,61 @@
+/* Copyright 2026 The xLLM Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://github.com/jd-opensource/xllm/blob/main/LICENSE
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#pragma once
+
+#include <torch/torch.h>
+
+#include <optional>
+
+#include "framework/state_dict/state_dict.h"
+#include "framework/state_dict/utils.h"
+
+namespace xllm {
+namespace layer {
+
+class MOESoftPlusTopKImpl final : public torch::nn::Module {
+ public:
+  MOESoftPlusTopKImpl() = default;
+
+  MOESoftPlusTopKImpl(int64_t n_routed_experts,
+                      int64_t n_activated_experts,
+                      float route_scale,
+                      int64_t vocab_size,
+                      bool use_hash,
+                      const torch::TensorOptions& options);
+
+  std::tuple<torch::Tensor, torch::Tensor> forward(
+      const torch::Tensor& scores,
+      const std::optional<torch::Tensor>& input_ids = std::nullopt);
+
+  void load_state_dict(const StateDict& state_dict);
+
+ private:
+  int64_t n_routed_experts_ = 0;
+  int64_t topk_ = 0;
+  float route_scale_ = 1.0f;
+  int64_t vocab_size_ = 0;
+  bool use_hash_ = false;
+
+  DEFINE_WEIGHT(tid2eid);
+  DEFINE_WEIGHT(bias);
+
+  // Cached optional wrappers to avoid creating new objects on each forward
+  std::optional<torch::Tensor> tid2eid_opt_;
+  std::optional<torch::Tensor> bias_opt_;
+};
+TORCH_MODULE(MOESoftPlusTopK);
+}  // namespace layer
+}  // namespace xllm


### PR DESCRIPTION
 ## Description

  Add DeepSeek V4 MLU MoE support.

  This PR introduces:
  - DeepSeek V4 hyper connection layers for MLU: HC pre, post, and head.
  - `sqrtsoftplus` MoE routing on MLU, including optional hash-based routing via `tid2eid`.
  - DeepSeek V4 SwiGLU clamping through `swiglu_limit` for routed and shared MoE paths.
  - `input_ids` propagation through MLU MoE routing so hash-based top-k routing can use token IDs.
  - CMake wiring and MLU unit tests for DeepSeek V4 hyper connection and DeepSeek V4 MoE forward paths.


  ## Change Type

  - [ ] Bug fix
  - [x] New feature
  - [ ] Performance improvement
  - [ ] Refactor
  - [ ] Documentation
  - [ ] Test
  - [ ] Build or CI


## Pull Request Checklist

Thank you for contributing to xLLM. Before requesting review, please make sure the following items are complete.

### PR Title and Commit Messages

- [x] The PR title and each commit message follow the xLLM commit format: `<type>: <subject>`.

> Allowed types: feat, bugfix, docs, test, refactor, chore, style, revert, perf, model, build, release.
> The subject should use clear English, start with a verb, include at least 4 words, and end with `.`.

### Pre-commit Checks

- [x] I have installed `pre-commit` by running `pip install pre-commit` or an equivalent command.
- [x] I have installed the hooks with `pre-commit install`.
- [x] I have run `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

### Self Review

- [x] I have self-reviewed the code according to `.agents/skills/code-review/references/custom-code-style.md`, especially code written or assisted by AI.
- [x] I have rebased this PR onto the latest `main` branch.

### Build and Test Coverage

- [ ] Tests have been added or updated as needed.
- [ ] CUDA: `python setup.py build test` has passed on a CUDA machine.
- [ ] NPU: `python setup.py build test` has passed on an NPU machine.
- [x] MLU: `python setup.py build test` has passed on an MLU machine.

## Reviewer Notes

<!-- Optional: anything reviewers should focus on, known risks, follow-ups, or validation gaps. -->
