### PR TITLE
feat: support in-batch prefix cache.

### DIFF
--- a/tests/core/framework/block/block_manager_test.cpp
+++ b/tests/core/framework/block/block_manager_test.cpp
@@ -446,4 +446,29 @@ TEST(BlockManagerPoolTest, SequenceUpdateBlockHashes) {
             0);
 }
 
+// In-batch prefix cache publishes only the full blocks covered by the given
+// token budget. When the budget is overestimated, cache() must clamp to the
+// sequence's own tokens and register just the complete blocks.
+TEST(BlockManagerPoolTest,
+     CachePrefixClampsToSequenceTokensWhenBudgetIsOverestimated) {
+  ScopedValue<int32_t> max_seqs_guard(
+      &SchedulerConfig::get_instance().max_seqs_per_batch(), 2);
+
+  BlockManagerPool::Options options;
+  options.num_blocks(16).host_num_blocks(0).block_size(4).enable_prefix_cache(
+      true);
+  // Leak the pool intentionally: with prefix cache enabled, the cached block
+  // stays referenced by the prefix-cache table at teardown, which would trip
+  // the free-list check in ~BlockManagerImpl.
+  auto* pool = new BlockManagerPool(options, /*dp_size=*/1);
+
+  Sequence seq = MakeSequence(0, /*prompt_tokens=*/{1, 2, 3, 4, 5, 6, 7});
+  ASSERT_TRUE(pool->allocate(&seq));
+
+  // num_tokens (8) is larger than the 7 real tokens. cache() must clamp to the
+  // sequence tokens, so only the single full block (tokens [0, 4)) is cached.
+  EXPECT_NO_FATAL_FAILURE(pool->cache(&seq, /*num_tokens=*/8));
+  EXPECT_EQ(pool->num_blocks_in_prefix_cache()[0], 1u);
+}
+
 }  // namespace xllm

--- a/tests/core/scheduler/continuous_scheduler_test.cpp
+++ b/tests/core/scheduler/continuous_scheduler_test.cpp
@@ -8,6 +8,7 @@
 #include <optional>
 
 #include "chunked_prefill_scheduler.h"
+#include "core/framework/config/kv_cache_config.h"
 #include "core/framework/config/parallel_config.h"
 #include "core/framework/config/scheduler_config.h"
 #include "distributed_runtime/engine.h"
@@ -1027,7 +1028,146 @@ TEST(ContinuousSchedulerTest, PauseAbortCancelsRunningRequests) {
   EXPECT_EQ(scheduler->get_waiting_requests_num(), 0);     // NOT requeued
 
   (void)engine.release();
+}
 
+// With in-batch prefix cache enabled, a request admitted earlier in the same
+// scheduling step publishes its full prompt blocks, so a later request with the
+// same prefix reuses them (shared_kv_blocks_num > 0). When disabled, the later
+// request shares nothing within the same batch.
+TEST(ContinuousSchedulerTest,
+     InBatchCachePrefillBlocksIncreaseSharedBlocksForLaterRequests) {
+  const auto run_with_in_batch_prefix_cache =
+      [](bool enable_in_batch_prefix_cache) -> size_t {
+    KVCacheConfig& kv_config = KVCacheConfig::get_instance();
+    const bool saved_prefix_cache = kv_config.enable_prefix_cache();
+    const bool saved_in_batch = kv_config.enable_in_batch_prefix_cache();
+    kv_config.enable_prefix_cache(true);
+    kv_config.enable_in_batch_prefix_cache(enable_in_batch_prefix_cache);
+
+    ContinuousScheduler::Options opt =
+        create_scheduler_options(1024, 16, 0, 1024, 1);
+    auto engine =
+        std::make_unique<FakeEngine>(32, 4, /*enable_prefix_cache=*/true);
+    auto scheduler = std::make_unique<ContinuousScheduler>(engine.get(), opt);
+
+    auto first_request =
+        generate_request_with_prompt_tokens({1, 2, 3, 4, 5, 6, 7, 8}, 1, 30000);
+    auto second_request =
+        generate_request_with_prompt_tokens({1, 2, 3, 4, 5, 6, 7, 8}, 1, 30000);
+    scheduler->add_request(first_request);
+    scheduler->add_request(second_request);
+
+    auto batch = scheduler->prepare_batch_test();
+    EXPECT_EQ(batch.size(), 1);
+    EXPECT_EQ(batch[0].size(), 2);
+    EXPECT_EQ(first_request->sequences()[0]->kv_state().shared_kv_blocks_num(),
+              0u);
+    const size_t second_shared =
+        second_request->sequences()[0]->kv_state().shared_kv_blocks_num();
+
+    scheduler.reset();
+    // Leak the engine: cached blocks live in the prefix-cache table at
+    // teardown.
+    (void)engine.release();
+
+    kv_config.enable_prefix_cache(saved_prefix_cache);
+    kv_config.enable_in_batch_prefix_cache(saved_in_batch);
+    return second_shared;
+  };
+
+  const size_t shared_when_enabled = run_with_in_batch_prefix_cache(true);
+  const size_t shared_when_disabled = run_with_in_batch_prefix_cache(false);
+
+  EXPECT_GT(shared_when_enabled, shared_when_disabled);
+  EXPECT_GT(shared_when_enabled, 0u);
+  EXPECT_EQ(shared_when_disabled, 0u);
+}
+
+// End-to-end check through the real scheduler path (add_request ->
+// prepare_batch): two requests that share only the first 2 of 3 prompt blocks
+// are admitted in the same step. With in-batch prefix cache on, the first
+// request publishes its full blocks, so the second request reuses EXACTLY the 2
+// shared blocks (the 3rd differs and must be a miss). The prefix-cache table
+// also grows by the published blocks. With it off, nothing is shared in-batch.
+TEST(ContinuousSchedulerTest, InBatchCacheReusesPartialPrefixWithinSameBatch) {
+  // block_size = 4. 12 tokens => 3 full blocks per prompt.
+  const std::vector<int32_t> prompt_a = {1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12};
+  // Shares blocks [0,1] (tokens 0..7) with prompt_a, differs in block 2.
+  const std::vector<int32_t> prompt_b = {
+      1, 2, 3, 4, 5, 6, 7, 8, 99, 100, 101, 102};
+
+  struct Result {
+    size_t first_shared = 0;
+    size_t second_shared = 0;
+    size_t batch_count = 0;
+    size_t batch0_size = 0;
+    size_t prefix_cache_blocks = 0;
+  };
+
+  const auto run = [&](bool enable_in_batch_prefix_cache) -> Result {
+    KVCacheConfig& kv_config = KVCacheConfig::get_instance();
+    const bool saved_prefix_cache = kv_config.enable_prefix_cache();
+    const bool saved_in_batch = kv_config.enable_in_batch_prefix_cache();
+    kv_config.enable_prefix_cache(true);
+    kv_config.enable_in_batch_prefix_cache(enable_in_batch_prefix_cache);
+
+    ContinuousScheduler::Options opt =
+        create_scheduler_options(1024, 16, 0, 1024, 1);
+    auto engine =
+        std::make_unique<FakeEngine>(64, 4, /*enable_prefix_cache=*/true);
+    auto scheduler = std::make_unique<ContinuousScheduler>(engine.get(), opt);
+
+    auto first_request =
+        generate_request_with_prompt_tokens(prompt_a, 1, 30000);
+    auto second_request =
+        generate_request_with_prompt_tokens(prompt_b, 1, 30000);
+    scheduler->add_request(first_request);
+    scheduler->add_request(second_request);
+
+    auto batch = scheduler->prepare_batch_test();
+
+    Result r;
+    r.batch_count = batch.size();
+    r.batch0_size = batch.empty() ? 0 : batch[0].size();
+    r.first_shared =
+        first_request->sequences()[0]->kv_state().shared_kv_blocks_num();
+    r.second_shared =
+        second_request->sequences()[0]->kv_state().shared_kv_blocks_num();
+    r.prefix_cache_blocks =
+        engine->block_manager_pool()->num_blocks_in_prefix_cache()[0];
+
+    scheduler.reset();
+    // Leak the engine: published blocks live in the prefix-cache table at
+    // teardown, which would otherwise trip the free-list check in dtor.
+    (void)engine.release();
+
+    kv_config.enable_prefix_cache(saved_prefix_cache);
+    kv_config.enable_in_batch_prefix_cache(saved_in_batch);
+    return r;
+  };
+
+  const Result enabled = run(true);
+  const Result disabled = run(false);
+
+  // Both requests must land in the same batch for in-batch reuse to apply.
+  EXPECT_EQ(enabled.batch_count, 1u);
+  EXPECT_EQ(enabled.batch0_size, 2u);
+
+  // The first request can never share within the same step (nothing published
+  // yet when it is admitted).
+  EXPECT_EQ(enabled.first_shared, 0u);
+
+  // The second request reuses exactly the 2 identical leading blocks.
+  EXPECT_EQ(enabled.second_shared, 2u);
+
+  // Prefix cache holds first request's 3 blocks plus the second request's one
+  // distinct trailing block => 4 unique blocks.
+  EXPECT_EQ(enabled.prefix_cache_blocks, 4u);
+
+  // With the feature disabled, no in-batch sharing happens.
+  EXPECT_EQ(disabled.first_shared, 0u);
+  EXPECT_EQ(disabled.second_shared, 0u);
+  EXPECT_GT(enabled.second_shared, disabled.second_shared);
 }
 
 }  // namespace xllm

--- a/xllm/core/common/global_flags.h
+++ b/xllm/core/common/global_flags.h
@@ -53,6 +53,8 @@ DECLARE_string(kv_cache_dtype);
 
 DECLARE_bool(enable_prefix_cache);
 
+DECLARE_bool(enable_in_batch_prefix_cache);
+
 DECLARE_int64(max_encoder_cache_size);
 
 DECLARE_uint32(xxh3_128bits_seed);

--- a/xllm/core/framework/block/block_manager_pool.cpp
+++ b/xllm/core/framework/block/block_manager_pool.cpp
@@ -425,6 +425,46 @@ void BlockManagerPool::cache(Sequence* sequence) {
                                   sequence->block_hashes());
 }
 
+void BlockManagerPool::cache(Sequence* sequence, size_t num_tokens) {
+  CHECK(sequence != nullptr);
+  if (!options_.enable_prefix_cache()) {
+    return;
+  }
+  int32_t dp_rank = get_dp_rank(sequence);
+  if (block_managers_[dp_rank]->is_composite()) {
+    // Prefix cache is not supported for CompositeBlockManager yet.
+    return;
+  }
+
+  // Only publish the full blocks that are guaranteed to be computed: clamp the
+  // requested token budget to the blocks actually allocated and to the
+  // sequence's own tokens. The last partial block is dropped by the prefix
+  // cache insert (it aligns to block boundary).
+  const size_t block_size = static_cast<size_t>(options_.block_size());
+  const size_t available_tokens_num =
+      std::min({num_tokens,
+                sequence->kv_state().num_kv_blocks() * block_size,
+                sequence->tokens().size()});
+  const size_t existed_shared_blocks_num =
+      sequence->kv_state().shared_kv_blocks_num();
+  if (available_tokens_num <= existed_shared_blocks_num * block_size) {
+    return;
+  }
+
+  // Block hashes are already computed during allocate(); this is an idempotent
+  // no-op kept for safety so we do not depend on allocate() running first.
+  sequence->update_block_hashes(static_cast<uint32_t>(options_.block_size()),
+                                options_.hasher_type());
+  const auto token_ids = sequence->tokens().slice(0, available_tokens_num);
+  auto* blocks = sequence->kv_state().mutable_kv_blocks();
+  CHECK_GE(blocks->size(), existed_shared_blocks_num);
+  block_managers_[dp_rank]->cache(token_ids,
+                                  *blocks,
+                                  existed_shared_blocks_num,
+                                  sequence->mm_data(),
+                                  sequence->block_hashes());
+}
+
 void BlockManagerPool::get_merged_kvcache_event(KvCacheEvent* event) const {
   for (int32_t i = 0; i < block_managers_.size(); ++i) {
     block_managers_[i]->get_merged_kvcache_event(event);

--- a/xllm/core/framework/block/block_manager_pool.h
+++ b/xllm/core/framework/block/block_manager_pool.h
@@ -81,6 +81,7 @@ class BlockManagerPool : public KVCacheManager {
 
   virtual void allocate_shared(Sequence* sequence) override;
   virtual void cache(Sequence* sequence) override;
+  virtual void cache(Sequence* sequence, size_t num_tokens) override;
 
   virtual std::vector<std::vector<BlockTransferInfo>>*
   get_swap_block_transfer_infos() override;

--- a/xllm/core/framework/block/hierarchy_block_manager_pool.cpp
+++ b/xllm/core/framework/block/hierarchy_block_manager_pool.cpp
@@ -15,6 +15,8 @@ limitations under the License.
 
 #include "hierarchy_block_manager_pool.h"
 
+#include <algorithm>
+
 #include "block_manager_impl.h"
 #include "concurrent_block_manager_impl.h"
 
@@ -84,7 +86,13 @@ void HierarchyBlockManagerPool::deallocate(Sequence* sequence) {
         host_block_managers_[dp_rank]->allocate(needed_block_num));
   }
 
-  for (size_t i = cached_host_block_num; i < host_blocks->size(); i++) {
+  // Only offload blocks that are fully computed on device. In-batch prefix
+  // cache insertion may register blocks before they are computed, so bound the
+  // offload range by cached_device_block_num to avoid copying uncomputed data
+  // to host/store.
+  const size_t offload_end_block_num =
+      std::min({cached_device_block_num, host_blocks->size(), blocks->size()});
+  for (size_t i = cached_host_block_num; i < offload_end_block_num; i++) {
     if (blocks->at(i).ref_count() != 2) {
       continue;
     }

--- a/xllm/core/framework/block/kv_cache_manager.h
+++ b/xllm/core/framework/block/kv_cache_manager.h
@@ -55,6 +55,10 @@ class KVCacheManager {
 
   virtual void allocate_shared(Sequence* sequence) = 0;
   virtual void cache(Sequence* sequence) = 0;
+  // Cache only the full blocks covered by the first `num_tokens` tokens. Used
+  // by in-batch prefix cache to publish admitted prefill blocks before they are
+  // deallocated, so later requests in the same batch can share them.
+  virtual void cache(Sequence* sequence, size_t num_tokens) = 0;
 
   virtual std::vector<std::vector<BlockTransferInfo>>*
   get_swap_block_transfer_infos() = 0;

--- a/xllm/core/framework/config/kv_cache_config.cpp
+++ b/xllm/core/framework/config/kv_cache_config.cpp
@@ -43,6 +43,11 @@ DEFINE_bool(enable_prefix_cache,
             true,
             "Whether to enable the prefix cache for the block manager.");
 
+DEFINE_bool(enable_in_batch_prefix_cache,
+            false,
+            "Whether to cache admitted prefill full blocks into the prefix "
+            "cache so that later requests in the same batch can share them.");
+
 DEFINE_uint32(xxh3_128bits_seed, 1024, "Default XXH3 128-bits hash seed.");
 
 DEFINE_bool(
@@ -64,6 +69,7 @@ void KVCacheConfig::from_flags() {
   XLLM_CONFIG_ASSIGN_FROM_FLAG(max_memory_utilization);
   XLLM_CONFIG_ASSIGN_FROM_FLAG(kv_cache_dtype);
   XLLM_CONFIG_ASSIGN_FROM_FLAG(enable_prefix_cache);
+  XLLM_CONFIG_ASSIGN_FROM_FLAG(enable_in_batch_prefix_cache);
   XLLM_CONFIG_ASSIGN_FROM_FLAG(xxh3_128bits_seed);
   XLLM_CONFIG_ASSIGN_FROM_FLAG(enable_xtensor);
   XLLM_CONFIG_ASSIGN_FROM_FLAG(phy_page_granularity_size);
@@ -75,6 +81,7 @@ void KVCacheConfig::from_json(const JsonReader& json) {
   XLLM_CONFIG_ASSIGN_FROM_JSON(max_memory_utilization);
   XLLM_CONFIG_ASSIGN_FROM_JSON(kv_cache_dtype);
   XLLM_CONFIG_ASSIGN_FROM_JSON(enable_prefix_cache);
+  XLLM_CONFIG_ASSIGN_FROM_JSON(enable_in_batch_prefix_cache);
   XLLM_CONFIG_ASSIGN_FROM_JSON(xxh3_128bits_seed);
   XLLM_CONFIG_ASSIGN_FROM_JSON(enable_xtensor);
   XLLM_CONFIG_ASSIGN_FROM_JSON(phy_page_granularity_size);
@@ -93,6 +100,8 @@ void KVCacheConfig::append_config_json(
       config_json, default_config, kv_cache_dtype);
   APPEND_CONFIG_JSON_VALUE_IF_NOT_DEFAULT(
       config_json, default_config, enable_prefix_cache);
+  APPEND_CONFIG_JSON_VALUE_IF_NOT_DEFAULT(
+      config_json, default_config, enable_in_batch_prefix_cache);
   APPEND_CONFIG_JSON_VALUE_IF_NOT_DEFAULT(
       config_json, default_config, xxh3_128bits_seed);
   APPEND_CONFIG_JSON_VALUE_IF_NOT_DEFAULT(

--- a/xllm/core/framework/config/kv_cache_config.h
+++ b/xllm/core/framework/config/kv_cache_config.h
@@ -46,6 +46,7 @@ class KVCacheConfig final {
          "max_memory_utilization",
          "kv_cache_dtype",
          "enable_prefix_cache",
+         "enable_in_batch_prefix_cache",
          "xxh3_128bits_seed",
          "enable_xtensor",
          "phy_page_granularity_size"}};
@@ -61,6 +62,8 @@ class KVCacheConfig final {
   PROPERTY(std::string, kv_cache_dtype) = "auto";
 
   PROPERTY(bool, enable_prefix_cache) = true;
+
+  PROPERTY(bool, enable_in_batch_prefix_cache) = false;
 
   PROPERTY(uint32_t, xxh3_128bits_seed) = 1024;
 

--- a/xllm/core/framework/xtensor/xtensor_manager_pool.h
+++ b/xllm/core/framework/xtensor/xtensor_manager_pool.h
@@ -40,6 +40,9 @@ class XTensorManagerPool final : public KVCacheManager {
 
   // unimplemented functions
   void cache(Sequence* sequence) override { NOT_IMPLEMENTED(); }
+  void cache(Sequence* sequence, size_t num_tokens) override {
+    NOT_IMPLEMENTED();
+  }
 
   bool allocate(Sequence* sequence,
                 size_t num_tokens,

--- a/xllm/core/scheduler/chunked_prefill_scheduler.cpp
+++ b/xllm/core/scheduler/chunked_prefill_scheduler.cpp
@@ -237,6 +237,7 @@ void ChunkedPrefillScheduler::handle_running_queue_requests(
       running_sequences_budgets_.insert(running_sequences_budgets_.end(),
                                         candidate_token_budgets.begin(),
                                         candidate_token_budgets.end());
+      cache_in_batch_prefix(candidate_sequences, candidate_token_budgets);
       remaining_token_budget -= allocated_tokens;
       remaining_seq_budget -= allocated_seqs;
       estimate_latency += allocated_estimate_latency;
@@ -508,6 +509,7 @@ void ChunkedPrefillScheduler::handle_prefill_requests(
     running_sequences_budgets_.insert(running_sequences_budgets_.end(),
                                       prefill_sequences_budget.begin(),
                                       prefill_sequences_budget.end());
+    cache_in_batch_prefix(prefill_sequences, prefill_sequences_budget);
   }
   // maybe can pre-compute if prompt beyond length
   if (running_sequences_.empty() && !waiting_priority_queue->empty() &&

--- a/xllm/core/scheduler/continuous_scheduler.cpp
+++ b/xllm/core/scheduler/continuous_scheduler.cpp
@@ -111,6 +111,8 @@ ContinuousScheduler::ContinuousScheduler(Engine* engine, const Options& options)
 
   enable_prefix_cache_ =
       ::xllm::KVCacheConfig::get_instance().enable_prefix_cache();
+  enable_in_batch_prefix_cache_ =
+      ::xllm::KVCacheConfig::get_instance().enable_in_batch_prefix_cache();
 
   last_batch_.resize(options_.dp_size());
 
@@ -351,6 +353,26 @@ bool ContinuousScheduler::check_if_enough_to_evict(
   return false;
 }
 
+void ContinuousScheduler::cache_in_batch_prefix(
+    const std::vector<Sequence*>& sequences,
+    const std::vector<size_t>& current_step_token_budgets) {
+  if (!enable_prefix_cache_ || !enable_in_batch_prefix_cache_ ||
+      sequences.empty()) {
+    return;
+  }
+  CHECK_EQ(sequences.size(), current_step_token_budgets.size());
+  for (size_t i = 0; i < sequences.size(); ++i) {
+    Sequence* sequence = sequences[i];
+    if (sequence == nullptr || !sequence->is_prefill_stage()) {
+      continue;
+    }
+    const size_t max_handle_num_tokens =
+        sequence->kv_state().kv_cache_tokens_num() +
+        current_step_token_budgets[i];
+    kv_cache_manager_->cache(sequence, max_handle_num_tokens);
+  }
+}
+
 void ContinuousScheduler::clear_mtp_bootstrap(Request* request) {
   if (!options_.enable_disagg_pd() || options_.num_speculative_tokens() <= 0 ||
       request == nullptr || request->sequences().empty()) {
@@ -547,6 +569,7 @@ void ContinuousScheduler::handle_prefill_requests(
     running_sequences_budgets_.insert(running_sequences_budgets_.end(),
                                       prefill_sequences_budget.begin(),
                                       prefill_sequences_budget.end());
+    cache_in_batch_prefix(prefill_sequences, prefill_sequences_budget);
   }
   // maybe can pre-compute if prompt beyond length
   if (running_sequences_.empty() && !waiting_priority_queue->empty() &&

--- a/xllm/core/scheduler/continuous_scheduler.h
+++ b/xllm/core/scheduler/continuous_scheduler.h
@@ -276,6 +276,8 @@ class ContinuousScheduler : public Scheduler {
 
   bool enable_prefix_cache_ = false;
 
+  bool enable_in_batch_prefix_cache_ = false;
+
   // the number of requests that are waiting to be scheduled
   std::atomic<size_t> pending_requests_{0};
 
@@ -343,6 +345,12 @@ class ContinuousScheduler : public Scheduler {
                                 Sequence* prefill_sequence,
                                 size_t max_handle_num_tokens,
                                 size_t& num_request_to_evict);
+
+  // Publish the full prefill blocks admitted in this scheduling step into the
+  // prefix cache, so later requests in the same batch can share them.
+  void cache_in_batch_prefix(
+      const std::vector<Sequence*>& sequences,
+      const std::vector<size_t>& current_step_token_budgets);
 
   // build a batch of requests from the priority queue
   virtual std::vector<Batch> prepare_batch();

--- a/xllm/core/scheduler/mix_scheduler.cpp
+++ b/xllm/core/scheduler/mix_scheduler.cpp
@@ -407,6 +407,7 @@ void MixScheduler::handle_running_queue_requests(
       running_sequences_budgets_.insert(running_sequences_budgets_.end(),
                                         candidate_token_budgets.begin(),
                                         candidate_token_budgets.end());
+      cache_in_batch_prefix(candidate_sequences, candidate_token_budgets);
       remaining_token_budget -= allocated_tokens;
       remaining_seq_budget -= allocated_seqs;
       remaining_copy_blocks_budget -= allocated_copy_blocks;

--- a/xllm/core/scheduler/prefill_only_scheduler.cpp
+++ b/xllm/core/scheduler/prefill_only_scheduler.cpp
@@ -215,6 +215,7 @@ void PrefillOnlyScheduler::handle_prefill_requests(
     running_sequences_budgets_.insert(running_sequences_budgets_.end(),
                                       prefill_sequences_budget.begin(),
                                       prefill_sequences_budget.end());
+    cache_in_batch_prefix(prefill_sequences, prefill_sequences_budget);
   }
   // maybe can pre-compute if prompt beyond length
   if (running_sequences_.empty() && !waiting_priority_queue->empty() &&
@@ -403,6 +404,7 @@ void PrefillOnlyScheduler::handle_last_step_prefill_requests(
     running_sequences_budgets_.insert(running_sequences_budgets_.end(),
                                       prefill_sequences_budget.begin(),
                                       prefill_sequences_budget.end());
+    cache_in_batch_prefix(prefill_sequences, prefill_sequences_budget);
   }
   // maybe can pre-compute if prompt beyond length
   if (running_sequences_.empty() && !last_step_prefill_requests.empty() &&


### PR DESCRIPTION
## Description

Support **in-batch prefix cache**: publish the full prefill blocks admitted
within a single scheduling step into the prefix cache immediately, so that later
requests in the *same* batch sharing the same prefix can reuse them — instead of
waiting until a request finishes its own prefill (first decode step) or
deallocates. This closes the gap where several concurrent same-prefix requests
in one prefill batch each recompute the shared prefix.

Key points:
- New flag `enable_in_batch_prefix_cache` (default `false`), wired through
  `KVCacheConfig` and the scheduler options. It is an opt-in enhancement layered
  on top of `enable_prefix_cache`; when prefix cache is off, this feature is a
  no-op by design (guarded at scheduler, `BlockManagerPool`, and
  `BlockManagerImpl` levels).
- Add `KVCacheManager::cache(Sequence*, size_t num_tokens)` overload that
  publishes only the full blocks covered by the step's token budget (clamped to
  allocated blocks and the sequence's own tokens; partial trailing block is
  dropped by the prefix-cache insert). This differs from the existing
  `cache(Sequence*)`, which caches already-computed tokens at deallocate time.
- Bound the hierarchy offload range by the computed device blocks so that
  blocks registered early (but not yet computed) are not offloaded to host.
- Invoke `cache_in_batch_prefix` per admitted request in the continuous,
  chunked-prefill, mix, and prefill-only schedulers. In chunked prefill it runs
  per chunk and incrementally publishes only the newly completed full blocks.

## Related Issues

N/A

## Change Type

- [ ] Bug fix
- [x] New feature
- [ ] Performance improvement
- [ ] Refactor
- [ ] Documentation
- [ ] Test
- [ ] Build or CI

## Pull Request Checklist

### PR Title and Commit Messages

- [x] The PR title and each commit message follow the xLLM commit format: `<type>: <subject>`.

### Pre-commit Checks

- [x] I have installed `pre-commit` by running `pip install pre-commit` or an equivalent command.
- [x] I have installed the hooks with `pre-commit install`.
- [x] I have run `pre-commit run --all-files` and fixed any reported issues.

### Self Review

- [x] I have self-reviewed the code according to `.agents/skills/code-review/references/custom-code-style.md`, especially code written or assisted by AI.
- [ ] I have rebased this PR onto the latest `main` branch.

### Build and Test Coverage

- [x] Tests have been added or updated as needed.
- [ ] CUDA: `python setup.py build test` has passed on a CUDA machine.
- [ ] NPU: `python setup.py build test` has passed on an NPU machine.
- [ ] MLU: `python setup.py build test` has passed on an MLU machine.

## Reviewer Notes

- Correctness relies on the invariant that **prefill sequences admitted in a
  step are not preempted within that same step** (so the blocks published before
  forward are guaranteed to be computed by that step's forward). This holds today
  because decode-side preemption only runs when no prefill is scheduled
  (`if (running_sequences_.empty())`), and prefill-side preemption only evicts
  previously-running offline requests. If the scheduler changes here, revisit
  this feature.
- Default is `false`; behavior is unchanged unless the flag is explicitly enabled
  on top of `enable_prefix_cache`.
- Not applied to `ZeroEvictionScheduler` / `FixedStepsScheduler` (they override
  `handle_prefill_requests` without the call) nor to
  `DisaggPDChunkedPrefillScheduler`'s custom chunked path.
- Validation gap: a full `python setup.py build test` could not be completed in
  the current environment (unrelated mid-refactor proto staleness + an
  `xllm_ops` reconfigure failure). The new scheduler test TU was verified to
  compile cleanly against current headers; please run the test suite on a proper
  build machine before merge.