### PR TITLE
perf: reduce qwen3.5 moe allreduce overhead.

### DIFF
--- a/xllm/core/layers/npu_torch/fused_moe.cpp
+++ b/xllm/core/layers/npu_torch/fused_moe.cpp
@@ -1095,8 +1095,8 @@ torch::Tensor FusedMoEImpl::forward_expert(
         final_hidden_states =
             parallel_state::reduce(final_hidden_states, tp_pg_);
       }
-      final_hidden_states = parallel_state::reduce(final_hidden_states,
-                                                   parallel_args_.moe_ep_group_);
+      final_hidden_states = parallel_state::reduce(
+          final_hidden_states, parallel_args_.moe_ep_group_);
 
       auto reduced_shared_output = shared_output.value();
       if (tp_pg_->world_size() > 1) {
@@ -1110,8 +1110,8 @@ torch::Tensor FusedMoEImpl::forward_expert(
       final_hidden_states = parallel_state::reduce(final_hidden_states, tp_pg_);
     }
     if (parallel_args_.ep_size() > 1) {
-      final_hidden_states = parallel_state::reduce(final_hidden_states,
-                                                   parallel_args_.moe_ep_group_);
+      final_hidden_states = parallel_state::reduce(
+          final_hidden_states, parallel_args_.moe_ep_group_);
     }
   }
   return final_hidden_states;

--- a/xllm/core/layers/npu_torch/fused_moe.cpp
+++ b/xllm/core/layers/npu_torch/fused_moe.cpp
@@ -1085,7 +1085,7 @@ torch::Tensor FusedMoEImpl::forward_expert(
     if (parallel_args_.ep_size() == 1) {
       // reduce(a) + reduce(b) == reduce(a + b). Combining the routed and shared
       // partial outputs avoids one small TP allreduce in each MoE decode layer.
-      final_hidden_states = final_hidden_states + shared_output.value();
+      final_hidden_states.add_(shared_output.value());
       if (tp_pg_->world_size() > 1) {
         final_hidden_states =
             parallel_state::reduce(final_hidden_states, tp_pg_);

--- a/xllm/core/layers/npu_torch/fused_moe.cpp
+++ b/xllm/core/layers/npu_torch/fused_moe.cpp
@@ -1081,20 +1081,38 @@ torch::Tensor FusedMoEImpl::forward_expert(
   // reshape the final hidden states to the original shape
   final_hidden_states = final_hidden_states.reshape(hidden_states_shape);
 
-  if (tp_pg_->world_size() > 1) {
-    final_hidden_states = parallel_state::reduce(final_hidden_states, tp_pg_);
-  }
-  if (parallel_args_.ep_size() > 1) {
-    final_hidden_states = parallel_state::reduce(final_hidden_states,
-                                                 parallel_args_.moe_ep_group_);
-  }
   if (shared_output.has_value()) {
-    auto reduced_shared_output = shared_output.value();
-    if (tp_pg_->world_size() > 1) {
-      reduced_shared_output =
-          parallel_state::reduce(reduced_shared_output, tp_pg_);
+    if (parallel_args_.ep_size() == 1) {
+      // reduce(a) + reduce(b) == reduce(a + b). Combining the routed and shared
+      // partial outputs avoids one small TP allreduce in each MoE decode layer.
+      final_hidden_states = final_hidden_states + shared_output.value();
+      if (tp_pg_->world_size() > 1) {
+        final_hidden_states =
+            parallel_state::reduce(final_hidden_states, tp_pg_);
+      }
+    } else {
+      if (tp_pg_->world_size() > 1) {
+        final_hidden_states =
+            parallel_state::reduce(final_hidden_states, tp_pg_);
+      }
+      final_hidden_states = parallel_state::reduce(final_hidden_states,
+                                                   parallel_args_.moe_ep_group_);
+
+      auto reduced_shared_output = shared_output.value();
+      if (tp_pg_->world_size() > 1) {
+        reduced_shared_output =
+            parallel_state::reduce(reduced_shared_output, tp_pg_);
+      }
+      final_hidden_states = final_hidden_states + reduced_shared_output;
     }
-    final_hidden_states = final_hidden_states + reduced_shared_output;
+  } else {
+    if (tp_pg_->world_size() > 1) {
+      final_hidden_states = parallel_state::reduce(final_hidden_states, tp_pg_);
+    }
+    if (parallel_args_.ep_size() > 1) {
+      final_hidden_states = parallel_state::reduce(final_hidden_states,
+                                                   parallel_args_.moe_ep_group_);
+    }
   }
   return final_hidden_states;
 }


### PR DESCRIPTION
## 背景

Qwen3.5 MoE 模型在 NPU TP decode 场景下，routed expert 输出和 shared expert
输出都会产生 Tensor Parallel allreduce。profiling 显示，这类小粒度
`allreduceAicpuKernel` wrapper 的调用次数会直接影响 TPOT。

原始 xLLM MoE decode 路径中，routed expert output 和 shared expert output 分别做
TP allreduce：

```text
reduce(routed_partial) + reduce(shared_partial)
```

当 `ep_size == 1` 时，二者都是同一个 TP group 上的 partial output，allreduce 具备
线性性质，因此可以改写为：

```text
reduce(routed_partial + shared_partial)
```

这样每个 MoE decode layer 可以少一次 shared expert 的小 TP allreduce。

## 改动内容

- 在 `parallel_args_.ep_size() == 1` 时，先将 routed MoE output 和 shared expert
  output 相加，再做一次 TP allreduce。
- 合并时使用 in-place `add_`，避免 hot path 上额外 tensor 分配。
- 保持 `ep_size > 1` 路径不变：routed output 仍按原逻辑先做 TP reduce 和 MoE EP
  group reduce，shared expert output 仍单独做 TP reduce 后再相加。
- 保持无 shared expert 的路径语义不变。

## 通信量减少

本改动减少的是 decode 阶段小粒度 TP allreduce wrapper 调用次数，而不是单次 HCCL
payload 大小。

以 Qwen3.5-35B-A3B 为例，该模型有 40 层 MoE/Hybrid decode 路径。原始路径每层大致
包含：

```text
1 次 attention / linear-attention output TP reduce
1 次 routed MoE output TP reduce
1 次 shared expert output TP reduce
```

即约 `40 * 3 = 120` 次 allreduce wrapper / decode step。

本改动后，`ep_size == 1` 的 MoE 层中 routed output 和 shared output 共用一次 TP
reduce：

```text
1 次 attention / linear-attention output TP reduce
1 次 combined MoE output TP reduce
```

即约 `40 * 2 = 80` 次 allreduce wrapper / decode step。

在 Qwen3-Next 的补充 profiling 中也能看到同样趋势：allreduce wrapper 调用密度从
约 `146.88/step` 降到 `96.75/token`，与预期的少一次 shared expert TP reduce 对齐。

| 场景 | allreduceAicpuKernel count | 归一化调用次数 | 平均 wrapper 时间 |
|---|---:|---:|---:|
| Qwen3-Next 原始 xLLM profiling | 7344 | 146.88 / decode step | 146.557 us |
| vLLM-Ascend 参考 profiling | 4782-4850 | 约 98-100 / decode step | 约 98-100 us |
| Qwen3-Next 本改动后 profiling | 37152 | 96.75 / generated token | 141.485 us |

这说明本 PR 主要解决的是“allreduce 调用次数过多”。剩余 gap 仍主要来自单次
wrapper 的下发和同步成本。

## 性能收益

### Qwen3.5-35B-A3B 主验证

测试模型：

```text
Qwen3.5-35B-A3B
TP=4
NPU
```

关键启动参数：

```text
enable_graph=true
enable_schedule_overlap=true
enable_chunked_prefill=false
enable_prefix_cache=false
max_tokens_per_batch=256
max_seqs_per_batch=1
```

评测 workload：

```text
input_tokens=128
output_tokens=128
parallel=1
```

稳态实测结果：

| 场景 | stream TPOT | e2e TPOT | TTFT |
|---|---:|---:|---:|
| baseline | 10.518 ms | 11.296 ms | 109.871 ms |
| 本改动后 | 9.928 ms | 10.679 ms | 105.875 ms |

收益：

- stream TPOT 下降 `0.591 ms/token`，提升 `5.61%`
- e2e TPOT 下降 `0.617 ms/token`，提升 `5.46%`

### Qwen3-Next 补充验证

同一 MoE reduce 优化也在 Qwen3-Next-80B-A3B-Instruct 上做了补充验证：

```text
Qwen3-Next-80B-A3B-Instruct
TP=4
NPU
input_tokens=128
output_tokens=128
parallel=1
enable_graph=true
enable_schedule_overlap=true
```

稳态实测结果：

| 场景 | stream TPOT | e2e TPOT | TTFT |
|---|---:|---:|---:|
| baseline | 14.421 ms | 15.340 ms | 131.807 ms |
| 本改动后 | 13.658 ms | 14.559 ms | 128.745 ms |

收益：

- stream TPOT 下降 `0.762 ms/token`，提升 `5.29%`
- e2e TPOT 提升 `5.09%`

## 验证说明

- 已完成 xLLM 编译。
- 已使用 `Qwen3.5-35B-A3B` TP4 启动服务并完成 before / after TPOT 对比。
- 已确认 `enable_graph=true` 和 `enable_schedule_overlap=true` 同时开启。
- 已补充验证 `Qwen3-Next-80B-A3B-Instruct` TP4 的 TPOT 与 profiling signature。
