### PR TITLE
refactor: complete BlockManager composition - composite owns all leaves (3/n).

### DIFF
--- a/tests/core/framework/block/composite_block_manager_test.cpp
+++ b/tests/core/framework/block/composite_block_manager_test.cpp
@@ -130,14 +130,14 @@ TEST(CompositeBlockManagerTest, AllocateForSequence_SingleSeq) {
   BlockManager::Options opts = MakeCompositeOptions(
       base_num_blocks, base_block_size, window_size, max_seqs_per_batch);
 
-  CompositeBlockManager manager(opts);
+  CompositeBlockManager manager(build_composite_leaves(opts));
   EXPECT_TRUE(manager.is_composite());
   EXPECT_EQ(manager.num_sub_managers(), 3u);
 
   Sequence seq = MakeTestSequence(0, std::vector<int32_t>(1024, 1));
   const size_t num_tokens = 1024;
 
-  EXPECT_TRUE(manager.allocate_for_sequence(&seq, num_tokens));
+  EXPECT_TRUE(manager.allocate_sequence(&seq, num_tokens));
 
   const std::vector<Block> swa = SwaBlocks(seq);
   const std::vector<Block> c4 = C4Blocks(seq);
@@ -166,7 +166,7 @@ TEST(CompositeBlockManagerTest, AllocateForSequence_SingleSeq) {
     EXPECT_EQ(b.size(), kBlockSizeRatio128);
   }
 
-  manager.deallocate_sequence(&seq);
+  manager.deallocate_for_sequence(&seq);
 }
 
 TEST(CompositeBlockManagerTest, AllocateForSequence_DifferentBatchSeqs) {
@@ -178,12 +178,12 @@ TEST(CompositeBlockManagerTest, AllocateForSequence_DifferentBatchSeqs) {
 
   BlockManager::Options opts = MakeCompositeOptions(
       base_num_blocks, kBaseBlockSize, window_size, max_seqs_per_batch);
-  CompositeBlockManager manager(opts);
+  CompositeBlockManager manager(build_composite_leaves(opts));
 
   // Seq1: 1024 tokens. Ratio 4: ceil(1024/512)=2; ratio 128:
   // ceil(1024/16384)=1.
   Sequence seq1 = MakeTestSequence(0, std::vector<int32_t>(1024, 1));
-  EXPECT_TRUE(manager.allocate_for_sequence(&seq1, 1024));
+  EXPECT_TRUE(manager.allocate_sequence(&seq1, 1024));
   const std::vector<Block> s1_swa = SwaBlocks(seq1);
   const std::vector<Block> s1_c4 = C4Blocks(seq1);
   const std::vector<Block> s1_c128 = C128Blocks(seq1);
@@ -195,7 +195,7 @@ TEST(CompositeBlockManagerTest, AllocateForSequence_DifferentBatchSeqs) {
   // ceil(1400/16384)=1. Keep total SWA logical blocks within the dynamic
   // pool budget derived from max_tokens_per_batch.
   Sequence seq2 = MakeTestSequence(1, std::vector<int32_t>(1400, 1));
-  EXPECT_TRUE(manager.allocate_for_sequence(&seq2, 1400));
+  EXPECT_TRUE(manager.allocate_sequence(&seq2, 1400));
   const std::vector<Block> s2_swa = SwaBlocks(seq2);
   const std::vector<Block> s2_c4 = C4Blocks(seq2);
   const std::vector<Block> s2_c128 = C128Blocks(seq2);
@@ -220,8 +220,8 @@ TEST(CompositeBlockManagerTest, AllocateForSequence_DifferentBatchSeqs) {
   for (int32_t id : ids1_0) EXPECT_LE(id, max_swa_block_id);
   for (int32_t id : ids2_0) EXPECT_LE(id, max_swa_block_id);
 
-  manager.deallocate_sequence(&seq1);
-  manager.deallocate_sequence(&seq2);
+  manager.deallocate_for_sequence(&seq1);
+  manager.deallocate_for_sequence(&seq2);
 }
 
 TEST(CompositeBlockManagerTest, AllocateForSequence_GrowSameSeq) {
@@ -231,52 +231,52 @@ TEST(CompositeBlockManagerTest, AllocateForSequence_GrowSameSeq) {
 
   BlockManager::Options opts = MakeCompositeOptions(
       base_num_blocks, kBaseBlockSize, window_size, max_seqs_per_batch);
-  CompositeBlockManager manager(opts);
+  CompositeBlockManager manager(build_composite_leaves(opts));
 
   Sequence seq = MakeTestSequence(0, {1, 2, 3});
   // 600 tokens: ratio 4 needs ceil(600/512)=2 blocks, ratio 128 needs 1 block.
-  EXPECT_TRUE(manager.allocate_for_sequence(&seq, 600));
+  EXPECT_TRUE(manager.allocate_sequence(&seq, 600));
   EXPECT_EQ(SwaBlocks(seq).size(), ExpectedSwaLogicalBlocks(600));
   EXPECT_EQ(C4Blocks(seq).size(), CeilBlocks(600, kBlockSizeRatio4));
   EXPECT_EQ(C128Blocks(seq).size(), CeilBlocks(600, kBlockSizeRatio128));
 
   // Grow to 1200 tokens: ratio 4 needs 3 blocks, ratio 128 still 1 block.
-  EXPECT_TRUE(manager.allocate_for_sequence(&seq, 1200));
+  EXPECT_TRUE(manager.allocate_sequence(&seq, 1200));
   EXPECT_EQ(SwaBlocks(seq).size(), ExpectedSwaLogicalBlocks(1200));
   EXPECT_EQ(C4Blocks(seq).size(), CeilBlocks(1200, kBlockSizeRatio4));
   EXPECT_EQ(C128Blocks(seq).size(), CeilBlocks(1200, kBlockSizeRatio128));
 
   // No growth: still 1200 tokens, block counts unchanged.
-  EXPECT_TRUE(manager.allocate_for_sequence(&seq, 1200));
+  EXPECT_TRUE(manager.allocate_sequence(&seq, 1200));
   EXPECT_EQ(C4Blocks(seq).size(), CeilBlocks(1200, kBlockSizeRatio4));
   EXPECT_EQ(C128Blocks(seq).size(), CeilBlocks(1200, kBlockSizeRatio128));
 
-  manager.deallocate_sequence(&seq);
+  manager.deallocate_for_sequence(&seq);
 }
 
 TEST(CompositeBlockManagerTest, AllocateContinuesAfterSatisfiedTokenManager) {
   BlockManager::Options opts =
       MakeCompositeOptions(4096, kBaseBlockSize, 128, 4);
   opts.compress_ratios({0, 128, 4});
-  CompositeBlockManager manager(opts);
+  CompositeBlockManager manager(build_composite_leaves(opts));
 
   Sequence seq = MakeTestSequence(0, {1});
-  EXPECT_TRUE(manager.allocate_for_sequence(&seq, 1024));
+  EXPECT_TRUE(manager.allocate_sequence(&seq, 1024));
   EXPECT_EQ(C128Blocks(seq).size(), CeilBlocks(1024, kBlockSizeRatio128));
   EXPECT_EQ(C4Blocks(seq).size(), CeilBlocks(1024, kBlockSizeRatio4));
 
-  EXPECT_TRUE(manager.allocate_for_sequence(&seq, 1500));
+  EXPECT_TRUE(manager.allocate_sequence(&seq, 1500));
   EXPECT_EQ(C128Blocks(seq).size(), CeilBlocks(1500, kBlockSizeRatio128));
   EXPECT_EQ(C4Blocks(seq).size(), CeilBlocks(1500, kBlockSizeRatio4));
 
-  manager.deallocate_sequence(&seq);
+  manager.deallocate_for_sequence(&seq);
 }
 
 TEST(CompositeBlockManagerTest, AllocateForSequence_NullSeqReturnsFalse) {
   BlockManager::Options opts =
       MakeCompositeOptions(4096, kBaseBlockSize, 128, 4);
-  CompositeBlockManager manager(opts);
-  EXPECT_FALSE(manager.allocate_for_sequence(nullptr, 10));
+  CompositeBlockManager manager(build_composite_leaves(opts));
+  EXPECT_FALSE(manager.allocate_sequence(nullptr, 10));
 }
 
 TEST(CompositeBlockManagerTest, FailedGrowthRollsBackNewBlocks) {
@@ -284,10 +284,10 @@ TEST(CompositeBlockManagerTest, FailedGrowthRollsBackNewBlocks) {
                                                     kBaseBlockSize,
                                                     /*window_size=*/12,
                                                     /*max_seqs_per_batch=*/4);
-  CompositeBlockManager manager(opts);
+  CompositeBlockManager manager(build_composite_leaves(opts));
 
   Sequence seq = MakeTestSequence(0, {1});
-  ASSERT_TRUE(manager.allocate_for_sequence(&seq, 1024));
+  ASSERT_TRUE(manager.allocate_sequence(&seq, 1024));
   const size_t used_before = manager.num_used_blocks();
   const std::vector<Block> before_swa = SwaBlocks(seq);
   const size_t swa_blocks_before = before_swa.size();
@@ -301,7 +301,7 @@ TEST(CompositeBlockManagerTest, FailedGrowthRollsBackNewBlocks) {
   }
   seq.kv_state().incr_kv_cache_tokens_num(1024);
 
-  EXPECT_FALSE(manager.allocate_for_sequence(&seq, 4096));
+  EXPECT_FALSE(manager.allocate_sequence(&seq, 4096));
   EXPECT_EQ(manager.num_used_blocks(), used_before);
 
   const std::vector<Block> after_swa = SwaBlocks(seq);
@@ -314,7 +314,7 @@ TEST(CompositeBlockManagerTest, FailedGrowthRollsBackNewBlocks) {
     EXPECT_EQ(after_swa[i].id(), swa_ids_before[i]);
   }
 
-  manager.deallocate_sequence(&seq);
+  manager.deallocate_for_sequence(&seq);
 }
 
 TEST(CompositeBlockManagerTest, DeallocateToleratesRolledBackEmptySequence) {
@@ -322,12 +322,12 @@ TEST(CompositeBlockManagerTest, DeallocateToleratesRolledBackEmptySequence) {
                                                     kBaseBlockSize,
                                                     /*window_size=*/12,
                                                     /*max_seqs_per_batch=*/4);
-  CompositeBlockManager manager(opts);
+  CompositeBlockManager manager(build_composite_leaves(opts));
 
   Sequence seq = MakeTestSequence(0, {1});
 
-  EXPECT_FALSE(manager.allocate_for_sequence(&seq, 4096));
-  EXPECT_NO_FATAL_FAILURE(manager.deallocate_sequence(&seq));
+  EXPECT_FALSE(manager.allocate_sequence(&seq, 4096));
+  EXPECT_NO_FATAL_FAILURE(manager.deallocate_for_sequence(&seq));
   EXPECT_FALSE(seq.kv_state().has_multi_block_export());
   EXPECT_EQ(manager.num_used_blocks(), 0u);
 }
@@ -341,7 +341,7 @@ TEST(CompositeBlockManagerTest, TokenIncrease_AddsBlocksIncrementally) {
 
   BlockManager::Options opts = MakeCompositeOptions(
       base_num_blocks, kBaseBlockSize, window_size, max_seqs_per_batch);
-  CompositeBlockManager manager(opts);
+  CompositeBlockManager manager(build_composite_leaves(opts));
 
   Sequence seq = MakeTestSequence(0, {1});
   std::vector<size_t> token_steps = {100, 600, 1200, 2000, 2400};
@@ -350,7 +350,7 @@ TEST(CompositeBlockManagerTest, TokenIncrease_AddsBlocksIncrementally) {
   std::vector<std::set<int32_t>> prev_ids_2;
 
   for (size_t num_tokens : token_steps) {
-    EXPECT_TRUE(manager.allocate_for_sequence(&seq, num_tokens));
+    EXPECT_TRUE(manager.allocate_sequence(&seq, num_tokens));
 
     const std::vector<Block> c4 = C4Blocks(seq);
     const std::vector<Block> c128 = C128Blocks(seq);
@@ -377,7 +377,7 @@ TEST(CompositeBlockManagerTest, TokenIncrease_AddsBlocksIncrementally) {
     prev_ids_2.push_back(ids_2);
   }
 
-  manager.deallocate_sequence(&seq);
+  manager.deallocate_for_sequence(&seq);
 }
 
 TEST(CompositeBlockManagerTest, SlidingWindowReleasesSkippedPhysicalBlocks) {
@@ -389,13 +389,13 @@ TEST(CompositeBlockManagerTest, SlidingWindowReleasesSkippedPhysicalBlocks) {
 
   BlockManager::Options opts = MakeCompositeOptions(
       base_num_blocks, kBaseBlockSize, window_size, max_seqs_per_batch);
-  CompositeBlockManager manager(opts);
+  CompositeBlockManager manager(build_composite_leaves(opts));
 
   Sequence seq = MakeTestSequence(0, {1});
   const size_t window_tokens =
       static_cast<size_t>(sliding_window_blocks_per_sequence) * kBaseBlockSize;
 
-  EXPECT_TRUE(manager.allocate_for_sequence(&seq, window_tokens));
+  EXPECT_TRUE(manager.allocate_sequence(&seq, window_tokens));
   const std::vector<Block> initial = SwaBlocks(seq);
   ASSERT_EQ(initial.size(), sliding_window_blocks_per_sequence);
   seq.kv_state().incr_kv_cache_tokens_num(window_tokens);
@@ -407,7 +407,7 @@ TEST(CompositeBlockManagerTest, SlidingWindowReleasesSkippedPhysicalBlocks) {
   }
 
   EXPECT_TRUE(
-      manager.allocate_for_sequence(&seq, window_tokens + 2 * kBaseBlockSize));
+      manager.allocate_sequence(&seq, window_tokens + 2 * kBaseBlockSize));
   const std::vector<Block> boundary = SwaBlocks(seq);
   ASSERT_EQ(boundary.size(), sliding_window_blocks_per_sequence + 2);
   for (size_t i = 0; i < initial_ids.size(); ++i) {
@@ -416,7 +416,7 @@ TEST(CompositeBlockManagerTest, SlidingWindowReleasesSkippedPhysicalBlocks) {
   seq.kv_state().incr_kv_cache_tokens_num(2 * kBaseBlockSize);
 
   EXPECT_TRUE(
-      manager.allocate_for_sequence(&seq, window_tokens + 3 * kBaseBlockSize));
+      manager.allocate_sequence(&seq, window_tokens + 3 * kBaseBlockSize));
   const std::vector<Block> exceeded = SwaBlocks(seq);
   ASSERT_EQ(exceeded.size(), sliding_window_blocks_per_sequence + 3);
   EXPECT_FALSE(exceeded[0].is_valid());
@@ -430,17 +430,17 @@ TEST(CompositeBlockManagerTest, SlidingWindowReleasesSkippedPhysicalBlocks) {
     EXPECT_TRUE(exceeded[i].is_valid());
   }
 
-  manager.deallocate_sequence(&seq);
+  manager.deallocate_for_sequence(&seq);
 }
 
 TEST(CompositeBlockManagerTest, DeallocateSliceDispatchesToOwnerManagers) {
   BlockManager::Options opts =
       MakeCompositeOptions(4096, kBaseBlockSize, 128, 4);
   opts.enable_prefix_cache(false);
-  CompositeBlockManager manager(opts);
+  CompositeBlockManager manager(build_composite_leaves(opts));
 
   Sequence seq = MakeTestSequence(0, {1});
-  EXPECT_TRUE(manager.allocate_for_sequence(&seq, 1500));
+  EXPECT_TRUE(manager.allocate_sequence(&seq, 1500));
   EXPECT_GT(manager.num_used_blocks(), 0u);
 
   std::vector<Block> flat_blocks;
@@ -461,10 +461,10 @@ TEST(CompositeBlockManagerTest,
      DeallocateSliceDispatchesWithoutInflatingRefCount) {
   BlockManager::Options opts =
       MakeCompositeOptions(4096, kBaseBlockSize, 128, 4);
-  CompositeBlockManager manager(opts);
+  CompositeBlockManager manager(build_composite_leaves(opts));
 
   Sequence seq = MakeTestSequence(0, {1});
-  EXPECT_TRUE(manager.allocate_for_sequence(&seq, 1500));
+  EXPECT_TRUE(manager.allocate_sequence(&seq, 1500));
   EXPECT_GT(manager.num_used_blocks(), 0u);
 
   std::vector<const Block*> flat_blocks;
@@ -492,6 +492,40 @@ TEST(CompositeBlockManagerTest,
   }
 
   seq.reset();
+}
+
+// Finding 3 regression: composite capacity stats must report a single admission
+// leaf's raw block count (the smallest-block-size one = C4 here), NOT a min/sum
+// mix across C4+C128. C128's raw count (32) must never define pool capacity,
+// otherwise schedulers (which read num_free * block_size() as base tokens)
+// badly under-estimate capacity.
+TEST(CompositeBlockManagerTest, CapacityStatsUseFinestAdmissionLeaf) {
+  // base_num_blocks=4096 -> C4: 4096/4=1024 blocks (bs=512);
+  //                         C128: 4096/128=32 blocks (bs=16384).
+  BlockManager::Options opts =
+      MakeCompositeOptions(4096, kBaseBlockSize, 128, 4);
+  CompositeBlockManager manager(build_composite_leaves(opts));
+
+  // num_total_blocks must equal the C4 leaf's total (1024 - padding), i.e. far
+  // larger than C128's 32. Assert it is well above the C128 count so a min/sum
+  // regression (which would yield ~32 or 1024+32) is caught.
+  const size_t total = manager.num_total_blocks();
+  EXPECT_GT(total, 900u);   // C4 ~1023, not C128's ~31
+  EXPECT_LT(total, 1100u);  // not C4+C128 sum territory either
+
+  // Free (no sequence yet) equals total; used is 0.
+  EXPECT_EQ(manager.num_free_blocks(), total);
+  EXPECT_EQ(manager.num_used_blocks(), 0u);
+
+  // After allocating one sequence, used reflects ONLY the C4 leaf (capacity
+  // leaf), not a C4+C128 sum.
+  Sequence seq = MakeTestSequence(0, std::vector<int32_t>(1024, 1));
+  ASSERT_TRUE(manager.allocate_sequence(&seq, 1024));
+  const size_t c4_used = C4Blocks(seq).size();  // capacity leaf's used count
+  EXPECT_EQ(manager.num_used_blocks(), c4_used);
+  EXPECT_EQ(manager.num_free_blocks(), total - c4_used);
+
+  manager.deallocate_for_sequence(&seq);
 }
 
 }  // namespace xllm

--- a/tests/core/framework/block/concurrent_block_manager_test.cpp
+++ b/tests/core/framework/block/concurrent_block_manager_test.cpp
@@ -17,9 +17,11 @@ limitations under the License.
 
 #include <atomic>
 #include <cstdint>
+#include <memory>
 #include <thread>
 #include <vector>
 
+#include "block_manager_impl.h"
 #include "concurrent_block_manager_impl.h"
 #include "framework/prefix_cache/prefix_cache.h"
 
@@ -39,7 +41,8 @@ TEST(ConcurrentBlockManagerTest, ContinuesPrefixCacheFromExistingBlocks) {
   const uint32_t block_size = 2;
   BlockManager::Options options;
   options.num_blocks(5).block_size(block_size).enable_prefix_cache(true);
-  ConcurrentBlockManagerImpl manager(options);
+  ConcurrentBlockManagerImpl manager(
+      std::make_unique<BlockManagerImpl>(options));
 
   std::vector<int32_t> token_ids = {11, 12, 13, 14};
   std::vector<Block> seed_blocks = manager.allocate(/*num_blocks=*/2);
@@ -85,7 +88,8 @@ TEST(ConcurrentBlockManagerTest, ContinuesPrefixCacheFromExistingBlocks) {
 TEST(ConcurrentBlockManagerTest, AllocatesWhileBlocksReleaseConcurrently) {
   BlockManager::Options options;
   options.num_blocks(65).block_size(2).enable_prefix_cache(false);
-  ConcurrentBlockManagerImpl manager(options);
+  ConcurrentBlockManagerImpl manager(
+      std::make_unique<BlockManagerImpl>(options));
 
   constexpr int32_t kNumThreads = 8;
   constexpr int32_t kNumIterations = 10000;

--- a/tests/core/framework/block/single_block_manager_test.cpp
+++ b/tests/core/framework/block/single_block_manager_test.cpp
@@ -66,28 +66,30 @@ TEST(SingleBlockManagerTest, AllocateSingleDiesWhenExhausted) {
   EXPECT_DEATH(manager.allocate(), "No more single blocks available");
 }
 
-TEST(SingleBlockManagerTest, PrefixCacheStyleApisAreSafeNoopsWhenDisabled) {
+TEST(SingleBlockManagerTest, PrefixCacheApisAreNotImplemented) {
   SingleBlockManager manager(2, "single");
 
   const int32_t token_ids_arr[] = {1, 2, 3};
   const Slice<int32_t> token_ids(token_ids_arr, 3);
 
-  // allocate_shared should be safely substitutable with BlockManager behavior
-  // when prefix cache is disabled.
-  const auto shared = manager.allocate_shared(token_ids);
-  EXPECT_TRUE(shared.empty());
+  // SINGLE never serves the prefix cache. These APIs are explicitly
+  // NOT_IMPLEMENTED so a stray caller fails loudly instead of silently
+  // mis-routing (the composite only calls them on prefix-capable leaves).
+  EXPECT_DEATH(manager.allocate_shared(token_ids), "not implemented");
 
   std::vector<Block> blocks = manager.allocate(1);
   ASSERT_EQ(blocks.size(), 1u);
-
-  // cache() overloads should be safe no-ops.
-  EXPECT_NO_FATAL_FAILURE(manager.cache(token_ids, blocks));
-  EXPECT_NO_FATAL_FAILURE(manager.cache(blocks));
+  EXPECT_DEATH(manager.cache(token_ids, blocks), "not implemented");
+  EXPECT_DEATH(manager.cache(blocks), "not implemented");
 }
 
-TEST(SingleBlockManagerTest, UsedBlocksAccountingDoesNotLeakWithAliases) {
-  // id 0 is reserved internally, so 2 physical slots expose a single usable
-  // block.
+TEST(SingleBlockManagerTest, UsedBlocksAccountingRoundTrips) {
+  // SingleBlockManager now reuses BlockManagerImpl's free list. With prefix
+  // cache disabled there is no aliasing scenario (single blocks live only in
+  // the owning sequence, never in a prefix cache), so deallocate drops
+  // effective usage immediately and the physical id returns when the Block is
+  // destroyed. id 0 is reserved internally, so 2 physical slots expose a single
+  // usable block.
   SingleBlockManager manager(2, "single");
   EXPECT_EQ(manager.num_used_blocks(), 0u);
   EXPECT_EQ(manager.num_free_blocks(), 1u);
@@ -97,23 +99,16 @@ TEST(SingleBlockManagerTest, UsedBlocksAccountingDoesNotLeakWithAliases) {
     EXPECT_EQ(manager.num_used_blocks(), 1u);
     EXPECT_EQ(manager.num_free_blocks(), 0u);
 
-    // Create an alias to simulate an external holder (e.g. prefix-cache style
-    // reference) that outlives the "sequence-owned" reference.
-    Block alias = block;
-    EXPECT_EQ(block.ref_count(), 2u);
-
-    // Deallocate the sequence-owned reference while an alias still exists.
+    // Deallocate the owning reference: effective usage drops immediately.
     manager.deallocate(Slice<Block>(&block, 1));
-    EXPECT_EQ(manager.num_used_blocks(), 1u);
+    EXPECT_EQ(manager.num_used_blocks(), 0u);
 
-    // Drop the sequence-owned reference without calling deallocate again.
+    // Physical id returns to the free list when the Block is destroyed.
     block = Block();
-    EXPECT_EQ(alias.ref_count(), 1u);
-    EXPECT_EQ(manager.num_used_blocks(), 1u);
-    EXPECT_EQ(manager.num_free_blocks(), 0u);
+    EXPECT_EQ(manager.num_used_blocks(), 0u);
+    EXPECT_EQ(manager.num_free_blocks(), 1u);
   }
 
-  // When the last alias is released, used block accounting should converge.
   EXPECT_EQ(manager.num_used_blocks(), 0u);
   EXPECT_EQ(manager.num_free_blocks(), 1u);
 }

--- a/tests/core/framework/request/sequence_kv_state_test.cpp
+++ b/tests/core/framework/request/sequence_kv_state_test.cpp
@@ -36,4 +36,45 @@ TEST(KVCacheStateTest, TransferCursorTracksAndResets) {
   EXPECT_EQ(state.next_transfer_block_idx(), 0u);
 }
 
+// Finding 2 regression: has_any_blocks() must report true for ANY
+// cache-bearing type (KV / SWA / C4 / C128) and IGNORE SINGLE. The pool's
+// "started_empty" rollback decision relies on this so that a DSV4 sequence
+// (which holds SWA/C4/C128 but no KV) is not treated as fresh on a failed grow.
+TEST(KVCacheStateTest, HasAnyBlocksIgnoresSingle) {
+  auto make_block = [](int32_t id) {
+    return std::vector<Block>{Block(id, /*manager=*/nullptr)};
+  };
+
+  // Empty state.
+  {
+    KVCacheState state;
+    EXPECT_FALSE(state.has_any_blocks());
+  }
+
+  // SINGLE-only must NOT count as cache.
+  {
+    KVCacheState state;
+    state.add_blocks(BlockType::SINGLE, make_block(1));
+    EXPECT_FALSE(state.has_any_blocks());
+  }
+
+  // Each cache-bearing type alone counts.
+  for (const BlockType type :
+       {BlockType::KV, BlockType::SWA, BlockType::C4, BlockType::C128}) {
+    KVCacheState state;
+    state.add_blocks(type, make_block(2));
+    EXPECT_TRUE(state.has_any_blocks()) << "type=" << static_cast<int>(type);
+  }
+
+  // DSV4-like: SWA/C4/C128 present, no KV -> still true.
+  {
+    KVCacheState state;
+    state.add_blocks(BlockType::SWA, make_block(3));
+    state.add_blocks(BlockType::C4, make_block(4));
+    state.add_blocks(BlockType::C128, make_block(5));
+    state.add_blocks(BlockType::SINGLE, make_block(6));
+    EXPECT_TRUE(state.has_any_blocks());
+  }
+}
+
 }  // namespace xllm

--- a/xllm/core/framework/block/block.h
+++ b/xllm/core/framework/block/block.h
@@ -85,6 +85,12 @@ class Block final {
   // owner manager that allocated this block.
   BlockManager* manager() const { return manager_; }
 
+  // Reassign this block's owning manager. Used by concurrency wrappers (e.g.
+  // ConcurrentBlockManagerImpl) to route Block dtor -> free() through the
+  // wrapper layer so the wrapper's lock covers the free path too. Must not be
+  // used to transfer ownership across pools.
+  void set_manager(BlockManager* manager) { manager_ = manager; }
+
   // NOTE: Below block `hash_value_` is used for prefix cache and
   // for recording the hash value of the current block and previous blocks.
   // hash_value_ = Hash(current_block, Hash(pre_block)).

--- a/xllm/core/framework/block/block_manager.cpp
+++ b/xllm/core/framework/block/block_manager.cpp
@@ -1,0 +1,19 @@
+/* Copyright 2025-2026 The xLLM Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://github.com/jd-opensource/xllm/blob/main/LICENSE
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+// Intentionally empty. BlockManager is now a pure interface; its former
+// default allocate_for_sequence (flat-KV growth) moved to BlockManagerImpl.
+// This file is no longer part of the build (removed from CMakeLists SRCS) and
+// can be deleted once tooling permits.

--- a/xllm/core/framework/block/block_manager.h
+++ b/xllm/core/framework/block/block_manager.h
@@ -23,6 +23,7 @@ limitations under the License.
 #include <cstdint>
 #include <memory>
 #include <mutex>
+#include <optional>
 #include <string>
 #include <vector>
 
@@ -58,6 +59,21 @@ class BlockManager {
     PROPERTY(uint32_t, max_seqs_per_batch) = 0;
     // Hasher type bound to the engine (TEXT for LLM, MM for VLM).
     PROPERTY(BlockHasherType, hasher_type) = BlockHasherType::TEXT;
+    // The block category used as the composite's map key for this leaf. The
+    // leaf itself is type-free (no block_type() accessor); the spec builder
+    // carries this value to decide the map key. Flat KV uses KV.
+    PROPERTY(BlockType, block_type) = BlockType::KV;
+    // Whether the kvcache-store (host offload) path is enabled. Composite
+    // leaves are wrapped in ConcurrentBlockManagerImpl when this (or
+    // enable_disagg_pd) is set.
+    PROPERTY(bool, enable_kvcache_store) = false;
+    // xtensor (VMM) KV leaf parameters. When enable_xtensor is set, the KV leaf
+    // is an XTensorBlockManagerImpl instead of a flat BlockManagerImpl; these
+    // carry the construction args the spec builder needs.
+    PROPERTY(bool, enable_xtensor) = false;
+    PROPERTY(int64_t, num_layers) = 0;
+    PROPERTY(int64_t, slot_size) = 0;
+    PROPERTY(std::string, model_id);
   };
 
   explicit BlockManager(Options options) : options_(options) {}
@@ -96,6 +112,12 @@ class BlockManager {
   // get number of slots per block
   size_t block_size() const { return options_.block_size(); }
 
+  // The block category this leaf serves (KV / SWA / C4 / C128 / SINGLE). A leaf
+  // reads its own held-block count from the sequence under this type, and the
+  // CompositeBlockManager inserts the returned blocks into the sequence under
+  // this type. Carried via Options by the spec builder.
+  BlockType block_type() const { return options_.block_type(); }
+
   // call BlockManager to free block used by Block.
   virtual void free(int32_t block_id) = 0;
 
@@ -108,12 +130,34 @@ class BlockManager {
   // get number of total blocks
   virtual size_t num_total_blocks() const = 0;
 
-  // CompositeBlockManager: Pool calls these when is_composite() is true.
+  // True only for CompositeBlockManager. Leaves and flat managers return false.
   virtual bool is_composite() const { return false; }
-  virtual bool allocate_for_sequence(Sequence* seq, size_t num_tokens) {
-    return false;
-  }
-  virtual void deallocate_sequence(Sequence* seq) {}
+
+  // —— Sequence-level growth interface (pure: every concrete manager defines
+  // its own policy) ——
+  // Grows this manager's block_type() blocks for a sequence and returns the
+  // blocks it newly allocated this round (empty when nothing is needed),
+  // std::nullopt on shortage. The flat-KV default lives in BlockManagerImpl;
+  // SlidingWindow / Single override; CompositeBlockManager fans out to leaves.
+  // Most managers do NOT insert into the sequence -- the composite stages the
+  // returned blocks and commits them under block_type() (the SWA leaf also
+  // releases its own slid-out blocks in place as part of this call).
+  virtual std::optional<std::vector<Block>> allocate_for_sequence(
+      Sequence* seq,
+      size_t num_tokens) = 0;
+
+  // Sliding-window hook: release leading blocks that have slid out of the
+  // window. The composite calls this on every leaf AFTER a successful
+  // allocate_sequence commit; non-SWA leaves keep the empty default (no-op).
+  // Running post-commit means a failed round never releases existing blocks.
+  virtual void release_out_of_window(Sequence* /*seq*/) {}
+
+  // Post-construction init hook: only the xtensor leaf needs it (KV tensors
+  // must be created on the worker before VMM physical pages can be mapped to
+  // reserve the padding block). Empty base default; the composite fans it out
+  // to every leaf, so non-xtensor leaves are a no-op. This keeps the
+  // out-of-band timing free of any dynamic_cast through the composite.
+  virtual void reserve_xtensor_padding_blocks() {}
 
  protected:
   // the options for the block manager

--- a/xllm/core/framework/block/block_manager_impl.cpp
+++ b/xllm/core/framework/block/block_manager_impl.cpp
@@ -227,4 +227,31 @@ void BlockManagerImpl::free(int32_t block_id) {
   }
 }
 
+// Flat incremental growth (the default sequence-level policy). Reads how many
+// blocks the sequence already holds for this manager's block_type(), allocates
+// the delta to cover num_tokens, and returns it (does not insert into the
+// sequence -- the CompositeBlockManager commits the returned blocks). Returns
+// std::nullopt on post-eviction shortage. SlidingWindow / Single override.
+std::optional<std::vector<Block>> BlockManagerImpl::allocate_for_sequence(
+    Sequence* seq,
+    size_t num_tokens) {
+  if (seq == nullptr) {
+    return std::nullopt;
+  }
+  if (block_size_ == 0) {
+    return std::vector<Block>{};
+  }
+  const size_t held = seq->kv_state().num_blocks(block_type());
+  const size_t num_blocks_needed = (num_tokens + block_size_ - 1) / block_size_;
+  if (num_blocks_needed <= held) {
+    return std::vector<Block>{};
+  }
+  const size_t num_additional = num_blocks_needed - held;
+  std::vector<Block> blocks = allocate(num_additional);
+  if (blocks.size() != num_additional) {
+    return std::nullopt;
+  }
+  return blocks;
+}
+
 }  // namespace xllm

--- a/xllm/core/framework/block/block_manager_impl.h
+++ b/xllm/core/framework/block/block_manager_impl.h
@@ -34,6 +34,13 @@ class BlockManagerImpl : public BlockManager {
 
   void deallocate(const Slice<Block>& blocks) override;
 
+  // Flat incremental growth: allocate ceil(num_tokens/block_size) - held blocks
+  // and return them (does not insert into the sequence). The shared default for
+  // flat-KV / compressed / xtensor leaves; SlidingWindow and Single override.
+  std::optional<std::vector<Block>> allocate_for_sequence(
+      Sequence* seq,
+      size_t num_tokens) override;
+
   // allocate shared blocks when enable prefix cache
   std::vector<Block> allocate_shared(
       const Slice<int32_t>& token_ids,

--- a/xllm/core/framework/block/block_manager_pool.cpp
+++ b/xllm/core/framework/block/block_manager_pool.cpp
@@ -34,20 +34,24 @@ BlockManagerPool::BlockManagerPool(const Options& options, int32_t dp_size)
     : options_(options) {
   CHECK(dp_size > 0) << "dp_size must be greater than 0";
   block_managers_.reserve(dp_size);
-  single_block_managers_.reserve(dp_size);
 
   BlockManager::Options block_options;
   block_options.num_blocks(options_.num_blocks())
       .block_size(options_.block_size())
       .enable_prefix_cache(options_.enable_prefix_cache())
       .enable_disagg_pd(options_.enable_disagg_pd())
+      .enable_kvcache_store(options_.enable_kvcache_store())
       .sliding_window_size(options_.sliding_window_size())
       .swa_blocks_per_seq(options_.swa_blocks_per_seq())
       .max_tokens_per_batch(options_.max_tokens_per_batch())
       .manager_types(options_.manager_types())
       .compress_ratios(options_.compress_ratios())
       .max_seqs_per_batch(options_.max_seqs_per_batch())
-      .hasher_type(options_.hasher_type());
+      .hasher_type(options_.hasher_type())
+      .enable_xtensor(options_.enable_xtensor())
+      .num_layers(options_.num_layers())
+      .slot_size(options_.slot_size())
+      .model_id(options_.model_id());
 
   const uint32_t max_single_block_sequences =
       options_.max_concurrent_requests() > 0
@@ -60,42 +64,31 @@ BlockManagerPool::BlockManagerPool(const Options& options, int32_t dp_size)
   CHECK_GT(num_single_blocks, 0u) << "num_single_blocks must be positive";
 
   for (int32_t i = 0; i < dp_size; ++i) {
-    if (options_.enable_xtensor()) {
-      // Use XTensorBlockManagerImpl for xtensor mode.
-      CHECK_GT(options_.num_layers(), 0)
-          << "num_layers must be set when enable_xtensor is true";
-      CHECK_GT(options_.slot_size(), 0)
-          << "slot_size must be set when enable_xtensor is true";
-      size_t page_size =
-          ::xllm::KVCacheConfig::get_instance().phy_page_granularity_size();
-      // In the current implementation, K and V must be the same size, so we
-      // divide by 2.
-      size_t block_mem_size =
-          static_cast<size_t>(options_.block_size()) * options_.slot_size() / 2;
-      block_managers_.emplace_back(
-          std::make_unique<XTensorBlockManagerImpl>(block_options,
-                                                    options_.num_layers(),
-                                                    block_mem_size,
-                                                    page_size,
-                                                    /*dp_rank=*/i,
-                                                    options_.model_id()));
-    } else if (!options_.manager_types().empty()) {
-      block_managers_.emplace_back(
-          std::make_unique<CompositeBlockManager>(block_options));
-    } else if (options_.enable_disagg_pd() || options_.enable_kvcache_store()) {
-      block_managers_.emplace_back(
-          std::make_unique<ConcurrentBlockManagerImpl>(block_options));
-    } else {
-      block_managers_.emplace_back(
-          std::make_unique<BlockManagerImpl>(block_options));
+    // The pool always holds a CompositeBlockManager. Its KV leaf is a flat
+    // BlockManagerImpl, or an XTensorBlockManagerImpl when enable_xtensor (the
+    // builder picks); SWA / C4 / C128 come from manager_types; the per-sequence
+    // SINGLE resource leaf is appended here under the SINGLE key. Every leaf is
+    // routed by its BlockType, so xtensor and Single are ordinary leaves.
+    auto leaves = build_composite_leaves(block_options, /*dp_rank=*/i);
+    // SINGLE leaf needs the same concurrency wrapper as the other leaves when
+    // sequence-level entry points run off the scheduler thread (disagg PD /
+    // kvcache store prefill threadpools call try_allocate concurrently).
+    std::unique_ptr<BlockManager> single_leaf =
+        std::make_unique<SingleBlockManager>(
+            /*num_blocks=*/num_single_blocks,
+            /*resource_name=*/"single block",
+            /*exhaustion_message=*/"No more single-block ids available");
+    if (options_.enable_disagg_pd() || options_.enable_kvcache_store()) {
+      single_leaf =
+          std::make_unique<ConcurrentBlockManagerImpl>(std::move(single_leaf));
     }
-    // Scheduler-side per-sequence resources share one logical single-block
-    // pool. Worker-side embedding and linear-state caches remain physically
-    // separate and are addressed via transport fields.
-    single_block_managers_.emplace_back(std::make_unique<SingleBlockManager>(
-        /*num_blocks=*/num_single_blocks,
-        /*resource_name=*/"single block",
-        /*exhaustion_message=*/"No more single-block ids available"));
+    leaves.emplace(
+        BlockType::SINGLE,
+        CompositeBlockManager::LeafEntry{std::move(single_leaf),
+                                         /*participates_in_admission=*/false,
+                                         /*supports_prefix_cache=*/false});
+    block_managers_.emplace_back(
+        std::make_unique<CompositeBlockManager>(std::move(leaves)));
   }
   swap_block_transfer_infos_.clear();
   swap_block_transfer_infos_.resize(block_managers_.size());
@@ -130,43 +123,6 @@ int32_t BlockManagerPool::get_dp_rank(Sequence* sequence) const {
   return dp_rank;
 }
 
-bool BlockManagerPool::allocate_single_block(Sequence* sequence,
-                                             int32_t dp_rank) {
-  CHECK(sequence != nullptr);
-  CHECK_GE(dp_rank, 0);
-  CHECK_LT(static_cast<size_t>(dp_rank), single_block_managers_.size());
-  if (sequence->get_single_block_id() >= 0) {
-    return true;
-  }
-
-  auto single_blocks = single_block_managers_[dp_rank]->allocate(1);
-  if (single_blocks.empty()) {
-    const auto* manager = single_block_managers_[dp_rank].get();
-    LOG(ERROR) << "Failed to allocate single block! dp_rank=" << dp_rank
-               << ", free=" << manager->num_free_blocks()
-               << ", used=" << manager->num_used_blocks()
-               << ", total=" << manager->num_total_blocks()
-               << ", max_seqs_per_batch=" << options_.max_seqs_per_batch()
-               << ", configured_single_blocks=" << options_.num_single_blocks();
-    return false;
-  }
-  sequence->add_blocks(BlockType::SINGLE, single_blocks);
-  return true;
-}
-
-void BlockManagerPool::deallocate_single_block(Sequence* sequence,
-                                               int32_t dp_rank) {
-  DCHECK(sequence != nullptr);
-  CHECK_GE(dp_rank, 0);
-  CHECK_LT(static_cast<size_t>(dp_rank), single_block_managers_.size());
-  const Slice<Block> single = sequence->kv_state().blocks(BlockType::SINGLE);
-  if (single.empty()) {
-    return;
-  }
-  single_block_managers_[dp_rank]->deallocate(single);
-  sequence->kv_state().erase_blocks(BlockType::SINGLE);
-}
-
 void BlockManagerPool::deallocate(Request* request) {
   DCHECK(request != nullptr);
   for (auto& sequence : request->sequences()) {
@@ -183,21 +139,11 @@ void BlockManagerPool::deallocate(std::vector<Sequence*>& sequences) {
 void BlockManagerPool::deallocate(Sequence* sequence) {
   DCHECK(sequence != nullptr);
   int32_t dp_rank = get_dp_rank(sequence);
-
-  if (block_managers_[dp_rank]->is_composite()) {
-    // TODO: not supporte prefix cache for composite manager yet.
-    block_managers_[dp_rank]->deallocate_sequence(sequence);
-    deallocate_single_block(sequence, dp_rank);
-    sequence->reset();
-    return;
-  }
-
-  // add blocks to the prefix cache
-  cache(sequence);
-  block_managers_[dp_rank]->deallocate(
-      sequence->kv_state().blocks(BlockType::KV));
-  deallocate_single_block(sequence, dp_rank);
-  // release the blocks after prefix cache insertion
+  // The composite fans deallocate (with final cache) out across all leaves,
+  // including the SINGLE resource leaf and the (flat or xtensor) KV leaf.
+  auto* composite =
+      static_cast<CompositeBlockManager*>(block_managers_[dp_rank].get());
+  composite->deallocate_for_sequence(sequence);
   sequence->reset();
 }
 
@@ -226,59 +172,38 @@ bool BlockManagerPool::allocate(Sequence* sequence, size_t num_tokens) {
   AUTO_COUNTER(allocate_blocks_latency_seconds);
   DCHECK(sequence != nullptr);
   int32_t dp_rank = get_dp_rank(sequence);
-  const bool started_empty =
-      sequence->kv_state().num_blocks(BlockType::KV) == 0;
-  const bool needs_single_block = sequence->get_single_block_id() < 0;
-  if (needs_single_block && !allocate_single_block(sequence, dp_rank)) {
+  // "Started empty" = the sequence holds no cache-bearing blocks of ANY type
+  // (KV / SWA / C4 / C128), not just KV. DSV4 sequences never hold KV, so a
+  // KV-only check would treat every DSV4 grow as a fresh allocation and, on
+  // failure, wrongly deallocate + reset the already-held SWA/C4/C128 blocks.
+  const bool started_empty = !sequence->kv_state().has_any_blocks();
+
+  // The leaves (KV / SWA / C4 / C128 / Single) each apply their own strategy;
+  // the pool only orchestrates prefix-share-then-beam-then-grow, which beam (KV
+  // copy-on-write) must sit between.
+  auto* composite =
+      static_cast<CompositeBlockManager*>(block_managers_[dp_rank].get());
+  if (started_empty) {
+    composite->allocate_shared_for_sequence(sequence);
+  }
+  // Beam swap decision uses the KV block count after the shared attach.
+  const size_t kv_blocks = sequence->kv_state().num_blocks(BlockType::KV);
+  const size_t block_size = options_.block_size();
+  const size_t kv_blocks_needed = (num_tokens + block_size - 1) / block_size;
+  const bool kv_already_satisfied = kv_blocks_needed <= kv_blocks;
+  if (!process_beam_search(sequence, /*need_swap*/ kv_already_satisfied)) {
     return false;
   }
-
-  if (block_managers_[dp_rank]->is_composite()) {
-    // TODO: not supporte prefix cache for composite manager yet.
-    if (!block_managers_[dp_rank]->allocate_for_sequence(sequence,
-                                                         num_tokens)) {
-      if (needs_single_block) {
-        deallocate_single_block(sequence, dp_rank);
-      }
-      return false;
-    }
-    return true;
-  }
-
-  // first try to allocate shared blocks
-  if (started_empty) {
-    BlockManagerPool::allocate_shared(sequence);
-  }
-
-  const size_t num_blocks = sequence->kv_state().num_blocks(BlockType::KV);
-  // round up to the nearest block number
-  const size_t block_size = options_.block_size();
-  const size_t num_blocks_needed = (num_tokens + block_size - 1) / block_size;
-  if (num_blocks_needed <= num_blocks) {
-    return process_beam_search(sequence, /*need_swap*/ true);
-  }
-  process_beam_search(sequence);
-
-  const uint32_t num_additional_blocks = num_blocks_needed - num_blocks;
-
-  const auto blocks = block_managers_[dp_rank]->allocate(num_additional_blocks);
-  if (blocks.size() != num_additional_blocks) {
+  // Always run the composite growth pass: even when KV is already satisfied, a
+  // sequence (e.g. a fork/clone of a beam parent) may still be missing its
+  // per-sequence SINGLE block. The composite skips no-op leaves internally.
+  if (!composite->allocate_sequence(sequence, num_tokens)) {
     if (started_empty) {
-      block_managers_[dp_rank]->deallocate(
-          sequence->kv_state().blocks(BlockType::KV));
-      if (needs_single_block) {
-        deallocate_single_block(sequence, dp_rank);
-      }
+      composite->deallocate_for_sequence(sequence);
       sequence->reset();
     }
-    // LOG(ERROR) << " Fail to allocate " << num_additional_blocks << "
-    // blocks.";
-
     return false;
   }
-
-  sequence->add_blocks(BlockType::KV, blocks);
-
   return true;
 }
 
@@ -296,72 +221,37 @@ std::vector<Block> BlockManagerPool::allocate(size_t num_tokens,
   dp_rank = get_manager_with_max_free_blocks();
   const size_t block_size = options_.block_size();
   const size_t num_blocks_needed = (num_tokens + block_size - 1) / block_size;
-  return block_managers_[dp_rank]->allocate(num_blocks_needed);
+  // block_managers_[dp_rank] is always a CompositeBlockManager, whose
+  // type-ambiguous allocate(size_t) is NOT_IMPLEMENTED. Route to the KV leaf
+  // explicitly (this raw-block path is the flat-KV-only helper used to seed /
+  // evict the prefix cache; DSV4 has no KV leaf and must not call it).
+  auto* composite =
+      static_cast<CompositeBlockManager*>(block_managers_[dp_rank].get());
+  return composite->allocate_blocks(BlockType::KV, num_blocks_needed);
 }
 
 bool BlockManagerPool::try_allocate(Sequence* sequence) {
   int32_t dp_rank = get_dp_rank(sequence);
-  const bool needs_single_block = sequence->get_single_block_id() < 0;
-  if (needs_single_block && !allocate_single_block(sequence, dp_rank)) {
+
+  // Composite path: prefix-share + grow via the leaves, then advance the token
+  // counter (try_allocate admits the full prompt up front).
+  auto* composite =
+      static_cast<CompositeBlockManager*>(block_managers_[dp_rank].get());
+  composite->allocate_shared_for_sequence(sequence);
+  if (!composite->allocate_sequence(sequence, sequence->num_tokens())) {
+    composite->deallocate_for_sequence(sequence);
+    sequence->reset();
     return false;
   }
-  if (block_managers_[dp_rank]->is_composite()) {
-    if (!block_managers_[dp_rank]->allocate_for_sequence(
-            sequence, sequence->num_tokens())) {
-      if (needs_single_block) {
-        deallocate_single_block(sequence, dp_rank);
-      }
-      return false;
-    }
-    return true;
+  // add_shared_blocks (called inside allocate_shared_for_sequence) may have
+  // already advanced kv_cache_tokens_num_ to num_shared_tokens on a prefix hit.
+  // Only increment the remaining delta so the total reaches tokens().size().
+  const size_t already_counted = sequence->kv_state().kv_cache_tokens_num();
+  const size_t total_tokens = sequence->tokens().size();
+  if (total_tokens > already_counted) {
+    sequence->kv_state().incr_kv_cache_tokens_num(total_tokens -
+                                                  already_counted);
   }
-
-  std::vector<Block> shared_blocks;
-  size_t shared_num = 0;
-  if (options_.enable_prefix_cache()) {
-    sequence->update_block_hashes(static_cast<uint32_t>(options_.block_size()),
-                                  options_.hasher_type());
-    const auto& existed_shared_blocks =
-        sequence->kv_state()
-            .blocks(BlockType::KV)
-            .slice(0, sequence->kv_state().shared_blocks_num(BlockType::KV));
-    // If the sequence holds shared_blocks, the hash values of these blocks do
-    // not need to be recalculated and can be reused directly.
-    shared_blocks =
-        block_managers_[dp_rank]->allocate_shared(sequence->tokens(),
-                                                  existed_shared_blocks,
-                                                  sequence->mm_data(),
-                                                  sequence->block_hashes());
-
-    if (!shared_blocks.empty()) {
-      sequence->add_blocks(BlockType::KV, shared_blocks);
-      sequence->kv_state().incr_shared_blocks_num(BlockType::KV,
-                                                  shared_blocks.size());
-      shared_num = shared_blocks.size();
-    }
-  }
-
-  const size_t block_size = options_.block_size();
-  size_t num_tokens = sequence->tokens().size() - shared_num * block_size;
-
-  const size_t num_blocks_needed = (num_tokens + block_size - 1) / block_size;
-  if (num_blocks_needed > 0) {
-    const auto blocks = block_managers_[dp_rank]->allocate(num_blocks_needed);
-    if (blocks.size() != num_blocks_needed) {
-      if (needs_single_block) {
-        deallocate_single_block(sequence, dp_rank);
-      }
-      if (shared_num != 0) {
-        block_managers_[dp_rank]->deallocate(shared_blocks);
-        sequence->reset();
-      }
-      return false;
-    }
-
-    sequence->add_blocks(BlockType::KV, std::move(blocks));
-  }
-
-  sequence->kv_state().incr_kv_cache_tokens_num(sequence->tokens().size());
   return true;
 }
 
@@ -379,7 +269,13 @@ bool BlockManagerPool::process_beam_search(Sequence* sequence, bool need_swap) {
   // allocate a new block for this sequence
   if (need_swap && sequence->kv_state().need_swap()) {
     int32_t dp_rank = get_dp_rank(sequence);
-    auto new_blocks = block_managers_[dp_rank]->allocate(1);
+    // Beam copy-on-write needs exactly one KV block; route through the
+    // composite's typed allocation so it reaches the (possibly concurrency-
+    // wrapped) KV leaf.
+    auto* composite =
+        static_cast<CompositeBlockManager*>(block_managers_[dp_rank].get());
+    std::vector<Block> new_blocks =
+        composite->allocate_blocks(BlockType::KV, 1);
     if (new_blocks.size() == 0) {
       return false;
     }
@@ -393,43 +289,21 @@ bool BlockManagerPool::process_beam_search(Sequence* sequence, bool need_swap) {
 }
 
 void BlockManagerPool::allocate_shared(Sequence* sequence) {
-  // only allocate shared blocks for prefill sequences
-  if (options_.enable_prefix_cache()) {
-    int32_t dp_rank = get_dp_rank(sequence);
-    sequence->update_block_hashes(static_cast<uint32_t>(options_.block_size()),
-                                  options_.hasher_type());
-    const auto& existed_shared_blocks =
-        sequence->kv_state()
-            .blocks(BlockType::KV)
-            .slice(0, sequence->kv_state().shared_blocks_num(BlockType::KV));
-    // If the sequence holds shared_blocks, the hash values of these blocks do
-    // not need to be recalculated and can be reused directly.
-    std::vector<Block> shared_blocks =
-        block_managers_[dp_rank]->allocate_shared(sequence->tokens(),
-                                                  existed_shared_blocks,
-                                                  sequence->mm_data(),
-                                                  sequence->block_hashes());
-    sequence->add_shared_blocks(BlockType::KV, std::move(shared_blocks));
+  if (!options_.enable_prefix_cache()) {
+    return;
   }
+  int32_t dp_rank = get_dp_rank(sequence);
+  static_cast<CompositeBlockManager*>(block_managers_[dp_rank].get())
+      ->allocate_shared_for_sequence(sequence);
 }
 
 void BlockManagerPool::cache(Sequence* sequence) {
-  int32_t dp_rank = get_dp_rank(sequence);
-  if (block_managers_[dp_rank]->is_composite()) {
-    // Prefix cache is not supported for CompositeBlockManager yet.
+  if (!options_.enable_prefix_cache()) {
     return;
   }
-  sequence->update_block_hashes(static_cast<uint32_t>(options_.block_size()),
-                                options_.hasher_type());
-  const auto token_ids = sequence->cached_tokens();
-  auto* blocks = sequence->kv_state().mutable_blocks(BlockType::KV);
-  auto existed_shared_blocks_num =
-      sequence->kv_state().shared_blocks_num(BlockType::KV);
-  block_managers_[dp_rank]->cache(token_ids,
-                                  *blocks,
-                                  existed_shared_blocks_num,
-                                  sequence->mm_data(),
-                                  sequence->block_hashes());
+  int32_t dp_rank = get_dp_rank(sequence);
+  static_cast<CompositeBlockManager*>(block_managers_[dp_rank].get())
+      ->cache_for_sequence(sequence);
 }
 
 void BlockManagerPool::cache(Sequence* sequence, size_t num_tokens) {
@@ -438,38 +312,10 @@ void BlockManagerPool::cache(Sequence* sequence, size_t num_tokens) {
     return;
   }
   int32_t dp_rank = get_dp_rank(sequence);
-  if (block_managers_[dp_rank]->is_composite()) {
-    // Prefix cache is not supported for CompositeBlockManager yet.
-    return;
-  }
-
-  // Only publish the full blocks that are guaranteed to be computed: clamp the
-  // requested token budget to the blocks actually allocated and to the
-  // sequence's own tokens. The last partial block is dropped by the prefix
-  // cache insert (it aligns to block boundary).
-  const size_t block_size = static_cast<size_t>(options_.block_size());
-  const size_t available_tokens_num =
-      std::min({num_tokens,
-                sequence->kv_state().num_blocks(BlockType::KV) * block_size,
-                sequence->tokens().size()});
-  const size_t existed_shared_blocks_num =
-      sequence->kv_state().shared_blocks_num(BlockType::KV);
-  if (available_tokens_num <= existed_shared_blocks_num * block_size) {
-    return;
-  }
-
-  // Block hashes are already computed during allocate(); this is an idempotent
-  // no-op kept for safety so we do not depend on allocate() running first.
-  sequence->update_block_hashes(static_cast<uint32_t>(options_.block_size()),
-                                options_.hasher_type());
-  const auto token_ids = sequence->tokens().slice(0, available_tokens_num);
-  auto* blocks = sequence->kv_state().mutable_blocks(BlockType::KV);
-  CHECK_GE(blocks->size(), existed_shared_blocks_num);
-  block_managers_[dp_rank]->cache(token_ids,
-                                  *blocks,
-                                  existed_shared_blocks_num,
-                                  sequence->mm_data(),
-                                  sequence->block_hashes());
+  // Fan out the in-batch publish to the prefix leaf (KV); the composite no-ops
+  // for shapes without a prefix-capable KV leaf (DSV4 / xtensor).
+  static_cast<CompositeBlockManager*>(block_managers_[dp_rank].get())
+      ->cache_for_sequence(sequence, num_tokens);
 }
 
 float BlockManagerPool::get_gpu_cache_usage_perc() const {
@@ -499,11 +345,6 @@ std::vector<size_t> BlockManagerPool::num_blocks_in_prefix_cache() const {
     return num_blocks_in_prefix_cache;
   }
   for (size_t dp_rank = 0; dp_rank < block_managers_.size(); ++dp_rank) {
-    if (block_managers_[dp_rank]->is_composite()) {
-      // CompositeBlockManager does not support prefix-cache stats yet.
-      num_blocks_in_prefix_cache[dp_rank] = 0;
-      continue;
-    }
     num_blocks_in_prefix_cache[dp_rank] =
         block_managers_[dp_rank]->num_blocks_in_prefix_cache();
   }
@@ -536,12 +377,19 @@ double BlockManagerPool::kv_cache_utilization() const {
 void BlockManagerPool::deallocate_without_cache(Sequence* sequence) {
   DCHECK(sequence != nullptr);
   int32_t dp_rank = get_dp_rank(sequence);
-  DCHECK(!block_managers_[dp_rank].get()->is_composite())
-      << "Composite manager does not support deallocate_without_cache yet.";
-
-  block_managers_[dp_rank]->deallocate(
-      sequence->kv_state().blocks(BlockType::KV));
-  deallocate_single_block(sequence, dp_rank);
+  // Release every leaf's blocks directly (no prefix-cache final flush). Routing
+  // by Block::manager() inside composite::deallocate dispatches each block to
+  // its owning leaf.
+  for (const BlockType type : {BlockType::KV,
+                               BlockType::SWA,
+                               BlockType::C4,
+                               BlockType::C128,
+                               BlockType::SINGLE}) {
+    const Slice<Block> blocks = sequence->kv_state().blocks(type);
+    if (!blocks.empty()) {
+      block_managers_[dp_rank]->deallocate(blocks);
+    }
+  }
   sequence->reset();
 }
 
@@ -549,17 +397,13 @@ void BlockManagerPool::reserve_xtensor_padding_blocks() {
   if (!options_.enable_xtensor()) {
     return;
   }
-
-  // Reserve padding block on each XTensorBlockManagerImpl.
+  // The xtensor KV leaf is a CompositeBlockManager leaf now; fan the padding
+  // reservation out through the composite (no dynamic_cast). Non-xtensor leaves
+  // inherit the empty base default and are no-ops.
   for (auto& manager : block_managers_) {
-    auto* xtensor_manager =
-        dynamic_cast<XTensorBlockManagerImpl*>(manager.get());
-    if (xtensor_manager) {
-      xtensor_manager->reserve_xtensor_padding_blocks();
-    }
+    manager->reserve_xtensor_padding_blocks();
   }
-
-  // Start prealloc thread once (PageAllocator is shared by all managers)
+  // Start prealloc thread once (PageAllocator is shared by all managers).
   PageAllocator::get_instance().start_prealloc_thread();
 }
 

--- a/xllm/core/framework/block/block_manager_pool.h
+++ b/xllm/core/framework/block/block_manager_pool.h
@@ -107,12 +107,9 @@ class BlockManagerPool : public KVCacheManager {
   int32_t get_dp_rank(Sequence* sequence) const;
 
   bool process_beam_search(Sequence* sequence, bool need_swap = false);
-  bool allocate_single_block(Sequence* sequence, int32_t dp_rank);
-  void deallocate_single_block(Sequence* sequence, int32_t dp_rank);
 
  private:
   std::vector<std::vector<BlockTransferInfo>> swap_block_transfer_infos_;
-  std::vector<std::unique_ptr<SingleBlockManager>> single_block_managers_;
 
  protected:
   // the options for the block manager

--- a/xllm/core/framework/block/composite_block_manager.cpp
+++ b/xllm/core/framework/block/composite_block_manager.cpp
@@ -16,11 +16,14 @@ limitations under the License.
 #include "composite_block_manager.h"
 
 #include <algorithm>
-#include <iterator>
+#include <limits>
 #include <utility>
 
 #include "block_manager_impl.h"
-#include "framework/block/block_utils.h"
+#include "concurrent_block_manager_impl.h"
+#include "core/framework/config/kv_cache_config.h"
+#include "framework/xtensor/xtensor_block_manager_impl.h"
+#include "single_block_manager.h"
 #include "sliding_window_block_manager.h"
 
 namespace xllm {
@@ -35,215 +38,277 @@ uint32_t ceil_div(uint32_t numerator, uint32_t denominator) {
   return (numerator + denominator - 1) / denominator;
 }
 
+// Wrap a leaf in a concurrency adapter when sequence-level entry points may run
+// off the scheduler thread (disagg PD / kvcache store prefill threadpools).
+std::unique_ptr<BlockManager> maybe_concurrent(
+    std::unique_ptr<BlockManager> leaf,
+    const BlockManager::Options& options) {
+  if (options.enable_disagg_pd() || options.enable_kvcache_store()) {
+    return std::make_unique<ConcurrentBlockManagerImpl>(std::move(leaf));
+  }
+  return leaf;
+}
+
+// Build the KV leaf: an xtensor VMM manager when enable_xtensor, otherwise the
+// flat free-list BlockManagerImpl. xtensor does not support prefix cache.
+std::unique_ptr<BlockManager> make_kv_leaf(const BlockManager::Options& kv_opts,
+                                           int32_t dp_rank) {
+  if (!kv_opts.enable_xtensor()) {
+    return std::make_unique<BlockManagerImpl>(kv_opts);
+  }
+  CHECK_GT(kv_opts.num_layers(), 0)
+      << "num_layers must be set when enable_xtensor is true";
+  CHECK_GT(kv_opts.slot_size(), 0)
+      << "slot_size must be set when enable_xtensor is true";
+  const size_t page_size =
+      ::xllm::KVCacheConfig::get_instance().phy_page_granularity_size();
+  // K and V are the same size in the current implementation, so divide by 2.
+  const size_t block_mem_size =
+      static_cast<size_t>(kv_opts.block_size()) * kv_opts.slot_size() / 2;
+  return std::make_unique<XTensorBlockManagerImpl>(kv_opts,
+                                                   kv_opts.num_layers(),
+                                                   block_mem_size,
+                                                   page_size,
+                                                   dp_rank,
+                                                   kv_opts.model_id());
+}
+
 }  // namespace
 
-CompositeBlockManager::CompositeBlockManager(
-    const BlockManager::Options& options)
-    : BlockManager(options) {
-  const size_t n = options_.manager_types().size();
-  CHECK_EQ(n, options_.compress_ratios().size())
-      << "manager_types and compress_ratios must have the same size";
-  CHECK_GT(n, 0u) << "CompositeBlockManager requires at least one sub-manager";
+std::map<BlockType, CompositeBlockManager::LeafEntry> build_composite_leaves(
+    const BlockManager::Options& options,
+    int32_t dp_rank) {
+  std::map<BlockType, CompositeBlockManager::LeafEntry> leaves;
 
-  sub_managers_.reserve(n);
-  sub_manager_types_.reserve(n);
+  if (options.manager_types().empty()) {
+    // Normal / Qwen / xtensor model: a single KV leaf. It is the admission
+    // source; prefix cache is on only for the flat (non-xtensor) KV leaf.
+    BlockManager::Options kv_opts = options;
+    kv_opts.block_type(BlockType::KV);
+    leaves.emplace(
+        BlockType::KV,
+        CompositeBlockManager::LeafEntry{
+            maybe_concurrent(make_kv_leaf(kv_opts, dp_rank), options),
+            /*participates_in_admission=*/true,
+            /*supports_prefix_cache=*/
+            options.enable_prefix_cache() && !options.enable_xtensor()});
+    return leaves;
+  }
+
+  // DSV4: SWA + compressed (C4 / C128) leaves, derived from manager_types /
+  // compress_ratios (kept identical to the previous in-composite construction).
+  const size_t n = options.manager_types().size();
+  CHECK_EQ(n, options.compress_ratios().size())
+      << "manager_types and compress_ratios must have the same size";
+  CHECK_GT(n, 0u) << "Composite requires at least one sub-manager";
 
   for (size_t i = 0; i < n; ++i) {
-    const uint32_t type = options_.manager_types()[i];
-    const uint32_t compress_ratio = options_.compress_ratios()[i];
-    BlockManager::Options opts = options_;
+    const uint32_t type = options.manager_types()[i];
+    const uint32_t compress_ratio = options.compress_ratios()[i];
+    BlockManager::Options opts = options;
 
     if (type == kManagerTypeBlockManagerImpl) {
-      opts.block_size(static_cast<uint32_t>(options_.block_size()) *
+      opts.block_size(static_cast<uint32_t>(options.block_size()) *
                       compress_ratio);
-      opts.num_blocks(static_cast<uint32_t>(options_.num_blocks()) /
+      opts.num_blocks(static_cast<uint32_t>(options.num_blocks()) /
                       compress_ratio);
-      // Compressed incremental groups are keyed by their compression ratio.
       CHECK(compress_ratio == 4 || compress_ratio == 128)
           << "unexpected compress_ratio " << compress_ratio
           << " for composite BlockManagerImpl sub-manager";
-      sub_managers_.push_back(std::make_unique<BlockManagerImpl>(opts));
-      sub_manager_types_.push_back(compress_ratio == 4 ? BlockType::C4
-                                                       : BlockType::C128);
+      const BlockType key =
+          compress_ratio == 4 ? BlockType::C4 : BlockType::C128;
+      opts.block_type(key);
+      // Compressed groups are admission sources but do not serve prefix cache.
+      leaves.emplace(key,
+                     CompositeBlockManager::LeafEntry{
+                         maybe_concurrent(
+                             std::make_unique<BlockManagerImpl>(opts), options),
+                         /*participates_in_admission=*/true,
+                         /*supports_prefix_cache=*/false});
     } else if (type == kManagerTypeSlidingWindowBlockManager) {
-      const uint32_t swa_blocks_per_seq = options_.swa_blocks_per_seq();
+      const uint32_t swa_blocks_per_seq = options.swa_blocks_per_seq();
       CHECK_GT(swa_blocks_per_seq, 0u) << "swa_blocks_per_seq must be positive";
-      CHECK_GT(options_.block_size(), 0) << "block_size must be positive";
+      CHECK_GT(options.block_size(), 0) << "block_size must be positive";
       const uint32_t sliding_window_size =
-          std::max(options_.sliding_window_size(), 1u);
-      const uint32_t max_seqs = std::max(options_.max_seqs_per_batch(), 1u);
+          std::max(options.sliding_window_size(), 1u);
+      const uint32_t max_seqs = std::max(options.max_seqs_per_batch(), 1u);
       const uint32_t burst_blocks =
-          ceil_div(std::max(options_.max_tokens_per_batch(), 1u),
-                   static_cast<uint32_t>(options_.block_size()));
+          ceil_div(std::max(options.max_tokens_per_batch(), 1u),
+                   static_cast<uint32_t>(options.block_size()));
       const uint32_t swa_total_blocks =
           swa_blocks_per_seq * max_seqs + burst_blocks + max_seqs + 2;
       opts.num_blocks(swa_total_blocks)
           .swa_blocks_per_seq(swa_blocks_per_seq)
-          .sliding_window_size(sliding_window_size);
-      LOG(INFO)
-          << "CompositeBlockManager uses dynamic sliding-window allocation: "
-             "swa_blocks_per_seq="
-          << swa_blocks_per_seq
-          << ", sliding_window_size=" << sliding_window_size
-          << ", block_size=" << options_.block_size()
-          << ", burst_blocks=" << burst_blocks
-          << ", total_blocks=" << swa_total_blocks << ", max_seqs=" << max_seqs
-          << ". SWA blocks outside the sliding window are returned to the "
-             "physical SW cache pool.";
-      sub_managers_.push_back(
-          std::make_unique<SlidingWindowBlockManager>(opts));
-      sub_manager_types_.push_back(BlockType::SWA);
+          .sliding_window_size(sliding_window_size)
+          .block_type(BlockType::SWA);
+      // SWA neither participates in admission nor serves prefix cache.
+      leaves.emplace(
+          BlockType::SWA,
+          CompositeBlockManager::LeafEntry{
+              maybe_concurrent(
+                  std::make_unique<SlidingWindowBlockManager>(opts), options),
+              /*participates_in_admission=*/false,
+              /*supports_prefix_cache=*/false});
     } else {
       LOG(FATAL) << "Unknown manager_type " << type;
     }
   }
+  return leaves;
 }
 
-bool CompositeBlockManager::allocate_for_sequence(Sequence* seq,
-                                                  size_t num_tokens) {
+CompositeBlockManager::CompositeBlockManager(
+    std::map<BlockType, LeafEntry> leaves)
+    : BlockManager(BlockManager::Options()), leaves_(std::move(leaves)) {
+  CHECK(!leaves_.empty()) << "CompositeBlockManager requires at least one leaf";
+}
+
+BlockManager* CompositeBlockManager::leaf_of(BlockType type) const {
+  auto it = leaves_.find(type);
+  return it == leaves_.end() ? nullptr : it->second.leaf.get();
+}
+
+bool CompositeBlockManager::allocate_sequence(Sequence* seq,
+                                              size_t num_tokens) {
   if (seq == nullptr) {
     return false;
   }
   KVCacheState& kv_state = seq->kv_state();
-  // Per sub-manager block list (keyed by its BlockType), created on demand. The
-  // index i stays aligned with sub_managers_[i].
-  std::vector<std::vector<Block>*> manager_blocks(sub_managers_.size());
-  std::vector<size_t> original_sizes(sub_managers_.size(), 0);
-  for (size_t i = 0; i < sub_managers_.size(); ++i) {
-    manager_blocks[i] = kv_state.mutable_blocks(sub_manager_types_[i]);
-    original_sizes[i] = manager_blocks[i]->size();
-  }
 
-  // Blocks taken from each compressed sub-manager during this call. They are
-  // staged here and only committed into manager_blocks after every group's
-  // allocation has succeeded; the SWA group grows in place, so its rollback is
-  // tracked by size instead.
-  std::vector<std::vector<Block>> pending_blocks(sub_managers_.size());
+  // Each leaf grows its own block_type() blocks for the sequence and returns
+  // the blocks it newly allocated; it does not insert them. The composite
+  // stages them keyed by BlockType and commits only after every leaf succeeds.
+  // Rollback = deallocate every staged run (the sequence is never grown before
+  // commit, so existing blocks stay intact).
+  std::vector<std::pair<BlockType, std::vector<Block>>> staged;
 
-  // Undo every allocation this call has made. Each batch is returned through
-  // its owning sub-manager's deallocate() (logical release) before the Block
-  // refs are dropped (physical return on destruction), mirroring
-  // deallocate_sequence(); a bare resize() would skip the sub-manager and leak
-  // the staged pending_blocks that were never inserted into manager_blocks.
-  auto rollback = [&]() {
-    std::vector<Block>& swa = *manager_blocks[0];
-    if (swa.size() > original_sizes[0]) {
-      sub_managers_[0]->deallocate(Slice<Block>(
-          swa.data() + original_sizes[0], swa.size() - original_sizes[0]));
-      swa.resize(original_sizes[0]);
-    }
-    for (size_t i = 1; i < sub_managers_.size(); ++i) {
-      if (!pending_blocks[i].empty()) {
-        sub_managers_[i]->deallocate(pending_blocks[i]);
-        pending_blocks[i].clear();
+  for (auto& [type, entry] : leaves_) {
+    std::optional<std::vector<Block>> blocks =
+        entry.leaf->allocate_for_sequence(seq, num_tokens);
+    if (!blocks.has_value()) {
+      for (auto& [staged_type, staged_blocks] : staged) {
+        leaf_of(staged_type)->deallocate(staged_blocks);
       }
-    }
-  };
-
-  std::vector<Block>& swa_blocks = *manager_blocks[0];
-  const size_t block_size = sub_managers_[0]->block_size();
-  const size_t cached_tokens = kv_state.kv_cache_tokens_num();
-  const size_t sliding_window_tokens =
-      std::max<size_t>(sub_managers_[0]->options().sliding_window_size(), 1);
-  size_t release_blocks = 0;
-  if (cached_tokens >= sliding_window_tokens) {
-    const size_t skipped_tokens = cached_tokens - sliding_window_tokens + 1;
-    const size_t skipped_blocks = skipped_tokens / block_size;
-    release_blocks = std::min(skipped_blocks, swa_blocks.size());
-  }
-
-  size_t valid_release_blocks = 0;
-  for (size_t j = 0; j < release_blocks; ++j) {
-    if (swa_blocks[j].is_valid()) {
-      ++valid_release_blocks;
-    }
-  }
-
-  const size_t swa_blocks_needed = (num_tokens + block_size - 1) / block_size;
-  const size_t old_swa_size = swa_blocks.size();
-  const size_t additional_swa_blocks =
-      swa_blocks_needed > old_swa_size ? swa_blocks_needed - old_swa_size : 0;
-  if (additional_swa_blocks >
-      sub_managers_[0]->num_free_blocks() + valid_release_blocks) {
-    rollback();
-    return false;
-  }
-
-  for (size_t i = 1; i < sub_managers_.size(); ++i) {
-    const size_t num_blocks = manager_blocks[i]->size();
-    const size_t block_size = sub_managers_[i]->block_size();
-    const size_t num_blocks_needed = (num_tokens + block_size - 1) / block_size;
-    if (num_blocks_needed <= num_blocks) {
-      continue;
-    }
-
-    const uint32_t num_additional_blocks = num_blocks_needed - num_blocks;
-    pending_blocks[i] = sub_managers_[i]->allocate(num_additional_blocks);
-    if (pending_blocks[i].size() != num_additional_blocks) {
-      rollback();
       return false;
     }
-  }
-
-  if (release_blocks > 0) {
-    std::vector<Block> blocks_to_release;
-    blocks_to_release.reserve(release_blocks);
-    for (size_t j = 0; j < release_blocks; ++j) {
-      if (swa_blocks[j].is_valid()) {
-        blocks_to_release.emplace_back(std::move(swa_blocks[j]));
-      }
-    }
-    if (!blocks_to_release.empty()) {
-      sub_managers_[0]->deallocate(blocks_to_release);
-      // Drop the last Block references so released ids re-enter the pool
-      // before this allocation grows the next chunk.
-      blocks_to_release.clear();
+    if (!blocks->empty()) {
+      staged.emplace_back(type, std::move(*blocks));
     }
   }
 
-  if (swa_blocks.size() < swa_blocks_needed) {
-    const size_t old_size = swa_blocks.size();
-    swa_blocks.resize(swa_blocks_needed);
-    std::vector<Block> blocks =
-        sub_managers_[0]->allocate(swa_blocks_needed - old_size);
-    if (blocks.size() != swa_blocks_needed - old_size) {
-      swa_blocks.resize(old_size);
-      rollback();
-      return false;
-    }
-    std::move(blocks.begin(), blocks.end(), swa_blocks.begin() + old_size);
+  // Commit: append staged blocks to the sequence under each leaf's block type.
+  for (auto& [type, blocks] : staged) {
+    kv_state.add_blocks(type, blocks);
   }
-
-  for (size_t i = 1; i < sub_managers_.size(); ++i) {
-    if (pending_blocks[i].empty()) {
-      continue;
-    }
-    manager_blocks[i]->insert(
-        manager_blocks[i]->end(),
-        std::make_move_iterator(pending_blocks[i].begin()),
-        std::make_move_iterator(pending_blocks[i].end()));
+  // Post-commit: release blocks that have slid out of the window (SWA only;
+  // other leaves are a no-op). Runs only after a fully successful round, so a
+  // failed allocation never releases the sequence's existing blocks.
+  for (auto& [type, entry] : leaves_) {
+    entry.leaf->release_out_of_window(seq);
   }
   return true;
 }
 
-void CompositeBlockManager::deallocate_sequence(Sequence* seq) {
+void CompositeBlockManager::deallocate_for_sequence(Sequence* seq) {
   if (seq == nullptr) {
     return;
   }
-  KVCacheState& kv_state = seq->kv_state();
-  for (size_t i = 0; i < sub_managers_.size(); ++i) {
-    const Slice<Block> group_blocks = kv_state.blocks(sub_manager_types_[i]);
-    if (!group_blocks.empty()) {
-      sub_managers_[i]->deallocate(group_blocks);
-    }
+  // Publish prefix cache first (prefix leaves only), then release every leaf's
+  // blocks by key. seq->reset() stays with the pool caller.
+  cache_for_sequence(seq);
+  for (auto& [type, entry] : leaves_) {
+    entry.leaf->deallocate(seq->kv_state().blocks(type));
   }
 }
 
+void CompositeBlockManager::allocate_shared_for_sequence(Sequence* seq) {
+  // Today only the flat-KV model supports prefix cache. Other shapes (DSV4 /
+  // xtensor) leave the KV entry's supports_prefix_cache=false (or have no KV
+  // leaf at all), so this is a no-op for them.
+  if (seq == nullptr) {
+    return;
+  }
+  auto it = leaves_.find(BlockType::KV);
+  if (it == leaves_.end() || !it->second.supports_prefix_cache) {
+    return;
+  }
+  BlockManager& kv_leaf = *it->second.leaf;
+  seq->update_block_hashes(static_cast<uint32_t>(kv_leaf.block_size()),
+                           kv_leaf.options().hasher_type());
+  KVCacheState& kv_state = seq->kv_state();
+  const auto existed = kv_state.blocks(BlockType::KV)
+                           .slice(0, kv_state.shared_blocks_num(BlockType::KV));
+  std::vector<Block> shared = kv_leaf.allocate_shared(
+      seq->tokens(), existed, seq->mm_data(), seq->block_hashes());
+  seq->add_shared_blocks(BlockType::KV, std::move(shared));
+}
+
+void CompositeBlockManager::cache_for_sequence(Sequence* seq) {
+  if (seq == nullptr) {
+    return;
+  }
+  auto it = leaves_.find(BlockType::KV);
+  if (it == leaves_.end() || !it->second.supports_prefix_cache) {
+    return;
+  }
+  BlockManager& kv_leaf = *it->second.leaf;
+  seq->update_block_hashes(static_cast<uint32_t>(kv_leaf.block_size()),
+                           kv_leaf.options().hasher_type());
+  KVCacheState& kv_state = seq->kv_state();
+  std::vector<Block>* blocks = kv_state.mutable_blocks(BlockType::KV);
+  kv_leaf.cache(seq->cached_tokens(),
+                *blocks,
+                kv_state.shared_blocks_num(BlockType::KV),
+                seq->mm_data(),
+                seq->block_hashes());
+}
+
+void CompositeBlockManager::cache_for_sequence(Sequence* seq,
+                                               size_t num_tokens) {
+  if (seq == nullptr) {
+    return;
+  }
+  auto it = leaves_.find(BlockType::KV);
+  if (it == leaves_.end() || !it->second.supports_prefix_cache) {
+    return;
+  }
+  BlockManager& kv_leaf = *it->second.leaf;
+  KVCacheState& kv_state = seq->kv_state();
+  const size_t block_size = kv_leaf.block_size();
+  // Clamp to blocks actually allocated and to the sequence's own tokens; the
+  // last partial block is dropped by the prefix-cache insert.
+  const size_t available_tokens_num =
+      std::min({num_tokens,
+                kv_state.num_blocks(BlockType::KV) * block_size,
+                seq->tokens().size()});
+  const size_t existed_shared_blocks_num =
+      kv_state.shared_blocks_num(BlockType::KV);
+  if (available_tokens_num <= existed_shared_blocks_num * block_size) {
+    return;
+  }
+  seq->update_block_hashes(static_cast<uint32_t>(block_size),
+                           kv_leaf.options().hasher_type());
+  std::vector<Block>* blocks = kv_state.mutable_blocks(BlockType::KV);
+  CHECK_GE(blocks->size(), existed_shared_blocks_num);
+  kv_leaf.cache(seq->tokens().slice(0, available_tokens_num),
+                *blocks,
+                existed_shared_blocks_num,
+                seq->mm_data(),
+                seq->block_hashes());
+}
+
+std::vector<Block> CompositeBlockManager::allocate_blocks(BlockType type,
+                                                          size_t num_blocks) {
+  BlockManager* leaf = leaf_of(type);
+  CHECK(leaf != nullptr) << "CompositeBlockManager has no leaf for block type "
+                         << static_cast<int>(type);
+  return leaf->allocate(num_blocks);
+}
+
 void CompositeBlockManager::deallocate(const Slice<Block>& blocks) {
+  // Route each run of blocks to its owning leaf by Block::manager().
   if (blocks.empty()) {
     return;
   }
-
   size_t run_start = 0;
   BlockManager* run_manager = nullptr;
   for (size_t i = 0; i < blocks.size(); ++i) {
@@ -259,16 +324,6 @@ void CompositeBlockManager::deallocate(const Slice<Block>& blocks) {
     BlockManager* manager = block.manager();
     CHECK(manager != nullptr)
         << "CompositeBlockManager got a valid block without owner manager";
-    const auto it =
-        std::find_if(sub_managers_.begin(),
-                     sub_managers_.end(),
-                     [manager](const std::unique_ptr<BlockManager>& sub_mgr) {
-                       return sub_mgr.get() == manager;
-                     });
-    CHECK(it != sub_managers_.end())
-        << "CompositeBlockManager cannot deallocate block " << block.id()
-        << " from a manager outside this composite manager";
-
     if (run_manager == nullptr) {
       run_manager = manager;
       run_start = i;
@@ -288,6 +343,16 @@ std::vector<Block> CompositeBlockManager::allocate(size_t /*num_blocks*/) {
   return {};
 }
 
+std::optional<std::vector<Block>> CompositeBlockManager::allocate_for_sequence(
+    Sequence* /*seq*/,
+    size_t /*num_tokens*/) {
+  // The composition is driven via allocate_sequence(), which fans out to each
+  // leaf's allocate_for_sequence. The leaf-level entry point is meaningless on
+  // the composite itself.
+  NOT_IMPLEMENTED();
+  return std::nullopt;
+}
+
 std::vector<Block> CompositeBlockManager::allocate_shared(
     const Slice<int32_t>& /*tokens_ids*/,
     const Slice<Block>& /*existed_shared_blocks*/,
@@ -302,33 +367,70 @@ void CompositeBlockManager::cache(const Slice<int32_t>& /*token_ids*/,
                                   size_t /*existed_shared_blocks_num*/,
                                   const MMData& /*mm_data*/,
                                   const Slice<XXH3Key>& /*block_hashes*/) {
-  // Prefix cache is not supported for CompositeBlockManager yet.
-  // Keep cache() as a no-op so scheduler-side prefill cache hooks
-  // do not crash when composite manager is enabled (e.g. DeepSeek V4).
+  NOT_IMPLEMENTED();
 }
 
 void CompositeBlockManager::cache(const std::vector<Block>& /*blocks*/) {
-  // Prefix cache is not supported for CompositeBlockManager yet.
+  NOT_IMPLEMENTED();
+}
+
+void CompositeBlockManager::reset_prefix_cache() {
+  for (auto& [type, entry] : leaves_) {
+    entry.leaf->reset_prefix_cache();
+  }
 }
 
 size_t CompositeBlockManager::num_blocks_in_prefix_cache() const {
-  LOG(FATAL) << "CompositeBlockManager not support prefix cache yet";
-  return 0;
+  size_t total = 0;
+  for (const auto& [type, entry] : leaves_) {
+    total += entry.leaf->num_blocks_in_prefix_cache();
+  }
+  return total;
+}
+
+const CompositeBlockManager::LeafEntry* CompositeBlockManager::capacity_leaf()
+    const {
+  const LeafEntry* chosen = nullptr;
+  for (const auto& [type, entry] : leaves_) {
+    if (!entry.participates_in_admission) {
+      continue;
+    }
+    // Smallest block_size = finest granularity = closest to the base block the
+    // scheduler assumes. For normal models this is the lone KV leaf; for DSV4
+    // (C4 bs=4*base, C128 bs=128*base) this is C4.
+    if (chosen == nullptr ||
+        entry.leaf->block_size() < chosen->leaf->block_size()) {
+      chosen = &entry;
+    }
+  }
+  return chosen;
 }
 
 size_t CompositeBlockManager::num_free_blocks() const {
-  return sub_managers_[1]->num_free_blocks();
+  // Scheduler-facing capacity is reported as a single admission leaf's raw
+  // block count (see capacity_leaf): mixing leaves of different block_size
+  // would make num_free * block_size() meaningless. This reproduces the
+  // pre-refactor single-group (`sub_managers_[1]`) semantics and is identical
+  // to the old BlockManagerImpl for normal models (KV is the only admission
+  // leaf).
+  const LeafEntry* leaf = capacity_leaf();
+  return leaf == nullptr ? 0 : leaf->leaf->num_free_blocks();
 }
 
 size_t CompositeBlockManager::num_used_blocks() const {
-  return sub_managers_[1]->num_used_blocks();
+  const LeafEntry* leaf = capacity_leaf();
+  return leaf == nullptr ? 0 : leaf->leaf->num_used_blocks();
 }
 
 double CompositeBlockManager::kv_cache_utilization() const {
-  return sub_managers_[1]->kv_cache_utilization();
+  const size_t total = num_total_blocks();
+  if (total == 0) {
+    return 0.0;
+  }
+  return static_cast<double>(num_used_blocks()) / static_cast<double>(total);
 }
 
-void CompositeBlockManager::free(int32_t block_id) {
+void CompositeBlockManager::free(int32_t /*block_id*/) {
   LOG(FATAL) << "CompositeBlockManager::free should not be called";
 }
 
@@ -338,7 +440,14 @@ Block CompositeBlockManager::allocate() {
 }
 
 size_t CompositeBlockManager::num_total_blocks() const {
-  return sub_managers_[1]->num_total_blocks();
+  const LeafEntry* leaf = capacity_leaf();
+  return leaf == nullptr ? 0 : leaf->leaf->num_total_blocks();
+}
+
+void CompositeBlockManager::reserve_xtensor_padding_blocks() {
+  for (auto& [type, entry] : leaves_) {
+    entry.leaf->reserve_xtensor_padding_blocks();
+  }
 }
 
 }  // namespace xllm

--- a/xllm/core/framework/block/composite_block_manager.h
+++ b/xllm/core/framework/block/composite_block_manager.h
@@ -15,28 +15,62 @@ limitations under the License.
 
 #pragma once
 
+#include <map>
 #include <memory>
+#include <utility>
 #include <vector>
 
 #include "block_manager.h"
 
 namespace xllm {
 
-// BlockManager composed of multiple sub-managers, created from options.
-// manager_type: 0 = BlockManagerImpl, 1 = SlidingWindowBlockManager.
-// Options come from BlockManager::Options (passed from upstream via
-// BlockManagerPool).
+// Generic composition of multiple BlockManager leaves keyed by BlockType. The
+// map key decides which KVCacheState slot a leaf's blocks land in; the leaf
+// itself is type-free. The composite is the only block-side class that touches
+// Sequence: it extracts parameters, drives the leaves' pure planners and
+// type-free primitives, and writes results back by key. It holds no
+// model-specific logic.
 class CompositeBlockManager : public BlockManager {
  public:
-  explicit CompositeBlockManager(const BlockManager::Options& options);
+  // Per-leaf entry. The admission / prefix roles live here (on the composite),
+  // not on the leaf: the same BlockManagerImpl is a prefix-capable admission
+  // leaf under the KV key but a non-prefix admission leaf under C4/C128.
+  struct LeafEntry {
+    std::unique_ptr<BlockManager> leaf;
+    bool participates_in_admission = true;
+    bool supports_prefix_cache = false;
+  };
+
+  explicit CompositeBlockManager(std::map<BlockType, LeafEntry> leaves);
   ~CompositeBlockManager() override = default;
 
   bool is_composite() const override { return true; }
-  bool allocate_for_sequence(Sequence* seq, size_t num_tokens) override;
-  void deallocate_sequence(Sequence* seq) override;
 
+  // —— Sequence-level orchestration (the only Sequence-aware surface) ——
+  // Drives every leaf's allocate_for_sequence(seq, num_tokens), stages the
+  // blocks each leaf returns, and commits them into the sequence under the
+  // leaf's block_type() once all succeed (rolling back on any failure).
+  // Distinct from the leaf-level BlockManager::allocate_for_sequence, which
+  // returns the blocks for a single leaf without inserting them.
+  bool allocate_sequence(Sequence* seq, size_t num_tokens);
+  void deallocate_for_sequence(Sequence* seq);
+  void allocate_shared_for_sequence(Sequence* seq);
+  void cache_for_sequence(Sequence* seq);
+  void cache_for_sequence(Sequence* seq, size_t num_tokens);
+
+  // Typed block-level allocation routed to the leaf under `type`. Used by the
+  // pool for beam copy-on-write (which needs exactly one KV block).
+  std::vector<Block> allocate_blocks(BlockType type, size_t num_blocks);
+
+  // Type-ambiguous block-level primitives are not meaningful on a composition.
   void deallocate(const Slice<Block>& blocks) override;
   std::vector<Block> allocate(size_t num_blocks) override;
+  // Leaf-level growth is not meaningful on the composition: the pool drives the
+  // composite via allocate_sequence() (which fans out to each leaf's
+  // allocate_for_sequence). Satisfies the pure-virtual base; never called.
+  std::optional<std::vector<Block>> allocate_for_sequence(
+      Sequence* seq,
+      size_t num_tokens) override;
   std::vector<Block> allocate_shared(
       const Slice<int32_t>& tokens_ids,
       const Slice<Block>& existed_shared_blocks = {},
@@ -48,22 +82,46 @@ class CompositeBlockManager : public BlockManager {
              const MMData& mm_data = MMData(),
              const Slice<XXH3Key>& block_hashes = {}) override;
   void cache(const std::vector<Block>& blocks) override;
-  size_t num_blocks_in_prefix_cache() const override;
-  size_t num_free_blocks() const override;
-  size_t num_used_blocks() const override;
+
+  // RL sleep/wakeup: fan out to every leaf (non-prefix leaves are a no-op).
+  void reset_prefix_cache() override;
+
+  // Stats reported from the single capacity leaf (see capacity_leaf()).
+  size_t num_blocks_in_prefix_cache() const override;  // sum over all leaves
+  size_t num_free_blocks() const override;             // from capacity leaf
+  size_t num_used_blocks() const override;             // from capacity leaf
   double kv_cache_utilization() const override;
   void free(int32_t block_id) override;
   Block allocate() override;
-  size_t num_total_blocks() const override;
+  size_t num_total_blocks() const override;  // from capacity leaf
 
-  size_t num_sub_managers() const { return sub_managers_.size(); }
+  void reserve_xtensor_padding_blocks() override;
+
+  size_t num_sub_managers() const { return leaves_.size(); }
 
  private:
-  std::vector<std::unique_ptr<BlockManager>> sub_managers_;
-  // The KVCacheState slot each sub-manager fills, parallel to sub_managers_.
-  // The composite owns this mapping; the sub-managers themselves are unaware of
-  // which block type they serve.
-  std::vector<BlockType> sub_manager_types_;
+  // Leaf serving `type`, or nullptr if none.
+  BlockManager* leaf_of(BlockType type) const;
+  // The single admission leaf whose raw block count defines the pool's
+  // scheduler-facing capacity unit. Schedulers treat num_free/used/total_blocks
+  // as counts of base (block_size()) blocks, so we must report one leaf's raw
+  // count rather than mixing leaves of different block sizes. Picks the
+  // admission leaf with the smallest block_size (the finest-grained, closest to
+  // base): KV for normal models, C4 for DSV4. Reproduces the pre-refactor
+  // single-`sub_managers_[1]` capacity semantics. nullptr if none.
+  const LeafEntry* capacity_leaf() const;
+
+  std::map<BlockType, LeafEntry> leaves_;
 };
+
+// Build the leaf map for one DP rank from the pool options (per-model:
+// normal/Qwen -> {KV, SINGLE}; DSV4 -> {SWA, C4, C128, SINGLE}; xtensor ->
+// {KV(XTensorBlockManagerImpl), SINGLE}). Leaves are wrapped in
+// ConcurrentBlockManagerImpl when disagg-PD / kvcache store is enabled. The
+// SINGLE entry is appended by the caller (pool). dp_rank is needed by the
+// xtensor KV leaf (per-rank VMM page pool).
+std::map<BlockType, CompositeBlockManager::LeafEntry> build_composite_leaves(
+    const BlockManager::Options& options,
+    int32_t dp_rank = 0);
 
 }  // namespace xllm

--- a/xllm/core/framework/block/concurrent_block_manager_impl.cpp
+++ b/xllm/core/framework/block/concurrent_block_manager_impl.cpp
@@ -15,19 +15,43 @@ limitations under the License.
 
 #include "concurrent_block_manager_impl.h"
 
+#include <utility>
+
 namespace xllm {
 
-ConcurrentBlockManagerImpl::ConcurrentBlockManagerImpl(const Options& options)
-    : BlockManagerImpl(options) {}
+ConcurrentBlockManagerImpl::ConcurrentBlockManagerImpl(
+    std::unique_ptr<BlockManager> inner)
+    : BlockManager(inner->options()), inner_(std::move(inner)) {
+  CHECK(inner_ != nullptr) << "ConcurrentBlockManagerImpl needs an inner leaf";
+}
 
 std::vector<Block> ConcurrentBlockManagerImpl::allocate(size_t num_blocks) {
   std::lock_guard<std::recursive_mutex> lock(mutex_);
-  return BlockManagerImpl::allocate(num_blocks);
+  std::vector<Block> blocks = inner_->allocate(num_blocks);
+  // Route Block dtor -> free through this wrapper so the wrapper's lock covers
+  // the free path. inner_ remains the physical owner; free(id) re-acquires the
+  // wrapper lock and forwards.
+  for (Block& block : blocks) {
+    block.set_manager(this);
+  }
+  return blocks;
+}
+
+Block ConcurrentBlockManagerImpl::allocate() {
+  std::lock_guard<std::recursive_mutex> lock(mutex_);
+  Block block = inner_->allocate();
+  block.set_manager(this);
+  return block;
 }
 
 void ConcurrentBlockManagerImpl::deallocate(const Slice<Block>& blocks) {
   std::lock_guard<std::recursive_mutex> lock(mutex_);
-  BlockManagerImpl::deallocate(blocks);
+  inner_->deallocate(blocks);
+}
+
+void ConcurrentBlockManagerImpl::free(int32_t block_id) {
+  std::lock_guard<std::recursive_mutex> lock(mutex_);
+  inner_->free(block_id);
 }
 
 std::vector<Block> ConcurrentBlockManagerImpl::allocate_shared(
@@ -36,8 +60,12 @@ std::vector<Block> ConcurrentBlockManagerImpl::allocate_shared(
     const MMData& mm_data,
     const Slice<XXH3Key>& block_hashes) {
   std::lock_guard<std::recursive_mutex> lock(mutex_);
-  return BlockManagerImpl::allocate_shared(
+  std::vector<Block> blocks = inner_->allocate_shared(
       token_ids, existed_shared_blocks, mm_data, block_hashes);
+  for (Block& block : blocks) {
+    block.set_manager(this);
+  }
+  return blocks;
 }
 
 void ConcurrentBlockManagerImpl::cache(const Slice<int32_t>& token_ids,
@@ -46,43 +74,64 @@ void ConcurrentBlockManagerImpl::cache(const Slice<int32_t>& token_ids,
                                        const MMData& mm_data,
                                        const Slice<XXH3Key>& block_hashes) {
   std::lock_guard<std::recursive_mutex> lock(mutex_);
-  BlockManagerImpl::cache(
+  inner_->cache(
       token_ids, blocks, existed_shared_blocks_num, mm_data, block_hashes);
 }
 
 void ConcurrentBlockManagerImpl::cache(const std::vector<Block>& blocks) {
   std::lock_guard<std::recursive_mutex> lock(mutex_);
-  BlockManagerImpl::cache(blocks);
+  inner_->cache(blocks);
+}
+
+std::optional<std::vector<Block>>
+ConcurrentBlockManagerImpl::allocate_for_sequence(Sequence* seq,
+                                                  size_t num_tokens) {
+  std::lock_guard<std::recursive_mutex> lock(mutex_);
+  auto blocks = inner_->allocate_for_sequence(seq, num_tokens);
+  if (blocks.has_value()) {
+    // Route Block dtor -> free through this wrapper so the wrapper's lock
+    // covers the free path. inner_ stays the physical owner; free(id)
+    // re-acquires the wrapper lock and forwards.
+    for (Block& block : *blocks) {
+      block.set_manager(this);
+    }
+  }
+  return blocks;
+}
+
+void ConcurrentBlockManagerImpl::release_out_of_window(Sequence* seq) {
+  std::lock_guard<std::recursive_mutex> lock(mutex_);
+  inner_->release_out_of_window(seq);
+}
+
+void ConcurrentBlockManagerImpl::reset_prefix_cache() {
+  std::lock_guard<std::recursive_mutex> lock(mutex_);
+  inner_->reset_prefix_cache();
 }
 
 size_t ConcurrentBlockManagerImpl::num_blocks_in_prefix_cache() const {
   std::lock_guard<std::recursive_mutex> lock(mutex_);
-  return BlockManagerImpl::num_blocks_in_prefix_cache();
+  return inner_->num_blocks_in_prefix_cache();
 }
 
 size_t ConcurrentBlockManagerImpl::num_free_blocks() const {
   std::lock_guard<std::recursive_mutex> lock(mutex_);
-  return BlockManagerImpl::num_free_blocks();
-}
-
-double ConcurrentBlockManagerImpl::kv_cache_utilization() const {
-  std::lock_guard<std::recursive_mutex> lock(mutex_);
-  return BlockManagerImpl::kv_cache_utilization();
+  return inner_->num_free_blocks();
 }
 
 size_t ConcurrentBlockManagerImpl::num_used_blocks() const {
   std::lock_guard<std::recursive_mutex> lock(mutex_);
-  return BlockManagerImpl::num_used_blocks();
+  return inner_->num_used_blocks();
 }
 
-void ConcurrentBlockManagerImpl::free(int32_t block_id) {
+size_t ConcurrentBlockManagerImpl::num_total_blocks() const {
   std::lock_guard<std::recursive_mutex> lock(mutex_);
-  BlockManagerImpl::free(block_id);
+  return inner_->num_total_blocks();
 }
 
-Block ConcurrentBlockManagerImpl::allocate() {
+double ConcurrentBlockManagerImpl::kv_cache_utilization() const {
   std::lock_guard<std::recursive_mutex> lock(mutex_);
-  return BlockManagerImpl::allocate();
+  return inner_->kv_cache_utilization();
 }
 
 }  // namespace xllm

--- a/xllm/core/framework/block/concurrent_block_manager_impl.h
+++ b/xllm/core/framework/block/concurrent_block_manager_impl.h
@@ -15,29 +15,38 @@ limitations under the License.
 
 #pragma once
 
-#include "block_manager_impl.h"
+#include <memory>
+#include <mutex>
+
+#include "block_manager.h"
 
 namespace xllm {
 
-class ConcurrentBlockManagerImpl : public BlockManagerImpl {
+// Concurrency adapter: wraps an inner leaf BlockManager and serializes every
+// entry point under one recursive mutex. Used for modes whose sequence-level
+// calls run off the scheduler thread (disagg PD / kvcache store prefill
+// threadpools).
+//
+// Composition, not inheritance: the inner manager is always a leaf
+// (BlockManagerImpl / SingleBlockManager / ...), never a CompositeBlockManager.
+// The composite constructs this wrapper around the leaves that need it.
+class ConcurrentBlockManagerImpl : public BlockManager {
  public:
-  explicit ConcurrentBlockManagerImpl(const Options& options);
-  virtual ~ConcurrentBlockManagerImpl() = default;
+  explicit ConcurrentBlockManagerImpl(std::unique_ptr<BlockManager> inner);
+  ~ConcurrentBlockManagerImpl() override = default;
 
-  // Try to allocate blocks with num_blocks,
-  // return {} if not enough blocks
+  // Block-level primitives.
   std::vector<Block> allocate(size_t num_blocks) override;
-
+  Block allocate() override;
   void deallocate(const Slice<Block>& blocks) override;
+  void free(int32_t block_id) override;
 
-  // try to share blocks among sequences with the same prefix
   std::vector<Block> allocate_shared(
       const Slice<int32_t>& token_ids,
       const Slice<Block>& existed_shared_blocks = {},
       const MMData& mm_data = MMData(),
       const Slice<XXH3Key>& block_hashes = {}) override;
 
-  // cache the blocks
   void cache(const Slice<int32_t>& token_ids,
              std::vector<Block>& blocks,
              size_t existed_shared_blocks_num = 0,
@@ -45,24 +54,27 @@ class ConcurrentBlockManagerImpl : public BlockManagerImpl {
              const Slice<XXH3Key>& block_hashes = {}) override;
   void cache(const std::vector<Block>& blocks) override;
 
-  // get the number of blocks in the prefix cache
+  // Sequence-level growth forwards under the lock (touches the inner leaf's
+  // free list / pool).
+  std::optional<std::vector<Block>> allocate_for_sequence(
+      Sequence* seq,
+      size_t num_tokens) override;
+  void release_out_of_window(Sequence* seq) override;
+
+  void reset_prefix_cache() override;
+
   size_t num_blocks_in_prefix_cache() const override;
-
-  // get the number of free blocks in the block allocator
   size_t num_free_blocks() const override;
-
-  // get the block utilization.
+  size_t num_used_blocks() const override;
+  size_t num_total_blocks() const override;
   double kv_cache_utilization() const override;
 
-  size_t num_used_blocks() const override;
-
-  void free(int32_t block_id) override;
-
-  Block allocate() override;
-
  private:
-  // Prefix cache eviction can release Blocks while allocator APIs hold the
-  // manager lock, so free() must be able to re-enter from the same thread.
+  std::unique_ptr<BlockManager> inner_;  // always a leaf, never a composite
+  // Recursive: Block dtors call free() through this wrapper (we rewrite each
+  // returned Block's manager_ to this), and inner_->allocate() may trigger
+  // prefix-cache eviction which destroys cached Blocks while we still hold the
+  // lock from the outer wrapper call.
   mutable std::recursive_mutex mutex_;
 };
 

--- a/xllm/core/framework/block/single_block_manager.cpp
+++ b/xllm/core/framework/block/single_block_manager.cpp
@@ -22,12 +22,16 @@ limitations under the License.
 namespace xllm {
 namespace {
 
+// One physical id == one block; no prefix cache; blocks live under the SINGLE
+// slot of the sequence's KVCacheState. id 0 stays the reserved padding slot
+// (BlockManagerImpl reserves it in its ctor), so usable ids are [1, n-1].
 BlockManager::Options make_single_block_options(uint32_t num_blocks) {
   BlockManager::Options options;
   options.num_blocks(num_blocks);
-  options.block_size(/*unused=*/1);
+  options.block_size(/*unused, one id == one block=*/1);
   options.enable_prefix_cache(false);
   options.enable_disagg_pd(false);
+  options.block_type(BlockType::SINGLE);
   return options;
 }
 
@@ -36,103 +40,46 @@ BlockManager::Options make_single_block_options(uint32_t num_blocks) {
 SingleBlockManager::SingleBlockManager(uint32_t num_blocks,
                                        std::string resource_name,
                                        std::string exhaustion_message)
-    : BlockManager(make_single_block_options(num_blocks)),
+    : BlockManagerImpl(make_single_block_options(num_blocks)),
       resource_name_(std::move(resource_name)),
-      exhaustion_message_(std::move(exhaustion_message)) {
-  CHECK_GT(num_blocks, 0) << "No blocks to allocate";
-  // Reserve id 0 as the padding slot, matching BlockManagerImpl's contract:
-  // `num_blocks` is the number of physical slots, id 0 is permanently held for
-  // padding, and only ids [1, num_blocks - 1] are handed out to sequences. This
-  // keeps the scheduler-side single-block ids inside the worker-side live
-  // region, whose row 0 is kPaddingLinearStateId; ids must never reach the
-  // checkpoint rows.
-  //
-  // BlockManagerImpl reserves id 0 by actually calling allocate() in its
-  // constructor and parking the returned Block in a member (padding_block_),
-  // relying on that Block's refcount staying >= 1 so free(0) is never reached.
-  // That indirection only exists because BlockManagerImpl has no in-use bitmap
-  // -- a Block handle is its only way to keep an id out of the free list. This
-  // manager already tracks occupancy in `in_use_ids_`, so it reserves id 0
-  // directly: mark it in use and never push it onto `free_ids_`. The observable
-  // contract is identical (id 0 unallocatable, usable count == num_blocks - 1,
-  // free(0) is a no-op); only the mechanism is simpler because the data
-  // structure differs.
-  in_use_ids_.resize(num_blocks, false);
-  usage_accounted_ids_.resize(num_blocks, false);
-  in_use_ids_[0] = true;
-  free_ids_.reserve(num_blocks - 1);
-  for (uint32_t id = 1; id < num_blocks; ++id) {
-    free_ids_.emplace_back(static_cast<int32_t>(num_blocks - id));
-  }
-  num_free_blocks_.store(free_ids_.size(), std::memory_order_relaxed);
-}
+      exhaustion_message_(std::move(exhaustion_message)) {}
 
-std::vector<Block> SingleBlockManager::allocate(size_t num_blocks) {
-  std::lock_guard<std::mutex> lock(mutex_);
-  if (num_blocks > num_free_blocks_.load(std::memory_order_relaxed)) {
-    return {};
+std::optional<std::vector<Block>> SingleBlockManager::allocate_for_sequence(
+    Sequence* seq,
+    size_t /*num_tokens*/) {
+  if (seq == nullptr) {
+    return std::nullopt;
   }
-
-  std::vector<Block> blocks;
-  blocks.reserve(num_blocks);
-  for (size_t i = 0; i < num_blocks; ++i) {
-    size_t prev_count =
-        num_free_blocks_.fetch_sub(1, std::memory_order_relaxed);
-    const int32_t block_id = free_ids_[prev_count - 1];
-    CHECK_GT(block_id, 0);
-    CHECK_LT(static_cast<size_t>(block_id), in_use_ids_.size());
-    CHECK(!in_use_ids_[block_id])
-        << resource_name_ << " id " << block_id << " was allocated repeatedly";
-    in_use_ids_[block_id] = true;
-    usage_accounted_ids_[block_id] = true;
-    blocks.emplace_back(block_id, this);
+  // One block per sequence, reused for its lifetime.
+  if (seq->kv_state().num_blocks(block_type()) > 0) {
+    return std::vector<Block>{};
   }
-  num_used_blocks_.fetch_add(num_blocks, std::memory_order_relaxed);
+  std::vector<Block> blocks = allocate(1);
+  if (blocks.empty()) {
+    LOG(ERROR) << "Failed to allocate " << resource_name_
+               << "! free=" << num_free_blocks()
+               << ", used=" << num_used_blocks()
+               << ", total=" << num_total_blocks()
+               << (exhaustion_message_.empty() ? "" : ". ")
+               << exhaustion_message_;
+    return std::nullopt;
+  }
   return blocks;
 }
 
 Block SingleBlockManager::allocate() {
-  std::lock_guard<std::mutex> lock(mutex_);
-  if (exhaustion_message_.empty()) {
-    CHECK_GT(num_free_blocks_.load(std::memory_order_relaxed), 0)
-        << "No more " << resource_name_ << " blocks available";
-  } else {
-    CHECK_GT(num_free_blocks_.load(std::memory_order_relaxed), 0)
-        << exhaustion_message_;
-  }
-  size_t prev_count = num_free_blocks_.fetch_sub(1, std::memory_order_relaxed);
-  const int32_t block_id = free_ids_[prev_count - 1];
-  CHECK_GT(block_id, 0);
-  CHECK_LT(static_cast<size_t>(block_id), in_use_ids_.size());
-  CHECK(!in_use_ids_[block_id])
-      << resource_name_ << " id " << block_id << " was allocated repeatedly";
-  in_use_ids_[block_id] = true;
-  usage_accounted_ids_[block_id] = true;
-  num_used_blocks_.fetch_add(1, std::memory_order_relaxed);
-  return {block_id, this};
-}
-
-void SingleBlockManager::deallocate(const Slice<Block>& blocks) {
-  for (const auto& block : blocks) {
-    if (!block.is_valid()) {
-      continue;
-    }
-    const int32_t block_id = block.id();
-    if (block_id < 0) {
-      continue;
-    }
-    std::lock_guard<std::mutex> lock(mutex_);
-    CHECK_LT(static_cast<size_t>(block_id), usage_accounted_ids_.size());
-
-    // Drop effective usage only when the deallocated reference is the last live
-    // `Block` reference. If shared aliases exist, `free()` will reconcile usage
-    // when the last alias releases the id.
-    if (usage_accounted_ids_[block_id] && block.ref_count() == 1) {
-      usage_accounted_ids_[block_id] = false;
-      CHECK_GT(num_used_blocks_.load(std::memory_order_relaxed), 0u);
-      num_used_blocks_.fetch_sub(1, std::memory_order_relaxed);
-    }
-  }
+  // Surface exhaustion with this resource's identity instead of the generic
+  // base message, then delegate to the counting allocate(1) path (the base
+  // zero-arg allocate() skips num_used accounting -- it exists for padding).
+  // The base ctor's padding reservation runs before this vtable entry is
+  // active, so it still uses BlockManagerImpl::allocate().
+  CHECK_GT(num_free_blocks(), 0u)
+      << (exhaustion_message_.empty()
+              ? "No more " + resource_name_ + " blocks available"
+              : exhaustion_message_);
+  std::vector<Block> blocks = BlockManagerImpl::allocate(1);
+  CHECK_EQ(blocks.size(), 1u);
+  return std::move(blocks[0]);
 }
 
 std::vector<Block> SingleBlockManager::allocate_shared(
@@ -140,8 +87,7 @@ std::vector<Block> SingleBlockManager::allocate_shared(
     const Slice<Block>& /*existed_shared_blocks*/,
     const MMData& /*mm_data*/,
     const Slice<XXH3Key>& /*block_hashes*/) {
-  // Prefix cache is disabled in this manager. Keep it substitutable with
-  // BlockManager behavior under enable_prefix_cache=false.
+  NOT_IMPLEMENTED();
   return {};
 }
 
@@ -150,57 +96,11 @@ void SingleBlockManager::cache(const Slice<int32_t>& /*token_ids*/,
                                size_t /*existed_shared_blocks_num*/,
                                const MMData& /*mm_data*/,
                                const Slice<XXH3Key>& /*block_hashes*/) {
-  // Prefix cache is disabled in this manager: no-op.
+  NOT_IMPLEMENTED();
 }
 
 void SingleBlockManager::cache(const std::vector<Block>& /*blocks*/) {
-  // Prefix cache is disabled in this manager: no-op.
+  NOT_IMPLEMENTED();
 }
-
-size_t SingleBlockManager::num_blocks_in_prefix_cache() const { return 0; }
-
-size_t SingleBlockManager::num_free_blocks() const { return num_free_blocks_; }
-
-size_t SingleBlockManager::num_used_blocks() const { return num_used_blocks_; }
-
-double SingleBlockManager::kv_cache_utilization() const {
-  const size_t total = num_total_blocks();
-  if (total == 0) {
-    return 0.0;
-  }
-  return static_cast<double>(num_used_blocks_.load(std::memory_order_relaxed)) /
-         static_cast<double>(total);
-}
-
-void SingleBlockManager::free(int32_t block_id) {
-  // id 0 is the reserved padding slot and is never returned to the pool. This
-  // mirrors BlockManagerImpl::free(), which guards the same id with
-  // `if (block_id != 0)`. The guard matters at teardown too: BlockManagerImpl's
-  // padding_block_ destructs and calls free(0), and here a stray Block(0) (e.g.
-  // from a defaulted/zeroed handle) could do the same -- both must be no-ops so
-  // the padding id is never recycled.
-  if (block_id <= 0) {
-    return;
-  }
-  std::lock_guard<std::mutex> lock(mutex_);
-  CHECK_LT(static_cast<size_t>(block_id), in_use_ids_.size());
-  CHECK(in_use_ids_[block_id])
-      << resource_name_ << " id " << block_id << " was deallocated repeatedly";
-  in_use_ids_[block_id] = false;
-
-  // If `deallocate()` was skipped (or called on a different alias), converge
-  // effective usage when the last `Block` reference releases the id.
-  if (usage_accounted_ids_[block_id]) {
-    usage_accounted_ids_[block_id] = false;
-    CHECK_GT(num_used_blocks_.load(std::memory_order_relaxed), 0u);
-    num_used_blocks_.fetch_sub(1, std::memory_order_relaxed);
-  }
-
-  size_t prev_count = num_free_blocks_.fetch_add(1, std::memory_order_relaxed);
-  CHECK_LT(prev_count, free_ids_.size());
-  free_ids_[prev_count] = block_id;
-}
-
-size_t SingleBlockManager::num_total_blocks() const { return free_ids_.size(); }
 
 }  // namespace xllm

--- a/xllm/core/framework/block/single_block_manager.h
+++ b/xllm/core/framework/block/single_block_manager.h
@@ -15,33 +15,49 @@ limitations under the License.
 
 #pragma once
 
-#include <atomic>
-#include <cstdint>
-#include <mutex>
 #include <string>
-#include <vector>
 
-#include "block_manager.h"
+#include "block_manager_impl.h"
 
 namespace xllm {
 
-class SingleBlockManager final : public BlockManager {
+// Per-sequence single-resource leaf (BlockType::SINGLE): linear-state /
+// embedding row id, exactly one block per sequence, reused for its lifetime.
+//
+// The physical id pool (free list, allocate / deallocate / free, num_*
+// accounting, id-0 padding) is identical to BlockManagerImpl, so this derives
+// from it and reuses that machinery. block_size is 1 (each id is one block) and
+// there is no prefix cache. What differs is the sequence-level policy: grow
+// allocates one block only when the sequence does not already hold one.
+class SingleBlockManager final : public BlockManagerImpl {
  public:
   SingleBlockManager(uint32_t num_blocks,
                      std::string resource_name,
                      std::string exhaustion_message = "");
   ~SingleBlockManager() override = default;
 
-  std::vector<Block> allocate(size_t num_blocks) override;
-  Block allocate() override;
-  void deallocate(const Slice<Block>& blocks) override;
+  // One block per sequence: empty when already held, else a single block (or
+  // std::nullopt when the pool is exhausted). Does not insert into the sequence
+  // -- the composite commits the returned block under BlockType::SINGLE.
+  std::optional<std::vector<Block>> allocate_for_sequence(
+      Sequence* seq,
+      size_t num_tokens) override;
 
+  // Single-block allocate: reuses the base free list but reports exhaustion
+  // with this resource's name / message. Only this leaf calls it directly (the
+  // base ctor's padding reservation runs before the vtable points here, so it
+  // still uses BlockManagerImpl::allocate()). Bring the base allocate(size_t)
+  // overload back into scope: declaring the zero-arg allocate() here would
+  // otherwise hide it (name hiding).
+  using BlockManagerImpl::allocate;
+  Block allocate() override;
+
+  // SINGLE never serves prefix cache; these must not be reached.
   std::vector<Block> allocate_shared(
       const Slice<int32_t>& token_ids,
       const Slice<Block>& existed_shared_blocks = {},
       const MMData& mm_data = MMData(),
       const Slice<XXH3Key>& block_hashes = {}) override;
-
   void cache(const Slice<int32_t>& token_ids,
              std::vector<Block>& blocks,
              size_t existed_shared_blocks_num = 0,
@@ -49,27 +65,9 @@ class SingleBlockManager final : public BlockManager {
              const Slice<XXH3Key>& block_hashes = {}) override;
   void cache(const std::vector<Block>& blocks) override;
 
-  size_t num_blocks_in_prefix_cache() const override;
-  size_t num_free_blocks() const override;
-  size_t num_used_blocks() const override;
-  double kv_cache_utilization() const override;
-  void free(int32_t block_id) override;
-  size_t num_total_blocks() const override;
-
  private:
-  std::vector<int32_t> free_ids_;
-  std::vector<bool> in_use_ids_;
-  // Tracks whether `num_used_blocks_` currently includes this block id.
-  // Semantics: `num_used_blocks()` reports logical/effective usage. It may
-  // temporarily differ from `num_free_blocks()` because `deallocate()` can
-  // drop effective usage before the last `Block` reference is released and
-  // the id is physically returned to `free_ids_` via `free()`.
-  std::vector<bool> usage_accounted_ids_;
-  std::atomic<size_t> num_free_blocks_{0};
-  std::atomic<size_t> num_used_blocks_{0};
   std::string resource_name_;
   std::string exhaustion_message_;
-  mutable std::mutex mutex_;
 };
 
 }  // namespace xllm

--- a/xllm/core/framework/block/sliding_window_block_manager.cpp
+++ b/xllm/core/framework/block/sliding_window_block_manager.cpp
@@ -15,16 +15,86 @@ limitations under the License.
 
 #include "sliding_window_block_manager.h"
 
+#include <algorithm>
+
 namespace xllm {
 
+namespace {
+
+// SWA never serves prefix cache; force it off so the base does not build one.
+BlockManager::Options without_prefix_cache(BlockManager::Options options) {
+  options.enable_prefix_cache(false);
+  return options;
+}
+
+}  // namespace
+
 SlidingWindowBlockManager::SlidingWindowBlockManager(const Options& options)
-    : BlockManagerImpl(options) {
+    : BlockManagerImpl(without_prefix_cache(options)) {
   CHECK_GT(options_.swa_blocks_per_seq(), 0u)
       << "swa_blocks_per_seq must be positive";
 }
 
-std::vector<Block> SlidingWindowBlockManager::allocate(size_t num_blocks) {
-  return BlockManagerImpl::allocate(num_blocks);
+void SlidingWindowBlockManager::release_out_of_window(Sequence* seq) {
+  if (seq == nullptr) {
+    return;
+  }
+  KVCacheState& kv_state = seq->kv_state();
+  std::vector<Block>& swa_blocks = *kv_state.mutable_blocks(block_type());
+  const size_t block_size = options_.block_size();
+  if (block_size == 0 || swa_blocks.empty()) {
+    return;
+  }
+  // Leading logical blocks that have fully slid out of the window can be freed.
+  // Runs AFTER the composite has committed this round's growth, and only on a
+  // successful allocation, so a failed allocate_sequence never releases the
+  // sequence's existing SWA blocks.
+  const size_t cached_tokens = kv_state.kv_cache_tokens_num();
+  const size_t sliding_window_tokens =
+      std::max<size_t>(options_.sliding_window_size(), 1);
+  if (cached_tokens < sliding_window_tokens) {
+    return;
+  }
+  const size_t skipped_tokens = cached_tokens - sliding_window_tokens + 1;
+  const size_t skipped_blocks = skipped_tokens / block_size;
+  const size_t release_blocks = std::min(skipped_blocks, swa_blocks.size());
+  if (release_blocks == 0) {
+    return;
+  }
+  // Move slid-out blocks out (leaving invalid placeholders so logical-position
+  // indexing stays stable) and deallocate them through the base free list. The
+  // is_valid() guard makes re-entry a safe no-op.
+  std::vector<Block> blocks_to_release;
+  blocks_to_release.reserve(release_blocks);
+  for (size_t j = 0; j < release_blocks; ++j) {
+    if (swa_blocks[j].is_valid()) {
+      blocks_to_release.emplace_back(std::move(swa_blocks[j]));
+    }
+  }
+  if (!blocks_to_release.empty()) {
+    deallocate(blocks_to_release);
+  }
+}
+
+std::vector<Block> SlidingWindowBlockManager::allocate_shared(
+    const Slice<int32_t>& /*token_ids*/,
+    const Slice<Block>& /*existed_shared_blocks*/,
+    const MMData& /*mm_data*/,
+    const Slice<XXH3Key>& /*block_hashes*/) {
+  NOT_IMPLEMENTED();
+  return {};
+}
+
+void SlidingWindowBlockManager::cache(const Slice<int32_t>& /*token_ids*/,
+                                      std::vector<Block>& /*blocks*/,
+                                      size_t /*existed_shared_blocks_num*/,
+                                      const MMData& /*mm_data*/,
+                                      const Slice<XXH3Key>& /*block_hashes*/) {
+  NOT_IMPLEMENTED();
+}
+
+void SlidingWindowBlockManager::cache(const std::vector<Block>& /*blocks*/) {
+  NOT_IMPLEMENTED();
 }
 
 }  // namespace xllm

--- a/xllm/core/framework/block/sliding_window_block_manager.h
+++ b/xllm/core/framework/block/sliding_window_block_manager.h
@@ -19,13 +19,44 @@ limitations under the License.
 
 namespace xllm {
 
-// Sliding-window sub-manager used by CompositeBlockManager.
+// Sliding-window leaf of CompositeBlockManager.
+//
+// The low-level physical block pool (free list, allocate / deallocate / free,
+// num_* accounting, id-0 padding) is identical to BlockManagerImpl, so this
+// derives from it and reuses that machinery unchanged. Growth is the base flat
+// append (allocate_for_sequence inherited). The sliding-window specifics are:
+//   - release_out_of_window() drops leading blocks that have slid out of the
+//     window; the composite calls it AFTER committing a successful round, so a
+//     failed allocate_sequence never releases the sequence's existing blocks;
+//   - the SWA block list grows by logical position and never shrinks in size;
+//     released leading positions become invalid placeholders;
+//   - the pool is sized with slack (see build_composite_leaves) so the peak
+//     "old blocks not yet released + new tail" fits without borrowing capacity;
+//   - no prefix cache.
 class SlidingWindowBlockManager : public BlockManagerImpl {
  public:
   explicit SlidingWindowBlockManager(const Options& options);
   ~SlidingWindowBlockManager() override = default;
 
-  std::vector<Block> allocate(size_t num_blocks) override;
+  // Release the leading SWA blocks of the sequence that have fully slid out of
+  // the window: move them out (leaving invalid placeholders so logical-position
+  // indexing stays stable) and return their ids to the pool. Called by the
+  // composite after a successful allocate commit. Growth reuses the inherited
+  // BlockManagerImpl::allocate_for_sequence (flat append).
+  void release_out_of_window(Sequence* seq) override;
+
+  // SWA never serves prefix cache; these must not be reached.
+  std::vector<Block> allocate_shared(
+      const Slice<int32_t>& token_ids,
+      const Slice<Block>& existed_shared_blocks = {},
+      const MMData& mm_data = MMData(),
+      const Slice<XXH3Key>& block_hashes = {}) override;
+  void cache(const Slice<int32_t>& token_ids,
+             std::vector<Block>& blocks,
+             size_t existed_shared_blocks_num = 0,
+             const MMData& mm_data = MMData(),
+             const Slice<XXH3Key>& block_hashes = {}) override;
+  void cache(const std::vector<Block>& blocks) override;
 
   uint32_t swa_blocks_per_seq() const { return options_.swa_blocks_per_seq(); }
 };

--- a/xllm/core/framework/request/sequence_kv_state.cpp
+++ b/xllm/core/framework/request/sequence_kv_state.cpp
@@ -70,6 +70,19 @@ size_t KVCacheState::num_blocks(BlockType type) const {
   return it == composite_blocks_.end() ? 0 : it->second.size();
 }
 
+bool KVCacheState::has_any_blocks() const {
+  // Cache-bearing types only; SINGLE is a per-sequence resource block, not
+  // token cache, and must not count toward "the sequence already holds cache".
+  for (const BlockType type :
+       {BlockType::KV, BlockType::SWA, BlockType::C4, BlockType::C128}) {
+    const auto it = composite_blocks_.find(type);
+    if (it != composite_blocks_.end() && !it->second.empty()) {
+      return true;
+    }
+  }
+  return false;
+}
+
 std::vector<int32_t> KVCacheState::cache_slots(BlockType type,
                                                int32_t pos_start,
                                                int32_t pos_end) {

--- a/xllm/core/framework/request/sequence_kv_state.h
+++ b/xllm/core/framework/request/sequence_kv_state.h
@@ -40,6 +40,11 @@ class KVCacheState {
   std::vector<Block>* mutable_blocks(BlockType type);
   // Number of blocks held under `type`.
   size_t num_blocks(BlockType type) const;
+  // True if the sequence holds any cache-bearing blocks (KV / SWA / C4 / C128).
+  // Excludes SINGLE, which is a per-sequence resource, not token cache. Used to
+  // decide whether an allocation that started from an empty sequence should be
+  // fully rolled back on failure (vs. a grow on an already-populated sequence).
+  bool has_any_blocks() const;
   // token <-> physical slot mapping for `type` (paged attention). CHECKs the
   // type is present.
   std::vector<int32_t> cache_slots(BlockType type,

--- a/xllm/core/framework/xtensor/xtensor_block_manager_impl.cpp
+++ b/xllm/core/framework/xtensor/xtensor_block_manager_impl.cpp
@@ -158,6 +158,29 @@ std::vector<Block> XTensorBlockManagerImpl::allocate(size_t num_blocks) {
   return blocks;
 }
 
+std::optional<std::vector<Block>>
+XTensorBlockManagerImpl::allocate_for_sequence(Sequence* seq,
+                                               size_t num_tokens) {
+  if (seq == nullptr) {
+    return std::nullopt;
+  }
+  const size_t block_size = options_.block_size();
+  if (block_size == 0) {
+    return std::vector<Block>{};
+  }
+  const size_t held = seq->kv_state().num_blocks(block_type());
+  const size_t num_blocks_needed = (num_tokens + block_size - 1) / block_size;
+  if (num_blocks_needed <= held) {
+    return std::vector<Block>{};
+  }
+  const size_t num_additional = num_blocks_needed - held;
+  std::vector<Block> blocks = allocate(num_additional);  // VMM page alloc
+  if (blocks.size() != num_additional) {
+    return std::nullopt;
+  }
+  return blocks;
+}
+
 Block XTensorBlockManagerImpl::allocate() {
   auto blocks = allocate(1);
   if (blocks.empty()) {

--- a/xllm/core/framework/xtensor/xtensor_block_manager_impl.h
+++ b/xllm/core/framework/xtensor/xtensor_block_manager_impl.h
@@ -61,6 +61,16 @@ class XTensorBlockManagerImpl : public BlockManager {
   // Deallocate blocks
   void deallocate(const Slice<Block>& blocks) override;
 
+  // Flat incremental growth: allocate ceil(num_tokens/block_size) - held blocks
+  // (physical allocate() maps VMM pages) and return them; the
+  // CompositeBlockManager commits them under BlockType::KV. std::nullopt on
+  // shortage. XTensor derives from BlockManager (the pure interface), not
+  // BlockManagerImpl (whose pool is a free list, not VMM pages), so it
+  // implements this directly.
+  std::optional<std::vector<Block>> allocate_for_sequence(
+      Sequence* seq,
+      size_t num_tokens) override;
+
   // Allocate shared blocks (prefix cache not supported)
   std::vector<Block> allocate_shared(
       const Slice<int32_t>& token_ids,
@@ -114,7 +124,7 @@ class XTensorBlockManagerImpl : public BlockManager {
 
   // Reserve padding block for padding tokens.
   // Should be called after KV tensors are created.
-  void reserve_xtensor_padding_blocks();
+  void reserve_xtensor_padding_blocks() override;
 
  private:
   DISALLOW_COPY_AND_ASSIGN(XTensorBlockManagerImpl);


### PR DESCRIPTION
Finalize the device-side KV block-manager composition refactor: the pool always
holds a CompositeBlockManager that owns every block leaf (KV / SWA / C4 / C128 /
SINGLE, and the xtensor KV leaf) keyed by BlockType. Schedulers see an unchanged
KVCacheManager interface.

Core changes:
- BlockManager is now a pure interface; the flat-KV allocate_for_sequence default
  moves into BlockManagerImpl. Leaves return newly allocated blocks and the
  composite stages + commits them into the sequence by BlockType (staged-commit,
  no-snapshot rollback).
- SlidingWindow / Single re-derive from BlockManagerImpl, reusing its single
  free-list / allocate / deallocate / free / id-0 padding; they override only the
  sequence-level policy. SWA growth is flat-append; slid-out blocks are released
  via release_out_of_window() after a successful commit (a failed round never
  releases the sequence's existing blocks).
- xtensor folded into the composite as the KV leaf when enable_xtensor; pool loses
  all allocate-path enable_xtensor() branches and the separate
  single_block_managers_ / allocate_single_block / deallocate_single_block. The
  xtensor-specific prefix logic in cache()/allocate_shared() is removed (xtensor
  has no prefix cache; the composite skips it via LeafEntry.supports_prefix_cache).
- ConcurrentBlockManagerImpl wraps a leaf by composition with a recursive_mutex,
  redirecting each returned Block's owner via Block::set_manager so the free path
  is covered by the wrapper lock.

Fixes (see review):
- BlockManagerPool::allocate(size_t, dp_rank&) routed to the KV leaf via
  allocate_blocks(BlockType::KV, n) instead of the composite's NOT_IMPLEMENTED
  allocate(size_t) (was aborting; hit by request_prefix_cache_tokens_test).
- started_empty now uses KVCacheState::has_any_blocks() (KV/SWA/C4/C128, excludes
  SINGLE) so a failed DSV4 grow no longer deallocate+resets existing blocks.
- Composite capacity stats (num_free/used/total_blocks) report the single
  finest-grained admission leaf (capacity_leaf) instead of mixing leaves of
  different block sizes, preserving the pre-refactor scheduler-facing unit.

Tests: block_test, concurrent_block_manager_test, sequence_kv_state_test,
request_prefix_cache_tokens_test all pass.






```mermaid
classDiagram
  class KVCacheManager {
    <<interface>>
    +allocate(Sequence*, num_tokens) bool
    +try_allocate(Sequence*) bool
    +deallocate(Sequence*)
    +allocate_shared(Sequence*)
    +cache(Sequence*)
    +num_free_blocks() vector~size_t~
  }

  class BlockManagerPool {
    -Options options_
    -vector~unique_ptr~BlockManager~~ block_managers_  // 每 dp 一个 Composite
    -vector~vector~BlockTransferInfo~~ swap_block_transfer_infos_
    +allocate(Sequence*, num_tokens) bool   // 路由 dp + 转发
    +allocate(size_t, dp_rank&) vector~Block~  // 路由 composite KV leaf
    +deallocate(Sequence*)
    -get_dp_rank(Sequence*) int32_t
  }
  note for BlockManagerPool "无 single_block_managers_<br/>无 is_composite 分叉<br/>无 enable_xtensor() 分配分叉（只剩 reserve 守卫）<br/>process_beam_search 保留（改用 composite.allocate_blocks）<br/>reserve_xtensor_padding_blocks 转发 composite（无 dynamic_cast）"

  class BlockManager {
    <<abstract>>
    +Options options_
    +block_type() BlockType
    +allocate(size_t) vector~Block~
    +deallocate(Slice~Block~)
    +allocate_shared(token_ids, ...) vector~Block~
    +cache(token_ids, blocks, ...)
    +free(int32_t)
    +num_free_blocks() / num_used_blocks() / num_total_blocks() size_t
    +allocate_for_sequence(Sequence*, num_tokens) optional~vector~Block~~  // 默认 flat 增长，返回新块、不插入
    +release_out_of_window(Sequence*)        // 默认 no-op，仅 SWA override
    +reset_prefix_cache()
    +reserve_xtensor_padding_blocks()
  }
  note for BlockManager "所有 BlockManager（含 leaves）都能访问 Sequence<br/>leaf 自报 block_type()，自读 seq->kv_state().num_blocks(block_type())<br/>无 plan_* 接口（早期草案，已删）"

  class CompositeBlockManager {
    -map~BlockType, LeafEntry~ leaves_   // key 决定块在 sequence 的槽位
    +allocate_sequence(Sequence*, n) bool   // 逐 leaf allocate_for_sequence→暂存→按 key add_blocks→release_out_of_window
    +deallocate_for_sequence(Sequence*)          // 先 cache 再按 key deallocate
    +allocate_shared_for_sequence(Sequence*)     // KV-only 直连 leaf.allocate_shared
    +cache_for_sequence(Sequence*)               // KV-only 直连 leaf.cache
    +allocate_blocks(BlockType, n) vector~Block~  // 路由 map[type]（供 beam COW / pool 兼容 allocate）
    +reset_prefix_cache()                // fan-out 各 leaf
    +num_free_blocks() / num_used_blocks() / num_total_blocks() size_t  // capacity_leaf 原始块数
    +allocate(size_t) vector~Block~      // NOT_IMPLEMENTED
  }
  note for CompositeBlockManager "不持有 block 池/Sequence 状态；只编排 leaves<br/>LeafEntry={leaf, participates_in_admission, supports_prefix_cache}<br/>admission/prefix 角色在 LeafEntry；stats 取 capacity_leaf（最小 bs 的 admission leaf）"

  class BlockManagerImpl {
    -unique_ptr~PrefixCache~ prefix_cache_
    -vector~int32_t~ free_blocks_ / usage_accounted_ids_
    +allocate / deallocate / free / num_*    // 唯一一份底层 block 池实现
    +allocate_for_sequence(...)              // 基类默认：flat 增长（KV/C4/C128/xtensor 复用）
    +allocate_shared / cache                 // prefix match / insert（prefix 开时）
  }

  class SlidingWindowBlockManager {
    +release_out_of_window(Sequence*)    // 释放滑出窗口的 leading 块（留 invalid 占位）
    +allocate_shared / cache             // override = NOT_IMPLEMENTED
  }

  class SingleBlockManager {
    +allocate_for_sequence(...)          // 已持有返回空，否则分配 1 块
    +allocate() Block                    // 带 resource_name/exhaustion 文案，委托基类 allocate(1)
    +allocate_shared / cache             // override = NOT_IMPLEMENTED
  }

  class XTensorBlockManagerImpl {
    +allocate / free                     // VMM 页 map/unmap（替代 free-list）
    +allocate_for_sequence(...)          // 继承基类 flat 增长，底层走 VMM
    +reserve_xtensor_padding_blocks()    // override：KV tensors 建好后预留 padding 页
  }

  class ConcurrentBlockManagerImpl {
    -unique_ptr~BlockManager~ inner_     // 永远是叶子
    -recursive_mutex mutex_
    +allocate / deallocate / allocate_for_sequence  // lock + inner_，返回前 Block::set_manager(this)
  }

  KVCacheManager <|.. BlockManagerPool
  BlockManager <|-- CompositeBlockManager
  BlockManager <|-- BlockManagerImpl
  BlockManager <|-- XTensorBlockManagerImpl
  BlockManager <|-- ConcurrentBlockManagerImpl
  BlockManagerImpl <|-- SlidingWindowBlockManager
  BlockManagerImpl <|-- SingleBlockManager
  BlockManager ..> Sequence : reads/writes kv_state()
  BlockManagerPool o-- "N(dp)" CompositeBlockManager : owns
  CompositeBlockManager o-- "M(BlockType→leaf)" BlockManager : owns leaves_ (map)
  ConcurrentBlockManagerImpl o-- "1" BlockManager : wraps inner_ (leaf)
```