### PR TITLE
feat: enable SwiGluQuant fusion for Qwen3 MLP 

### DIFF
--- a/xllm/core/layers/npu/loader/qwen3_decoder_loader.cpp
+++ b/xllm/core/layers/npu/loader/qwen3_decoder_loader.cpp
@@ -125,8 +125,8 @@ void Qwen3DecoderLoader::merge_host_at_weights() {
     if (t[IN_MLP_CPROJ_BIAS].numel() > 1) {
       t[IN_MLP_CPROJ_BIAS] = t[IN_MLP_CPROJ_BIAS].to(torch::kInt32);
       t[IN_MLP_CPROJ_DEQSCALE] = t[IN_MLP_CPROJ_DEQSCALE].to(torch::kFloat32);
-      t[IN_MLP_CPROJ_OFFSET] = t[IN_MLP_CPROJ_OFFSET].to(torch::kInt8);
-      t[IN_MLP_CPROJ_SCALE] = t[IN_MLP_CPROJ_SCALE].to(dtype_);
+      t[IN_MLP_CPROJ_OFFSET] = t[IN_MLP_CPROJ_OFFSET].to(torch::kFloat32);
+      t[IN_MLP_CPROJ_SCALE] = t[IN_MLP_CPROJ_SCALE].to(torch::kFloat32);
       down_proj_quantized_ = true;
     }
 

--- a/xllm/core/layers/npu/npu_qwen3_decoder_layer_impl.cpp
+++ b/xllm/core/layers/npu/npu_qwen3_decoder_layer_impl.cpp
@@ -148,6 +148,7 @@ void NpuQwen3DecoderLayerImpl::initialize_parallel_parameters(
 
 void NpuQwen3DecoderLayerImpl::initialize_quantization_parameters(
     atb_speed::qwen::QwenLayerParam& param) {
+  param.enableSwigluQuant = false;
   if (quantize_type_.empty()) {
     param.linearDescs = {static_cast<int>(LinearTypeV2::BFLOAT16),
                          static_cast<int>(LinearTypeV2::INVALID),
@@ -229,6 +230,7 @@ int64_t NpuQwen3DecoderLayerImpl::init_layer() {
             static_cast<int>(LinearTypeV2::W8A8);
         p.linearQuantType[atb_speed::common::DOWN_LINEAR_INDEX] =
             static_cast<int>(LinearType::INT);
+        p.enableSwigluQuant = true;
       };
       update_down_proj(prefill_param_);
       update_down_proj(decode_graph_param_);


### PR DESCRIPTION
## Description

Enable the `DequantSwigluQuant` fused ACLNN operator for Qwen3 decoder MLP across prefill and decode paths. This fuses SwiGLU activation and quantization into a single kernel, eliminating intermediate BF16 tensor round-trips between `SwiGluForwardKernel` and `ElewiseQuant`.

##  Performance benefits

Single operator profit of about 3us, whole network quantification of 30 layers-down proj profit of about 0.1ms