### PR TITLE
build: align xllm_ops marker path with ascend opp vendor. 

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -29,7 +29,7 @@ if(USE_NPU)
   )
 
   if(DEFINED ENV{ASCEND_OPP_PATH} AND NOT "$ENV{ASCEND_OPP_PATH}" STREQUAL "")
-    set(XLLM_OPS_MARKER_PATH "$ENV{ASCEND_OPP_PATH}/vendors/custom_xllm_math/.xllm_ops_git_head")
+    set(XLLM_OPS_MARKER_PATH "$ENV{ASCEND_OPP_PATH}/vendors/xllm/.xllm_ops_git_head")
   else()
     message(FATAL_ERROR "ASCEND_OPP_PATH is not initialized for NPU build.")
   endif()
@@ -57,7 +57,9 @@ if(USE_NPU)
     endif()
 
     ## Adapt to the modification in DeekSeekV4 where the installation path of xllm_ops has been changed to custom_xllm_math
-    if(EXISTS "$ENV{NPU_HOME_PATH}/opp/vendors/custom_xllm_math/op_api/include/aclnnop")
+    ## Probe under ASCEND_OPP_PATH (the same root the marker is written to, and the
+    ## one scripts/build_support/utils.py reads) so the read and write paths cannot diverge.
+    if(EXISTS "$ENV{ASCEND_OPP_PATH}/vendors/custom_xllm_math/op_api/include/aclnnop")
       set(XLLM_OPS_MARKER_PATH "$ENV{ASCEND_OPP_PATH}/vendors/custom_xllm_math/.xllm_ops_git_head")
     endif()
     message(STATUS "XLLM_OPS_MARKER_PATH: ${XLLM_OPS_MARKER_PATH}")

--- a/scripts/build_support/utils.py
+++ b/scripts/build_support/utils.py
@@ -388,13 +388,25 @@ def _get_cmake_cache_path() -> str:
 
 def _get_xllm_ops_marker_path() -> str:
     opp_root = os.getenv("ASCEND_OPP_PATH")
-    if opp_root:
-        opp_root = os.path.abspath(os.path.expanduser(opp_root))
-        return os.path.join(opp_root, "vendors", "xllm", ".xllm_ops_git_head")
+    if not opp_root:
+        logger.error("ASCEND_OPP_PATH is not initialized for NPU build.")
+        _print_manual_check_commands(["echo $ASCEND_OPP_PATH"])
+        exit(1)
 
-    logger.error("ASCEND_OPP_PATH is not initialized for NPU build.")
-    _print_manual_check_commands(["echo $ASCEND_OPP_PATH"])
-    exit(1)
+    opp_root = os.path.abspath(os.path.expanduser(opp_root))
+    # Adapt to the DeepSeekV4 / CANN 9.0 change where xllm_ops installs under the
+    # "custom_xllm_math" vendor instead of "xllm". The marker must be read from the
+    # same vendor directory CMakeLists.txt writes it to; otherwise the read and
+    # write paths diverge and the incremental-build cache never hits. Detection
+    # mirrors CMakeLists.txt exactly (same ASCEND_OPP_PATH root and probe path).
+    vendor = "xllm"
+    if os.path.isdir(
+        os.path.join(
+            opp_root, "vendors", "custom_xllm_math", "op_api", "include", "aclnnop"
+        )
+    ):
+        vendor = "custom_xllm_math"
+    return os.path.join(opp_root, "vendors", vendor, ".xllm_ops_git_head")
 
 
 def _clear_xllm_ops_cache_git_head(cache_path: str) -> bool:


### PR DESCRIPTION
## Description

Backport the NPU `xllm_ops` build-cache fixes to `release/v0.10.0`.

This PR cherry-picks the following fixes from `main`:

- `#1707`: align the `xllm_ops` git-head marker read/write path with the actual Ascend OPP vendor directory.
- `#1728`: update `third_party/xllm_ops` so caller-provided external CMake build caches are checked before configure and stale source-root mismatches are cleared.

Together these fixes prevent NPU CI from repeatedly rebuilding `xllm_ops` because marker paths diverge, and prevent self-hosted NPU CI from reusing a stale persistent `xllm_ops` CMake cache created from a different source root.

## 中文说明

这个 PR 是面向 `release/v0.10.0` 的回合修复，回合了 `main` 上两个和 NPU `xllm_ops` 构建缓存相关的修复：

- `#1707`：统一 `xllm_ops` git-head marker 的读写路径，确保 CMake 写入 marker 的 vendor 目录和 Python 预检查读取的 vendor 目录一致。
- `#1728`：更新 `third_party/xllm_ops` 引用，在调用方显式设置 `XLLM_OPS_BUILD_DIR` 时，构建前检查外部 `CMakeCache.txt` 中的 `CMAKE_HOME_DIRECTORY`。如果 cached source root 和当前 `xllm_ops` source root 不一致，则清理这个 stale 外部 build cache 并重新生成。

该修复用于解决 NPU self-hosted CI 上的两个问题：一是 `xllm_ops` 安装 marker 路径不一致导致增量构建缓存无法命中；二是外部持久化 CMake build cache 可能来自旧 source root，导致 CMake 报 source directory mismatch。

## Related Issues

Related CI failure: https://github.com/jd-opensource/xllm/actions/runs/27339200059/job/80910537297

Related PRs:

- #1707
- #1728

## Change Type

- [x] Bug fix
- [ ] New feature
- [ ] Performance improvement
- [ ] Refactor
- [ ] Documentation
- [ ] Test
- [x] Build or CI

## Pull Request Checklist

Thank you for contributing to xLLM. Before requesting review, please make sure the following items are complete.

### PR Title and Commit Messages

- [x] The PR title and each commit message follow the xLLM commit format: `<type>: <subject>`.

> Allowed types: feat, bugfix, docs, test, refactor, chore, style, revert, perf, model, build, release.
> The subject should use clear English, start with a verb, include at least 4 words, and end with `.`.

### Pre-commit Checks

- [ ] I have installed `pre-commit` by running `pip install pre-commit` or an equivalent command.
- [ ] I have installed the hooks with `pre-commit install`.
- [ ] I have run `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

### Self Review

- [x] I have self-reviewed the code according to `.agents/skills/code-review/references/custom-code-style.md`, especially code written or assisted by AI.
- [ ] I have rebased this PR onto the latest `main` branch. Not applicable for this release backport; the branch is based on `release/v0.10.0`.

### Build and Test Coverage

- [ ] Tests have been added or updated as needed.
- [ ] CUDA: `python setup.py build test` has passed on a CUDA machine.
- [x] NPU: `python setup.py build test` has passed on an NPU machine.
- [ ] MLU: `python setup.py build test` has passed on an MLU machine.

## Reviewer Notes

This is a focused backport to `release/v0.10.0`; it contains only the two cherry-picked build-cache fixes and the corresponding `third_party/xllm_ops` submodule reference update.

Validation for the cherry-picked change set was run through `/export/home/zhangminchao1/git_repositories/xllm_scripts/rebuild_xllm_in_container.sh` inside the NPU container after simulating the GitHub NPU CI stale-cache scenario:

- Created a stale external cache at `/export/home/zhangminchao1/npu_xllm_ops_build_cache/CMakeCache.txt` with `CMAKE_HOME_DIRECTORY` pointing to `third_party/xllm_ops`.
- Forced `xllm_ops` precompile by removing the installed `.xllm_ops_git_head` marker.
- Confirmed the new cleanup path was hit:
  - `XLLM_OPS_BUILD_DIR is set, clear stale xllm_ops CMake cache before configure`
  - `cached source=.../third_party/xllm_ops, current source=.../third_party/xllm_ops/xllm_ops`
- Confirmed the CMake source-directory mismatch did not reappear.
- Final result: `100% tests passed, 0 tests failed out of 608`; `All tests passed!`

## 中文验证说明

我在本地 NPU 容器中模拟了 GitHub NPU CI 的 stale cache 场景：先在外部 cache 目录中写入旧的 `CMAKE_HOME_DIRECTORY=third_party/xllm_ops`，再删除已安装的 `.xllm_ops_git_head` marker 强制触发 `xllm_ops` 预编译。重新执行容器内构建测试后，日志确认命中了 stale cache 清理逻辑，并且没有再出现 CMake source directory mismatch。最终 NPU build/test 通过，CTest 结果为 `100% tests passed, 0 tests failed out of 608`。
