### PR TITLE
refactor: drop dead USE_A3 branches in deepseek v2/v32 decoder loaders.

### DIFF
--- a/xllm/core/layers/npu/loader/deepseek_v2_decoder_loader.cpp
+++ b/xllm/core/layers/npu/loader/deepseek_v2_decoder_loader.cpp
@@ -389,18 +389,14 @@ void DeekseekV2DecoderLoader::merge_experts_weights() {
                               experts_weights_["up_proj.weight_scale"]);
   }
 
-  // Preserve pre-existing mode divergence for IN_MLP_DOWN_WEIGHT_EXPERT:
+  // IN_MLP_DOWN_WEIGHT_EXPERT:
   //   eager: NZ when not quantized, else ND;
-  //   manual: ND on A3 or when decode is non-BF16; NZ otherwise.
+  //   manual: NZ when decode is BF16, else ND.
   torch::Tensor mlp_down_weight = merge_experts_weights(
       experts_weights_["down_proj.weight"], /*transpose=*/false);
   bool down_is_nz;
   if (load_to_host()) {
-#if defined(USE_A3)
-    down_is_nz = false;
-#else
     down_is_nz = decode_isBF16_;
-#endif
   } else {
     down_is_nz = (quantize_type_ == "");
   }

--- a/xllm/core/layers/npu/loader/deepseek_v32_decoder_loader.cpp
+++ b/xllm/core/layers/npu/loader/deepseek_v32_decoder_loader.cpp
@@ -393,16 +393,12 @@ void DeekseekV32DecoderLoader::merge_experts_weights() {
                               experts_weights_["up_proj.weight_scale"]);
   }
 
-  // IN_MLP_DOWN_WEIGHT_EXPERT: eager always NZ; manual NZ on A3 else ND.
+  // IN_MLP_DOWN_WEIGHT_EXPERT: eager always NZ; manual ND.
   torch::Tensor mlp_down_weight = merge_experts_weights(
       experts_weights_["down_proj.weight"], /*transpose=*/false);
   bool down_is_nz;
   if (load_to_host()) {
-#if defined(USE_A3)
-    down_is_nz = true;
-#else
     down_is_nz = false;
-#endif
   } else {
     down_is_nz = true;
   }


### PR DESCRIPTION
USE_A3 is no longer defined by the build system after the A2/A3 to npu device-type unification, so the `#if defined(USE_A3)` branches were dead code. Collapse them to the active (npu) branch when deciding the MLP down weight layout, leaving runtime behavior unchanged.
