### PR TITLE
feat: add pd aware graph warmup.

### DIFF
--- a/tests/core/scheduler/profile/profile_graph_warmup_test.cpp
+++ b/tests/core/scheduler/profile/profile_graph_warmup_test.cpp
@@ -88,6 +88,18 @@ TEST(GraphWarmupTest, AllowsAllBucketsSkipped) {
   EXPECT_TRUE(buckets.empty());
 }
 
+TEST(GraphWarmupTest, PrefillRoleUsesPrefillOnlyPlan) {
+  EXPECT_EQ(graph_warmup_plan(InstanceRole::PREFILL),
+            GraphWarmupPlan::PREFILL_ONLY);
+}
+
+TEST(GraphWarmupTest, NonPrefillRolesUseUnifiedPlan) {
+  EXPECT_EQ(graph_warmup_plan(InstanceRole::DEFAULT), GraphWarmupPlan::UNIFIED);
+  EXPECT_EQ(graph_warmup_plan(InstanceRole::DECODE), GraphWarmupPlan::UNIFIED);
+  EXPECT_EQ(graph_warmup_plan(InstanceRole::MIX), GraphWarmupPlan::UNIFIED);
+  EXPECT_EQ(graph_warmup_plan(InstanceRole::INVALID), GraphWarmupPlan::UNIFIED);
+}
+
 TEST(GraphWarmupTest, FormatsWarmupProgress) {
   const std::string progress = graph_warmup_progress(
       /*completed=*/3, /*total=*/8, /*bucket=*/8, /*latency_ms=*/12.5);

--- a/tests/core/scheduler/profile/profile_graph_warmup_test.cpp
+++ b/tests/core/scheduler/profile/profile_graph_warmup_test.cpp
@@ -95,9 +95,13 @@ TEST(GraphWarmupTest, PrefillRoleUsesPrefillOnlyPlan) {
 
 TEST(GraphWarmupTest, NonPrefillRolesUseUnifiedPlan) {
   EXPECT_EQ(graph_warmup_plan(InstanceRole::DEFAULT), GraphWarmupPlan::UNIFIED);
-  EXPECT_EQ(graph_warmup_plan(InstanceRole::DECODE), GraphWarmupPlan::UNIFIED);
   EXPECT_EQ(graph_warmup_plan(InstanceRole::MIX), GraphWarmupPlan::UNIFIED);
   EXPECT_EQ(graph_warmup_plan(InstanceRole::INVALID), GraphWarmupPlan::UNIFIED);
+}
+
+TEST(GraphWarmupTest, DecodeRoleUsesDecodeOnlyPlan) {
+  EXPECT_EQ(graph_warmup_plan(InstanceRole::DECODE),
+            GraphWarmupPlan::DECODE_ONLY);
 }
 
 TEST(GraphWarmupTest, FormatsWarmupProgress) {

--- a/xllm/core/scheduler/continuous_scheduler.cpp
+++ b/xllm/core/scheduler/continuous_scheduler.cpp
@@ -124,6 +124,7 @@ ContinuousScheduler::ContinuousScheduler(Engine* engine, const Options& options)
       .max_seqs_per_batch(options.max_seqs_per_batch())
       .max_global_tpot_ms(options.max_global_tpot_ms())
       .max_global_ttft_ms(options.max_global_ttft_ms())
+      .instance_role(options.instance_role().value_or(InstanceRole::DEFAULT))
       .enable_profile_token_budget(options.enable_profile_token_budget());
   profile_manager_ =
       std::make_unique<ProfileManager>(engine, profile_manager_options);

--- a/xllm/core/scheduler/profile/graph_warmup.cpp
+++ b/xllm/core/scheduler/profile/graph_warmup.cpp
@@ -32,6 +32,14 @@ constexpr int32_t kGraphWarmupBarWidth = 20;
 
 }  // namespace
 
+GraphWarmupPlan graph_warmup_plan(InstanceRole role) {
+  if (role == InstanceRole::PREFILL) {
+    return GraphWarmupPlan::PREFILL_ONLY;
+  }
+
+  return GraphWarmupPlan::UNIFIED;
+}
+
 std::vector<int32_t> graph_warmup_buckets(int32_t max_seqs_per_batch) {
   CHECK_GT(max_seqs_per_batch, 0);
 

--- a/xllm/core/scheduler/profile/graph_warmup.cpp
+++ b/xllm/core/scheduler/profile/graph_warmup.cpp
@@ -36,6 +36,9 @@ GraphWarmupPlan graph_warmup_plan(InstanceRole role) {
   if (role == InstanceRole::PREFILL) {
     return GraphWarmupPlan::PREFILL_ONLY;
   }
+  if (role == InstanceRole::DECODE) {
+    return GraphWarmupPlan::DECODE_ONLY;
+  }
 
   return GraphWarmupPlan::UNIFIED;
 }

--- a/xllm/core/scheduler/profile/graph_warmup.h
+++ b/xllm/core/scheduler/profile/graph_warmup.h
@@ -28,6 +28,7 @@ class Sequence;
 enum class GraphWarmupPlan : int8_t {
   UNIFIED = 0,
   PREFILL_ONLY = 1,
+  DECODE_ONLY = 2,
 };
 
 GraphWarmupPlan graph_warmup_plan(InstanceRole role);

--- a/xllm/core/scheduler/profile/graph_warmup.h
+++ b/xllm/core/scheduler/profile/graph_warmup.h
@@ -19,9 +19,18 @@ limitations under the License.
 #include <string>
 #include <vector>
 
+#include "common/types.h"
+
 namespace xllm {
 
 class Sequence;
+
+enum class GraphWarmupPlan : int8_t {
+  UNIFIED = 0,
+  PREFILL_ONLY = 1,
+};
+
+GraphWarmupPlan graph_warmup_plan(InstanceRole role);
 
 std::vector<int32_t> graph_warmup_buckets(int32_t max_seqs_per_batch);
 

--- a/xllm/core/scheduler/profile/profile_manager.cpp
+++ b/xllm/core/scheduler/profile/profile_manager.cpp
@@ -925,17 +925,34 @@ void ProfileManager::generate_random_decode_batch(
 }
 
 void ProfileManager::warmup_for_graph() {
+  const GraphWarmupPlan plan = graph_warmup_plan(options_.instance_role());
+  if (plan == GraphWarmupPlan::PREFILL_ONLY) {
+    LOG(INFO) << "PREFILL graph warmup: prefill only";
+    warmup_prefill_for_graph();
+    return;
+  }
+
+  warmup_unified_for_graph();
+}
+
+void ProfileManager::warmup_prefill_for_graph() {
   auto& model_args = engine_->model_args();
   int32_t max_context_len = model_args.max_position_embeddings();
 
   int32_t prefill_tokens =
       std::min(options_.max_tokens_per_batch(), max_context_len);
-  int32_t max_seqs_per_batch = options_.max_seqs_per_batch();
-  int32_t decode_seq_len = std::min(16, max_context_len);
-
   double prefill_latency = run_request(prefill_tokens, 0, 1);
   LOG(INFO) << "Prefill warmup completed: tokens=" << prefill_tokens
             << ", latency=" << prefill_latency << " ms";
+}
+
+void ProfileManager::warmup_unified_for_graph() {
+  auto& model_args = engine_->model_args();
+  int32_t max_context_len = model_args.max_position_embeddings();
+  int32_t max_seqs_per_batch = options_.max_seqs_per_batch();
+  int32_t decode_seq_len = std::min(16, max_context_len);
+
+  warmup_prefill_for_graph();
 
   std::vector<int32_t> decode_batch_sizes =
       graph_decode_buckets(max_seqs_per_batch, options_.dp_size());

--- a/xllm/core/scheduler/profile/profile_manager.cpp
+++ b/xllm/core/scheduler/profile/profile_manager.cpp
@@ -946,7 +946,7 @@ void ProfileManager::warmup_prefill_for_graph() {
 
   int32_t prefill_tokens =
       std::min(options_.max_tokens_per_batch(), max_context_len);
-  double prefill_latency = run_request(prefill_tokens, 0, 1);
+  double prefill_latency = run_request(prefill_tokens, /*prefix_length=*/0, /*batch_size=*/1);
   LOG(INFO) << "Prefill warmup completed: tokens=" << prefill_tokens
             << ", latency=" << prefill_latency << " ms";
 }

--- a/xllm/core/scheduler/profile/profile_manager.cpp
+++ b/xllm/core/scheduler/profile/profile_manager.cpp
@@ -946,7 +946,8 @@ void ProfileManager::warmup_prefill_for_graph() {
 
   int32_t prefill_tokens =
       std::min(options_.max_tokens_per_batch(), max_context_len);
-  double prefill_latency = run_request(prefill_tokens, /*prefix_length=*/0, /*batch_size=*/1);
+  double prefill_latency =
+      run_request(prefill_tokens, /*prefix_length=*/0, /*batch_size=*/1);
   LOG(INFO) << "Prefill warmup completed: tokens=" << prefill_tokens
             << ", latency=" << prefill_latency << " ms";
 }

--- a/xllm/core/scheduler/profile/profile_manager.cpp
+++ b/xllm/core/scheduler/profile/profile_manager.cpp
@@ -931,6 +931,11 @@ void ProfileManager::warmup_for_graph() {
     warmup_prefill_for_graph();
     return;
   }
+  if (plan == GraphWarmupPlan::DECODE_ONLY) {
+    LOG(INFO) << "DECODE graph warmup: decode buckets only";
+    warmup_decode_for_graph();
+    return;
+  }
 
   warmup_unified_for_graph();
 }
@@ -947,12 +952,15 @@ void ProfileManager::warmup_prefill_for_graph() {
 }
 
 void ProfileManager::warmup_unified_for_graph() {
+  warmup_prefill_for_graph();
+  warmup_decode_for_graph();
+}
+
+void ProfileManager::warmup_decode_for_graph() {
   auto& model_args = engine_->model_args();
   int32_t max_context_len = model_args.max_position_embeddings();
   int32_t max_seqs_per_batch = options_.max_seqs_per_batch();
   int32_t decode_seq_len = std::min(16, max_context_len);
-
-  warmup_prefill_for_graph();
 
   std::vector<int32_t> decode_batch_sizes =
       graph_decode_buckets(max_seqs_per_batch, options_.dp_size());

--- a/xllm/core/scheduler/profile/profile_manager.h
+++ b/xllm/core/scheduler/profile/profile_manager.h
@@ -151,6 +151,8 @@ class ProfileManager {
 
   void warmup_prefill_for_graph();
 
+  void warmup_decode_for_graph();
+
   void warmup_unified_for_graph();
 
   bool check_if_satisfy_slo(int32_t num_tokens, int32_t tpot_slo_ms);

--- a/xllm/core/scheduler/profile/profile_manager.h
+++ b/xllm/core/scheduler/profile/profile_manager.h
@@ -53,6 +53,8 @@ class ProfileManager {
     PROPERTY(int32_t, max_global_ttft_ms) = std::numeric_limits<int32_t>::max();
 
     PROPERTY(int32_t, max_global_tpot_ms) = std::numeric_limits<int32_t>::max();
+
+    PROPERTY(InstanceRole, instance_role) = InstanceRole::DEFAULT;
   };
 
   struct CopyBlockProfile {
@@ -144,8 +146,12 @@ class ProfileManager {
 
   void profile_token_budget();
 
-  // Warmup ACL graph executor with prefill and decode requests
+  // Warmup ACL graph executor according to the instance role.
   void warmup_for_graph();
+
+  void warmup_prefill_for_graph();
+
+  void warmup_unified_for_graph();
 
   bool check_if_satisfy_slo(int32_t num_tokens, int32_t tpot_slo_ms);
 


### PR DESCRIPTION
  feat: Support role-aware graph warmup plans.

  ## Description

  This PR makes ACL graph warmup aware of the serving instance role used in PD deployments.

  It adds a graph warmup plan selector so:
  - prefill instances only warm up prefill graph requests
  - decode instances only warm up decode graph buckets
  - default, mixed, and invalid roles keep the existing unified prefill + decode warmup behavior

  The scheduler now passes `instance_role` into `ProfileManager`, and the graph warmup unit test covers the new role-to-plan mapping.

  ## Related Issues

  N/A

  ## Change Type

  - [ ] Bug fix
  - [x] New feature
  - [ ] Performance improvement
  - [ ] Refactor
  - [ ] Documentation
  - [x] Test
  - [ ] Build or CI

  ## Pull Request Checklist

  Thank you for contributing to xLLM. Before requesting review, please make sure the following items are complete.

  ### PR Title and Commit Messages

  - [x] The PR title and each commit message follow the xLLM commit format: `<type>: <subject>`.

  > Allowed types: feat, bugfix, docs, test, refactor, chore, style, revert, perf, model, build, release.
  > The subject should use clear English, start with a verb, include at least 4 words, and end with `.`.

  ### Pre-commit Checks

  - [x] I have installed `pre-commit` by running `pip install pre-commit` or an equivalent command.
  - [x] I have installed the hooks with `pre-commit install`.
  - [x] I have run `pre-commit run --all-files` and fixed any reported issues.

  ### Self Review

  - [ ] I have self-reviewed the code according to `.agents/skills/code-review/references/custom-code-style.md`,
  especially code written or assisted by AI.
  - [x] I have rebased this PR onto the latest `main` branch.

  ### Build and Test Coverage

  - [x] Tests have been added or updated as needed.
  - [ ] CUDA: `python setup.py build test` has passed on a CUDA machine.
  - [x] NPU: `python setup.py build test` has passed on an NPU machine.
  - [x] MLU: `python setup.py build test` has passed on an MLU machine.

  ## Reviewer Notes

  Please focus on whether the role-based warmup split matches PD serving expectations:
  - `InstanceRole::PREFILL` skips decode bucket warmup.
  - `InstanceRole::DECODE` skips prefill warmup.
  - non-PD roles preserve the previous unified warmup path.

  Validation gap: pre-commit and device build/test results are not included here.
