### PR TITLE
bugfix: fix double-free in PrefixCacheWithUpload destructor.

### DIFF
--- a/xllm/core/framework/prefix_cache/prefix_cache_with_upload.cpp
+++ b/xllm/core/framework/prefix_cache/prefix_cache_with_upload.cpp
@@ -26,7 +26,7 @@ PrefixCacheWithUpload::~PrefixCacheWithUpload() {
     delete back;
   }
 
-  auto front = db_kvcache_events_.get_back_value();
+  auto front = db_kvcache_events_.get_front_value();
   if (front) {
     delete front;
   }


### PR DESCRIPTION
## Description

<!-- What does this PR do? Briefly describe the changes and why they are needed. -->
Fix a double-free bug in `PrefixCacheWithUpload::~PrefixCacheWithUpload()`: the destructor called `get_back_value()` twice instead of `get_back_value()` + `get_front_value()`, causing the back `KvCacheEvent` to be freed twice and the front one to be leaked.

## Related Issues

<!-- Link related issues here. Use "Fixes #123" when this PR closes an issue. -->

## Change Type

- [x] Bug fix
- [ ] New feature
- [ ] Performance improvement
- [ ] Refactor
- [ ] Documentation
- [ ] Test
- [ ] Build or CI

## Pull Request Checklist

Thank you for contributing to xLLM. Before requesting review, please make sure the following items are complete.

### PR Title and Commit Messages

- [x] The PR title and each commit message follow the xLLM commit format: `<type>: <subject>`.

> Allowed types: feat, bugfix, docs, test, refactor, chore, style, revert, perf, model, build, release.
> The subject should use clear English, start with a verb, include at least 4 words, and end with `.`.

### Pre-commit Checks

- [x] I have installed `pre-commit` by running `pip install pre-commit` or an equivalent command.
- [x] I have installed the hooks with `pre-commit install`.
- [x] I have run `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

### Self Review

- [ ] I have self-reviewed the code according to `.agents/skills/code-review/references/custom-code-style.md`, especially code written or assisted by AI.
- [x] I have rebased this PR onto the latest `main` branch.

### Build and Test Coverage

- [ ] Tests have been added or updated as needed.
- [ ] CUDA: `python setup.py build test` has passed on a CUDA machine.
- [ ] NPU: `python setup.py build test` has passed on an NPU machine.
- [ ] MLU: `python setup.py build test` has passed on an MLU machine.

## Reviewer Notes

<!-- Optional: anything reviewers should focus on, known risks, follow-ups, or validation gaps. -->
