### PR TITLE
build: limit tilelang compile worker concurrency.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -56,7 +56,7 @@ def _ensure_tilelang_ascend_ready(target_platform: str, arch: str) -> None:
     prepare_ascend(target_platform, arch)
 
 
-def _maybe_compile_tilelang_kernels(device: str) -> None:
+def _maybe_compile_tilelang_kernels(device: str, jobs: int | str | None = None) -> None:
     if device != "npu":
         return
     target_platform = get_ascend_platform()
@@ -78,6 +78,8 @@ def _maybe_compile_tilelang_kernels(device: str) -> None:
         "--device",
         target_platform,
     ]
+    if jobs is not None:
+        cmd.extend(["--jobs", str(jobs)])
     logger.info("compiling TileLang kernels via source-tree launcher")
     subprocess.check_call(cmd, cwd=base_dir, env=env)
 
@@ -138,6 +140,7 @@ class ExtBuild(build_ext):
         ("device=", None, "target device type (npu or mlu or cuda or ilu or musa)"),
         ("arch=", None, "target arch type (x86 or arm)"),
         ("generate-so=", None, "generate so or binary"),
+        ("tilelang-jobs=", None, "maximum parallel TileLang compile workers"),
     ]
 
     def initialize_options(self) -> None:
@@ -146,6 +149,7 @@ class ExtBuild(build_ext):
         self.device: Optional[str] = None
         self.arch: Optional[str] = None
         self.generate_so: bool = False
+        self.tilelang_jobs: int | str | None = None
 
     def finalize_options(self) -> None:
         build_ext.finalize_options(self)
@@ -227,7 +231,7 @@ class ExtBuild(build_ext):
         if self.device == "npu":
             cmake_args += ["-DUSE_NPU=ON"]
             set_npu_envs()
-            _maybe_compile_tilelang_kernels(self.device)
+            _maybe_compile_tilelang_kernels(self.device, self.tilelang_jobs)
         elif self.device == "mlu":
             cmake_args += ["-DUSE_MLU=ON"]
             set_mlu_envs()
@@ -427,12 +431,14 @@ class BuildDistWheel(bdist_wheel):
     user_options = bdist_wheel.user_options + [
         ("device=", None, "target device type (npu or mlu or cuda or ilu or musa)"),
         ("arch=", None, "target arch type (x86 or arm)"),
+        ("tilelang-jobs=", None, "maximum parallel TileLang compile workers"),
     ]
 
     def initialize_options(self) -> None:
         super().initialize_options()
         self.device: Optional[str] = None
         self.arch: Optional[str] = None
+        self.tilelang_jobs: int | str | None = None
         # Cache the original dist name early so finalize_options is idempotent
         # and so name changes are visible to egg_info/metadata generation.
         self._base_dist_name = self.distribution.metadata.name
@@ -459,6 +465,7 @@ class BuildDistWheel(bdist_wheel):
         build_ext_cmd = self.get_finalized_command('build_ext')
         build_ext_cmd.device = self.device
         build_ext_cmd.arch = self.arch
+        build_ext_cmd.tilelang_jobs = self.tilelang_jobs
 
         logger.info("🔨 build project...")
         self.run_command('build')
@@ -662,6 +669,7 @@ class SingleTest(Command):
         ("device=", None, "target device type (npu or mlu or cuda or ilu)"),
         ("arch=", None, "target arch type (x86 or arm)"),
         ("generate-so=", None, "generate so or binary"),
+        ("tilelang-jobs=", None, "maximum parallel TileLang compile workers"),
     ]
 
     def initialize_options(self) -> None:
@@ -669,6 +677,7 @@ class SingleTest(Command):
         self.device: Optional[str] = None
         self.arch: Optional[str] = None
         self.generate_so: bool = False
+        self.tilelang_jobs: int | str | None = None
 
     def finalize_options(self) -> None:
         if not self.test_name:
@@ -682,6 +691,7 @@ class SingleTest(Command):
         build_ext.device = self.device
         build_ext.arch = self.arch
         build_ext.generate_so = self.generate_so
+        build_ext.tilelang_jobs = self.tilelang_jobs
         build_ext.finalize_options()
 
         # Ensure extension modules are set
@@ -726,6 +736,12 @@ def parse_arguments() -> dict[str, Any]:
         default=None,
         help='Name of the test target to build and run; when omitted, all tests run'
     )
+    parser.add_argument(
+        '--tilelang-jobs',
+        type=int,
+        default=None,
+        help='Maximum parallel TileLang compile workers, e.g. --tilelang-jobs 16; auto-selects a safe default when omitted'
+    )
 
     args = parser.parse_args()
 
@@ -737,6 +753,7 @@ def parse_arguments() -> dict[str, Any]:
         'device': args.device,
         'generate_so': generate_so,
         'test_name': args.test_name,
+        'tilelang_jobs': args.tilelang_jobs,
     }
 
 if __name__ == "__main__":
@@ -755,6 +772,7 @@ if __name__ == "__main__":
 
     generate_so = config['generate_so']
     test_name = config.get('test_name')
+    tilelang_jobs = config.get('tilelang_jobs')
 
     if "SKIP_TEST" in os.environ:
         BUILD_TEST_FILE = False
@@ -771,11 +789,13 @@ if __name__ == "__main__":
         'build_ext': {
             'device': device,
             'arch': arch,
-            'generate_so': generate_so
+            'generate_so': generate_so,
+            'tilelang_jobs': tilelang_jobs,
         },
         'bdist_wheel': {
             'device': device,
             'arch': arch,
+            'tilelang_jobs': tilelang_jobs,
         }
     }
     if test_name:
@@ -784,6 +804,7 @@ if __name__ == "__main__":
             'arch': arch,
             'generate_so': generate_so,
             'test_name': test_name,
+            'tilelang_jobs': tilelang_jobs,
         }
 
     setup(

--- a/xllm/compiler/tilelang/cli/compile_kernels.py
+++ b/xllm/compiler/tilelang/cli/compile_kernels.py
@@ -38,6 +38,12 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
         action="store_true",
         help="Force recompilation even when cache is hit.",
     )
+    parser.add_argument(
+        "--jobs",
+        type=int,
+        default=None,
+        help="Maximum parallel workers for compiling TileLang variants, e.g. --jobs 16.",
+    )
     return parser.parse_args(argv)
 
 
@@ -59,6 +65,7 @@ def main(argv: list[str] | None = None) -> None:
             kernel_names=args.kernels,
             force=args.force,
             device=args.device,
+            jobs=args.jobs,
         )
     elif args.target == "cuda":
         from ..targets.cuda.build import build_kernels

--- a/xllm/compiler/tilelang/targets/ascend/build.py
+++ b/xllm/compiler/tilelang/targets/ascend/build.py
@@ -17,6 +17,7 @@ def build_kernel_family(
     output_root: str | Path,
     force: bool = False,
     device: str | None = None,
+    jobs: int | str | None = None,
 ) -> KernelFamilyManifest:
     context = resolve_build_context(
         device=device,
@@ -27,6 +28,7 @@ def build_kernel_family(
         output_root=output_root,
         context=context,
         force=force,
+        jobs=jobs,
     )
 
 
@@ -35,6 +37,7 @@ def build_kernels(
     kernel_names: list[str] | None = None,
     force: bool = False,
     device: str | None = None,
+    jobs: int | str | None = None,
 ) -> list[KernelFamilyManifest]:
     context = resolve_build_context(
         device=device,
@@ -48,6 +51,7 @@ def build_kernels(
                 output_root=output_root,
                 context=context,
                 force=force,
+                jobs=jobs,
             )
         )
     return manifests

--- a/xllm/compiler/tilelang/targets/ascend/kernel_family_builder.py
+++ b/xllm/compiler/tilelang/targets/ascend/kernel_family_builder.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from concurrent.futures import ProcessPoolExecutor, as_completed
 from dataclasses import dataclass
 import importlib
+import multiprocessing
 import os
 from pathlib import Path
 
@@ -15,6 +16,37 @@ from .kernel_registry import RegisteredKernelFamily
 from .kernels import utils as kernel_utils
 from .kernels.utils import render_family_registry_inc, render_family_variants_inc
 from .toolchain import AscendBuildContext, TILELANG_BISHENG_COMMON_FLAGS
+
+
+# TileLang variant compilation is much heavier than ordinary C++ compilation:
+# each worker may lower Python/TVM IR and launch bisheng.  Keep the automatic
+# default conservative on large hosts; for example, a 640-CPU build machine uses
+# 16 workers by default instead of trying to spawn hundreds of workers.  The
+# default mapping is <=4 -> 1, <=8 -> 2, <=16 -> 4, <=64 -> 8, and >64 -> 16.
+_DEFAULT_TILELANG_JOB_LIMITS = (
+    (4, 1),
+    (8, 2),
+    (16, 4),
+    (64, 8),
+)
+_DEFAULT_TILELANG_JOBS_FOR_LARGE_HOST = 16
+
+
+def default_tilelang_jobs(cpu_count: int | None = None) -> int:
+    cpus = cpu_count or os.cpu_count() or 1
+    for max_cpus, jobs in _DEFAULT_TILELANG_JOB_LIMITS:
+        if cpus <= max_cpus:
+            return jobs
+    return _DEFAULT_TILELANG_JOBS_FOR_LARGE_HOST
+
+
+def _resolve_tilelang_jobs(jobs: int | str | None) -> int:
+    if jobs is None:
+        return default_tilelang_jobs()
+    resolved_jobs = int(jobs)
+    if resolved_jobs < 1:
+        raise ValueError(f"TileLang jobs must be positive, got: {jobs}")
+    return resolved_jobs
 
 
 @dataclass(frozen=True)
@@ -196,6 +228,7 @@ def build_kernel_family(
     output_root: str | Path,
     context: AscendBuildContext,
     force: bool = False,
+    jobs: int | str | None = None,
 ) -> KernelFamilyManifest:
     family_output_dir = Path(output_root) / "targets" / "ascend" / family.kernel_name
     family_output_dir.mkdir(parents=True, exist_ok=True)
@@ -303,8 +336,17 @@ def build_kernel_family(
         )
 
     if worker_args_list:
-        max_workers = max(1, os.cpu_count() or 1)
-        with ProcessPoolExecutor(max_workers=max_workers) as executor:
+        max_workers = _resolve_tilelang_jobs(jobs)
+        # Use spawn rather than Linux's default fork.  Fork can inherit
+        # TileLang/TVM lowering state from the parent process; in repeated full
+        # builds this intermittently stalled after 242 variants
+        # (fused_gdn_gating 240 + rope 2), before split_qkv_rmsnorm_mrope made
+        # bisheng progress.
+        multiprocessing_context = multiprocessing.get_context("spawn")
+        with ProcessPoolExecutor(
+            max_workers=max_workers,
+            mp_context=multiprocessing_context,
+        ) as executor:
             future_to_args = {
                 executor.submit(_run_variant_worker, args): args
                 for args in worker_args_list


### PR DESCRIPTION
## 背景

TileLang Ascend kernel 首次编译会一次性展开多个 kernel family 和 shape specialization。当前 main 上全量 TileLang 编译规模为 6 个 family、596 个编译变体：

| Kernel family | 变体数 |
| --- | ---: |
| causal_conv1d | 4 |
| causal_conv1d_decode | 22 |
| chunk_gated_delta_rule_fwd_h | 16 |
| fused_gdn_gating | 240 |
| rope | 2 |
| split_qkv_rmsnorm_mrope | 312 |
| **Total** | **596** |

在大 CPU 机器上，如果默认按全部 CPU 数启动 TileLang 编译 worker，实际会把大量 `bisheng` 编译进程同时拉起。对于 640 CPU 机器，这会造成更高的内存峰值、load、进程数和 system CPU 开销，反而降低首次编译完成速度，并增加机器卡住风险。

## 改动

- 新增 `setup.py build --tilelang-jobs N` 参数，用于显式控制 TileLang 编译并发。
- 将该参数透传到 TileLang compile CLI 和 Ascend kernel builder。
- 默认并发不再直接使用全部 CPU，而是按 CPU 数映射到保守档位：

| CPU 数 | 默认 TileLang jobs |
| ---: | ---: |
| <= 4 | 1 |
| <= 8 | 2 |
| <= 16 | 4 |
| <= 64 | 8 |
| > 64 | 16 |

- TileLang 编译 worker 使用 `spawn` multiprocessing context，避免 `fork` 继承父进程中已加载的 Python/C++/编译器相关状态导致长尾卡住或不稳定。

## 验证结果

说明：`内存 used` 是系统级采样，会受页缓存和背景负载影响；这里主要看同次实验里的峰值、进程数、load 和耗时变化。

### jobs 必要性验证

单 kernel family：`fused_gdn_gating`，240 个变体。

| 配置 | 状态 | TileLang 耗时 | 产物 | 内存峰值 | Swap 峰值 | load1 峰值 | bisheng 峰值 | user/sys CPU |
| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
| spawn + jobs=16 | 成功 | 104s | 240/240 | 133.7 GiB | 7.28 GiB | 14.99 | 32 | 1268.7s / 131.8s |
| spawn + jobs=640 | 成功 | 179s | 240/240 | 408.7 GiB | 7.28 GiB | 188.60 | 180 | 3912.8s / 3695.8s |

全量 TileLang：596 个变体。

| 配置 | 状态 | TileLang 耗时 | 产物 | 内存峰值 | Swap 峰值 | load1 峰值 | bisheng 峰值 | Python 峰值 | user/sys CPU |
| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
| spawn + jobs=16 | 成功 | 340s | 596/596 | 747.7 GiB | 7.28 GiB | 78.37 | 32 | 18 | 3998.3s / 416.7s |
| spawn + jobs=640 | 成功 | 464s | 596/596 | 1417.9 GiB | 7.29 GiB | 309.62 | 249 | 315 | 10765.7s / 14605.8s |

结论：`jobs=640` 不仅资源占用更高，而且全量编译更慢。默认限制 jobs 是必要的。

### fork/spawn 必要性验证

固定 `jobs=16`，只切换 multiprocessing context。

| 配置 | 状态 | TileLang 耗时 | 产物 | 内存峰值 | Swap 峰值 | load1 峰值 | bisheng 峰值 | Python 峰值 |
| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
| spawn + jobs=16 | 成功 | 340s | 596/596 | 747.7 GiB | 7.28 GiB | 78.37 | 32 | 18 |
| fork + jobs=16, run 1 | 超时 | 600s | 42/596 | 1456.0 GiB | 9.43 GiB | 185.19 | 32 | 20 |
| fork + jobs=16, run 2 | 成功 | 254s | 596/596 | 106.4 GiB | 9.43 GiB | 85.73 | 32 | 18 |

结论：`fork` 不是每次都失败，但会在相同 jobs 下出现长尾/超时，只完成部分产物。`spawn` 的价值是稳定隔离 worker 状态，避免把父进程中已加载的运行时、编译器、Python 状态继承到子进程里。这个改动是稳定性修复，不应被理解为单纯提速。

## 使用方式

默认情况下用户不需要配置：

```bash
python setup.py build
```

在 640 CPU 机器上默认会选择 `tilelang_jobs=16`，避免一次性拉满全部 CPU。

如需手动覆盖：

```bash
python setup.py build --tilelang-jobs 8
python setup.py build --tilelang-jobs 16
python setup.py build --tilelang-jobs 32
```

建议从默认值开始；只有在机器空闲、内存充足、确认不会影响其他任务时再提高。

## 验证

- `python -m py_compile` 通过。
- `setup.py --help` 可见 `--tilelang-jobs`。
- TileLang compile CLI 可见 `--jobs`。
- `git diff --check` 通过。
- `python setup.py --device npu build test` 通过，656 个测试全部通过。

## 影响

该改动不改变任何 TileLang kernel 的 shape 覆盖范围，也不减少编译产物数量；只改变编译 worker 的并发控制和进程启动方式。因此不会因为默认 jobs 限制导致 27B/35B 等模型缺少 shape 编译，也不会影响性能测试覆盖面。
