### PR TITLE
feat: add MegaChunkGDN fused operator for Qwen3.5 on npu device.

### DIFF
--- a/xllm/CMakeLists.txt
+++ b/xllm/CMakeLists.txt
@@ -24,6 +24,10 @@ if(CMAKE_CXX_COMPILER_ID MATCHES "GNU|Clang")
   add_compile_options(
     $<$<COMPILE_LANGUAGE:CXX>:-Werror>
     $<$<COMPILE_LANGUAGE:C>:-Werror>
+    # Downgrade -Wmaybe-uninitialized from error to warning.
+    # Triggered by third-party header ylt/coro_rpc/impl/coro_rpc_client.hpp.
+    $<$<COMPILE_LANGUAGE:CXX>:-Wno-error=maybe-uninitialized>
+    $<$<COMPILE_LANGUAGE:C>:-Wno-error=maybe-uninitialized>
   )
 
   if(CMAKE_CXX_COMPILER_ID MATCHES "Clang")

--- a/xllm/CMakeLists.txt
+++ b/xllm/CMakeLists.txt
@@ -24,10 +24,6 @@ if(CMAKE_CXX_COMPILER_ID MATCHES "GNU|Clang")
   add_compile_options(
     $<$<COMPILE_LANGUAGE:CXX>:-Werror>
     $<$<COMPILE_LANGUAGE:C>:-Werror>
-    # Downgrade -Wmaybe-uninitialized from error to warning.
-    # Triggered by third-party header ylt/coro_rpc/impl/coro_rpc_client.hpp.
-    $<$<COMPILE_LANGUAGE:CXX>:-Wno-error=maybe-uninitialized>
-    $<$<COMPILE_LANGUAGE:C>:-Wno-error=maybe-uninitialized>
   )
 
   if(CMAKE_CXX_COMPILER_ID MATCHES "Clang")

--- a/xllm/core/kernels/npu/xllm_ops/CMakeLists.txt
+++ b/xllm/core/kernels/npu/xllm_ops/CMakeLists.txt
@@ -33,6 +33,7 @@ cc_library(
     beam_search_rec.cpp
     rec_constrained_topk_fused.cpp
     beam_search_rec_final.cpp
+    npu_mega_chunk_gdn.cpp
   INCLUDES
     ${PROJECT_SOURCE_DIR}/third_party/xllm_ops/build/autogen
   DEPS

--- a/xllm/core/kernels/npu/xllm_ops/hc_pre.cpp
+++ b/xllm/core/kernels/npu/xllm_ops/hc_pre.cpp
@@ -35,7 +35,7 @@ std::tuple<torch::Tensor, torch::Tensor, torch::Tensor> hc_pre(
 
   c10::ScalarType original_type = x.scalar_type();
   torch::Tensor x_bf16 = x;
-  if (x_bf16.dtype() != torch::kBFloat16) {
+  if (x_bf16.scalar_type() != torch::kBFloat16) {
     x_bf16 = x_bf16.to(torch::kBFloat16);
   }
 

--- a/xllm/core/kernels/npu/xllm_ops/hc_pre.cpp
+++ b/xllm/core/kernels/npu/xllm_ops/hc_pre.cpp
@@ -33,7 +33,7 @@ std::tuple<torch::Tensor, torch::Tensor, torch::Tensor> hc_pre(
               x.dim(),
               ".");
 
-  c10::ScalarType original_type = x.dtype();
+  c10::ScalarType original_type = x.scalar_type();
   torch::Tensor x_bf16 = x;
   if (x_bf16.dtype() != torch::kBFloat16) {
     x_bf16 = x_bf16.to(torch::kBFloat16);

--- a/xllm/core/kernels/npu/xllm_ops/npu_mega_chunk_gdn.cpp
+++ b/xllm/core/kernels/npu/xllm_ops/npu_mega_chunk_gdn.cpp
@@ -1,0 +1,192 @@
+/* Copyright 2026 The xLLM Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://github.com/jd-opensource/xllm/blob/main/LICENSE
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include <glog/logging.h>
+
+#include <unordered_map>
+
+#include "core/kernels/npu/aclnn/pytorch_npu_helper.hpp"
+#include "core/kernels/npu/xllm_ops/xllm_ops_api.h"
+
+namespace xllm::kernel::npu {
+
+namespace {
+constexpr int64_t kMegaChunkSize = 128;
+
+struct MaskCache {
+  torch::Tensor mask_lower;
+  torch::Tensor mask_full;
+  torch::Tensor minus_identity;
+};
+
+std::unordered_map<int, MaskCache> g_mask_cache;
+
+MaskCache& get_or_create_masks(const torch::Device& device) {
+  int device_index = device.index();
+  auto it = g_mask_cache.find(device_index);
+  if (it != g_mask_cache.end()) {
+    return it->second;
+  }
+  MaskCache cache;
+  cache.mask_lower = torch::tril(
+      torch::ones({kMegaChunkSize, kMegaChunkSize},
+                  torch::TensorOptions(device).dtype(torch::kFloat32)),
+      /*diagonal=*/-1);
+  cache.mask_full = torch::tril(
+      torch::ones({kMegaChunkSize, kMegaChunkSize},
+                  torch::TensorOptions(device).dtype(torch::kFloat32)),
+      /*diagonal=*/0);
+  cache.minus_identity =
+      torch::zeros({kMegaChunkSize, kMegaChunkSize},
+                   torch::TensorOptions(device).dtype(torch::kFloat16));
+  cache.minus_identity.diagonal().fill_(-1);
+  g_mask_cache[device_index] = std::move(cache);
+  return g_mask_cache[device_index];
+}
+}  // namespace
+
+std::pair<torch::Tensor, torch::Tensor> npu_mega_chunk_gdn(
+    torch::Tensor& q,
+    torch::Tensor& k,
+    torch::Tensor& v,
+    torch::Tensor& g,
+    torch::Tensor& beta,
+    const std::optional<float>& scale,
+    const std::optional<torch::Tensor>& initial_state,
+    bool output_final_state,
+    const std::optional<torch::Tensor>& cu_seqlens,
+    bool use_qk_l2norm_in_kernel) {
+  const auto input_dtype = q.scalar_type();
+  const auto k_dtype = k.scalar_type();
+  const auto v_dtype = v.scalar_type();
+
+  // Apply L2 normalization to q and k if requested
+  torch::Tensor q_normalized = q;
+  torch::Tensor k_normalized = k;
+  if (use_qk_l2norm_in_kernel) {
+    auto q_norm = torch::linalg_norm(q, 2, -1, true);
+    q_normalized = q / q_norm.clamp_min(1e-6);
+    auto k_norm = torch::linalg_norm(k, 2, -1, true);
+    k_normalized = k / k_norm.clamp_min(1e-6);
+  }
+
+  auto q_fp16 = q_normalized.to(torch::kFloat16);
+  auto k_fp16 = k_normalized.to(torch::kFloat16);
+  auto v_fp16 = v.to(torch::kFloat16);
+  auto g_fp16 = g.to(torch::kFloat16);
+  auto beta_fp16 = beta.to(torch::kFloat16);
+
+  torch::Tensor cu_seqlens_int32;
+  if (cu_seqlens.has_value() && cu_seqlens->defined()) {
+    cu_seqlens_int32 = cu_seqlens->to(torch::kInt32);
+  } else {
+    const int64_t total_tokens = q.size(1);
+    cu_seqlens_int32 =
+        torch::tensor({0, static_cast<int32_t>(total_tokens)},
+                      torch::TensorOptions(q.device()).dtype(torch::kInt32));
+  }
+
+  const int64_t num_sequences = cu_seqlens_int32.numel() - 1;
+  const int64_t num_value_heads = v.size(2);
+
+  auto cu_cpu = cu_seqlens_int32.to(torch::kCPU);
+  auto cu_data = cu_cpu.accessor<int32_t, 1>();
+  int64_t num_chunks = 0;
+  for (int64_t i = 0; i < num_sequences; ++i) {
+    const int64_t seq_len = cu_data[i + 1] - cu_data[i];
+    num_chunks += (seq_len + kMegaChunkSize - 1) / kMegaChunkSize;
+  }
+  const int64_t num_matrices = num_chunks * num_value_heads;
+
+  auto& masks = get_or_create_masks(q.device());
+
+  const int64_t B = q.size(0);
+  const int64_t T = q.size(1);
+  const int64_t Hqk = k.size(2);
+  const int64_t K = q.size(3);
+  const int64_t H = v.size(2);
+  const int64_t V = v.size(3);
+
+  // Calculate default scale if not provided
+  float scale_value = scale.has_value()
+                          ? scale.value()
+                          : std::pow(static_cast<float>(K), -0.5f);
+
+  auto opts_fp16 = torch::TensorOptions(q.device()).dtype(torch::kFloat16);
+  auto opts_fp32 = torch::TensorOptions(q.device()).dtype(torch::kFloat32);
+
+  auto out = torch::empty({B, T, H, V}, opts_fp16);
+  auto g_sum = torch::empty({B, T, H}, opts_fp16);
+  auto g_t = torch::empty({B, num_chunks, H, kMegaChunkSize}, opts_fp16);
+  auto beta_t = torch::empty({B, num_chunks, H, kMegaChunkSize}, opts_fp16);
+  auto a = torch::empty({B, num_chunks, H, kMegaChunkSize, kMegaChunkSize},
+                        opts_fp16);
+  auto a_inv_f32 = torch::empty(
+      {B, num_chunks, H, kMegaChunkSize, kMegaChunkSize}, opts_fp32);
+  auto a_inv = torch::empty({B, num_chunks, H, kMegaChunkSize, kMegaChunkSize},
+                            opts_fp16);
+  auto w = torch::empty({B, num_chunks, H, K, V}, opts_fp16);
+  auto u = torch::empty({B, num_chunks, H, V}, opts_fp16);
+  auto h = torch::empty({B, num_chunks, H, K, V}, opts_fp16);
+  auto v_new = torch::empty({B, T, H, V}, opts_fp16);
+
+  torch::Tensor initial_state_arg;
+  bool has_initial_state = false;
+  if (initial_state.has_value() && initial_state->defined()) {
+    initial_state_arg = initial_state->to(torch::kFloat16);
+    has_initial_state = true;
+  } else {
+    initial_state_arg = torch::zeros({num_sequences, H, K, V}, opts_fp16);
+  }
+
+  auto final_state = torch::empty({num_sequences, H, K, V}, opts_fp32);
+
+  EXEC_NPU_CMD(aclnnMegaChunkGdn,
+               q_fp16,
+               k_fp16,
+               v_fp16,
+               g_fp16,
+               beta_fp16,
+               masks.mask_lower,
+               masks.mask_full,
+               masks.minus_identity,
+               cu_seqlens_int32,
+               initial_state_arg,
+               out,
+               g_sum,
+               g_t,
+               beta_t,
+               a,
+               a_inv_f32,
+               a_inv,
+               w,
+               u,
+               h,
+               v_new,
+               final_state,
+               num_matrices,
+               has_initial_state);
+
+  auto output = (out * scale_value).to(input_dtype);
+
+  torch::Tensor final_state_out;
+  if (output_final_state) {
+    final_state_out = final_state.to(torch::kFloat32);
+  }
+
+  return {output, final_state_out};
+}
+
+}  // namespace xllm::kernel::npu

--- a/xllm/core/kernels/npu/xllm_ops/npu_mega_chunk_gdn.cpp
+++ b/xllm/core/kernels/npu/xllm_ops/npu_mega_chunk_gdn.cpp
@@ -85,7 +85,7 @@ std::pair<torch::Tensor, torch::Tensor> npu_mega_chunk_gdn(
   auto q_fp16 = q_normalized.to(torch::kFloat16);
   auto k_fp16 = k_normalized.to(torch::kFloat16);
   auto v_fp16 = v.to(torch::kFloat16);
-  auto g_fp16 = g.to(torch::kFloat16);
+  auto g_fp32 = g.to(torch::kFloat32);
   auto beta_fp16 = beta.to(torch::kFloat16);
 
   torch::Tensor cu_seqlens_int32;
@@ -128,18 +128,15 @@ std::pair<torch::Tensor, torch::Tensor> npu_mega_chunk_gdn(
   auto opts_fp32 = torch::TensorOptions(q.device()).dtype(torch::kFloat32);
 
   auto out = torch::empty({B, T, H, V}, opts_fp16);
-  auto g_sum = torch::empty({B, T, H}, opts_fp16);
-  auto g_t = torch::empty({B, num_chunks, H, kMegaChunkSize}, opts_fp16);
-  auto beta_t = torch::empty({B, num_chunks, H, kMegaChunkSize}, opts_fp16);
-  auto a = torch::empty({B, num_chunks, H, kMegaChunkSize, kMegaChunkSize},
-                        opts_fp16);
-  auto a_inv_f32 = torch::empty(
-      {B, num_chunks, H, kMegaChunkSize, kMegaChunkSize}, opts_fp32);
-  auto a_inv = torch::empty({B, num_chunks, H, kMegaChunkSize, kMegaChunkSize},
-                            opts_fp16);
-  auto w = torch::empty({B, num_chunks, H, K, V}, opts_fp16);
-  auto u = torch::empty({B, num_chunks, H, V}, opts_fp16);
-  auto h = torch::empty({B, num_chunks, H, K, V}, opts_fp16);
+  auto g_sum = torch::empty({B, T, H}, opts_fp32);
+  auto g_t = torch::empty({H, T}, opts_fp32);
+  auto beta_t = torch::empty({H, T}, opts_fp16);
+  auto a = torch::zeros({B, T, H, kMegaChunkSize}, opts_fp16);
+  auto a_inv_f32 = torch::zeros({B, T, H, kMegaChunkSize}, opts_fp32);
+  auto a_inv = torch::zeros({B, T, H, kMegaChunkSize}, opts_fp16);
+  auto w = torch::empty({B, T, H, V}, opts_fp16);
+  auto u = torch::empty({B, T, H, V}, opts_fp16);
+  auto h = torch::zeros({num_matrices, K, V}, opts_fp16);
   auto v_new = torch::empty({B, T, H, V}, opts_fp16);
 
   torch::Tensor initial_state_arg;
@@ -151,19 +148,21 @@ std::pair<torch::Tensor, torch::Tensor> npu_mega_chunk_gdn(
     initial_state_arg = torch::zeros({num_sequences, H, K, V}, opts_fp16);
   }
 
-  auto final_state = torch::empty({num_sequences, H, K, V}, opts_fp32);
+  auto final_state = torch::zeros({num_sequences * H, K, V}, opts_fp16);
 
   EXEC_NPU_CMD(aclnnMegaChunkGdn,
                q_fp16,
                k_fp16,
                v_fp16,
-               g_fp16,
+               g_fp32,
                beta_fp16,
                masks.mask_lower,
                masks.mask_full,
                masks.minus_identity,
                cu_seqlens_int32,
                initial_state_arg,
+               num_matrices,
+               has_initial_state,
                out,
                g_sum,
                g_t,
@@ -175,15 +174,14 @@ std::pair<torch::Tensor, torch::Tensor> npu_mega_chunk_gdn(
                u,
                h,
                v_new,
-               final_state,
-               num_matrices,
-               has_initial_state);
+               final_state);
 
   auto output = (out * scale_value).to(input_dtype);
 
   torch::Tensor final_state_out;
   if (output_final_state) {
-    final_state_out = final_state.to(torch::kFloat32);
+    final_state_out =
+        final_state.view({num_sequences, H, K, V}).to(torch::kFloat32);
   }
 
   return {output, final_state_out};

--- a/xllm/core/kernels/npu/xllm_ops/xllm_ops_api.h
+++ b/xllm/core/kernels/npu/xllm_ops/xllm_ops_api.h
@@ -356,4 +356,16 @@ void npu_inplace_partial_rotary_mul(torch::Tensor& x,
 void scatter_nd_update(torch::Tensor& var,
                        const torch::Tensor& indices,
                        const torch::Tensor& updates);
+
+std::pair<torch::Tensor, torch::Tensor> npu_mega_chunk_gdn(
+    torch::Tensor& q,
+    torch::Tensor& k,
+    torch::Tensor& v,
+    torch::Tensor& g,
+    torch::Tensor& beta,
+    const std::optional<float>& scale = std::nullopt,
+    const std::optional<torch::Tensor>& initial_state = std::nullopt,
+    bool output_final_state = false,
+    const std::optional<torch::Tensor>& cu_seqlens = std::nullopt,
+    bool use_qk_l2norm_in_kernel = false);
 }  // namespace xllm::kernel::npu

--- a/xllm/core/kernels/ops_api.cpp
+++ b/xllm/core/kernels/ops_api.cpp
@@ -1600,6 +1600,24 @@ std::pair<torch::Tensor, torch::Tensor> chunk_gated_delta_rule(
 #endif
 }
 
+std::pair<torch::Tensor, torch::Tensor> mega_chunk_gdn(
+    MegaChunkGdnParams& params) {
+#if defined(USE_NPU)
+  return npu::npu_mega_chunk_gdn(params.q,
+                                 params.k,
+                                 params.v,
+                                 params.g,
+                                 params.beta,
+                                 params.scale,
+                                 params.initial_state,
+                                 params.output_final_state,
+                                 params.cu_seqlens,
+                                 params.use_qk_l2norm_in_kernel);
+#else
+  NOT_IMPLEMENTED();
+#endif
+}
+
 void npu_inplace_partial_rotary_mul(NpuInplacePartialRotaryMulParams& params) {
 #if defined(USE_NPU)
   npu::npu_inplace_partial_rotary_mul(params.x,

--- a/xllm/core/kernels/ops_api.h
+++ b/xllm/core/kernels/ops_api.h
@@ -244,6 +244,9 @@ torch::Tensor build_split_qkv_rmsnorm_mrope_gather_pattern(
 std::pair<torch::Tensor, torch::Tensor> chunk_gated_delta_rule(
     ChunkGatedDeltaRuleParams& params);
 
+std::pair<torch::Tensor, torch::Tensor> mega_chunk_gdn(
+    MegaChunkGdnParams& params);
+
 torch::Tensor recurrent_gated_delta_rule(
     const torch::Tensor& query,
     const torch::Tensor& key,

--- a/xllm/core/kernels/param.h
+++ b/xllm/core/kernels/param.h
@@ -1640,6 +1640,31 @@ struct ChunkGatedDeltaRuleParams {
   // Whether to apply L2 norm to q and k inside the kernel. Default: false.
   bool use_qk_l2norm_in_kernel = false;
 };
+
+struct MegaChunkGdnParams {
+  // Query tensor. Shape: [B, T, Hqk, K]. Dtype: bfloat16.
+  torch::Tensor q;
+  // Key tensor. Shape: [B, T, Hqk, K]. Dtype: bfloat16.
+  torch::Tensor k;
+  // Value tensor. Shape: [B, T, H, V]. Dtype: bfloat16.
+  torch::Tensor v;
+  // Gating tensor. Shape: [B, T, H]. Dtype: float32 or bfloat16.
+  torch::Tensor g;
+  // Beta tensor. Shape: [B, T, H]. Dtype: float32 or bfloat16.
+  torch::Tensor beta;
+  // Optional scale factor for attention. Default: K^(-0.5).
+  std::optional<float> scale = std::nullopt;
+  // Optional initial state tensor. Shape: [N, H, K, V]. Dtype: bfloat16.
+  std::optional<torch::Tensor> initial_state = std::nullopt;
+  // Whether to output the final state.
+  bool output_final_state = false;
+  // Optional cumulative sequence lengths. Shape: [num_sequences + 1]. Dtype:
+  // int32.
+  std::optional<torch::Tensor> cu_seqlens = std::nullopt;
+  // Whether to apply L2 norm to q and k inside the kernel. Default: false.
+  bool use_qk_l2norm_in_kernel = false;
+};
+
 struct HcPostParams {
   torch::Tensor x;
   torch::Tensor residual;

--- a/xllm/core/layers/common/dsa_metadata.h
+++ b/xllm/core/layers/common/dsa_metadata.h
@@ -168,6 +168,7 @@ struct DSAMetadata {
 
   // MLU-only canonical query sequence lengths consumed by DSA operators.
   // q_cu_seq_lens: (batch_size+1,) with leading 0.
+  // (kv_cu_seq_lens is declared above in the general sequence-length section.)
   torch::Tensor q_cu_seq_lens;
   // kv_seq_lens / q_seq_lens: (batch_size,) per-sequence lengths.
   torch::Tensor kv_seq_lens;

--- a/xllm/core/layers/common/dsa_metadata.h
+++ b/xllm/core/layers/common/dsa_metadata.h
@@ -166,10 +166,9 @@ struct DSAMetadata {
   int64_t swa_max_history_len = 0;
   int64_t swa_max_context_len = 0;
 
-  // MLU-only canonical sequence lengths consumed by DSA operators.
-  // q_cu_seq_lens / kv_cu_seq_lens: (batch_size+1,) with leading 0.
+  // MLU-only canonical query sequence lengths consumed by DSA operators.
+  // q_cu_seq_lens: (batch_size+1,) with leading 0.
   torch::Tensor q_cu_seq_lens;
-  torch::Tensor kv_cu_seq_lens;
   // kv_seq_lens / q_seq_lens: (batch_size,) per-sequence lengths.
   torch::Tensor kv_seq_lens;
   torch::Tensor q_seq_lens;

--- a/xllm/core/layers/npu_torch/qwen3_gated_delta_net_base.cpp
+++ b/xllm/core/layers/npu_torch/qwen3_gated_delta_net_base.cpp
@@ -710,12 +710,12 @@ torch::Tensor Qwen3GatedDeltaNetBaseImpl::forward(
     torch::Tensor packed_g_tensor = torch::cat(packed_g, 0).unsqueeze(0);
     torch::Tensor packed_beta_tensor = torch::cat(packed_beta, 0).unsqueeze(0);
 
-    xllm::kernel::ChunkGatedDeltaRuleParams chunk_gated_delta_params;
-    chunk_gated_delta_params.q = packed_processed_q;
-    chunk_gated_delta_params.k = packed_processed_k;
-    chunk_gated_delta_params.v = packed_processed_v;
-    chunk_gated_delta_params.g = packed_g_tensor;
-    chunk_gated_delta_params.beta = packed_beta_tensor;
+    xllm::kernel::MegaChunkGdnParams mega_chunk_gdn_params;
+    mega_chunk_gdn_params.q = packed_processed_q;
+    mega_chunk_gdn_params.k = packed_processed_k;
+    mega_chunk_gdn_params.v = packed_processed_v;
+    mega_chunk_gdn_params.g = packed_g_tensor;
+    mega_chunk_gdn_params.beta = packed_beta_tensor;
     // Get initial state from ssm_cache for sequences with previous state
     // Shape: [batch_size, num_heads, head_k_dim, head_v_dim]
     torch::Tensor initial_state_tensor =
@@ -733,14 +733,13 @@ torch::Tensor Qwen3GatedDeltaNetBaseImpl::forward(
       initial_state_tensor =
           initial_state_tensor.transpose(-1, -2).contiguous();
     }
-    chunk_gated_delta_params.initial_state = initial_state_tensor;
-    chunk_gated_delta_params.output_final_state = true;
-    chunk_gated_delta_params.cu_seqlens = attn_metadata.q_cu_seq_lens;
-    chunk_gated_delta_params.head_first = false;
-    chunk_gated_delta_params.use_qk_l2norm_in_kernel = true;
+    mega_chunk_gdn_params.initial_state = initial_state_tensor;
+    mega_chunk_gdn_params.output_final_state = true;
+    mega_chunk_gdn_params.cu_seqlens = attn_metadata.q_cu_seq_lens;
+    mega_chunk_gdn_params.use_qk_l2norm_in_kernel = true;
     torch::Tensor packed_core_attn_out;
     std::tie(packed_core_attn_out, last_recurrent_state) =
-        xllm::kernel::chunk_gated_delta_rule(chunk_gated_delta_params);
+        xllm::kernel::mega_chunk_gdn(mega_chunk_gdn_params);
     core_attn_out = torch::zeros_like(processed_v);
     int64_t packed_offset = 0;
     for (int64_t batch_idx = 0; batch_idx < batch_size; ++batch_idx) {


### PR DESCRIPTION
## Description

Adds the NPU MegaChunkGDN fused operator path for Qwen3.5 Gated Delta Net.

This PR wires the new NPU operator through xLLM kernel APIs, metadata, and the Qwen3.5 GDN layer path to reduce overhead in the gated delta net execution path. It also removes an unrelated global `-Wno-error=maybe-uninitialized` CMake change after verifying the NPU build passes without it.

## Related Issues

None.

## Change Type

- [ ] Bug fix
- [x] New feature
- [x] Performance improvement
- [ ] Refactor
- [ ] Documentation
- [ ] Test
- [ ] Build or CI

## Pull Request Checklist

Thank you for contributing to xLLM. Before requesting review, please make sure the following items are complete.

### PR Title and Commit Messages

- [x] The PR title and each commit message follow the xLLM commit format: `<type>: <subject>`.

> Allowed types: feat, bugfix, docs, test, refactor, chore, style, revert, perf, model, build, release.  
> The subject should use clear English, start with a verb, include at least 4 words, and end with `.`.

### Pre-commit Checks

- [x] I have installed `pre-commit` by running `pip install pre-commit` or an equivalent command.
- [x] I have installed the hooks with `pre-commit install`.
- [x] I have run `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

### Self Review

- [ ] I have self-reviewed the code according to `.agents/skills/code-review/references/custom-code-style.md`, especially code written or assisted by AI.
- [ ] I have rebased this PR onto the latest `main` branch.

### Build and Test Coverage

- [ ] Tests have been added or updated as needed.
- [ ] CUDA: `python setup.py build test` has passed on a CUDA machine.
- [x] NPU: `python setup.py build test` has passed on an NPU machine.
- [ ] MLU: `python setup.py build test` has passed on an MLU machine.

## Reviewer Notes

Validation performed:
- `python setup.py build --device npu` passed on an NPU machine.
- Qwen3.5-27B TP2 no-MTP 2k/2k concurrency=1 , 2 ,4 benchmark passed 4/4 requests on continuous NPU devices `10,11`.
