### PR TITLE
refactor: init gflags when reading config from json file and update FLAGS to config struct.

### DIFF
--- a/.agents/skills/code-review/references/custom-code-style.md
+++ b/.agents/skills/code-review/references/custom-code-style.md
@@ -309,7 +309,7 @@ for (int32_t i = 0; i < num_layers; ++i) {
 
 ## 10. Global Flags
 
-- **Do not overuse `FLAGS_` global variables**. Prefer passing configuration through constructor parameters or config structs. Only use global flags for top-level, process-wide settings.
+- **Do not use `FLAGS_` global variables**. Prefer passing configuration through constructor parameters or config structs.
 - **Register new flags in their config category**. When adding a flag under `xllm/core/framework/config/`, add it to that config class's `option_category()` so `core/framework/config/help_formatter.h` can print it in `--help`.
 - **Keep config defaults explicit**. Primitive `PROPERTY` fields such as `bool`, `int32_t`, `int64_t`, and `double` must keep an in-class default matching the corresponding `DEFINE_*` default.
 ---

--- a/xllm/core/framework/config/config_utils.h
+++ b/xllm/core/framework/config/config_utils.h
@@ -56,8 +56,12 @@ void dump_startup_config();
     property(FLAGS_##property);                \
   } while (false)
 
+// Assign a config property from JSON, then write the resolved value back to
+// the corresponding FLAGS_ global so that code reading FLAGS_##property
+// directly observes the JSON-provided value instead of the gflags default.
 #define XLLM_CONFIG_ASSIGN_FROM_JSON(property)                               \
   do {                                                                       \
     property(json.value_or<std::decay_t<decltype(property())>>(#property,    \
                                                                property())); \
+    FLAGS_##property = property();                                           \
   } while (false)

--- a/xllm/core/framework/hf_model_loader.cpp
+++ b/xllm/core/framework/hf_model_loader.cpp
@@ -34,7 +34,6 @@ limitations under the License.
 #include <unordered_map>
 #include <vector>
 
-#include "core/common/global_flags.h"
 #include "core/common/version_singleton.h"
 #include "core/framework/config/model_config.h"
 #include "core/framework/config/rec_config.h"
@@ -780,8 +779,10 @@ bool HFModelLoader::load_model_args(const std::string& model_weights_path) {
     return false;
   }
 
-  const std::string model_type = util::get_model_type(
-      reader, std::filesystem::path(model_weights_path), FLAGS_backend);
+  const std::string model_type =
+      util::get_model_type(reader,
+                           std::filesystem::path(model_weights_path),
+                           ModelConfig::get_instance().backend());
 
   std::string resolved_model_type;
   std::string error_message;
@@ -800,8 +801,9 @@ bool HFModelLoader::load_model_args(const std::string& model_weights_path) {
   }
   const JsonReader config_reader = normalize_config_torch_dtype(reader);
   model_args_loader(config_reader, &args_);
-  args_.enable_mla(util::should_enable_mla(
-      std::filesystem::path(model_weights_path), FLAGS_backend));
+  args_.enable_mla(
+      util::should_enable_mla(std::filesystem::path(model_weights_path),
+                              ModelConfig::get_instance().backend()));
 
   return true;
 }

--- a/xllm/core/framework/parallel_state/collective_communicator.cpp
+++ b/xllm/core/framework/parallel_state/collective_communicator.cpp
@@ -30,7 +30,6 @@ limitations under the License.
 #elif defined(USE_MUSA)
 #include "musa_process_group.h"
 #endif
-#include "common/global_flags.h"
 #include "core/framework/config/eplb_config.h"
 #include "core/framework/config/kernel_config.h"
 #include "core/framework/config/parallel_config.h"
@@ -162,12 +161,15 @@ DispatchAndCombineComm create_dispatch_and_combine_comm(int32_t global_rank,
       .sp_size(1)
       .cp_size(normalized_cp_size);
 
-  MappingNPU mapping_npu(
-      FLAGS_rank_tablefile, world_size, global_rank, mapping_options);
+  MappingNPU mapping_npu(EPLBConfig::get_instance().rank_tablefile(),
+                         world_size,
+                         global_rank,
+                         mapping_options);
   DispatchAndCombineComm result;
   result.mapping_data = mapping_npu.to_json();
   result.mapping.ParseParam(result.mapping_data);
-  result.mapping.InitGlobalCommDomain(FLAGS_communication_backend);
+  result.mapping.InitGlobalCommDomain(
+      ParallelConfig::get_instance().communication_backend());
 
   auto moe_ep_parallel_info = result.mapping.Get(atb_speed::base::MOE_EP);
   const bool moe_ep_is_world =
@@ -180,7 +182,7 @@ DispatchAndCombineComm create_dispatch_and_combine_comm(int32_t global_rank,
           moe_ep_parallel_info.groupId,
           moe_ep_parallel_info.rankIds,
           moe_ep_parallel_info.rank,
-          FLAGS_communication_backend,
+          ParallelConfig::get_instance().communication_backend(),
           comm_buffer_size,
           0,
           reuse_comm_domain);
@@ -440,7 +442,8 @@ void CollectiveCommunicator::create_process_groups(
 
 #if defined(USE_NPU)
   if (::xllm::KernelConfig::get_instance().npu_kernel_backend() == "TORCH" &&
-      FLAGS_expert_parallel_degree == 2 && ep_size == world_size) {
+      ::xllm::EPLBConfig::get_instance().expert_parallel_degree() == 2 &&
+      ep_size == world_size) {
     auto dispatch_and_combine_comm = create_dispatch_and_combine_comm(
         global_rank, world_size, dp_size, ep_size, cp_size);
     parallel_args_->mapping_data(dispatch_and_combine_comm.mapping_data);

--- a/xllm/core/framework/prefix_cache/block_hasher.cpp
+++ b/xllm/core/framework/prefix_cache/block_hasher.cpp
@@ -18,7 +18,6 @@ limitations under the License.
 #include <string.h>
 #include <xxHash/xxhash.h>
 
-#include "common/global_flags.h"
 #include "core/framework/config/kv_cache_config.h"
 
 namespace xllm {
@@ -76,7 +75,7 @@ void mm_xxh3_128bits_hash(const std::vector<const uint8_t*>& mm_hash_values,
   XXH128_hash_t mm_hash =
       XXH3_128bits_withSeed(reinterpret_cast<const void*>(key_buffer.data()),
                             key_buffer.size(),
-                            FLAGS_xxh3_128bits_seed);
+                            KVCacheConfig::get_instance().xxh3_128bits_seed());
   std::memcpy(hash_value, &mm_hash, sizeof(mm_hash));
 }
 

--- a/xllm/core/layers/npu/npu_column_parallel_linear_impl.cpp
+++ b/xllm/core/layers/npu/npu_column_parallel_linear_impl.cpp
@@ -15,7 +15,6 @@ limitations under the License.
 
 #include "layers/npu/npu_column_parallel_linear_impl.h"
 
-#include "common/global_flags.h"
 #include "core/framework/config/load_config.h"
 #include "core/framework/config/parallel_config.h"
 namespace xllm {
@@ -43,7 +42,8 @@ void NpuColumnParallelLinearImpl::param_from_args(
       const int32_t tp_group_id =
           use_local_tp ? (parallel_args.rank() / dp_local_tp_size_) : 0;
       param.tensorParallelInfo.commDomain = std::to_string(tp_group_id);
-      param.tensorParallelInfo.backend = FLAGS_communication_backend;
+      param.tensorParallelInfo.backend =
+          ParallelConfig::get_instance().communication_backend();
     } else {
       param.parallelType = atb_speed::common::COLUMN_PARALLEL;
       atb_speed::common::ParallelInfo parallelInfo =

--- a/xllm/core/layers/npu/npu_kimik25_vision_encoder_layer_impl.cpp
+++ b/xllm/core/layers/npu/npu_kimik25_vision_encoder_layer_impl.cpp
@@ -21,6 +21,7 @@ limitations under the License.
 #include <iostream>
 #include <map>
 
+#include "core/framework/config/parallel_config.h"
 #include "torch_npu/csrc/core/npu/NPUCachingAllocator.h"
 #include "torch_npu/csrc/core/npu/NPUException.h"
 #include "xllm_atb_layers/models/kimik25/kimik25_encoder.h"
@@ -60,7 +61,7 @@ void NpuKimik25VisionEncoderLayerImpl::param_from_args(
   param.numKeyValueHeadsPerRank =
       static_cast<int>(optionalValue.value()) / param.worldSize;
   param.rank = dp_local_tp_rank;
-  param.backend = FLAGS_communication_backend;
+  param.backend = ParallelConfig::get_instance().communication_backend();
   param.enableLogN = false;
   param.MLPActivationType = atb::infer::ActivationType::ACTIVATION_GELU;
   param.mapping = parallel_args.mapping();

--- a/xllm/core/layers/npu_torch/fused_moe.cpp
+++ b/xllm/core/layers/npu_torch/fused_moe.cpp
@@ -32,7 +32,7 @@ limitations under the License.
 #include <torch_npu/csrc/aten/NPUNativeFunctions.h>
 #endif
 
-#include "common/global_flags.h"
+#include "framework/config/eplb_config.h"
 #include "framework/config/kernel_config.h"
 #include "framework/parallel_state/parallel_state.h"
 #include "kernels/ops_api.h"
@@ -396,7 +396,9 @@ FusedMoEImpl::FusedMoEImpl(const ModelArgs& model_args,
   num_experts_per_rank_ = num_experts / ep_size;
   start_expert_id_ = ep_rank * num_experts_per_rank_;
   enable_ep2_dispatch_combine_ =
-      is_deepseek_v4_ && FLAGS_expert_parallel_degree == 2 && ep_size > 1;
+      is_deepseek_v4_ &&
+      ::xllm::EPLBConfig::get_instance().expert_parallel_degree() == 2 &&
+      ep_size > 1;
   if (enable_ep2_dispatch_combine_) {
     CHECK(parallel_args_.moe_ep_group_ != nullptr)
         << "DeepSeek-V4 NPU EP2 dispatch/combine requires moe_ep_group.";

--- a/xllm/core/runtime/dcu_graph_executor_impl.cpp
+++ b/xllm/core/runtime/dcu_graph_executor_impl.cpp
@@ -22,9 +22,9 @@ limitations under the License.
 #include <numeric>
 #include <vector>
 
-#include "core/common/global_flags.h"
 #include "core/common/metrics.h"
 #include "core/framework/config/execution_config.h"
+#include "core/framework/config/scheduler_config.h"
 #include "core/layers/common/attention_metadata.h"
 #include "core/layers/common/attention_metadata_builder.h"
 #include "core/util/rec_model_utils.h"
@@ -101,7 +101,8 @@ DcuGraphPersistentParam::DcuGraphPersistentParam(
       device_(device),
       options_(options),
       num_decoding_tokens_(options.num_decoding_tokens()) {
-  const int64_t max_tokens_per_batch = FLAGS_max_tokens_per_batch;
+  const int64_t max_tokens_per_batch =
+      SchedulerConfig::get_instance().max_tokens_per_batch();
 
   int64_t max_seqs_per_batch = options.max_seqs_per_batch();
   if (is_rec_multi_round_mode()) {
@@ -353,7 +354,7 @@ std::optional<ModelInputParams> DcuGraphPersistentParam::update(
   if (params.embedding.input_embedding.defined()) {
     if (!input_embeds_.defined() || input_embeds_.numel() == 0) {
       auto shape = params.embedding.input_embedding.sizes().vec();
-      shape[0] = FLAGS_max_tokens_per_batch;
+      shape[0] = SchedulerConfig::get_instance().max_tokens_per_batch();
       input_embeds_ = torch::zeros(
           shape, params.embedding.input_embedding.options().device(device_));
     }
@@ -533,7 +534,7 @@ void DcuGraphPersistentParam::update_decode_input_buffer(
   if (params.embedding.input_embedding.defined()) {
     if (!input_embeds_.defined() || input_embeds_.numel() == 0) {
       auto shape = params.embedding.input_embedding.sizes().vec();
-      shape[0] = FLAGS_max_tokens_per_batch;
+      shape[0] = SchedulerConfig::get_instance().max_tokens_per_batch();
       input_embeds_ = torch::zeros(
           shape, params.embedding.input_embedding.options().device(device_));
     }
@@ -623,7 +624,7 @@ void DcuGraphPersistentParam::set_aux_hidden_states(
 
   if (!aux_hidden_states_.defined() || aux_hidden_states_.numel() == 0) {
     auto shape = value.sizes().vec();
-    shape[0] = FLAGS_max_tokens_per_batch;
+    shape[0] = SchedulerConfig::get_instance().max_tokens_per_batch();
     aux_hidden_states_ = torch::zeros(shape, value.options().device(device_));
   }
 

--- a/xllm/core/runtime/mtp_worker_impl.cpp
+++ b/xllm/core/runtime/mtp_worker_impl.cpp
@@ -21,7 +21,6 @@ limitations under the License.
 #include <cctype>
 #include <memory>
 
-#include "common/global_flags.h"
 #include "common/metrics.h"
 #if defined(USE_MLU)
 #include "framework/kv_cache_transfer/mooncake_kv_cache_transfer.h"
@@ -509,7 +508,7 @@ void force_atb_spec_kernel_for_qwen3_5_mtp(
   if (!is_qwen3_5_target_model_type(model_type)) {
     return;
   }
-  FLAGS_enable_atb_spec_kernel = true;
+  SpeculativeConfig::get_instance().enable_atb_spec_kernel(true);
 }
 #endif
 

--- a/xllm/core/scheduler/continuous_scheduler.cpp
+++ b/xllm/core/scheduler/continuous_scheduler.cpp
@@ -30,7 +30,6 @@ limitations under the License.
 #include <sstream>
 #include <vector>
 
-#include "common/global_flags.h"
 #include "common/metrics.h"
 #include "core/framework/config/kv_cache_config.h"
 #include "core/framework/config/parallel_config.h"
@@ -226,7 +225,7 @@ void ContinuousScheduler::get_latency_budget_and_request_order(
     latency_budget = std::max(min_remaining_time, latency_budget_threshold);
   }
 
-  const double lambda = FLAGS_aggressive_coeff;
+  const double lambda = SchedulerConfig::get_instance().aggressive_coeff();
   double load_judge_func = 0.0;
   if (for_prefill) {
     load_judge_func = total_exec_time + constant_overhead;
@@ -242,12 +241,13 @@ void ContinuousScheduler::get_latency_budget_and_request_order(
     auto request = *it;
     auto& sequence = request->sequences()[0];
 
-    if (FLAGS_enable_starve_prevent) {
+    if (SchedulerConfig::get_instance().enable_starve_prevent()) {
       const int32_t starve_unit_time = sequence->is_prefill_stage()
                                            ? -request->ttft_slo_ms()
                                            : -request->tpot_slo_ms();
-      const int32_t starve_time_threshold =
-          static_cast<int32_t>(FLAGS_starve_threshold * starve_unit_time);
+      const int32_t starve_time_threshold = static_cast<int32_t>(
+          SchedulerConfig::get_instance().starve_threshold() *
+          starve_unit_time);
       if (request->get_remaining_time() < starve_time_threshold) {
         request->set_starved(true);
       }

--- a/xllm/core/util/hash_util.cpp
+++ b/xllm/core/util/hash_util.cpp
@@ -15,7 +15,7 @@ limitations under the License.
 
 #include "hash_util.h"
 
-#include "core/common/global_flags.h"
+#include "core/framework/config/kv_cache_config.h"
 
 namespace xllm {
 
@@ -25,7 +25,7 @@ XXH3Key hash_tensor(const torch::Tensor& tensor) {
   XXH128_hash_t hash = XXH3_128bits_withSeed(
       reinterpret_cast<const void*>(contiguous_tensor.data_ptr()),
       tensor.numel() * tensor.element_size(),
-      FLAGS_xxh3_128bits_seed);
+      KVCacheConfig::get_instance().xxh3_128bits_seed());
   std::memcpy(key.data, &hash, sizeof(hash));
   return key;
 }
@@ -35,7 +35,7 @@ XXH3Key hash_string(const std::string& str) {
   XXH128_hash_t hash =
       XXH3_128bits_withSeed(reinterpret_cast<const void*>(str.data()),
                             str.size(),
-                            FLAGS_xxh3_128bits_seed);
+                            KVCacheConfig::get_instance().xxh3_128bits_seed());
   std::memcpy(key.data, &hash, sizeof(hash));
   return key;
 }

--- a/xllm/models/dit/pipelines/pipeline_wan_i2v.h
+++ b/xllm/models/dit/pipelines/pipeline_wan_i2v.h
@@ -19,6 +19,7 @@ limitations under the License.
 #include <cstring>
 #include <memory>
 
+#include "core/framework/config/parallel_config.h"
 #include "core/framework/dit_model_loader.h"
 #include "core/framework/model_context.h"
 #include "core/framework/request/dit_request_state.h"
@@ -511,7 +512,7 @@ class WanImageToVideoPipelineImpl : public torch::nn::Module {
       torch::Tensor noise_pred;
       torch::Tensor noise_uncond;
       if (do_classifier_free_guidance) {
-        if (FLAGS_cfg_size == 2) {
+        if (ParallelConfig::get_instance().cfg_size() == 2) {
           int32_t rank = parallel_args_.dit_cfg_group_->rank();
           if (rank == 0) {
             noise_pred = current_model->forward(latent_model_input,

--- a/xllm/models/dit/transformers/transformer_wan.h
+++ b/xllm/models/dit/transformers/transformer_wan.h
@@ -26,6 +26,7 @@ limitations under the License.
 #include <string>
 #include <vector>
 
+#include "core/framework/config/parallel_config.h"
 #include "core/framework/dit_model_loader.h"
 #include "core/framework/model/model_input_params.h"
 #include "core/framework/state_dict/state_dict.h"
@@ -252,14 +253,15 @@ class WanGELUImpl : public torch::nn::Module {
       : approximate_(approximate),
         options_(context.get_tensor_options()),
         parallel_args_(parallel_args) {
-    LinearType linear_type =
-        FLAGS_tp_size > 1 ? LinearType::TensorParallel : LinearType::Default;
+    LinearType linear_type = ParallelConfig::get_instance().tp_size() > 1
+                                 ? LinearType::TensorParallel
+                                 : LinearType::Default;
     std::optional<TpOptions> tp_options = std::nullopt;
-    if (FLAGS_tp_size > 1) {
+    if (ParallelConfig::get_instance().tp_size() > 1) {
       tp_options = TpOptions(
           /*column_parallel=*/true,
           /*tp_rank=*/parallel_args_.dit_tp_group_->rank(),
-          /*tp_size=*/FLAGS_tp_size,
+          /*tp_size=*/ParallelConfig::get_instance().tp_size(),
           /*gather_output=*/false,
           /*need_scatter=*/false,
           /*process_group=*/parallel_args_.dit_tp_group_);
@@ -346,14 +348,15 @@ class WanFeedForwardImpl : public torch::nn::Module {
 
     dropout_ = register_module("dropout", torch::nn::Dropout(dropout));
 
-    LinearType linear_out_type =
-        FLAGS_tp_size > 1 ? LinearType::TensorParallel : LinearType::Default;
+    LinearType linear_out_type = ParallelConfig::get_instance().tp_size() > 1
+                                     ? LinearType::TensorParallel
+                                     : LinearType::Default;
     std::optional<TpOptions> tp_out_options = std::nullopt;
-    if (FLAGS_tp_size > 1) {
+    if (ParallelConfig::get_instance().tp_size() > 1) {
       tp_out_options = TpOptions(
           /*column_parallel=*/false,
           /*tp_rank=*/parallel_args_.dit_tp_group_->rank(),
-          /*tp_size=*/FLAGS_tp_size,
+          /*tp_size=*/ParallelConfig::get_instance().tp_size(),
           /*gather_output=*/true,
           /*need_scatter=*/false,
           /*process_group=*/parallel_args_.dit_tp_group_);
@@ -490,25 +493,26 @@ class WanAttentionImpl : public torch::nn::Module {
     } else {
       kv_inner_dim_ = heads_ * dim_head_;
     }
-    LinearType linear_type =
-        FLAGS_tp_size > 1 ? LinearType::TensorParallel : LinearType::Default;
+    LinearType linear_type = ParallelConfig::get_instance().tp_size() > 1
+                                 ? LinearType::TensorParallel
+                                 : LinearType::Default;
     // ===== TP OPTIONS: to_q/to_k use gather_output=false for TP-RMSNorm =====
     // gather_output=false → Q/K stay sharded, no AllGather
     // tp_rms_norm() handles RMSNorm on sharded tensor with scalar AR (~6KB)
     std::optional<TpOptions> tp_options_qk = std::nullopt;
     std::optional<TpOptions> tp_options_v = std::nullopt;
-    if (FLAGS_tp_size > 1) {
+    if (ParallelConfig::get_instance().tp_size() > 1) {
       tp_options_qk = TpOptions(
           /*column_parallel=*/true,
           /*tp_rank=*/parallel_args_.dit_tp_group_->rank(),
-          /*tp_size=*/FLAGS_tp_size,
+          /*tp_size=*/ParallelConfig::get_instance().tp_size(),
           /*gather_output=*/false,
           /*need_scatter=*/false,
           /*process_group=*/parallel_args_.dit_tp_group_);
       tp_options_v = TpOptions(
           /*column_parallel=*/true,
           /*tp_rank=*/parallel_args_.dit_tp_group_->rank(),
-          /*tp_size=*/FLAGS_tp_size,
+          /*tp_size=*/ParallelConfig::get_instance().tp_size(),
           /*gather_output=*/false,
           /*need_scatter=*/false,
           /*process_group=*/parallel_args_.dit_tp_group_);
@@ -537,14 +541,15 @@ class WanAttentionImpl : public torch::nn::Module {
                                   std::nullopt,
                                   tp_options_v);
     to_v_ = register_module("to_v", to_v);
-    LinearType to_out_type =
-        FLAGS_tp_size > 1 ? LinearType::TensorParallel : LinearType::Default;
+    LinearType to_out_type = ParallelConfig::get_instance().tp_size() > 1
+                                 ? LinearType::TensorParallel
+                                 : LinearType::Default;
     std::optional<TpOptions> tp_to_out_options = std::nullopt;
-    if (FLAGS_tp_size > 1) {
+    if (ParallelConfig::get_instance().tp_size() > 1) {
       tp_to_out_options = TpOptions(
           /*column_parallel=*/false,
           /*tp_rank=*/parallel_args_.dit_tp_group_->rank(),
-          /*tp_size=*/FLAGS_tp_size,
+          /*tp_size=*/ParallelConfig::get_instance().tp_size(),
           /*gather_output=*/true,
           /*need_scatter=*/false,
           /*process_group=*/parallel_args_.dit_tp_group_);
@@ -562,22 +567,23 @@ class WanAttentionImpl : public torch::nn::Module {
     norm_k_ = register_module(
         "norm_k", layer::RMSNorm(dim_head_ * heads_, eps_, options_));
     if (added_kv_proj_dim_ > 0) {
-      LinearType add_kv_type =
-          FLAGS_tp_size > 1 ? LinearType::TensorParallel : LinearType::Default;
+      LinearType add_kv_type = ParallelConfig::get_instance().tp_size() > 1
+                                   ? LinearType::TensorParallel
+                                   : LinearType::Default;
       std::optional<TpOptions> add_k_options = std::nullopt;
       std::optional<TpOptions> add_v_options = std::nullopt;
-      if (FLAGS_tp_size > 1) {
+      if (ParallelConfig::get_instance().tp_size() > 1) {
         add_k_options = TpOptions(
             /*column_parallel=*/true,
             /*tp_rank=*/parallel_args_.dit_tp_group_->rank(),
-            /*tp_size=*/FLAGS_tp_size,
+            /*tp_size=*/ParallelConfig::get_instance().tp_size(),
             /*gather_output=*/false,
             /*need_scatter=*/false,
             /*process_group=*/parallel_args_.dit_tp_group_);
         add_v_options = TpOptions(
             /*column_parallel=*/true,
             /*tp_rank=*/parallel_args_.dit_tp_group_->rank(),
-            /*tp_size=*/FLAGS_tp_size,
+            /*tp_size=*/ParallelConfig::get_instance().tp_size(),
             /*gather_output=*/false,
             /*need_scatter=*/false,
             /*process_group=*/parallel_args_.dit_tp_group_);
@@ -664,7 +670,7 @@ class WanAttentionImpl : public torch::nn::Module {
     torch::Tensor key = to_k_->forward(encoder_hidden_states_text);
     torch::Tensor value = to_v_->forward(encoder_hidden_states_text);
 
-    if (FLAGS_tp_size > 1) {
+    if (ParallelConfig::get_instance().tp_size() > 1) {
       query = dit::tp_rms_norm(query, norm_q_, parallel_args_.dit_tp_group_);
       key = dit::tp_rms_norm(key, norm_k_, parallel_args_.dit_tp_group_);
     } else {
@@ -674,8 +680,8 @@ class WanAttentionImpl : public torch::nn::Module {
 
     int64_t batch_size = query.size(0);
     int64_t n_heads = heads_;
-    if (FLAGS_tp_size > 1) {
-      n_heads = heads_ / FLAGS_tp_size;
+    if (ParallelConfig::get_instance().tp_size() > 1) {
+      n_heads = heads_ / ParallelConfig::get_instance().tp_size();
     }
     query = query.view({batch_size, -1, n_heads, dim_head_});
     key = key.view({batch_size, -1, n_heads, dim_head_});
@@ -693,7 +699,7 @@ class WanAttentionImpl : public torch::nn::Module {
       torch::Tensor key_img = add_k_proj_->forward(encoder_hidden_states_img);
       torch::Tensor value_img = add_v_proj_->forward(encoder_hidden_states_img);
 
-      if (FLAGS_tp_size > 1) {
+      if (ParallelConfig::get_instance().tp_size() > 1) {
         key_img = dit::tp_rms_norm(
             key_img, norm_added_k_, parallel_args_.dit_tp_group_);
       } else {

--- a/xllm/models/llm/deepseek_v4.h
+++ b/xllm/models/llm/deepseek_v4.h
@@ -32,8 +32,8 @@ limitations under the License.
 #include <unordered_set>
 #include <utility>
 
-#include "core/common/global_flags.h"
 #include "core/framework/config/execution_config.h"
+#include "core/framework/config/kv_cache_config.h"
 #include "core/framework/state_dict/utils.h"
 #include "core/kernels/ops_api.h"
 #include "core/layers/common/dsa_metadata.h"
@@ -334,7 +334,7 @@ inline void deepseek_v4_build_cache_specs(
   const auto& compress_ratios = model_args.compress_ratios();
   const int32_t window_size = model_args.window_size();
   const int32_t base_block_size = 128;
-  CHECK_EQ(FLAGS_block_size, base_block_size)
+  CHECK_EQ(KVCacheConfig::get_instance().block_size(), base_block_size)
       << "DeepSeek V4 currently only supports block_size=128.";
 
   std::unordered_map<DSAGroupKey, int32_t, DSAGroupKeyHash> group_key_map;
@@ -497,7 +497,7 @@ class DeepseekV4ModelImpl
     // TODO: Wire runtime block_size into model metadata so this stays aligned
     // with the DSv4 KV cache and block manager when the default changes.
     const int32_t base_block_size = 128;  // default block size
-    CHECK_EQ(FLAGS_block_size, base_block_size)
+    CHECK_EQ(KVCacheConfig::get_instance().block_size(), base_block_size)
         << "DeepSeek V4 currently only supports block_size=128.";
 
     std::unordered_map<DSAGroupKey, int32_t, DSAGroupKeyHash> group_key_map;

--- a/xllm/models/llm/mlu/deepseek_v4.h
+++ b/xllm/models/llm/mlu/deepseek_v4.h
@@ -31,8 +31,8 @@ limitations under the License.
 #include <utility>
 #include <vector>
 
-#include "core/common/global_flags.h"
 #include "core/framework/config/execution_config.h"
+#include "core/framework/config/kv_cache_config.h"
 #include "core/framework/model/causal_lm.h"
 #include "core/framework/state_dict/utils.h"
 #include "core/layers/common/attention_metadata.h"
@@ -605,7 +605,8 @@ class DeepseekV4ModelImpl final
 
   void build_dsa_cache_info(const ModelArgs& model_args) {
     const std::vector<int32_t>& compress_ratios = model_args.compress_ratios();
-    const int32_t base_block_size = FLAGS_block_size;
+    const int32_t base_block_size =
+        ::xllm::KVCacheConfig::get_instance().block_size();
     CHECK_GT(base_block_size, 0) << "DeepSeek V4 block_size must be positive.";
 
     std::unordered_map<DSAGroupKey, int32_t, DSAGroupKeyHash> group_key_map;

--- a/xllm/models/llm/npu/minimax_m2.h
+++ b/xllm/models/llm/npu/minimax_m2.h
@@ -26,8 +26,8 @@ limitations under the License.
 #include <unordered_set>
 #include <vector>
 
-#include "core/common/global_flags.h"
 #include "core/common/interruption_bus.h"
+#include "core/framework/config/scheduler_config.h"
 #include "core/framework/hf_model_loader.h"
 #include "core/framework/model/model_input_params.h"
 #include "core/framework/model/model_output.h"
@@ -213,7 +213,9 @@ class MiniMaxM2ModelImpl : public torch::nn::Module {
                                              options));
     norm_ = register_module("norm", layer::RMSNorm(context));
 
-    int32_t mask_value = FLAGS_enable_chunked_prefill ? -9984 : 1;
+    int32_t mask_value =
+        ::xllm::SchedulerConfig::get_instance().enable_chunked_prefill() ? -9984
+                                                                         : 1;
     attn_mask_ = layer::AttentionMask(
         options.device(), options.dtype().toScalarType(), mask_value);
 
@@ -295,7 +297,7 @@ class MiniMaxM2ModelImpl : public torch::nn::Module {
 
     max_seq_len_ = std::max(params.meta.kv_max_seq_len, max_seq_len_);
     torch::Tensor attn_mask;
-    if (FLAGS_enable_chunked_prefill) {
+    if (::xllm::SchedulerConfig::get_instance().enable_chunked_prefill()) {
       const int32_t max_kv_seq = params.meta.kv_max_seq_len;
       const int32_t num_sequences = params.meta.num_sequences;
       if (num_sequences > 0) {

--- a/xllm/xllm.cpp
+++ b/xllm/xllm.cpp
@@ -456,7 +456,7 @@ int run() {
   if (options.node_rank() != 0) {
     if (model_config.backend() == "dit") {
       master = std::make_unique<DiTAssistantMaster>(options);
-    } else if (FLAGS_backend == "vlm") {
+    } else if (model_config.backend() == "vlm") {
       master = std::make_unique<VLMAssistantMaster>(options);
     } else {
       master = std::make_unique<LLMAssistantMaster>(options);


### PR DESCRIPTION


## Description

<!-- What does this PR do? Briefly describe the changes and why they are needed. -->

  This commit fixes a config-resolution bug and cleans up direct FLAGS_ usage across the codebase.

  **Root-cause fix**

  - config_utils.h: the shared XLLM_CONFIG_ASSIGN_FROM_JSON macro now writes the resolved value back to FLAGS_##property. Previously, from_json() only updated the config singleton, so any code reading FLAGS_x
  directly saw the stale gflags default instead of the JSON value. One macro change covers all 17 config classes.

  **FLAGS_ → config conversion (15 files)**

  Replaced direct config-backed flag reads with their config singletons:
  - xxh3_128bits_seed → KVCacheConfig; backend → ModelConfig; communication_backend/tp_size/cfg_size → ParallelConfig; expert_parallel_degree/rank_tablefile → EPLBConfig;
  max_tokens_per_batch/aggressive_coeff/starve_threshold/enable_starve_prevent/enable_chunked_prefill → SchedulerConfig; block_size → KVCacheConfig.
  - Also fixed a latent bug: mtp_worker_impl.cpp wrote FLAGS_enable_atb_spec_kernel at runtime, but all readers use SpeculativeConfig — now uses the config setter.
  - System flags (glog/brpc), enable_atb_comm_multiprocess, and test helpers were intentionally left untouched.

  **Doc**

  - custom-code-style.md: tightened the rule from "Do not overuse FLAGS_" to "Do not use FLAGS_".

## Related Issues

<!-- Link related issues here. Use "Fixes #123" when this PR closes an issue. -->

## Change Type

- [x] Bug fix
- [ ] New feature
- [ ] Performance improvement
- [x] Refactor
- [ ] Documentation
- [ ] Test
- [ ] Build or CI

## Pull Request Checklist

Thank you for contributing to xLLM. Before requesting review, please make sure the following items are complete.

### PR Title and Commit Messages

- [x] The PR title and each commit message follow the xLLM commit format: `<type>: <subject>`.

> Allowed types: feat, bugfix, docs, test, refactor, chore, style, revert, perf, model, build, release.
> The subject should use clear English, start with a verb, include at least 4 words, and end with `.`.

### Pre-commit Checks

- [x] I have installed `pre-commit` by running `pip install pre-commit` or an equivalent command.
- [x] I have installed the hooks with `pre-commit install`.
- [x] I have run `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

### Self Review

- [x] I have self-reviewed the code according to `.agents/skills/code-review/references/custom-code-style.md`, especially code written or assisted by AI.
- [x] I have rebased this PR onto the latest `main` branch.

### Build and Test Coverage

- [ ] Tests have been added or updated as needed.
- [x] CUDA: `python setup.py build test` has passed on a CUDA machine.
- [x] NPU: `python setup.py build test` has passed on an NPU machine.
- [x] MLU: `python setup.py build test` has passed on an MLU machine.

## Reviewer Notes

<!-- Optional: anything reviewers should focus on, known risks, follow-ups, or validation gaps. -->
