### PR TITLE
bugfix: restore GLM5/GLM5.2 long-context accuracy with indexer RoPE layout preprocessing

### DIFF
--- a/xllm/core/layers/npu/loader/deepseek_v32_decoder_loader.cpp
+++ b/xllm/core/layers/npu/loader/deepseek_v32_decoder_loader.cpp
@@ -1043,10 +1043,10 @@ void DeekseekV32DecoderLoader::preprocess_linear_for_rope() {
 
   std::vector<std::string> indexer_linear_for_rope;
   indexer_linear_for_rope.reserve(5);
-  int32_t processed_indexer_rope_tensors = 0;
   indexer_linear_for_rope.emplace_back("self_attn.indexer.wq_b.weight");
   if (is_attn_dynamic_desc(kIndexerWqBLinearIndex)) {
-    indexer_linear_for_rope.emplace_back("self_attn.indexer.wq_b.weight_offset");
+    indexer_linear_for_rope.emplace_back(
+        "self_attn.indexer.wq_b.weight_offset");
     indexer_linear_for_rope.emplace_back("self_attn.indexer.wq_b.weight_scale");
   } else {
     indexer_linear_for_rope.emplace_back("self_attn.indexer.wq_b.quant_bias");
@@ -1067,7 +1067,6 @@ void DeekseekV32DecoderLoader::preprocess_linear_for_rope() {
     if (t[index].sizes() == std::vector<int64_t>({1})) {
       continue;
     }
-    ++processed_indexer_rope_tensors;
     t[index] = view_indexer_tensor(t[index], name, true);
     t[index] = trans_front_rope_weight(t[index]);
     t[index] = view_indexer_tensor(t[index], name, false);
@@ -1149,10 +1148,8 @@ torch::Tensor DeekseekV32DecoderLoader::trans_front_rope_weight(
     torch::Tensor weight) {
   int64_t rope_dim = prefill_qkRopeHeadDim_;
   torch::Tensor output = load_to_host() ? weight.clone() : weight;
-  torch::Tensor weight_1 =
-      weight.slice(-2, 0, rope_dim, 2).contiguous();
-  torch::Tensor weight_2 =
-      weight.slice(-2, 1, rope_dim, 2).contiguous();
+  torch::Tensor weight_1 = weight.slice(-2, 0, rope_dim, 2).contiguous();
+  torch::Tensor weight_2 = weight.slice(-2, 1, rope_dim, 2).contiguous();
   torch::Tensor combined = torch::cat({weight_1, weight_2}, -2);
   output.slice(-2, 0, rope_dim).copy_(combined);
   return output.contiguous();

--- a/xllm/core/layers/npu/loader/deepseek_v32_decoder_loader.cpp
+++ b/xllm/core/layers/npu/loader/deepseek_v32_decoder_loader.cpp
@@ -206,9 +206,13 @@ DeekseekV32DecoderLoader::DeekseekV32DecoderLoader(
       kv_lora_rank_(kv_lora_rank),
       num_key_value_heads_(num_key_value_heads),
       v_head_dim_(v_head_dim),
+      index_n_heads_(0),
+      index_head_dim_(0),
       prefill_isBF16_(prefill_isBF16),
       decode_isBF16_(decode_isBF16),
       skip_topk_(skip_topk),
+      is_glm_moe_dsa_(false),
+      indexer_rope_interleave_(false),
       attn_linear_quant_types_(attn_linear_quant_types) {
   auto model_args = context.get_model_args();
   auto quant_args = context.get_quant_args();
@@ -218,6 +222,11 @@ DeekseekV32DecoderLoader::DeekseekV32DecoderLoader(
   first_k_dense_replace_ = model_args.first_k_dense_replace();
   n_layers_ = model_args.n_layers();
   num_experts_ = model_args.n_routed_experts();
+  index_n_heads_ = model_args.index_n_heads();
+  index_head_dim_ = model_args.index_head_dim();
+  is_glm_moe_dsa_ =
+      model_args.model_type().find("glm_moe_dsa") != std::string::npos;
+  indexer_rope_interleave_ = model_args.indexer_rope_interleave();
   quant_group_size_ = static_cast<int32_t>(quant_args.group_size());
   if (quantize_type_ == "w4a8_dynamic") {
     CHECK_GE(quant_group_size_, 0)
@@ -1026,6 +1035,46 @@ void DeekseekV32DecoderLoader::preprocess_linear_for_rope() {
       t[index] = t[index].flatten();
     }
   }
+
+  if (!is_glm_moe_dsa_ || !indexer_rope_interleave_ ||
+      prefill_qkRopeHeadDim_ <= 0 || index_head_dim_ < prefill_qkRopeHeadDim_) {
+    return;
+  }
+
+  std::vector<std::string> indexer_linear_for_rope;
+  indexer_linear_for_rope.reserve(5);
+  int32_t processed_indexer_rope_tensors = 0;
+  indexer_linear_for_rope.emplace_back("self_attn.indexer.wq_b.weight");
+  if (is_attn_dynamic_desc(kIndexerWqBLinearIndex)) {
+    indexer_linear_for_rope.emplace_back("self_attn.indexer.wq_b.weight_offset");
+    indexer_linear_for_rope.emplace_back("self_attn.indexer.wq_b.weight_scale");
+  } else {
+    indexer_linear_for_rope.emplace_back("self_attn.indexer.wq_b.quant_bias");
+    indexer_linear_for_rope.emplace_back("self_attn.indexer.wq_b.deq_scale");
+  }
+  indexer_linear_for_rope.emplace_back("self_attn.indexer.wk.weight");
+
+  for (const auto& name : indexer_linear_for_rope) {
+    if (!use_quant_weight_mapping() && !absl::EndsWith(name, "weight")) {
+      continue;
+    }
+    auto index_it = WEIGHT_MAPPING_W8A8.find(name);
+    if (index_it == WEIGHT_MAPPING_W8A8.end()) {
+      LOG(WARNING) << "Skip unsupported GLM5 indexer rope tensor: " << name;
+      continue;
+    }
+    int32_t index = index_it->second;
+    if (t[index].sizes() == std::vector<int64_t>({1})) {
+      continue;
+    }
+    ++processed_indexer_rope_tensors;
+    t[index] = view_indexer_tensor(t[index], name, true);
+    t[index] = trans_front_rope_weight(t[index]);
+    t[index] = view_indexer_tensor(t[index], name, false);
+    if (!absl::EndsWith(name, "weight")) {
+      t[index] = t[index].flatten();
+    }
+  }
 }
 
 torch::Tensor DeekseekV32DecoderLoader::view_tensor(torch::Tensor weight,
@@ -1048,6 +1097,22 @@ torch::Tensor DeekseekV32DecoderLoader::view_tensor(torch::Tensor weight,
   } else if (absl::StrContains(name, "kv_a_proj_with_mqa")) {
     return weight.view({kv_lora_rank_ + prefill_qkRopeHeadDim_, -1})
         .contiguous();
+  }
+  return weight;
+}
+
+torch::Tensor DeekseekV32DecoderLoader::view_indexer_tensor(
+    torch::Tensor weight,
+    const std::string& name,
+    bool pre_view) {
+  if (absl::StrContains(name, "indexer.wq_b")) {
+    if (pre_view) {
+      return weight.view({index_n_heads_, index_head_dim_, -1}).contiguous();
+    }
+    return weight.view({index_n_heads_ * index_head_dim_, -1}).contiguous();
+  }
+  if (absl::StrContains(name, "indexer.wk")) {
+    return weight.view({index_head_dim_, -1}).contiguous();
   }
   return weight;
 }
@@ -1078,6 +1143,19 @@ torch::Tensor DeekseekV32DecoderLoader::trans_rope_weight(
   torch::Tensor combined = torch::cat({weight_1, weight_2}, -2);
   weight.slice(-2, d - rope_dim, d).copy_(combined);
   return weight.contiguous();
+}
+
+torch::Tensor DeekseekV32DecoderLoader::trans_front_rope_weight(
+    torch::Tensor weight) {
+  int64_t rope_dim = prefill_qkRopeHeadDim_;
+  torch::Tensor output = load_to_host() ? weight.clone() : weight;
+  torch::Tensor weight_1 =
+      weight.slice(-2, 0, rope_dim, 2).contiguous();
+  torch::Tensor weight_2 =
+      weight.slice(-2, 1, rope_dim, 2).contiguous();
+  torch::Tensor combined = torch::cat({weight_1, weight_2}, -2);
+  output.slice(-2, 0, rope_dim).copy_(combined);
+  return output.contiguous();
 }
 
 void DeekseekV32DecoderLoader::initialize_device_expert_list(

--- a/xllm/core/layers/npu/loader/deepseek_v32_decoder_loader.h
+++ b/xllm/core/layers/npu/loader/deepseek_v32_decoder_loader.h
@@ -135,9 +135,14 @@ class DeekseekV32DecoderLoader : public BaseLoader {
                             const std::string& name,
                             bool pre_view);
 
+  torch::Tensor view_indexer_tensor(torch::Tensor weight,
+                                    const std::string& name,
+                                    bool pre_view);
+
   void reserve_experts_weights(int num_of_device_experts);
 
   torch::Tensor trans_rope_weight(torch::Tensor weight);
+  torch::Tensor trans_front_rope_weight(torch::Tensor weight);
 
   int32_t rank_;
   int32_t first_k_dense_replace_;
@@ -158,6 +163,8 @@ class DeekseekV32DecoderLoader : public BaseLoader {
   int32_t qk_nope_head_dim_;
   int32_t kv_lora_rank_;
   int32_t v_head_dim_;
+  int32_t index_n_heads_;
+  int32_t index_head_dim_;
   int32_t num_key_value_heads_;
   int32_t prefill_firstKDenseReplace_;
   int32_t prefill_numOfDeviceExperts_;
@@ -167,6 +174,8 @@ class DeekseekV32DecoderLoader : public BaseLoader {
   bool prefill_isBF16_;
   bool decode_isBF16_;
   bool skip_topk_;
+  bool is_glm_moe_dsa_;
+  bool indexer_rope_interleave_;
   // Compatibility vector: entries may be legacy LinearType or new LinearDesc.
   std::vector<int32_t> attn_linear_quant_types_;
   std::mutex shared_experts_mutex_;

--- a/xllm/core/layers/npu/npu_deepseek_v32_decoder_layer_impl.cpp
+++ b/xllm/core/layers/npu/npu_deepseek_v32_decoder_layer_impl.cpp
@@ -615,8 +615,7 @@ void NpuDeepseekV32DecoderLayerImpl::initialize_mlp_parameters(
   param.numOfDeviceExperts = num_experts_per_partition_;
   param.maskStartIdx = 0;
   param.firstKDenseReplace = args.first_k_dense_replace();
-  // param.numOfSharedExperts = args.n_shared_experts();
-  param.numOfSharedExperts = 2;
+  param.numOfSharedExperts = args.n_shared_experts();
   param.routingMethod = "noAuxTc";
   param.numOfGroups = args.n_group();
   param.topkGroups = atb::SVector<int>{args.topk_group()};

--- a/xllm/models/llm/npu/glm5_moe.h
+++ b/xllm/models/llm/npu/glm5_moe.h
@@ -15,55 +15,10 @@ limitations under the License.
 
 #pragma once
 
-#include <sstream>
-
-#include <glog/logging.h>
-
 #include "core/layers/npu/npu_deepseek_v32_decoder_layer_impl.h"
 #include "deepseek_v32.h"
 
 namespace xllm::npu::model {
-
-namespace detail {
-
-inline std::string format_eos_token_ids(
-  const std::vector<int32_t>& token_ids) {
-  std::ostringstream stream;
-  for (size_t index = 0; index < token_ids.size(); ++index) {
-    if (index > 0) {
-      stream << ",";
-    }
-    stream << token_ids[index];
-  }
-  return stream.str();
-}
-
-inline void log_glm5_npu_model_args(const ModelArgs& model_args,
-                                    const std::string& model_tag) {
-  LOG(INFO) << model_tag
-            << " parsed args: model_type=" << model_args.model_type()
-            << ", dtype=" << model_args.dtype()
-            << ", max_position_embeddings="
-            << model_args.max_position_embeddings()
-            << ", rope_theta=" << model_args.rope_theta()
-            << ", n_shared_experts=" << model_args.n_shared_experts()
-            << ", num_experts_per_tok=" << model_args.num_experts_per_tok()
-            << ", scoring_func=" << model_args.scoring_func()
-            << ", index_n_heads=" << model_args.index_n_heads()
-            << ", index_head_dim=" << model_args.index_head_dim()
-            << ", index_topk=" << model_args.index_topk()
-            << ", index_topk_freq=" << model_args.index_topk_freq()
-            << ", index_skip_topk_offset="
-            << model_args.index_skip_topk_offset()
-            << ", indexer_rope_interleave=" << std::boolalpha
-            << model_args.indexer_rope_interleave()
-            << ", num_nextn_predict_layers="
-            << model_args.num_nextn_predict_layers()
-            << ", eos_token_ids=["
-            << format_eos_token_ids(model_args.eos_token_id_vec()) << "]";
-}
-
-}  // namespace detail
 
 using torch::indexing::None;
 using ISlice = torch::indexing::Slice;
@@ -83,7 +38,6 @@ class GlmMoeDsaModelImpl : public torch::nn::Module {
     dtype_ = options.dtype().toScalarType();
     num_speculative_tokens_ = model_args.num_speculative_tokens();
     index_topk_ = model_args.index_topk();
-    detail::log_glm5_npu_model_args(model_args, "GLM5 NPU main model");
 
     npu_embed_tokens_ =
         register_module("npu_embed_tokens", layer::NpuWordEmbedding(context));
@@ -365,9 +319,7 @@ TORCH_MODULE(GlmMoeDsaForCausalLM);
 REGISTER_CAUSAL_MODEL(glm_moe_dsa, GlmMoeDsaForCausalLM);
 
 // register the model args
-REGISTER_MODEL_ARGS(
-    glm_moe_dsa,
-    ([&] {
+REGISTER_MODEL_ARGS(glm_moe_dsa, [&] {
   LOAD_ARG_OR(model_type, "model_type", "glm_moe_dsa");
   LOAD_ARG_OR(dtype, "dtype", "");
   LOAD_ARG_OR(attention_bias, "attention_bias", false);
@@ -416,7 +368,8 @@ REGISTER_MODEL_ARGS(
   LOAD_ARG_OR(index_topk_freq, "index_topk_freq", 1);
   LOAD_ARG_OR(index_topk_pattern, "index_topk_pattern", "");
   LOAD_ARG_OR(index_skip_topk_offset, "index_skip_topk_offset", 0);
-  LOAD_ARG_OR(index_share_for_mtp_iteration, "index_share_for_mtp_iteration", false);
+  LOAD_ARG_OR(
+      index_share_for_mtp_iteration, "index_share_for_mtp_iteration", false);
 
   LOAD_ARG_OR(use_qk_norm, "use_qk_norm", true);
   LOAD_ARG_OR(indexer_rope_interleave, "indexer_rope_interleave", true);
@@ -430,5 +383,5 @@ REGISTER_MODEL_ARGS(
   SET_ARG(stop_token_ids,
           std::unordered_set<int32_t>(args->eos_token_id_vec().begin(),
                                       args->eos_token_id_vec().end()));
-    }));
+});
 }  // namespace xllm::npu::model

--- a/xllm/models/llm/npu/glm5_moe.h
+++ b/xllm/models/llm/npu/glm5_moe.h
@@ -15,10 +15,55 @@ limitations under the License.
 
 #pragma once
 
+#include <sstream>
+
+#include <glog/logging.h>
+
 #include "core/layers/npu/npu_deepseek_v32_decoder_layer_impl.h"
 #include "deepseek_v32.h"
 
 namespace xllm::npu::model {
+
+namespace detail {
+
+inline std::string format_eos_token_ids(
+  const std::vector<int32_t>& token_ids) {
+  std::ostringstream stream;
+  for (size_t index = 0; index < token_ids.size(); ++index) {
+    if (index > 0) {
+      stream << ",";
+    }
+    stream << token_ids[index];
+  }
+  return stream.str();
+}
+
+inline void log_glm5_npu_model_args(const ModelArgs& model_args,
+                                    const std::string& model_tag) {
+  LOG(INFO) << model_tag
+            << " parsed args: model_type=" << model_args.model_type()
+            << ", dtype=" << model_args.dtype()
+            << ", max_position_embeddings="
+            << model_args.max_position_embeddings()
+            << ", rope_theta=" << model_args.rope_theta()
+            << ", n_shared_experts=" << model_args.n_shared_experts()
+            << ", num_experts_per_tok=" << model_args.num_experts_per_tok()
+            << ", scoring_func=" << model_args.scoring_func()
+            << ", index_n_heads=" << model_args.index_n_heads()
+            << ", index_head_dim=" << model_args.index_head_dim()
+            << ", index_topk=" << model_args.index_topk()
+            << ", index_topk_freq=" << model_args.index_topk_freq()
+            << ", index_skip_topk_offset="
+            << model_args.index_skip_topk_offset()
+            << ", indexer_rope_interleave=" << std::boolalpha
+            << model_args.indexer_rope_interleave()
+            << ", num_nextn_predict_layers="
+            << model_args.num_nextn_predict_layers()
+            << ", eos_token_ids=["
+            << format_eos_token_ids(model_args.eos_token_id_vec()) << "]";
+}
+
+}  // namespace detail
 
 using torch::indexing::None;
 using ISlice = torch::indexing::Slice;
@@ -38,6 +83,7 @@ class GlmMoeDsaModelImpl : public torch::nn::Module {
     dtype_ = options.dtype().toScalarType();
     num_speculative_tokens_ = model_args.num_speculative_tokens();
     index_topk_ = model_args.index_topk();
+    detail::log_glm5_npu_model_args(model_args, "GLM5 NPU main model");
 
     npu_embed_tokens_ =
         register_module("npu_embed_tokens", layer::NpuWordEmbedding(context));
@@ -319,7 +365,9 @@ TORCH_MODULE(GlmMoeDsaForCausalLM);
 REGISTER_CAUSAL_MODEL(glm_moe_dsa, GlmMoeDsaForCausalLM);
 
 // register the model args
-REGISTER_MODEL_ARGS(glm_moe_dsa, [&] {
+REGISTER_MODEL_ARGS(
+    glm_moe_dsa,
+    ([&] {
   LOAD_ARG_OR(model_type, "model_type", "glm_moe_dsa");
   LOAD_ARG_OR(dtype, "dtype", "");
   LOAD_ARG_OR(attention_bias, "attention_bias", false);
@@ -333,13 +381,18 @@ REGISTER_MODEL_ARGS(glm_moe_dsa, [&] {
   LOAD_ARG_OR(intermediate_size, "intermediate_size", 12288);
   LOAD_ARG_OR(max_position_embeddings, "max_position_embeddings", 202752);
   LOAD_ARG_OR(rms_norm_eps, "rms_norm_eps", 1e-5);
-  LOAD_ARG_OR(eos_token_id_vec, "eos_token_id", std::vector<int>{154820});
+  LOAD_ARG_OR_FUNC(eos_token_id_vec, "eos_token_id", [&] {
+    return std::vector<int32_t>{154820, 154827, 154829};
+  });
+  LOAD_ARG_OR(bos_token_id, "bos_token_id", 0);
+  LOAD_ARG_OR(rope_theta, "rope_parameters.rope_theta", 1000000.0f);
 
   LOAD_ARG_OR(use_sliding_window, "use_sliding_window", false);
   LOAD_ARG_OR(sliding_window, "sliding_window", 4096);
   LOAD_ARG_OR(max_window_layers, "max_window_layers", 61);
 
   LOAD_ARG_OR(first_k_dense_replace, "first_k_dense_replace", 3);
+  LOAD_ARG_OR(hidden_act, "hidden_act", "silu");
   LOAD_ARG_OR(moe_layer_freq, "moe_layer_freq", 1);
   LOAD_ARG_OR(topk_method, "topk_method", "noaux_tc");
   LOAD_ARG_OR(n_routed_experts, "n_routed_experts", 256);
@@ -350,20 +403,24 @@ REGISTER_MODEL_ARGS(glm_moe_dsa, [&] {
   LOAD_ARG_OR(norm_topk_prob, "norm_topk_prob", true);
   LOAD_ARG_OR(n_group, "n_group", 1);
   LOAD_ARG_OR(topk_group, "topk_group", 1);
+  LOAD_ARG_OR(scoring_func, "scoring_func", "sigmoid");
   LOAD_ARG_OR(qk_nope_head_dim, "qk_nope_head_dim", 192);
   LOAD_ARG_OR(qk_rope_head_dim, "qk_rope_head_dim", 64);
   LOAD_ARG_OR(v_head_dim, "v_head_dim", 256);
   LOAD_ARG_OR(q_lora_rank, "q_lora_rank", 2048);
   LOAD_ARG_OR(kv_lora_rank, "kv_lora_rank", 512);
   LOAD_ARG_OR(index_head_dim, "index_head_dim", 128);
-  LOAD_ARG_OR(index_n_heads, "index_n_heads", 0);
+  LOAD_ARG_OR(num_nextn_predict_layers, "num_nextn_predict_layers", 1);
+  LOAD_ARG_OR(index_n_heads, "index_n_heads", 32);
   LOAD_ARG_OR(index_topk, "index_topk", 2048);
   LOAD_ARG_OR(index_topk_freq, "index_topk_freq", 1);
   LOAD_ARG_OR(index_topk_pattern, "index_topk_pattern", "");
   LOAD_ARG_OR(index_skip_topk_offset, "index_skip_topk_offset", 0);
+  LOAD_ARG_OR(index_share_for_mtp_iteration, "index_share_for_mtp_iteration", false);
 
   LOAD_ARG_OR(use_qk_norm, "use_qk_norm", true);
-  LOAD_ARG_OR(rope_theta, "rope_theta", 1000000.0f);
+  LOAD_ARG_OR(indexer_rope_interleave, "indexer_rope_interleave", true);
+  LOAD_ARG_OR(rope_theta, "rope_theta", args->rope_theta());
   LOAD_ARG_OR(tie_word_embeddings, "tie_word_embeddings", false);
 
   SET_ARG(head_dim, args->qk_nope_head_dim() + args->qk_rope_head_dim());
@@ -373,5 +430,5 @@ REGISTER_MODEL_ARGS(glm_moe_dsa, [&] {
   SET_ARG(stop_token_ids,
           std::unordered_set<int32_t>(args->eos_token_id_vec().begin(),
                                       args->eos_token_id_vec().end()));
-});
+    }));
 }  // namespace xllm::npu::model

--- a/xllm/models/llm/npu/glm5_moe_mtp.h
+++ b/xllm/models/llm/npu/glm5_moe_mtp.h
@@ -15,11 +15,59 @@ limitations under the License.
 
 #pragma once
 
+#include <sstream>
+
+#include <glog/logging.h>
+
 #include "core/layers/common/rotary_embedding_util.h"
 #include "deepseek_v32.h"
 #include "mtp_model_base.h"
 
 namespace xllm::npu::model {
+
+namespace detail {
+
+inline std::string format_glm5_mtp_eos_token_ids(
+  const std::vector<int32_t>& token_ids) {
+  std::ostringstream stream;
+  for (size_t index = 0; index < token_ids.size(); ++index) {
+    if (index > 0) {
+      stream << ",";
+    }
+    stream << token_ids[index];
+  }
+  return stream.str();
+}
+
+inline void log_glm5_mtp_model_args(const ModelArgs& model_args,
+                                    const std::string& model_tag) {
+  LOG(INFO) << model_tag
+            << " parsed args: model_type=" << model_args.model_type()
+            << ", dtype=" << model_args.dtype()
+            << ", max_position_embeddings="
+            << model_args.max_position_embeddings()
+            << ", rope_theta=" << model_args.rope_theta()
+            << ", n_shared_experts=" << model_args.n_shared_experts()
+            << ", num_experts_per_tok=" << model_args.num_experts_per_tok()
+            << ", scoring_func=" << model_args.scoring_func()
+            << ", index_n_heads=" << model_args.index_n_heads()
+            << ", index_head_dim=" << model_args.index_head_dim()
+            << ", index_topk=" << model_args.index_topk()
+            << ", index_topk_freq=" << model_args.index_topk_freq()
+            << ", index_skip_topk_offset="
+            << model_args.index_skip_topk_offset()
+            << ", index_share_for_mtp_iteration=" << std::boolalpha
+            << model_args.index_share_for_mtp_iteration()
+            << ", indexer_rope_interleave=" << std::boolalpha
+            << model_args.indexer_rope_interleave()
+            << ", num_nextn_predict_layers="
+            << model_args.num_nextn_predict_layers()
+            << ", eos_token_ids=["
+            << format_glm5_mtp_eos_token_ids(model_args.eos_token_id_vec())
+            << "]";
+}
+
+}  // namespace detail
 
 class GlmMoeDsaMtpModelImpl
     : public xllm::npu::model::MtpModelImplBase<DeepseekV32DecoderLayer> {
@@ -30,6 +78,7 @@ class GlmMoeDsaMtpModelImpl
             context) {
     auto model_args = context.get_model_args();
     auto options = context.get_tensor_options();
+    detail::log_glm5_mtp_model_args(model_args, "GLM5 NPU MTP model");
 
     int32_t mask_value = model_args.dtype() == "bfloat16" ? 1 : -9984;
     attn_mask_ = layer::AttentionMask(options.device(),
@@ -82,7 +131,9 @@ TORCH_MODULE(GlmMoeDsaMtpForCausalLM);
 // register the causal model
 REGISTER_CAUSAL_MODEL(glm_moe_dsa_mtp, GlmMoeDsaMtpForCausalLM);
 
-REGISTER_MODEL_ARGS(glm_moe_dsa_mtp, [&] {
+REGISTER_MODEL_ARGS(
+    glm_moe_dsa_mtp,
+    ([&] {
   LOAD_ARG_OR(model_type, "model_type", "glm_moe_dsa_mtp");
   LOAD_ARG_OR(dtype, "dtype", "");
   LOAD_ARG_OR(attention_bias, "attention_bias", false);
@@ -96,14 +147,18 @@ REGISTER_MODEL_ARGS(glm_moe_dsa_mtp, [&] {
   LOAD_ARG_OR(intermediate_size, "intermediate_size", 12288);
   LOAD_ARG_OR(max_position_embeddings, "max_position_embeddings", 202752);
   LOAD_ARG_OR(rms_norm_eps, "rms_norm_eps", 1e-5);
-  // LOAD_ARG_OR(eos_token_id, "eos_token_id", 1);
-  LOAD_ARG_OR(eos_token_id_vec, "eos_token_id", std::vector<int>{154820});
+  LOAD_ARG_OR_FUNC(eos_token_id_vec, "eos_token_id", [&] {
+    return std::vector<int32_t>{154820, 154827, 154829};
+  });
+  LOAD_ARG_OR(bos_token_id, "bos_token_id", 0);
+  LOAD_ARG_OR(rope_theta, "rope_parameters.rope_theta", 1000000.0f);
 
   LOAD_ARG_OR(use_sliding_window, "use_sliding_window", false);
   LOAD_ARG_OR(sliding_window, "sliding_window", 4096);
   LOAD_ARG_OR(max_window_layers, "max_window_layers", 61);
 
   LOAD_ARG_OR(first_k_dense_replace, "first_k_dense_replace", 3);
+  LOAD_ARG_OR(hidden_act, "hidden_act", "silu");
   LOAD_ARG_OR(moe_layer_freq, "moe_layer_freq", 1);
   LOAD_ARG_OR(topk_method, "topk_method", "noaux_tc");
   LOAD_ARG_OR(n_routed_experts, "n_routed_experts", 256);
@@ -114,22 +169,24 @@ REGISTER_MODEL_ARGS(glm_moe_dsa_mtp, [&] {
   LOAD_ARG_OR(norm_topk_prob, "norm_topk_prob", true);
   LOAD_ARG_OR(n_group, "n_group", 1);
   LOAD_ARG_OR(topk_group, "topk_group", 1);
+  LOAD_ARG_OR(scoring_func, "scoring_func", "sigmoid");
   LOAD_ARG_OR(qk_nope_head_dim, "qk_nope_head_dim", 192);
   LOAD_ARG_OR(qk_rope_head_dim, "qk_rope_head_dim", 64);
   LOAD_ARG_OR(v_head_dim, "v_head_dim", 256);
   LOAD_ARG_OR(q_lora_rank, "q_lora_rank", 2048);
   LOAD_ARG_OR(kv_lora_rank, "kv_lora_rank", 512);
   LOAD_ARG_OR(index_head_dim, "index_head_dim", 128);
-  LOAD_ARG_OR(index_n_heads, "index_n_heads", 0);
+  LOAD_ARG_OR(num_nextn_predict_layers, "num_nextn_predict_layers", 1);
+  LOAD_ARG_OR(index_n_heads, "index_n_heads", 32);
   LOAD_ARG_OR(index_topk, "index_topk", 2048);
   LOAD_ARG_OR(index_topk_freq, "index_topk_freq", 1);
   LOAD_ARG_OR(index_topk_pattern, "index_topk_pattern", "");
   LOAD_ARG_OR(index_skip_topk_offset, "index_skip_topk_offset", 0);
-  LOAD_ARG_OR(
-      index_share_for_mtp_iteration, "index_share_for_mtp_iteration", false);
+  LOAD_ARG_OR(index_share_for_mtp_iteration, "index_share_for_mtp_iteration", false);
 
   LOAD_ARG_OR(use_qk_norm, "use_qk_norm", true);
-  LOAD_ARG_OR(rope_theta, "rope_theta", 1000000.0f);
+  LOAD_ARG_OR(indexer_rope_interleave, "indexer_rope_interleave", true);
+  LOAD_ARG_OR(rope_theta, "rope_theta", args->rope_theta());
   LOAD_ARG_OR(tie_word_embeddings, "tie_word_embeddings", false);
 
   SET_ARG(head_dim, args->qk_nope_head_dim() + args->qk_rope_head_dim());
@@ -139,5 +196,5 @@ REGISTER_MODEL_ARGS(glm_moe_dsa_mtp, [&] {
   SET_ARG(stop_token_ids,
           std::unordered_set<int32_t>(args->eos_token_id_vec().begin(),
                                       args->eos_token_id_vec().end()));
-});
+    }));
 }  // namespace xllm::npu::model

--- a/xllm/models/llm/npu/glm5_moe_mtp.h
+++ b/xllm/models/llm/npu/glm5_moe_mtp.h
@@ -15,59 +15,11 @@ limitations under the License.
 
 #pragma once
 
-#include <sstream>
-
-#include <glog/logging.h>
-
 #include "core/layers/common/rotary_embedding_util.h"
 #include "deepseek_v32.h"
 #include "mtp_model_base.h"
 
 namespace xllm::npu::model {
-
-namespace detail {
-
-inline std::string format_glm5_mtp_eos_token_ids(
-  const std::vector<int32_t>& token_ids) {
-  std::ostringstream stream;
-  for (size_t index = 0; index < token_ids.size(); ++index) {
-    if (index > 0) {
-      stream << ",";
-    }
-    stream << token_ids[index];
-  }
-  return stream.str();
-}
-
-inline void log_glm5_mtp_model_args(const ModelArgs& model_args,
-                                    const std::string& model_tag) {
-  LOG(INFO) << model_tag
-            << " parsed args: model_type=" << model_args.model_type()
-            << ", dtype=" << model_args.dtype()
-            << ", max_position_embeddings="
-            << model_args.max_position_embeddings()
-            << ", rope_theta=" << model_args.rope_theta()
-            << ", n_shared_experts=" << model_args.n_shared_experts()
-            << ", num_experts_per_tok=" << model_args.num_experts_per_tok()
-            << ", scoring_func=" << model_args.scoring_func()
-            << ", index_n_heads=" << model_args.index_n_heads()
-            << ", index_head_dim=" << model_args.index_head_dim()
-            << ", index_topk=" << model_args.index_topk()
-            << ", index_topk_freq=" << model_args.index_topk_freq()
-            << ", index_skip_topk_offset="
-            << model_args.index_skip_topk_offset()
-            << ", index_share_for_mtp_iteration=" << std::boolalpha
-            << model_args.index_share_for_mtp_iteration()
-            << ", indexer_rope_interleave=" << std::boolalpha
-            << model_args.indexer_rope_interleave()
-            << ", num_nextn_predict_layers="
-            << model_args.num_nextn_predict_layers()
-            << ", eos_token_ids=["
-            << format_glm5_mtp_eos_token_ids(model_args.eos_token_id_vec())
-            << "]";
-}
-
-}  // namespace detail
 
 class GlmMoeDsaMtpModelImpl
     : public xllm::npu::model::MtpModelImplBase<DeepseekV32DecoderLayer> {
@@ -78,7 +30,6 @@ class GlmMoeDsaMtpModelImpl
             context) {
     auto model_args = context.get_model_args();
     auto options = context.get_tensor_options();
-    detail::log_glm5_mtp_model_args(model_args, "GLM5 NPU MTP model");
 
     int32_t mask_value = model_args.dtype() == "bfloat16" ? 1 : -9984;
     attn_mask_ = layer::AttentionMask(options.device(),
@@ -131,9 +82,7 @@ TORCH_MODULE(GlmMoeDsaMtpForCausalLM);
 // register the causal model
 REGISTER_CAUSAL_MODEL(glm_moe_dsa_mtp, GlmMoeDsaMtpForCausalLM);
 
-REGISTER_MODEL_ARGS(
-    glm_moe_dsa_mtp,
-    ([&] {
+REGISTER_MODEL_ARGS(glm_moe_dsa_mtp, [&] {
   LOAD_ARG_OR(model_type, "model_type", "glm_moe_dsa_mtp");
   LOAD_ARG_OR(dtype, "dtype", "");
   LOAD_ARG_OR(attention_bias, "attention_bias", false);
@@ -182,7 +131,8 @@ REGISTER_MODEL_ARGS(
   LOAD_ARG_OR(index_topk_freq, "index_topk_freq", 1);
   LOAD_ARG_OR(index_topk_pattern, "index_topk_pattern", "");
   LOAD_ARG_OR(index_skip_topk_offset, "index_skip_topk_offset", 0);
-  LOAD_ARG_OR(index_share_for_mtp_iteration, "index_share_for_mtp_iteration", false);
+  LOAD_ARG_OR(
+      index_share_for_mtp_iteration, "index_share_for_mtp_iteration", false);
 
   LOAD_ARG_OR(use_qk_norm, "use_qk_norm", true);
   LOAD_ARG_OR(indexer_rope_interleave, "indexer_rope_interleave", true);
@@ -196,5 +146,5 @@ REGISTER_MODEL_ARGS(
   SET_ARG(stop_token_ids,
           std::unordered_set<int32_t>(args->eos_token_id_vec().begin(),
                                       args->eos_token_id_vec().end()));
-    }));
+});
 }  // namespace xllm::npu::model


### PR DESCRIPTION
## Summary

This PR fixes GLM-5.2 NPU accuracy issues caused by the indexer RoPE layout mismatch.

For `GlmMoeDsaForCausalLM` models with `"indexer_rope_interleave": true`, the indexer RoPE inputs are expected to use the interleaved layout instead of the NeoX / half-split layout.

For example, given the input:

```text
[x0, x1, x2, x3, x4, x5, x6, x7]
```

The RoPE dimension pairing should be:

```text
NeoX / half-split:
(x0, x4), (x1, x5), (x2, x6), (x3, x7)

Interleaved:
(x0, x1), (x2, x3), (x4, x5), (x6, x7)
```

Using the wrong indexer RoPE layout changes the indexer attention scores and may lead to semantic accuracy degradation. The impact is more visible in long-context generation, where sparse index selection becomes more sensitive to positional encoding errors.

Instead of inserting extra layout conversions before or after RoPE at runtime, this PR reorders the affected indexer weights during model loading. This keeps the runtime execution path unchanged and avoids additional runtime overhead.

## Changes

* Add indexer weight preprocessing for GLM-5 / GLM-5.2 NPU models with `"indexer_rope_interleave": true`
* Reorder the RoPE-related front dimensions of:

  * `self_attn.indexer.wq_b.weight`
  * `self_attn.indexer.wk.weight`
  * associated quantization metadata for `wq_b`
* Fix `rope_theta` parsing from `config.json`
* Fix GLM-5 / GLM-5-MTP NPU model argument parsing
* Restore `numOfSharedExperts` to use the model config value instead of a hardcoded value

## Validation

* IFBench: `72.33`
* GPQA_DIAMOND: `89.39`
