### PR TITLE
feat: support quantization for Qwen3.5/Qwen3.6 series models.

### DIFF
--- a/xllm/core/layers/common/linear.h
+++ b/xllm/core/layers/common/linear.h
@@ -170,6 +170,14 @@ class QKVParallelLinearImpl : public torch::nn::Module {
   torch::Tensor weight() const { return weight_; }
   bool is_weight_loaded() const { return weight_is_loaded_; }
 
+  // Accessors for W8A8 dynamic quantization parameters.
+  // Used by attention layers to reorder weight_scale/weight_offset
+  // when attn_output_gate is enabled.
+  torch::Tensor weight_scale() const { return weight_scale_; }
+  torch::Tensor weight_offset() const { return weight_offset_; }
+  bool is_weight_scale_loaded() const { return weight_scale_is_loaded_; }
+  bool is_weight_offset_loaded() const { return weight_offset_is_loaded_; }
+
   // Get FP8 input scale for fused RMSNorm+FP8 quantization
   // For QKV, returns max of Q/K/V scales (per-tensor)
   std::optional<torch::Tensor> get_input_scale() const;

--- a/xllm/core/layers/npu_torch/qwen3_gated_delta_net_base.cpp
+++ b/xllm/core/layers/npu_torch/qwen3_gated_delta_net_base.cpp
@@ -493,7 +493,10 @@ void Qwen3GatedDeltaNetBaseImpl::load_common_state_dict(
 
   if (auto w = state_dict.get_tensor("conv1d.weight"); w.defined()) {
     conv1d_->load_state_dict(
-        StateDict({{"weight", w.squeeze(1)}}), shard_tensor_count, shard_sizes);
+        StateDict({{"weight", w.squeeze(1)}},
+                  static_cast<std::string>(state_dict.prefix()) + "conv1d."),
+        shard_tensor_count,
+        shard_sizes);
     conv1d_->weight().set_(conv1d_->weight().transpose(0, 1).contiguous());
   }
   o_proj_->load_state_dict(state_dict.get_dict_with_prefix("out_proj."));

--- a/xllm/core/layers/npu_torch/qwen3_next_attention.cpp
+++ b/xllm/core/layers/npu_torch/qwen3_next_attention.cpp
@@ -63,7 +63,8 @@ Qwen3NextAttentionImpl::Qwen3NextAttentionImpl(
                         /*bias=*/args.attention_bias(),
                         /*gather_output=*/false,
                         parallel_args,
-                        options));
+                        options,
+                        quant_args));
 
   // 2. O proj
   o_proj_ = register_module("o_proj",
@@ -218,6 +219,31 @@ void Qwen3NextAttentionImpl::load_state_dict(const StateDict& state_dict) {
         {q_part.reshape({q_size_, hidden}), g_part.reshape({q_size_, hidden})},
         0);
     qg_rows.copy_(reordered);
+
+    // Reorder weight_scale and weight_offset for W8A8 dynamic quantization.
+    // These are per-channel (per output row) tensors that must match the
+    // reordered weight layout for correct dequantization.
+    const int64_t qg_size = q_size_ * 2;
+    auto reorder_per_channel = [this, qg_size](torch::Tensor tensor) {
+      if (!tensor.defined() || tensor.numel() == 0) {
+        return;
+      }
+      auto qg_part = tensor.slice(0, 0, qg_size);
+      auto qg_2d = qg_part.view({num_heads_, 2 * head_dim_});
+      auto q_scale = qg_2d.slice(1, 0, head_dim_);
+      auto g_scale = qg_2d.slice(1, head_dim_, 2 * head_dim_);
+      auto reordered_scale = torch::cat(
+          {q_scale.reshape({q_size_}), g_scale.reshape({q_size_})}, 0);
+      qg_part.copy_(reordered_scale);
+    };
+
+    if (qkv_proj_->is_weight_scale_loaded()) {
+      reorder_per_channel(qkv_proj_->weight_scale());
+    }
+    if (qkv_proj_->is_weight_offset_loaded()) {
+      reorder_per_channel(qkv_proj_->weight_offset());
+    }
+
     qkv_weight_reordered_ = true;
   }
 


### PR DESCRIPTION
## Description
### Support W8A8 quantization for Qwen3.5/Qwen3.6/Qwen3-Next dense/moe models.
1. linear.h: Exposes new accessors on QKVParallelLinearImpl: weight_scale(), weight_offset(), is_weight_scale_loaded(), and is_weight_offset_loaded(). These allow attention layers to access and reorder quantization parameters when attn_output_gate is enabled.
2. qwen3_gated_delta_net_base.cpp: Fixes conv1d weight loading by passing the correct prefix ("conv1d.") to StateDict, ensuring proper tensor sharding during model loading.
3. qwen3_next_attention.cpp  Two changes:
- Passes quant_args to the QKV projection constructor, enabling quantization for this layer.
- After the existing QKV weight reordering (which interleaves Q and gate rows), adds matching reordering logic for weight_scale and weight_offset, these per-channel quantization tensors must follow the same row layout as the weights for correct dequantization.

### Accuracy stats:
| model | quant type | dataset | accuracy before | accuracy after |
|-----|-----|-----|-----|-----|
| Qwen3.5-35B-A3B | w8a8 dynamic | ceval | 89.47 | 90.71 |
| Qwen3.5-27B | w8a8 dynamic | ceval | 92.59 | 91.75 |
| Qwen3-Next-80B-A3B-Instruct | w8a8 dynamic | ceval | 91.69 | 90.71|

### Performance stats:

### Qwen3.5-27B (Dense Model, MTP=3)
Config: input=2048 tokens, output=2048 tokens, tp=2

### Parallel=4 (number=16)

| Metric | BF16 | W8A8 | Change |
|---|---|---|---|
| **TPOT (avg)** | **16.77ms** | 17.04ms | +1.6% |
| **TPOT (p50)** | **17.14ms** | 17.46ms | +1.9% |
| **TTFT (avg)** | 673.59ms | **614.20ms** | **-8.8%** |
| Output Throughput | 224.56 tok/s | 223.22 tok/s | -0.6% |
| Total Throughput | 449.17 tok/s | 446.46 tok/s | -0.6% |
| Avg Latency | **34.99s** | 35.49s | +1.4% |
| Spec Accept Rate | 69% | 66% | ~ |
| Decoded Tok/Iter | 3.19 | 2.98 | ~ |

### Parallel=8 (number=32)

| Metric | BF16 | W8A8 | Change |
|---|---|---|---|
| **TPOT (avg)** | 21.45ms | **19.35ms** | **-9.8%** |
| **TPOT (p50)** | 22.11ms | **19.40ms** | **-12.3%** |
| **TTFT (avg)** | 942.98ms | **797.12ms** | **-15.5%** |
| Output Throughput | 344.64 tok/s | **392.60 tok/s** | **+13.9%** |
| Total Throughput | 689.34 tok/s | **785.29 tok/s** | **+13.9%** |
| Avg Latency | 44.86s | **40.41s** | **-9.9%** |
| Spec Accept Rate | 68% | 68% | ~ |
| Decoded Tok/Iter | 3.17 | 3.16 | ~ |

### Parallel=16 (number=64)

| Metric | BF16 | W8A8 | Change |
|---|---|---|---|
| **TPOT (avg)** | 29.12ms | **26.86ms** | **-7.8%** |
| **TPOT (p50)** | 29.96ms | **27.34ms** | **-8.7%** |
| **TTFT (avg)** | 1374.59ms | **1292.10ms** | **-6.0%** |
| Output Throughput | 500.30 tok/s | **536.52 tok/s** | **+7.2%** |
| Total Throughput | 1501.18 tok/s | **1609.76 tok/s** | **+7.2%** |
| Avg Latency | 31.16s | **28.77s** | **-7.7%** |
| Spec Accept Rate | 67% | 67% | ~ |
| Decoded Tok/Iter | 3.00 | 3.02 | ~ |

### Qwen3.5-35B-A3B (MoE Model, MTP=3)
Config: input=2048 tokens, output=2048 tokens, tp=2

### Parallel=4 (number=16)

| Metric | BF16 | W8A8 | Change |
|---|---|---|---|
| **TPOT (avg)** | 10.59ms | **10.17ms** | **-4.0%** |
| **TPOT (p50)** | 10.76ms | **10.48ms** | **-2.6%** |
| TTFT (avg) | 358.77ms | **350.29ms** | **-2.4%** |
| Output Throughput | 356.05 tok/s | 354.86 tok/s | -0.3% |
| Total Throughput | 712.57 tok/s | 709.75 tok/s | -0.4% |
| Avg Latency | 22.03s | **21.17s** | **-3.9%** |
| Spec Accept Rate | 68% | 68% | ~ |
| Decoded Tok/Iter | 3.13 | 3.15 | ~ |

### Parallel=8 (number=32)

| Metric | BF16 | W8A8 | Change |
|---|---|---|---|
| **TPOT (avg)** | 13.93ms | **12.58ms** | **-9.7%** |
| **TPOT (p50)** | 13.92ms | **12.53ms** | **-10.0%** |
| TTFT (avg) | 313.23ms | 364.77ms | +16.5% |
| Output Throughput | 536.05 tok/s | **571.50 tok/s** | **+6.6%** |
| Total Throughput | 1072.18 tok/s | **1143.08 tok/s** | **+6.6%** |
| Avg Latency | 28.83s | **26.12s** | **-9.4%** |
| Spec Accept Rate | 68% | 69% | ~ |
| Decoded Tok/Iter | 3.08 | 3.18 | ~ |

### Parallel=16 (number=64)

| Metric | BF16 | W8A8 | Change |
|---|---|---|---|
| **TPOT (avg)** | 17.78ms | **16.58ms** | **-6.7%** |
| **TPOT (p50)** | 17.88ms | **16.77ms** | **-6.2%** |
| TTFT (avg) | 449.72ms | 478.37ms | +6.4% |
| Output Throughput | 807.50 tok/s | **912.56 tok/s** | **+13.0%** |
| Total Throughput | 1615.14 tok/s | **1825.73 tok/s** | **+13.0%** |
| Avg Latency | 36.85s | **34.42s** | **-6.6%** |
| Spec Accept Rate | 68% | 68% | ~ |
| Decoded Tok/Iter | 3.16 | 3.13 | ~ |

### Conclusion: 
The longer the MatMul execution time, the greater the benefit from quantization. For small-scale models or low-concurrency scenarios, the gains from MatMul quantization cannot offset the overhead of the dequantization operator. However, for large-scale models or high-concurrency scenarios, especially when MTP is enabled and the decode phase becomes compute-bound, the benefits of quantization become significantly more pronounced. As shown in the experiments above, at higher concurrency levels, throughput can improve by over 10%.

References to w8a8 quantizatied models:
https://www.modelscope.cn/models/Eco-Tech/Qwen3.5-27B-w8a8-mtp
https://www.modelscope.cn/models/Eco-Tech/Qwen3.5-35B-A3B-w8a8-mtp
https://www.modelscope.cn/models/Eco-Tech/Qwen3.6-27B-w8a8
https://www.modelscope.cn/models/Eco-Tech/Qwen3.6-35B-A3B-w8a8
https://www.modelscope.cn/models/vllm-ascend/Qwen3-Next-80B-A3B-Instruct-W8A8


## Change Type

- [ ] Bug fix
- [x] New feature
- [ ] Performance improvement
- [ ] Refactor
- [ ] Documentation
- [ ] Test
- [ ] Build or CI

### PR Title and Commit Messages

- [x] The PR title and each commit message follow the xLLM commit format: `<type>: <subject>`.

### Build and Test Coverage

- [x] Tests have been added or updated as needed.
- [ ] CUDA: `python setup.py build test` has passed on a CUDA machine.
- [x] NPU: `python setup.py build test` has passed on an NPU machine.
- [ ] MLU: `python setup.py build test` has passed on an MLU machine.