### PR TITLE
bugfix: skip lm head in embedding mode.

### DIFF
--- a/xllm/core/framework/model/model_args.h
+++ b/xllm/core/framework/model/model_args.h
@@ -419,6 +419,7 @@ struct ModelArgs {
 
   PROPERTY(int32_t, query_num) = 0;
   PROPERTY(bool, encoder_embedding_mode) = false;
+  PROPERTY(bool, embedding_mode) = false;
 
   // number of speculative decoding tokens
   PROPERTY(int64_t, num_speculative_tokens) = 0;
@@ -569,6 +570,7 @@ inline bool has_linear_attention_layers(const ModelArgs& args) {
 inline std::ostream& operator<<(std::ostream& os, const ModelArgs& args) {
   os << "ModelArgs: [model_type: " << args.model_type();
   os << ", encoder_embedding_mode: " << args.encoder_embedding_mode();
+  os << ", embedding_mode: " << args.embedding_mode();
   os << ", dtype: " << args.dtype();
   os << ", hidden_size: " << args.hidden_size();
   os << ", hidden_act: " << args.hidden_act();

--- a/xllm/core/runtime/worker_impl.cpp
+++ b/xllm/core/runtime/worker_impl.cpp
@@ -1287,6 +1287,8 @@ bool WorkerImpl::init_model(const std::string& model_weights_path,
 
   auto args = model_loader->model_args();
   auto quant_args = model_loader->quant_args();
+  const bool embedding_mode = options_.task_type() == "embed";
+  args.embedding_mode(embedding_mode);
   torch::ScalarType dtype = util::parse_dtype(args.dtype(), device_);
 
   const int64_t tokenizer_vocab_size = tokenizer->vocab_size();

--- a/xllm/models/llm/llm_model_base.h
+++ b/xllm/models/llm/llm_model_base.h
@@ -171,9 +171,14 @@ class LlmForCausalLMImplBase : public torch::nn::Module {
  public:
   LlmForCausalLMImplBase(const ModelContext& context) {
     tie_word_embeddings = context.get_model_args().tie_word_embeddings();
+    embedding_mode_ = context.get_model_args().embedding_mode();
     // register submodules
     model_ = register_module("model", LlmModelType(context));
-    lm_head_ = register_module("lm_head", layer::LmHead(context));
+    if (!embedding_mode_) {
+      lm_head_ = register_module("lm_head", layer::LmHead(context));
+    } else {
+      LOG(INFO) << "Skip registering lm_head in embedding mode.";
+    }
   }
 
   torch::Tensor get_input_embeddings(torch::Tensor input_ids) {
@@ -195,6 +200,8 @@ class LlmForCausalLMImplBase : public torch::nn::Module {
   // returns: [num_tokens, vocab_size]
   virtual torch::Tensor logits(const torch::Tensor& hidden_states,
                                const torch::Tensor& seleted_idxes) {
+    CHECK(!lm_head_.is_empty())
+        << "lm_head is not initialized in embedding mode.";
     // select tokens if provided
     auto h = hidden_states;
     if (seleted_idxes.defined()) {
@@ -229,21 +236,23 @@ class LlmForCausalLMImplBase : public torch::nn::Module {
                                    "model.",
                                    ""}));
 
-      if (tie_word_embeddings) {
-        auto lm_head_state_dict =
-            state_dict->get_dict_with_prefix(std::vector<std::string>{
-                prefix + "embed_tokens.", "embed_tokens.", "embed."});
-        lm_head_->load_state_dict(lm_head_state_dict);
-      } else {
-        auto lm_head_state_dict = state_dict->get_dict_with_prefix(
-            std::vector<std::string>{"lm_head.",
-                                     "model.lm_head.",
-                                     "model.head.",
-                                     "head.",
-                                     prefix,
-                                     prefix + "lm_head.",
-                                     prefix + "head."});
-        lm_head_->load_state_dict(lm_head_state_dict);
+      if (!embedding_mode_) {
+        if (tie_word_embeddings) {
+          auto lm_head_state_dict =
+              state_dict->get_dict_with_prefix(std::vector<std::string>{
+                  prefix + "embed_tokens.", "embed_tokens.", "embed."});
+          lm_head_->load_state_dict(lm_head_state_dict);
+        } else {
+          auto lm_head_state_dict = state_dict->get_dict_with_prefix(
+              std::vector<std::string>{"lm_head.",
+                                       "model.lm_head.",
+                                       "model.head.",
+                                       "head.",
+                                       prefix,
+                                       prefix + "lm_head.",
+                                       prefix + "head."});
+          lm_head_->load_state_dict(lm_head_state_dict);
+        }
       }
     }
   }
@@ -254,7 +263,11 @@ class LlmForCausalLMImplBase : public torch::nn::Module {
   }
   virtual void update_expert_weight(int32_t layer_id) { return; }
 
-  virtual layer::LmHead get_lm_head() { return lm_head_; }
+  virtual layer::LmHead get_lm_head() {
+    CHECK(!lm_head_.is_empty())
+        << "lm_head is not initialized in embedding mode.";
+    return lm_head_;
+  }
 
   virtual void set_lm_head(layer::LmHead& head) { lm_head_ = head; }
 
@@ -270,6 +283,7 @@ class LlmForCausalLMImplBase : public torch::nn::Module {
   // parameter members, must be registered
   LlmModelType model_{nullptr};
   bool tie_word_embeddings{false};
+  bool embedding_mode_{false};
   // test
   layer::LmHead lm_head_{nullptr};
 };

--- a/xllm/models/llm/npu/llm_model_base.h
+++ b/xllm/models/llm/npu/llm_model_base.h
@@ -406,10 +406,15 @@ class LlmForCausalLMImplBase : public torch::nn::Module {
  public:
   LlmForCausalLMImplBase(const ModelContext& context) {
     tie_word_embeddings = context.get_model_args().tie_word_embeddings();
+    embedding_mode_ = context.get_model_args().embedding_mode();
     // register submodules
     model_ = register_module("model", LlmModelType(context));
 
-    npu_lm_head_ = register_module("npu_lm_head", layer::NpuLmHead(context));
+    if (!embedding_mode_) {
+      npu_lm_head_ = register_module("npu_lm_head", layer::NpuLmHead(context));
+    } else {
+      LOG(INFO) << "Skip registering npu_lm_head in embedding mode.";
+    }
   }
 
   torch::Tensor get_input_embeddings(torch::Tensor input_ids) {
@@ -431,6 +436,8 @@ class LlmForCausalLMImplBase : public torch::nn::Module {
   // returns: [num_tokens, vocab_size]
   virtual torch::Tensor logits(const torch::Tensor& hidden_states,
                                const torch::Tensor& seleted_idxes) {
+    CHECK(!npu_lm_head_.is_empty())
+        << "npu_lm_head is not initialized in embedding mode.";
     return npu_lm_head_(hidden_states, seleted_idxes, 0);
   }
 
@@ -441,6 +448,8 @@ class LlmForCausalLMImplBase : public torch::nn::Module {
   virtual torch::Tensor logits(const torch::Tensor& hidden_states,
                                const torch::Tensor& seleted_idxes,
                                torch::Tensor& out_hidden) {
+    CHECK(!npu_lm_head_.is_empty())
+        << "npu_lm_head is not initialized in embedding mode.";
     return npu_lm_head_->forward_with_hidden(
         hidden_states, seleted_idxes, out_hidden, 0);
   }
@@ -470,27 +479,32 @@ class LlmForCausalLMImplBase : public torch::nn::Module {
                                    prefix,
                                    "model.",
                                    ""}));
-      if (tie_word_embeddings) {
-        npu_lm_head_->load_state_dict(
-            state_dict->get_dict_with_prefix(std::vector<std::string>{
-                prefix + "embed_tokens.", "embed_tokens."}));
-      } else {
-        npu_lm_head_->load_state_dict(
-            state_dict->get_dict_with_prefix("lm_head."));
+      if (!embedding_mode_) {
+        if (tie_word_embeddings) {
+          npu_lm_head_->load_state_dict(
+              state_dict->get_dict_with_prefix(std::vector<std::string>{
+                  prefix + "embed_tokens.", "embed_tokens."}));
+        } else {
+          npu_lm_head_->load_state_dict(
+              state_dict->get_dict_with_prefix("lm_head."));
+        }
       }
     }
 
     // verify
     model_->verify_loaded_weights(prefix);
-    if (tie_word_embeddings) {
-      npu_lm_head_->verify_loaded_weights("embed_tokens.");
-    } else {
-      npu_lm_head_->verify_loaded_weights("lm_head.");
+    if (!embedding_mode_) {
+      if (tie_word_embeddings) {
+        npu_lm_head_->verify_loaded_weights("embed_tokens.");
+      } else {
+        npu_lm_head_->verify_loaded_weights("lm_head.");
+      }
     }
 
     model_->merge_loaded_weights();
-    // test
-    npu_lm_head_->merge_loaded_weights();
+    if (!embedding_mode_) {
+      npu_lm_head_->merge_loaded_weights();
+    }
   }
 
   virtual void lazy_load_model(
@@ -502,21 +516,30 @@ class LlmForCausalLMImplBase : public torch::nn::Module {
     }
     for (const auto& state_dict : loader->get_state_dicts()) {
       model_->load_state_dict(state_dict->get_dict_with_prefix(prefix));
-      if (tie_word_embeddings) {
-        npu_lm_head_->load_state_dict(
-            state_dict->get_dict_with_prefix(prefix + "embed_tokens."));
-      } else {
-        npu_lm_head_->load_state_dict(
-            state_dict->get_dict_with_prefix("lm_head."));
+      if (!embedding_mode_) {
+        if (tie_word_embeddings) {
+          npu_lm_head_->load_state_dict(
+              state_dict->get_dict_with_prefix(prefix + "embed_tokens."));
+        } else {
+          npu_lm_head_->load_state_dict(
+              state_dict->get_dict_with_prefix("lm_head."));
+        }
       }
     }
     // verify
     model_->verify_loaded_weights(prefix);
-    npu_lm_head_->verify_loaded_weights("lm_head.");
+    if (!embedding_mode_) {
+      if (tie_word_embeddings) {
+        npu_lm_head_->verify_loaded_weights(prefix + "embed_tokens.");
+      } else {
+        npu_lm_head_->verify_loaded_weights("lm_head.");
+      }
+    }
 
     model_->merge_and_move_pinned_host();
-    // test
-    npu_lm_head_->merge_and_move_pinned_host();
+    if (!embedding_mode_) {
+      npu_lm_head_->merge_and_move_pinned_host();
+    }
 
     keep_host_weights = true;
   }
@@ -527,13 +550,17 @@ class LlmForCausalLMImplBase : public torch::nn::Module {
       return;
     }
     model_->free_weights();
-    npu_lm_head_->free_weights();
+    if (!npu_lm_head_.is_empty()) {
+      npu_lm_head_->free_weights();
+    }
     keep_host_weights = false;
   }
 
   virtual void reload_model_weights() {
     model_->reload_weights();
-    npu_lm_head_->reload_weights();
+    if (!npu_lm_head_.is_empty()) {
+      npu_lm_head_->reload_weights();
+    }
     auto stream = c10_npu::getCurrentNPUStream();
     stream.synchronize();
   }
@@ -541,14 +568,18 @@ class LlmForCausalLMImplBase : public torch::nn::Module {
   virtual void init_rolling_model_state() {
     model_->reload_non_decoder_weights();
     model_->refresh_rolling_weights();
-    npu_lm_head_->reload_weights();
+    if (!npu_lm_head_.is_empty()) {
+      npu_lm_head_->reload_weights();
+    }
     auto stream = c10_npu::getCurrentNPUStream();
     stream.synchronize();
   }
 
   virtual void reload_model_weights_from_device() {
     model_->reload_weights_from_device();
-    npu_lm_head_->reload_weights_from_device();
+    if (!npu_lm_head_.is_empty()) {
+      npu_lm_head_->reload_weights_from_device();
+    }
   }
 
   virtual void prepare_expert_weight(int32_t layer_id,
@@ -557,7 +588,11 @@ class LlmForCausalLMImplBase : public torch::nn::Module {
   }
   virtual void update_expert_weight(int32_t layer_id) { return; }
 
-  virtual layer::NpuLmHead get_npu_lm_head() { return npu_lm_head_; }
+  virtual layer::NpuLmHead get_npu_lm_head() {
+    CHECK(!npu_lm_head_.is_empty())
+        << "npu_lm_head is not initialized in embedding mode.";
+    return npu_lm_head_;
+  }
 
   virtual void set_npu_lm_head(layer::NpuLmHead& head) { npu_lm_head_ = head; }
 
@@ -634,6 +669,7 @@ class LlmForCausalLMImplBase : public torch::nn::Module {
   LlmModelType model_{nullptr};
   int device_id = 0;
   bool tie_word_embeddings{false};
+  bool embedding_mode_{false};
   bool keep_host_weights{false};
   std::shared_ptr<layer::RollingWeightBuffer> rolling_weight_buffer_{nullptr};
   std::unique_ptr<RollingLoadManager> rolling_load_manager_{nullptr};


### PR DESCRIPTION
## Description

This PR fixes embedding inference for Qwen3/Qwen3-VL embedding checkpoints by skipping `lm_head` registration, loading, and verification when the runtime task is `embed`.

For embedding tasks, xLLM only needs the language model backbone and pooling/embedding path. The final `lm_head` is not used, but the previous loading path still forced `lm_head` to be registered and verified. This could fail on some embedding checkpoints, such as Qwen3-VL-Embedding-8B, when the final `lm_head` weight is absent or not loaded as expected.

Main changes:

- Add `embedding_mode` to `ModelArgs`.
- Set `embedding_mode` from `task_type == "embed"` in `WorkerImpl`.
- Skip common LLM `lm_head_` registration/loading in embedding mode.
- Skip NPU `npu_lm_head_` registration/loading/verification/merge/reload paths in embedding mode.
- Keep `encoder_embedding_mode` behavior unchanged for VLM encoder-only `mm_embed` paths.

This keeps normal generation behavior unchanged, because `lm_head` is still required and loaded when `task_type` is not `embed`.

## Related Issues

N/A

## Change Type

- [x] Bug fix
- [ ] New feature
- [ ] Performance improvement
- [ ] Refactor
- [ ] Documentation
- [ ] Test
- [ ] Build or CI

## Pull Request Checklist

Thank you for contributing to xLLM. Before requesting review, please make sure the following items are complete.

### PR Title and Commit Messages

- [x] The PR title and each commit message follow the xLLM commit format: `<type>: <subject>`.

> Allowed types: feat, bugfix, docs, test, refactor, chore, style, revert, perf, model, build, release.
> The subject should use clear English, start with a verb, include at least 4 words, and end with `.`.

### Pre-commit Checks

- [ ] I have installed `pre-commit` by running `pip install pre-commit` or an equivalent command.
- [ ] I have installed the hooks with `pre-commit install`.
- [ ] I have run `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

### Self Review

- [x] I have self-reviewed the code according to `.agents/skills/code-review/references/custom-code-style.md`, especially code written or assisted by AI.
- [ ] I have rebased this PR onto the latest `main` branch.

### Build and Test Coverage

- [ ] Tests have been added or updated as needed.
- [ ] CUDA: `python setup.py build test` has passed on a CUDA machine.
- [ ] NPU: `python setup.py build test` has passed on an NPU machine.
- [ ] MLU: `python setup.py build test` has passed on an MLU machine.

## Reviewer Notes
