### PR TITLE
feat: add support for host parameter operator in graph and update conv1d_update operator for Qwen3.5.

### DIFF
--- a/tests/core/runtime/CMakeLists.txt
+++ b/tests/core/runtime/CMakeLists.txt
@@ -31,6 +31,37 @@ if(USE_NPU)
     "-Wl,--whole-archive"
     "${CMAKE_BINARY_DIR}/third_party/spdlog/libspdlog.a"
     "-Wl,--no-whole-archive")
+
+  cc_test(
+    NAME
+      acl_graph_task_update_test
+    SRCS
+      acl_graph_task_update_test.cpp
+    DEPS
+      :xllm_server
+      :runtime
+      :model_loader
+      :batch
+      :block
+      :model
+      :models
+      :sampler
+      :kv_cache
+      GTest::gtest_main
+      torch_npu
+      atb_customize
+  )
+  target_link_libraries(acl_graph_task_update_test
+                        PRIVATE
+                        torch_npu
+                        ascendcl
+                        hccl
+                        c_sec
+                        nnopbase)
+  target_link_options(acl_graph_task_update_test PRIVATE
+    "-Wl,--whole-archive"
+    "${CMAKE_BINARY_DIR}/third_party/spdlog/libspdlog.a"
+    "-Wl,--no-whole-archive")
 endif()
 
 cc_test(

--- a/tests/core/runtime/acl_graph_task_update_test.cpp
+++ b/tests/core/runtime/acl_graph_task_update_test.cpp
@@ -1,0 +1,659 @@
+/* Copyright 2026 The xLLM Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://github.com/jd-opensource/xllm/blob/main/LICENSE
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include <acl/acl.h>
+#include <glog/logging.h>
+#include <gtest/gtest.h>
+#include <torch/torch.h>
+#include <torch_npu/torch_npu.h>
+
+#include <cstdlib>
+#include <memory>
+#include <vector>
+
+#include "core/framework/batch/batch.h"
+#include "core/framework/block/block.h"
+#include "core/framework/block/block_manager_impl.h"
+#include "core/framework/kv_cache/kv_cache.h"
+#include "core/framework/model/model_args.h"
+#include "core/framework/model/model_output.h"
+#include "core/framework/model_loader.h"
+#include "core/framework/request/sequence.h"
+#include "core/framework/request/stopping_checker.h"
+#include "core/framework/sampling/sampling_params.h"
+#include "core/kernels/ops_api.h"
+#include "core/layers/npu/npu_lm_head_impl.h"
+#include "core/layers/npu/npu_word_embedding_impl.h"
+#include "core/platform/npu/acl_graph_task_update_context.h"
+#include "core/runtime/acl_graph_executor_impl.h"
+#include "core/runtime/base_executor_impl.h"
+#include "core/runtime/options.h"
+
+#if defined(__GNUC__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wattributes"
+#endif
+
+#include "torch_npu/csrc/core/npu/NPUEvent.h"
+#include "torch_npu/csrc/core/npu/NPUGraph.h"
+
+#if defined(__GNUC__)
+#pragma GCC diagnostic pop
+#endif
+
+class AclGraphTaskUpdateTestEnvironment : public ::testing::Environment {
+ public:
+  void SetUp() override {
+    google::InitGoogleLogging("acl_graph_task_update_test");
+    google::SetStderrLogging(google::INFO);
+    int ret = aclrtSetDevice(0);
+    if (ret != 0) {
+      LOG(ERROR) << "ACL set device id: 0 failed, ret:" << ret;
+    }
+    torch_npu::init_npu("npu:0");
+  }
+
+  void TearDown() override {
+    google::ShutdownGoogleLogging();
+    torch_npu::finalize_npu();
+    aclrtResetDevice(0);
+    aclFinalize();
+  }
+};
+
+::testing::Environment* const task_update_test_env =
+    ::testing::AddGlobalTestEnvironment(new AclGraphTaskUpdateTestEnvironment);
+
+namespace xllm {
+
+namespace {
+
+constexpr int64_t kConvKernelSize = 4;
+constexpr int64_t kConvChannels = 2048;
+constexpr int64_t kHiddenSize = 2048;
+constexpr int64_t kMaxSeqLen = 256;
+constexpr int64_t kVocabSize = 1000;
+constexpr int64_t kNumBlocks = 100;
+constexpr int64_t kBlockSize = 4;
+
+constexpr torch::ScalarType kDtype = torch::kFloat16;
+
+}  // namespace
+
+class HybridConv1dMockLM final : public CausalLM {
+ public:
+  HybridConv1dMockLM(const ModelArgs& args, const torch::Device& device)
+      : args_(args), device_(device) {
+    linear_ = register_module(
+        "linear",
+        torch::nn::Linear(torch::nn::LinearOptions(kHiddenSize, kHiddenSize)));
+
+    conv_weight_ =
+        register_parameter("conv_weight",
+                           torch::randn({kConvKernelSize, kConvChannels},
+                                        torch::dtype(kDtype).device(device)));
+
+    token_embedding_table_ =
+        register_parameter("token_embedding",
+                           torch::randn({kVocabSize, kHiddenSize},
+                                        torch::dtype(kDtype).device(device)));
+
+    pos_embedding_table_ =
+        register_parameter("pos_embedding",
+                           torch::randn({kMaxSeqLen, kHiddenSize},
+                                        torch::dtype(kDtype).device(device)));
+
+    this->to(device);
+  }
+
+  ModelOutput forward(const torch::Tensor& tokens,
+                      const torch::Tensor& positions,
+                      std::vector<KVCache>& kv_caches,
+                      const ModelInputParams& params) override {
+    const int64_t num_tokens = tokens.size(0);
+    auto token_emb = torch::embedding(token_embedding_table_, tokens);
+    auto pos_emb = torch::embedding(pos_embedding_table_, positions);
+    auto hidden = token_emb + pos_emb;
+
+    auto graph_context = params.graph.acl_graph_task_update_context;
+    const bool register_graph_task =
+        graph_context != nullptr && graph_context->capturing;
+
+    for (auto& kv_cache : kv_caches) {
+      if (kv_cache.empty() || !kv_cache.get_conv_cache().defined()) {
+        continue;
+      }
+      torch::Tensor conv_cache = kv_cache.get_conv_cache();
+      torch::Tensor conv_input =
+          hidden.slice(/*dim=*/1, 0, kConvChannels).contiguous();
+
+      const bool is_spec_verify = params.is_spec_verify;
+      const std::vector<int64_t> empty_host_args;
+      const std::vector<int64_t> cache_indices(
+          params.embedding.linear_state_ids.begin(),
+          params.embedding.linear_state_ids.end());
+      const auto& nat_ref =
+          is_spec_verify ? params.num_accepted_tokens_host : empty_host_args;
+
+      if (register_graph_task) {
+        const auto branch = is_spec_verify
+                                ? npu::CausalConv1dGraphBranch::kSpecVerify
+                                : npu::CausalConv1dGraphBranch::kDecode;
+
+        torch::Tensor conv_output = torch::empty_like(conv_input);
+        c10_npu::NPUStream stream = c10_npu::getCurrentNPUStream();
+        auto event = std::make_shared<c10_npu::NPUEvent>(ACL_EVENT_EXTERNAL);
+        event->block(stream);
+        event->reset(stream);
+
+        c10_npu::graph_task_group_begin(stream);
+        xllm::kernel::causal_conv1d_out(
+            conv_output,
+            conv_input,
+            conv_weight_,
+            conv_cache,
+            std::optional<torch::Tensor>(),
+            torch::IntArrayRef(params.parallel.query_start_loc),
+            torch::IntArrayRef(cache_indices),
+            torch::IntArrayRef(empty_host_args),
+            torch::IntArrayRef(nat_ref),
+            /*activation_mode=*/npu::kCausalConv1dActivationSilu,
+            /*pad_slot_id=*/npu::kCausalConv1dGraphPadSlotId,
+            /*run_mode=*/npu::kCausalConv1dRunModeUpdate);
+        c10_npu::NPUTaskGroupHandle handle =
+            c10_npu::graph_task_group_end(stream);
+
+        npu::CausalConv1dGraphTask task;
+        task.output = conv_output;
+        task.x = conv_input;
+        task.weight = conv_weight_;
+        task.conv_state = conv_cache;
+        task.bias = std::nullopt;
+        task.activation_mode = npu::kCausalConv1dActivationSilu;
+        task.pad_slot_id = npu::kCausalConv1dGraphPadSlotId;
+        task.run_mode = npu::kCausalConv1dRunModeUpdate;
+        task.branch = branch;
+        task.handle = handle;
+        task.event = std::move(event);
+        graph_context->causal_conv1d_tasks.emplace_back(std::move(task));
+
+        auto conv_proj =
+            torch::zeros({num_tokens, kHiddenSize}, conv_input.options());
+        conv_proj.slice(/*dim=*/1, 0, kConvChannels).copy_(conv_output);
+        hidden = hidden + conv_proj;
+      } else {
+        torch::Tensor conv_output = torch::empty_like(conv_input);
+        xllm::kernel::causal_conv1d_out(
+            conv_output,
+            conv_input,
+            conv_weight_,
+            conv_cache,
+            std::optional<torch::Tensor>(),
+            torch::IntArrayRef(params.parallel.query_start_loc),
+            torch::IntArrayRef(cache_indices),
+            torch::IntArrayRef(empty_host_args),
+            torch::IntArrayRef(nat_ref),
+            /*activation_mode=*/npu::kCausalConv1dActivationSilu,
+            /*pad_slot_id=*/npu::kCausalConv1dGraphPadSlotId,
+            /*run_mode=*/npu::kCausalConv1dRunModeUpdate);
+
+        auto conv_proj =
+            torch::zeros({num_tokens, kHiddenSize}, conv_input.options());
+        conv_proj.slice(/*dim=*/1, 0, kConvChannels).copy_(conv_output);
+        hidden = hidden + conv_proj;
+      }
+      break;
+    }
+
+    hidden = linear_->forward(hidden);
+
+    return ModelOutput(hidden);
+  }
+
+  bool is_hybrid_linear_attention() override { return true; }
+
+  const torch::TensorOptions& options() const override {
+    static torch::TensorOptions opts = torch::dtype(kDtype).device(device_);
+    return opts;
+  }
+
+  torch::Tensor logits(const torch::Tensor& hidden_states,
+                       const torch::Tensor& selected_idxes) override {
+    return torch::randn({hidden_states.size(0), kVocabSize},
+                        torch::dtype(kDtype).device(device_));
+  }
+
+  void load_model(std::unique_ptr<ModelLoader> loader) override {}
+  torch::Device device() const override { return device_; }
+  void prepare_expert_weight(int32_t, const std::vector<int32_t>&) override {}
+  void update_expert_weight(int32_t) override {}
+  layer::NpuLmHead get_npu_lm_head() override {
+    return layer::NpuLmHead(nullptr);
+  }
+  void set_npu_lm_head(layer::NpuLmHead&) override {}
+  layer::NpuWordEmbedding get_npu_word_embedding() override {
+    return layer::NpuWordEmbedding(nullptr);
+  }
+  void set_npu_word_embedding(layer::NpuWordEmbedding&) override {}
+
+ private:
+  ModelArgs args_;
+  torch::Device device_;
+  torch::nn::Linear linear_{nullptr};
+  torch::Tensor conv_weight_;
+  torch::Tensor token_embedding_table_;
+  torch::Tensor pos_embedding_table_;
+};
+
+class AclGraphTaskUpdateTest : public ::testing::Test {
+ protected:
+  void SetUp() override {
+    sequences_.reserve(100);
+
+    model_args_.model_type("test_hybrid_model");
+    model_args_.dtype("float16");
+    model_args_.hidden_size(kHiddenSize);
+    model_args_.max_position_embeddings(kMaxSeqLen);
+    model_args_.vocab_size(kVocabSize);
+    model_args_.n_layers(2);
+    model_args_.layer_types({"linear_attention", "full_attention"});
+
+    device_ = std::make_unique<torch::Device>("npu:0");
+    options_.num_decoding_tokens(1);
+    options_.block_size(kBlockSize);
+    options_.max_seqs_per_batch(16);
+
+    model_ = std::make_unique<HybridConv1dMockLM>(model_args_, *device_);
+
+    BlockManager::Options block_options;
+    block_options.num_blocks(kNumBlocks).block_size(kBlockSize);
+    block_manager_ = std::make_unique<BlockManagerImpl>(block_options);
+
+    sampling_param_.frequency_penalty = 0.0f;
+    stopping_checker_.set_max_generated_tokens(20);
+
+    seq_params_.seq_capacity = 100;
+    seq_params_.stopping_checker = &stopping_checker_;
+    seq_params_.sampling_param = &sampling_param_;
+    seq_params_.skip_special_tokens = true;
+    seq_params_.echo = false;
+    seq_params_.logprobs = false;
+    seq_params_.enable_schedule_overlap = false;
+
+    input_embedding_ =
+        torch::zeros({1, kHiddenSize}, torch::dtype(kDtype).device(*device_));
+    mm_data_ = MMData();
+  }
+
+  void TearDown() override {}
+
+  void reset_sequences() {
+    for (auto& sequence : sequences_) {
+      auto blocks = sequence.kv_state().kv_blocks();
+      if (!blocks.empty()) {
+        block_manager_->deallocate(blocks);
+      }
+    }
+    sequences_.clear();
+  }
+
+  std::vector<KVCache> create_hybrid_kv_caches() {
+    std::vector<KVCache> kv_caches;
+    auto conv_cache =
+        torch::zeros({kNumBlocks, kConvKernelSize - 1, kConvChannels},
+                     torch::dtype(kDtype).device(*device_));
+    auto ssm_cache = torch::zeros({kNumBlocks, 8, 64, 64},
+                                  torch::dtype(kDtype).device(*device_));
+    kv_caches.emplace_back(
+        LinearAttentionKVCacheTensors{conv_cache, ssm_cache});
+
+    auto k_cache = torch::randn({kNumBlocks, kBlockSize * kHiddenSize},
+                                torch::dtype(kDtype).device(*device_));
+    auto v_cache = k_cache.clone();
+    kv_caches.emplace_back(KVCacheTensors{k_cache, v_cache});
+    return kv_caches;
+  }
+
+  std::vector<KVCache> clone_kv_caches(const std::vector<KVCache>& src) {
+    std::vector<KVCache> cloned;
+    cloned.emplace_back(LinearAttentionKVCacheTensors{
+        src[0].get_conv_cache().clone(), src[0].get_ssm_cache().clone()});
+    cloned.emplace_back(KVCacheTensors{src[1].get_k_cache().clone(),
+                                       src[1].get_v_cache().clone()});
+    return cloned;
+  }
+
+  void populate_query_start_loc(ModelInputParams& params) {
+    const auto& q_seq_lens = params.attention.host.q_seq_lens;
+    params.parallel.query_start_loc.clear();
+    params.parallel.query_start_loc.reserve(q_seq_lens.size() + 1);
+    params.parallel.query_start_loc.push_back(0);
+    for (auto len : q_seq_lens) {
+      params.parallel.query_start_loc.push_back(
+          params.parallel.query_start_loc.back() + len);
+    }
+  }
+
+  std::unique_ptr<Batch> create_decode_batch(uint32_t batch_size,
+                                             int32_t token_seed = 100) {
+    auto batch = std::make_unique<Batch>();
+    for (uint32_t i = 0; i < batch_size; ++i) {
+      sequences_.emplace_back(i,
+                              std::vector<int32_t>{1, 3, 5, 7},
+                              input_embedding_,
+                              mm_data_,
+                              fake_decoder_,
+                              seq_params_);
+      auto& sequence = sequences_.back();
+
+      auto linear_state_block = block_manager_->allocate(1);
+      sequence.set_single_block(std::move(linear_state_block[0]));
+      sequence.add_kv_blocks(block_manager_->allocate(2));
+      sequence.kv_state().incr_kv_cache_tokens_num(4);
+      sequence.append_token(token_seed + static_cast<int32_t>(i));
+      batch->add(&sequence);
+    }
+    return batch;
+  }
+
+  std::unique_ptr<Batch> create_decode_batch_with_prompts(
+      const std::vector<std::vector<int32_t>>& prompts,
+      int32_t token_seed = 100) {
+    auto batch = std::make_unique<Batch>();
+    for (size_t i = 0; i < prompts.size(); ++i) {
+      const auto& prompt = prompts[i];
+      int64_t prompt_len = static_cast<int64_t>(prompt.size());
+      int64_t total_len = prompt_len + 1;
+      int64_t num_kv_blocks = (total_len + kBlockSize - 1) / kBlockSize;
+
+      sequences_.emplace_back(
+          i, prompt, input_embedding_, mm_data_, fake_decoder_, seq_params_);
+      auto& sequence = sequences_.back();
+
+      auto linear_state_block = block_manager_->allocate(1);
+      sequence.set_single_block(std::move(linear_state_block[0]));
+      sequence.add_kv_blocks(
+          block_manager_->allocate(static_cast<size_t>(num_kv_blocks)));
+      sequence.kv_state().incr_kv_cache_tokens_num(
+          static_cast<size_t>(prompt_len));
+      sequence.append_token(token_seed + static_cast<int32_t>(i));
+      batch->add(&sequence);
+    }
+    return batch;
+  }
+
+  void setup_spec_verify_input(ForwardInput& fi,
+                               int32_t num_sequences,
+                               int32_t num_spec_tokens) {
+    int32_t total_tokens = num_sequences * num_spec_tokens;
+
+    fi.input_params.meta.batch_forward_type =
+        BatchForwardType(BatchForwardType::CHUNKED_PREFILL);
+    fi.input_params.meta.q_max_seq_len = num_spec_tokens;
+    fi.input_params.meta.num_sequences = num_sequences;
+    fi.input_params.is_spec_verify = true;
+
+    fi.input_params.attention.host.q_seq_lens.assign(
+        static_cast<size_t>(num_sequences), num_spec_tokens);
+
+    fi.input_params.num_accepted_tokens_host.assign(
+        static_cast<size_t>(num_sequences), 1);
+    fi.input_params.num_accepted_tokens = torch::ones(
+        {num_sequences}, torch::dtype(torch::kInt32).device(*device_));
+
+    std::vector<int32_t> token_ids_vec;
+    std::vector<int32_t> positions_vec;
+    token_ids_vec.reserve(static_cast<size_t>(total_tokens));
+    positions_vec.reserve(static_cast<size_t>(total_tokens));
+    for (int32_t s = 0; s < num_sequences; ++s) {
+      int32_t kv_len =
+          fi.input_params.attention.host.kv_seq_lens[static_cast<size_t>(s)];
+      for (int32_t t = 0; t < num_spec_tokens; ++t) {
+        token_ids_vec.push_back(50 + s * num_spec_tokens + t);
+        positions_vec.push_back(kv_len + t);
+      }
+    }
+    fi.token_ids = torch::tensor(token_ids_vec, torch::kInt32).to(*device_);
+    fi.positions = torch::tensor(positions_vec, torch::kInt32).to(*device_);
+
+    fi.input_params.graph.use_expanded_decode_for_spec_verify_attention = true;
+    std::vector<int32_t> expanded_kv_vec;
+    expanded_kv_vec.reserve(static_cast<size_t>(total_tokens));
+    for (int32_t s = 0; s < num_sequences; ++s) {
+      int32_t kv_len =
+          fi.input_params.attention.host.kv_seq_lens[static_cast<size_t>(s)];
+      for (int32_t t = 0; t < num_spec_tokens; ++t) {
+        expanded_kv_vec.push_back(kv_len + t + 1);
+      }
+    }
+    fi.input_params.graph.expanded_kv_seq_lens_vec = expanded_kv_vec;
+    fi.input_params.graph.expanded_kv_seq_lens =
+        torch::tensor(expanded_kv_vec, torch::kInt32).to(*device_);
+
+    auto block_tables = fi.input_params.attention.device.block_tables;
+    int64_t block_table_stride = block_tables.size(1);
+    auto expanded_bt =
+        torch::zeros({static_cast<int64_t>(total_tokens), block_table_stride},
+                     block_tables.options());
+    for (int32_t s = 0; s < num_sequences; ++s) {
+      for (int32_t t = 0; t < num_spec_tokens; ++t) {
+        expanded_bt[s * num_spec_tokens + t] = block_tables[s];
+      }
+    }
+    fi.input_params.graph.expanded_block_tables = expanded_bt;
+
+    std::vector<int32_t> q_cu_vec;
+    q_cu_vec.reserve(static_cast<size_t>(num_sequences + 1));
+    q_cu_vec.push_back(0);
+    for (int32_t s = 0; s < num_sequences; ++s) {
+      q_cu_vec.push_back(q_cu_vec.back() + num_spec_tokens);
+    }
+    fi.input_params.attention.host.q_cu_seq_lens = q_cu_vec;
+
+    populate_query_start_loc(fi.input_params);
+
+    fi.input_params.attention.rebuild_device_buffer(*device_);
+  }
+
+  ModelArgs model_args_;
+  std::unique_ptr<torch::Device> device_;
+  runtime::Options options_;
+  std::unique_ptr<HybridConv1dMockLM> model_;
+  std::unique_ptr<BlockManagerImpl> block_manager_;
+  RequestSamplingParam sampling_param_;
+  StoppingChecker stopping_checker_;
+  SequenceParams seq_params_;
+  torch::Tensor input_embedding_;
+  MMData mm_data_;
+  std::vector<Sequence> sequences_;
+  IncrementalDecoder fake_decoder_ = IncrementalDecoder("", 1, false, false);
+};
+
+TEST_F(AclGraphTaskUpdateTest, CaptureReplayVsEagerDecodeBranch) {
+  auto batch = create_decode_batch(/*batch_size=*/2);
+  ASSERT_FALSE(batch->empty());
+
+  auto forward_input = batch->prepare_forward_input(
+      options_.num_decoding_tokens(), 0, model_args_);
+  forward_input = forward_input.to(*device_, kDtype);
+  populate_query_start_loc(forward_input.input_params);
+
+  auto kv_eager = create_hybrid_kv_caches();
+  auto eager_out = model_->forward({forward_input.token_ids},
+                                   {forward_input.positions},
+                                   kv_eager,
+                                   {forward_input.input_params});
+
+  auto kv_graph = create_hybrid_kv_caches();
+  auto graph_exec = std::make_unique<npu::AclGraphExecutorImpl>(
+      model_.get(), model_args_, *device_, options_);
+  auto graph_out = graph_exec->run({forward_input.token_ids},
+                                   {forward_input.positions},
+                                   kv_graph,
+                                   {forward_input.input_params});
+
+  EXPECT_EQ(eager_out.hidden_states.sizes(), graph_out.hidden_states.sizes());
+  EXPECT_TRUE(torch::allclose(eager_out.hidden_states.to(torch::kFloat32),
+                              graph_out.hidden_states.to(torch::kFloat32),
+                              /*rtol=*/1e-2,
+                              /*atol=*/1e-2))
+      << "Decode branch: eager vs graph mismatch";
+}
+
+TEST_F(AclGraphTaskUpdateTest,
+       ReplayWithDifferentParamsProducesDifferentOutputs) {
+  std::vector<std::vector<int32_t>> prompts_run1 = {{1, 3, 5, 7}, {2, 4, 6, 8}};
+  auto batch1 =
+      create_decode_batch_with_prompts(prompts_run1, /*token_seed=*/100);
+  auto fi1 = batch1->prepare_forward_input(
+      options_.num_decoding_tokens(), 0, model_args_);
+  fi1 = fi1.to(*device_, kDtype);
+  populate_query_start_loc(fi1.input_params);
+
+  auto kv_graph = create_hybrid_kv_caches();
+  auto graph_exec = std::make_unique<npu::AclGraphExecutorImpl>(
+      model_.get(), model_args_, *device_, options_);
+
+  auto out1 = graph_exec->run(
+      {fi1.token_ids}, {fi1.positions}, kv_graph, {fi1.input_params});
+
+  auto kv_eager1 = create_hybrid_kv_caches();
+  auto eager1 = model_->forward(
+      {fi1.token_ids}, {fi1.positions}, kv_eager1, {fi1.input_params});
+  EXPECT_TRUE(torch::allclose(out1.hidden_states.to(torch::kFloat32),
+                              eager1.hidden_states.to(torch::kFloat32),
+                              /*rtol=*/1e-2,
+                              /*atol=*/1e-2))
+      << "Run 1: graph vs eager mismatch";
+
+  reset_sequences();
+  std::vector<std::vector<int32_t>> prompts_run2 = {
+      {10, 20, 30, 40, 50, 60, 70, 80}, {11, 22}};
+  auto batch2 =
+      create_decode_batch_with_prompts(prompts_run2, /*token_seed=*/200);
+  auto fi2 = batch2->prepare_forward_input(
+      options_.num_decoding_tokens(), 0, model_args_);
+  fi2 = fi2.to(*device_, kDtype);
+  populate_query_start_loc(fi2.input_params);
+
+  EXPECT_NE(fi1.input_params.embedding.linear_state_ids,
+            fi2.input_params.embedding.linear_state_ids)
+      << "linear_state_ids (cache_indices) must differ between runs";
+
+  auto out1_saved = out1.hidden_states.clone();
+  auto out2 = graph_exec->run(
+      {fi2.token_ids}, {fi2.positions}, kv_graph, {fi2.input_params});
+
+  EXPECT_FALSE(torch::allclose(out1_saved.to(torch::kFloat32),
+                               out2.hidden_states.to(torch::kFloat32),
+                               /*rtol=*/1e-2,
+                               /*atol=*/1e-2))
+      << "Task update failed: different params produced identical outputs";
+}
+
+TEST_F(AclGraphTaskUpdateTest, PaddingBatchDoesNotPolluteRealSequences) {
+  constexpr uint32_t kCaptureBatchSize = 4;
+  constexpr uint32_t kReplayBatchSize = 3;
+
+  auto capture_batch = create_decode_batch(kCaptureBatchSize);
+  auto capture_fi = capture_batch->prepare_forward_input(
+      options_.num_decoding_tokens(), 0, model_args_);
+  capture_fi = capture_fi.to(*device_, kDtype);
+  populate_query_start_loc(capture_fi.input_params);
+
+  auto kv_graph = create_hybrid_kv_caches();
+  auto graph_exec = std::make_unique<npu::AclGraphExecutorImpl>(
+      model_.get(), model_args_, *device_, options_);
+  graph_exec->run({capture_fi.token_ids},
+                  {capture_fi.positions},
+                  kv_graph,
+                  {capture_fi.input_params});
+
+  reset_sequences();
+
+  auto replay_batch = create_decode_batch(kReplayBatchSize);
+  auto replay_fi = replay_batch->prepare_forward_input(
+      options_.num_decoding_tokens(), 0, model_args_);
+  replay_fi = replay_fi.to(*device_, kDtype);
+  populate_query_start_loc(replay_fi.input_params);
+
+  auto kv_eager = clone_kv_caches(kv_graph);
+
+  auto graph_out = graph_exec->run({replay_fi.token_ids},
+                                   {replay_fi.positions},
+                                   kv_graph,
+                                   {replay_fi.input_params});
+  auto eager_out = model_->forward({replay_fi.token_ids},
+                                   {replay_fi.positions},
+                                   kv_eager,
+                                   {replay_fi.input_params});
+
+  const int64_t real_tokens =
+      static_cast<int64_t>(kReplayBatchSize) * options_.num_decoding_tokens();
+  EXPECT_EQ(graph_out.hidden_states.size(0), real_tokens);
+
+  auto eager_real =
+      eager_out.hidden_states.slice(0, 0, real_tokens).to(torch::kFloat32);
+  auto graph_real =
+      graph_out.hidden_states.slice(0, 0, real_tokens).to(torch::kFloat32);
+
+  auto diff = (eager_real - graph_real).abs();
+  float max_diff = diff.max().item<float>();
+  float mean_diff = diff.mean().item<float>();
+  LOG(INFO) << "Padding test max_diff=" << max_diff
+            << " mean_diff=" << mean_diff;
+
+  EXPECT_TRUE(torch::allclose(eager_real,
+                              graph_real,
+                              /*rtol=*/1e-2,
+                              /*atol=*/1e-2))
+      << "Padding batch pollutes real sequence output, max_diff=" << max_diff;
+}
+
+TEST_F(AclGraphTaskUpdateTest, CaptureReplayVsEagerSpecVerifyBranch) {
+  constexpr int32_t kNumSequences = 2;
+  constexpr int32_t kNumSpecTokens = 4;
+
+  auto batch = create_decode_batch(/*batch_size=*/kNumSequences);
+  ASSERT_FALSE(batch->empty());
+
+  auto fi = batch->prepare_forward_input(
+      options_.num_decoding_tokens(), 0, model_args_);
+  fi = fi.to(*device_, kDtype);
+  setup_spec_verify_input(fi, kNumSequences, kNumSpecTokens);
+
+  ASSERT_TRUE(fi.input_params.is_spec_verify);
+  ASSERT_EQ(fi.input_params.num_accepted_tokens_host.size(),
+            static_cast<size_t>(kNumSequences));
+
+  auto kv_eager = create_hybrid_kv_caches();
+  auto eager_out =
+      model_->forward(fi.token_ids, fi.positions, kv_eager, fi.input_params);
+
+  auto kv_graph = create_hybrid_kv_caches();
+  auto graph_exec = std::make_unique<npu::AclGraphExecutorImpl>(
+      model_.get(), model_args_, *device_, options_);
+  auto graph_out =
+      graph_exec->run(fi.token_ids, fi.positions, kv_graph, fi.input_params);
+
+  EXPECT_EQ(eager_out.hidden_states.sizes(), graph_out.hidden_states.sizes());
+  EXPECT_TRUE(torch::allclose(eager_out.hidden_states.to(torch::kFloat32),
+                              graph_out.hidden_states.to(torch::kFloat32),
+                              /*rtol=*/1e-2,
+                              /*atol=*/1e-2))
+      << "Spec-verify branch: eager vs graph mismatch";
+}
+
+}  // namespace xllm

--- a/xllm/core/framework/model/causal_lm.h
+++ b/xllm/core/framework/model/causal_lm.h
@@ -67,6 +67,8 @@ class CausalLM : public torch::nn::Module {
 
   virtual bool requires_graph_forward_metadata() { return false; }
 
+  virtual bool is_hybrid_linear_attention() { return false; }
+
   virtual std::unique_ptr<ModelGraphMetadataState>
   create_graph_forward_metadata_state() {
     return nullptr;
@@ -183,6 +185,14 @@ class CausalLMImpl : public CausalLM {
       return model_->requires_graph_forward_metadata();
     } else {
       return CausalLM::requires_graph_forward_metadata();
+    }
+  }
+
+  bool is_hybrid_linear_attention() override {
+    if constexpr (detail::has_is_hybrid_linear_attention<Model>::value) {
+      return model_->is_hybrid_linear_attention();
+    } else {
+      return CausalLM::is_hybrid_linear_attention();
     }
   }
 

--- a/xllm/core/framework/model/causal_vlm.h
+++ b/xllm/core/framework/model/causal_vlm.h
@@ -61,6 +61,14 @@ class CausalVLMImpl : public CausalVLM {
     return model_->forward(tokens, positions, kv_caches, parameters);
   }
 
+  bool is_hybrid_linear_attention() override {
+    if constexpr (detail::has_is_hybrid_linear_attention<Model>::value) {
+      return model_->is_hybrid_linear_attention();
+    } else {
+      return CausalLM::is_hybrid_linear_attention();
+    }
+  }
+
   torch::Tensor pooler(const torch::Tensor& hidden_states,
                        const torch::Tensor& seleted_idxes) override {
     if constexpr (detail::has_pooler<Model>::value) {

--- a/xllm/core/framework/model/model_input_params.h
+++ b/xllm/core/framework/model/model_input_params.h
@@ -46,6 +46,9 @@ limitations under the License.
 #include "util/tensor_helper.h"
 
 namespace xllm {
+namespace npu {
+struct AclGraphTaskUpdateContext;
+}  // namespace npu
 namespace layer {
 struct AttentionMetadata;
 }  // namespace layer
@@ -867,6 +870,9 @@ struct GraphInput {
   torch::Tensor expanded_block_tables;
   torch::Tensor expanded_tiling_data;
   std::vector<int32_t> expanded_kv_seq_lens_vec;
+#if defined(USE_NPU)
+  std::shared_ptr<npu::AclGraphTaskUpdateContext> acl_graph_task_update_context;
+#endif
 
   GraphInput to(const torch::Device& device) const {
     GraphInput out;
@@ -878,6 +884,9 @@ struct GraphInput {
     out.expanded_block_tables = safe_to(expanded_block_tables, device, true);
     out.expanded_tiling_data = safe_to(expanded_tiling_data, device, true);
     out.expanded_kv_seq_lens_vec = expanded_kv_seq_lens_vec;
+#if defined(USE_NPU)
+    out.acl_graph_task_update_context = acl_graph_task_update_context;
+#endif
     return out;
   }
 };
@@ -896,6 +905,7 @@ struct ModelInputParams {
     params.dit_forward_input = dit_forward_input.to(device);
     params.is_spec_verify = is_spec_verify;
     params.num_accepted_tokens = safe_to(num_accepted_tokens, device, true);
+    params.num_accepted_tokens_host = num_accepted_tokens_host;
     params.dsa_topk_indices = safe_to(dsa_topk_indices, device, true);
     for (const auto& table : multi_block_tables) {
       params.multi_block_tables.push_back(
@@ -1023,6 +1033,7 @@ struct ModelInputParams {
   bool is_spec_verify = false;
   torch::Tensor num_accepted_tokens;
   torch::Tensor dsa_topk_indices;
+  std::vector<int64_t> num_accepted_tokens_host;
 
   RecModelInputParams rec_params;
 

--- a/xllm/core/framework/model/model_traits.h
+++ b/xllm/core/framework/model/model_traits.h
@@ -128,6 +128,15 @@ struct has_requires_graph_forward_metadata<
     : std::true_type {};
 
 template <typename T, typename = void>
+struct has_is_hybrid_linear_attention : std::false_type {};
+
+template <typename T>
+struct has_is_hybrid_linear_attention<
+    T,
+    std::void_t<decltype(std::declval<T>()->is_hybrid_linear_attention())>>
+    : std::true_type {};
+
+template <typename T, typename = void>
 struct has_create_graph_forward_metadata_state : std::false_type {};
 
 template <typename T>

--- a/xllm/core/kernels/npu/npu_causal_conv1d.cpp
+++ b/xllm/core/kernels/npu/npu_causal_conv1d.cpp
@@ -19,17 +19,19 @@ limitations under the License.
 
 namespace xllm::kernel::npu {
 
-torch::Tensor causal_conv1d(const torch::Tensor& x,
-                            const torch::Tensor& weight,
-                            const torch::Tensor& conv_state,
-                            const std::optional<torch::Tensor>& bias_opt,
-                            const torch::IntArrayRef query_start_loc_opt,
-                            const torch::IntArrayRef cache_indices_opt,
-                            const torch::IntArrayRef initial_state_mode_opt,
-                            const torch::IntArrayRef num_accepted_tokens_opt,
-                            int64_t activation_mode,
-                            int64_t pad_slot_id,
-                            int64_t run_mode) {
+void causal_conv1d_out(const torch::Tensor& output,
+                       const torch::Tensor& x,
+                       const torch::Tensor& weight,
+                       const torch::Tensor& conv_state,
+                       const std::optional<torch::Tensor>& bias_opt,
+                       const torch::IntArrayRef query_start_loc_opt,
+                       const torch::IntArrayRef cache_indices_opt,
+                       const torch::IntArrayRef initial_state_mode_opt,
+                       const torch::IntArrayRef num_accepted_tokens_opt,
+                       int64_t activation_mode,
+                       int64_t pad_slot_id,
+                       int64_t run_mode) {
+  check_tensor(output, "output", "causal_conv1d");
   check_tensor(x, "x", "causal_conv1d");
   check_tensor(weight, "weight", "causal_conv1d");
   check_tensor(conv_state, "conv_state", "causal_conv1d");
@@ -39,7 +41,6 @@ torch::Tensor causal_conv1d(const torch::Tensor& x,
     bias_tensor = bias_opt.value();
   }
 
-  torch::Tensor output = torch::empty(x.sizes(), x.options());
   EXEC_NPU_CMD(aclnnCausalConv1d,
                x,
                weight,
@@ -53,6 +54,32 @@ torch::Tensor causal_conv1d(const torch::Tensor& x,
                pad_slot_id,
                run_mode,
                output);
+}
+
+torch::Tensor causal_conv1d(const torch::Tensor& x,
+                            const torch::Tensor& weight,
+                            const torch::Tensor& conv_state,
+                            const std::optional<torch::Tensor>& bias_opt,
+                            const torch::IntArrayRef query_start_loc_opt,
+                            const torch::IntArrayRef cache_indices_opt,
+                            const torch::IntArrayRef initial_state_mode_opt,
+                            const torch::IntArrayRef num_accepted_tokens_opt,
+                            int64_t activation_mode,
+                            int64_t pad_slot_id,
+                            int64_t run_mode) {
+  torch::Tensor output = torch::empty(x.sizes(), x.options());
+  causal_conv1d_out(output,
+                    x,
+                    weight,
+                    conv_state,
+                    bias_opt,
+                    query_start_loc_opt,
+                    cache_indices_opt,
+                    initial_state_mode_opt,
+                    num_accepted_tokens_opt,
+                    activation_mode,
+                    pad_slot_id,
+                    run_mode);
   return output;
 }
 

--- a/xllm/core/kernels/npu/npu_ops_api.h
+++ b/xllm/core/kernels/npu/npu_ops_api.h
@@ -321,4 +321,17 @@ torch::Tensor causal_conv1d(const torch::Tensor& x,
                             int64_t activation_mode,
                             int64_t pad_slot_id,
                             int64_t run_mode);
+
+void causal_conv1d_out(const torch::Tensor& output,
+                       const torch::Tensor& x,
+                       const torch::Tensor& weight,
+                       const torch::Tensor& conv_state,
+                       const std::optional<torch::Tensor>& bias_opt,
+                       const torch::IntArrayRef query_start_loc_opt,
+                       const torch::IntArrayRef cache_indices_opt,
+                       const torch::IntArrayRef initial_state_mode_opt,
+                       const torch::IntArrayRef num_accepted_tokens_opt,
+                       int64_t activation_mode,
+                       int64_t pad_slot_id,
+                       int64_t run_mode);
 }  // namespace xllm::kernel::npu

--- a/xllm/core/kernels/ops_api.cpp
+++ b/xllm/core/kernels/ops_api.cpp
@@ -1771,4 +1771,34 @@ torch::Tensor causal_conv1d(const torch::Tensor& x,
   NOT_IMPLEMENTED();
 #endif
 }
+
+void causal_conv1d_out(const torch::Tensor& output,
+                       const torch::Tensor& x,
+                       const torch::Tensor& weight,
+                       const torch::Tensor& conv_state,
+                       const std::optional<torch::Tensor>& bias_opt,
+                       const torch::IntArrayRef query_start_loc_opt,
+                       const torch::IntArrayRef cache_indices_opt,
+                       const torch::IntArrayRef initial_state_mode_opt,
+                       const torch::IntArrayRef num_accepted_tokens_opt,
+                       int64_t activation_mode,
+                       int64_t pad_slot_id,
+                       int64_t run_mode) {
+#if defined(USE_NPU)
+  npu::causal_conv1d_out(output,
+                         x,
+                         weight,
+                         conv_state,
+                         bias_opt,
+                         query_start_loc_opt,
+                         cache_indices_opt,
+                         initial_state_mode_opt,
+                         num_accepted_tokens_opt,
+                         activation_mode,
+                         pad_slot_id,
+                         run_mode);
+#else
+  NOT_IMPLEMENTED();
+#endif
+}
 }  // namespace xllm::kernel

--- a/xllm/core/kernels/ops_api.h
+++ b/xllm/core/kernels/ops_api.h
@@ -268,4 +268,17 @@ torch::Tensor causal_conv1d(const torch::Tensor& x,
                             int64_t activation_mode,
                             int64_t pad_slot_id,
                             int64_t run_mode);
+
+void causal_conv1d_out(const torch::Tensor& output,
+                       const torch::Tensor& x,
+                       const torch::Tensor& weight,
+                       const torch::Tensor& conv_state,
+                       const std::optional<torch::Tensor>& bias_opt,
+                       const torch::IntArrayRef query_start_loc_opt,
+                       const torch::IntArrayRef cache_indices_opt,
+                       const torch::IntArrayRef initial_state_mode_opt,
+                       const torch::IntArrayRef num_accepted_tokens_opt,
+                       int64_t activation_mode,
+                       int64_t pad_slot_id,
+                       int64_t run_mode);
 }  // namespace xllm::kernel

--- a/xllm/core/layers/npu_torch/qwen3_gated_delta_net_base.cpp
+++ b/xllm/core/layers/npu_torch/qwen3_gated_delta_net_base.cpp
@@ -357,9 +357,9 @@ torch::Tensor run_causal_conv1d_graph_update(
                                   torch::IntArrayRef(cache_indices),
                                   torch::IntArrayRef(empty_host_args),
                                   torch::IntArrayRef(num_accepted_tokens),
-                                  1,
+                                  xllm::npu::kCausalConv1dActivationSilu,
                                   xllm::npu::kCausalConv1dGraphPadSlotId,
-                                  1);
+                                  xllm::npu::kCausalConv1dRunModeUpdate);
   c10_npu::NPUTaskGroupHandle handle = c10_npu::graph_task_group_end(stream);
 
   xllm::npu::CausalConv1dGraphTask task;
@@ -368,9 +368,9 @@ torch::Tensor run_causal_conv1d_graph_update(
   task.weight = weight;
   task.conv_state = conv_state;
   task.bias = bias;
-  task.activation_mode = 1;
+  task.activation_mode = xllm::npu::kCausalConv1dActivationSilu;
   task.pad_slot_id = xllm::npu::kCausalConv1dGraphPadSlotId;
-  task.run_mode = 1;
+  task.run_mode = xllm::npu::kCausalConv1dRunModeUpdate;
   task.branch = branch;
   task.handle = handle;
   task.event = std::move(event);
@@ -588,10 +588,9 @@ torch::Tensor Qwen3GatedDeltaNetBaseImpl::forward(
         torch::IntArrayRef(linear_state_indices_vec),
         torch::IntArrayRef(input_params.parallel.has_initial_state),
         num_accepted_tokens_opt,
-        1,   // activation_mode
-        -1,  // pad_slot_id
-        0    // run mode  0:fn, 1:update
-    );
+        xllm::npu::kCausalConv1dActivationSilu,
+        xllm::npu::kCausalConv1dGraphPadSlotId,
+        xllm::npu::kCausalConv1dRunModeForward);
 
     mixed_qkv = reshape_qkvz_with_pad(attn_metadata, mixed_qkv);
     mixed_qkv = mixed_qkv.transpose(1, 2);
@@ -633,9 +632,9 @@ torch::Tensor Qwen3GatedDeltaNetBaseImpl::forward(
           torch::IntArrayRef(linear_state_indices_host),
           torch::IntArrayRef(std::vector<int64_t>()),
           torch::IntArrayRef(num_accepted),
-          1,
+          xllm::npu::kCausalConv1dActivationSilu,
           xllm::npu::kCausalConv1dGraphPadSlotId,
-          1);
+          xllm::npu::kCausalConv1dRunModeUpdate);
       mixed_qkv = output;
     }
     mixed_qkv = reshape_qkvz_with_pad(attn_metadata, mixed_qkv);

--- a/xllm/core/layers/npu_torch/qwen3_gated_delta_net_base.cpp
+++ b/xllm/core/layers/npu_torch/qwen3_gated_delta_net_base.cpp
@@ -18,6 +18,7 @@ limitations under the License.
 #include <tuple>
 
 #include "xllm/core/kernels/ops_api.h"
+#include "xllm/core/platform/npu/acl_graph_task_update_context.h"
 
 namespace xllm {
 namespace layer {
@@ -316,47 +317,65 @@ torch::Tensor expand_sequence_tensor_to_batch(const torch::Tensor& tensor,
       .contiguous();
 }
 
-torch::Tensor run_spec_verify_conv(const torch::Tensor& mixed_qkv,
-                                   const torch::Tensor& conv_cache,
-                                   const torch::Tensor& logical_state_indices,
-                                   const torch::Tensor& num_accepted_tokens,
-                                   const torch::Tensor& q_cu_seq_lens,
-                                   const torch::Tensor& conv_weight,
-                                   int32_t conv_kernel_size) {
-  const int64_t batch_size = mixed_qkv.size(0);
-  const int64_t seq_len = mixed_qkv.size(2);
-  const int64_t expanded_state_len = conv_cache.size(1);
-  CHECK_EQ(expanded_state_len, conv_kernel_size - 1 + seq_len - 1)
-      << "unexpected speculative conv cache len, expected "
-      << (conv_kernel_size - 1 + seq_len - 1) << ", got " << expanded_state_len;
+torch::Tensor run_causal_conv1d_graph_update(
+    const std::shared_ptr<xllm::npu::AclGraphTaskUpdateContext>& graph_context,
+    const torch::Tensor& x,
+    const torch::Tensor& weight,
+    const torch::Tensor& conv_state,
+    const std::optional<torch::Tensor>& bias,
+    const std::vector<int64_t>& query_start_loc,
+    const std::vector<int64_t>& cache_indices,
+    const std::vector<int64_t>& num_accepted_tokens,
+    xllm::npu::CausalConv1dGraphBranch branch) {
+  CHECK(graph_context != nullptr && graph_context->capturing)
+      << "causal_conv1d graph update can only be registered during capture";
+  CHECK(!query_start_loc.empty())
+      << "query_start_loc must be populated for causal_conv1d graph update";
+  CHECK_EQ(query_start_loc.back(), x.size(0))
+      << "query_start_loc must be padded to x.shape[0] during graph capture";
+  CHECK_EQ(cache_indices.size() + 1, query_start_loc.size())
+      << "cache_indices must be sequence-scoped";
+  if (branch == xllm::npu::CausalConv1dGraphBranch::kSpecVerify) {
+    CHECK_EQ(num_accepted_tokens.size(), cache_indices.size())
+        << "num_accepted_tokens must be sequence-scoped for spec verify";
+  }
 
-  xllm::kernel::CausalConv1dUpdateParams conv1d_params;
-  conv1d_params.x = mixed_qkv.transpose(1, 2)
-                        .reshape({batch_size * seq_len, mixed_qkv.size(1)})
-                        .contiguous();
-  conv1d_params.conv_state = conv_cache.transpose(1, 2);
-  conv1d_params.weight = conv_weight;
-  conv1d_params.activation = true;
-  conv1d_params.conv_state_indices =
-      expand_sequence_tensor_to_batch(
-          logical_state_indices, batch_size, "logical_state_indices")
-          .contiguous();
-  conv1d_params.num_accepted_tokens =
-      expand_sequence_tensor_to_batch(
-          num_accepted_tokens.to(mixed_qkv.device(), torch::kInt32),
-          batch_size,
-          "num_accepted_tokens")
-          .contiguous();
-  conv1d_params.query_start_loc = q_cu_seq_lens;
-  conv1d_params.max_query_len = static_cast<int32_t>(seq_len);
+  const std::vector<int64_t> empty_host_args;
+  torch::Tensor output = torch::empty_like(x);
+  c10_npu::NPUStream stream = c10_npu::getCurrentNPUStream();
+  auto event = std::make_shared<c10_npu::NPUEvent>(ACL_EVENT_EXTERNAL);
+  event->block(stream);
+  event->reset(stream);
 
-  torch::Tensor conv_output =
-      xllm::kernel::causal_conv1d_update(conv1d_params)
-          .view({batch_size, seq_len, mixed_qkv.size(1)})
-          .transpose(1, 2)
-          .contiguous();
+  c10_npu::graph_task_group_begin(stream);
+  xllm::kernel::causal_conv1d_out(output,
+                                  x,
+                                  weight,
+                                  conv_state,
+                                  bias,
+                                  torch::IntArrayRef(query_start_loc),
+                                  torch::IntArrayRef(cache_indices),
+                                  torch::IntArrayRef(empty_host_args),
+                                  torch::IntArrayRef(num_accepted_tokens),
+                                  1,
+                                  xllm::npu::kCausalConv1dGraphPadSlotId,
+                                  1);
+  c10_npu::NPUTaskGroupHandle handle = c10_npu::graph_task_group_end(stream);
 
-  return conv_output;
+  xllm::npu::CausalConv1dGraphTask task;
+  task.output = output;
+  task.x = x;
+  task.weight = weight;
+  task.conv_state = conv_state;
+  task.bias = bias;
+  task.activation_mode = 1;
+  task.pad_slot_id = xllm::npu::kCausalConv1dGraphPadSlotId;
+  task.run_mode = 1;
+  task.branch = branch;
+  task.handle = handle;
+  task.event = std::move(event);
+  graph_context->causal_conv1d_tasks.emplace_back(std::move(task));
+  return output;
 }
 
 torch::Tensor run_spec_verify_gated_delta_rule(
@@ -550,6 +569,9 @@ torch::Tensor Qwen3GatedDeltaNetBaseImpl::forward(
   const bool use_spec_verify = input_params.is_spec_verify;
   const bool is_any_prefill =
       attn_metadata.is_prefill || attn_metadata.is_chunked_prefill;
+  auto graph_context = input_params.graph.acl_graph_task_update_context;
+  const bool register_conv1d_graph_update =
+      graph_context != nullptr && graph_context->capturing;
 
   if (!use_spec_verify && is_any_prefill) {
     torch::IntArrayRef num_accepted_tokens_opt;
@@ -573,37 +595,50 @@ torch::Tensor Qwen3GatedDeltaNetBaseImpl::forward(
 
     mixed_qkv = reshape_qkvz_with_pad(attn_metadata, mixed_qkv);
     mixed_qkv = mixed_qkv.transpose(1, 2);
-  } else if (use_spec_verify) {
-    CHECK(input_params.num_accepted_tokens.defined())
-        << "num_accepted_tokens must be populated for Qwen3.5 spec verify";
-    torch::Tensor conv_weight_for_update =
-        conv_weight.transpose(0, 1).contiguous();
-    torch::Tensor pre_conv_mixed_qkv = mixed_qkv.transpose(1, 2);
-    mixed_qkv =
-        run_spec_verify_conv(pre_conv_mixed_qkv,
-                             conv_cache,
-                             logical_state_indices,
-                             input_params.num_accepted_tokens.to(device),
-                             attn_metadata.q_cu_seq_lens,
-                             conv_weight_for_update,
-                             conv_kernel_size_);
   } else {
-    torch::Tensor conv_weight_for_update =
-        conv_weight.transpose(0, 1).contiguous();
-    xllm::kernel::CausalConv1dUpdateParams conv1d_params;
-    conv1d_params.x = mixed_qkv.reshape({-1, mixed_qkv.size(-1)});
-    conv1d_params.conv_state = conv_cache.transpose(1, 2);
-    conv1d_params.weight = conv_weight_for_update;
-    conv1d_params.conv_state_indices = logical_state_indices;
-    conv1d_params.block_idx_last_scheduled_token =
-        std::optional<torch::Tensor>();
-    conv1d_params.initial_state_idx = std::optional<torch::Tensor>();
-    conv1d_params.query_start_loc = attn_metadata.q_cu_seq_lens;
-    conv1d_params.max_query_len = attn_metadata.max_query_len;
-    mixed_qkv = xllm::kernel::causal_conv1d_update(conv1d_params);
-    // Reshape back to 3D [batch_size, dim, seq_len]
-    mixed_qkv =
-        mixed_qkv.view({batch_size, -1, mixed_qkv.size(-1)}).contiguous();
+    if (use_spec_verify) {
+      CHECK(input_params.num_accepted_tokens.defined())
+          << "num_accepted_tokens must be populated for Qwen3.5 spec verify";
+    }
+    torch::Tensor conv_input = reshape_qkvz_unpad(attn_metadata, mixed_qkv);
+    const auto& num_accepted = use_spec_verify
+                                   ? input_params.num_accepted_tokens_host
+                                   : std::vector<int64_t>();
+    const std::vector<int64_t> linear_state_indices_host(
+        input_params.embedding.linear_state_ids.begin(),
+        input_params.embedding.linear_state_ids.end());
+    if (register_conv1d_graph_update) {
+      const auto conv1d_branch =
+          use_spec_verify ? xllm::npu::CausalConv1dGraphBranch::kSpecVerify
+                          : xllm::npu::CausalConv1dGraphBranch::kDecode;
+      mixed_qkv =
+          run_causal_conv1d_graph_update(graph_context,
+                                         conv_input,
+                                         conv_weight,
+                                         conv_cache,
+                                         std::optional<torch::Tensor>(),
+                                         input_params.parallel.query_start_loc,
+                                         linear_state_indices_host,
+                                         num_accepted,
+                                         conv1d_branch);
+    } else {
+      torch::Tensor output = torch::empty_like(conv_input);
+      xllm::kernel::causal_conv1d_out(
+          output,
+          conv_input,
+          conv_weight,
+          conv_cache,
+          std::optional<torch::Tensor>(),
+          torch::IntArrayRef(input_params.parallel.query_start_loc),
+          torch::IntArrayRef(linear_state_indices_host),
+          torch::IntArrayRef(std::vector<int64_t>()),
+          torch::IntArrayRef(num_accepted),
+          1,
+          xllm::npu::kCausalConv1dGraphPadSlotId,
+          1);
+      mixed_qkv = output;
+    }
+    mixed_qkv = reshape_qkvz_with_pad(attn_metadata, mixed_qkv);
     mixed_qkv = mixed_qkv.transpose(1, 2);
   }
   const bool fla_ssm_state_layout = use_fla_ssm_state_layout();

--- a/xllm/core/platform/npu/CMakeLists.txt
+++ b/xllm/core/platform/npu/CMakeLists.txt
@@ -6,6 +6,7 @@ cc_library(
   HDRS
     npu_layer_synchronizer.h
     device_capture_lock.h
+    acl_graph_task_update_context.h
   SRCS
     npu_layer_synchronizer.cpp
   DEPS

--- a/xllm/core/platform/npu/acl_graph_task_update_context.h
+++ b/xllm/core/platform/npu/acl_graph_task_update_context.h
@@ -37,6 +37,9 @@ limitations under the License.
 namespace xllm::npu {
 
 constexpr int64_t kCausalConv1dGraphPadSlotId = -1;
+constexpr int64_t kCausalConv1dActivationSilu = 1;
+constexpr int64_t kCausalConv1dRunModeForward = 0;
+constexpr int64_t kCausalConv1dRunModeUpdate = 1;
 
 enum class CausalConv1dGraphBranch {
   kDecode,
@@ -49,15 +52,16 @@ struct CausalConv1dGraphTask {
   torch::Tensor weight;
   torch::Tensor conv_state;
   std::optional<torch::Tensor> bias;
-  int64_t activation_mode = 1;
+  int64_t activation_mode = kCausalConv1dActivationSilu;
   int64_t pad_slot_id = kCausalConv1dGraphPadSlotId;
-  int64_t run_mode = 1;
+  int64_t run_mode = kCausalConv1dRunModeUpdate;
   CausalConv1dGraphBranch branch = CausalConv1dGraphBranch::kDecode;
   c10_npu::NPUTaskGroupHandle handle{};
   std::shared_ptr<c10_npu::NPUEvent> event;
 };
 
-struct AclGraphTaskUpdateContext {
+class AclGraphTaskUpdateContext final {
+ public:
   void begin_capture() {
     capturing = true;
     causal_conv1d_tasks.clear();

--- a/xllm/core/platform/npu/acl_graph_task_update_context.h
+++ b/xllm/core/platform/npu/acl_graph_task_update_context.h
@@ -1,0 +1,72 @@
+/* Copyright 2026 The xLLM Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://github.com/jd-opensource/xllm/blob/main/LICENSE
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#pragma once
+
+#include <torch/torch.h>
+
+#include <cstdint>
+#include <memory>
+#include <optional>
+#include <vector>
+
+#if defined(__GNUC__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wattributes"
+#endif
+
+#include "torch_npu/csrc/core/npu/NPUEvent.h"
+#include "torch_npu/csrc/core/npu/NPUGraph.h"
+
+#if defined(__GNUC__)
+#pragma GCC diagnostic pop
+#endif
+
+namespace xllm::npu {
+
+constexpr int64_t kCausalConv1dGraphPadSlotId = -1;
+
+enum class CausalConv1dGraphBranch {
+  kDecode,
+  kSpecVerify,
+};
+
+struct CausalConv1dGraphTask {
+  torch::Tensor output;
+  torch::Tensor x;
+  torch::Tensor weight;
+  torch::Tensor conv_state;
+  std::optional<torch::Tensor> bias;
+  int64_t activation_mode = 1;
+  int64_t pad_slot_id = kCausalConv1dGraphPadSlotId;
+  int64_t run_mode = 1;
+  CausalConv1dGraphBranch branch = CausalConv1dGraphBranch::kDecode;
+  c10_npu::NPUTaskGroupHandle handle{};
+  std::shared_ptr<c10_npu::NPUEvent> event;
+};
+
+struct AclGraphTaskUpdateContext {
+  void begin_capture() {
+    capturing = true;
+    causal_conv1d_tasks.clear();
+  }
+
+  void end_capture() { capturing = false; }
+
+  bool capturing = false;
+  std::vector<CausalConv1dGraphTask> causal_conv1d_tasks;
+};
+
+}  // namespace xllm::npu

--- a/xllm/core/runtime/acl_graph_executor_impl.cpp
+++ b/xllm/core/runtime/acl_graph_executor_impl.cpp
@@ -19,6 +19,7 @@ limitations under the License.
 #include <c10/core/TensorOptions.h>
 #include <glog/logging.h>
 #include <torch/torch.h>
+#include <torch_npu/csrc/core/npu/NPUGuard.h>
 #include <torch_npu/csrc/libs/init_npu.h>
 #include <torch_npu/torch_npu.h>
 
@@ -33,7 +34,9 @@ limitations under the License.
 #include <torch_npu/csrc/framework/utils/OpPreparation.h>
 #endif
 #include "core/common/metrics.h"
+#include "core/kernels/ops_api.h"
 #include "core/platform/device.h"
+#include "core/platform/npu/acl_graph_task_update_context.h"
 #include "core/util/utils.h"
 #include "platform/npu/device_capture_lock.h"
 
@@ -54,11 +57,6 @@ std::pair<torch::Tensor, torch::Tensor> find_attention_plan_kv_cache(
     }
   }
   return {torch::Tensor(), torch::Tensor()};
-}
-
-bool is_qwen3_5_model_type(const std::string& model_type) {
-  return model_type == "qwen3_5" || model_type == "qwen3_5_moe" ||
-         model_type == "qwen3_5_text" || model_type.rfind("qwen3_5_", 0) == 0;
 }
 
 }  // namespace
@@ -111,6 +109,12 @@ bool AclGraph::capture(CausalLM* model,
       persistent_param_.persistent_positions(num_tokens_),
       graph_params.value());
 
+  if (model->is_hybrid_linear_attention()) {
+    graph_task_context_ = std::make_shared<AclGraphTaskUpdateContext>();
+    graph_task_context_->begin_capture();
+    graph_params->graph.acl_graph_task_update_context = graph_task_context_;
+  }
+
   // Synchronize stream to ensure all data is copied to graph persistent buffers
   aclrtSynchronizeStream(stream);
 
@@ -157,6 +161,9 @@ bool AclGraph::capture(CausalLM* model,
       persistent_param_.set_aux_hidden_states(forward_result.aux_hidden_states);
     }
     graph_.capture_end();
+    if (graph_task_context_ != nullptr) {
+      graph_task_context_->end_capture();
+    }
     // Lock is automatically released here when lock goes out of scope
     if (need_restore_stream) {
       c10_npu::setCurrentNPUStream(
@@ -166,11 +173,67 @@ bool AclGraph::capture(CausalLM* model,
   // Synchronize and test replay to verify graph capture
   aclrtSynchronizeStream(graph_stream_);
   aclrtSynchronizeStream(stream);
-
   graph_.replay();
-
+  update_graph_tasks(graph_params.value());
   make_current_stream_wait_for_graph(stream);
   return true;
+}
+
+void AclGraph::update_graph_tasks(const ModelInputParams& params) {
+  if (graph_task_context_ == nullptr ||
+      graph_task_context_->causal_conv1d_tasks.empty()) {
+    return;
+  }
+
+  const std::vector<int64_t> empty_host_args;
+  CHECK(!params.parallel.query_start_loc.empty())
+      << "causal_conv1d graph update requires padded query_start_loc";
+  CHECK(!params.embedding.linear_state_ids.empty())
+      << "causal_conv1d graph update requires padded cache indices";
+
+  std::vector<int64_t> linear_state_indices_host(
+      params.embedding.linear_state_ids.begin(),
+      params.embedding.linear_state_ids.end());
+
+  c10_npu::NPUStream update_stream = update_stream_.value();
+  c10_npu::NPUStreamGuard stream_guard(update_stream);
+
+  for (auto& task : graph_task_context_->causal_conv1d_tasks) {
+    CHECK_EQ(params.parallel.query_start_loc.back(), task.x.size(0))
+        << "causal_conv1d graph update host args must be padded to the "
+           "capture x.shape[0]";
+    CHECK_EQ(linear_state_indices_host.size() + 1,
+             params.parallel.query_start_loc.size())
+        << "cache_indices must be sequence-scoped";
+
+    const std::vector<int64_t>& num_accepted_tokens =
+        task.branch == CausalConv1dGraphBranch::kSpecVerify
+            ? params.num_accepted_tokens_host
+            : empty_host_args;
+    if (task.branch == CausalConv1dGraphBranch::kSpecVerify) {
+      CHECK_EQ(num_accepted_tokens.size(), linear_state_indices_host.size())
+          << "spec causal_conv1d graph update requires accepted-token counts";
+    }
+
+    c10_npu::graph_task_update_begin(update_stream, task.handle);
+    xllm::kernel::causal_conv1d_out(
+        task.output,
+        task.x,
+        task.weight,
+        task.conv_state,
+        task.bias,
+        torch::IntArrayRef(params.parallel.query_start_loc),
+        torch::IntArrayRef(linear_state_indices_host),
+        torch::IntArrayRef(empty_host_args),
+        torch::IntArrayRef(num_accepted_tokens),
+        task.activation_mode,
+        task.pad_slot_id,
+        task.run_mode);
+    c10_npu::graph_task_update_end(update_stream);
+    if (task.event != nullptr) {
+      task.event->record(update_stream);
+    }
+  }
 }
 
 AclGraph::~AclGraph() {
@@ -191,6 +254,7 @@ void AclGraph::initialize_capture_stream(c10::DeviceIndex device_index) {
   // must be performed on a non-default stream (see
   // torch_npu/csrc/core/npu/NPUGraph.cpp:159).
   capture_stream_ = c10_npu::getStreamFromPool(true, device_index);
+  update_stream_ = c10_npu::getStreamFromPool(true, device_index);
   device_index_ = device_index;
   CHECK_EQ(aclrtCreateEventWithFlag(&replay_done_event_, ACL_EVENT_SYNC),
            ACL_SUCCESS)
@@ -247,7 +311,8 @@ ModelOutput AclGraph::replay(CausalLM* model,
   // be updated when Full Attention layers are involved, which is determined
   // by k_cache being valid and non-empty
   auto [k_cache, v_cache] = find_attention_plan_kv_cache(kv_cache);
-  const bool needs_graph_metadata = model->requires_graph_forward_metadata();
+  const bool needs_graph_metadata = model->requires_graph_forward_metadata() ||
+                                    model->is_hybrid_linear_attention();
   std::optional<ModelInputParams> graph_params =
       persistent_param_.update(tokens,
                                k_cache,
@@ -270,7 +335,11 @@ ModelOutput AclGraph::replay(CausalLM* model,
   aclrtStream stream = c10_npu::getCurrentNPUStream().stream();
 
   graph_.replay();
-
+  if (model->is_hybrid_linear_attention()) {
+    CHECK(graph_params.has_value())
+        << "update() should return ModelInputParams for graph task update";
+    update_graph_tasks(graph_params.value());
+  }
   make_current_stream_wait_for_graph(stream);
 
   // Return the actual num_tokens portion of ModelOutput
@@ -284,9 +353,10 @@ AclGraphExecutorImpl::AclGraphExecutorImpl(CausalLM* model,
                                            const torch::Device& device,
                                            const runtime::Options& options)
     : model_(model), args_(args), device_(device), options_(options) {
-  const bool need_update_attn_mask = is_qwen3_5_model_type(args.model_type());
+  const bool need_update_attn_mask = model->is_hybrid_linear_attention();
+  const bool is_hybrid_linear_attn = model->is_hybrid_linear_attention();
   persistent_param_ = std::make_unique<GraphPersistentParam>(
-      args_, device_, options_, need_update_attn_mask);
+      args_, device_, options_, need_update_attn_mask, is_hybrid_linear_attn);
 }
 
 ForwardInput AclGraphExecutorImpl::prepare_inputs(Batch& batch) {
@@ -322,11 +392,11 @@ ModelOutput AclGraphExecutorImpl::run(const torch::Tensor& tokens,
     COUNTER_INC(num_model_execution_total_eager);
     return model_->forward(tokens, positions, kv_caches, params);
   }
-  if (in_spec_verify_phase && !is_qwen3_5_model_type(args_.model_type())) {
+  if (in_spec_verify_phase && !model_->is_hybrid_linear_attention()) {
     LOG_FIRST_N(WARNING, 1)
         << "Falling back to eager mode for spec verify because the "
            "chunked-prefill validate graph path is currently only adapted for "
-           "Qwen3.5.";
+           "hybrid linear attention models.";
     COUNTER_INC(num_model_execution_total_eager);
     return model_->forward(tokens, positions, kv_caches, params);
   }

--- a/xllm/core/runtime/acl_graph_executor_impl.h
+++ b/xllm/core/runtime/acl_graph_executor_impl.h
@@ -46,6 +46,8 @@ limitations under the License.
 
 namespace xllm::npu {
 
+struct AclGraphTaskUpdateContext;
+
 // ACL graph executor using libtorch NPUGraph for memory management
 // NPUGraph provides mempool to manage temporary tensors during forward pass
 class AclGraph {
@@ -91,6 +93,8 @@ class AclGraph {
                                     const torch::Tensor& positions,
                                     ModelInputParams& params);
 
+  void update_graph_tasks(const ModelInputParams& params);
+
   // NPUGraph with mempool for managing temporary tensors during forward pass
   c10_npu::NPUGraph graph_;
   uint32_t num_tokens_;
@@ -105,6 +109,9 @@ class AclGraph {
   aclrtStream graph_stream_ = nullptr;
   aclrtEvent replay_done_event_ = nullptr;
   c10::DeviceIndex device_index_;
+  std::shared_ptr<AclGraphTaskUpdateContext> graph_task_context_;
+
+  std::optional<c10_npu::NPUStream> update_stream_;
 };
 
 // Executor implementation using ACL graph optimization

--- a/xllm/core/runtime/acl_graph_persistent_param.cpp
+++ b/xllm/core/runtime/acl_graph_persistent_param.cpp
@@ -126,25 +126,22 @@ int64_t infer_actual_batch_size(const ModelInputParams& params) {
   return 0;
 }
 
-bool is_qwen3_5_model_type(const std::string& model_type) {
-  return model_type == "qwen3_5" || model_type == "qwen3_5_moe" ||
-         model_type == "qwen3_5_text" || model_type.rfind("qwen3_5_", 0) == 0;
-}
-
 }  // namespace
 
 // GraphPersistentParam implementation
 GraphPersistentParam::GraphPersistentParam(const ModelArgs& args,
                                            const torch::Device& device,
                                            const runtime::Options& options,
-                                           bool need_update_attn_mask)
+                                           bool need_update_attn_mask,
+                                           bool is_hybrid_linear_attention)
     : args_(args),
       device_(device),
       options_(options),
       context_for_plan_(nullptr),
       custom_pa_op_for_plan_(nullptr),
       stream_for_plan_(nullptr),
-      need_update_attn_mask_(need_update_attn_mask) {
+      need_update_attn_mask_(need_update_attn_mask),
+      is_hybrid_linear_attention_(is_hybrid_linear_attention) {
   // Determine whether attention plan needs to be updated based on model type
   // Future logic can be extended here for more complex model-specific behavior
   need_update_attention_plan_ = (args.model_type() != "deepseek_v32" &&
@@ -577,7 +574,7 @@ std::optional<ModelInputParams> GraphPersistentParam::update(
       params.meta.batch_forward_type.is_chunked_prefill();
   const bool is_qwen3_5_spec_verify_chunked_prefill =
       params.is_spec_verify && is_chunked_prefill &&
-      is_qwen3_5_model_type(args_.model_type());
+      is_hybrid_linear_attention_;
   CHECK(is_decode || is_qwen3_5_spec_verify_chunked_prefill)
       << "ACL graph persistent param only supports decode or Qwen3.5 "
          "spec-verify chunked prefill";
@@ -815,8 +812,7 @@ std::optional<ModelInputParams> GraphPersistentParam::update(
           ? params.attention.device.q_cu_seq_lens.size(0)
           : 0;
   if (has_q_cu && q_cu_size > 0) {
-    const bool use_qwen3_5_query_start_loc =
-        is_qwen3_5_model_type(args_.model_type());
+    const bool use_qwen3_5_query_start_loc = is_hybrid_linear_attention_;
     const bool input_has_leading_zero =
         params.is_spec_verify && use_qwen3_5_query_start_loc;
     const int64_t required_q_cu_seq_lens =
@@ -1022,8 +1018,7 @@ std::optional<ModelInputParams> GraphPersistentParam::update(
           expanded_kv_seq_lens_vec;
     }
     if (params.attention.device.q_cu_seq_lens.defined()) {
-      const bool use_qwen3_5_query_start_loc =
-          is_qwen3_5_model_type(args_.model_type());
+      const bool use_qwen3_5_query_start_loc = is_hybrid_linear_attention_;
       params_for_capture->attention.device.q_cu_seq_lens = q_cu_seq_lens_.slice(
           /*dim=*/0,
           /*start=*/0,
@@ -1042,6 +1037,38 @@ std::optional<ModelInputParams> GraphPersistentParam::update(
     replace_capture_cp_ep_padding(
         params.parallel.cp_ep_padding_data,
         params_for_capture->parallel.cp_ep_padding_data);
+
+    auto& qsl = params_for_capture->parallel.query_start_loc;
+    qsl.clear();
+    qsl.reserve(static_cast<size_t>(padded_batch_size) + 1);
+    qsl.emplace_back(0);
+    for (int64_t i = 0; i < padded_batch_size; ++i) {
+      qsl.emplace_back(qsl.back() +
+                       padded_q_seq_lens_vec[static_cast<size_t>(i)]);
+    }
+
+    if (!params.parallel.has_initial_state.empty()) {
+      auto& his = params_for_capture->parallel.has_initial_state;
+      his = params.parallel.has_initial_state;
+      if (his.size() > static_cast<size_t>(actual_batch_size)) {
+        his.resize(static_cast<size_t>(actual_batch_size));
+      }
+      his.resize(static_cast<size_t>(padded_batch_size), 0);
+    }
+
+    if (params.num_accepted_tokens.defined() &&
+        params.num_accepted_tokens.numel() > 0) {
+      torch::Tensor nat_host = params.num_accepted_tokens.to(torch::kCPU)
+                                   .to(torch::kLong)
+                                   .contiguous();
+      const int64_t copy_size =
+          std::min<int64_t>(actual_batch_size, nat_host.numel());
+      const int64_t* data = nat_host.data_ptr<int64_t>();
+      params_for_capture->num_accepted_tokens_host.assign(data,
+                                                          data + copy_size);
+      params_for_capture->num_accepted_tokens_host.resize(
+          static_cast<size_t>(padded_batch_size), 1);
+    }
 
     return params_for_capture;
   }

--- a/xllm/core/runtime/acl_graph_persistent_param.h
+++ b/xllm/core/runtime/acl_graph_persistent_param.h
@@ -44,7 +44,8 @@ class GraphPersistentParam final {
   GraphPersistentParam(const ModelArgs& args,
                        const torch::Device& device,
                        const runtime::Options& options,
-                       bool need_update_attn_mask = false);
+                       bool need_update_attn_mask = false,
+                       bool is_hybrid_linear_attention = false);
 
   ~GraphPersistentParam();
 
@@ -250,6 +251,9 @@ class GraphPersistentParam final {
 
   // Flag indicating whether attention mask needs to be updated
   bool need_update_attn_mask_;
+  // Flag indicating whether the model uses hybrid linear attention
+  // (e.g., Qwen3.5/Next with gated delta net layers)
+  bool is_hybrid_linear_attention_;
   // Flag indicating whether attention plan needs to be updated based on model
   // type
   bool need_update_attention_plan_;

--- a/xllm/core/runtime/mtp_worker_impl.cpp
+++ b/xllm/core/runtime/mtp_worker_impl.cpp
@@ -1436,6 +1436,8 @@ void MTPWorkerImpl::prepare_validate_inputs(const ForwardInput& input,
     }
     input_params.num_accepted_tokens =
         torch::tensor(accepted_prefix_lengths, token_options);
+    input_params.num_accepted_tokens_host.assign(
+        accepted_prefix_lengths.begin(), accepted_prefix_lengths.end());
   }
 
   input_params.attention.rebuild_device_buffer(device_);

--- a/xllm/models/llm/qwen3_next_hybrid_base.h
+++ b/xllm/models/llm/qwen3_next_hybrid_base.h
@@ -307,6 +307,8 @@ class Qwen3HybridForCausalLMImplBase : public torch::nn::Module {
   }
   virtual void update_expert_weight(int32_t layer_id) { return; }
 
+  bool is_hybrid_linear_attention() { return true; }
+
   layer::LmHead get_lm_head() { return lm_head_; }
 
   void set_lm_head(layer::LmHead& head) { lm_head_ = head; }


### PR DESCRIPTION
## Description

1. Add causal_conv1d_out API with pre-allocated output for graph task update
2. Introduce AclGraphTaskUpdateContext to record and replay conv1d tasks
3. Update AclGraph capture/replay to handle conv1d task parameter updates
4. Add is_hybrid_linear_attention() model interface for Qwen3.5

Performance :
Average TPOT reduced by 10%+.
Qwen3.5 27B TP4 MTP: 20k input + 1k output && 1 batch, avg tpot 9.7ms.

## Change Type

- [ ] Bug fix
- [ ] New feature
- [x] Performance improvement
- [ ] Refactor
- [ ] Documentation
- [ ] Test
- [ ] Build or CI

### Build and Test Coverage

- [x] Tests have been added or updated as needed.
- [ ] CUDA: `python setup.py build test` has passed on a CUDA machine.
- [x] NPU: `python setup.py build test` has passed on an NPU machine.
- [ ] MLU: `python setup.py build test` has passed on an MLU machine.
