### PR TITLE
feat: enable W8A8 quantization for down_proj in Qwen3-VL 

### DIFF
--- a/xllm/core/layers/npu/loader/qwen3_decoder_loader.cpp
+++ b/xllm/core/layers/npu/loader/qwen3_decoder_loader.cpp
@@ -115,13 +115,19 @@ void Qwen3DecoderLoader::merge_host_at_weights() {
     t[IN_ATTENTION_OUT_OFFSET] = t[IN_ATTENTION_OUT_OFFSET].to(torch::kInt8);
     t[IN_MLP_W2_OFFSET] = t[IN_MLP_W2_OFFSET].to(torch::kInt8);
 
+    if (t[IN_MLP_CPROJ_BIAS].numel() > 1) {
+      t[IN_MLP_CPROJ_BIAS] = t[IN_MLP_CPROJ_BIAS].to(torch::kInt32);
+      t[IN_MLP_CPROJ_DEQSCALE] = t[IN_MLP_CPROJ_DEQSCALE].to(torch::kFloat32);
+      t[IN_MLP_CPROJ_OFFSET] = t[IN_MLP_CPROJ_OFFSET].to(torch::kInt8);
+      t[IN_MLP_CPROJ_SCALE] = t[IN_MLP_CPROJ_SCALE].to(dtype_);
+      down_proj_quantized_ = true;
+    }
+
     if (rank_id_ != 0) {
-      const auto& original = t[IN_ATTENTION_OUT_BIAS];
-      auto shape = original.sizes();
-      auto dtype = original.dtype();
-      auto device = original.device();
-      t[IN_ATTENTION_OUT_BIAS] = torch::zeros(
-          shape, torch::TensorOptions().dtype(dtype).device(device));
+      t[IN_ATTENTION_OUT_BIAS] = torch::zeros_like(t[IN_ATTENTION_OUT_BIAS]);
+      if (down_proj_quantized_) {
+        t[IN_MLP_CPROJ_BIAS] = torch::zeros_like(t[IN_MLP_CPROJ_BIAS]);
+      }
     }
   }
 
@@ -148,16 +154,15 @@ void Qwen3DecoderLoader::merge_host_at_weights() {
   if (enableAddNorm_) {
     if (quantize_type_.compare("w8a8") == 0) {
       torch::ScalarType weight_fill_dtype = torch::kBFloat16;
-      int64_t weight_attn_shape = t[IN_Q_WEIGHT].size(-1);
-      int64_t weight_mlp_shape = t[IN_MLP_W2_WEIGHT].size(-1);
+      int64_t hidden_size = t[IN_NORM_WEIGHT].size(0);
       t[IN_QKV_SCALE_FILL] =
-          t[IN_Q_SCALE].repeat(weight_attn_shape).to(weight_fill_dtype);
+          t[IN_Q_SCALE].repeat(hidden_size).to(weight_fill_dtype);
       t[IN_MLP_SCALE_FILL] =
-          t[IN_MLP_W2_SCALE].repeat(weight_mlp_shape).to(weight_fill_dtype);
+          t[IN_MLP_W2_SCALE].repeat(hidden_size).to(weight_fill_dtype);
       t[IN_QKV_OFFSET_FILL] =
-          t[IN_Q_OFFSET].repeat(weight_attn_shape).to(weight_fill_dtype);
+          t[IN_Q_OFFSET].repeat(hidden_size).to(weight_fill_dtype);
       t[IN_MLP_OFFSET_FILL] =
-          t[IN_MLP_W2_OFFSET].repeat(weight_mlp_shape).to(weight_fill_dtype);
+          t[IN_MLP_W2_OFFSET].repeat(hidden_size).to(weight_fill_dtype);
     } else {
       for (auto idx : {IN_QKV_SCALE_FILL,
                        IN_QKV_OFFSET_FILL,

--- a/xllm/core/layers/npu/loader/qwen3_decoder_loader.h
+++ b/xllm/core/layers/npu/loader/qwen3_decoder_loader.h
@@ -32,12 +32,14 @@ class Qwen3DecoderLoader : public BaseLoader {
 
   void load_state_dict(const StateDict& state_dict) override;
   void verify_loaded_weights() const override;
+  bool down_proj_quantized() const { return down_proj_quantized_; }
 
  protected:
   void merge_host_at_weights() override;
 
   torch::Tensor at_placeholder_;
   bool enableAddNorm_;
+  bool down_proj_quantized_ = false;
   int rank_id_;
 };
 

--- a/xllm/core/layers/npu/loader/qwen_loader_constants.h
+++ b/xllm/core/layers/npu/loader/qwen_loader_constants.h
@@ -281,6 +281,10 @@ static std::vector<std::pair<int, std::string>> WEIGHT_MAPPING_W8A8 = {
     {IN_MLP_W1_OFFSET, "mlp.up_proj.input_offset"},
     {IN_MLP_W1_SCALE, "mlp.up_proj.input_scale"},
     {IN_MLP_CPROJ_WEIGHT, "mlp.down_proj.weight"},
+    {IN_MLP_CPROJ_BIAS, "mlp.down_proj.quant_bias"},
+    {IN_MLP_CPROJ_DEQSCALE, "mlp.down_proj.deq_scale"},
+    {IN_MLP_CPROJ_OFFSET, "mlp.down_proj.input_offset"},
+    {IN_MLP_CPROJ_SCALE, "mlp.down_proj.input_scale"},
     {Q_NORM_WEIGHT, "self_attn.q_norm.weight"},
     {K_NORM_WEIGHT, "self_attn.k_norm.weight"}};
 

--- a/xllm/core/layers/npu/npu_qwen3_decoder_layer_impl.cpp
+++ b/xllm/core/layers/npu/npu_qwen3_decoder_layer_impl.cpp
@@ -27,6 +27,8 @@ limitations under the License.
 #include "core/framework/config/load_config.h"
 #include "core/framework/config/parallel_config.h"
 #include "core/framework/config/scheduler_config.h"
+#include "core/layers/npu/loader/qwen3_decoder_loader.h"
+#include "operations/fusion/mlp/mlp.h"
 #include "util/rec_model_utils.h"
 
 // #include "attn_mask.h"
@@ -205,6 +207,23 @@ int64_t NpuQwen3DecoderLayerImpl::init_layer() {
   init_attn_mask();
   name_ = "qwen3_decoder_layer";
   model_name_ = "qwen3";
+
+  if (quantize_type_ == "w8a8") {
+    Qwen3DecoderLoader* qwen3_loader =
+        dynamic_cast<Qwen3DecoderLoader*>(loader_.get());
+    if (qwen3_loader && qwen3_loader->down_proj_quantized()) {
+      auto update_down_proj = [](atb_speed::qwen::QwenLayerParam& p) {
+        p.linearDescs[atb_speed::common::DOWN_LINEAR_INDEX] =
+            static_cast<int>(LinearTypeV2::W8A8);
+        p.linearQuantType[atb_speed::common::DOWN_LINEAR_INDEX] =
+            static_cast<int>(LinearType::INT);
+      };
+      update_down_proj(prefill_param_);
+      update_down_proj(decode_graph_param_);
+      update_down_proj(decode_eager_param_);
+    }
+  }
+
   CHECK_OPERATION_STATUS_RETURN(init_node(prefill_node_, prefill_param_));
   CHECK_OPERATION_STATUS_RETURN(
       init_node(decode_graph_node_, decode_graph_param_));


### PR DESCRIPTION
# Qwen3-VL-32B W8A8 量化指南：Down-Projection 适配

本文档介绍如何使用 msmodelslim 对 Qwen3-VL-32B-Instruct 进行 W8A8 量化，并适配 down\_proj 量化以获得最优推理性能。

## 目录

- [环境准备](#环境准备)
- [安装 msmodelslim](#安装-msmodelslim)
- [一键量化（不含 down\_proj）](#一键量化不含-down_proj)
- [精细化量化（含 down\_proj 适配）](#精细化量化含-down_proj-适配)
- [敏感层分析与 down\_proj 排除策略](#敏感层分析与-down_proj-排除策略)
- [量化产物验证](#量化产物验证)
- [推理部署](#推理部署)

***

## 环境准备

基于昇腾 NPU 的推理环境，可使用 xllm 或 vllm-ascend 镜像启动 Docker 容器：

```bash
可基于一个xllm镜像或vllm-ascend镜像启动
```

> 镜像中需包含昇腾 CANN 驱动及 PyTorch NPU 环境。

***

## 安装 msmodelslim

```bash
git clone https://gitcode.com/Ascend/msmodelslim.git
cd msmodelslim
bash install.sh
pip install accelerate
pip install transformers==4.57.1
```

> Qwen3-VL 量化参考文档：[msmodelslim Qwen3-VL example](https://gitcode.com/Ascend/msmodelslim/tree/master/example/multimodal_vlm/Qwen3-VL)

***

## 一键量化（不含 down\_proj）

对于标准 W8A8 量化（不量化 down\_proj），可使用一键量化命令：

```bash
msmodelslim quant \
  --model_path /path/to/Qwen3-VL-32B-Instruct \
  --save_path /path/to/Qwen3-VL-32B-Instruct-quant \
  --device npu \
  --model_type qwen3_vl \
  --quant_type w8a8 \
  --trust_remote_code True
```

> `model_type` 请参考 [config.ini](https://gitcode.com/Ascend/msmodelslim/blob/master/config/config.ini) 中的模型类型列表。

此方式下，down_proj 保持 BF16 精度，不会参与 W8A8 量化。（本pr主要适配以下描述的down_\_proj量化）

***

## 精细化量化（含 down\_proj 适配）

### 背景

Qwen3-VL-32B 的 64 层 Transformer 中，部分层的 `down_proj` 对量化敏感。直接对所有层进行 W8A8 量化（含 down\_proj）会导致精度下降。需要通过 YAML 配置文件精细控制哪些层的 down\_proj 排除在量化之外。

### 步骤一：修改 YAML 配置文件

YAML 配置文件位于：[qwen3_vl_w8a8.yaml](https://gitcode.com/Ascend/msmodelslim/blob/master/lab_practice/qwen3_vl/qwen3_vl_w8a8.yaml)
msmodelslim/lab_practice/qwen3_vl/qwen3_vl_w8a8.yaml

需要在 `exclude` 列表中添加需要排除 down\_proj 量化的层。以下 30 层的 down\_proj 需要排除（保持 BF16）：

```yaml
exclude:
  - "*merger*"
  - "model.visual*"
  - "model.language_model.layers.7.mlp.down_proj"
  - "model.language_model.layers.2.mlp.down_proj"
  - "model.language_model.layers.6.mlp.down_proj"
  - "model.language_model.layers.57.mlp.down_proj"
  - "model.language_model.layers.56.mlp.down_proj"
  - "model.language_model.layers.31.mlp.down_proj"
  - "model.language_model.layers.59.mlp.down_proj"
  - "model.language_model.layers.58.mlp.down_proj"
  - "model.language_model.layers.53.mlp.down_proj"
  - "model.language_model.layers.55.mlp.down_proj"
  - "model.language_model.layers.5.mlp.down_proj"
  - "model.language_model.layers.30.mlp.down_proj"
  - "model.language_model.layers.3.mlp.down_proj"
  - "model.language_model.layers.62.mlp.down_proj"
  - "model.language_model.layers.1.mlp.down_proj"
  - "model.language_model.layers.60.mlp.down_proj"
  - "model.language_model.layers.33.mlp.down_proj"
  - "model.language_model.layers.32.mlp.down_proj"
  - "model.language_model.layers.4.mlp.down_proj"
  - "model.language_model.layers.54.mlp.down_proj"
  - "model.language_model.layers.61.mlp.down_proj"
  - "model.language_model.layers.52.mlp.down_proj"
  - "model.language_model.layers.28.mlp.down_proj"
  - "model.language_model.layers.63.mlp.down_proj"
  - "model.language_model.layers.37.mlp.down_proj"
  - "model.language_model.layers.36.mlp.down_proj"
  - "model.language_model.layers.29.mlp.down_proj"
  - "model.language_model.layers.51.mlp.down_proj"
  - "model.language_model.layers.47.mlp.down_proj"
  - "model.language_model.layers.49.mlp.down_proj"
```

> **说明**：
>
> - `*merger*` 和 `model.visual*` 排除视觉编码器和合并器，这些模块不参与 W8A8 量化
> - 其余 30 条规则排除特定层的 down\_proj，这些层的 down\_proj 量化后精度损失较大
> - 未被排除的 34 层（0, 8-27, 34, 35, 38-46, 48, 50）的 down\_proj 将参与 W8A8 量化

### 步骤二：执行量化

修改完 YAML 配置后，执行量化：

```bash
export ASCEND_RT_VISIBLE_DEVICES=0,1,2,3,4,5,6,7
export 

export MODEL_PATH="/path/to/Qwen3-VL-32B-Instruct"
export SAVE_PATH="/path/to/Qwen3-VL-32B-Instruct-quant-exclude-34-down-proj"

msmodelslim quant \
  --model_path $MODEL_PATH \
  --save_path $SAVE_PATH \
  --device npu \
  --model_type qwen3_vl \
  --config_path /path/to/qwen3_vl_w8a8.yaml \
  --trust_remote_code True
```

***

###

### 排除策略总结

| 场景                     | 排除规则             | down\_proj 量化层数 | 说明                      |
| ---------------------- | ---------------- | --------------- | ----------------------- |
| 全量 W8A8（不含 down\_proj） | 无需排除 down\_proj  | 0               | 默认行为，down\_proj 保持 BF16 |
| 部分排除 down\_proj        | 排除 30 个敏感层       | 34              | 兼顾精度与性能                 |
| 全量 W8A8（含 down\_proj）  | 不排除任何 down\_proj | 64              | 最大化性能，但精度损失较大           |

***

## 量化产物验证

量化完成后，输出目录结构如下：

```
Qwen3-VL-32B-Instruct-quant-exclude-34-down-proj/
├── config.json
├── configuration.json
├── generation_config.json
├── quant_model_description.json
├── quant_model_weight_w8a8.safetensors
├── README.md
├── tokenizer.json
└── tokenizer_config.json
```

###

- [msmodelslim 代码仓](https://gitcode.com/Ascend/msmodelslim)
- [Qwen3-VL 量化示例](https://gitcode.com/Ascend/msmodelslim/tree/master/example/multimodal_vlm/Qwen3-VL)
- [qwen3\_vl\_w8a8.yaml 配置文件](https://gitcode.com/Ascend/msmodelslim/blob/master/lab_practice/qwen3_vl/qwen3_vl_w8a8.yaml)

