### PR TITLE
bugfix: set guard in BuildDistWheel to fix bdist_wheel.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -483,7 +483,11 @@ class BuildDistWheel(bdist_wheel):
         BUILD_TEST_FILE = False
 
         self.skip_build = True
-        super().run()
+        InstallWheel._building_wheel = True
+        try:
+            super().run()
+        finally:
+            InstallWheel._building_wheel = False
 
 class InstallWheel(install):
     """`python setup.py install` builds the wheel, then pip-installs it.


### PR DESCRIPTION


## Description

When running `python setup.py bdist_wheel` directly, the standard bdist_wheel internally invokes the install command to stage files. The custom InstallWheel class sees _building_wheel=False and enters its "build wheel + pip install" path instead of normal file staging, causing egg-info to never be written to the wheel build directory.

This results in:
  ValueError: Egg metadata expected at build/.../xllm_npu_torch2.9.0-0.9.0-py3.11.egg-info but not found

Fix by setting InstallWheel._building_wheel = True before calling super().run() in BuildDistWheel, so the internal install sub-command falls through to standard staging behavior.

## Related Issues

<!-- Link related issues here. Use "Fixes #123" when this PR closes an issue. -->

## Change Type

- [x] Bug fix
- [ ] New feature
- [ ] Performance improvement
- [ ] Refactor
- [ ] Documentation
- [ ] Test
- [ ] Build or CI

## Pull Request Checklist

Thank you for contributing to xLLM. Before requesting review, please make sure the following items are complete.

### PR Title and Commit Messages

- [ ] The PR title and each commit message follow the xLLM commit format: `<type>: <subject>`.

> Allowed types: feat, bugfix, docs, test, refactor, chore, style, revert, perf, model, build, release.
> The subject should use clear English, start with a verb, include at least 4 words, and end with `.`.

### Pre-commit Checks

- [ ] I have installed `pre-commit` by running `pip install pre-commit` or an equivalent command.
- [ ] I have installed the hooks with `pre-commit install`.
- [ ] I have run `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

### Self Review

- [ ] I have self-reviewed the code according to `.agents/skills/code-review/references/custom-code-style.md`, especially code written or assisted by AI.
- [ ] I have rebased this PR onto the latest `main` branch.

### Build and Test Coverage

- [ ] Tests have been added or updated as needed.
- [ ] CUDA: `python setup.py build test` has passed on a CUDA machine.
- [x] NPU: `python setup.py build test` has passed on an NPU machine.
- [ ] MLU: `python setup.py build test` has passed on an MLU machine.

## Reviewer Notes

<!-- Optional: anything reviewers should focus on, known risks, follow-ups, or validation gaps. -->
