### PR TITLE
bugfix: guard graph prepare stream wait.

### DIFF
--- a/xllm/core/runtime/worker_impl.cpp
+++ b/xllm/core/runtime/worker_impl.cpp
@@ -508,6 +508,18 @@ bool WorkerImpl::can_prepare_npu_graph_decode_input(
 #endif
 }
 
+bool WorkerImpl::can_prepare_without_compute_stream_wait(
+    const ModelInputParams& input_params) const {
+#if defined(USE_NPU)
+  (void)input_params;
+  return !options_.enable_speculative_decode() && FLAGS_enable_graph &&
+         FLAGS_enable_graph_double_buffer && options_.backend() == "llm";
+#else
+  (void)input_params;
+  return false;
+#endif
+}
+
 bool WorkerImpl::can_skip_npu_graph_decode_sync(
     const ModelInputParams& input_params) const {
 #if defined(USE_NPU)
@@ -727,10 +739,11 @@ void WorkerImpl::prepare_work_before_execute_on_stream(
   }
 #endif
   c10::StreamGuard stream_guard = prepare_stream.set_stream_guard();
-  if (enable_schedule_overlap() && options_.enable_speculative_decode() &&
+  if (enable_schedule_overlap() &&
+      !can_prepare_without_compute_stream_wait(input.input_params) &&
       compute_stream_) {
     // MTP updates reuse shared prepare/compute streams and need this ordering;
-    // ordinary graph-decode overlap must keep prepare independent of compute.
+    // only graph double-buffer decode can prepare the next slot independently.
     prepare_stream.wait_stream(*compute_stream_);
   }
   CHECK(prepare_stream.wait_event(input.metadata_ready_event))

--- a/xllm/core/runtime/worker_impl.cpp
+++ b/xllm/core/runtime/worker_impl.cpp
@@ -727,14 +727,10 @@ void WorkerImpl::prepare_work_before_execute_on_stream(
   }
 #endif
   c10::StreamGuard stream_guard = prepare_stream.set_stream_guard();
-  const bool can_prepare_graph_decode_independently =
-      can_prepare_npu_graph_decode_input(input.input_params);
-  if (enable_schedule_overlap() &&
-      (options_.enable_speculative_decode() ||
-       !can_prepare_graph_decode_independently) &&
+  if (enable_schedule_overlap() && options_.enable_speculative_decode() &&
       compute_stream_) {
     // MTP updates reuse shared prepare/compute streams and need this ordering;
-    // only graph double-buffer decode can prepare the next slot independently.
+    // ordinary graph-decode overlap must keep prepare independent of compute.
     prepare_stream.wait_stream(*compute_stream_);
   }
   CHECK(prepare_stream.wait_event(input.metadata_ready_event))

--- a/xllm/core/runtime/worker_impl.h
+++ b/xllm/core/runtime/worker_impl.h
@@ -219,6 +219,8 @@ class WorkerImpl {
 
   bool can_prepare_npu_graph_decode_input(
       const ModelInputParams& input_params) const;
+  bool can_prepare_without_compute_stream_wait(
+      const ModelInputParams& input_params) const;
   bool can_skip_npu_graph_decode_sync(
       const ModelInputParams& input_params) const;
 


### PR DESCRIPTION
## 概述

本 PR 修复 PR #1668 合入后在普通 graph decode double-buffer 场景下出现的性能回退，并补充对 review 风险点的边界保护。

核心问题在 `WorkerImpl::prepare_work_before_execute_on_stream()` 的 stream ordering 条件：

- 普通 NPU LLM graph double-buffer decode 中，prepare 更新的是下一组 persistent param/graph slot，不需要等待上一轮 compute 完成。
- speculative/MTP 以及非 graph double-buffer 路径仍可能复用共享状态或依赖上一轮 compute 结果，需要保留 `prepare_stream.wait_stream(compute_stream)`。

因此本 PR 将“prepare 可独立执行”的条件收敛为配置级 guard：

```cpp
!options_.enable_speculative_decode() &&
FLAGS_enable_graph &&
FLAGS_enable_graph_double_buffer &&
options_.backend() == "llm"
```

最终效果：

- `enable_graph=false`：继续 wait。
- `enable_graph_double_buffer=false`：继续 wait。
- speculative decode/MTP：继续 wait。
- 普通 NPU LLM graph double-buffer decode：跳过 wait，保留 PR #1668 的性能路径。

## 条件尝试与结论

本地验证过几种候选方案：

1. 使用 `batch_forward_type.is_decode()` 作为跳过 wait 条件。
   - 结果：TPOT 稳定回退到约 `5.4ms` 到 `5.5ms`。
   - 结论：这个判断过窄，`prepare_work_before_execute_on_stream()` 处的 batch type 不能可靠表达 graph double-buffer prepare 是否可独立执行。

2. 使用 `batch_forward_type.has_decode()` / `can_prepare_npu_graph_decode_input(input.input_params)` 作为跳过 wait 条件。
   - 结果：TPOT 仍稳定回退到约 `5.4ms` 到 `5.5ms`。
   - 结论：继续把 skip-wait 绑定到 `input.input_params` 会错过 PR #1668 要恢复的 graph double-buffer fast path。

3. 尝试将 graph 判断从 `FLAGS_enable_graph` / `FLAGS_enable_graph_double_buffer` 改为 `ExecutionConfig`。
   - 结果：不是解决 review 问题的必要改动，也没有改善性能回退。
   - 结论：去掉该尝试，保持 diff 最小。

最终采用配置级 guard，是因为它同时满足两个目标：

- 对 review 提到的非 graph、double-buffer 关闭、speculative 场景保留 stream ordering。
- 对 PR #1668 的普通 graph double-buffer decode 保持 prepare 独立，避免重新引入 decode 间 host 空泡。

## 根因

PR #1668 的目标是让普通 graph decode double-buffer 的 prepare 与 compute 解耦。但合入后的 wait 条件依赖 `input.input_params` 判断是否可独立 prepare。

在该 prepare 阶段，`input.input_params` 不能可靠作为 graph double-buffer fast path 的判据，导致普通 graph decode 仍可能执行 `prepare_stream.wait_stream(compute_stream)`，重新引入约 700us 的 decode 间空泡。

## 验证

验证配置：

- 模型：`Qwen3-1.7B`
- `enable_schedule_overlap=true`
- `enable_graph=true`
- `enable_graph_double_buffer=true`
- 流式输出，`max_tokens=128`
- 请求侧去除 `top_k/top_p/temperature`

构建验证：

- `python setup.py build` 通过

性能验证：

- 连续 3 轮请求测试：
  - avg TPOT：`0.0048s`
  - avg TPOT：`0.0049s`
  - avg TPOT：`0.0049s`

Profiling 验证：

- 观测边界：`ArgMaxV2 -> next MODEL_EXECUTE`
- pair count：`128`
- gap median：`8.25us`
- gap p90：`8.525us`
- gap max：`9.0us`
- `>100us` gap count：`0`

对比失败候选：

- `is_decode()` / `has_decode()` 相关候选方案均稳定回退到约 `5.4ms` 到 `5.5ms` TPOT。

对比原回退现象：

- 平均 TPOT 约 `0.0054s` 到 `0.0055s`
- decode 间 gap 曾出现约 `700us` 级空泡

## 修改范围

本 PR 仅修改 `xllm/core/runtime/worker_impl.cpp` 和 `xllm/core/runtime/worker_impl.h` 中的 stream wait guard，不包含本地验证环境使用的权重加载 workaround。
