### PR TITLE
fix: keep graph decode prepare independent

### DIFF
--- a/xllm/core/runtime/worker_impl.cpp
+++ b/xllm/core/runtime/worker_impl.cpp
@@ -727,14 +727,10 @@ void WorkerImpl::prepare_work_before_execute_on_stream(
   }
 #endif
   c10::StreamGuard stream_guard = prepare_stream.set_stream_guard();
-  const bool can_prepare_graph_decode_independently =
-      can_prepare_npu_graph_decode_input(input.input_params);
-  if (enable_schedule_overlap() &&
-      (options_.enable_speculative_decode() ||
-       !can_prepare_graph_decode_independently) &&
+  if (enable_schedule_overlap() && options_.enable_speculative_decode() &&
       compute_stream_) {
     // MTP updates reuse shared prepare/compute streams and need this ordering;
-    // only graph double-buffer decode can prepare the next slot independently.
+    // ordinary graph-decode overlap must keep prepare independent of compute.
     prepare_stream.wait_stream(*compute_stream_);
   }
   CHECK(prepare_stream.wait_event(input.metadata_ready_event))


### PR DESCRIPTION
## Summary

This PR fixes a performance regression introduced by the merged PR #1668 path.

The final PR #1668 source branch was merged with a guarded wait condition in
`WorkerImpl::prepare_work_before_execute_on_stream()`:

```cpp
const bool can_prepare_graph_decode_independently =
    can_prepare_npu_graph_decode_input(input.input_params);
if (enable_schedule_overlap() &&
    (options_.enable_speculative_decode() ||
     !can_prepare_graph_decode_independently) &&
    compute_stream_) {
  prepare_stream.wait_stream(*compute_stream_);
}
```

In this prepare stage, `input.input_params` is not a reliable predicate for the
next ordinary graph-decode double-buffer prepare. As a result,
`can_prepare_graph_decode_independently` can evaluate false and ordinary
graph-decode prepare waits on the previous compute stream again. This brings
back the inter-decode host bubble that PR #1668 was intended to remove.

This PR restores the validated behavior: keep the prepare/compute stream wait
only for speculative decode, where target/draft workers share the streams and
still need the ordering. Ordinary graph-decode overlap keeps prepare independent
from compute.

## Root Cause

The reviewed and validated local fix contained:

- `0cd634f6 fix: keep graph decode prepare independent`
- `e04ac3fb fix: keep fallback token update synchronized`

However, the PR #1668 source branch that was ultimately merged pointed to
`8eb0bc52`, whose wait condition still used the
`can_prepare_npu_graph_decode_input(input.input_params)` guard. The merged
commit `5f9ec8f1` therefore reintroduced the wait for the Qwen3-1.7B graph
double-buffer decode path.

## Validation

Environment:

- Model: `Qwen3-1.7B`
- Command: `/home/g00510989/profiling/qwen1.7b/1.7/run.sh`
- Request script: `/home/g00510989/profiling/qwen1.7b/1.7/send_request.py`
- Flags: `enable_schedule_overlap=true`, `enable_graph=true`,
  `enable_graph_double_buffer=true`

Build:

- `python setup.py build` passed

Performance after this fix, `send_request.py --no-top`, 3 repeated runs:

- run1: avg TPOT `0.0049s`
- run2: avg TPOT `0.0049s`
- run3: avg TPOT `0.0049s`

Profiling after this fix:

- Boundary: `ArgMaxV2AiCore -> MODEL_EXECUTE`
- pair_count: `128`
- gap median: `8.25us`
- gap p90: `8.75us`
- gap max: `9.0us`

For comparison, current `main` before this fix showed:

- avg TPOT about `0.0054s` to `0.0055s`
- `ArgMaxV2AiCore -> MODEL_EXECUTE` gap median `706.625us`
- gap p90 `765.5us`

## Scope

This PR is intentionally limited to one runtime synchronization condition in
`worker_impl.cpp`. It does not include the local weight-loading workaround used
for this machine's validation environment.
