### PR TITLE
bugfix: resolve cross-NUMA spawn worker isolation issues

### DIFF
--- a/xllm/core/common/global_flags.h
+++ b/xllm/core/common/global_flags.h
@@ -321,6 +321,8 @@ DECLARE_int32(flashinfer_workspace_buffer_size);
 
 DECLARE_int32(random_seed);
 
+DECLARE_string(spawn_worker_dir);
+
 DECLARE_string(dit_cache_policy);
 
 DECLARE_int64(dit_cache_warmup_steps);

--- a/xllm/core/distributed_runtime/dist_manager.cpp
+++ b/xllm/core/distributed_runtime/dist_manager.cpp
@@ -119,6 +119,10 @@ void setup_numa_affinity_and_isolation(
   }
 
   if (engine_numa_node >= 0) {
+    if (numa::preserve_current_cpu_affinity_for_spawn_worker() != 0) {
+      LOG(WARNING) << "Failed to preserve CPU affinity before NUMA binding, "
+                      "spawn workers may fail to reset inherited NUMA binding";
+    }
     if (numa::bind_process_to_numa_node(engine_numa_node) != 0) {
       LOG(WARNING) << "Failed to pin engine process to NUMA node "
                    << engine_numa_node

--- a/xllm/core/distributed_runtime/spawn_worker_server/spawn_worker_server.cpp
+++ b/xllm/core/distributed_runtime/spawn_worker_server/spawn_worker_server.cpp
@@ -140,6 +140,12 @@ SpawnWorkerServer::SpawnWorkerServer(const std::string& master_node_addr,
   if (numa_node >= 0) {
     LOG(INFO) << "Worker process (device " << device_idx
               << ") binding to NUMA node " << numa_node;
+    // Reset NUMA state inherited across posix_spawnp before rebinding;
+    // otherwise bind_process_to_numa_node cannot move to a different node.
+    if (numa::reset_inherited_numa_binding() != 0) {
+      LOG(WARNING) << "Failed to reset inherited NUMA binding for device "
+                   << device_idx << ", continuing best-effort";
+    }
     int32_t ret = numa::bind_process_to_numa_node(numa_node);
     if (ret != 0) {
       LOG(WARNING) << "Failed to bind worker process to NUMA node " << numa_node

--- a/xllm/core/distributed_runtime/spawn_worker_server/spawn_worker_server.cpp
+++ b/xllm/core/distributed_runtime/spawn_worker_server/spawn_worker_server.cpp
@@ -140,10 +140,10 @@ SpawnWorkerServer::SpawnWorkerServer(const std::string& master_node_addr,
   if (numa_node >= 0) {
     LOG(INFO) << "Worker process (device " << device_idx
               << ") binding to NUMA node " << numa_node;
-    // Reset NUMA state inherited across posix_spawnp before rebinding;
-    // otherwise bind_process_to_numa_node cannot move to a different node.
-    if (numa::reset_inherited_numa_binding() != 0) {
-      LOG(WARNING) << "Failed to reset inherited NUMA binding for device "
+    // Prepare inherited affinity and memory policy before binding this worker
+    // to the device-local NUMA node.
+    if (numa::prepare_spawn_worker_for_numa_binding() != 0) {
+      LOG(WARNING) << "Failed to prepare spawn worker NUMA binding for device "
                    << device_idx << ", continuing best-effort";
     }
     int32_t ret = numa::bind_process_to_numa_node(numa_node);

--- a/xllm/core/framework/config/execution_config.cpp
+++ b/xllm/core/framework/config/execution_config.cpp
@@ -76,6 +76,11 @@ DEFINE_uint64(output_shm_size,
 
 DEFINE_int32(random_seed, -1, "Random seed for random number generator.");
 
+DEFINE_string(spawn_worker_dir,
+              "",
+              "Directory of the spawn_worker binary, "
+              "empty means the root directory(i.e /spawn_worker).");
+
 namespace xllm {
 
 void ExecutionConfig::from_flags() {
@@ -90,6 +95,7 @@ void ExecutionConfig::from_flags() {
   XLLM_CONFIG_ASSIGN_FROM_FLAG(input_shm_size);
   XLLM_CONFIG_ASSIGN_FROM_FLAG(output_shm_size);
   XLLM_CONFIG_ASSIGN_FROM_FLAG(random_seed);
+  XLLM_CONFIG_ASSIGN_FROM_FLAG(spawn_worker_dir);
 }
 
 void ExecutionConfig::from_json(const JsonReader& json) {
@@ -104,6 +110,7 @@ void ExecutionConfig::from_json(const JsonReader& json) {
   XLLM_CONFIG_ASSIGN_FROM_JSON(input_shm_size);
   XLLM_CONFIG_ASSIGN_FROM_JSON(output_shm_size);
   XLLM_CONFIG_ASSIGN_FROM_JSON(random_seed);
+  XLLM_CONFIG_ASSIGN_FROM_JSON(spawn_worker_dir);
 }
 
 void ExecutionConfig::append_config_json(
@@ -131,6 +138,8 @@ void ExecutionConfig::append_config_json(
       config_json, default_config, output_shm_size);
   APPEND_CONFIG_JSON_VALUE_IF_NOT_DEFAULT(
       config_json, default_config, random_seed);
+  APPEND_CONFIG_JSON_VALUE_IF_NOT_DEFAULT(
+      config_json, default_config, spawn_worker_dir);
 }
 
 ExecutionConfig& ExecutionConfig::get_instance() {

--- a/xllm/core/framework/config/execution_config.h
+++ b/xllm/core/framework/config/execution_config.h
@@ -50,7 +50,8 @@ class ExecutionConfig final {
          "use_contiguous_input_buffer",
          "input_shm_size",
          "output_shm_size",
-         "random_seed"}};
+         "random_seed",
+         "spawn_worker_dir"}};
     return kOptionCategory;
   }
 
@@ -75,6 +76,8 @@ class ExecutionConfig final {
   PROPERTY(uint64_t, output_shm_size) = 128;
 
   PROPERTY(int32_t, random_seed) = -1;
+
+  PROPERTY(std::string, spawn_worker_dir) = "";
 };
 
 }  // namespace xllm

--- a/xllm/core/platform/numa_utils.cpp
+++ b/xllm/core/platform/numa_utils.cpp
@@ -59,10 +59,11 @@ int32_t get_numa_node_from_sysfs(const std::string& backend,
                                  const std::string& pci_bus_id) {
   // Device APIs may return uppercase hex, but sysfs PCI dirs require lowercase.
   std::string lower_bus_id = pci_bus_id;
-  std::transform(lower_bus_id.begin(),
-                 lower_bus_id.end(),
-                 lower_bus_id.begin(),
-                 [](unsigned char ch) { return std::tolower(ch); });
+  std::transform(
+      lower_bus_id.begin(),
+      lower_bus_id.end(),
+      lower_bus_id.begin(),
+      [](unsigned char ch) { return static_cast<char>(std::tolower(ch)); });
   std::string numa_path = "/sys/bus/pci/devices/" + lower_bus_id + "/numa_node";
   LOG(INFO) << backend << " device " << device_index
             << " NUMA sysfs path: " << numa_path;

--- a/xllm/core/platform/numa_utils.cpp
+++ b/xllm/core/platform/numa_utils.cpp
@@ -28,6 +28,8 @@ limitations under the License.
 #include <sched.h>
 #include <unistd.h>
 
+#include <algorithm>
+#include <cctype>
 #include <cerrno>
 #include <cstring>
 #include <fstream>
@@ -55,7 +57,13 @@ bool read_numa_node(const std::string& numa_path, int32_t* numa_node) {
 int32_t get_numa_node_from_sysfs(const std::string& backend,
                                  int32_t device_index,
                                  const std::string& pci_bus_id) {
-  std::string numa_path = "/sys/bus/pci/devices/" + pci_bus_id + "/numa_node";
+  // Device APIs may return uppercase hex, but sysfs PCI dirs require lowercase.
+  std::string lower_bus_id = pci_bus_id;
+  std::transform(lower_bus_id.begin(),
+                 lower_bus_id.end(),
+                 lower_bus_id.begin(),
+                 [](unsigned char ch) { return std::tolower(ch); });
+  std::string numa_path = "/sys/bus/pci/devices/" + lower_bus_id + "/numa_node";
   LOG(INFO) << backend << " device " << device_index
             << " NUMA sysfs path: " << numa_path;
 
@@ -220,6 +228,34 @@ int32_t get_device_numa_node(int32_t device_index) {
 #endif
 
   return -1;
+}
+
+int32_t reset_inherited_numa_binding() {
+  if (!is_numa_available()) {
+    LOG(WARNING) << "NUMA not available, skipping inherited binding reset";
+    return -1;
+  }
+
+  // Reset to all CPUs so build_cpu_set_for_numa_node can pick the target
+  // NUMA's CPUs (inherited mask would leave the intersection empty).
+  cpu_set_t all_cpus;
+  CPU_ZERO(&all_cpus);
+  const int32_t nr_possible_cpus = numa_num_possible_cpus();
+  for (int32_t cpu = 0; cpu < nr_possible_cpus && cpu < CPU_SETSIZE; ++cpu) {
+    CPU_SET(cpu, &all_cpus);
+  }
+  if (sched_setaffinity(0, sizeof(cpu_set_t), &all_cpus) != 0) {
+    LOG(ERROR) << "Failed to reset CPU affinity: " << strerror(errno);
+    return -1;
+  }
+
+  // Clear inherited strict membind so bind_process_to_numa_node can
+  // install a fresh policy without bad_alloc.
+  numa_set_strict(0);
+  numa_set_localalloc();
+
+  LOG(INFO) << "Reset inherited NUMA CPU affinity and memory policy";
+  return 0;
 }
 
 int32_t bind_process_to_numa_node(int32_t numa_node) {

--- a/xllm/core/platform/numa_utils.cpp
+++ b/xllm/core/platform/numa_utils.cpp
@@ -31,13 +31,18 @@ limitations under the License.
 #include <algorithm>
 #include <cctype>
 #include <cerrno>
+#include <cstdlib>
 #include <cstring>
 #include <fstream>
+#include <sstream>
 #include <string>
 
 namespace xllm {
 namespace numa {
 namespace {
+
+constexpr const char* kSpawnWorkerAllowedCpusEnv =
+    "XLLM_SPAWN_WORKER_ALLOWED_CPUS";
 
 bool read_numa_node(const std::string& numa_path, int32_t* numa_node) {
   if (numa_node == nullptr) {
@@ -138,6 +143,76 @@ bool build_cpu_set_for_numa_node(int32_t numa_node,
   return (*nr_cpus > 0);
 }
 
+std::string cpu_set_to_string(const cpu_set_t& cpu_set) {
+  std::ostringstream oss;
+  bool is_first_cpu = true;
+  for (int32_t cpu = 0; cpu < CPU_SETSIZE; ++cpu) {
+    if (!CPU_ISSET(cpu, &cpu_set)) {
+      continue;
+    }
+    if (!is_first_cpu) {
+      oss << ",";
+    }
+    oss << cpu;
+    is_first_cpu = false;
+  }
+  return oss.str();
+}
+
+bool parse_cpu_set_string(const std::string& cpu_set_str,
+                          cpu_set_t* cpu_set,
+                          int32_t* nr_cpus) {
+  if (cpu_set == nullptr || nr_cpus == nullptr) {
+    return false;
+  }
+
+  CPU_ZERO(cpu_set);
+  *nr_cpus = 0;
+
+  std::stringstream ss(cpu_set_str);
+  std::string token;
+  while (std::getline(ss, token, ',')) {
+    if (token.empty()) {
+      LOG(WARNING) << "Empty CPU id in preserved spawn worker affinity";
+      return false;
+    }
+
+    char* end = nullptr;
+    errno = 0;
+    int64_t parsed_cpu = std::strtol(token.c_str(), &end, 10);
+    if (errno != 0 || end == token.c_str() || *end != '\0' || parsed_cpu < 0 ||
+        parsed_cpu >= CPU_SETSIZE) {
+      LOG(WARNING) << "Invalid CPU id in preserved spawn worker affinity: "
+                   << token;
+      return false;
+    }
+
+    int32_t cpu = static_cast<int32_t>(parsed_cpu);
+    if (!CPU_ISSET(cpu, cpu_set)) {
+      CPU_SET(cpu, cpu_set);
+      ++(*nr_cpus);
+    }
+  }
+
+  return (*nr_cpus > 0);
+}
+
+bool get_preserved_cpu_affinity_for_spawn_worker(cpu_set_t* cpu_set,
+                                                 int32_t* nr_cpus) {
+  const char* env_value = std::getenv(kSpawnWorkerAllowedCpusEnv);
+  if (env_value == nullptr || env_value[0] == '\0') {
+    return false;
+  }
+  return parse_cpu_set_string(std::string(env_value), cpu_set, nr_cpus);
+}
+
+void clear_inherited_memory_policy() {
+  // Clear inherited strict membind so bind_process_to_numa_node can
+  // install a fresh policy without bad_alloc.
+  numa_set_strict(0);
+  numa_set_localalloc();
+}
+
 void apply_process_memory_policy(int32_t numa_node) {
   struct bitmask* node_mask = numa_allocate_nodemask();
   if (node_mask == nullptr) {
@@ -231,31 +306,66 @@ int32_t get_device_numa_node(int32_t device_index) {
   return -1;
 }
 
-int32_t reset_inherited_numa_binding() {
+int32_t preserve_current_cpu_affinity_for_spawn_worker() {
+  cpu_set_t current_affinity;
+  CPU_ZERO(&current_affinity);
+  if (sched_getaffinity(0, sizeof(cpu_set_t), &current_affinity) != 0) {
+    LOG(ERROR) << "Failed to preserve CPU affinity for spawn worker: "
+               << strerror(errno);
+    return -1;
+  }
+
+  std::string cpu_set_str = cpu_set_to_string(current_affinity);
+  if (cpu_set_str.empty()) {
+    LOG(ERROR) << "Current CPU affinity is empty, cannot preserve for spawn "
+                  "worker";
+    return -1;
+  }
+
+  if (::setenv(kSpawnWorkerAllowedCpusEnv,
+               cpu_set_str.c_str(),
+               /*overwrite=*/1) != 0) {
+    LOG(ERROR) << "Failed to set " << kSpawnWorkerAllowedCpusEnv << ": "
+               << strerror(errno);
+    return -1;
+  }
+
+  LOG(INFO) << "Preserved spawn worker CPU affinity in "
+            << kSpawnWorkerAllowedCpusEnv << ": " << cpu_set_str;
+  return 0;
+}
+
+int32_t prepare_spawn_worker_for_numa_binding() {
   if (!is_numa_available()) {
-    LOG(WARNING) << "NUMA not available, skipping inherited binding reset";
+    LOG(WARNING) << "NUMA not available, skipping spawn worker NUMA binding "
+                    "preparation";
     return -1;
   }
 
-  // Reset to all CPUs so build_cpu_set_for_numa_node can pick the target
-  // NUMA's CPUs (inherited mask would leave the intersection empty).
-  cpu_set_t all_cpus;
-  CPU_ZERO(&all_cpus);
-  const int32_t nr_possible_cpus = numa_num_possible_cpus();
-  for (int32_t cpu = 0; cpu < nr_possible_cpus && cpu < CPU_SETSIZE; ++cpu) {
-    CPU_SET(cpu, &all_cpus);
-  }
-  if (sched_setaffinity(0, sizeof(cpu_set_t), &all_cpus) != 0) {
-    LOG(ERROR) << "Failed to reset CPU affinity: " << strerror(errno);
+  cpu_set_t preserved_cpus;
+  CPU_ZERO(&preserved_cpus);
+  int32_t nr_preserved_cpus = 0;
+  if (!get_preserved_cpu_affinity_for_spawn_worker(&preserved_cpus,
+                                                   &nr_preserved_cpus)) {
+    clear_inherited_memory_policy();
+    LOG(WARNING) << "No preserved CPU affinity found for spawn worker, "
+                    "cleared inherited memory policy only";
     return -1;
   }
 
-  // Clear inherited strict membind so bind_process_to_numa_node can
-  // install a fresh policy without bad_alloc.
-  numa_set_strict(0);
-  numa_set_localalloc();
+  // Restore the pre-binding CPU set so build_cpu_set_for_numa_node can pick
+  // the target NUMA's CPUs without escaping external cpuset constraints.
+  if (sched_setaffinity(0, sizeof(cpu_set_t), &preserved_cpus) != 0) {
+    LOG(ERROR) << "Failed to restore preserved CPU affinity: "
+               << strerror(errno);
+    clear_inherited_memory_policy();
+    return -1;
+  }
 
-  LOG(INFO) << "Reset inherited NUMA CPU affinity and memory policy";
+  clear_inherited_memory_policy();
+
+  LOG(INFO) << "Prepared spawn worker for NUMA binding with "
+            << nr_preserved_cpus << " preserved CPUs and cleared memory policy";
   return 0;
 }
 

--- a/xllm/core/platform/numa_utils.h
+++ b/xllm/core/platform/numa_utils.h
@@ -48,10 +48,17 @@ int32_t get_device_numa_node(int32_t device_index);
 int32_t bind_process_to_numa_node(int32_t numa_node);
 
 /**
- * @brief Reset CPU affinity and NUMA memory policy inherited from parent.
+ * @brief Save current CPU affinity so spawned workers can restore it after
+ * exec.
  * @return 0 on success, non-zero on failure
  */
-int32_t reset_inherited_numa_binding();
+int32_t preserve_current_cpu_affinity_for_spawn_worker();
+
+/**
+ * @brief Prepare spawn worker before binding it to a device-local NUMA node.
+ * @return 0 on success, non-zero on failure
+ */
+int32_t prepare_spawn_worker_for_numa_binding();
 
 /**
  * @brief Bind current thread to a specific NUMA node

--- a/xllm/core/platform/numa_utils.h
+++ b/xllm/core/platform/numa_utils.h
@@ -48,6 +48,12 @@ int32_t get_device_numa_node(int32_t device_index);
 int32_t bind_process_to_numa_node(int32_t numa_node);
 
 /**
+ * @brief Reset CPU affinity and NUMA memory policy inherited from parent.
+ * @return 0 on success, non-zero on failure
+ */
+int32_t reset_inherited_numa_binding();
+
+/**
  * @brief Bind current thread to a specific NUMA node
  * @param numa_node The NUMA node ID to bind to
  * @return 0 on success, non-zero on failure

--- a/xllm/xllm.cpp
+++ b/xllm/xllm.cpp
@@ -230,6 +230,8 @@ Options create_options(const std::string& instance_name, bool is_local) {
     options.draft_devices(draft_devices);
   }
 
+  options.spawn_worker_path(execution_config.spawn_worker_dir());
+
   return options;
 }
 


### PR DESCRIPTION
## Description
This PR fixes several issues in the existing cross-NUMA spawn worker implementation on CUDA/MLU/DCU, including:

- Fix PCI bus_id case mismatch for NUMA detection (observed on CUDA).

- Initialize spawn_worker_dir for the xllm server binary and add the --spawn_worker_dir option.

- Reset inherited CPU affinity and NUMA memory policy before binding the spawned worker to the target NUMA node.
  (This change saves the original CPU affinity before engine NUMA binding, clears the memory policy inherited by spawned workers, restores the saved affinity in each spawned worker, and then binds the worker to its target NUMA node.)

These fixes improve the correctness of spawn worker initialization and NUMA binding. While no fatal issues were observed in small-scale model testing, they eliminate several potential issues in cross-NUMA deployments.

<!-- What does this PR do? Briefly describe the changes and why they are needed. -->

## Related Issues

<!-- Link related issues here. Use "Fixes #123" when this PR closes an issue. -->

## Change Type

- [x] Bug fix
- [ ] New feature
- [ ] Performance improvement
- [ ] Refactor
- [ ] Documentation
- [ ] Test
- [ ] Build or CI

## Pull Request Checklist

Thank you for contributing to xLLM. Before requesting review, please make sure the following items are complete.

### PR Title and Commit Messages

- [x] The PR title and each commit message follow the xLLM commit format: `<type>: <subject>`.

> Allowed types: feat, bugfix, docs, test, refactor, chore, style, revert, perf, model, build, release.
> The subject should use clear English, start with a verb, include at least 4 words, and end with `.`.

### Pre-commit Checks

- [x] I have installed `pre-commit` by running `pip install pre-commit` or an equivalent command.
- [x] I have installed the hooks with `pre-commit install`.
- [x] I have run `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

### Self Review

- [x] I have self-reviewed the code according to `.agents/skills/code-review/references/custom-code-style.md`, especially code written or assisted by AI.
- [x] I have rebased this PR onto the latest `main` branch.

### Build and Test Coverage

- [ ] Tests have been added or updated as needed.
- [x] CUDA: `python setup.py build test` has passed on a CUDA machine.
- [ ] NPU: `python setup.py build test` has passed on an NPU machine.
- [ ] MLU: `python setup.py build test` has passed on an MLU machine.

## Reviewer Notes

<!-- Optional: anything reviewers should focus on, known risks, follow-ups, or validation gaps. -->
