### PR TITLE
feat: add configurable Qwen image edit VAE size

### DIFF
--- a/xllm/core/common/global_flags.h
+++ b/xllm/core/common/global_flags.h
@@ -349,6 +349,8 @@ DECLARE_int64(dit_sp_communication_overlap);
 
 DECLARE_int64(dit_generation_image_area_max);
 
+DECLARE_int64(dit_vae_image_size);
+
 DECLARE_bool(dit_debug_print);
 
 DECLARE_bool(use_audio_in_video);

--- a/xllm/core/framework/config/dit_config.cpp
+++ b/xllm/core/framework/config/dit_config.cpp
@@ -66,6 +66,11 @@ DEFINE_int64(dit_generation_image_area_max,
              "Maximum allowed image area (width * height) for image generation "
              "requests. If set to 0, there is no limit.");
 
+DEFINE_int64(
+    dit_vae_image_size,
+    1048576,
+    "Qwen Image Edit Plus VAE image size used to calculate dimensions.");
+
 namespace xllm {
 
 void DiTConfig::from_flags() {
@@ -82,6 +87,7 @@ void DiTConfig::from_flags() {
   XLLM_CONFIG_ASSIGN_FROM_FLAG(dit_sp_communication_overlap);
   XLLM_CONFIG_ASSIGN_FROM_FLAG(dit_debug_print);
   XLLM_CONFIG_ASSIGN_FROM_FLAG(dit_generation_image_area_max);
+  XLLM_CONFIG_ASSIGN_FROM_FLAG(dit_vae_image_size);
 }
 
 void DiTConfig::from_json(const JsonReader& json) {
@@ -98,6 +104,7 @@ void DiTConfig::from_json(const JsonReader& json) {
   XLLM_CONFIG_ASSIGN_FROM_JSON(dit_sp_communication_overlap);
   XLLM_CONFIG_ASSIGN_FROM_JSON(dit_debug_print);
   XLLM_CONFIG_ASSIGN_FROM_JSON(dit_generation_image_area_max);
+  XLLM_CONFIG_ASSIGN_FROM_JSON(dit_vae_image_size);
 }
 
 void DiTConfig::append_config_json(nlohmann::ordered_json& config_json) const {
@@ -128,6 +135,8 @@ void DiTConfig::append_config_json(nlohmann::ordered_json& config_json) const {
       config_json, default_config, dit_debug_print);
   APPEND_CONFIG_JSON_VALUE_IF_NOT_DEFAULT(
       config_json, default_config, dit_generation_image_area_max);
+  APPEND_CONFIG_JSON_VALUE_IF_NOT_DEFAULT(
+      config_json, default_config, dit_vae_image_size);
 }
 
 DiTConfig& DiTConfig::get_instance() {

--- a/xllm/core/framework/config/dit_config.h
+++ b/xllm/core/framework/config/dit_config.h
@@ -52,8 +52,9 @@ class DiTConfig final {
          "dit_cache_start_blocks",
          "dit_cache_end_blocks",
          "dit_sp_communication_overlap",
-         "dit_debug_print"
-         "dit_generation_image_area_max"}};
+         "dit_debug_print",
+         "dit_generation_image_area_max",
+         "dit_vae_image_size"}};
     return kOptionCategory;
   }
 
@@ -82,6 +83,8 @@ class DiTConfig final {
   PROPERTY(bool, dit_debug_print) = false;
 
   PROPERTY(int64_t, dit_generation_image_area_max) = 0;
+
+  PROPERTY(int64_t, dit_vae_image_size) = 1048576;
 };
 
 }  // namespace xllm

--- a/xllm/models/dit/pipelines/pipeline_qwenimage_edit_plus.h
+++ b/xllm/models/dit/pipelines/pipeline_qwenimage_edit_plus.h
@@ -42,7 +42,6 @@ limitations under the License.
 #include "util/tensor_helper.h"
 
 #define CONDITION_IMAGE_SIZE 147456
-#define VAE_IMAGE_SIZE 1048576
 
 namespace xllm {
 class QwenImageEditPlusPipelineImpl : public torch::nn::Module {
@@ -375,8 +374,9 @@ class QwenImageEditPlusPipelineImpl : public torch::nn::Module {
             static_cast<double>(image_list[i].size(2)) / image_list[i].size(1);
         auto [condition_width, condition_height] =
             xllm::dit::calculate_dimensions(CONDITION_IMAGE_SIZE, aspect_ratio);
-        auto [vae_width, vae_height] =
-            xllm::dit::calculate_dimensions(VAE_IMAGE_SIZE, aspect_ratio);
+        auto [vae_width, vae_height] = xllm::dit::calculate_dimensions(
+            ::xllm::DiTConfig::get_instance().dit_vae_image_size(),
+            aspect_ratio);
         condition_image_sizes.push_back({condition_width, condition_height});
         vae_image_sizes.push_back({vae_width, vae_height});
         auto img = image_list[i].unsqueeze(0);


### PR DESCRIPTION
## Description

This PR adds a configurable `dit_vae_image_size` option for the Qwen Image Edit pipeline. Previously, the Qwen Image Edit VAE resize size was fixed in the pipeline. This change exposes it through DiT config/global flags so it can be configured at runtime while preserving the existing default behavior when the flag is not set.

## Related Issues

N/A

## Change Type

- [ ] Bug fix
- [x] New feature
- [ ] Performance improvement
- [ ] Refactor
- [ ] Documentation
- [ ] Test
- [ ] Build or CI

## Pull Request Checklist

Thank you for contributing to xLLM. Before requesting review, please make sure the following items are complete.

### PR Title and Commit Messages

- [x] The PR title and each commit message follow the xLLM commit format: `<type>: <subject>`.

> Allowed types: feat, bugfix, docs, test, refactor, chore, style, revert, perf, model, build, release.
> The subject should use clear English, start with a verb, include at least 4 words, and end with `.`.

### Pre-commit Checks

- [x] I have installed `pre-commit` by running `pip install pre-commit` or an equivalent command.
- [x] I have installed the hooks with `pre-commit install`.
- [x] I have run `pre-commit run clang-format --files ...` and fixed reported issues.

> If you are unsure how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

### Self Review

- [x] I have self-reviewed the code according to `.agents/skills/code-review/references/custom-code-style.md`, especially code written or assisted by AI.
- [x] I have rebased this PR onto the latest `main` branch.

### Build and Test Coverage

- [ ] Tests have been added or updated as needed.
- [ ] CUDA: `python setup.py build test` has passed on a CUDA machine.
- [x] NPU: `python setup.py build test` has passed on an NPU machine.
- [ ] MLU: `python setup.py build test` has passed on an MLU machine.



