### PR TITLE
feat: replace conv1d Triton operator with AscendC operator for Qwen3.5.

### DIFF
--- a/xllm/core/framework/model/causal_lm.h
+++ b/xllm/core/framework/model/causal_lm.h
@@ -67,6 +67,8 @@ class CausalLM : public torch::nn::Module {
 
   virtual bool requires_graph_forward_metadata() { return false; }
 
+  virtual bool is_hybrid_linear_attention() { return false; }
+
   virtual std::unique_ptr<ModelGraphMetadataState>
   create_graph_forward_metadata_state() {
     return nullptr;
@@ -183,6 +185,14 @@ class CausalLMImpl : public CausalLM {
       return model_->requires_graph_forward_metadata();
     } else {
       return CausalLM::requires_graph_forward_metadata();
+    }
+  }
+
+  bool is_hybrid_linear_attention() override {
+    if constexpr (detail::has_is_hybrid_linear_attention<Model>::value) {
+      return model_->is_hybrid_linear_attention();
+    } else {
+      return CausalLM::is_hybrid_linear_attention();
     }
   }
 

--- a/xllm/core/framework/model/causal_vlm.h
+++ b/xllm/core/framework/model/causal_vlm.h
@@ -61,6 +61,14 @@ class CausalVLMImpl : public CausalVLM {
     return model_->forward(tokens, positions, kv_caches, parameters);
   }
 
+  bool is_hybrid_linear_attention() override {
+    if constexpr (detail::has_is_hybrid_linear_attention<Model>::value) {
+      return model_->is_hybrid_linear_attention();
+    } else {
+      return CausalLM::is_hybrid_linear_attention();
+    }
+  }
+
   torch::Tensor pooler(const torch::Tensor& hidden_states,
                        const torch::Tensor& seleted_idxes) override {
     if constexpr (detail::has_pooler<Model>::value) {

--- a/xllm/core/framework/model/model_input_params.h
+++ b/xllm/core/framework/model/model_input_params.h
@@ -42,6 +42,9 @@ limitations under the License.
 #include "util/tensor_helper.h"
 
 namespace xllm {
+namespace npu {
+struct AclGraphTaskUpdateContext;
+}  // namespace npu
 namespace layer {
 struct AttentionMetadata;
 }  // namespace layer
@@ -861,6 +864,9 @@ struct GraphInput {
   torch::Tensor expanded_block_tables;
   torch::Tensor expanded_tiling_data;
   std::vector<int32_t> expanded_kv_seq_lens_vec;
+#if defined(USE_NPU)
+  std::shared_ptr<npu::AclGraphTaskUpdateContext> acl_graph_task_update_context;
+#endif
 
   GraphInput to(const torch::Device& device) const {
     GraphInput out;
@@ -872,6 +878,9 @@ struct GraphInput {
     out.expanded_block_tables = safe_to(expanded_block_tables, device, true);
     out.expanded_tiling_data = safe_to(expanded_tiling_data, device, true);
     out.expanded_kv_seq_lens_vec = expanded_kv_seq_lens_vec;
+#if defined(USE_NPU)
+    out.acl_graph_task_update_context = acl_graph_task_update_context;
+#endif
     return out;
   }
 };
@@ -890,6 +899,7 @@ struct ModelInputParams {
     params.dit_forward_input = dit_forward_input.to(device);
     params.is_spec_verify = is_spec_verify;
     params.num_accepted_tokens = safe_to(num_accepted_tokens, device, true);
+    params.num_accepted_tokens_host = num_accepted_tokens_host;
     params.dsa_topk_indices = safe_to(dsa_topk_indices, device, true);
     for (const auto& table : multi_block_tables) {
       params.multi_block_tables.push_back(
@@ -1017,6 +1027,7 @@ struct ModelInputParams {
   bool is_spec_verify = false;
   torch::Tensor num_accepted_tokens;
   torch::Tensor dsa_topk_indices;
+  std::vector<int64_t> num_accepted_tokens_host;
 
   RecModelInputParams rec_params;
 

--- a/xllm/core/framework/model/model_traits.h
+++ b/xllm/core/framework/model/model_traits.h
@@ -128,6 +128,15 @@ struct has_requires_graph_forward_metadata<
     : std::true_type {};
 
 template <typename T, typename = void>
+struct has_is_hybrid_linear_attention : std::false_type {};
+
+template <typename T>
+struct has_is_hybrid_linear_attention<
+    T,
+    std::void_t<decltype(std::declval<T>()->is_hybrid_linear_attention())>>
+    : std::true_type {};
+
+template <typename T, typename = void>
 struct has_create_graph_forward_metadata_state : std::false_type {};
 
 template <typename T>

--- a/xllm/core/kernels/npu/npu_causal_conv1d.cpp
+++ b/xllm/core/kernels/npu/npu_causal_conv1d.cpp
@@ -19,17 +19,19 @@ limitations under the License.
 
 namespace xllm::kernel::npu {
 
-torch::Tensor causal_conv1d(const torch::Tensor& x,
-                            const torch::Tensor& weight,
-                            const torch::Tensor& conv_state,
-                            const std::optional<torch::Tensor>& bias_opt,
-                            const torch::IntArrayRef query_start_loc_opt,
-                            const torch::IntArrayRef cache_indices_opt,
-                            const torch::IntArrayRef initial_state_mode_opt,
-                            const torch::IntArrayRef num_accepted_tokens_opt,
-                            int64_t activation_mode,
-                            int64_t pad_slot_id,
-                            int64_t run_mode) {
+void causal_conv1d_out(const torch::Tensor& output,
+                       const torch::Tensor& x,
+                       const torch::Tensor& weight,
+                       const torch::Tensor& conv_state,
+                       const std::optional<torch::Tensor>& bias_opt,
+                       const torch::IntArrayRef query_start_loc_opt,
+                       const torch::IntArrayRef cache_indices_opt,
+                       const torch::IntArrayRef initial_state_mode_opt,
+                       const torch::IntArrayRef num_accepted_tokens_opt,
+                       int64_t activation_mode,
+                       int64_t pad_slot_id,
+                       int64_t run_mode) {
+  check_tensor(output, "output", "causal_conv1d");
   check_tensor(x, "x", "causal_conv1d");
   check_tensor(weight, "weight", "causal_conv1d");
   check_tensor(conv_state, "conv_state", "causal_conv1d");
@@ -39,7 +41,6 @@ torch::Tensor causal_conv1d(const torch::Tensor& x,
     bias_tensor = bias_opt.value();
   }
 
-  torch::Tensor output = torch::empty(x.sizes(), x.options());
   EXEC_NPU_CMD(aclnnCausalConv1d,
                x,
                weight,
@@ -53,6 +54,32 @@ torch::Tensor causal_conv1d(const torch::Tensor& x,
                pad_slot_id,
                run_mode,
                output);
+}
+
+torch::Tensor causal_conv1d(const torch::Tensor& x,
+                            const torch::Tensor& weight,
+                            const torch::Tensor& conv_state,
+                            const std::optional<torch::Tensor>& bias_opt,
+                            const torch::IntArrayRef query_start_loc_opt,
+                            const torch::IntArrayRef cache_indices_opt,
+                            const torch::IntArrayRef initial_state_mode_opt,
+                            const torch::IntArrayRef num_accepted_tokens_opt,
+                            int64_t activation_mode,
+                            int64_t pad_slot_id,
+                            int64_t run_mode) {
+  torch::Tensor output = torch::empty(x.sizes(), x.options());
+  causal_conv1d_out(output,
+                    x,
+                    weight,
+                    conv_state,
+                    bias_opt,
+                    query_start_loc_opt,
+                    cache_indices_opt,
+                    initial_state_mode_opt,
+                    num_accepted_tokens_opt,
+                    activation_mode,
+                    pad_slot_id,
+                    run_mode);
   return output;
 }
 

--- a/xllm/core/kernels/npu/npu_ops_api.h
+++ b/xllm/core/kernels/npu/npu_ops_api.h
@@ -321,4 +321,17 @@ torch::Tensor causal_conv1d(const torch::Tensor& x,
                             int64_t activation_mode,
                             int64_t pad_slot_id,
                             int64_t run_mode);
+
+void causal_conv1d_out(const torch::Tensor& output,
+                       const torch::Tensor& x,
+                       const torch::Tensor& weight,
+                       const torch::Tensor& conv_state,
+                       const std::optional<torch::Tensor>& bias_opt,
+                       const torch::IntArrayRef query_start_loc_opt,
+                       const torch::IntArrayRef cache_indices_opt,
+                       const torch::IntArrayRef initial_state_mode_opt,
+                       const torch::IntArrayRef num_accepted_tokens_opt,
+                       int64_t activation_mode,
+                       int64_t pad_slot_id,
+                       int64_t run_mode);
 }  // namespace xllm::kernel::npu

--- a/xllm/core/kernels/ops_api.cpp
+++ b/xllm/core/kernels/ops_api.cpp
@@ -1690,4 +1690,34 @@ torch::Tensor causal_conv1d(const torch::Tensor& x,
   NOT_IMPLEMENTED();
 #endif
 }
+
+void causal_conv1d_out(const torch::Tensor& output,
+                       const torch::Tensor& x,
+                       const torch::Tensor& weight,
+                       const torch::Tensor& conv_state,
+                       const std::optional<torch::Tensor>& bias_opt,
+                       const torch::IntArrayRef query_start_loc_opt,
+                       const torch::IntArrayRef cache_indices_opt,
+                       const torch::IntArrayRef initial_state_mode_opt,
+                       const torch::IntArrayRef num_accepted_tokens_opt,
+                       int64_t activation_mode,
+                       int64_t pad_slot_id,
+                       int64_t run_mode) {
+#if defined(USE_NPU)
+  npu::causal_conv1d_out(output,
+                         x,
+                         weight,
+                         conv_state,
+                         bias_opt,
+                         query_start_loc_opt,
+                         cache_indices_opt,
+                         initial_state_mode_opt,
+                         num_accepted_tokens_opt,
+                         activation_mode,
+                         pad_slot_id,
+                         run_mode);
+#else
+  NOT_IMPLEMENTED();
+#endif
+}
 }  // namespace xllm::kernel

--- a/xllm/core/kernels/ops_api.h
+++ b/xllm/core/kernels/ops_api.h
@@ -271,4 +271,17 @@ torch::Tensor causal_conv1d(const torch::Tensor& x,
                             int64_t activation_mode,
                             int64_t pad_slot_id,
                             int64_t run_mode);
+
+void causal_conv1d_out(const torch::Tensor& output,
+                       const torch::Tensor& x,
+                       const torch::Tensor& weight,
+                       const torch::Tensor& conv_state,
+                       const std::optional<torch::Tensor>& bias_opt,
+                       const torch::IntArrayRef query_start_loc_opt,
+                       const torch::IntArrayRef cache_indices_opt,
+                       const torch::IntArrayRef initial_state_mode_opt,
+                       const torch::IntArrayRef num_accepted_tokens_opt,
+                       int64_t activation_mode,
+                       int64_t pad_slot_id,
+                       int64_t run_mode);
 }  // namespace xllm::kernel

--- a/xllm/core/layers/npu_torch/qwen3_gated_delta_net_base.cpp
+++ b/xllm/core/layers/npu_torch/qwen3_gated_delta_net_base.cpp
@@ -378,49 +378,6 @@ torch::Tensor run_causal_conv1d_graph_update(
   return output;
 }
 
-torch::Tensor run_spec_verify_conv(const torch::Tensor& mixed_qkv,
-                                   const torch::Tensor& conv_cache,
-                                   const torch::Tensor& logical_state_indices,
-                                   const torch::Tensor& num_accepted_tokens,
-                                   const torch::Tensor& q_cu_seq_lens,
-                                   const torch::Tensor& conv_weight,
-                                   int32_t conv_kernel_size) {
-  const int64_t batch_size = mixed_qkv.size(0);
-  const int64_t seq_len = mixed_qkv.size(2);
-  const int64_t expanded_state_len = conv_cache.size(1);
-  CHECK_EQ(expanded_state_len, conv_kernel_size - 1 + seq_len - 1)
-      << "unexpected speculative conv cache len, expected "
-      << (conv_kernel_size - 1 + seq_len - 1) << ", got " << expanded_state_len;
-
-  xllm::kernel::CausalConv1dUpdateParams conv1d_params;
-  conv1d_params.x = mixed_qkv.transpose(1, 2)
-                        .reshape({batch_size * seq_len, mixed_qkv.size(1)})
-                        .contiguous();
-  conv1d_params.conv_state = conv_cache.transpose(1, 2);
-  conv1d_params.weight = conv_weight;
-  conv1d_params.activation = true;
-  conv1d_params.conv_state_indices =
-      expand_sequence_tensor_to_batch(
-          logical_state_indices, batch_size, "logical_state_indices")
-          .contiguous();
-  conv1d_params.num_accepted_tokens =
-      expand_sequence_tensor_to_batch(
-          num_accepted_tokens.to(mixed_qkv.device(), torch::kInt32),
-          batch_size,
-          "num_accepted_tokens")
-          .contiguous();
-  conv1d_params.query_start_loc = q_cu_seq_lens;
-  conv1d_params.max_query_len = static_cast<int32_t>(seq_len);
-
-  torch::Tensor conv_output =
-      xllm::kernel::causal_conv1d_update(conv1d_params)
-          .view({batch_size, seq_len, mixed_qkv.size(1)})
-          .transpose(1, 2)
-          .contiguous();
-
-  return conv_output;
-}
-
 torch::Tensor run_spec_verify_gated_delta_rule(
     torch::Tensor query,
     torch::Tensor key,

--- a/xllm/core/layers/npu_torch/qwen3_gated_delta_net_base.cpp
+++ b/xllm/core/layers/npu_torch/qwen3_gated_delta_net_base.cpp
@@ -18,6 +18,7 @@ limitations under the License.
 #include <tuple>
 
 #include "xllm/core/kernels/ops_api.h"
+#include "xllm/core/platform/npu/acl_graph_task_update_context.h"
 
 namespace xllm {
 namespace layer {
@@ -316,6 +317,67 @@ torch::Tensor expand_sequence_tensor_to_batch(const torch::Tensor& tensor,
       .contiguous();
 }
 
+torch::Tensor run_causal_conv1d_graph_update(
+    const std::shared_ptr<xllm::npu::AclGraphTaskUpdateContext>& graph_context,
+    const torch::Tensor& x,
+    const torch::Tensor& weight,
+    const torch::Tensor& conv_state,
+    const std::optional<torch::Tensor>& bias,
+    const std::vector<int64_t>& query_start_loc,
+    const std::vector<int64_t>& cache_indices,
+    const std::vector<int64_t>& num_accepted_tokens,
+    xllm::npu::CausalConv1dGraphBranch branch) {
+  CHECK(graph_context != nullptr && graph_context->capturing)
+      << "causal_conv1d graph update can only be registered during capture";
+  CHECK(!query_start_loc.empty())
+      << "query_start_loc must be populated for causal_conv1d graph update";
+  CHECK_EQ(query_start_loc.back(), x.size(0))
+      << "query_start_loc must be padded to x.shape[0] during graph capture";
+  CHECK_EQ(cache_indices.size() + 1, query_start_loc.size())
+      << "cache_indices must be sequence-scoped";
+  if (branch == xllm::npu::CausalConv1dGraphBranch::kSpecVerify) {
+    CHECK_EQ(num_accepted_tokens.size(), cache_indices.size())
+        << "num_accepted_tokens must be sequence-scoped for spec verify";
+  }
+
+  const std::vector<int64_t> empty_host_args;
+  torch::Tensor output = torch::empty_like(x);
+  c10_npu::NPUStream stream = c10_npu::getCurrentNPUStream();
+  auto event = std::make_shared<c10_npu::NPUEvent>(ACL_EVENT_EXTERNAL);
+  event->block(stream);
+  event->reset(stream);
+
+  c10_npu::graph_task_group_begin(stream);
+  xllm::kernel::causal_conv1d_out(output,
+                                  x,
+                                  weight,
+                                  conv_state,
+                                  bias,
+                                  torch::IntArrayRef(query_start_loc),
+                                  torch::IntArrayRef(cache_indices),
+                                  torch::IntArrayRef(empty_host_args),
+                                  torch::IntArrayRef(num_accepted_tokens),
+                                  1,
+                                  xllm::npu::kCausalConv1dGraphPadSlotId,
+                                  1);
+  c10_npu::NPUTaskGroupHandle handle = c10_npu::graph_task_group_end(stream);
+
+  xllm::npu::CausalConv1dGraphTask task;
+  task.output = output;
+  task.x = x;
+  task.weight = weight;
+  task.conv_state = conv_state;
+  task.bias = bias;
+  task.activation_mode = 1;
+  task.pad_slot_id = xllm::npu::kCausalConv1dGraphPadSlotId;
+  task.run_mode = 1;
+  task.branch = branch;
+  task.handle = handle;
+  task.event = std::move(event);
+  graph_context->causal_conv1d_tasks.emplace_back(std::move(task));
+  return output;
+}
+
 torch::Tensor run_spec_verify_conv(const torch::Tensor& mixed_qkv,
                                    const torch::Tensor& conv_cache,
                                    const torch::Tensor& logical_state_indices,
@@ -550,6 +612,9 @@ torch::Tensor Qwen3GatedDeltaNetBaseImpl::forward(
   const bool use_spec_verify = input_params.is_spec_verify;
   const bool is_any_prefill =
       attn_metadata.is_prefill || attn_metadata.is_chunked_prefill;
+  auto graph_context = input_params.graph.acl_graph_task_update_context;
+  const bool register_conv1d_graph_update =
+      graph_context != nullptr && graph_context->capturing;
 
   if (!use_spec_verify && is_any_prefill) {
     torch::IntArrayRef num_accepted_tokens_opt;
@@ -573,37 +638,50 @@ torch::Tensor Qwen3GatedDeltaNetBaseImpl::forward(
 
     mixed_qkv = reshape_qkvz_with_pad(attn_metadata, mixed_qkv);
     mixed_qkv = mixed_qkv.transpose(1, 2);
-  } else if (use_spec_verify) {
-    CHECK(input_params.num_accepted_tokens.defined())
-        << "num_accepted_tokens must be populated for Qwen3.5 spec verify";
-    torch::Tensor conv_weight_for_update =
-        conv_weight.transpose(0, 1).contiguous();
-    torch::Tensor pre_conv_mixed_qkv = mixed_qkv.transpose(1, 2);
-    mixed_qkv =
-        run_spec_verify_conv(pre_conv_mixed_qkv,
-                             conv_cache,
-                             logical_state_indices,
-                             input_params.num_accepted_tokens.to(device),
-                             attn_metadata.q_cu_seq_lens,
-                             conv_weight_for_update,
-                             conv_kernel_size_);
   } else {
-    torch::Tensor conv_weight_for_update =
-        conv_weight.transpose(0, 1).contiguous();
-    xllm::kernel::CausalConv1dUpdateParams conv1d_params;
-    conv1d_params.x = mixed_qkv.reshape({-1, mixed_qkv.size(-1)});
-    conv1d_params.conv_state = conv_cache.transpose(1, 2);
-    conv1d_params.weight = conv_weight_for_update;
-    conv1d_params.conv_state_indices = logical_state_indices;
-    conv1d_params.block_idx_last_scheduled_token =
-        std::optional<torch::Tensor>();
-    conv1d_params.initial_state_idx = std::optional<torch::Tensor>();
-    conv1d_params.query_start_loc = attn_metadata.q_cu_seq_lens;
-    conv1d_params.max_query_len = attn_metadata.max_query_len;
-    mixed_qkv = xllm::kernel::causal_conv1d_update(conv1d_params);
-    // Reshape back to 3D [batch_size, dim, seq_len]
-    mixed_qkv =
-        mixed_qkv.view({batch_size, -1, mixed_qkv.size(-1)}).contiguous();
+    if (use_spec_verify) {
+      CHECK(input_params.num_accepted_tokens.defined())
+          << "num_accepted_tokens must be populated for Qwen3.5 spec verify";
+    }
+    torch::Tensor conv_input = reshape_qkvz_unpad(attn_metadata, mixed_qkv);
+    const auto& num_accepted = use_spec_verify
+                                   ? input_params.num_accepted_tokens_host
+                                   : std::vector<int64_t>();
+    const std::vector<int64_t> linear_state_indices_host(
+        input_params.embedding.linear_state_ids.begin(),
+        input_params.embedding.linear_state_ids.end());
+    if (register_conv1d_graph_update) {
+      const auto conv1d_branch =
+          use_spec_verify ? xllm::npu::CausalConv1dGraphBranch::kSpecVerify
+                          : xllm::npu::CausalConv1dGraphBranch::kDecode;
+      mixed_qkv =
+          run_causal_conv1d_graph_update(graph_context,
+                                         conv_input,
+                                         conv_weight,
+                                         conv_cache,
+                                         std::optional<torch::Tensor>(),
+                                         input_params.parallel.query_start_loc,
+                                         linear_state_indices_host,
+                                         num_accepted,
+                                         conv1d_branch);
+    } else {
+      torch::Tensor output = torch::empty_like(conv_input);
+      xllm::kernel::causal_conv1d_out(
+          output,
+          conv_input,
+          conv_weight,
+          conv_cache,
+          std::optional<torch::Tensor>(),
+          torch::IntArrayRef(input_params.parallel.query_start_loc),
+          torch::IntArrayRef(linear_state_indices_host),
+          torch::IntArrayRef(std::vector<int64_t>()),
+          torch::IntArrayRef(num_accepted),
+          1,
+          xllm::npu::kCausalConv1dGraphPadSlotId,
+          1);
+      mixed_qkv = output;
+    }
+    mixed_qkv = reshape_qkvz_with_pad(attn_metadata, mixed_qkv);
     mixed_qkv = mixed_qkv.transpose(1, 2);
   }
   const bool fla_ssm_state_layout = use_fla_ssm_state_layout();

--- a/xllm/core/platform/npu/CMakeLists.txt
+++ b/xllm/core/platform/npu/CMakeLists.txt
@@ -6,6 +6,7 @@ cc_library(
   HDRS
     npu_layer_synchronizer.h
     device_capture_lock.h
+    acl_graph_task_update_context.h
   SRCS
     npu_layer_synchronizer.cpp
   DEPS

--- a/xllm/core/platform/npu/acl_graph_task_update_context.h
+++ b/xllm/core/platform/npu/acl_graph_task_update_context.h
@@ -1,0 +1,72 @@
+/* Copyright 2026 The xLLM Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://github.com/jd-opensource/xllm/blob/main/LICENSE
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#pragma once
+
+#include <torch/torch.h>
+
+#include <cstdint>
+#include <memory>
+#include <optional>
+#include <vector>
+
+#if defined(__GNUC__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wattributes"
+#endif
+
+#include "torch_npu/csrc/core/npu/NPUEvent.h"
+#include "torch_npu/csrc/core/npu/NPUGraph.h"
+
+#if defined(__GNUC__)
+#pragma GCC diagnostic pop
+#endif
+
+namespace xllm::npu {
+
+constexpr int64_t kCausalConv1dGraphPadSlotId = -1;
+
+enum class CausalConv1dGraphBranch {
+  kDecode,
+  kSpecVerify,
+};
+
+struct CausalConv1dGraphTask {
+  torch::Tensor output;
+  torch::Tensor x;
+  torch::Tensor weight;
+  torch::Tensor conv_state;
+  std::optional<torch::Tensor> bias;
+  int64_t activation_mode = 1;
+  int64_t pad_slot_id = kCausalConv1dGraphPadSlotId;
+  int64_t run_mode = 1;
+  CausalConv1dGraphBranch branch = CausalConv1dGraphBranch::kDecode;
+  c10_npu::NPUTaskGroupHandle handle{};
+  std::shared_ptr<c10_npu::NPUEvent> event;
+};
+
+struct AclGraphTaskUpdateContext {
+  void begin_capture() {
+    capturing = true;
+    causal_conv1d_tasks.clear();
+  }
+
+  void end_capture() { capturing = false; }
+
+  bool capturing = false;
+  std::vector<CausalConv1dGraphTask> causal_conv1d_tasks;
+};
+
+}  // namespace xllm::npu

--- a/xllm/core/runtime/acl_graph_executor_impl.cpp
+++ b/xllm/core/runtime/acl_graph_executor_impl.cpp
@@ -67,8 +67,7 @@ bool AclGraph::capture(CausalLM* model,
                        const torch::Tensor& positions,
                        const ModelInputParams& params,
                        std::vector<KVCache>& kv_cache,
-                       uint32_t bucket_num_tokens,
-                       const ModelArgs& args) {
+                       uint32_t bucket_num_tokens) {
   // Save bucket num_tokens for this graph instance
   num_tokens_ = bucket_num_tokens;
 
@@ -522,8 +521,7 @@ ModelOutput AclGraphExecutorImpl::run(const torch::Tensor& tokens,
                                      positions_tensor,
                                      params_single,
                                      kv_caches,
-                                     bucket_num_tokens,
-                                     args_);
+                                     bucket_num_tokens);
   } catch (const std::exception& e) {
     LOG(ERROR) << "ACL graph capture threw exception for bucket num_tokens="
                << bucket_num_tokens << ": " << e.what()

--- a/xllm/core/runtime/acl_graph_executor_impl.cpp
+++ b/xllm/core/runtime/acl_graph_executor_impl.cpp
@@ -19,6 +19,7 @@ limitations under the License.
 #include <c10/core/TensorOptions.h>
 #include <glog/logging.h>
 #include <torch/torch.h>
+#include <torch_npu/csrc/core/npu/NPUGuard.h>
 #include <torch_npu/csrc/libs/init_npu.h>
 #include <torch_npu/torch_npu.h>
 
@@ -33,7 +34,9 @@ limitations under the License.
 #include <torch_npu/csrc/framework/utils/OpPreparation.h>
 #endif
 #include "core/common/metrics.h"
+#include "core/kernels/ops_api.h"
 #include "core/platform/device.h"
+#include "core/platform/npu/acl_graph_task_update_context.h"
 #include "core/util/utils.h"
 #include "platform/npu/device_capture_lock.h"
 
@@ -56,11 +59,6 @@ std::pair<torch::Tensor, torch::Tensor> find_attention_plan_kv_cache(
   return {torch::Tensor(), torch::Tensor()};
 }
 
-bool is_qwen3_5_model_type(const std::string& model_type) {
-  return model_type == "qwen3_5" || model_type == "qwen3_5_moe" ||
-         model_type == "qwen3_5_text" || model_type.rfind("qwen3_5_", 0) == 0;
-}
-
 }  // namespace
 
 bool AclGraph::capture(CausalLM* model,
@@ -69,7 +67,8 @@ bool AclGraph::capture(CausalLM* model,
                        const torch::Tensor& positions,
                        const ModelInputParams& params,
                        std::vector<KVCache>& kv_cache,
-                       uint32_t bucket_num_tokens) {
+                       uint32_t bucket_num_tokens,
+                       const ModelArgs& args) {
   // Save bucket num_tokens for this graph instance
   num_tokens_ = bucket_num_tokens;
 
@@ -110,6 +109,12 @@ bool AclGraph::capture(CausalLM* model,
       model,
       persistent_param_.persistent_positions(num_tokens_),
       graph_params.value());
+
+  if (model->is_hybrid_linear_attention()) {
+    graph_task_context_ = std::make_shared<AclGraphTaskUpdateContext>();
+    graph_task_context_->begin_capture();
+    graph_params->graph.acl_graph_task_update_context = graph_task_context_;
+  }
 
   // Synchronize stream to ensure all data is copied to graph persistent buffers
   aclrtSynchronizeStream(stream);
@@ -157,6 +162,9 @@ bool AclGraph::capture(CausalLM* model,
       persistent_param_.set_aux_hidden_states(forward_result.aux_hidden_states);
     }
     graph_.capture_end();
+    if (graph_task_context_ != nullptr) {
+      graph_task_context_->end_capture();
+    }
     // Lock is automatically released here when lock goes out of scope
     if (need_restore_stream) {
       c10_npu::setCurrentNPUStream(
@@ -166,11 +174,67 @@ bool AclGraph::capture(CausalLM* model,
   // Synchronize and test replay to verify graph capture
   aclrtSynchronizeStream(graph_stream_);
   aclrtSynchronizeStream(stream);
-
   graph_.replay();
-
+  update_graph_tasks(graph_params.value());
   make_current_stream_wait_for_graph(stream);
   return true;
+}
+
+void AclGraph::update_graph_tasks(const ModelInputParams& params) {
+  if (graph_task_context_ == nullptr ||
+      graph_task_context_->causal_conv1d_tasks.empty()) {
+    return;
+  }
+
+  const std::vector<int64_t> empty_host_args;
+  CHECK(!params.parallel.query_start_loc.empty())
+      << "causal_conv1d graph update requires padded query_start_loc";
+  CHECK(!params.embedding.linear_state_ids.empty())
+      << "causal_conv1d graph update requires padded cache indices";
+
+  std::vector<int64_t> linear_state_indices_host(
+      params.embedding.linear_state_ids.begin(),
+      params.embedding.linear_state_ids.end());
+
+  c10_npu::NPUStream update_stream = update_stream_.value();
+  c10_npu::NPUStreamGuard stream_guard(update_stream);
+
+  for (auto& task : graph_task_context_->causal_conv1d_tasks) {
+    CHECK_EQ(params.parallel.query_start_loc.back(), task.x.size(0))
+        << "causal_conv1d graph update host args must be padded to the "
+           "capture x.shape[0]";
+    CHECK_EQ(linear_state_indices_host.size() + 1,
+             params.parallel.query_start_loc.size())
+        << "cache_indices must be sequence-scoped";
+
+    const std::vector<int64_t>& num_accepted_tokens =
+        task.branch == CausalConv1dGraphBranch::kSpecVerify
+            ? params.num_accepted_tokens_host
+            : empty_host_args;
+    if (task.branch == CausalConv1dGraphBranch::kSpecVerify) {
+      CHECK_EQ(num_accepted_tokens.size(), linear_state_indices_host.size())
+          << "spec causal_conv1d graph update requires accepted-token counts";
+    }
+
+    c10_npu::graph_task_update_begin(update_stream, task.handle);
+    xllm::kernel::causal_conv1d_out(
+        task.output,
+        task.x,
+        task.weight,
+        task.conv_state,
+        task.bias,
+        torch::IntArrayRef(params.parallel.query_start_loc),
+        torch::IntArrayRef(linear_state_indices_host),
+        torch::IntArrayRef(empty_host_args),
+        torch::IntArrayRef(num_accepted_tokens),
+        task.activation_mode,
+        task.pad_slot_id,
+        task.run_mode);
+    c10_npu::graph_task_update_end(update_stream);
+    if (task.event != nullptr) {
+      task.event->record(update_stream);
+    }
+  }
 }
 
 AclGraph::~AclGraph() {
@@ -191,6 +255,7 @@ void AclGraph::initialize_capture_stream(c10::DeviceIndex device_index) {
   // must be performed on a non-default stream (see
   // torch_npu/csrc/core/npu/NPUGraph.cpp:159).
   capture_stream_ = c10_npu::getStreamFromPool(true, device_index);
+  update_stream_ = c10_npu::getStreamFromPool(true, device_index);
   device_index_ = device_index;
   CHECK_EQ(aclrtCreateEventWithFlag(&replay_done_event_, ACL_EVENT_SYNC),
            ACL_SUCCESS)
@@ -247,7 +312,8 @@ ModelOutput AclGraph::replay(CausalLM* model,
   // be updated when Full Attention layers are involved, which is determined
   // by k_cache being valid and non-empty
   auto [k_cache, v_cache] = find_attention_plan_kv_cache(kv_cache);
-  const bool needs_graph_metadata = model->requires_graph_forward_metadata();
+  const bool needs_graph_metadata = model->requires_graph_forward_metadata() ||
+                                    model->is_hybrid_linear_attention();
   std::optional<ModelInputParams> graph_params =
       persistent_param_.update(tokens,
                                k_cache,
@@ -270,7 +336,11 @@ ModelOutput AclGraph::replay(CausalLM* model,
   aclrtStream stream = c10_npu::getCurrentNPUStream().stream();
 
   graph_.replay();
-
+  if (model->is_hybrid_linear_attention()) {
+    CHECK(graph_params.has_value())
+        << "update() should return ModelInputParams for graph task update";
+    update_graph_tasks(graph_params.value());
+  }
   make_current_stream_wait_for_graph(stream);
 
   // Return the actual num_tokens portion of ModelOutput
@@ -284,9 +354,10 @@ AclGraphExecutorImpl::AclGraphExecutorImpl(CausalLM* model,
                                            const torch::Device& device,
                                            const runtime::Options& options)
     : model_(model), args_(args), device_(device), options_(options) {
-  const bool need_update_attn_mask = is_qwen3_5_model_type(args.model_type());
+  const bool need_update_attn_mask = model->is_hybrid_linear_attention();
+  const bool is_hybrid_linear_attn = model->is_hybrid_linear_attention();
   persistent_param_ = std::make_unique<GraphPersistentParam>(
-      args_, device_, options_, need_update_attn_mask);
+      args_, device_, options_, need_update_attn_mask, is_hybrid_linear_attn);
 }
 
 ForwardInput AclGraphExecutorImpl::prepare_inputs(Batch& batch) {
@@ -322,11 +393,11 @@ ModelOutput AclGraphExecutorImpl::run(const torch::Tensor& tokens,
     COUNTER_INC(num_model_execution_total_eager);
     return model_->forward(tokens, positions, kv_caches, params);
   }
-  if (in_spec_verify_phase && !is_qwen3_5_model_type(args_.model_type())) {
+  if (in_spec_verify_phase && !model_->is_hybrid_linear_attention()) {
     LOG_FIRST_N(WARNING, 1)
         << "Falling back to eager mode for spec verify because the "
            "chunked-prefill validate graph path is currently only adapted for "
-           "Qwen3.5.";
+           "hybrid linear attention models.";
     COUNTER_INC(num_model_execution_total_eager);
     return model_->forward(tokens, positions, kv_caches, params);
   }
@@ -451,7 +522,8 @@ ModelOutput AclGraphExecutorImpl::run(const torch::Tensor& tokens,
                                      positions_tensor,
                                      params_single,
                                      kv_caches,
-                                     bucket_num_tokens);
+                                     bucket_num_tokens,
+                                     args_);
   } catch (const std::exception& e) {
     LOG(ERROR) << "ACL graph capture threw exception for bucket num_tokens="
                << bucket_num_tokens << ": " << e.what()

--- a/xllm/core/runtime/acl_graph_executor_impl.h
+++ b/xllm/core/runtime/acl_graph_executor_impl.h
@@ -46,6 +46,8 @@ limitations under the License.
 
 namespace xllm::npu {
 
+struct AclGraphTaskUpdateContext;
+
 // ACL graph executor using libtorch NPUGraph for memory management
 // NPUGraph provides mempool to manage temporary tensors during forward pass
 class AclGraph {
@@ -66,7 +68,8 @@ class AclGraph {
                const torch::Tensor& positions,
                const ModelInputParams& params,
                std::vector<KVCache>& kv_cache,
-               uint32_t bucket_num_tokens);
+               uint32_t bucket_num_tokens,
+               const ModelArgs& args);
 
   // Replay captured graph with new input data
   ModelOutput replay(CausalLM* model,
@@ -91,6 +94,8 @@ class AclGraph {
                                     const torch::Tensor& positions,
                                     ModelInputParams& params);
 
+  void update_graph_tasks(const ModelInputParams& params);
+
   // NPUGraph with mempool for managing temporary tensors during forward pass
   c10_npu::NPUGraph graph_;
   uint32_t num_tokens_;
@@ -105,6 +110,9 @@ class AclGraph {
   aclrtStream graph_stream_ = nullptr;
   aclrtEvent replay_done_event_ = nullptr;
   c10::DeviceIndex device_index_;
+  std::shared_ptr<AclGraphTaskUpdateContext> graph_task_context_;
+
+  std::optional<c10_npu::NPUStream> update_stream_;
 };
 
 // Executor implementation using ACL graph optimization

--- a/xllm/core/runtime/acl_graph_executor_impl.h
+++ b/xllm/core/runtime/acl_graph_executor_impl.h
@@ -68,8 +68,7 @@ class AclGraph {
                const torch::Tensor& positions,
                const ModelInputParams& params,
                std::vector<KVCache>& kv_cache,
-               uint32_t bucket_num_tokens,
-               const ModelArgs& args);
+               uint32_t bucket_num_tokens);
 
   // Replay captured graph with new input data
   ModelOutput replay(CausalLM* model,

--- a/xllm/core/runtime/acl_graph_persistent_param.cpp
+++ b/xllm/core/runtime/acl_graph_persistent_param.cpp
@@ -126,25 +126,22 @@ int64_t infer_actual_batch_size(const ModelInputParams& params) {
   return 0;
 }
 
-bool is_qwen3_5_model_type(const std::string& model_type) {
-  return model_type == "qwen3_5" || model_type == "qwen3_5_moe" ||
-         model_type == "qwen3_5_text" || model_type.rfind("qwen3_5_", 0) == 0;
-}
-
 }  // namespace
 
 // GraphPersistentParam implementation
 GraphPersistentParam::GraphPersistentParam(const ModelArgs& args,
                                            const torch::Device& device,
                                            const runtime::Options& options,
-                                           bool need_update_attn_mask)
+                                           bool need_update_attn_mask,
+                                           bool is_hybrid_linear_attention)
     : args_(args),
       device_(device),
       options_(options),
       context_for_plan_(nullptr),
       custom_pa_op_for_plan_(nullptr),
       stream_for_plan_(nullptr),
-      need_update_attn_mask_(need_update_attn_mask) {
+      need_update_attn_mask_(need_update_attn_mask),
+      is_hybrid_linear_attention_(is_hybrid_linear_attention) {
   // Determine whether attention plan needs to be updated based on model type
   // Future logic can be extended here for more complex model-specific behavior
   need_update_attention_plan_ = (args.model_type() != "deepseek_v32" &&
@@ -589,7 +586,7 @@ std::optional<ModelInputParams> GraphPersistentParam::update(
       params.meta.batch_forward_type.is_chunked_prefill();
   const bool is_qwen3_5_spec_verify_chunked_prefill =
       params.is_spec_verify && is_chunked_prefill &&
-      is_qwen3_5_model_type(args_.model_type());
+      is_hybrid_linear_attention_;
   CHECK(is_decode || is_qwen3_5_spec_verify_chunked_prefill)
       << "ACL graph persistent param only supports decode or Qwen3.5 "
          "spec-verify chunked prefill";
@@ -827,8 +824,7 @@ std::optional<ModelInputParams> GraphPersistentParam::update(
           ? params.attention.device.q_cu_seq_lens.size(0)
           : 0;
   if (has_q_cu && q_cu_size > 0) {
-    const bool use_qwen3_5_query_start_loc =
-        is_qwen3_5_model_type(args_.model_type());
+    const bool use_qwen3_5_query_start_loc = is_hybrid_linear_attention_;
     const bool input_has_leading_zero =
         params.is_spec_verify && use_qwen3_5_query_start_loc;
     const int64_t required_q_cu_seq_lens =
@@ -900,9 +896,9 @@ std::optional<ModelInputParams> GraphPersistentParam::update(
     padded_q_seq_lens_vec[static_cast<size_t>(i)] =
         is_chunked_prefill ? q_max_seq_len : 1;
   }
-  const bool use_expanded_spec_decode_attention =
-      params.is_spec_verify && is_chunked_prefill &&
-      is_qwen3_5_model_type(args_.model_type());
+  const bool use_expanded_spec_decode_attention = params.is_spec_verify &&
+                                                  is_chunked_prefill &&
+                                                  is_hybrid_linear_attention_;
   std::vector<int32_t> expanded_kv_seq_lens_vec;
   if (use_expanded_spec_decode_attention) {
     expanded_kv_seq_lens_vec = update_expanded_spec_decode_attention(
@@ -1030,8 +1026,7 @@ std::optional<ModelInputParams> GraphPersistentParam::update(
           expanded_kv_seq_lens_vec;
     }
     if (params.attention.device.q_cu_seq_lens.defined()) {
-      const bool use_qwen3_5_query_start_loc =
-          is_qwen3_5_model_type(args_.model_type());
+      const bool use_qwen3_5_query_start_loc = is_hybrid_linear_attention_;
       params_for_capture->attention.device.q_cu_seq_lens = q_cu_seq_lens_.slice(
           /*dim=*/0,
           /*start=*/0,
@@ -1050,6 +1045,38 @@ std::optional<ModelInputParams> GraphPersistentParam::update(
     replace_capture_cp_ep_padding(
         params.parallel.cp_ep_padding_data,
         params_for_capture->parallel.cp_ep_padding_data);
+
+    auto& qsl = params_for_capture->parallel.query_start_loc;
+    qsl.clear();
+    qsl.reserve(static_cast<size_t>(padded_batch_size) + 1);
+    qsl.emplace_back(0);
+    for (int64_t i = 0; i < padded_batch_size; ++i) {
+      qsl.emplace_back(qsl.back() +
+                       padded_q_seq_lens_vec[static_cast<size_t>(i)]);
+    }
+
+    if (!params.parallel.has_initial_state.empty()) {
+      auto& his = params_for_capture->parallel.has_initial_state;
+      his = params.parallel.has_initial_state;
+      if (his.size() > static_cast<size_t>(actual_batch_size)) {
+        his.resize(static_cast<size_t>(actual_batch_size));
+      }
+      his.resize(static_cast<size_t>(padded_batch_size), 0);
+    }
+
+    if (params.num_accepted_tokens.defined() &&
+        params.num_accepted_tokens.numel() > 0) {
+      torch::Tensor nat_host = params.num_accepted_tokens.to(torch::kCPU)
+                                   .to(torch::kLong)
+                                   .contiguous();
+      const int64_t copy_size =
+          std::min<int64_t>(actual_batch_size, nat_host.numel());
+      const int64_t* data = nat_host.data_ptr<int64_t>();
+      params_for_capture->num_accepted_tokens_host.assign(data,
+                                                          data + copy_size);
+      params_for_capture->num_accepted_tokens_host.resize(
+          static_cast<size_t>(padded_batch_size), 1);
+    }
 
     return params_for_capture;
   }

--- a/xllm/core/runtime/acl_graph_persistent_param.h
+++ b/xllm/core/runtime/acl_graph_persistent_param.h
@@ -44,7 +44,8 @@ class GraphPersistentParam final {
   GraphPersistentParam(const ModelArgs& args,
                        const torch::Device& device,
                        const runtime::Options& options,
-                       bool need_update_attn_mask = false);
+                       bool need_update_attn_mask = false,
+                       bool is_hybrid_linear_attention = false);
 
   ~GraphPersistentParam();
 
@@ -251,6 +252,9 @@ class GraphPersistentParam final {
 
   // Flag indicating whether attention mask needs to be updated
   bool need_update_attn_mask_;
+  // Flag indicating whether the model uses hybrid linear attention
+  // (e.g., Qwen3.5/Next with gated delta net layers)
+  bool is_hybrid_linear_attention_;
   // Flag indicating whether attention plan needs to be updated based on model
   // type
   bool need_update_attention_plan_;

--- a/xllm/core/runtime/mtp_worker_impl.cpp
+++ b/xllm/core/runtime/mtp_worker_impl.cpp
@@ -1313,6 +1313,8 @@ void MTPWorkerImpl::prepare_validate_inputs(const ForwardInput& input,
     }
     input_params.num_accepted_tokens =
         torch::tensor(accepted_prefix_lengths, token_options);
+    input_params.num_accepted_tokens_host.assign(
+        accepted_prefix_lengths.begin(), accepted_prefix_lengths.end());
   }
 
   input_params.attention.rebuild_device_buffer(device_);

--- a/xllm/models/llm/qwen3_next_hybrid_base.h
+++ b/xllm/models/llm/qwen3_next_hybrid_base.h
@@ -307,6 +307,8 @@ class Qwen3HybridForCausalLMImplBase : public torch::nn::Module {
   }
   virtual void update_expert_weight(int32_t layer_id) { return; }
 
+  bool is_hybrid_linear_attention() { return true; }
+
   layer::LmHead get_lm_head() { return lm_head_; }
 
   void set_lm_head(layer::LmHead& head) { lm_head_ = head; }


### PR DESCRIPTION
## Description
- Add causal_conv1d_out API with pre-allocated output for graph task update
- Introduce AclGraphTaskUpdateContext to record and replay conv1d tasks
- Update AclGraph capture/replay to handle conv1d task parameter updates
- Add is_hybrid_linear_attention() model interface for Qwen3.5

Performance :
1. Average TPOT reduced by 10%+. 
2. Qwen3.5 27B TP4 MTP: 20k input + 1k output && 1 batch, avg tpot 9.7ms.

## Change Type

- [ ] Bug fix
- [x] New feature
- [ ] Performance improvement
- [ ] Refactor
- [ ] Documentation
- [ ] Test
- [ ] Build or CI

### Build and Test Coverage

- [x] Tests have been added or updated as needed.
- [ ] CUDA: `python setup.py build test` has passed on a CUDA machine.
- [x] NPU: `python setup.py build test` has passed on an NPU machine.
- [ ] MLU: `python setup.py build test` has passed on an MLU machine.
