### PR TITLE
bugfix: fix mtp with scheduler overlap embedding race and sampling RNG issue for mlu.

### DIFF
--- a/tests/core/framework/parallel_state/parallel_state_test.cpp
+++ b/tests/core/framework/parallel_state/parallel_state_test.cpp
@@ -75,6 +75,16 @@ struct AllGatherBaseTestParams {
   int64_t input_size;
   int64_t hidden_dim;
 };
+
+struct BroadcastTestParams {
+  int32_t rank;
+  int32_t world_size;
+  int32_t port;
+  std::string host;
+  int32_t device_index;
+  int64_t numel;
+  int32_t root_rank;
+};
 // Child process test function
 int run_reduce_scatter_test_child(const TestParams& params) {
   try {
@@ -200,6 +210,52 @@ int run_reduce_scatter_test_child(const TestParams& params) {
     LOG(INFO) << "Rank " << params.rank << ": reduce_scatter test passed";
     return 0;
 
+  } catch (const std::exception& e) {
+    LOG(ERROR) << "Rank " << params.rank << ": Exception: " << e.what();
+    return 1;
+  }
+}
+
+// Child process test function for broadcast.
+// Each rank seeds its tensor with a distinct value (rank + 1); after broadcast
+// from root_rank every rank must hold root_rank's value (root_rank + 1).
+// Verifies int64 dtype and a non-zero root_rank.
+int run_broadcast_test_child(const BroadcastTestParams& params) {
+  try {
+    xllm::Device xllm_device(params.device_index);
+    xllm_device.set_device();
+    torch::Device device = xllm_device.unwrap();
+
+    auto process_group = create_test_process_group(
+        params.rank, params.world_size, params.port, params.host, device);
+    if (!process_group) {
+      LOG(ERROR) << "Rank " << params.rank << ": Failed to create ProcessGroup";
+      return 1;
+    }
+
+    auto options = torch::TensorOptions()
+                       .dtype(torch::kInt64)
+                       .device(device)
+                       .requires_grad(false);
+    torch::Tensor input = torch::full(
+        {params.numel}, static_cast<int64_t>(params.rank + 1), options);
+
+    process_group->broadcast(input, params.root_rank);
+    xllm_device.synchronize_default_stream();
+
+    int64_t expected_value = static_cast<int64_t>(params.root_rank + 1);
+    torch::Tensor input_cpu = input.to(torch::kCPU);
+    auto values = input_cpu.accessor<int64_t, 1>();
+    for (int64_t i = 0; i < params.numel; ++i) {
+      if (values[i] != expected_value) {
+        LOG(ERROR) << "Rank " << params.rank << ": broadcast mismatch at [" << i
+                   << "]: expected=" << expected_value << ", got=" << values[i];
+        return 1;
+      }
+    }
+
+    LOG(INFO) << "Rank " << params.rank << ": broadcast test passed";
+    return 0;
   } catch (const std::exception& e) {
     LOG(ERROR) << "Rank " << params.rank << ": Exception: " << e.what();
     return 1;
@@ -439,6 +495,78 @@ class AllGatherBaseMultiDeviceTest : public ::testing::Test {
   int64_t input_size_ = 0;
   int64_t hidden_dim_ = 0;
 };
+class BroadcastMultiDeviceTest : public ::testing::Test {
+ protected:
+  void SetUp() override {
+    world_size_ = 2;
+    port_ = 29551;
+    host_ = "127.0.0.1";
+    numel_ = 16;
+  }
+
+  void RunMultiProcessTest(int32_t root_rank) {
+    std::vector<pid_t> child_pids;
+    std::vector<int> child_statuses(world_size_);
+
+    for (int32_t rank = 0; rank < world_size_; ++rank) {
+      pid_t pid = fork();
+      if (pid == 0) {
+        BroadcastTestParams params;
+        params.rank = rank;
+        params.world_size = world_size_;
+        params.port = port_;
+        params.host = host_;
+        params.device_index = rank % Device::device_count();
+        params.numel = numel_;
+        params.root_rank = root_rank;
+        _exit(run_broadcast_test_child(params));
+      } else if (pid > 0) {
+        child_pids.push_back(pid);
+      } else {
+        LOG(FATAL) << "Failed to fork child process for rank " << rank;
+      }
+    }
+
+    bool all_passed = true;
+    for (size_t i = 0; i < child_pids.size(); ++i) {
+      int status;
+      pid_t waited_pid = waitpid(child_pids[i], &status, 0);
+      if (waited_pid == child_pids[i]) {
+        if (WIFEXITED(status)) {
+          child_statuses[i] = WEXITSTATUS(status);
+          if (child_statuses[i] != 0) {
+            all_passed = false;
+            LOG(ERROR) << "Child process for rank " << i << " exited with code "
+                       << child_statuses[i];
+          }
+        } else {
+          all_passed = false;
+          LOG(ERROR) << "Child process for rank " << i
+                     << " did not exit normally";
+        }
+      } else {
+        all_passed = false;
+        LOG(ERROR) << "Failed to wait for child process for rank " << i;
+      }
+    }
+
+    CHECK(all_passed) << "One or more child processes failed";
+  }
+
+  int32_t world_size_ = 0;
+  int32_t port_ = 0;
+  std::string host_;
+  int64_t numel_ = 0;
+};
+
+TEST_F(BroadcastMultiDeviceTest, BroadcastFromRoot0) {
+  RunMultiProcessTest(/*root_rank=*/0);
+}
+
+TEST_F(BroadcastMultiDeviceTest, BroadcastFromNonZeroRoot) {
+  RunMultiProcessTest(/*root_rank=*/1);
+}
+
 TEST_F(ReduceScatterMultiDeviceTest, BasicTest) {
   // Test with input size divisible by world_size
   RunMultiProcessTest(8, false);

--- a/tests/core/framework/parallel_state/parallel_state_test.cpp
+++ b/tests/core/framework/parallel_state/parallel_state_test.cpp
@@ -506,7 +506,7 @@ class BroadcastMultiDeviceTest : public ::testing::Test {
 
   void RunMultiProcessTest(int32_t root_rank) {
     std::vector<pid_t> child_pids;
-    std::vector<int> child_statuses(world_size_);
+    std::vector<int32_t> child_statuses(world_size_);
 
     for (int32_t rank = 0; rank < world_size_; ++rank) {
       pid_t pid = fork();

--- a/xllm/core/framework/model_context.cpp
+++ b/xllm/core/framework/model_context.cpp
@@ -103,6 +103,7 @@ void ModelContext::derive_optimization_config() {
   optimization_config_.enable_fused_spec_kernel = false;
   optimization_config_.enable_fused_mla_kernel = false;
   optimization_config_.enable_fused_indexer_qk = false;
+  optimization_config_.enable_spec_token_broadcast = false;
 
   // determine whether to enable fused kernel based on backend
   std::string backend = Device::type_str();
@@ -116,6 +117,9 @@ void ModelContext::derive_optimization_config() {
     // The current implementation of fused indexer qk is missing the
     //  weights and bias loading.
     optimization_config_.enable_fused_indexer_qk = true;
+    // Unify speculative sampling results across TP ranks to guard against
+    // per-rank RNG divergence under enable_schedule_overlap (see ADR-0001).
+    optimization_config_.enable_spec_token_broadcast = true;
   }
 }
 

--- a/xllm/core/framework/model_context.cpp
+++ b/xllm/core/framework/model_context.cpp
@@ -118,7 +118,7 @@ void ModelContext::derive_optimization_config() {
     //  weights and bias loading.
     optimization_config_.enable_fused_indexer_qk = true;
     // Unify speculative sampling results across TP ranks to guard against
-    // per-rank RNG divergence under enable_schedule_overlap (see ADR-0001).
+    // per-rank RNG divergence under enable_schedule_overlap.
     optimization_config_.enable_spec_token_broadcast = true;
   }
 }

--- a/xllm/core/framework/model_context.h
+++ b/xllm/core/framework/model_context.h
@@ -41,6 +41,12 @@ struct OptimizationConfig {
   bool enable_fused_mla_kernel = false;
   bool enable_fused_indexer_qk = false;
 
+  // Broadcast speculative-decoding sampling results across the TP consensus
+  // group so every rank adopts rank 0's accepted/draft tokens. Guards against
+  // per-rank RNG divergence crashing the draft decoder's TP all-reduce under
+  // enable_schedule_overlap. Only set on the MLU backend (see ADR-0001).
+  bool enable_spec_token_broadcast = false;
+
   // we can detailize this part later. for example:
   // PROPERTY(bool, enable_fused_mlp_kernel) = false;
 };

--- a/xllm/core/framework/model_context.h
+++ b/xllm/core/framework/model_context.h
@@ -44,7 +44,7 @@ struct OptimizationConfig {
   // Broadcast speculative-decoding sampling results across the TP consensus
   // group so every rank adopts rank 0's accepted/draft tokens. Guards against
   // per-rank RNG divergence crashing the draft decoder's TP all-reduce under
-  // enable_schedule_overlap. Only set on the MLU backend (see ADR-0001).
+  // enable_schedule_overlap.
   bool enable_spec_token_broadcast = false;
 
   // we can detailize this part later. for example:

--- a/xllm/core/framework/parallel_state/process_group.cpp
+++ b/xllm/core/framework/parallel_state/process_group.cpp
@@ -166,6 +166,20 @@ void ProcessGroup::reduce_scatter(const torch::Tensor& input,
       ->wait();
 }
 
+void ProcessGroup::broadcast(torch::Tensor& input, int32_t root_rank) {
+  CHECK(pg_ != nullptr) << "Process group is not initialized.";
+  // single-rank group: nothing to unify, the local tensor is already the
+  // source of truth.
+  if (world_size() <= 1) {
+    return;
+  }
+  CHECK(input.is_contiguous()) << "input is not contiguous.";
+  std::vector<torch::Tensor> tensors = {input};
+  c10d::BroadcastOptions opts;
+  opts.rootRank = root_rank;
+  pg_->broadcast(tensors, opts)->wait();
+}
+
 void ProcessGroup::all_to_all_single(
     torch::Tensor output,
     torch::Tensor input,

--- a/xllm/core/framework/parallel_state/process_group.h
+++ b/xllm/core/framework/parallel_state/process_group.h
@@ -93,6 +93,11 @@ class ProcessGroup {
   virtual void reduce_scatter(const torch::Tensor& input,
                               torch::Tensor& output);
 
+  // broadcast: in-place overwrite the input tensor on every process with the
+  // copy held by root_rank. Used to unify per-rank sampling results to a single
+  // source of truth across the consensus group.
+  virtual void broadcast(torch::Tensor& input, int32_t root_rank = 0);
+
   virtual void all_to_all_single(
       torch::Tensor output,
       torch::Tensor input,

--- a/xllm/core/runtime/mtp_worker_impl.cpp
+++ b/xllm/core/runtime/mtp_worker_impl.cpp
@@ -1593,6 +1593,13 @@ void MTPWorkerImpl::prepare_draft_extend_inputs(
     }
   }
   input_params.attention.rebuild_device_buffer(device_);
+
+  // Establish cross-stream ordering before stacking the draft-extend
+  // embeddings. The stack runs on prepare_stream_, but the embedding rows it
+  // reads are produced/finalized by work enqueued on compute_stream_. Make
+  // prepare_stream_ wait on compute_stream_ via an event.
+  prepare_stream_->wait_stream(*compute_stream_);
+
   input_params.embedding.input_embedding = torch::stack(expanded_embeddings);
 
   if (!input_params.parallel.dp_global_token_nums.empty()) {

--- a/xllm/core/runtime/mtp_worker_impl.cpp
+++ b/xllm/core/runtime/mtp_worker_impl.cpp
@@ -46,6 +46,29 @@ constexpr uint64_t MBUF_SIZE = 128 * 1024 * 1024;
 
 namespace {
 
+// The TP consensus group whose post-attention all-reduce the draft decoder
+// runs on. Speculative sampling results must be unified across exactly this
+// group so the next draft-extend step lays out identical rows on every rank
+// (see ADR-0001). Falls back to the global process group when no dedicated TP
+// group exists.
+ProcessGroup* spec_consensus_group(const ParallelArgs& parallel_args) {
+  return parallel_args.tp_group_ != nullptr ? parallel_args.tp_group_
+                                            : parallel_args.process_group_;
+}
+
+// In-place unify a speculative-decoding token tensor across the consensus group
+// to root_rank's copy. No-op for single-rank groups or undefined tensors. Must
+// be issued under the stream that produced the tensor so the collective orders
+// after the sampler kernel without a host sync.
+void unify_spec_tokens_across_tp(torch::Tensor& tokens,
+                                 ProcessGroup* pg,
+                                 int32_t root_rank = 0) {
+  if (pg == nullptr || pg->world_size() <= 1 || !tokens.defined()) {
+    return;
+  }
+  pg->broadcast(tokens, root_rank);
+}
+
 int64_t get_dp_local_tp_size(const ParallelArgs& parallel_args) {
   const int64_t dp_size = std::max<int64_t>(parallel_args.dp_size(), 1);
   const int64_t cp_size = std::max<int64_t>(parallel_args.cp_size(), 1);
@@ -1085,6 +1108,21 @@ std::optional<ForwardOutput> MTPWorkerImpl::run_validate(
       validate(input.sampling_params, draft_outputs, target_output);
   COUNTER_ADD(speculative_execution_latency_seconds_validation,
               timer.elapsed_seconds());
+
+  // Catch-all for cross-rank RNG divergence: unify the accepted next_tokens to
+  // the consensus group's rank 0 so all_draft_accepted and the next
+  // draft-extend row layout agree across ranks (see ADR-0001). Issued under
+  // compute_stream_ (the sampler kernel's stream) so the collective orders
+  // after the kernel without a host sync; must run before the device->host copy
+  // below. Only on MLU + overlap; collective is called unconditionally on every
+  // rank to avoid hangs.
+  if (get_optimization_config().enable_spec_token_broadcast &&
+      enable_schedule_overlap()) {
+    c10::StreamGuard stream_guard = compute_stream_->set_stream_guard();
+    val_output.next_tokens = val_output.next_tokens.contiguous();
+    unify_spec_tokens_across_tp(val_output.next_tokens,
+                                spec_consensus_group(parallel_args_));
+  }
 
   compute_stream_->synchronize();
   val_output.next_tokens = val_output.next_tokens.to(torch::kCPU);

--- a/xllm/core/runtime/mtp_worker_impl.cpp
+++ b/xllm/core/runtime/mtp_worker_impl.cpp
@@ -57,6 +57,7 @@ void unify_spec_tokens_across_tp(torch::Tensor& tokens,
   if (pg == nullptr || pg->world_size() <= 1 || !tokens.defined()) {
     return;
   }
+  tokens = tokens.contiguous();
   pg->broadcast(tokens, root_rank);
 }
 
@@ -1024,7 +1025,6 @@ std::optional<ForwardOutput> MTPWorkerImpl::step_decode(
         enable_schedule_overlap()) {
       c10::StreamGuard stream_guard = compute_stream_->set_stream_guard();
       SampleOutput& draft_sample = draft_outputs.back().sample_output;
-      draft_sample.next_tokens = draft_sample.next_tokens.contiguous();
       unify_spec_tokens_across_tp(draft_sample.next_tokens,
                                   spec_consensus_group(parallel_args_));
     }
@@ -1118,7 +1118,6 @@ std::optional<ForwardOutput> MTPWorkerImpl::run_validate(
   if (get_optimization_config().enable_spec_token_broadcast &&
       enable_schedule_overlap()) {
     c10::StreamGuard stream_guard = compute_stream_->set_stream_guard();
-    val_output.next_tokens = val_output.next_tokens.contiguous();
     unify_spec_tokens_across_tp(val_output.next_tokens,
                                 spec_consensus_group(parallel_args_));
   }

--- a/xllm/core/runtime/mtp_worker_impl.cpp
+++ b/xllm/core/runtime/mtp_worker_impl.cpp
@@ -1025,6 +1025,23 @@ std::optional<ForwardOutput> MTPWorkerImpl::step_decode(
     if (reuse_mtp_topk_indices) {
       mtp_topk_indices = draft_outputs.back().dsa_topk_indices;
     }
+    // Unify this step's draft next_tokens across the consensus group before
+    // process_draft_sample_output() compresses the still-full [batch, vocab]
+    // probs into the cache: gathering the cached prob with a unified token
+    // yields a unified prob, so we only broadcast the [batch] token tensor (see
+    // ADR-0001). The single broadcast also feeds identical draft tokens to the
+    // next-step draft input and to the validate forward, so every TP rank's
+    // model shard consumes the same token. Same gating/stream as the validate
+    // exit; runs every step (including the last, since
+    // process_draft_sample_output precedes the draft_idx==last continue).
+    if (get_optimization_config().enable_spec_token_broadcast &&
+        enable_schedule_overlap()) {
+      c10::StreamGuard stream_guard = compute_stream_->set_stream_guard();
+      SampleOutput& draft_sample = draft_outputs.back().sample_output;
+      draft_sample.next_tokens = draft_sample.next_tokens.contiguous();
+      unify_spec_tokens_across_tp(draft_sample.next_tokens,
+                                  spec_consensus_group(parallel_args_));
+    }
     process_draft_sample_output(draft_outputs.back().sample_output);
     if (draft_idx == num_speculative_tokens - 1) {
       continue;

--- a/xllm/core/runtime/mtp_worker_impl.cpp
+++ b/xllm/core/runtime/mtp_worker_impl.cpp
@@ -46,20 +46,11 @@ constexpr uint64_t MBUF_SIZE = 128 * 1024 * 1024;
 
 namespace {
 
-// The TP consensus group whose post-attention all-reduce the draft decoder
-// runs on. Speculative sampling results must be unified across exactly this
-// group so the next draft-extend step lays out identical rows on every rank
-// (see ADR-0001). Falls back to the global process group when no dedicated TP
-// group exists.
 ProcessGroup* spec_consensus_group(const ParallelArgs& parallel_args) {
   return parallel_args.tp_group_ != nullptr ? parallel_args.tp_group_
                                             : parallel_args.process_group_;
 }
 
-// In-place unify a speculative-decoding token tensor across the consensus group
-// to root_rank's copy. No-op for single-rank groups or undefined tensors. Must
-// be issued under the stream that produced the tensor so the collective orders
-// after the sampler kernel without a host sync.
 void unify_spec_tokens_across_tp(torch::Tensor& tokens,
                                  ProcessGroup* pg,
                                  int32_t root_rank = 0) {
@@ -1028,12 +1019,7 @@ std::optional<ForwardOutput> MTPWorkerImpl::step_decode(
     // Unify this step's draft next_tokens across the consensus group before
     // process_draft_sample_output() compresses the still-full [batch, vocab]
     // probs into the cache: gathering the cached prob with a unified token
-    // yields a unified prob, so we only broadcast the [batch] token tensor (see
-    // ADR-0001). The single broadcast also feeds identical draft tokens to the
-    // next-step draft input and to the validate forward, so every TP rank's
-    // model shard consumes the same token. Same gating/stream as the validate
-    // exit; runs every step (including the last, since
-    // process_draft_sample_output precedes the draft_idx==last continue).
+    // yields a unified prob, so we only broadcast the [batch] token tensor
     if (get_optimization_config().enable_spec_token_broadcast &&
         enable_schedule_overlap()) {
       c10::StreamGuard stream_guard = compute_stream_->set_stream_guard();
@@ -1128,11 +1114,7 @@ std::optional<ForwardOutput> MTPWorkerImpl::run_validate(
 
   // Catch-all for cross-rank RNG divergence: unify the accepted next_tokens to
   // the consensus group's rank 0 so all_draft_accepted and the next
-  // draft-extend row layout agree across ranks (see ADR-0001). Issued under
-  // compute_stream_ (the sampler kernel's stream) so the collective orders
-  // after the kernel without a host sync; must run before the device->host copy
-  // below. Only on MLU + overlap; collective is called unconditionally on every
-  // rank to avoid hangs.
+  // draft-extend row layout agree across ranks.
   if (get_optimization_config().enable_spec_token_broadcast &&
       enable_schedule_overlap()) {
     c10::StreamGuard stream_guard = compute_stream_->set_stream_guard();

--- a/xllm/core/runtime/mtp_worker_impl.cpp
+++ b/xllm/core/runtime/mtp_worker_impl.cpp
@@ -46,14 +46,14 @@ constexpr uint64_t MBUF_SIZE = 128 * 1024 * 1024;
 
 namespace {
 
-ProcessGroup* spec_consensus_group(const ParallelArgs& parallel_args) {
+ProcessGroup* spec_broadcast_group(const ParallelArgs& parallel_args) {
   return parallel_args.tp_group_ != nullptr ? parallel_args.tp_group_
                                             : parallel_args.process_group_;
 }
 
-void unify_spec_tokens_across_tp(torch::Tensor& tokens,
-                                 ProcessGroup* pg,
-                                 int32_t root_rank = 0) {
+void broadcast_spec_tokens(torch::Tensor& tokens,
+                           ProcessGroup* pg,
+                           int32_t root_rank = 0) {
   if (pg == nullptr || pg->world_size() <= 1 || !tokens.defined()) {
     return;
   }
@@ -1025,8 +1025,8 @@ std::optional<ForwardOutput> MTPWorkerImpl::step_decode(
         enable_schedule_overlap()) {
       c10::StreamGuard stream_guard = compute_stream_->set_stream_guard();
       SampleOutput& draft_sample = draft_outputs.back().sample_output;
-      unify_spec_tokens_across_tp(draft_sample.next_tokens,
-                                  spec_consensus_group(parallel_args_));
+      broadcast_spec_tokens(draft_sample.next_tokens,
+                            spec_broadcast_group(parallel_args_));
     }
     process_draft_sample_output(draft_outputs.back().sample_output);
     if (draft_idx == num_speculative_tokens - 1) {
@@ -1118,8 +1118,8 @@ std::optional<ForwardOutput> MTPWorkerImpl::run_validate(
   if (get_optimization_config().enable_spec_token_broadcast &&
       enable_schedule_overlap()) {
     c10::StreamGuard stream_guard = compute_stream_->set_stream_guard();
-    unify_spec_tokens_across_tp(val_output.next_tokens,
-                                spec_consensus_group(parallel_args_));
+    broadcast_spec_tokens(val_output.next_tokens,
+                          spec_broadcast_group(parallel_args_));
   }
 
   compute_stream_->synchronize();


### PR DESCRIPTION
## Description

Fix NaN crashes in the **MTP (speculative decoding) + TP + `enable_schedule_overlap`** path caused by per-rank sampling RNG divergence across TP ranks.

Under TP parallelism, speculative-decoding sampling (both the draft and validate phases) runs independently on each rank. Once `enable_schedule_overlap` is on, the per-rank RNG can produce inconsistent sampling results, so the `all_draft_accepted` decision, the draft-extend row layout, and the subsequent draft decoder's TP all-reduce diverge across ranks — ultimately triggering a NaN crash.

The core idea of this PR is to **unify the sampling results to rank 0 within the TP consensus group**, so every rank adopts the same accepted / draft tokens and cross-rank divergence is eliminated.

Key changes:

- **Add a `ProcessGroup::broadcast` primitive**: in-place overwrites the tensor on every rank in the group with `root_rank`'s copy; a single-rank group is skipped. Adds a multi-process unit test covering int64 dtype and a non-zero root rank (`BroadcastFromRoot0` / `BroadcastFromNonZeroRoot`).

- **Add the `enable_spec_token_broadcast` optimization flag** (`OptimizationConfig`): enabled by default only on the relevant backend, used to unify speculative sampling results across TP ranks.

- **Broadcast draft tokens per step during the draft phase** (`step_decode`): before `process_draft_sample_output()` compresses the still-full `[batch, vocab]` probs into the cache, broadcast the `[batch]` `next_tokens`. Since gathering the cached prob with a unified token naturally yields a unified prob, only the token tensor needs broadcasting to guarantee TP value correctness.

- **Broadcast accepted tokens at validate exit** (`run_validate`): as a catch-all for cross-rank RNG divergence, unify the accepted `next_tokens` to the consensus group's rank 0 so `all_draft_accepted` and the next-round draft-extend row layout agree across ranks.

- **Fix cross-stream ordering for the draft-extend embedding stack** (`prepare_draft_extend_inputs`): the embedding rows are produced by work on `compute_stream_`, while the stack runs on `prepare_stream_`, with no synchronization before. Add `prepare_stream_->wait_stream(*compute_stream_)` to establish cross-stream ordering, fixing the NaN crash under DP + overlap.

All broadcasts run within the consensus group (preferring `tp_group_`, falling back to `process_group_`) and only take effect when `enable_spec_token_broadcast && enable_schedule_overlap`, leaving other paths unaffected.

## Change Type

- [x] Bug fix
- [ ] New feature
- [ ] Performance improvement
- [ ] Refactor
- [ ] Documentation
- [ ] Test
- [ ] Build or CI

## Pull Request Checklist

Thank you for contributing to xLLM. Before requesting review, please make sure the following items are complete.

### PR Title and Commit Messages

- [x] The PR title and each commit message follow the xLLM commit format: `<type>: <subject>`.

> Allowed types: feat, bugfix, docs, test, refactor, chore, style, revert, perf, model, build, release.
> The subject should use clear English, start with a verb, include at least 4 words, and end with `.`.

### Pre-commit Checks

- [x] I have installed `pre-commit` by running `pip install pre-commit` or an equivalent command.
- [x] I have installed the hooks with `pre-commit install`.
- [x] I have run `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

### Self Review

- [x] I have self-reviewed the code according to `.agents/skills/code-review/references/custom-code-style.md`, especially code written or assisted by AI.
- [x] I have rebased this PR onto the latest `main` branch.

### Build and Test Coverage

- [ ] Tests have been added or updated as needed.
- [ ] CUDA: `python setup.py build test` has passed on a CUDA machine.
- [x] NPU: `python setup.py build test` has passed on an NPU machine.
- [x] MLU: `python setup.py build test` has passed on an MLU machine.

## Reviewer Notes

<!-- Optional: anything reviewers should focus on, known risks, follow-ups, or validation gaps. -->
