### PR TITLE
bugfix: guard GLM5 model args registration macro.

### DIFF
--- a/xllm/models/llm/npu/glm5_moe.h
+++ b/xllm/models/llm/npu/glm5_moe.h
@@ -319,69 +319,72 @@ TORCH_MODULE(GlmMoeDsaForCausalLM);
 REGISTER_CAUSAL_MODEL(glm_moe_dsa, GlmMoeDsaForCausalLM);
 
 // register the model args
-REGISTER_MODEL_ARGS(glm_moe_dsa, [&] {
-  LOAD_ARG_OR(model_type, "model_type", "glm_moe_dsa");
-  LOAD_ARG_OR(dtype, "dtype", "");
-  LOAD_ARG_OR(attention_bias, "attention_bias", false);
-  LOAD_ARG_OR(attention_dropout, "attention_dropout", 0.0f);
+REGISTER_MODEL_ARGS(
+    glm_moe_dsa,
+    ([&] {
+      LOAD_ARG_OR(model_type, "model_type", "glm_moe_dsa");
+      LOAD_ARG_OR(dtype, "dtype", "");
+      LOAD_ARG_OR(attention_bias, "attention_bias", false);
+      LOAD_ARG_OR(attention_dropout, "attention_dropout", 0.0f);
 
-  LOAD_ARG_OR(vocab_size, "vocab_size", 154880);
-  LOAD_ARG_OR(hidden_size, "hidden_size", 6144);
-  LOAD_ARG_OR(n_layers, "num_hidden_layers", 78);
-  LOAD_ARG_OR(n_heads, "num_attention_heads", 64);
-  LOAD_ARG_OR(n_kv_heads, "num_key_value_heads", 64);
-  LOAD_ARG_OR(intermediate_size, "intermediate_size", 12288);
-  LOAD_ARG_OR(max_position_embeddings, "max_position_embeddings", 202752);
-  LOAD_ARG_OR(rms_norm_eps, "rms_norm_eps", 1e-5);
-  LOAD_ARG_OR_FUNC(eos_token_id_vec, "eos_token_id", [&] {
-    return std::vector<int32_t>{154820, 154827, 154829};
-  });
-  LOAD_ARG_OR(bos_token_id, "bos_token_id", 0);
-  LOAD_ARG_OR(rope_theta, "rope_parameters.rope_theta", 1000000.0f);
+      LOAD_ARG_OR(vocab_size, "vocab_size", 154880);
+      LOAD_ARG_OR(hidden_size, "hidden_size", 6144);
+      LOAD_ARG_OR(n_layers, "num_hidden_layers", 78);
+      LOAD_ARG_OR(n_heads, "num_attention_heads", 64);
+      LOAD_ARG_OR(n_kv_heads, "num_key_value_heads", 64);
+      LOAD_ARG_OR(intermediate_size, "intermediate_size", 12288);
+      LOAD_ARG_OR(max_position_embeddings, "max_position_embeddings", 202752);
+      LOAD_ARG_OR(rms_norm_eps, "rms_norm_eps", 1e-5);
+      LOAD_ARG_OR_FUNC(eos_token_id_vec, "eos_token_id", [&] {
+        return std::vector<int32_t>{154820, 154827, 154829};
+      });
+      LOAD_ARG_OR(bos_token_id, "bos_token_id", 0);
+      LOAD_ARG_OR(rope_theta, "rope_parameters.rope_theta", 1000000.0f);
 
-  LOAD_ARG_OR(use_sliding_window, "use_sliding_window", false);
-  LOAD_ARG_OR(sliding_window, "sliding_window", 4096);
-  LOAD_ARG_OR(max_window_layers, "max_window_layers", 61);
+      LOAD_ARG_OR(use_sliding_window, "use_sliding_window", false);
+      LOAD_ARG_OR(sliding_window, "sliding_window", 4096);
+      LOAD_ARG_OR(max_window_layers, "max_window_layers", 61);
 
-  LOAD_ARG_OR(first_k_dense_replace, "first_k_dense_replace", 3);
-  LOAD_ARG_OR(hidden_act, "hidden_act", "silu");
-  LOAD_ARG_OR(moe_layer_freq, "moe_layer_freq", 1);
-  LOAD_ARG_OR(topk_method, "topk_method", "noaux_tc");
-  LOAD_ARG_OR(n_routed_experts, "n_routed_experts", 256);
-  LOAD_ARG_OR(n_shared_experts, "n_shared_experts", 1);
-  LOAD_ARG_OR(num_experts_per_tok, "num_experts_per_tok", 8);
-  LOAD_ARG_OR(moe_intermediate_size, "moe_intermediate_size", 2048);
-  LOAD_ARG_OR(routed_scaling_factor, "routed_scaling_factor", 2.5f);
-  LOAD_ARG_OR(norm_topk_prob, "norm_topk_prob", true);
-  LOAD_ARG_OR(n_group, "n_group", 1);
-  LOAD_ARG_OR(topk_group, "topk_group", 1);
-  LOAD_ARG_OR(scoring_func, "scoring_func", "sigmoid");
-  LOAD_ARG_OR(qk_nope_head_dim, "qk_nope_head_dim", 192);
-  LOAD_ARG_OR(qk_rope_head_dim, "qk_rope_head_dim", 64);
-  LOAD_ARG_OR(v_head_dim, "v_head_dim", 256);
-  LOAD_ARG_OR(q_lora_rank, "q_lora_rank", 2048);
-  LOAD_ARG_OR(kv_lora_rank, "kv_lora_rank", 512);
-  LOAD_ARG_OR(index_head_dim, "index_head_dim", 128);
-  LOAD_ARG_OR(num_nextn_predict_layers, "num_nextn_predict_layers", 1);
-  LOAD_ARG_OR(index_n_heads, "index_n_heads", 32);
-  LOAD_ARG_OR(index_topk, "index_topk", 2048);
-  LOAD_ARG_OR(index_topk_freq, "index_topk_freq", 1);
-  LOAD_ARG_OR(index_topk_pattern, "index_topk_pattern", "");
-  LOAD_ARG_OR(index_skip_topk_offset, "index_skip_topk_offset", 0);
-  LOAD_ARG_OR(
-      index_share_for_mtp_iteration, "index_share_for_mtp_iteration", false);
+      LOAD_ARG_OR(first_k_dense_replace, "first_k_dense_replace", 3);
+      LOAD_ARG_OR(hidden_act, "hidden_act", "silu");
+      LOAD_ARG_OR(moe_layer_freq, "moe_layer_freq", 1);
+      LOAD_ARG_OR(topk_method, "topk_method", "noaux_tc");
+      LOAD_ARG_OR(n_routed_experts, "n_routed_experts", 256);
+      LOAD_ARG_OR(n_shared_experts, "n_shared_experts", 1);
+      LOAD_ARG_OR(num_experts_per_tok, "num_experts_per_tok", 8);
+      LOAD_ARG_OR(moe_intermediate_size, "moe_intermediate_size", 2048);
+      LOAD_ARG_OR(routed_scaling_factor, "routed_scaling_factor", 2.5f);
+      LOAD_ARG_OR(norm_topk_prob, "norm_topk_prob", true);
+      LOAD_ARG_OR(n_group, "n_group", 1);
+      LOAD_ARG_OR(topk_group, "topk_group", 1);
+      LOAD_ARG_OR(scoring_func, "scoring_func", "sigmoid");
+      LOAD_ARG_OR(qk_nope_head_dim, "qk_nope_head_dim", 192);
+      LOAD_ARG_OR(qk_rope_head_dim, "qk_rope_head_dim", 64);
+      LOAD_ARG_OR(v_head_dim, "v_head_dim", 256);
+      LOAD_ARG_OR(q_lora_rank, "q_lora_rank", 2048);
+      LOAD_ARG_OR(kv_lora_rank, "kv_lora_rank", 512);
+      LOAD_ARG_OR(index_head_dim, "index_head_dim", 128);
+      LOAD_ARG_OR(num_nextn_predict_layers, "num_nextn_predict_layers", 1);
+      LOAD_ARG_OR(index_n_heads, "index_n_heads", 32);
+      LOAD_ARG_OR(index_topk, "index_topk", 2048);
+      LOAD_ARG_OR(index_topk_freq, "index_topk_freq", 1);
+      LOAD_ARG_OR(index_topk_pattern, "index_topk_pattern", "");
+      LOAD_ARG_OR(index_skip_topk_offset, "index_skip_topk_offset", 0);
+      LOAD_ARG_OR(index_share_for_mtp_iteration,
+                  "index_share_for_mtp_iteration",
+                  false);
 
-  LOAD_ARG_OR(use_qk_norm, "use_qk_norm", true);
-  LOAD_ARG_OR(indexer_rope_interleave, "indexer_rope_interleave", true);
-  LOAD_ARG_OR(rope_theta, "rope_theta", args->rope_theta());
-  LOAD_ARG_OR(tie_word_embeddings, "tie_word_embeddings", false);
+      LOAD_ARG_OR(use_qk_norm, "use_qk_norm", true);
+      LOAD_ARG_OR(indexer_rope_interleave, "indexer_rope_interleave", true);
+      LOAD_ARG_OR(rope_theta, "rope_theta", args->rope_theta());
+      LOAD_ARG_OR(tie_word_embeddings, "tie_word_embeddings", false);
 
-  SET_ARG(head_dim, args->qk_nope_head_dim() + args->qk_rope_head_dim());
-  LOAD_ARG_OR_FUNC(
-      rotary_dim, "rotary_dim", [&] { return args->qk_rope_head_dim(); });
+      SET_ARG(head_dim, args->qk_nope_head_dim() + args->qk_rope_head_dim());
+      LOAD_ARG_OR_FUNC(
+          rotary_dim, "rotary_dim", [&] { return args->qk_rope_head_dim(); });
 
-  SET_ARG(stop_token_ids,
-          std::unordered_set<int32_t>(args->eos_token_id_vec().begin(),
-                                      args->eos_token_id_vec().end()));
-});
+      SET_ARG(stop_token_ids,
+              std::unordered_set<int32_t>(args->eos_token_id_vec().begin(),
+                                          args->eos_token_id_vec().end()));
+    }));
 }  // namespace xllm::npu::model

--- a/xllm/models/llm/npu/glm5_moe_mtp.h
+++ b/xllm/models/llm/npu/glm5_moe_mtp.h
@@ -82,69 +82,72 @@ TORCH_MODULE(GlmMoeDsaMtpForCausalLM);
 // register the causal model
 REGISTER_CAUSAL_MODEL(glm_moe_dsa_mtp, GlmMoeDsaMtpForCausalLM);
 
-REGISTER_MODEL_ARGS(glm_moe_dsa_mtp, [&] {
-  LOAD_ARG_OR(model_type, "model_type", "glm_moe_dsa_mtp");
-  LOAD_ARG_OR(dtype, "dtype", "");
-  LOAD_ARG_OR(attention_bias, "attention_bias", false);
-  LOAD_ARG_OR(attention_dropout, "attention_dropout", 0.0f);
+REGISTER_MODEL_ARGS(
+    glm_moe_dsa_mtp,
+    ([&] {
+      LOAD_ARG_OR(model_type, "model_type", "glm_moe_dsa_mtp");
+      LOAD_ARG_OR(dtype, "dtype", "");
+      LOAD_ARG_OR(attention_bias, "attention_bias", false);
+      LOAD_ARG_OR(attention_dropout, "attention_dropout", 0.0f);
 
-  LOAD_ARG_OR(vocab_size, "vocab_size", 154880);
-  LOAD_ARG_OR(hidden_size, "hidden_size", 6144);
-  LOAD_ARG_OR(n_layers, "num_hidden_layers", 1);
-  LOAD_ARG_OR(n_heads, "num_attention_heads", 64);
-  LOAD_ARG_OR(n_kv_heads, "num_key_value_heads", 64);
-  LOAD_ARG_OR(intermediate_size, "intermediate_size", 12288);
-  LOAD_ARG_OR(max_position_embeddings, "max_position_embeddings", 202752);
-  LOAD_ARG_OR(rms_norm_eps, "rms_norm_eps", 1e-5);
-  LOAD_ARG_OR_FUNC(eos_token_id_vec, "eos_token_id", [&] {
-    return std::vector<int32_t>{154820, 154827, 154829};
-  });
-  LOAD_ARG_OR(bos_token_id, "bos_token_id", 0);
-  LOAD_ARG_OR(rope_theta, "rope_parameters.rope_theta", 1000000.0f);
+      LOAD_ARG_OR(vocab_size, "vocab_size", 154880);
+      LOAD_ARG_OR(hidden_size, "hidden_size", 6144);
+      LOAD_ARG_OR(n_layers, "num_hidden_layers", 1);
+      LOAD_ARG_OR(n_heads, "num_attention_heads", 64);
+      LOAD_ARG_OR(n_kv_heads, "num_key_value_heads", 64);
+      LOAD_ARG_OR(intermediate_size, "intermediate_size", 12288);
+      LOAD_ARG_OR(max_position_embeddings, "max_position_embeddings", 202752);
+      LOAD_ARG_OR(rms_norm_eps, "rms_norm_eps", 1e-5);
+      LOAD_ARG_OR_FUNC(eos_token_id_vec, "eos_token_id", [&] {
+        return std::vector<int32_t>{154820, 154827, 154829};
+      });
+      LOAD_ARG_OR(bos_token_id, "bos_token_id", 0);
+      LOAD_ARG_OR(rope_theta, "rope_parameters.rope_theta", 1000000.0f);
 
-  LOAD_ARG_OR(use_sliding_window, "use_sliding_window", false);
-  LOAD_ARG_OR(sliding_window, "sliding_window", 4096);
-  LOAD_ARG_OR(max_window_layers, "max_window_layers", 61);
+      LOAD_ARG_OR(use_sliding_window, "use_sliding_window", false);
+      LOAD_ARG_OR(sliding_window, "sliding_window", 4096);
+      LOAD_ARG_OR(max_window_layers, "max_window_layers", 61);
 
-  LOAD_ARG_OR(first_k_dense_replace, "first_k_dense_replace", 3);
-  LOAD_ARG_OR(hidden_act, "hidden_act", "silu");
-  LOAD_ARG_OR(moe_layer_freq, "moe_layer_freq", 1);
-  LOAD_ARG_OR(topk_method, "topk_method", "noaux_tc");
-  LOAD_ARG_OR(n_routed_experts, "n_routed_experts", 256);
-  LOAD_ARG_OR(n_shared_experts, "n_shared_experts", 1);
-  LOAD_ARG_OR(num_experts_per_tok, "num_experts_per_tok", 8);
-  LOAD_ARG_OR(moe_intermediate_size, "moe_intermediate_size", 2048);
-  LOAD_ARG_OR(routed_scaling_factor, "routed_scaling_factor", 2.5f);
-  LOAD_ARG_OR(norm_topk_prob, "norm_topk_prob", true);
-  LOAD_ARG_OR(n_group, "n_group", 1);
-  LOAD_ARG_OR(topk_group, "topk_group", 1);
-  LOAD_ARG_OR(scoring_func, "scoring_func", "sigmoid");
-  LOAD_ARG_OR(qk_nope_head_dim, "qk_nope_head_dim", 192);
-  LOAD_ARG_OR(qk_rope_head_dim, "qk_rope_head_dim", 64);
-  LOAD_ARG_OR(v_head_dim, "v_head_dim", 256);
-  LOAD_ARG_OR(q_lora_rank, "q_lora_rank", 2048);
-  LOAD_ARG_OR(kv_lora_rank, "kv_lora_rank", 512);
-  LOAD_ARG_OR(index_head_dim, "index_head_dim", 128);
-  LOAD_ARG_OR(num_nextn_predict_layers, "num_nextn_predict_layers", 1);
-  LOAD_ARG_OR(index_n_heads, "index_n_heads", 32);
-  LOAD_ARG_OR(index_topk, "index_topk", 2048);
-  LOAD_ARG_OR(index_topk_freq, "index_topk_freq", 1);
-  LOAD_ARG_OR(index_topk_pattern, "index_topk_pattern", "");
-  LOAD_ARG_OR(index_skip_topk_offset, "index_skip_topk_offset", 0);
-  LOAD_ARG_OR(
-      index_share_for_mtp_iteration, "index_share_for_mtp_iteration", false);
+      LOAD_ARG_OR(first_k_dense_replace, "first_k_dense_replace", 3);
+      LOAD_ARG_OR(hidden_act, "hidden_act", "silu");
+      LOAD_ARG_OR(moe_layer_freq, "moe_layer_freq", 1);
+      LOAD_ARG_OR(topk_method, "topk_method", "noaux_tc");
+      LOAD_ARG_OR(n_routed_experts, "n_routed_experts", 256);
+      LOAD_ARG_OR(n_shared_experts, "n_shared_experts", 1);
+      LOAD_ARG_OR(num_experts_per_tok, "num_experts_per_tok", 8);
+      LOAD_ARG_OR(moe_intermediate_size, "moe_intermediate_size", 2048);
+      LOAD_ARG_OR(routed_scaling_factor, "routed_scaling_factor", 2.5f);
+      LOAD_ARG_OR(norm_topk_prob, "norm_topk_prob", true);
+      LOAD_ARG_OR(n_group, "n_group", 1);
+      LOAD_ARG_OR(topk_group, "topk_group", 1);
+      LOAD_ARG_OR(scoring_func, "scoring_func", "sigmoid");
+      LOAD_ARG_OR(qk_nope_head_dim, "qk_nope_head_dim", 192);
+      LOAD_ARG_OR(qk_rope_head_dim, "qk_rope_head_dim", 64);
+      LOAD_ARG_OR(v_head_dim, "v_head_dim", 256);
+      LOAD_ARG_OR(q_lora_rank, "q_lora_rank", 2048);
+      LOAD_ARG_OR(kv_lora_rank, "kv_lora_rank", 512);
+      LOAD_ARG_OR(index_head_dim, "index_head_dim", 128);
+      LOAD_ARG_OR(num_nextn_predict_layers, "num_nextn_predict_layers", 1);
+      LOAD_ARG_OR(index_n_heads, "index_n_heads", 32);
+      LOAD_ARG_OR(index_topk, "index_topk", 2048);
+      LOAD_ARG_OR(index_topk_freq, "index_topk_freq", 1);
+      LOAD_ARG_OR(index_topk_pattern, "index_topk_pattern", "");
+      LOAD_ARG_OR(index_skip_topk_offset, "index_skip_topk_offset", 0);
+      LOAD_ARG_OR(index_share_for_mtp_iteration,
+                  "index_share_for_mtp_iteration",
+                  false);
 
-  LOAD_ARG_OR(use_qk_norm, "use_qk_norm", true);
-  LOAD_ARG_OR(indexer_rope_interleave, "indexer_rope_interleave", true);
-  LOAD_ARG_OR(rope_theta, "rope_theta", args->rope_theta());
-  LOAD_ARG_OR(tie_word_embeddings, "tie_word_embeddings", false);
+      LOAD_ARG_OR(use_qk_norm, "use_qk_norm", true);
+      LOAD_ARG_OR(indexer_rope_interleave, "indexer_rope_interleave", true);
+      LOAD_ARG_OR(rope_theta, "rope_theta", args->rope_theta());
+      LOAD_ARG_OR(tie_word_embeddings, "tie_word_embeddings", false);
 
-  SET_ARG(head_dim, args->qk_nope_head_dim() + args->qk_rope_head_dim());
-  LOAD_ARG_OR_FUNC(
-      rotary_dim, "rotary_dim", [&] { return args->qk_rope_head_dim(); });
+      SET_ARG(head_dim, args->qk_nope_head_dim() + args->qk_rope_head_dim());
+      LOAD_ARG_OR_FUNC(
+          rotary_dim, "rotary_dim", [&] { return args->qk_rope_head_dim(); });
 
-  SET_ARG(stop_token_ids,
-          std::unordered_set<int32_t>(args->eos_token_id_vec().begin(),
-                                      args->eos_token_id_vec().end()));
-});
+      SET_ARG(stop_token_ids,
+              std::unordered_set<int32_t>(args->eos_token_id_vec().begin(),
+                                          args->eos_token_id_vec().end()));
+    }));
 }  // namespace xllm::npu::model


### PR DESCRIPTION
## Summary
- Wrap GLM5 and GLM5-MTP NPU `REGISTER_MODEL_ARGS` lambdas in parentheses.
- Prevent macro argument splitting when the registration body contains comma expressions.

## Validation
- `pre-commit run clang-format --files xllm/models/llm/npu/glm5_moe.h xllm/models/llm/npu/glm5_moe_mtp.h`
- compile success