### PR TITLE
bugfix: enable spawn worker on dcu device.

### DIFF
--- a/xllm/core/distributed_runtime/CMakeLists.txt
+++ b/xllm/core/distributed_runtime/CMakeLists.txt
@@ -1,6 +1,6 @@
 include(cc_library)
 
-if(USE_NPU OR USE_CUDA OR USE_MLU)
+if(USE_NPU OR USE_CUDA OR USE_MLU OR USE_DCU)
   include_directories(
     ${CMAKE_SOURCE_DIR}/third_party/spdlog/include
   )

--- a/xllm/core/distributed_runtime/spawn_worker_server/spawn_worker_server.cpp
+++ b/xllm/core/distributed_runtime/spawn_worker_server/spawn_worker_server.cpp
@@ -123,7 +123,7 @@ SpawnWorkerServer::SpawnWorkerServer(const std::string& master_node_addr,
   KVCacheConfig::get_instance().block_size(block_size);
   EPLBConfig::get_instance().rank_tablefile(rank_tablefile);
 
-  xllm::Device device{torch::Device(xllm::Device::type_torch(), device_idx)};
+  xllm::Device device{device_idx};
   device.set_device();
 
 #if defined(USE_NPU)

--- a/xllm/core/distributed_runtime/spawn_worker_server/spawn_worker_server.cpp
+++ b/xllm/core/distributed_runtime/spawn_worker_server/spawn_worker_server.cpp
@@ -123,9 +123,7 @@ SpawnWorkerServer::SpawnWorkerServer(const std::string& master_node_addr,
   KVCacheConfig::get_instance().block_size(block_size);
   EPLBConfig::get_instance().rank_tablefile(rank_tablefile);
 
-  const std::string device_type = xllm::Device::type_str();
-  const std::string device_str = device_type + ":" + std::to_string(device_idx);
-  xllm::Device device{torch::Device(device_str)};
+  xllm::Device device{torch::Device(xllm::Device::type_torch(), device_idx)};
   device.set_device();
 
 #if defined(USE_NPU)

--- a/xllm/core/platform/device_name_utils.cpp
+++ b/xllm/core/platform/device_name_utils.cpp
@@ -45,7 +45,7 @@ std::vector<torch::Device> DeviceNameUtils::parse_devices(
     }
     devices.reserve(num_devices);
     for (int32_t i = 0; i < num_devices; ++i) {
-      devices.emplace_back(torch::Device(Device::type_torch(), i));
+      devices.emplace_back(Device::type_torch(), i);
     }
     return devices;
   }

--- a/xllm/core/platform/device_name_utils.cpp
+++ b/xllm/core/platform/device_name_utils.cpp
@@ -45,8 +45,7 @@ std::vector<torch::Device> DeviceNameUtils::parse_devices(
     }
     devices.reserve(num_devices);
     for (int32_t i = 0; i < num_devices; ++i) {
-      std::string device_name = to_device_string(i);
-      devices.emplace_back(torch::Device(device_name));
+      devices.emplace_back(torch::Device(Device::type_torch(), i));
     }
     return devices;
   }


### PR DESCRIPTION
## Description

-  Add `USE_DCU` to the CMake conditional for `distributed_runtime` so that `spawn_worker_server` is built for DCU.

- Avoid constructing `torch::Device` from strings such as `"dcu:<idx>"`, since PyTorch does not recognize `"dcu"` as a device prefix. Use `Device::type_torch()` with the device index instead, matching the current backend mapping to `torch::kCUDA`.

-  Use the same construction method in `DeviceNameUtils::parse_devices` for consistency.

Note: This change only addresses DCU-specific issues in the spawn worker path. Additional spawn worker issues have been addressed separately in [#1776](https://github.com/jd-opensource/xllm/pull/1776).

<!-- What does this PR do? Briefly describe the changes and why they are needed. -->

## Related Issues

<!-- Link related issues here. Use "Fixes #123" when this PR closes an issue. -->

## Change Type

- [x] Bug fix
- [ ] New feature
- [ ] Performance improvement
- [ ] Refactor
- [ ] Documentation
- [ ] Test
- [ ] Build or CI

## Pull Request Checklist

Thank you for contributing to xLLM. Before requesting review, please make sure the following items are complete.

### PR Title and Commit Messages

- [x] The PR title and each commit message follow the xLLM commit format: `<type>: <subject>`.

> Allowed types: feat, bugfix, docs, test, refactor, chore, style, revert, perf, model, build, release.
> The subject should use clear English, start with a verb, include at least 4 words, and end with `.`.

### Pre-commit Checks

- [x] I have installed `pre-commit` by running `pip install pre-commit` or an equivalent command.
- [x] I have installed the hooks with `pre-commit install`.
- [x] I have run `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

### Self Review

- [x] I have self-reviewed the code according to `.agents/skills/code-review/references/custom-code-style.md`, especially code written or assisted by AI.
- [x] I have rebased this PR onto the latest `main` branch.

### Build and Test Coverage

- [ ] Tests have been added or updated as needed.
- [x] CUDA: `python setup.py build test` has passed on a CUDA machine.
- [ ] NPU: `python setup.py build test` has passed on an NPU machine.
- [ ] MLU: `python setup.py build test` has passed on an MLU machine.

## Reviewer Notes

<!-- Optional: anything reviewers should focus on, known risks, follow-ups, or validation gaps. -->
