### PR TITLE
bugfix: fix tilelang test segfaults on exit by completing acl teardown.

### DIFF
--- a/tests/core/kernels/npu/tilelang/rope_wrapper_test.cpp
+++ b/tests/core/kernels/npu/tilelang/rope_wrapper_test.cpp
@@ -33,7 +33,11 @@ class TileLangRopeWrapperTest : public ::testing::Test {
  protected:
   static void SetUpTestSuite() { torch_npu::init_npu("npu:0"); }
 
-  static void TearDownTestSuite() { torch_npu::finalize_npu(); }
+  static void TearDownTestSuite() {
+    torch_npu::finalize_npu();
+    aclrtResetDevice(0);
+    aclFinalize();
+  }
 };
 
 struct RopeTestCase {

--- a/tests/core/kernels/npu/tilelang/split_qkv_rmsnorm_mrope_wrapper_test.cpp
+++ b/tests/core/kernels/npu/tilelang/split_qkv_rmsnorm_mrope_wrapper_test.cpp
@@ -36,7 +36,11 @@ class TileLangSplitQkvRmsnormMRopeWrapperTest : public ::testing::Test {
  protected:
   static void SetUpTestSuite() { torch_npu::init_npu("npu:0"); }
 
-  static void TearDownTestSuite() { torch_npu::finalize_npu(); }
+  static void TearDownTestSuite() {
+    torch_npu::finalize_npu();
+    aclrtResetDevice(0);
+    aclFinalize();
+  }
 };
 
 struct SplitQkvTestCase {


### PR DESCRIPTION
## Description

Fix `TileLangRopeWrapperTest` and `TileLangSplitQkvRmsnormMRopeWrapperTest` segfaults on process exit.

Both tests use ACL event APIs (`aclrtCreateEvent`, `aclrtRecordEvent`, etc.) for performance measurement but only called `torch_npu::finalize_npu()` in `TearDownTestSuite()`. The incomplete teardown left ACL runtime resources dangling, causing segfaults during static destruction on process exit.

Fixed by adding `aclrtResetDevice(0)` and `aclFinalize()` after `finalize_npu()`, following the same pattern used by `acl_graph_executor_test` and `shared_vmm_allocator_test`.

Note: each tilelang test is a separate binary (invoked via `gtest_add_tests` with `--gtest_filter`), so `aclFinalize()` only affects the current process — it does not interfere with other test suites.

## Related Issues

Fixes CI segfault failures in NPU tilelang tests.

## Change Type

- [x] Bug fix
- [ ] New feature
- [ ] Performance improvement
- [ ] Refactor
- [ ] Documentation
- [x] Test
- [ ] Build or CI

## Pull Request Checklist

### PR Title and Commit Messages

- [x] The PR title and each commit message follow the xLLM commit format: `<type>: <subject>`.

### Pre-commit Checks

- [x] I have installed `pre-commit` by running `pip install pre-commit` or an equivalent command.
- [x] I have installed the hooks with `pre-commit install`.
- [x] I have run `pre-commit run --all-files` and fixed any reported issues.

### Self Review

- [x] I have self-reviewed the code according to `.agents/skills/code-review/references/custom-code-style.md`, especially code written or assisted by AI.
- [x] I have rebased this PR onto the latest `main` branch.

### Build and Test Coverage

- [x] Tests have been added or updated as needed.
- [ ] CUDA: `python setup.py build test` has passed on a CUDA machine.
- [x] NPU: `python setup.py build test` has passed on an NPU machine.
- [ ] MLU: `python setup.py build test` has passed on an MLU machine.

## Reviewer Notes

- The Gemini Code Assist review flagged `aclFinalize()` as risky for subsequent test suites. This does not apply here: CTest invokes each tilelang test as an independent process (via `gtest_add_tests`), so `aclFinalize()` only tears down the current process. Other NPU tests (`acl_graph_executor_test`, `shared_vmm_allocator_test`) use the same pattern without issues.
- Previously this PR also contained a `setup.py` dots→underscores change which has been removed as unnecessary — the real bdist_wheel fix landed in #1807.
