### PR TITLE
feat: support deepseek-v2 on dcu device.

### DIFF
--- a/scripts/build_support/env.py
+++ b/scripts/build_support/env.py
@@ -82,6 +82,21 @@ def get_torch_musa_root_path() -> Optional[str]:
     except ImportError:
         return None
 
+
+def find_dcu_so(package: str, pattern: str) -> Optional[str]:
+    try:
+        import glob
+        import importlib.util
+        import os
+        spec = importlib.util.find_spec(package)
+    except Exception:
+        return None
+    if not spec or not spec.submodule_search_locations:
+        return None
+    files = glob.glob(os.path.join(spec.submodule_search_locations[0], pattern))
+    return files[0] if files else None
+
+
 def prepend_path_env(var_name: str, path: str, sep: str = os.pathsep) -> None:
     """Prepend a path into a path env var without duplicates."""
     if not path:
@@ -213,6 +228,14 @@ def set_cuda_envs() -> None:
 def set_dcu_envs() -> None:
     set_common_envs()
     os.environ["DCU_PATH"] = get_dcu_root_path() or ""
+    if not os.getenv("FLASH_MLA_LIB"):
+        flash_mla_lib = find_dcu_so("flash_mla", "cuda*.so")
+        if flash_mla_lib:
+            os.environ["FLASH_MLA_LIB"] = flash_mla_lib
+    if not os.getenv("AITER_CPP_API_LIB"):
+        aiter_cpp_api_lib = find_dcu_so("aiter", "jit/module_cpp_api.so")
+        if aiter_cpp_api_lib:
+            os.environ["AITER_CPP_API_LIB"] = aiter_cpp_api_lib
 
 def set_ilu_envs() -> None:
     set_common_envs()

--- a/scripts/build_support/env.py
+++ b/scripts/build_support/env.py
@@ -83,7 +83,7 @@ def get_torch_musa_root_path() -> Optional[str]:
         return None
 
 
-def find_dcu_so(package: str, pattern: str) -> Optional[str]:
+def _find_dcu_so(package: str, pattern: str) -> Optional[str]:
     try:
         import glob
         import importlib.util
@@ -229,11 +229,11 @@ def set_dcu_envs() -> None:
     set_common_envs()
     os.environ["DCU_PATH"] = get_dcu_root_path() or ""
     if not os.getenv("FLASH_MLA_LIB"):
-        flash_mla_lib = find_dcu_so("flash_mla", "cuda*.so")
+        flash_mla_lib = _find_dcu_so("flash_mla", "cuda*.so")
         if flash_mla_lib:
             os.environ["FLASH_MLA_LIB"] = flash_mla_lib
     if not os.getenv("AITER_CPP_API_LIB"):
-        aiter_cpp_api_lib = find_dcu_so("aiter", "jit/module_cpp_api.so")
+        aiter_cpp_api_lib = _find_dcu_so("aiter", "jit/module_cpp_api.so")
         if aiter_cpp_api_lib:
             os.environ["AITER_CPP_API_LIB"] = aiter_cpp_api_lib
 

--- a/setup.py
+++ b/setup.py
@@ -256,13 +256,21 @@ class ExtBuild(build_ext):
                 if dcu_arch:
                     cmake_args += [f"-DCMAKE_HIP_ARCHITECTURES={dcu_arch}"]
 
+                set_dcu_envs()
+
                 # Pass FLASH_ATTENTION_LIB to CMake so the DCU layers can
                 # link against libflash_attention.so (prefix prefill/decode).
                 flash_attn_lib = os.getenv("FLASH_ATTENTION_LIB")
                 if flash_attn_lib:
                     cmake_args += [f"-DFLASH_ATTENTION_LIB={flash_attn_lib}"]
 
-                set_dcu_envs()
+                flash_mla_lib = os.getenv("FLASH_MLA_LIB")
+                if flash_mla_lib:
+                    cmake_args += [f"-DFLASH_MLA_LIB={flash_mla_lib}"]
+
+                aiter_cpp_api_lib = os.getenv("AITER_CPP_API_LIB")
+                if aiter_cpp_api_lib:
+                    cmake_args += [f"-DAITER_CPP_API_LIB={aiter_cpp_api_lib}"]
             else:
                 raise RuntimeError(
                     "DCU build requires a HIP/ROCm PyTorch environment. "

--- a/xllm/core/framework/kv_cache/kv_cache_shape.cpp
+++ b/xllm/core/framework/kv_cache/kv_cache_shape.cpp
@@ -353,7 +353,7 @@ void KVCacheShape::apply_device_layout(const ModelArgs& model_args) {
   }
 #endif
 
-#if defined(USE_MLU)
+#if defined(USE_MLU) || defined(USE_DCU)
   if (model_args.enable_mla()) {
     CHECK(key_cache_shape_.has_value())
         << "key_cache_shape is not initialized.";

--- a/xllm/core/kernels/dcu/CMakeLists.txt
+++ b/xllm/core/kernels/dcu/CMakeLists.txt
@@ -51,6 +51,8 @@ set(DCU_LOCAL_HIP_SOURCES
   ${CMAKE_SOURCE_DIR}/xllm/core/kernels/dcu/piecewise_graphs.cpp
   ${CMAKE_SOURCE_DIR}/xllm/core/kernels/dcu/global_capture_instance.cpp
   ${CMAKE_SOURCE_DIR}/xllm/core/kernels/dcu/group_gemm.cpp
+  ${CMAKE_SOURCE_DIR}/xllm/core/kernels/dcu/flash_mla_adapter.cpp
+  ${CMAKE_SOURCE_DIR}/xllm/core/kernels/dcu/topk_gate.cpp
 )
 
 hipify_sources_target(
@@ -67,6 +69,23 @@ set(DCU_SOURCE_FILES
   ${DCU_LOCAL_HIP_SOURCES}
 )
 
+if(NOT DEFINED FLASH_MLA_LIB OR NOT EXISTS "${FLASH_MLA_LIB}")
+  message(FATAL_ERROR
+    "FLASH_MLA_LIB is required for DCU FlashMLA. Install flash_mla and set "
+    "FLASH_MLA_LIB before invoking setup.py.")
+endif()
+add_library(flash_mla SHARED IMPORTED)
+set_target_properties(flash_mla PROPERTIES IMPORTED_LOCATION "${FLASH_MLA_LIB}")
+
+if(NOT DEFINED AITER_CPP_API_LIB OR NOT EXISTS "${AITER_CPP_API_LIB}")
+  message(FATAL_ERROR
+    "AITER_CPP_API_LIB is required for DCU grouped topk. Install aiter and set "
+    "AITER_CPP_API_LIB before invoking setup.py.")
+endif()
+add_library(aiter_cpp_api SHARED IMPORTED)
+set_target_properties(aiter_cpp_api PROPERTIES
+  IMPORTED_LOCATION "${AITER_CPP_API_LIB}")
+
 cc_library(
   NAME
     dcu_kernels
@@ -80,9 +99,16 @@ cc_library(
     torch
     glog::glog
     :platform
+    aiter_cpp_api
+    flash_mla
 )
 
 add_dependencies(dcu_kernels ${DCU_HIPIFY_TARGET})
+
+get_filename_component(FLASH_MLA_LIB_DIR "${FLASH_MLA_LIB}" DIRECTORY)
+get_filename_component(AITER_CPP_API_LIB_DIR "${AITER_CPP_API_LIB}" DIRECTORY)
+set_property(TARGET dcu_kernels APPEND PROPERTY BUILD_RPATH "${FLASH_MLA_LIB_DIR}")
+set_property(TARGET dcu_kernels APPEND PROPERTY BUILD_RPATH "${AITER_CPP_API_LIB_DIR}")
 
 target_include_directories(dcu_kernels
   PUBLIC

--- a/xllm/core/kernels/dcu/dcu_ops_api.h
+++ b/xllm/core/kernels/dcu/dcu_ops_api.h
@@ -79,6 +79,26 @@ torch::Tensor rejection_sample(const torch::Tensor& draft_token_ids,
                                const torch::Tensor& uniform_probs,
                                int64_t max_spec_len);
 
+std::tuple<torch::Tensor, torch::Tensor> moe_grouped_topk(
+    torch::Tensor& gating_output,
+    int64_t topk,
+    int64_t num_expert_group,
+    int64_t topk_group,
+    bool renormalize,
+    const std::optional<torch::Tensor>& correction_bias,
+    const std::string& scoring_func,
+    double routed_scaling_factor);
+
+std::tuple<torch::Tensor, torch::Tensor> moe_active_topk(
+    torch::Tensor& gating_output,
+    int64_t topk,
+    int64_t num_expert_group,
+    int64_t topk_group,
+    bool renormalize,
+    const std::optional<torch::Tensor>& correction_bias,
+    const std::string& scoring_func,
+    double routed_scaling_factor);
+
 // DCU W8A8 dynamic activation quantization.
 // Current DCU implementation supports only no-smooth per-token INT8
 // quantization and returns one fp32 scale per token row.

--- a/xllm/core/kernels/dcu/flash_mla_adapter.cpp
+++ b/xllm/core/kernels/dcu/flash_mla_adapter.cpp
@@ -1,0 +1,158 @@
+/* Copyright 2026 The xLLM Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://github.com/jd-opensource/xllm/blob/main/LICENSE
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include "kernels/dcu/flash_mla_adapter.h"
+
+#include <glog/logging.h>
+#include <torch/torch.h>
+
+#include <cstdint>
+#include <optional>
+#include <vector>
+
+// flash-mla native extension symbols. Keep these declarations at global scope
+// to match the unqualified symbols exported by the .so.
+
+// Returns {tile_scheduler_metadata, num_splits}.
+std::vector<torch::Tensor> get_mla_decoding_metadata_dense_fp8(
+    torch::Tensor& seqlens_k,
+    int32_t num_heads_per_head_k,
+    int32_t num_heads_k);
+
+// Split-q BF16/FP16 MLA decode.
+std::vector<torch::Tensor> mha_fwd_kvcache_mla_nope_pe(
+    torch::Tensor& q_nope,
+    torch::Tensor& q_pe,
+    const torch::Tensor& kcache,
+    std::optional<const torch::Tensor>& vcache,
+    int32_t head_size_v,
+    const torch::Tensor& seqlens_k,
+    const torch::Tensor& block_table,
+    float softmax_scale,
+    bool is_causal,
+    const torch::Tensor& tile_scheduler_metadata,
+    const torch::Tensor& num_splits);
+
+namespace xllm {
+namespace kernel {
+namespace dcu {
+namespace flash_mla {
+
+namespace {
+
+void check_dense_decode_inputs(const DenseDecodeParams& params) {
+  CHECK(params.q_nope.defined()) << "flash_mla: q_nope must be defined";
+  CHECK(params.q_pe.defined()) << "flash_mla: q_pe must be defined";
+  CHECK(params.k_cache.defined()) << "flash_mla: k_cache must be defined";
+  CHECK(params.seqlens_k.defined()) << "flash_mla: seqlens_k must be defined";
+  CHECK(params.block_table.defined())
+      << "flash_mla: block_table must be defined";
+
+  const torch::Device kDev = params.k_cache.device();
+  const torch::Device q_nope_dev = params.q_nope.device();
+  const torch::Device q_pe_dev = params.q_pe.device();
+  const torch::Device seqlens_dev = params.seqlens_k.device();
+  const torch::Device block_table_dev = params.block_table.device();
+  CHECK(q_nope_dev == kDev) << "flash_mla: q_nope must be on the DCU device";
+  CHECK(q_pe_dev == kDev) << "flash_mla: q_pe must be on the DCU device";
+  CHECK(seqlens_dev == kDev)
+      << "flash_mla: seqlens_k must be on the DCU device";
+  CHECK(block_table_dev == kDev)
+      << "flash_mla: block_table must be on the DCU device";
+
+  CHECK_EQ(params.q_nope.dim(), 4)
+      << "flash_mla: q_nope must be 4D [B,S_q,H_q,D]";
+  CHECK_EQ(params.q_pe.dim(), 4) << "flash_mla: q_pe must be 4D [B,S_q,H_q,D]";
+  CHECK_EQ(params.k_cache.dim(), 4)
+      << "flash_mla: k_cache must be 4D [blocks,page,1,D]";
+  CHECK_EQ(params.k_cache.size(1), 64)
+      << "flash_mla: page/block size must be 64, got "
+      << params.k_cache.size(1);
+  CHECK_EQ(params.k_cache.size(2), 1)
+      << "flash_mla: MLA expects a single KV head (num_heads_k == 1)";
+  CHECK_EQ(params.seqlens_k.dim(), 1) << "flash_mla: seqlens_k must be 1D [B]";
+  CHECK_EQ(params.block_table.dim(), 2)
+      << "flash_mla: block_table must be 2D [B,max_blocks]";
+
+  const int64_t q_nope_dim = params.q_nope.size(3);
+  const int64_t q_pe_dim = params.q_pe.size(3);
+  CHECK_EQ(params.k_cache.size(3), q_nope_dim + q_pe_dim)
+      << "flash_mla: k_cache last dim must equal q_nope.dim + q_pe.dim";
+  CHECK_EQ(params.q_nope.size(0), params.q_pe.size(0))
+      << "flash_mla: q_nope/q_pe batch must match";
+  CHECK_EQ(params.q_nope.size(1), params.q_pe.size(1))
+      << "flash_mla: q_nope/q_pe seq must match";
+  CHECK_EQ(params.q_nope.size(2), params.q_pe.size(2))
+      << "flash_mla: q_nope/q_pe head count must match";
+  CHECK_GT(params.head_size_v, 0) << "flash_mla: head_size_v must be positive";
+}
+
+}  // namespace
+
+torch::Tensor dense_decode(DenseDecodeParams& params) {
+  CHECK(params.kind == DenseDecodeKind::kQNopePe)
+      << "flash_mla: only DenseDecodeKind::kQNopePe (BF16/FP16 split-q) is "
+         "supported in phase 1";
+  check_dense_decode_inputs(params);
+
+  torch::Tensor seqlens_k = params.seqlens_k;
+  if (seqlens_k.scalar_type() != torch::kInt32) {
+    seqlens_k = seqlens_k.to(torch::kInt32);
+  }
+  torch::Tensor block_table = params.block_table;
+  if (block_table.scalar_type() != torch::kInt32) {
+    block_table = block_table.to(torch::kInt32);
+  }
+
+  const int64_t seq_q = params.q_nope.size(1);
+  const int64_t heads_q = params.q_nope.size(2);
+  const int32_t num_heads_k = 1;
+  const int32_t num_heads_per_head_k =
+      static_cast<int32_t>(seq_q * heads_q / num_heads_k);
+
+  auto metadata = get_mla_decoding_metadata_dense_fp8(
+      seqlens_k, num_heads_per_head_k, num_heads_k);
+  CHECK_EQ(metadata.size(), 2u)
+      << "flash_mla: expected {tile_scheduler_metadata, num_splits}";
+  const torch::Tensor& tile_scheduler_metadata = metadata[0];
+  const torch::Tensor& num_splits = metadata[1];
+
+  CHECK_GT(params.softmax_scale, 0.0F)
+      << "flash_mla: softmax_scale must be set by the MLA attention layer";
+  const float softmax_scale = params.softmax_scale;
+
+  // MLA latent cache is key-only.
+  std::optional<const torch::Tensor> vcache = std::nullopt;
+
+  auto out_lse = mha_fwd_kvcache_mla_nope_pe(
+      /*q_nope=*/params.q_nope,
+      /*q_pe=*/params.q_pe,
+      /*kcache=*/params.k_cache,
+      /*vcache=*/vcache,
+      /*head_size_v=*/static_cast<int32_t>(params.head_size_v),
+      /*seqlens_k=*/seqlens_k,
+      /*block_table=*/block_table,
+      /*softmax_scale=*/softmax_scale,
+      /*is_causal=*/params.is_causal,
+      /*tile_scheduler_metadata=*/tile_scheduler_metadata,
+      /*num_splits=*/num_splits);
+  CHECK(!out_lse.empty()) << "flash_mla: decode returned no output";
+  return out_lse[0];
+}
+
+}  // namespace flash_mla
+}  // namespace dcu
+}  // namespace kernel
+}  // namespace xllm

--- a/xllm/core/kernels/dcu/flash_mla_adapter.h
+++ b/xllm/core/kernels/dcu/flash_mla_adapter.h
@@ -1,0 +1,58 @@
+/* Copyright 2026 The xLLM Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://github.com/jd-opensource/xllm/blob/main/LICENSE
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+// Thin adapter around the flash-mla native extension.
+
+#pragma once
+
+#include <torch/torch.h>
+
+#include <cstdint>
+
+namespace xllm {
+namespace kernel {
+namespace dcu {
+namespace flash_mla {
+
+enum class DenseDecodeKind {
+  kQNopePe,
+};
+
+// Inputs for flash-mla dense MLA decode.
+//
+//   q_nope:      [B, S_q, H_q, kv_lora_rank]
+//   q_pe:        [B, S_q, H_q, qk_rope_head_dim]
+//   k_cache:     [num_blocks, 64, 1, kv_lora_rank + qk_rope_head_dim]
+//   seqlens_k:   [B] int32
+//   block_table: [B, max_blocks] int32
+struct DenseDecodeParams {
+  torch::Tensor q_nope;
+  torch::Tensor q_pe;
+  torch::Tensor k_cache;
+  torch::Tensor seqlens_k;
+  torch::Tensor block_table;
+  int64_t head_size_v = 0;
+  float softmax_scale = -1.0F;
+  bool is_causal = false;
+  DenseDecodeKind kind = DenseDecodeKind::kQNopePe;
+};
+
+// Returns [B, S_q, H_q, head_size_v] on the DCU device.
+torch::Tensor dense_decode(DenseDecodeParams& params);
+
+}  // namespace flash_mla
+}  // namespace dcu
+}  // namespace kernel
+}  // namespace xllm

--- a/xllm/core/kernels/dcu/topk_gate.cpp
+++ b/xllm/core/kernels/dcu/topk_gate.cpp
@@ -1,0 +1,149 @@
+/* Copyright 2026 The xLLM Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://github.com/jd-opensource/xllm/blob/main/LICENSE
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include <glog/logging.h>
+
+#include <cstdint>
+#include <string>
+
+#include "kernels/cuda/cuda_ops_api.h"
+#include "kernels/dcu/dcu_ops_api.h"
+
+namespace aiter {
+namespace native {
+
+void grouped_topk(torch::Tensor& gating_output,
+                  torch::Tensor& topk_weights,
+                  torch::Tensor& topk_ids,
+                  int num_expert_group,
+                  int topk_group,
+                  bool need_renorm,
+                  bool is_softmax,
+                  float routed_scaling_factor);
+
+void biased_grouped_topk(torch::Tensor& gating_output,
+                         torch::Tensor& correction_bias,
+                         torch::Tensor& topk_weights,
+                         torch::Tensor& topk_ids,
+                         int num_expert_group,
+                         int topk_group,
+                         bool need_renorm,
+                         float routed_scaling_factor);
+
+}  // namespace native
+}  // namespace aiter
+
+namespace xllm {
+namespace kernel {
+namespace dcu {
+
+namespace {
+
+bool is_supported_scoring_func(const std::string& scoring_func) {
+  return scoring_func == "softmax" || scoring_func == "sigmoid";
+}
+
+}  // namespace
+
+std::tuple<torch::Tensor, torch::Tensor> moe_grouped_topk(
+    torch::Tensor& gating_output,
+    int64_t topk,
+    int64_t num_expert_group,
+    int64_t topk_group,
+    bool renormalize,
+    const std::optional<torch::Tensor>& correction_bias,
+    const std::string& scoring_func,
+    double routed_scaling_factor) {
+  CHECK(gating_output.defined()) << "dcu::moe_grouped_topk: input is undefined";
+  CHECK_EQ(gating_output.dim(), 2)
+      << "dcu::moe_grouped_topk: input must be [num_tokens, num_experts]";
+  CHECK_GT(topk, 0) << "dcu::moe_grouped_topk: topk must be positive";
+  CHECK_GT(num_expert_group, 1)
+      << "dcu::moe_grouped_topk requires num_expert_group > 1";
+  CHECK_GT(topk_group, 0)
+      << "dcu::moe_grouped_topk: topk_group must be positive";
+  CHECK_LE(topk_group, num_expert_group)
+      << "dcu::moe_grouped_topk: topk_group must not exceed "
+         "num_expert_group";
+  CHECK(is_supported_scoring_func(scoring_func))
+      << "dcu::moe_grouped_topk: unsupported scoring function " << scoring_func;
+
+  const int64_t num_tokens = gating_output.size(0);
+  torch::Tensor topk_weights = torch::empty(
+      {num_tokens, topk},
+      torch::dtype(torch::kFloat32).device(gating_output.device()));
+  torch::Tensor topk_ids =
+      torch::empty({num_tokens, topk},
+                   torch::dtype(torch::kInt32).device(gating_output.device()));
+
+  const int32_t num_expert_group_i32 = static_cast<int32_t>(num_expert_group);
+  const int32_t topk_group_i32 = static_cast<int32_t>(topk_group);
+  const float routed_scaling_factor_f32 =
+      static_cast<float>(routed_scaling_factor);
+
+  if (correction_bias.has_value()) {
+    CHECK_EQ(scoring_func, "sigmoid")
+        << "dcu::moe_grouped_topk: correction bias is supported only for "
+           "sigmoid scoring";
+    torch::Tensor bias = correction_bias.value();
+    aiter::native::biased_grouped_topk(gating_output,
+                                       bias,
+                                       topk_weights,
+                                       topk_ids,
+                                       num_expert_group_i32,
+                                       topk_group_i32,
+                                       renormalize,
+                                       routed_scaling_factor_f32);
+    return std::make_tuple(topk_weights, topk_ids);
+  }
+
+  const bool is_softmax = scoring_func == "softmax";
+  aiter::native::grouped_topk(gating_output,
+                              topk_weights,
+                              topk_ids,
+                              num_expert_group_i32,
+                              topk_group_i32,
+                              renormalize,
+                              is_softmax,
+                              routed_scaling_factor_f32);
+  return std::make_tuple(topk_weights, topk_ids);
+}
+
+std::tuple<torch::Tensor, torch::Tensor> moe_active_topk(
+    torch::Tensor& gating_output,
+    int64_t topk,
+    int64_t num_expert_group,
+    int64_t topk_group,
+    bool renormalize,
+    const std::optional<torch::Tensor>& correction_bias,
+    const std::string& scoring_func,
+    double routed_scaling_factor) {
+  if (num_expert_group > 1) {
+    return moe_grouped_topk(gating_output,
+                            topk,
+                            num_expert_group,
+                            topk_group,
+                            renormalize,
+                            correction_bias,
+                            scoring_func,
+                            routed_scaling_factor);
+  }
+  return cuda::moe_fused_topk(
+      gating_output, topk, renormalize, correction_bias, scoring_func);
+}
+
+}  // namespace dcu
+}  // namespace kernel
+}  // namespace xllm

--- a/xllm/core/kernels/ops_api.cpp
+++ b/xllm/core/kernels/ops_api.cpp
@@ -48,6 +48,56 @@ bool is_supported_initial_state_dtype(torch::ScalarType dtype) {
   return dtype == torch::kBFloat16 || dtype == torch::kFloat32;
 }
 #endif
+
+#if defined(USE_DCU)
+torch::Tensor pack_2d_position_ids(const torch::Tensor& position_ids,
+                                   const torch::Tensor& cu_query_lens,
+                                   const torch::Tensor& query) {
+  if (position_ids.numel() == query.size(0)) {
+    return position_ids.reshape({-1}).contiguous();
+  }
+
+  torch::Tensor cu_cpu = cu_query_lens.to(torch::kCPU).to(torch::kInt64);
+  CHECK_GE(cu_cpu.numel(), 2)
+      << "apply_rotary: cu_query_lens must have at least 2 elements when "
+         "packing 2D position_ids.";
+  const int64_t num_seqs = cu_cpu.numel() - 1;
+  CHECK_LE(num_seqs, position_ids.size(0))
+      << "apply_rotary: position_ids batch is smaller than cu_query_lens, "
+      << "position_ids: " << position_ids.sizes()
+      << ", cu_query_lens: " << cu_query_lens.sizes();
+
+  std::vector<torch::Tensor> packed_positions;
+  packed_positions.reserve(static_cast<size_t>(num_seqs));
+  int64_t total_tokens = 0;
+  for (int64_t seq_idx = 0; seq_idx < num_seqs; ++seq_idx) {
+    const int64_t start = cu_cpu[seq_idx].item<int64_t>();
+    const int64_t end = cu_cpu[seq_idx + 1].item<int64_t>();
+    const int64_t seq_len = end - start;
+    CHECK_GE(seq_len, 0) << "apply_rotary: cu_query_lens must be monotonic.";
+    CHECK_LE(seq_len, position_ids.size(1))
+        << "apply_rotary: position_ids seq dimension is smaller than "
+        << "q_seq_len, position_ids: " << position_ids.sizes()
+        << ", seq_len: " << seq_len;
+    if (seq_len > 0) {
+      packed_positions.emplace_back(
+          position_ids.select(/*dim=*/0, seq_idx)
+              .slice(/*dim=*/0, /*start=*/0, /*end=*/seq_len));
+    }
+    total_tokens += seq_len;
+  }
+  CHECK_EQ(total_tokens, query.size(0))
+      << "apply_rotary: packed position_ids token count mismatch, "
+      << "position_ids: " << position_ids.sizes()
+      << ", cu_query_lens: " << cu_query_lens.sizes()
+      << ", query: " << query.sizes();
+  if (packed_positions.empty()) {
+    return torch::empty({0}, position_ids.options().dtype(torch::kInt64));
+  }
+  return torch::cat(packed_positions, /*dim=*/0).to(torch::kInt64).contiguous();
+}
+
+#endif
 }  // namespace
 
 void apply_rotary(RotaryParams& params) {
@@ -74,6 +124,18 @@ void apply_rotary(RotaryParams& params) {
     // positions is already int64 on CUDA/MUSA/DCU (pre-converted in
     // ForwardInput::to).
     pos_ids = params.position_ids.value().to(torch::kInt64);
+#if defined(USE_DCU)
+    if (pos_ids.dim() == 2 && params.q.dim() == 3) {
+      CHECK(params.cu_query_lens.has_value())
+          << "apply_rotary: cu_query_lens is required to pack 2D "
+             "position_ids for packed query, position_ids: "
+          << pos_ids.sizes() << ", query: " << params.q.sizes();
+      pos_ids =
+          pack_2d_position_ids(pos_ids, params.cu_query_lens.value(), params.q);
+    } else {
+      pos_ids = pos_ids.contiguous();
+    }
+#endif
   } else if (params.cu_query_lens.has_value()) {
     auto cu = params.cu_query_lens.value().to(torch::kInt64);
     CHECK(cu.numel() >= 2)
@@ -119,7 +181,14 @@ void apply_rotary(RotaryParams& params) {
     LOG(FATAL) << "apply_rotary: neither cos_sin nor cos/sin "
                   "provided; cannot infer cos_sin.";
   }
+#if defined(USE_DCU)
+  std::optional<torch::Tensor> key =
+      params.k.defined() ? std::optional<torch::Tensor>(params.k)
+                         : std::nullopt;
+  cuda::rotary_embedding(pos_ids, params.q, key, cos_sin, is_neox);
+#else
   cuda::rotary_embedding(pos_ids, params.q, params.k, cos_sin, is_neox);
+#endif
 #elif defined(USE_ILU)
   torch::Tensor ilu_cos_sin;
   if (params.precomputed_cos_sin.defined()) {
@@ -528,7 +597,16 @@ std::tuple<torch::Tensor, torch::Tensor> moe_active_topk(
                               params.scoring_func,
                               params.route_scale,
                               params.e_score_correction_bias);
-#elif defined(USE_CUDA) || defined(USE_MUSA) || defined(USE_DCU)
+#elif defined(USE_DCU)
+  return dcu::moe_active_topk(params.input,
+                              params.topk,
+                              params.num_expert_group,
+                              params.topk_group,
+                              params.normalize,
+                              params.e_score_correction_bias,
+                              params.scoring_func,
+                              params.route_scale);
+#elif defined(USE_CUDA) || defined(USE_MUSA)
   return cuda::moe_fused_topk(params.input,
                               params.topk,
                               params.normalize,

--- a/xllm/core/kernels/ops_api.cpp
+++ b/xllm/core/kernels/ops_api.cpp
@@ -126,12 +126,16 @@ void apply_rotary(RotaryParams& params) {
     pos_ids = params.position_ids.value().to(torch::kInt64);
 #if defined(USE_DCU)
     if (pos_ids.dim() == 2 && params.q.dim() == 3) {
-      CHECK(params.cu_query_lens.has_value())
-          << "apply_rotary: cu_query_lens is required to pack 2D "
-             "position_ids for packed query, position_ids: "
-          << pos_ids.sizes() << ", query: " << params.q.sizes();
-      pos_ids =
-          pack_2d_position_ids(pos_ids, params.cu_query_lens.value(), params.q);
+      if (pos_ids.numel() == params.q.size(0)) {
+        pos_ids = pos_ids.reshape({-1}).contiguous();
+      } else {
+        CHECK(params.cu_query_lens.has_value())
+            << "apply_rotary: cu_query_lens is required to pack 2D "
+               "position_ids for packed query, position_ids: "
+            << pos_ids.sizes() << ", query: " << params.q.sizes();
+        pos_ids = pack_2d_position_ids(
+            pos_ids, params.cu_query_lens.value(), params.q);
+      }
     } else {
       pos_ids = pos_ids.contiguous();
     }

--- a/xllm/core/layers/common/rotary_embedding.cpp
+++ b/xllm/core/layers/common/rotary_embedding.cpp
@@ -271,6 +271,9 @@ void DeepseekScalingRotaryEmbeddingImpl::forward(
   if (is_prompt) {
     discrete = false;
     position_ids = std::nullopt;
+    if (Platform::is_dcu()) {
+      position_ids = positions;
+    }
   } else {
     discrete = true;
     position_ids = positions;

--- a/xllm/core/layers/dcu/CMakeLists.txt
+++ b/xllm/core/layers/dcu/CMakeLists.txt
@@ -36,12 +36,16 @@ cc_library(
     torch_attention.h
     flash_attention.h
     fused_moe.h
+    deepseek_v2_attention.h
+    deepseek_v2_decoder_layer_impl.h
   SRCS
     attention.cpp
     base_attention_impl.cpp
     torch_attention.cpp
     flash_attention.cpp
     fused_moe.cpp
+    deepseek_v2_attention.cpp
+    deepseek_v2_decoder_layer_impl.cpp
   DEPS
     :common_layers
     flash_attention

--- a/xllm/core/layers/dcu/deepseek_v2_attention.cpp
+++ b/xllm/core/layers/dcu/deepseek_v2_attention.cpp
@@ -1,0 +1,343 @@
+/* Copyright 2026 The xLLM Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://github.com/jd-opensource/xllm/blob/main/LICENSE
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include "layers/dcu/deepseek_v2_attention.h"
+
+#include <glog/logging.h>
+#include <torch/torch.h>
+
+#include <cmath>
+#include <optional>
+#include <tuple>
+#include <vector>
+
+#include "kernels/dcu/flash_mla_adapter.h"
+#include "layers/common/rotary_embedding.h"
+#include "layers/common/rotary_embedding_util.h"
+
+namespace xllm {
+namespace layer {
+
+namespace {
+
+torch::Tensor to_deepseek_rope_layout(const torch::Tensor& tensor) {
+  std::vector<int64_t> view_shape = tensor.sizes().vec();
+  const int64_t last_dim = view_shape.back();
+  CHECK_EQ(last_dim % 2, 0)
+      << "DeepSeek RoPE dimension must be even, tensor: " << tensor.sizes();
+  view_shape.back() = last_dim / 2;
+  view_shape.emplace_back(2);
+  return tensor.view(view_shape)
+      .transpose(-1, -2)
+      .reshape_as(tensor)
+      .contiguous();
+}
+
+}  // namespace
+
+DeepseekV2AttentionImpl::DeepseekV2AttentionImpl(
+    const ModelArgs& args,
+    const QuantArgs& quant_args,
+    const ParallelArgs& parallel_args,
+    const torch::TensorOptions& options)
+    : q_lora_rank_(args.q_lora_rank()),
+      kv_lora_rank_(args.kv_lora_rank()),
+      qk_nope_head_dim_(args.qk_nope_head_dim()),
+      qk_rope_head_dim_(args.qk_rope_head_dim()),
+      v_head_dim_(args.v_head_dim()),
+      eps_(args.rms_norm_eps()),
+      interleaved_(false) {
+  const int64_t tp_size = parallel_args.tp_group_->world_size();
+  const int64_t num_heads = args.n_heads();
+  const int64_t hidden_size = args.hidden_size();
+  const int64_t max_position_embeddings = args.max_position_embeddings();
+  CHECK_EQ(num_heads % tp_size, 0)
+      << "num_heads must be divisible by tensor parallel size";
+  tp_heads_ = num_heads / tp_size;
+  qk_head_dim_ = qk_nope_head_dim_ + qk_rope_head_dim_;
+
+  ProcessGroup* weight_group = parallel_args.tp_group_;
+  const LinearExtraArgs attention_linear_extra_args("none", false);
+
+  if (q_lora_rank_ > 0) {
+    q_a_proj_ = register_module(
+        "q_a_proj",
+        ReplicatedLinear(
+            hidden_size, q_lora_rank_, /*bias=*/false, QuantArgs(), options));
+    q_a_layernorm_ =
+        register_module("q_a_layernorm", RMSNorm(q_lora_rank_, eps_, options));
+    q_b_proj_ =
+        register_module("q_b_proj",
+                        ColumnParallelLinear(q_lora_rank_,
+                                             num_heads * qk_head_dim_,
+                                             /*bias=*/false,
+                                             /*gather_output=*/false,
+                                             quant_args,
+                                             weight_group,
+                                             options,
+                                             attention_linear_extra_args));
+  } else {
+    q_proj_ =
+        register_module("q_proj",
+                        ColumnParallelLinear(hidden_size,
+                                             num_heads * qk_head_dim_,
+                                             /*bias=*/false,
+                                             /*gather_output=*/false,
+                                             quant_args,
+                                             weight_group,
+                                             options,
+                                             attention_linear_extra_args));
+  }
+
+  kv_a_proj_with_mqa_ =
+      register_module("kv_a_proj_with_mqa",
+                      ReplicatedLinear(hidden_size,
+                                       kv_lora_rank_ + qk_rope_head_dim_,
+                                       /*bias=*/false,
+                                       QuantArgs(),
+                                       options));
+  kv_a_layernorm_ =
+      register_module("kv_a_layernorm", RMSNorm(kv_lora_rank_, eps_, options));
+  kv_b_proj_ = register_module(
+      "kv_b_proj",
+      ColumnParallelLinear(kv_lora_rank_,
+                           num_heads * (qk_nope_head_dim_ + v_head_dim_),
+                           /*bias=*/false,
+                           /*gather_output=*/false,
+                           QuantArgs(),
+                           weight_group,
+                           options,
+                           attention_linear_extra_args));
+
+  torch::Tensor weights = kv_b_proj_->weight().unflatten(
+      0, {tp_heads_, qk_nope_head_dim_ + v_head_dim_});
+  w_kc_ = weights.slice(1, 0, qk_nope_head_dim_);
+  w_vc_ = weights.slice(1, qk_nope_head_dim_, qk_nope_head_dim_ + v_head_dim_);
+
+  rotary_emb_ =
+      register_module("rotary_emb",
+                      create_mla_rotary_embedding(args,
+                                                  qk_rope_head_dim_,
+                                                  max_position_embeddings,
+                                                  interleaved_,
+                                                  options));
+
+  o_proj_ = register_module("o_proj",
+                            RowParallelLinear(num_heads * v_head_dim_,
+                                              hidden_size,
+                                              /*bias=*/false,
+                                              /*input_is_parallelized=*/true,
+                                              /*enable_result_reduction=*/false,
+                                              quant_args,
+                                              weight_group,
+                                              options,
+                                              attention_linear_extra_args));
+
+  softmax_scale_ = static_cast<float>(std::pow(
+      static_cast<double>(qk_nope_head_dim_ + qk_rope_head_dim_), -0.5));
+  if (args.rope_scaling_rope_type() == "deepseek_yarn") {
+    const float mscale = layer::rotary::yarn_get_mscale(
+        args.rope_scaling_factor(), args.rope_scaling_mscale_all_dim());
+    softmax_scale_ *= mscale * mscale;
+  }
+}
+
+torch::Tensor DeepseekV2AttentionImpl::prepare_query(
+    const torch::Tensor& hidden_states) {
+  torch::Tensor q;
+  if (q_lora_rank_ > 0) {
+    q = q_a_proj_(hidden_states);
+    torch::Tensor q_a = std::get<0>(q_a_layernorm_(q));
+    q = q_b_proj_->forward(q_a);
+  } else {
+    q = q_proj_->forward(hidden_states);
+  }
+  return q.view({-1, tp_heads_, qk_head_dim_});
+}
+
+void DeepseekV2AttentionImpl::store_latent_cache(
+    const torch::Tensor& latent_cache,
+    const torch::Tensor& slot_mapping,
+    const torch::Tensor& k_cache) {
+  const int64_t dim = k_cache.size(-1);
+  torch::Tensor k_cache_rows = k_cache.view({-1, dim});
+  k_cache_rows.index_copy_(
+      /*dim=*/0, slot_mapping.to(torch::kInt64), latent_cache);
+}
+
+torch::Tensor DeepseekV2AttentionImpl::project_output(
+    const torch::Tensor& attn_latent) {
+  torch::Tensor attn_bmm =
+      torch::bmm(attn_latent.transpose(0, 1), w_vc_);  // [tp_heads, tokens, v]
+  attn_bmm = attn_bmm.transpose(0, 1);                 // [tokens, tp_heads, v]
+  torch::Tensor proj_input = attn_bmm.flatten(1, 2);   // [tokens, tp_heads*v]
+  return o_proj_->forward(proj_input);
+}
+
+torch::Tensor DeepseekV2AttentionImpl::decode_flash_mla(
+    const torch::Tensor& q_nope_absorbed,
+    const torch::Tensor& q_pe,
+    const AttentionMetadata& attn_metadata,
+    KVCache& kv_cache) {
+  const int64_t batch = q_nope_absorbed.size(0);
+  kernel::dcu::flash_mla::DenseDecodeParams params;
+  params.q_nope = q_nope_absorbed.view({batch, 1, tp_heads_, kv_lora_rank_});
+  params.q_pe = q_pe.view({batch, 1, tp_heads_, qk_rope_head_dim_});
+  params.k_cache = kv_cache.get_k_cache();
+  params.seqlens_k = attn_metadata.kv_seq_lens;
+  params.block_table = attn_metadata.block_table;
+  params.head_size_v = kv_lora_rank_;
+  params.softmax_scale = softmax_scale_;
+  params.is_causal = attn_metadata.is_causal;
+  params.kind = kernel::dcu::flash_mla::DenseDecodeKind::kQNopePe;
+
+  torch::Tensor attn_latent =
+      kernel::dcu::flash_mla::dense_decode(params);  // [B, 1, H, kv_lora]
+  attn_latent = attn_latent.view({batch, tp_heads_, kv_lora_rank_});
+  return project_output(attn_latent);
+}
+
+torch::Tensor DeepseekV2AttentionImpl::prefill_sdpa(
+    const torch::Tensor& q_nope_absorbed,
+    const torch::Tensor& q_pe,
+    const torch::Tensor& latent_cache,
+    const AttentionMetadata& attn_metadata) {
+  const int64_t head_dim = kv_lora_rank_ + qk_rope_head_dim_;
+  torch::Tensor q_input = torch::cat({q_nope_absorbed, q_pe}, /*dim=*/-1);
+  const int64_t num_tokens = q_input.size(0);
+
+  torch::Tensor q_cu = attn_metadata.q_cu_seq_lens.cpu().to(torch::kInt64);
+  torch::Tensor kv_cu = attn_metadata.kv_cu_seq_lens.cpu().to(torch::kInt64);
+  const int64_t batch_size = q_cu.size(0) - 1;
+
+  torch::Tensor out_latent =
+      torch::empty({num_tokens, tp_heads_, kv_lora_rank_}, q_input.options());
+
+  for (int64_t i = 0; i < batch_size; ++i) {
+    const int64_t q_start = q_cu[i].item<int64_t>();
+    const int64_t q_end = q_cu[i + 1].item<int64_t>();
+    const int64_t kv_start = kv_cu[i].item<int64_t>();
+    const int64_t kv_end = kv_cu[i + 1].item<int64_t>();
+    const int64_t sq = q_end - q_start;
+    const int64_t sk = kv_end - kv_start;
+    if (sk == 0) {
+      continue;
+    }
+
+    torch::Tensor q_seq = q_input.slice(0, q_start, q_end);          // [sq,H,D]
+    torch::Tensor kv_seq = latent_cache.slice(0, kv_start, kv_end);  // [sk,D]
+
+    torch::Tensor q4 = q_seq.permute({1, 0, 2}).unsqueeze(0).contiguous();
+    torch::Tensor kv4 = kv_seq.view({1, 1, sk, head_dim});
+
+    torch::Tensor attn = torch::scaled_dot_product_attention(
+        q4,
+        kv4,
+        kv4,
+        std::nullopt,
+        /*dropout_p=*/0.0,
+        /*is_causal=*/attn_metadata.is_causal,
+        /*scale=*/static_cast<double>(softmax_scale_),
+        /*enable_gqa=*/true);                // [1, H, sq, D]
+    attn = attn.slice(-1, 0, kv_lora_rank_)  // keep o_latent cols
+               .squeeze(0)
+               .permute({1, 0, 2})
+               .contiguous();  // [sq, H, kv_lora]
+    out_latent.slice(0, q_start, q_end).copy_(attn);
+  }
+
+  return project_output(out_latent);
+}
+
+torch::Tensor DeepseekV2AttentionImpl::forward(
+    const torch::Tensor& positions,
+    const torch::Tensor& hidden_states,
+    const AttentionMetadata& attn_metadata,
+    KVCache& kv_cache) {
+  const bool is_prefill = attn_metadata.is_prefill;
+  CHECK(!attn_metadata.is_chunked_prefill)
+      << "DCU DeepSeek-V2 chunked prefill is not supported yet.";
+  CHECK_EQ(positions.numel(), hidden_states.size(0))
+      << "DCU DeepSeek-V2 position/token mismatch, positions: "
+      << positions.sizes() << ", hidden_states: " << hidden_states.sizes()
+      << ", q_cu_seq_lens: " << attn_metadata.q_cu_seq_lens.sizes()
+      << ", kv_cu_seq_lens: " << attn_metadata.kv_cu_seq_lens.sizes()
+      << ", is_prefill: " << attn_metadata.is_prefill
+      << ", is_chunked_prefill: " << attn_metadata.is_chunked_prefill;
+
+  torch::Tensor latent_cache =
+      kv_a_proj_with_mqa_(hidden_states);  // [tokens, kv_lora+rope]
+  torch::Tensor c_kv = latent_cache.slice(-1, 0, kv_lora_rank_);
+  torch::Tensor c_kv_normed = std::get<0>(kv_a_layernorm_(c_kv));
+  torch::Tensor k_pe = latent_cache.slice(-1, kv_lora_rank_).contiguous();
+  torch::Tensor k_pe_3d = to_deepseek_rope_layout(k_pe.unsqueeze(1));
+  rotary_emb_->forward(k_pe_3d,
+                       positions,
+                       attn_metadata.q_cu_seq_lens,
+                       attn_metadata.max_query_len,
+                       /*is_prompt=*/is_prefill);
+  k_pe = k_pe_3d.squeeze(1).contiguous();
+  torch::Tensor latent_normed = torch::cat({c_kv_normed, k_pe}, /*dim=*/-1);
+
+  const torch::Tensor k_cache = kv_cache.get_k_cache();
+  if (k_cache.defined() && attn_metadata.slot_mapping.defined()) {
+    store_latent_cache(latent_normed, attn_metadata.slot_mapping, k_cache);
+  }
+
+  torch::Tensor q = prepare_query(hidden_states);  // [tokens, H, qk_head_dim]
+  std::vector<torch::Tensor> q_vec =
+      q.split({qk_nope_head_dim_, qk_rope_head_dim_}, /*dim=*/-1);
+  torch::Tensor q_nope = q_vec[0].contiguous();  // [tokens, H, qk_nope]
+  torch::Tensor q_pe = q_vec[1].contiguous();    // [tokens, H, qk_rope]
+  q_pe = to_deepseek_rope_layout(q_pe);
+  rotary_emb_->forward(q_pe,
+                       positions,
+                       attn_metadata.q_cu_seq_lens,
+                       attn_metadata.max_query_len,
+                       /*is_prompt=*/is_prefill);
+  torch::Tensor q_nope_absorbed =
+      torch::bmm(q_nope.transpose(0, 1), w_kc_).transpose(0, 1);
+
+  if (is_prefill) {
+    return prefill_sdpa(q_nope_absorbed, q_pe, latent_normed, attn_metadata);
+  }
+  return decode_flash_mla(q_nope_absorbed, q_pe, attn_metadata, kv_cache);
+}
+
+void DeepseekV2AttentionImpl::load_state_dict(const StateDict& state_dict) {
+  if (q_proj_) {
+    q_proj_->load_state_dict(state_dict.get_dict_with_prefix("q_proj."));
+  } else {
+    q_a_proj_->load_state_dict(state_dict.get_dict_with_prefix("q_a_proj."));
+    q_b_proj_->load_state_dict(state_dict.get_dict_with_prefix("q_b_proj."));
+    q_a_layernorm_->load_state_dict(
+        state_dict.get_dict_with_prefix("q_a_layernorm."));
+  }
+  kv_a_proj_with_mqa_->load_state_dict(
+      state_dict.get_dict_with_prefix("kv_a_proj_with_mqa."));
+  kv_a_layernorm_->load_state_dict(
+      state_dict.get_dict_with_prefix("kv_a_layernorm."));
+  kv_b_proj_->load_state_dict(state_dict.get_dict_with_prefix("kv_b_proj."));
+  o_proj_->load_state_dict(state_dict.get_dict_with_prefix("o_proj."));
+
+  if (kv_b_proj_->is_weight_loaded() && !has_trans_) {
+    w_vc_ = w_vc_.transpose(1, 2)
+                .contiguous();  // [H, v_head, kv_lora] -> [H, kv_lora, v_head]
+    has_trans_ = true;
+  }
+}
+
+}  // namespace layer
+}  // namespace xllm

--- a/xllm/core/layers/dcu/deepseek_v2_attention.h
+++ b/xllm/core/layers/dcu/deepseek_v2_attention.h
@@ -1,0 +1,104 @@
+/* Copyright 2026 The xLLM Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://github.com/jd-opensource/xllm/blob/main/LICENSE
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+// DCU DeepSeek-V2 MLA attention. Prefill uses SDPA and decode uses FlashMLA.
+
+#pragma once
+
+#include <torch/torch.h>
+
+#include <memory>
+
+#include "framework/kv_cache/kv_cache.h"
+#include "framework/model/model_args.h"
+#include "framework/parallel_state/parallel_args.h"
+#include "framework/quant_args.h"
+#include "framework/state_dict/state_dict.h"
+#include "layers/common/attention_metadata.h"
+#include "layers/common/linear.h"
+#include "layers/common/rms_norm.h"
+#include "layers/common/rotary_embedding.h"
+
+namespace xllm {
+namespace layer {
+
+class DeepseekV2AttentionImpl final : public torch::nn::Module {
+ public:
+  DeepseekV2AttentionImpl(const ModelArgs& args,
+                          const QuantArgs& quant_args,
+                          const ParallelArgs& parallel_args,
+                          const torch::TensorOptions& options);
+
+  // positions:      [num_tokens] token positions
+  // hidden_states:  [num_tokens, hidden_size]
+  // Returns attention output [num_tokens, hidden_size].
+  torch::Tensor forward(const torch::Tensor& positions,
+                        const torch::Tensor& hidden_states,
+                        const AttentionMetadata& attn_metadata,
+                        KVCache& kv_cache);
+
+  void load_state_dict(const StateDict& state_dict);
+
+ private:
+  torch::Tensor prepare_query(const torch::Tensor& hidden_states);
+
+  void store_latent_cache(const torch::Tensor& latent_cache,
+                          const torch::Tensor& slot_mapping,
+                          const torch::Tensor& k_cache);
+
+  torch::Tensor decode_flash_mla(const torch::Tensor& q_nope_absorbed,
+                                 const torch::Tensor& q_pe,
+                                 const AttentionMetadata& attn_metadata,
+                                 KVCache& kv_cache);
+
+  torch::Tensor prefill_sdpa(const torch::Tensor& q_nope_absorbed,
+                             const torch::Tensor& q_pe,
+                             const torch::Tensor& latent_cache,
+                             const AttentionMetadata& attn_metadata);
+
+  torch::Tensor project_output(const torch::Tensor& attn_latent);
+
+  int64_t q_lora_rank_;
+  int64_t kv_lora_rank_;
+  int64_t qk_nope_head_dim_;
+  int64_t qk_rope_head_dim_;
+  int64_t qk_head_dim_;
+  int64_t v_head_dim_;
+  int64_t tp_heads_;
+  double eps_;
+  float softmax_scale_;
+  bool interleaved_;
+
+  ReplicatedLinear q_a_proj_{nullptr};
+  RMSNorm q_a_layernorm_{nullptr};
+  ColumnParallelLinear q_b_proj_{nullptr};
+  ColumnParallelLinear q_proj_{nullptr};  // used when q_lora_rank_ == 0
+
+  ReplicatedLinear kv_a_proj_with_mqa_{nullptr};
+  RMSNorm kv_a_layernorm_{nullptr};
+  ColumnParallelLinear kv_b_proj_{nullptr};
+  RowParallelLinear o_proj_{nullptr};
+
+  torch::Tensor w_kc_;  // [tp_heads, qk_nope, kv_lora]
+  torch::Tensor w_vc_;  // [tp_heads, kv_lora, v_head_dim]
+  bool has_trans_ = false;
+
+  std::shared_ptr<RotaryEmbeddingBase> rotary_emb_;
+};
+
+TORCH_MODULE(DeepseekV2Attention);
+
+}  // namespace layer
+}  // namespace xllm

--- a/xllm/core/layers/dcu/deepseek_v2_decoder_layer_impl.cpp
+++ b/xllm/core/layers/dcu/deepseek_v2_decoder_layer_impl.cpp
@@ -1,0 +1,129 @@
+/* Copyright 2026 The xLLM Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://github.com/jd-opensource/xllm/blob/main/LICENSE
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include "layers/dcu/deepseek_v2_decoder_layer_impl.h"
+
+#include <glog/logging.h>
+
+#include <string>
+
+#include "framework/parallel_state/parallel_state.h"
+
+namespace xllm {
+namespace layer {
+
+namespace {
+
+// DeepSeek: layers [0, first_k_dense_replace) are dense MLP; the rest are MoE.
+bool is_moe_layer(const ModelArgs& model_args, int32_t layer_id) {
+  return model_args.n_routed_experts() > 0 &&
+         layer_id >= model_args.first_k_dense_replace();
+}
+
+}  // namespace
+
+DeepseekV2DecoderLayerImpl::DeepseekV2DecoderLayerImpl(
+    const ModelContext& context,
+    int32_t layer_id)
+    : parallel_args_(context.get_parallel_args()),
+      is_moe_layer_(is_moe_layer(context.get_model_args(), layer_id)) {
+  const auto& model_args = context.get_model_args();
+  const auto& quant_args = context.get_quant_args();
+  const auto& options = context.get_tensor_options();
+
+  attention_ = register_module(
+      "self_attn",
+      DeepseekV2Attention(model_args, quant_args, parallel_args_, options));
+
+  input_norm_ = register_module(
+      "input_layernorm",
+      RMSNorm(model_args.hidden_size(), model_args.rms_norm_eps(), options));
+  post_norm_ = register_module(
+      "post_attention_layernorm",
+      RMSNorm(model_args.hidden_size(), model_args.rms_norm_eps(), options));
+
+  if (is_moe_layer_) {
+    moe_mlp_ = register_module("mlp",
+                               FusedMoE(model_args,
+                                        FusedMoEArgs{.is_gated = true},
+                                        quant_args,
+                                        parallel_args_,
+                                        options));
+  } else {
+    const std::string mlp_module_prefix =
+        "model.layers." + std::to_string(layer_id) + ".mlp";
+    mlp_ = register_module("mlp",
+                           DenseMLP(model_args.hidden_size(),
+                                    model_args.intermediate_size(),
+                                    /*is_gated=*/true,
+                                    /*has_bias=*/false,
+                                    model_args.hidden_act(),
+                                    /*enable_result_reduction=*/true,
+                                    quant_args,
+                                    parallel_args_.tp_group_,
+                                    options,
+                                    mlp_module_prefix));
+  }
+}
+
+void DeepseekV2DecoderLayerImpl::load_state_dict(const StateDict& state_dict) {
+  attention_->load_state_dict(state_dict.get_dict_with_prefix("self_attn."));
+  input_norm_->load_state_dict(
+      state_dict.get_dict_with_prefix("input_layernorm."));
+  post_norm_->load_state_dict(
+      state_dict.get_dict_with_prefix("post_attention_layernorm."));
+  if (moe_mlp_) {
+    moe_mlp_->load_state_dict(state_dict.get_dict_with_prefix("mlp."));
+  } else {
+    mlp_->load_state_dict(state_dict.get_dict_with_prefix("mlp."));
+  }
+}
+
+torch::Tensor DeepseekV2DecoderLayerImpl::forward(
+    torch::Tensor& x,
+    std::optional<torch::Tensor>& residual,
+    torch::Tensor& positions,
+    const AttentionMetadata& attn_metadata,
+    KVCache& kv_cache,
+    const ModelInputParams& input_params) {
+  // Pre-attention norm
+  if (!residual.has_value()) {
+    residual = x;
+    x = std::get<0>(input_norm_->forward(x));
+  } else {
+    std::tie(x, residual) = input_norm_->forward(x, residual);
+  }
+
+  // MLA attention
+  x = attention_->forward(positions, x, attn_metadata, kv_cache);
+  if (parallel_args_.tp_group_->world_size() > 1) {
+    x = parallel_state::reduce(x, parallel_args_.tp_group_);
+  }
+
+  // Post-attention norm
+  std::tie(x, residual) = post_norm_->forward(x, residual);
+
+  // MLP / MoE
+  if (moe_mlp_) {
+    x = moe_mlp_(x, input_params);
+  } else {
+    x = mlp_(x);
+  }
+
+  return x;
+}
+
+}  // namespace layer
+}  // namespace xllm

--- a/xllm/core/layers/dcu/deepseek_v2_decoder_layer_impl.h
+++ b/xllm/core/layers/dcu/deepseek_v2_decoder_layer_impl.h
@@ -1,0 +1,66 @@
+/* Copyright 2026 The xLLM Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://github.com/jd-opensource/xllm/blob/main/LICENSE
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#pragma once
+
+#include <torch/torch.h>
+
+#include <optional>
+
+#include "framework/kv_cache/kv_cache.h"
+#include "framework/model/model_args.h"
+#include "framework/model/model_input_params.h"
+#include "framework/model_context.h"
+#include "framework/parallel_state/parallel_args.h"
+#include "framework/state_dict/state_dict.h"
+#include "layers/common/dense_mlp.h"
+#include "layers/common/rms_norm.h"
+#include "layers/dcu/deepseek_v2_attention.h"
+#include "layers/dcu/fused_moe.h"
+
+namespace xllm {
+namespace layer {
+
+// DCU DeepSeek-V2 decoder layer.
+class DeepseekV2DecoderLayerImpl final : public torch::nn::Module {
+ public:
+  explicit DeepseekV2DecoderLayerImpl(const ModelContext& context,
+                                      int32_t layer_id);
+
+  void load_state_dict(const StateDict& state_dict);
+
+  void verify_loaded_weights() const {}
+
+  torch::Tensor forward(torch::Tensor& x,
+                        std::optional<torch::Tensor>& residual,
+                        torch::Tensor& positions,
+                        const AttentionMetadata& attn_metadata,
+                        KVCache& kv_cache,
+                        const ModelInputParams& input_params);
+
+ private:
+  DeepseekV2Attention attention_{nullptr};
+  DenseMLP mlp_{nullptr};
+  FusedMoE moe_mlp_{nullptr};
+  RMSNorm input_norm_{nullptr};
+  RMSNorm post_norm_{nullptr};
+  ParallelArgs parallel_args_;
+  bool is_moe_layer_;
+};
+
+TORCH_MODULE(DeepseekV2DecoderLayer);
+
+}  // namespace layer
+}  // namespace xllm

--- a/xllm/core/layers/dcu/fused_moe.cpp
+++ b/xllm/core/layers/dcu/fused_moe.cpp
@@ -79,7 +79,7 @@ FusedMoEImpl::FusedMoEImpl(const ModelArgs& model_args,
       CHECK(parallel_args_.ep_size() == parallel_args_.world_size())
           << "Models with shared experts only support ep_size equal to "
              "world size for now.";
-      shared_expert_pg = parallel_args.moe_tp_group_;
+      shared_expert_pg = parallel_args.tp_group_;
     } else {
       shared_expert_pg = parallel_args.process_group_;
     }

--- a/xllm/models/llm/deepseek_v2.h
+++ b/xllm/models/llm/deepseek_v2.h
@@ -22,7 +22,11 @@ limitations under the License.
 
 #include "core/common/global_flags.h"
 #include "core/framework/model/model_output.h"
+#if defined(USE_DCU)
+#include "core/layers/dcu/deepseek_v2_decoder_layer_impl.h"
+#elif defined(USE_MLU)
 #include "core/layers/mlu/deepseek_v2_decoder_layer_impl.h"
+#endif
 #include "llm_model_base.h"
 
 namespace xllm {
@@ -224,6 +228,8 @@ REGISTER_MODEL_ARGS(deepseek_v2, [&] {
   LOAD_ARG_OR(first_k_dense_replace, "first_k_dense_replace", 1);
   LOAD_ARG_OR(moe_layer_freq, "moe_layer_freq", 1);
   LOAD_ARG_OR(topk_method, "topk_method", "greedy");
+  LOAD_ARG_OR(hidden_act, "hidden_act", "silu");
+  LOAD_ARG_OR(scoring_func, "scoring_func", "softmax");
   LOAD_ARG_OR(n_routed_experts, "n_routed_experts", 64);
   LOAD_ARG_OR(n_shared_experts, "n_shared_experts", 2);
   LOAD_ARG_OR(num_experts_per_tok, "num_experts_per_tok", 6);
@@ -240,7 +246,7 @@ REGISTER_MODEL_ARGS(deepseek_v2, [&] {
   LOAD_ARG_OR(num_nextn_predict_layers, "num_nextn_predict_layers", 1);
 
   LOAD_ARG_OR_FUNC(head_dim, "head_dim", [&] {
-    return 256;  // args->qk_nope_head_dim() + args->qk_rope_head_dim();
+    return args->qk_nope_head_dim() + args->qk_rope_head_dim();
   });
   LOAD_ARG_OR_FUNC(
       rotary_dim, "rotary_dim", [&] { return args->qk_rope_head_dim(); });

--- a/xllm/models/models.h
+++ b/xllm/models/models.h
@@ -106,8 +106,9 @@ limitations under the License.
 #include "llm/musa/qwen3.h"  // IWYU pragma: keep
 #elif defined(USE_DCU)
 #include "dit/pipelines/pipeline_flux.h"
-#include "llm/mimo.h"      // IWYU pragma: keep
-#include "llm/mimo_mtp.h"  // IWYU pragma: keep
+#include "llm/deepseek_v2.h"  // IWYU pragma: keep
+#include "llm/mimo.h"         // IWYU pragma: keep
+#include "llm/mimo_mtp.h"     // IWYU pragma: keep
 #include "llm/qwen2.h"
 #include "llm/qwen3.h"
 #include "llm/qwen3_moe.h"


### PR DESCRIPTION
## Description
Integrate FlashMLA to support DeepSeek-V2/V2-Lite on DCU.

- Wire DCU build options for FlashMLA and AITER shared libraries.
- Add AITER grouped topk path for DeepSeek-V2 MoE routing.
- Adjust DCU MLA KV cache layout and DeepSeek RoPE position handling.
<!-- What does this PR do? Briefly describe the changes and why they are needed. -->

## Related Issues

<!-- Link related issues here. Use "Fixes #123" when this PR closes an issue. -->

## Change Type

- [ ] Bug fix
- [x] New feature
- [ ] Performance improvement
- [ ] Refactor
- [ ] Documentation
- [ ] Test
- [ ] Build or CI

## Pull Request Checklist

Thank you for contributing to xLLM. Before requesting review, please make sure the following items are complete.

### PR Title and Commit Messages

- [x] The PR title and each commit message follow the xLLM commit format: `<type>: <subject>`.

> Allowed types: feat, bugfix, docs, test, refactor, chore, style, revert, perf, model, build, release.
> The subject should use clear English, start with a verb, include at least 4 words, and end with `.`.

### Pre-commit Checks

- [x] I have installed `pre-commit` by running `pip install pre-commit` or an equivalent command.
- [x] I have installed the hooks with `pre-commit install`.
- [x] I have run `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

### Self Review

- [x] I have self-reviewed the code according to `.agents/skills/code-review/references/custom-code-style.md`, especially code written or assisted by AI.
- [x] I have rebased this PR onto the latest `main` branch.

### Build and Test Coverage

- [ ] Tests have been added or updated as needed.
- [x] CUDA: `python setup.py build test` has passed on a CUDA machine.
- [ ] NPU: `python setup.py build test` has passed on an NPU machine.
- [ ] MLU: `python setup.py build test` has passed on an MLU machine.

## Reviewer Notes

<!-- Optional: anything reviewers should focus on, known risks, follow-ups, or validation gaps. -->
