### PR TITLE
feat: add RainFusionV3 block sparse attention support for Wan2.2.

### DIFF
--- a/xllm/core/common/global_flags.h
+++ b/xllm/core/common/global_flags.h
@@ -356,6 +356,13 @@ DECLARE_int64(dit_vae_image_size);
 
 DECLARE_bool(dit_debug_print);
 
+DECLARE_bool(rainfusion_enabled);
+DECLARE_double(rainfusion_sparsity);
+DECLARE_int64(rainfusion_mask_refresh_interval);
+DECLARE_int64(rainfusion_pool_size);
+DECLARE_int64(rainfusion_sparse_start_step);
+DECLARE_int64(rainfusion_inner_precise);
+
 DECLARE_bool(use_audio_in_video);
 
 // --- kernel config ---

--- a/xllm/core/framework/config/dit_config.cpp
+++ b/xllm/core/framework/config/dit_config.cpp
@@ -71,6 +71,34 @@ DEFINE_int64(
     1048576,
     "Qwen Image Edit Plus VAE image size used to calculate dimensions.");
 
+DEFINE_bool(rainfusion_enabled,
+            false,
+            "Enable RainFusionV3 block-wise sparse attention for WAN.");
+
+DEFINE_double(rainfusion_sparsity,
+              0.5,
+              "RainFusionV3 sparsity ratio in [0.0, 1.0). 0.0 = dense "
+              "attention, 0.5 = drop 50 percent blocks.");
+
+DEFINE_int64(rainfusion_mask_refresh_interval,
+             1,
+             "RainFusionV3 mask refresh interval in steps. "
+             "0 = cache mask forever, N = recompute every N steps.");
+
+DEFINE_int64(
+    rainfusion_pool_size,
+    128,
+    "RainFusionV3 pooling window size for block-wise mask generation.");
+
+DEFINE_int64(rainfusion_sparse_start_step,
+             0,
+             "RainFusionV3 step index to start sparse attention. "
+             "Steps before this use dense attention.");
+
+DEFINE_int64(rainfusion_inner_precise,
+             0,
+             "RainFusionV3 aclnn inner precise mode (0 or 1).");
+
 namespace xllm {
 
 void DiTConfig::from_flags() {
@@ -88,6 +116,12 @@ void DiTConfig::from_flags() {
   XLLM_CONFIG_ASSIGN_FROM_FLAG(dit_debug_print);
   XLLM_CONFIG_ASSIGN_FROM_FLAG(dit_generation_image_area_max);
   XLLM_CONFIG_ASSIGN_FROM_FLAG(dit_vae_image_size);
+  XLLM_CONFIG_ASSIGN_FROM_FLAG(rainfusion_enabled);
+  XLLM_CONFIG_ASSIGN_FROM_FLAG(rainfusion_sparsity);
+  XLLM_CONFIG_ASSIGN_FROM_FLAG(rainfusion_mask_refresh_interval);
+  XLLM_CONFIG_ASSIGN_FROM_FLAG(rainfusion_pool_size);
+  XLLM_CONFIG_ASSIGN_FROM_FLAG(rainfusion_sparse_start_step);
+  XLLM_CONFIG_ASSIGN_FROM_FLAG(rainfusion_inner_precise);
 }
 
 void DiTConfig::from_json(const JsonReader& json) {
@@ -105,6 +139,12 @@ void DiTConfig::from_json(const JsonReader& json) {
   XLLM_CONFIG_ASSIGN_FROM_JSON(dit_debug_print);
   XLLM_CONFIG_ASSIGN_FROM_JSON(dit_generation_image_area_max);
   XLLM_CONFIG_ASSIGN_FROM_JSON(dit_vae_image_size);
+  XLLM_CONFIG_ASSIGN_FROM_JSON(rainfusion_enabled);
+  XLLM_CONFIG_ASSIGN_FROM_JSON(rainfusion_sparsity);
+  XLLM_CONFIG_ASSIGN_FROM_JSON(rainfusion_mask_refresh_interval);
+  XLLM_CONFIG_ASSIGN_FROM_JSON(rainfusion_pool_size);
+  XLLM_CONFIG_ASSIGN_FROM_JSON(rainfusion_sparse_start_step);
+  XLLM_CONFIG_ASSIGN_FROM_JSON(rainfusion_inner_precise);
 }
 
 void DiTConfig::append_config_json(nlohmann::ordered_json& config_json) const {
@@ -137,6 +177,18 @@ void DiTConfig::append_config_json(nlohmann::ordered_json& config_json) const {
       config_json, default_config, dit_generation_image_area_max);
   APPEND_CONFIG_JSON_VALUE_IF_NOT_DEFAULT(
       config_json, default_config, dit_vae_image_size);
+  APPEND_CONFIG_JSON_VALUE_IF_NOT_DEFAULT(
+      config_json, default_config, rainfusion_enabled);
+  APPEND_CONFIG_JSON_VALUE_IF_NOT_DEFAULT(
+      config_json, default_config, rainfusion_sparsity);
+  APPEND_CONFIG_JSON_VALUE_IF_NOT_DEFAULT(
+      config_json, default_config, rainfusion_mask_refresh_interval);
+  APPEND_CONFIG_JSON_VALUE_IF_NOT_DEFAULT(
+      config_json, default_config, rainfusion_pool_size);
+  APPEND_CONFIG_JSON_VALUE_IF_NOT_DEFAULT(
+      config_json, default_config, rainfusion_sparse_start_step);
+  APPEND_CONFIG_JSON_VALUE_IF_NOT_DEFAULT(
+      config_json, default_config, rainfusion_inner_precise);
 }
 
 DiTConfig& DiTConfig::get_instance() {

--- a/xllm/core/framework/config/dit_config.h
+++ b/xllm/core/framework/config/dit_config.h
@@ -54,7 +54,13 @@ class DiTConfig final {
          "dit_sp_communication_overlap",
          "dit_debug_print",
          "dit_generation_image_area_max",
-         "dit_vae_image_size"}};
+         "dit_vae_image_size",
+         "rainfusion_enabled",
+         "rainfusion_sparsity",
+         "rainfusion_mask_refresh_interval",
+         "rainfusion_pool_size",
+         "rainfusion_sparse_start_step",
+         "rainfusion_inner_precise"}};
     return kOptionCategory;
   }
 
@@ -85,6 +91,18 @@ class DiTConfig final {
   PROPERTY(int64_t, dit_generation_image_area_max) = 0;
 
   PROPERTY(int64_t, dit_vae_image_size) = 1048576;
+
+  PROPERTY(bool, rainfusion_enabled) = false;
+
+  PROPERTY(double, rainfusion_sparsity) = 0.5;
+
+  PROPERTY(int64_t, rainfusion_mask_refresh_interval) = 1;
+
+  PROPERTY(int64_t, rainfusion_pool_size) = 128;
+
+  PROPERTY(int64_t, rainfusion_sparse_start_step) = 0;
+
+  PROPERTY(int64_t, rainfusion_inner_precise) = 0;
 };
 
 }  // namespace xllm

--- a/xllm/core/kernels/npu/CMakeLists.txt
+++ b/xllm/core/kernels/npu/CMakeLists.txt
@@ -18,6 +18,7 @@ cc_library(
     npu_causal_conv1d.cpp
     npu_fused_infer_attention.cpp
     npu_gemma_rms_norm.cpp
+    npu_block_sparse_attention.cpp
     npu_grouped_matmul.cpp
     npu_moe_gating_topk_softmax.cpp
     npu_dispatch_ffn_combine.cpp

--- a/xllm/core/kernels/npu/npu_block_sparse_attention.cpp
+++ b/xllm/core/kernels/npu/npu_block_sparse_attention.cpp
@@ -1,0 +1,120 @@
+/* Copyright 2026 The xLLM Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://github.com/jd-opensource/xllm/blob/main/LICENSE
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include <glog/logging.h>
+
+#include "core/kernels/npu/aclnn/pytorch_npu_helper.hpp"
+#include "core/kernels/npu/npu_ops_api.h"
+
+namespace xllm::kernel::npu {
+
+namespace {
+constexpr int64_t kMaskType = 0;
+constexpr int64_t kPreTokens = 2147483647;
+constexpr int64_t kNextTokens = 2147483647;
+constexpr int64_t kBlockSize = 0;
+}  // namespace
+
+std::tuple<torch::Tensor, torch::Tensor> npu_block_sparse_attention(
+    const torch::Tensor& query,
+    const torch::Tensor& key,
+    const torch::Tensor& value,
+    const torch::Tensor& block_sparse_mask,
+    torch::IntArrayRef block_shape,
+    const std::string& q_input_layout,
+    const std::string& kv_input_layout,
+    int64_t num_key_value_heads,
+    double scale_value,
+    int64_t inner_precise,
+    int64_t softmax_lse_flag,
+    std::optional<torch::IntArrayRef> actual_seq_lengths,
+    std::optional<torch::IntArrayRef> actual_seq_lengths_kv) {
+  CHECK(q_input_layout == "BNSD" || q_input_layout == "TND")
+      << "q_input_layout only supports 'BNSD' and 'TND', got "
+      << q_input_layout;
+  CHECK(kv_input_layout == q_input_layout)
+      << "q_input_layout and kv_input_layout must be consistent";
+
+  // TND layout requires actual_seq_lengths for correct batch handling.
+  CHECK(q_input_layout != "TND" ||
+        (actual_seq_lengths.has_value() && actual_seq_lengths_kv.has_value()))
+      << "actual_seq_lengths and actual_seq_lengths_kv are required for TND "
+         "layout.";
+
+  const char* q_layout_ptr = q_input_layout.c_str();
+  const char* kv_layout_ptr = kv_input_layout.c_str();
+
+  // attenMaskOptional and blockTableOptional: always nullptr.
+  std::optional<torch::Tensor> null_tensor = std::nullopt;
+
+  // Convert std::optional<IntArrayRef> → std::optional<IntArrayRef>.
+  // nullopt → nullptr (acl op skips per-batch tiling);
+  // has_value() → the actual array.
+  std::optional<torch::IntArrayRef> opt_seq_lens =
+      actual_seq_lengths.has_value()
+          ? std::optional<torch::IntArrayRef>(actual_seq_lengths.value())
+          : std::nullopt;
+  std::optional<torch::IntArrayRef> opt_seq_lens_kv =
+      actual_seq_lengths_kv.has_value()
+          ? std::optional<torch::IntArrayRef>(actual_seq_lengths_kv.value())
+          : std::nullopt;
+
+  auto attention_out = torch::empty(query.sizes(), query.options());
+
+  // softmaxLse shape depends on layout.
+  //   TND:  [T, N, 1]      — batched by token (T).
+  //   BNSD: [B, N, S, 1]   — batched by batch (B).
+  // When softmax_lse_flag == 0, pass nullptr so the op skips the LSE write.
+  torch::Tensor softmax_lse;
+  std::optional<torch::Tensor> softmax_lse_opt = std::nullopt;
+  if (softmax_lse_flag != 0) {
+    if (q_input_layout == "TND") {
+      softmax_lse = torch::empty({query.size(0), query.size(1), 1},
+                                 query.options().dtype(torch::kFloat));
+    } else {
+      softmax_lse =
+          torch::empty({query.size(0), query.size(1), query.size(2), 1},
+                       query.options().dtype(torch::kFloat));
+    }
+    softmax_lse_opt = softmax_lse;
+  }
+
+  EXEC_NPU_CMD(aclnnBlockSparseAttention,
+               query,
+               key,
+               value,
+               block_sparse_mask,
+               null_tensor,  // attenMaskOptional
+               block_shape,
+               opt_seq_lens,     // actual_seq_lengths  (nullptr when unset)
+               opt_seq_lens_kv,  // actual_seq_lengths_kv
+               null_tensor,      // blockTableOptional
+               q_layout_ptr,
+               kv_layout_ptr,
+               num_key_value_heads,
+               kMaskType,
+               scale_value,
+               inner_precise,
+               kBlockSize,
+               kPreTokens,
+               kNextTokens,
+               softmax_lse_flag,
+               attention_out,
+               softmax_lse_opt);  // nullptr when flag==0
+
+  return std::make_tuple(attention_out, softmax_lse);
+}
+
+}  // namespace xllm::kernel::npu

--- a/xllm/core/kernels/npu/npu_ops_api.h
+++ b/xllm/core/kernels/npu/npu_ops_api.h
@@ -107,6 +107,21 @@ void npu_gemma_rms_norm(const torch::Tensor& x,
                         torch::Tensor& rstd_out,
                         torch::Tensor& y_out);
 
+std::tuple<torch::Tensor, torch::Tensor> npu_block_sparse_attention(
+    const torch::Tensor& query,
+    const torch::Tensor& key,
+    const torch::Tensor& value,
+    const torch::Tensor& block_sparse_mask,
+    torch::IntArrayRef block_shape,
+    const std::string& q_input_layout,
+    const std::string& kv_input_layout,
+    int64_t num_key_value_heads,
+    double scale_value,
+    int64_t inner_precise,
+    int64_t softmax_lse_flag = 0,
+    std::optional<torch::IntArrayRef> actual_seq_lengths = std::nullopt,
+    std::optional<torch::IntArrayRef> actual_seq_lengths_kv = std::nullopt);
+
 std::tuple<torch::Tensor, torch::Tensor, torch::Tensor> add_rms_norm(
     const torch::Tensor& x1,
     const torch::Tensor& x2,

--- a/xllm/models/dit/pipelines/pipeline_wan_i2v.h
+++ b/xllm/models/dit/pipelines/pipeline_wan_i2v.h
@@ -19,6 +19,7 @@ limitations under the License.
 #include <cstring>
 #include <memory>
 
+#include "core/framework/config/dit_config.h"
 #include "core/framework/dit_model_loader.h"
 #include "core/framework/model_context.h"
 #include "core/framework/request/dit_request_state.h"
@@ -465,6 +466,24 @@ class WanImageToVideoPipelineImpl : public torch::nn::Module {
     float boundary_timestep =
         boundary_ratio_ > 0.0f ? boundary_ratio_ * num_train_timesteps_ : -1.0f;
 
+    auto& dit_config = DiTConfig::get_instance();
+    xllm::dit::RainFusionState rf_state;
+    if (dit_config.rainfusion_enabled()) {
+      xllm::dit::RainFusionConfig rf_config;
+      rf_config.enabled = true;
+      rf_config.sparsity = static_cast<float>(dit_config.rainfusion_sparsity());
+      rf_config.pool_size = dit_config.rainfusion_pool_size();
+      rf_config.mask_refresh_interval =
+          dit_config.rainfusion_mask_refresh_interval();
+      rf_config.sparse_start_step = dit_config.rainfusion_sparse_start_step();
+      rf_config.inner_precise = dit_config.rainfusion_inner_precise();
+
+      transformer_->set_rainfusion_config(rf_config);
+      transformer_2_->set_rainfusion_config(rf_config);
+    }
+    xllm::dit::RainFusionState* rf_state_ptr =
+        dit_config.rainfusion_enabled() ? &rf_state : nullptr;
+
     for (int64_t i = 0; i < timesteps.numel(); ++i) {
       torch::Tensor t = timesteps[i];
       int64_t total_steps = timesteps.numel();
@@ -483,6 +502,8 @@ class WanImageToVideoPipelineImpl : public torch::nn::Module {
         current_model = transformer_2_;
         current_guidance = guidance_scale_2;
       }
+
+      rf_state.current_step = i;
 
       torch::Tensor latent_model_input;
       torch::Tensor timestep_input;
@@ -517,12 +538,14 @@ class WanImageToVideoPipelineImpl : public torch::nn::Module {
             noise_pred = current_model->forward(latent_model_input,
                                                 timestep_input,
                                                 encoded_prompt_embeds,
-                                                torch::Tensor());
+                                                torch::Tensor(),
+                                                rf_state_ptr);
           } else {
             noise_pred = current_model->forward(latent_model_input,
                                                 timestep_input,
                                                 encoded_negative_embeds,
-                                                torch::Tensor());
+                                                torch::Tensor(),
+                                                rf_state_ptr);
           }
           auto gathered = xllm::parallel_state::gather(
               noise_pred, parallel_args_.dit_cfg_group_, /*dim=*/0);
@@ -533,12 +556,14 @@ class WanImageToVideoPipelineImpl : public torch::nn::Module {
           noise_pred = current_model->forward(latent_model_input,
                                               timestep_input,
                                               encoded_prompt_embeds,
-                                              torch::Tensor());
+                                              torch::Tensor(),
+                                              rf_state_ptr);
 
           noise_uncond = current_model->forward(latent_model_input,
                                                 timestep_input,
                                                 encoded_negative_embeds,
-                                                torch::Tensor());
+                                                torch::Tensor(),
+                                                rf_state_ptr);
         }
 
         noise_pred = noise_uncond.to(torch::kFloat32) +

--- a/xllm/models/dit/transformers/transformer_wan.h
+++ b/xllm/models/dit/transformers/transformer_wan.h
@@ -33,6 +33,7 @@ limitations under the License.
 #include "core/layers/common/add_matmul.h"
 #include "core/layers/common/rms_norm.h"
 #include "models/dit/utils/dit_parallel_linear.h"
+#include "models/dit/utils/rainfusion_attention.h"
 
 using xllm::dit::DiTParallelLinear;
 using xllm::dit::LinearType;
@@ -605,12 +606,22 @@ class WanAttentionImpl : public torch::nn::Module {
 
   torch::Tensor at_npu_attention(const torch::Tensor& q,
                                  const torch::Tensor& k,
-                                 const torch::Tensor& v) {
+                                 const torch::Tensor& v,
+                                 xllm::dit::RainFusionState* rf_state) {
     const auto q_t = q.transpose(1, 2);
     const auto k_t = k.transpose(1, 2);
     const auto v_t = v.transpose(1, 2);
 
 #if defined(USE_NPU)
+    if (rf_state && rainfusion_config_.enabled &&
+        rf_state->current_step >= rainfusion_config_.sparse_start_step &&
+        q_t.size(2) == k_t.size(2)) {
+      auto [out_bnsd, new_mask] = xllm::dit::rainfusion_attention(
+          q_t, k_t, v_t, rainfusion_config_, *rf_state);
+      rf_state->cached_mask = new_mask;
+      return out_bnsd.transpose(1, 2).flatten(2, 3).to(q.dtype());
+    }
+
     const int64_t head_num = q_t.size(1);
     const int64_t head_dim = q_t.size(-1);
     const auto results = at_npu::native::custom_ops::npu_fusion_attention(
@@ -636,11 +647,16 @@ class WanAttentionImpl : public torch::nn::Module {
     return out.flatten(2, 3).to(q.dtype());
   }
 
+  void set_rainfusion_config(const xllm::dit::RainFusionConfig& config) {
+    rainfusion_config_ = config;
+  }
+
   torch::Tensor forward(
       const torch::Tensor& hidden_states_in,
       const torch::Tensor& encoder_hidden_states = torch::Tensor(),
       std::optional<std::pair<torch::Tensor, torch::Tensor>> rotary_emb =
-          std::nullopt) {
+          std::nullopt,
+      xllm::dit::RainFusionState* rf_state = nullptr) {
     torch::Tensor hidden_states = hidden_states_in;
     bool is_self_attention =
         !encoder_hidden_states.defined() ||
@@ -702,9 +718,9 @@ class WanAttentionImpl : public torch::nn::Module {
 
       key_img = key_img.view({batch_size, -1, n_heads, dim_head_});
       value_img = value_img.view({batch_size, -1, n_heads, dim_head_});
-      hidden_states_img = at_npu_attention(query, key_img, value_img);
+      hidden_states_img = at_npu_attention(query, key_img, value_img, rf_state);
     }
-    hidden_states = at_npu_attention(query, key, value);
+    hidden_states = at_npu_attention(query, key, value, rf_state);
     if (hidden_states_img.defined()) {
       hidden_states = hidden_states + hidden_states_img;
     }
@@ -770,6 +786,9 @@ class WanAttentionImpl : public torch::nn::Module {
   layer::RMSNorm norm_added_k_{nullptr};
 
   torch::TensorOptions options_;
+
+  // RainFusionV3 configuration (static, same for all requests)
+  xllm::dit::RainFusionConfig rainfusion_config_;
 };
 TORCH_MODULE(WanAttention);
 
@@ -1122,11 +1141,17 @@ class WanTransformerBlockImpl : public torch::nn::Module {
                                std::sqrt(static_cast<float>(dim_)));
   }
 
+  void set_rainfusion_config(const xllm::dit::RainFusionConfig& config) {
+    attn1_->set_rainfusion_config(config);
+    attn2_->set_rainfusion_config(config);
+  }
+
   torch::Tensor forward(const torch::Tensor& hidden_states_in,
                         const torch::Tensor& encoder_hidden_states,
                         const torch::Tensor& timestep_proj,
                         std::optional<std::pair<torch::Tensor, torch::Tensor>>
-                            rotary_emb = std::nullopt) {
+                            rotary_emb = std::nullopt,
+                        xllm::dit::RainFusionState* rf_state = nullptr) {
     torch::Tensor hidden_states = hidden_states_in;
     torch::Tensor shift_msa, scale_msa, gate_msa, c_shift_msa, c_scale_msa,
         c_gate_msa;
@@ -1157,8 +1182,8 @@ class WanTransformerBlockImpl : public torch::nn::Module {
     torch::Tensor norm1_result = norm1_->forward(hidden_states);
     torch::Tensor norm_hidden_states =
         (norm1_result.to(hidden_states.dtype()) * (1 + scale_msa) + shift_msa);
-    torch::Tensor attn_output =
-        attn1_->forward(norm_hidden_states, norm_hidden_states, rotary_emb);
+    torch::Tensor attn_output = attn1_->forward(
+        norm_hidden_states, norm_hidden_states, rotary_emb, rf_state);
     hidden_states = hidden_states + attn_output * gate_msa;
 
     if (cross_attn_norm_) {
@@ -1168,7 +1193,7 @@ class WanTransformerBlockImpl : public torch::nn::Module {
     }
 
     attn_output = attn2_->forward(
-        norm_hidden_states, encoder_hidden_states, std::nullopt);
+        norm_hidden_states, encoder_hidden_states, std::nullopt, rf_state);
     hidden_states = hidden_states + attn_output;
     torch::Tensor norm2_result = norm3_->forward(hidden_states);
     norm_hidden_states = (norm2_result * (1 + c_scale_msa) + c_shift_msa);
@@ -1289,11 +1314,18 @@ class WanTransformer3DModelImpl : public torch::nn::Module {
                                std::sqrt(static_cast<float>(inner_dim_)));
   }
 
+  void set_rainfusion_config(const xllm::dit::RainFusionConfig& config) {
+    for (auto& block : transformer_layers_) {
+      block->set_rainfusion_config(config);
+    }
+  }
+
   torch::Tensor forward(
       const torch::Tensor& hidden_states_in,
       const torch::Tensor& timestep,
       const torch::Tensor& encoder_hidden_states,
-      const torch::Tensor& encoder_hidden_states_image = torch::Tensor()) {
+      const torch::Tensor& encoder_hidden_states_image = torch::Tensor(),
+      xllm::dit::RainFusionState* rf_state = nullptr) {
     int64_t batch_size = hidden_states_in.size(0);
     int64_t num_frames = hidden_states_in.size(2);
     int64_t height = hidden_states_in.size(3);
@@ -1305,6 +1337,12 @@ class WanTransformer3DModelImpl : public torch::nn::Module {
     int64_t post_patch_num_frames = num_frames / p_t;
     int64_t post_patch_height = height / p_h;
     int64_t post_patch_width = width / p_w;
+
+    std::vector<int64_t> latent_shape = {
+        post_patch_num_frames, post_patch_height, post_patch_width};
+    if (rf_state) {
+      rf_state->latent_shape = latent_shape;
+    }
 
     torch::Tensor hidden_states = hidden_states_in;
 
@@ -1352,7 +1390,8 @@ class WanTransformer3DModelImpl : public torch::nn::Module {
           transformer_layers_[i]->forward(hidden_states,
                                           encoder_hidden_states_embedded,
                                           timestep_proj,
-                                          rotary_emb);
+                                          rotary_emb,
+                                          rf_state);
     }
 
     torch::Tensor shift, scale;

--- a/xllm/models/dit/utils/rainfusion_attention.h
+++ b/xllm/models/dit/utils/rainfusion_attention.h
@@ -1,0 +1,523 @@
+/* Copyright 2026 The xLLM Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://github.com/jd-opensource/xllm/blob/main/LICENSE
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#pragma once
+
+#include <torch/torch.h>
+
+#include <cmath>
+#include <tuple>
+#include <vector>
+
+#include "core/kernels/npu/npu_ops_api.h"
+
+namespace xllm::dit {
+
+struct RainFusionConfig {
+  float sparsity = 0.5;
+  int64_t pool_size = 128;
+  int64_t inner_precise = 0;
+  int64_t sparse_start_step = 0;
+  int64_t mask_refresh_interval = 1;
+  bool enabled = false;
+};
+
+// Per-request dynamic state for RainFusionV3 attention.
+// Must NOT be stored as model layer members — each request owns its own
+// instance, passed through the forward call chain.
+struct RainFusionState {
+  torch::Tensor cached_mask;
+  int64_t current_step = 0;
+  std::vector<int64_t> latent_shape = {1, 1, 1};
+};
+
+namespace {
+
+torch::Tensor avgpool(const torch::Tensor& input,
+                      int64_t pool_size,
+                      const std::string& input_layout) {
+  std::vector<torch::Tensor> pooled_parts;
+  if (input_layout == "BSND") {
+    int64_t batch = input.size(0);
+    int64_t seqlen = input.size(1);
+    int64_t headnum = input.size(2);
+    int64_t dim = input.size(3);
+    int64_t num_full_blocks = seqlen / pool_size;
+    int64_t tail_size = seqlen % pool_size;
+
+    if (num_full_blocks > 0) {
+      auto full_blocks = input.slice(1, 0, num_full_blocks * pool_size);
+      full_blocks = full_blocks.reshape(
+          {batch, num_full_blocks, pool_size, headnum, dim});
+      pooled_parts.emplace_back(full_blocks.mean(2));
+    }
+    if (tail_size > 0) {
+      auto tail_block = input.slice(1, num_full_blocks * pool_size, seqlen);
+      tail_block = tail_block.reshape({batch, 1, tail_size, headnum, dim});
+      pooled_parts.emplace_back(tail_block.mean(2));
+    }
+  } else {
+    // BNSD: [B, N, S, D]
+    int64_t batch = input.size(0);
+    int64_t headnum = input.size(1);
+    int64_t seqlen = input.size(2);
+    int64_t dim = input.size(3);
+    int64_t num_full_blocks = seqlen / pool_size;
+    int64_t tail_size = seqlen % pool_size;
+
+    if (num_full_blocks > 0) {
+      auto full_blocks = input.slice(2, 0, num_full_blocks * pool_size);
+      full_blocks = full_blocks.reshape(
+          {batch, headnum, num_full_blocks, pool_size, dim});
+      pooled_parts.emplace_back(full_blocks.mean(3));
+    }
+    if (tail_size > 0) {
+      auto tail_block = input.slice(2, num_full_blocks * pool_size, seqlen);
+      tail_block = tail_block.reshape({batch, headnum, 1, tail_size, dim});
+      pooled_parts.emplace_back(tail_block.mean(3));
+    }
+  }
+  if (pooled_parts.size() > 1) {
+    int64_t cat_dim = (input_layout == "BSND") ? 1 : 2;
+    return torch::cat(pooled_parts, cat_dim);
+  }
+  return pooled_parts[0];
+}
+
+// Rearrange tokens from (f, h, w) spatial order to (f, hn, wn, 8, 8) block
+// order. First frame is kept unchanged (first-frame protection).
+torch::Tensor rearrange_with_remaining(const torch::Tensor& tensor,
+                                       int64_t tq,
+                                       int64_t hq,
+                                       int64_t wq,
+                                       const std::string& input_layout) {
+  int64_t first_frame_len = hq * wq;
+  int64_t frame_num = tq;
+
+  if (hq % 8 == 0 && wq % 8 == 0) {
+    // Aligned path
+    int64_t hn = hq / 8;
+    int64_t wn = wq / 8;
+    if (input_layout == "BSND") {
+      return tensor
+          .reshape({tensor.size(0),
+                    frame_num,
+                    hn,
+                    8,
+                    wn,
+                    8,
+                    tensor.size(2),
+                    tensor.size(3)})
+          .permute({0, 1, 2, 4, 3, 5, 6, 7})
+          .contiguous()
+          .reshape({tensor.size(0), -1, tensor.size(2), tensor.size(3)});
+    } else {
+      // BNSD: [B, N, (f hn 8 wn 8), D] -> [B, N, (f hn wn 8 8), D]
+      return tensor
+          .reshape({tensor.size(0),
+                    tensor.size(1),
+                    frame_num,
+                    hn,
+                    8,
+                    wn,
+                    8,
+                    tensor.size(3)})
+          .permute({0, 1, 2, 3, 5, 4, 6, 7})
+          .contiguous()
+          .reshape({tensor.size(0), tensor.size(1), -1, tensor.size(3)});
+    }
+  }
+
+  // Remainder path
+  int64_t hq_block = (hq / 8) * 8;
+  int64_t wq_block = (wq / 8) * 8;
+  int64_t hq_rem = hq % 8;
+  int64_t wq_rem = wq % 8;
+  int64_t hn = hq_block / 8;
+  int64_t wn = wq_block / 8;
+
+  if (input_layout == "BSND") {
+    auto tensor_first = tensor.slice(1, 0, first_frame_len);
+    auto tensor_rest = tensor.slice(1, first_frame_len);
+    auto tensor_hwt = tensor_rest.reshape({tensor.size(0),
+                                           frame_num - 1,
+                                           hq,
+                                           wq,
+                                           tensor.size(2),
+                                           tensor.size(3)});
+    torch::Tensor tensor_h_r, tensor_w_r;
+    if (hq_rem > 0) {
+      auto splits = tensor_hwt.split({hq_block, hq_rem}, 2);
+      tensor_hwt = splits[0];
+      tensor_h_r = splits[1].reshape(
+          {tensor.size(0), frame_num - 1, -1, tensor.size(2), tensor.size(3)});
+    }
+    if (wq_rem > 0) {
+      auto splits = tensor_hwt.split({wq_block, wq_rem}, 3);
+      tensor_hwt = splits[0];
+      tensor_w_r = splits[1].reshape(
+          {tensor.size(0), frame_num - 1, -1, tensor.size(2), tensor.size(3)});
+    }
+    tensor_hwt = tensor_hwt
+                     .reshape({tensor.size(0),
+                               frame_num - 1,
+                               hn,
+                               8,
+                               wn,
+                               8,
+                               tensor.size(2),
+                               tensor.size(3)})
+                     .permute({0, 1, 2, 4, 3, 5, 6, 7})
+                     .contiguous()
+                     .reshape({tensor.size(0),
+                               frame_num - 1,
+                               hn * wn * 64,
+                               tensor.size(2),
+                               tensor.size(3)});
+    if (hq_rem > 0) {
+      tensor_hwt = torch::cat({tensor_hwt, tensor_h_r}, 2);
+    }
+    if (wq_rem > 0) {
+      tensor_hwt = torch::cat({tensor_hwt, tensor_w_r}, 2);
+    }
+    tensor_hwt = tensor_hwt.reshape(
+        {tensor.size(0), -1, tensor.size(2), tensor.size(3)});
+    return torch::cat({tensor_first, tensor_hwt}, 1);
+  } else {
+    // BNSD
+    auto tensor_first = tensor.slice(2, 0, first_frame_len);
+    auto tensor_rest = tensor.slice(2, first_frame_len);
+    auto tensor_hwt = tensor_rest.reshape({tensor.size(0),
+                                           tensor.size(1),
+                                           frame_num - 1,
+                                           hq,
+                                           wq,
+                                           tensor.size(3)});
+    torch::Tensor tensor_h_r, tensor_w_r;
+    if (hq_rem > 0) {
+      auto splits = tensor_hwt.split({hq_block, hq_rem}, 3);
+      tensor_hwt = splits[0];
+      tensor_h_r = splits[1].reshape(
+          {tensor.size(0), tensor.size(1), frame_num - 1, -1, tensor.size(3)});
+    }
+    if (wq_rem > 0) {
+      auto splits = tensor_hwt.split({wq_block, wq_rem}, 4);
+      tensor_hwt = splits[0];
+      tensor_w_r = splits[1].reshape(
+          {tensor.size(0), tensor.size(1), frame_num - 1, -1, tensor.size(3)});
+    }
+    tensor_hwt = tensor_hwt
+                     .reshape({tensor.size(0),
+                               tensor.size(1),
+                               frame_num - 1,
+                               hn,
+                               8,
+                               wn,
+                               8,
+                               tensor.size(3)})
+                     .permute({0, 1, 2, 3, 5, 4, 6, 7})
+                     .contiguous()
+                     .reshape({tensor.size(0),
+                               tensor.size(1),
+                               frame_num - 1,
+                               hn * wn * 64,
+                               tensor.size(3)});
+    if (hq_rem > 0) {
+      tensor_hwt = torch::cat({tensor_hwt, tensor_h_r}, 3);
+    }
+    if (wq_rem > 0) {
+      tensor_hwt = torch::cat({tensor_hwt, tensor_w_r}, 3);
+    }
+    tensor_hwt = tensor_hwt.reshape(
+        {tensor.size(0), tensor.size(1), -1, tensor.size(3)});
+    return torch::cat({tensor_first, tensor_hwt}, 2);
+  }
+}
+
+// Compute block sparse mask from pooled Q/K/V (concatenated along dim=0).
+// Returns int8 binary mask of shape [B, N, q_blocks, kv_blocks].
+torch::Tensor get_blockwise_mask(const torch::Tensor& q_pool,
+                                 const torch::Tensor& k_pool,
+                                 int64_t txt_len,
+                                 float sparsity,
+                                 double scale,
+                                 int64_t pool_size,
+                                 int64_t tq,
+                                 int64_t hq,
+                                 int64_t wq,
+                                 const std::string& input_layout,
+                                 bool protect_first_frame) {
+  // Each head computes its own mask independently
+  auto q_for_mask = q_pool;
+  auto k_for_mask = k_pool;
+
+  // Attention scores: Q @ K^T * scale
+  torch::Tensor attn_scores;
+  if (input_layout == "BSND") {
+    attn_scores =
+        torch::einsum("blnd,bsnd->bnls", {q_for_mask, k_for_mask}) * scale;
+  } else {
+    attn_scores =
+        torch::einsum("bnld,bnsd->bnls", {q_for_mask, k_for_mask}) * scale;
+  }
+
+  auto score_matrix = torch::softmax(attn_scores, -1);
+  int64_t cols = score_matrix.size(-1);
+  int64_t keep_len = std::max(
+      static_cast<int64_t>(std::ceil(cols * (1.0 - sparsity))), int64_t(1));
+
+  auto topk_result = score_matrix.topk(keep_len, -1);
+  auto thresholds = std::get<0>(topk_result).slice(-1, keep_len - 1, keep_len);
+  auto mask = score_matrix >= thresholds;
+
+  // Text token protection
+  int64_t text_block_num = (txt_len + pool_size - 1) / pool_size;
+  if (text_block_num > 0) {
+    mask.index_put_(
+        {torch::indexing::Slice(),
+         torch::indexing::Slice(),
+         torch::indexing::Slice(-text_block_num, torch::indexing::None),
+         torch::indexing::Slice()},
+        true);
+    mask.index_put_(
+        {torch::indexing::Slice(),
+         torch::indexing::Slice(),
+         torch::indexing::Slice(),
+         torch::indexing::Slice(-text_block_num, torch::indexing::None)},
+        true);
+  }
+
+  // First frame protection
+  if (protect_first_frame) {
+    int64_t first_frame_len = hq * wq;
+    int64_t firstframe_block_num =
+        (first_frame_len + pool_size - 1) / pool_size;
+    if (firstframe_block_num > 0) {
+      mask.index_put_({torch::indexing::Slice(),
+                       torch::indexing::Slice(),
+                       torch::indexing::Slice(0, firstframe_block_num),
+                       torch::indexing::Slice()},
+                      true);
+      mask.index_put_({torch::indexing::Slice(),
+                       torch::indexing::Slice(),
+                       torch::indexing::Slice(),
+                       torch::indexing::Slice(0, firstframe_block_num)},
+                      true);
+    }
+  }
+
+  auto mask_int8 = mask.to(torch::kInt8);
+  return mask_int8;
+}
+
+// Inverse of rearrange_with_remaining. Converts from (f, hn, wn, 8, 8) block
+// order back to (f, h, w) spatial order.
+torch::Tensor bsa_inv_rearrange(const torch::Tensor& out,
+                                int64_t tq,
+                                int64_t hq,
+                                int64_t wq,
+                                const std::string& input_layout) {
+  int64_t hn = hq / 8;
+  int64_t wn = wq / 8;
+
+  if (hq % 8 == 0 && wq % 8 == 0) {
+    if (input_layout == "BNSD") {
+      int64_t n = out.size(1);
+      return out.reshape({out.size(0), n, tq, hn, wn, 8, 8, out.size(3)})
+          .permute({0, 1, 2, 3, 5, 4, 6, 7})
+          .contiguous()
+          .reshape({out.size(0), n, tq * hq * wq, out.size(3)});
+    } else {
+      int64_t n = out.size(2);
+      return out.reshape({out.size(0), tq, hn, wn, 8, 8, n, out.size(3)})
+          .permute({0, 1, 2, 4, 3, 5, 6, 7})
+          .contiguous()
+          .reshape({out.size(0), tq * hq * wq, n, out.size(3)});
+    }
+  }
+
+  // Remainder path
+  int64_t first_frame_len = hq * wq;
+  int64_t hq_block = (hq / 8) * 8;
+  int64_t wq_block = (wq / 8) * 8;
+  int64_t hq_rem = hq % 8;
+  int64_t wq_rem = wq % 8;
+  int64_t block_size = hn * wn * 64;
+  int64_t h_rem_size = hq_rem * wq;
+
+  if (input_layout == "BNSD") {
+    int64_t n = out.size(1);
+    auto out_first = out.slice(2, 0, first_frame_len);
+    auto out_rest = out.slice(2, first_frame_len);
+    out_rest = out_rest.reshape({out.size(0), n, tq - 1, hq * wq, out.size(3)});
+
+    auto t_block = out_rest.slice(3, 0, block_size);
+    torch::Tensor t_h_r, t_w_r;
+    if (hq_rem > 0) {
+      t_h_r = out_rest.slice(3, block_size, block_size + h_rem_size);
+    }
+    if (wq_rem > 0) {
+      t_w_r = out_rest.slice(3, block_size + h_rem_size);
+    }
+
+    t_block =
+        t_block.reshape({out.size(0), n, tq - 1, hn, wn, 8, 8, out.size(3)})
+            .permute({0, 1, 2, 3, 5, 4, 6, 7})
+            .contiguous()
+            .reshape({out.size(0), n, tq - 1, hq_block, wq_block, out.size(3)});
+    if (wq_rem > 0) {
+      t_block = torch::cat(
+          {t_block,
+           t_w_r.reshape(
+               {out.size(0), n, tq - 1, hq_block, wq_rem, out.size(3)})},
+          4);
+    }
+    if (hq_rem > 0) {
+      t_block = torch::cat(
+          {t_block,
+           t_h_r.reshape({out.size(0), n, tq - 1, hq_rem, wq, out.size(3)})},
+          3);
+    }
+    auto out_rest_merged =
+        t_block.reshape({out.size(0), n, (tq - 1) * hq * wq, out.size(3)});
+    return torch::cat({out_first, out_rest_merged}, 2);
+  } else {
+    // BSND
+    int64_t n = out.size(2);
+    auto out_first = out.slice(1, 0, first_frame_len);
+    auto out_rest = out.slice(1, first_frame_len);
+    out_rest = out_rest.reshape({out.size(0), tq - 1, hq * wq, n, out.size(3)});
+
+    auto t_block = out_rest.slice(2, 0, block_size);
+    torch::Tensor t_h_r, t_w_r;
+    if (hq_rem > 0) {
+      t_h_r = out_rest.slice(2, block_size, block_size + h_rem_size);
+    }
+    if (wq_rem > 0) {
+      t_w_r = out_rest.slice(2, block_size + h_rem_size);
+    }
+
+    t_block =
+        t_block.reshape({out.size(0), tq - 1, hn, wn, 8, 8, n, out.size(3)})
+            .permute({0, 1, 2, 4, 3, 5, 6, 7})
+            .contiguous()
+            .reshape({out.size(0), tq - 1, hq_block, wq_block, n, out.size(3)});
+    if (wq_rem > 0) {
+      t_block = torch::cat(
+          {t_block,
+           t_w_r.reshape(
+               {out.size(0), tq - 1, hq_block, wq_rem, n, out.size(3)})},
+          3);
+    }
+    if (hq_rem > 0) {
+      t_block = torch::cat(
+          {t_block,
+           t_h_r.reshape({out.size(0), tq - 1, hq_rem, wq, n, out.size(3)})},
+          2);
+    }
+    auto out_rest_merged =
+        t_block.reshape({out.size(0), (tq - 1) * hq * wq, n, out.size(3)});
+    return torch::cat({out_first, out_rest_merged}, 1);
+  }
+}
+
+}  // namespace
+
+// RainFusionV3 block sparse attention — main entry point.
+// query/key/value are in BNSD layout [B, N, S, D].
+// state holds per-request dynamic state (cached_mask, current_step,
+// latent_shape).
+std::tuple<torch::Tensor, torch::Tensor> rainfusion_attention(
+    const torch::Tensor& query,
+    const torch::Tensor& key,
+    const torch::Tensor& value,
+    const RainFusionConfig& config,
+    RainFusionState& state) {
+  CHECK(query.dim() == 4) << "query must be 4D [B, N, S, D]";
+  CHECK(query.dtype() == torch::kHalf || query.dtype() == torch::kBFloat16)
+      << "query must be fp16 or bf16";
+  CHECK(config.sparsity >= 0.0f && config.sparsity < 1.0f)
+      << "sparsity must be in [0.0, 1.0)";
+  CHECK(config.pool_size > 0 && config.pool_size % 128 == 0)
+      << "pool_size must be positive multiple of 128";
+  int64_t tq = state.latent_shape[0];
+  int64_t hq = state.latent_shape[1];
+  int64_t wq = state.latent_shape[2];
+  int64_t num_heads = query.size(1);
+  double scale = std::pow(static_cast<double>(query.size(-1)), -0.5);
+
+  // Step 1: Rearrange Q, K, V individually to avoid 3× copy from torch::cat.
+  auto q_rearranged = rearrange_with_remaining(query, tq, hq, wq, "BNSD");
+  auto k_rearranged = rearrange_with_remaining(key, tq, hq, wq, "BNSD");
+  auto v_rearranged = rearrange_with_remaining(value, tq, hq, wq, "BNSD");
+
+  // Step 2-3: Pooling + mask generation (skip if using cached mask)
+  torch::Tensor new_mask;
+  bool use_cached = state.cached_mask.defined() &&
+                    (config.mask_refresh_interval <= 0 ||
+                     (state.current_step % config.mask_refresh_interval != 0));
+  if (!use_cached) {
+    auto qk = torch::cat({q_rearranged, k_rearranged}, 0);
+    auto qk_pool = avgpool(qk, config.pool_size, "BNSD");
+    auto chunks = qk_pool.chunk(2, 0);
+    // NOTE: txt_len=0 because RainFusion currently only runs on self-attention
+    // (pre-cross-attention path). Text token protection is reserved for future
+    // text-conditioned video generation where txt_len > 0.
+    new_mask = get_blockwise_mask(chunks[0],
+                                  chunks[1],
+                                  /*txt_len=*/0,
+                                  config.sparsity,
+                                  scale,
+                                  config.pool_size,
+                                  tq,
+                                  hq,
+                                  wq,
+                                  "BNSD",
+                                  /*protect_first_frame=*/true);
+  } else {
+    new_mask = state.cached_mask;
+  }
+
+  // Step 4: Block sparse attention via aclnn
+  int64_t batch_size = query.size(0);
+
+  // Per-batch actual sequence lengths after spatial rearrangement.
+  // The rearranged tensor packs (f * hn * wn * 64) tokens per batch;
+  // passing actual lengths lets the BSA kernel handle tail blocks correctly.
+  std::vector<int64_t> actual_seq_lens(batch_size,
+                                       q_rearranged.size(/*S dim in BNSD=*/2));
+
+  auto [attn_out, lse] = xllm::kernel::npu::npu_block_sparse_attention(
+      q_rearranged,
+      k_rearranged,
+      v_rearranged,
+      new_mask,
+      {config.pool_size, config.pool_size},
+      "BNSD",
+      "BNSD",
+      num_heads,
+      scale,
+      config.inner_precise,
+      /*softmax_lse_flag=*/0,
+      std::optional<torch::IntArrayRef>(actual_seq_lens),
+      std::optional<torch::IntArrayRef>(actual_seq_lens));
+
+  // Step 5: Inverse spatial rearrangement
+  auto out = bsa_inv_rearrange(attn_out, tq, hq, wq, "BNSD");
+
+  return std::make_tuple(out, new_mask);
+}
+
+}  // namespace xllm::dit


### PR DESCRIPTION
1. support the RainFusionV3 for wan22
2. add a new aclnn in xllm::kernel named aclnnBlockSparseAttention
3. servel params in dit added: 
   1) rainfusion_enabled ,  decide whether use this algo
   2) rainfusion_sparsity , higher value --> lower percision, faster
   3) rainfusion_mask_refresh_interval ---> how many steps to refresh mask, higher value --> lower percision, faster
   4) rainfusion_pool_size ---> 128 is fine, no need to change
   5) rainfusion_sparse_start_step --> on which step to start the sparse, higher value --> higher percision, slower
   6) rainfusion_inner_precise  ---> 0 for A3, and 4 for A5(need test later)
4. sparsity == 0.8  ;  mask_refresh_insterval == 4 ; sparse_start_step == 15;  tp 4, cfg 2;  time consuming 140.3 (vs no sparsity 162.5s)