### PR TITLE
build: align xllm_ops marker path with ascend opp vendor.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -29,7 +29,7 @@ if(USE_NPU)
   )
 
   if(DEFINED ENV{ASCEND_OPP_PATH} AND NOT "$ENV{ASCEND_OPP_PATH}" STREQUAL "")
-    set(XLLM_OPS_MARKER_PATH "$ENV{ASCEND_OPP_PATH}/vendors/custom_xllm_math/.xllm_ops_git_head")
+    set(XLLM_OPS_MARKER_PATH "$ENV{ASCEND_OPP_PATH}/vendors/xllm/.xllm_ops_git_head")
   else()
     message(FATAL_ERROR "ASCEND_OPP_PATH is not initialized for NPU build.")
   endif()
@@ -57,7 +57,9 @@ if(USE_NPU)
     endif()
 
     ## Adapt to the modification in DeekSeekV4 where the installation path of xllm_ops has been changed to custom_xllm_math
-    if(EXISTS "$ENV{NPU_HOME_PATH}/opp/vendors/custom_xllm_math/op_api/include/aclnnop")
+    ## Probe under ASCEND_OPP_PATH (the same root the marker is written to, and the
+    ## one scripts/build_support/utils.py reads) so the read and write paths cannot diverge.
+    if(EXISTS "$ENV{ASCEND_OPP_PATH}/vendors/custom_xllm_math/op_api/include/aclnnop")
       set(XLLM_OPS_MARKER_PATH "$ENV{ASCEND_OPP_PATH}/vendors/custom_xllm_math/.xllm_ops_git_head")
     endif()
     message(STATUS "XLLM_OPS_MARKER_PATH: ${XLLM_OPS_MARKER_PATH}")

--- a/scripts/build_support/utils.py
+++ b/scripts/build_support/utils.py
@@ -388,13 +388,25 @@ def _get_cmake_cache_path() -> str:
 
 def _get_xllm_ops_marker_path() -> str:
     opp_root = os.getenv("ASCEND_OPP_PATH")
-    if opp_root:
-        opp_root = os.path.abspath(os.path.expanduser(opp_root))
-        return os.path.join(opp_root, "vendors", "xllm", ".xllm_ops_git_head")
+    if not opp_root:
+        logger.error("ASCEND_OPP_PATH is not initialized for NPU build.")
+        _print_manual_check_commands(["echo $ASCEND_OPP_PATH"])
+        exit(1)
 
-    logger.error("ASCEND_OPP_PATH is not initialized for NPU build.")
-    _print_manual_check_commands(["echo $ASCEND_OPP_PATH"])
-    exit(1)
+    opp_root = os.path.abspath(os.path.expanduser(opp_root))
+    # Adapt to the DeepSeekV4 / CANN 9.0 change where xllm_ops installs under the
+    # "custom_xllm_math" vendor instead of "xllm". The marker must be read from the
+    # same vendor directory CMakeLists.txt writes it to; otherwise the read and
+    # write paths diverge and the incremental-build cache never hits. Detection
+    # mirrors CMakeLists.txt exactly (same ASCEND_OPP_PATH root and probe path).
+    vendor = "xllm"
+    if os.path.isdir(
+        os.path.join(
+            opp_root, "vendors", "custom_xllm_math", "op_api", "include", "aclnnop"
+        )
+    ):
+        vendor = "custom_xllm_math"
+    return os.path.join(opp_root, "vendors", vendor, ".xllm_ops_git_head")
 
 
 def _clear_xllm_ops_cache_git_head(cache_path: str) -> bool:


### PR DESCRIPTION
## Description

This PR fixes the xllm_ops incremental precompile cache for Ascend NPU builds after the vendor install path changed to `custom_xllm_math`.

Previously, CMake wrote the `.xllm_ops_git_head` marker under the new `custom_xllm_math` vendor path, while `scripts/build_support/utils.py` still read the marker from the old `vendors/xllm` path. As a result, repeated NPU builds could fail to recognize that the installed xllm_ops matched the current submodule HEAD and would unnecessarily trigger the xllm_ops precompile flow.

This change aligns the marker read/write path by:

- using `ASCEND_OPP_PATH` consistently as the marker root.
- detecting the `custom_xllm_math` vendor layout when its ACLNN headers are installed.
- falling back to the legacy `vendors/xllm` marker path when the new vendor layout is not present.
- updating the xllm_ops submodule to preserve its incremental build cache.

## Related Issues

N/A

## Change Type

- [ ] Bug fix
- [ ] New feature
- [ ] Performance improvement
- [ ] Refactor
- [ ] Documentation
- [ ] Test
- [x] Build or CI

## Pull Request Checklist

Thank you for contributing to xLLM. Before requesting review, please make sure the following items are complete.

### PR Title and Commit Messages

- [x] The PR title and each commit message follow the xLLM commit format: `<type>: <subject>`.

> Allowed types: feat, bugfix, docs, test, refactor, chore, style, revert, perf, model, build, release.
> The subject should use clear English, start with a verb, include at least 4 words, and end with `.`.

### Pre-commit Checks

- [x] I have installed `pre-commit` by running `pip install pre-commit` or an equivalent command.
- [ ] I have installed the hooks with `pre-commit install`.
- [x] I have run `pre-commit run --all-files` and fixed any reported issues.

### Self Review

- [x] I have self-reviewed the code according to `.agents/skills/code-review/references/custom-code-style.md`, especially code written or assisted by AI.
- [x] I have rebased this PR onto the latest `main` branch.

### Build and Test Coverage

- [ ] Tests have been added or updated as needed.
- [ ] CUDA: `python setup.py build test` has passed on a CUDA machine.
- [x] NPU: `python setup.py build test` has passed on an NPU machine.
- [ ] MLU: `python setup.py build test` has passed on an MLU machine.

## Reviewer Notes

Please focus on the marker path consistency between `CMakeLists.txt` and `scripts/build_support/utils.py`.

The key behavior to verify is that after xllm_ops is installed once, a repeated NPU build sees the matching git HEAD marker and skips the xllm_ops precompile step instead of rebuilding it unnecessarily.
