### PR TITLE
bugfix: propagate is_hybrid_linear_attention for Qwen3.5 VLM graph capture.

### DIFF
--- a/xllm/models/vlm/qwen3_vl_base.h
+++ b/xllm/models/vlm/qwen3_vl_base.h
@@ -207,6 +207,14 @@ class Qwen3VLForConditionalGenerationBase : public torch::nn::Module {
     }
   }
 
+  bool is_hybrid_linear_attention() {
+    if constexpr (detail::has_is_hybrid_linear_attention<
+                      LanguageModel>::value) {
+      return language_model_->is_hybrid_linear_attention();
+    }
+    return false;
+  }
+
   layer::LmHead get_lm_head() { return language_model_->get_lm_head(); }
   void set_lm_head(layer::LmHead& head) { language_model_->set_lm_head(head); }
 


### PR DESCRIPTION
## Description
Qwen3VLForConditionalGenerationBase was missing is_hybrid_linear_attention(), this made AclGraphExecutorImpl skip all Qwen3.5 hybrid-specific graph capture initialization (graph_task_context_, qwen3.5 query_start_loc handling, attention mask) when running with --backend=vlm, crashing in npu_fused_sigmoid_gating_delta_rule_update with: "initial_state_indices size must equal cu_seqlens size - 1"

## Change Type

- [x] Bug fix
- [ ] New feature
- [ ] Performance improvement
- [ ] Refactor
- [ ] Documentation
- [ ] Test
- [ ] Build or CI

## Pull Request Checklist

Thank you for contributing to xLLM. Before requesting review, please make sure the following items are complete.

### Build and Test Coverage

- [x] Tests have been added or updated as needed.
- [ ] CUDA: `python setup.py build test` has passed on a CUDA machine.
- [x] NPU: `python setup.py build test` has passed on an NPU machine.
- [ ] MLU: `python setup.py build test` has passed on an MLU machine.