### PR TITLE
perf: skip handle_remaining_budget when prefix_cache and linear attention are enabled

### DIFF
--- a/xllm/core/scheduler/chunked_prefill_scheduler.cpp
+++ b/xllm/core/scheduler/chunked_prefill_scheduler.cpp
@@ -672,7 +672,14 @@ std::vector<Batch> ChunkedPrefillScheduler::prepare_batch() {
 
   // step-3. remaining_token_budget > 0, try to allocate more tokens to
   // prefill stage reuquests.
-  if (remaining_token_budget > 0 && latency_budget > estimate_latency) {
+  // When prefix_cache is enabled and linear attention layers exist, skip
+  // this step to preserve the max_tokens_per_chunk_for_prefill chunk limit,
+  // which is required for correct linear state alignment.
+  static const bool has_linear_attention =
+      has_linear_attention_layers(engine_->model_args());
+  const bool has_linear_cache = enable_prefix_cache_ && has_linear_attention;
+  if (remaining_token_budget > 0 && latency_budget > estimate_latency &&
+      !has_linear_cache) {
     handle_remaining_budget(latency_budget,
                             estimate_latency,
                             remaining_token_budget,


### PR DESCRIPTION
## Description
1. handle_remaining_budget reallocates all remaining budget to prefill sequences, bypassing the max_tokens_per_chunk_for_prefill chunk limit
2. When prefix_cache and linear attention are enabled, linear state requires block-aligned chunk boundaries; bypassing the chunk limit makes max_tokens_per_chunk_for_prefill ineffective for single-batch scenarios

## Change Type

- [ ] Bug fix
- [ ] New feature
- [x] Performance improvement
- [ ] Refactor
- [ ] Documentation
- [ ] Test
- [ ] Build or CI

### Build and Test Coverage

- [x] Tests have been added or updated as needed.
- [ ] CUDA: `python setup.py build test` has passed on a CUDA machine.
- [x] NPU: `python setup.py build test` has passed on an NPU machine.
- [ ] MLU: `python setup.py build test` has passed on an MLU machine.

<img width="1142" height="252" alt="image" src="https://github.com/user-attachments/assets/a6e6a5d1-2284-47e8-8bac-1b123abec195" />
