### PR TITLE
fix: correct AddRmsNormQuant scale/offset repeat shape for TP4 W8A8

### DIFF
--- a/xllm/core/layers/npu/loader/qwen3_decoder_loader.cpp
+++ b/xllm/core/layers/npu/loader/qwen3_decoder_loader.cpp
@@ -148,16 +148,15 @@ void Qwen3DecoderLoader::merge_host_at_weights() {
   if (enableAddNorm_) {
     if (quantize_type_.compare("w8a8") == 0) {
       torch::ScalarType weight_fill_dtype = torch::kBFloat16;
-      int64_t weight_attn_shape = t[IN_Q_WEIGHT].size(-1);
-      int64_t weight_mlp_shape = t[IN_MLP_W2_WEIGHT].size(-1);
+      int64_t hidden_size = t[IN_NORM_WEIGHT].size(0);
       t[IN_QKV_SCALE_FILL] =
-          t[IN_Q_SCALE].repeat(weight_attn_shape).to(weight_fill_dtype);
+          t[IN_Q_SCALE].repeat(hidden_size).to(weight_fill_dtype);
       t[IN_MLP_SCALE_FILL] =
-          t[IN_MLP_W2_SCALE].repeat(weight_mlp_shape).to(weight_fill_dtype);
+          t[IN_MLP_W2_SCALE].repeat(hidden_size).to(weight_fill_dtype);
       t[IN_QKV_OFFSET_FILL] =
-          t[IN_Q_OFFSET].repeat(weight_attn_shape).to(weight_fill_dtype);
+          t[IN_Q_OFFSET].repeat(hidden_size).to(weight_fill_dtype);
       t[IN_MLP_OFFSET_FILL] =
-          t[IN_MLP_W2_OFFSET].repeat(weight_mlp_shape).to(weight_fill_dtype);
+          t[IN_MLP_W2_OFFSET].repeat(hidden_size).to(weight_fill_dtype);
     } else {
       for (auto idx : {IN_QKV_SCALE_FILL,
                        IN_QKV_OFFSET_FILL,


### PR DESCRIPTION
Use hidden_size (from norm weight) instead of weight column dimension for QKV_SCALE_FILL/QKV_OFFSET_FILL/MLP_SCALE_FILL/MLP_OFFSET_FILL repeat counts. The original code used the sharded weight dimension which is incorrect under tensor parallelism (TP>1), causing precision degradation in W8A8 mode with enableAddNorm.