### PR TITLE
feat: enable bf16 fallback for o_proj in Qwen3-VL W8A8 quantization

### DIFF
--- a/xllm/core/layers/npu/loader/qwen3_decoder_loader.cpp
+++ b/xllm/core/layers/npu/loader/qwen3_decoder_loader.cpp
@@ -85,8 +85,16 @@ void Qwen3DecoderLoader::merge_host_at_weights() {
       quantize_type_.empty();
 
   if (quantize_type_.compare("w8a8") == 0) {
-    t[IN_ATTENTION_OUT_DEQSCALE] =
-        t[IN_ATTENTION_OUT_DEQSCALE].to(torch::kFloat32);
+    // Detect if o_proj is non-quantized (bf16) by checking quant_bias numel
+    // If IN_ATTENTION_OUT_BIAS is placeholder (numel <= 1), o_proj is bf16
+    o_proj_quantized_ = t[IN_ATTENTION_OUT_BIAS].numel() > 1;
+
+    if (o_proj_quantized_) {
+      t[IN_ATTENTION_OUT_DEQSCALE] =
+          t[IN_ATTENTION_OUT_DEQSCALE].to(torch::kFloat32);
+      t[IN_ATTENTION_OUT_OFFSET] = t[IN_ATTENTION_OUT_OFFSET].to(torch::kInt8);
+    }
+
     t[IN_Q_DEQSCALE] =
         torch::cat({t[IN_Q_DEQSCALE], t[IN_K_DEQSCALE], t[IN_V_DEQSCALE]}, 0)
             .to(torch::kFloat32);
@@ -119,7 +127,6 @@ void Qwen3DecoderLoader::merge_host_at_weights() {
     }
 
     t[IN_Q_OFFSET] = t[IN_Q_OFFSET].to(torch::kInt8);
-    t[IN_ATTENTION_OUT_OFFSET] = t[IN_ATTENTION_OUT_OFFSET].to(torch::kInt8);
     t[IN_MLP_W2_OFFSET] = t[IN_MLP_W2_OFFSET].to(torch::kInt8);
 
     if (t[IN_MLP_CPROJ_BIAS].numel() > 1) {

--- a/xllm/core/layers/npu/loader/qwen3_decoder_loader.h
+++ b/xllm/core/layers/npu/loader/qwen3_decoder_loader.h
@@ -33,6 +33,7 @@ class Qwen3DecoderLoader : public BaseLoader {
   void load_state_dict(const StateDict& state_dict) override;
   void verify_loaded_weights() const override;
   bool down_proj_quantized() const { return down_proj_quantized_; }
+  bool o_proj_quantized() const { return o_proj_quantized_; }
 
  protected:
   void merge_host_at_weights() override;
@@ -40,6 +41,7 @@ class Qwen3DecoderLoader : public BaseLoader {
   torch::Tensor at_placeholder_;
   bool enableAddNorm_;
   bool down_proj_quantized_ = false;
+  bool o_proj_quantized_ = true;  // default true for W8A8 models
   int rank_id_;
 };
 

--- a/xllm/core/layers/npu/npu_qwen3_decoder_layer_impl.cpp
+++ b/xllm/core/layers/npu/npu_qwen3_decoder_layer_impl.cpp
@@ -234,6 +234,20 @@ int64_t NpuQwen3DecoderLayerImpl::init_layer() {
       update_down_proj(decode_graph_param_);
       update_down_proj(decode_eager_param_);
     }
+    if (qwen3_loader && !qwen3_loader->o_proj_quantized()) {
+      // o_proj is bf16: change linearDescs[kDenseLinearIndex] from W8A8 to
+      // BFLOAT16, same pattern as down_proj non-quantized adaptation
+      constexpr uint64_t kDenseLinearIndex = 3;
+      auto update_o_proj = [](atb_speed::qwen::QwenLayerParam& p) {
+        p.linearDescs[kDenseLinearIndex] =
+            static_cast<int>(LinearTypeV2::BFLOAT16);
+        p.linearQuantType[kDenseLinearIndex] =
+            static_cast<int>(LinearType::INVALID);
+      };
+      update_o_proj(prefill_param_);
+      update_o_proj(decode_graph_param_);
+      update_o_proj(decode_eager_param_);
+    }
   }
 
   CHECK_OPERATION_STATUS_RETURN(init_node(prefill_node_, prefill_param_));


### PR DESCRIPTION
## Problem

When o_proj weights fall back to bf16 in a W8A8 quantized model, the ATB LinearOperation fails with a dtype mismatch error:
CheckIniMatch Failed! Supported Combs:
[comb0]: inTensor0(int8,nd), inTensor1(int8,nd), inTensor2(int32,nd), inTensor3(float,nd), outTensor0(bf16,nd)
## Solution

Reuse the  non-quantized adaptation pattern for o_proj: