### PR TITLE
bugfix: fix qwen3.5 w8a8 weight loading.

### DIFF
--- a/tests/core/layers/mlu/CMakeLists.txt
+++ b/tests/core/layers/mlu/CMakeLists.txt
@@ -134,6 +134,7 @@ cc_test(
   SRCS
     moe_gate_test.cpp
     fused_moe_test.cpp
+    moe_weight_loader_helper_test.cpp
     deepseek_v2_sparse_moe_block_test.cpp
     deepseek_v4_sparse_moe_block_test.cpp
     tests_utils.cpp

--- a/tests/core/layers/mlu/moe_weight_loader_helper_test.cpp
+++ b/tests/core/layers/mlu/moe_weight_loader_helper_test.cpp
@@ -1,0 +1,335 @@
+/* Copyright 2026 The xLLM Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://github.com/jd-opensource/xllm/blob/main/LICENSE
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include "layers/common/moe_weight_loader_helper.h"
+
+#include <gtest/gtest.h>
+#include <torch/torch.h>
+
+#include <unordered_map>
+#include <vector>
+
+#include "framework/state_dict/state_dict.h"
+
+namespace xllm {
+namespace layer {
+namespace {
+
+torch::Tensor make_arange(const std::vector<int64_t>& sizes,
+                          torch::ScalarType dtype) {
+  int64_t numel = 1;
+  for (int64_t size : sizes) {
+    numel *= size;
+  }
+  torch::Tensor tensor =
+      torch::arange(numel, torch::TensorOptions().dtype(torch::kInt64));
+  return tensor.to(dtype).reshape(sizes);
+}
+
+TEST(MoEWeightHelperTest, LoadsGateUpSmoothquantShard) {
+  const int64_t rank = 1;
+  const int64_t world_size = 2;
+  const int64_t start_expert_id = 1;
+  const int64_t num_experts_per_rank = 2;
+  const int64_t hidden_size = 3;
+  const int64_t full_intermediate = 4;
+  const int64_t local_intermediate = full_intermediate / world_size;
+  const int64_t num_total_experts = 4;
+
+  std::unordered_map<std::string, torch::Tensor> tensors;
+  tensors["gate_up_proj.qweight"] = make_arange(
+      {num_total_experts, full_intermediate * 2, hidden_size}, torch::kInt8);
+  tensors["gate_up_proj.per_channel_scale"] =
+      make_arange({num_total_experts, full_intermediate * 2}, torch::kFloat32);
+  tensors["gate_up_proj.smooth"] =
+      torch::tensor({0.25f, 0.5f, 0.75f}, torch::kFloat32);
+  StateDict state_dict(std::move(tensors));
+
+  torch::Tensor w13 =
+      torch::empty({num_experts_per_rank, local_intermediate * 2, hidden_size},
+                   torch::kInt8);
+  torch::Tensor w13_scale = torch::empty(
+      {num_experts_per_rank, local_intermediate * 2}, torch::kFloat32);
+  torch::Tensor input_smooth =
+      torch::empty({num_total_experts, hidden_size}, torch::kFloat32);
+  bool w13_loaded = false;
+  bool scale_loaded = false;
+  bool smooth_loaded = false;
+
+  bool loaded = moe_weight::try_load_gate_up_sq(state_dict,
+                                                rank,
+                                                world_size,
+                                                start_expert_id,
+                                                num_experts_per_rank,
+                                                w13,
+                                                w13_scale,
+                                                input_smooth,
+                                                w13_loaded,
+                                                scale_loaded,
+                                                smooth_loaded);
+
+  torch::Tensor fused_qweight = state_dict.get_tensor("gate_up_proj.qweight");
+  torch::Tensor gate_qweight = fused_qweight.slice(
+      /*dim=*/1, rank * local_intermediate, (rank + 1) * local_intermediate);
+  torch::Tensor up_qweight =
+      fused_qweight.slice(/*dim=*/1,
+                          full_intermediate + rank * local_intermediate,
+                          full_intermediate + (rank + 1) * local_intermediate);
+  torch::Tensor expected_w13 =
+      torch::cat({gate_qweight, up_qweight}, /*dim=*/1)
+          .slice(/*dim=*/0,
+                 start_expert_id,
+                 start_expert_id + num_experts_per_rank)
+          .contiguous();
+
+  torch::Tensor fused_scale =
+      state_dict.get_tensor("gate_up_proj.per_channel_scale");
+  torch::Tensor gate_scale = fused_scale.slice(
+      /*dim=*/1, rank * local_intermediate, (rank + 1) * local_intermediate);
+  torch::Tensor up_scale =
+      fused_scale.slice(/*dim=*/1,
+                        full_intermediate + rank * local_intermediate,
+                        full_intermediate + (rank + 1) * local_intermediate);
+  torch::Tensor expected_scale =
+      torch::cat({gate_scale, up_scale}, /*dim=*/1)
+          .slice(/*dim=*/0,
+                 start_expert_id,
+                 start_expert_id + num_experts_per_rank)
+          .contiguous();
+  torch::Tensor expected_smooth = state_dict.get_tensor("gate_up_proj.smooth")
+                                      .reshape({1, -1})
+                                      .expand({num_total_experts, hidden_size});
+
+  EXPECT_TRUE(loaded);
+  EXPECT_TRUE(w13_loaded);
+  EXPECT_TRUE(scale_loaded);
+  EXPECT_TRUE(smooth_loaded);
+  EXPECT_TRUE(torch::equal(w13.cpu(), expected_w13.cpu()));
+  EXPECT_TRUE(torch::equal(w13_scale.cpu(), expected_scale.cpu()));
+  EXPECT_TRUE(torch::equal(input_smooth.cpu(), expected_smooth.cpu()));
+}
+
+TEST(MoEWeightHelperTest, LoadsDownSmoothquantShard) {
+  const int64_t rank = 1;
+  const int64_t world_size = 2;
+  const int64_t start_expert_id = 1;
+  const int64_t num_experts_per_rank = 2;
+  const int64_t num_total_experts = 4;
+  const int64_t hidden_size = 3;
+  const int64_t local_intermediate = 2;
+  const int64_t full_intermediate = local_intermediate * world_size;
+  const int64_t local_groups = 2;
+  const int64_t full_groups = local_groups * world_size;
+
+  std::unordered_map<std::string, torch::Tensor> tensors;
+  tensors["down_proj.qweight"] = make_arange(
+      {num_total_experts, hidden_size, full_intermediate}, torch::kInt8);
+  tensors["down_proj.per_channel_scale"] = make_arange(
+      {num_total_experts, hidden_size, full_groups}, torch::kFloat32);
+  tensors["down_proj.smooth"] =
+      torch::tensor({1.0f, 2.0f, 3.0f, 4.0f}, torch::kFloat32);
+  StateDict state_dict(std::move(tensors));
+
+  torch::Tensor w2 = torch::empty(
+      {num_experts_per_rank, hidden_size, local_intermediate}, torch::kInt8);
+  torch::Tensor w2_scale = torch::empty(
+      {num_experts_per_rank, hidden_size, local_groups}, torch::kFloat32);
+  torch::Tensor act_smooth =
+      torch::empty({num_experts_per_rank, local_intermediate}, torch::kFloat32);
+  bool w2_loaded = false;
+  bool scale_loaded = false;
+  bool smooth_loaded = false;
+
+  bool loaded = moe_weight::try_load_down_sq(state_dict,
+                                             rank,
+                                             world_size,
+                                             start_expert_id,
+                                             num_experts_per_rank,
+                                             w2,
+                                             w2_scale,
+                                             act_smooth,
+                                             w2_loaded,
+                                             scale_loaded,
+                                             smooth_loaded);
+
+  torch::Tensor expected_w2 = state_dict.get_tensor("down_proj.qweight")
+                                  .slice(/*dim=*/2,
+                                         rank * local_intermediate,
+                                         (rank + 1) * local_intermediate)
+                                  .slice(/*dim=*/0,
+                                         start_expert_id,
+                                         start_expert_id + num_experts_per_rank)
+                                  .contiguous();
+  torch::Tensor expected_scale =
+      state_dict.get_tensor("down_proj.per_channel_scale")
+          .slice(/*dim=*/2, rank * local_groups, (rank + 1) * local_groups)
+          .slice(/*dim=*/0,
+                 start_expert_id,
+                 start_expert_id + num_experts_per_rank)
+          .contiguous();
+  torch::Tensor expected_smooth =
+      state_dict.get_tensor("down_proj.smooth")
+          .slice(/*dim=*/0,
+                 rank * local_intermediate,
+                 (rank + 1) * local_intermediate)
+          .reshape({1, -1})
+          .expand({num_experts_per_rank, local_intermediate});
+
+  EXPECT_TRUE(loaded);
+  EXPECT_TRUE(w2_loaded);
+  EXPECT_TRUE(scale_loaded);
+  EXPECT_TRUE(smooth_loaded);
+  EXPECT_TRUE(torch::equal(w2.cpu(), expected_w2.cpu()));
+  EXPECT_TRUE(torch::equal(w2_scale.cpu(), expected_scale.cpu()));
+  EXPECT_TRUE(torch::equal(act_smooth.cpu(), expected_smooth.cpu()));
+}
+
+TEST(MoEWeightHelperTest, MissingFusedKeyReturnsFalseWithoutMutation) {
+  StateDict state_dict(std::unordered_map<std::string, torch::Tensor>{});
+  torch::Tensor w13 = torch::full({2, 4, 3}, -7, torch::kInt8);
+  torch::Tensor w13_scale = torch::full({2, 4}, -3.0f, torch::kFloat32);
+  torch::Tensor input_smooth = torch::full({4, 3}, -5.0f, torch::kFloat32);
+  torch::Tensor w2 = torch::full({2, 3, 2}, -9, torch::kInt8);
+  torch::Tensor w2_scale = torch::full({2, 3, 2}, -2.0f, torch::kFloat32);
+  torch::Tensor act_smooth = torch::full({2, 2}, -4.0f, torch::kFloat32);
+  torch::Tensor expected_w13 = w13.clone();
+  torch::Tensor expected_w13_scale = w13_scale.clone();
+  torch::Tensor expected_input_smooth = input_smooth.clone();
+  torch::Tensor expected_w2 = w2.clone();
+  torch::Tensor expected_w2_scale = w2_scale.clone();
+  torch::Tensor expected_act_smooth = act_smooth.clone();
+  bool w13_loaded = false;
+  bool w13_scale_loaded = false;
+  bool input_smooth_loaded = false;
+  bool w2_loaded = false;
+  bool w2_scale_loaded = false;
+  bool act_smooth_loaded = false;
+
+  bool gate_up_loaded =
+      moe_weight::try_load_gate_up_sq(state_dict,
+                                      /*rank=*/0,
+                                      /*world_size=*/2,
+                                      /*start_expert_id=*/0,
+                                      /*num_experts_per_rank=*/2,
+                                      w13,
+                                      w13_scale,
+                                      input_smooth,
+                                      w13_loaded,
+                                      w13_scale_loaded,
+                                      input_smooth_loaded);
+  bool down_loaded = moe_weight::try_load_down_sq(state_dict,
+                                                  /*rank=*/0,
+                                                  /*world_size=*/2,
+                                                  /*start_expert_id=*/0,
+                                                  /*num_experts_per_rank=*/2,
+                                                  w2,
+                                                  w2_scale,
+                                                  act_smooth,
+                                                  w2_loaded,
+                                                  w2_scale_loaded,
+                                                  act_smooth_loaded);
+
+  EXPECT_FALSE(gate_up_loaded);
+  EXPECT_FALSE(down_loaded);
+  EXPECT_FALSE(w13_loaded);
+  EXPECT_FALSE(w13_scale_loaded);
+  EXPECT_FALSE(input_smooth_loaded);
+  EXPECT_FALSE(w2_loaded);
+  EXPECT_FALSE(w2_scale_loaded);
+  EXPECT_FALSE(act_smooth_loaded);
+  EXPECT_TRUE(torch::equal(w13.cpu(), expected_w13.cpu()));
+  EXPECT_TRUE(torch::equal(w13_scale.cpu(), expected_w13_scale.cpu()));
+  EXPECT_TRUE(torch::equal(input_smooth.cpu(), expected_input_smooth.cpu()));
+  EXPECT_TRUE(torch::equal(w2.cpu(), expected_w2.cpu()));
+  EXPECT_TRUE(torch::equal(w2_scale.cpu(), expected_w2_scale.cpu()));
+  EXPECT_TRUE(torch::equal(act_smooth.cpu(), expected_act_smooth.cpu()));
+}
+
+TEST(MoEWeightHelperTest, ShapeMismatchReturnsFalseWithoutMutation) {
+  std::unordered_map<std::string, torch::Tensor> tensors;
+  tensors["gate_up_proj.qweight"] = make_arange({4, 8, 3}, torch::kInt8);
+  tensors["gate_up_proj.per_channel_scale"] =
+      make_arange({4, 8}, torch::kFloat32);
+  tensors["gate_up_proj.smooth"] =
+      torch::tensor({0.25f, 0.5f, 0.75f}, torch::kFloat32);
+  tensors["down_proj.qweight"] = make_arange({4, 3, 4}, torch::kInt8);
+  tensors["down_proj.per_channel_scale"] =
+      make_arange({4, 3, 4}, torch::kFloat32);
+  tensors["down_proj.smooth"] =
+      torch::tensor({1.0f, 2.0f, 3.0f, 4.0f}, torch::kFloat32);
+  StateDict state_dict(std::move(tensors));
+
+  torch::Tensor w13 = torch::full({2, 4, 3}, -7, torch::kInt8);
+  torch::Tensor bad_w13_scale = torch::full({2, 3}, -3.0f, torch::kFloat32);
+  torch::Tensor input_smooth = torch::full({4, 3}, -5.0f, torch::kFloat32);
+  torch::Tensor w2 = torch::full({2, 3, 2}, -9, torch::kInt8);
+  torch::Tensor bad_w2_scale = torch::full({2, 3, 1}, -2.0f, torch::kFloat32);
+  torch::Tensor act_smooth = torch::full({2, 2}, -4.0f, torch::kFloat32);
+  torch::Tensor expected_w13 = w13.clone();
+  torch::Tensor expected_w13_scale = bad_w13_scale.clone();
+  torch::Tensor expected_input_smooth = input_smooth.clone();
+  torch::Tensor expected_w2 = w2.clone();
+  torch::Tensor expected_w2_scale = bad_w2_scale.clone();
+  torch::Tensor expected_act_smooth = act_smooth.clone();
+  bool w13_loaded = false;
+  bool w13_scale_loaded = false;
+  bool input_smooth_loaded = false;
+  bool w2_loaded = false;
+  bool w2_scale_loaded = false;
+  bool act_smooth_loaded = false;
+
+  bool gate_up_loaded =
+      moe_weight::try_load_gate_up_sq(state_dict,
+                                      /*rank=*/1,
+                                      /*world_size=*/2,
+                                      /*start_expert_id=*/1,
+                                      /*num_experts_per_rank=*/2,
+                                      w13,
+                                      bad_w13_scale,
+                                      input_smooth,
+                                      w13_loaded,
+                                      w13_scale_loaded,
+                                      input_smooth_loaded);
+  bool down_loaded = moe_weight::try_load_down_sq(state_dict,
+                                                  /*rank=*/1,
+                                                  /*world_size=*/2,
+                                                  /*start_expert_id=*/1,
+                                                  /*num_experts_per_rank=*/2,
+                                                  w2,
+                                                  bad_w2_scale,
+                                                  act_smooth,
+                                                  w2_loaded,
+                                                  w2_scale_loaded,
+                                                  act_smooth_loaded);
+
+  EXPECT_FALSE(gate_up_loaded);
+  EXPECT_FALSE(down_loaded);
+  EXPECT_FALSE(w13_loaded);
+  EXPECT_FALSE(w13_scale_loaded);
+  EXPECT_FALSE(input_smooth_loaded);
+  EXPECT_FALSE(w2_loaded);
+  EXPECT_FALSE(w2_scale_loaded);
+  EXPECT_FALSE(act_smooth_loaded);
+  EXPECT_TRUE(torch::equal(w13.cpu(), expected_w13.cpu()));
+  EXPECT_TRUE(torch::equal(bad_w13_scale.cpu(), expected_w13_scale.cpu()));
+  EXPECT_TRUE(torch::equal(input_smooth.cpu(), expected_input_smooth.cpu()));
+  EXPECT_TRUE(torch::equal(w2.cpu(), expected_w2.cpu()));
+  EXPECT_TRUE(torch::equal(bad_w2_scale.cpu(), expected_w2_scale.cpu()));
+  EXPECT_TRUE(torch::equal(act_smooth.cpu(), expected_act_smooth.cpu()));
+}
+
+}  // namespace
+}  // namespace layer
+}  // namespace xllm

--- a/tests/core/layers/mlu/moe_weight_loader_helper_test.cpp
+++ b/tests/core/layers/mlu/moe_weight_loader_helper_test.cpp
@@ -196,6 +196,81 @@ TEST(MoEWeightHelperTest, LoadsDownSmoothquantShard) {
   EXPECT_TRUE(torch::equal(act_smooth.cpu(), expected_smooth.cpu()));
 }
 
+TEST(MoEWeightHelperTest, LoadsDownSmoothquantShardWith2DScale) {
+  const int64_t rank = 1;
+  const int64_t world_size = 2;
+  const int64_t start_expert_id = 1;
+  const int64_t num_experts_per_rank = 2;
+  const int64_t num_total_experts = 4;
+  const int64_t hidden_size = 3;
+  const int64_t local_intermediate = 2;
+  const int64_t full_intermediate = local_intermediate * world_size;
+
+  std::unordered_map<std::string, torch::Tensor> tensors;
+  tensors["down_proj.qweight"] = make_arange(
+      {num_total_experts, hidden_size, full_intermediate}, torch::kInt8);
+  tensors["down_proj.per_channel_scale"] =
+      make_arange({num_total_experts, full_intermediate}, torch::kFloat32);
+  tensors["down_proj.smooth"] =
+      torch::tensor({1.0f, 2.0f, 3.0f, 4.0f}, torch::kFloat32);
+  StateDict state_dict(std::move(tensors));
+
+  torch::Tensor w2 = torch::empty(
+      {num_experts_per_rank, hidden_size, local_intermediate}, torch::kInt8);
+  torch::Tensor w2_scale =
+      torch::empty({num_experts_per_rank, local_intermediate}, torch::kFloat32);
+  torch::Tensor act_smooth =
+      torch::empty({num_experts_per_rank, local_intermediate}, torch::kFloat32);
+  bool w2_loaded = false;
+  bool scale_loaded = false;
+  bool smooth_loaded = false;
+
+  bool loaded = moe_weight::try_load_down_sq(state_dict,
+                                             rank,
+                                             world_size,
+                                             start_expert_id,
+                                             num_experts_per_rank,
+                                             w2,
+                                             w2_scale,
+                                             act_smooth,
+                                             w2_loaded,
+                                             scale_loaded,
+                                             smooth_loaded);
+
+  torch::Tensor expected_w2 = state_dict.get_tensor("down_proj.qweight")
+                                  .slice(/*dim=*/2,
+                                         rank * local_intermediate,
+                                         (rank + 1) * local_intermediate)
+                                  .slice(/*dim=*/0,
+                                         start_expert_id,
+                                         start_expert_id + num_experts_per_rank)
+                                  .contiguous();
+  torch::Tensor expected_scale =
+      state_dict.get_tensor("down_proj.per_channel_scale")
+          .slice(/*dim=*/1,
+                 rank * local_intermediate,
+                 (rank + 1) * local_intermediate)
+          .slice(/*dim=*/0,
+                 start_expert_id,
+                 start_expert_id + num_experts_per_rank)
+          .contiguous();
+  torch::Tensor expected_smooth =
+      state_dict.get_tensor("down_proj.smooth")
+          .slice(/*dim=*/0,
+                 rank * local_intermediate,
+                 (rank + 1) * local_intermediate)
+          .reshape({1, -1})
+          .expand({num_experts_per_rank, local_intermediate});
+
+  EXPECT_TRUE(loaded);
+  EXPECT_TRUE(w2_loaded);
+  EXPECT_TRUE(scale_loaded);
+  EXPECT_TRUE(smooth_loaded);
+  EXPECT_TRUE(torch::equal(w2.cpu(), expected_w2.cpu()));
+  EXPECT_TRUE(torch::equal(w2_scale.cpu(), expected_scale.cpu()));
+  EXPECT_TRUE(torch::equal(act_smooth.cpu(), expected_smooth.cpu()));
+}
+
 TEST(MoEWeightHelperTest, MissingFusedKeyReturnsFalseWithoutMutation) {
   StateDict state_dict(std::unordered_map<std::string, torch::Tensor>{});
   torch::Tensor w13 = torch::full({2, 4, 3}, -7, torch::kInt8);

--- a/xllm/core/layers/common/linear.cpp
+++ b/xllm/core/layers/common/linear.cpp
@@ -528,7 +528,8 @@ ColumnParallelLinearImpl::ColumnParallelLinearImpl(
     const QuantArgs& quant_args,
     ProcessGroup* process_group,
     const torch::TensorOptions& options,
-    const LinearExtraArgs& linear_extra_args)
+    const LinearExtraArgs& linear_extra_args,
+    int32_t output_replicas)
     : gather_output_(gather_output),
       device_(options.device()),
       process_group_(process_group),
@@ -538,10 +539,17 @@ ColumnParallelLinearImpl::ColumnParallelLinearImpl(
       output_dtype_(c10::typeMetaToScalarType(options.dtype())) {
   rank_ = process_group_->rank();
   world_size_ = process_group_->world_size();
-  CHECK(out_features % world_size_ == 0)
-      << "out_features " << out_features << " not divisible by world_size "
-      << world_size_;
-  const int64_t out_features_per_partition = out_features / world_size_;
+  int32_t valid_output_replicas = output_replicas;
+  if (valid_output_replicas <= 0 || world_size_ % valid_output_replicas != 0 ||
+      (valid_output_replicas != 1 && gather_output)) {
+    valid_output_replicas = 1;
+  }
+  weight_rank_ = rank_ / valid_output_replicas;
+  weight_world_size_ = world_size_ / valid_output_replicas;
+  CHECK(out_features % weight_world_size_ == 0)
+      << "out_features " << out_features
+      << " not divisible by weight_world_size " << weight_world_size_;
+  const int64_t out_features_per_partition = out_features / weight_world_size_;
   // Note: torch.nn.functional.linear performs XA^T + b and as a result
   // we allocate the transpose.
   if (quant_args_.quant_method() == kQuantMethodSmoothquant) {
@@ -731,8 +739,8 @@ void ColumnParallelLinearImpl::load_state_dict(const StateDict& state_dict) {
   if (state_dict.size() == 0) {
     return;
   }
-  const int64_t rank = world_size_ == 1 ? 0 : rank_;
-  const int64_t world_size = world_size_;
+  const int64_t rank = weight_world_size_ == 1 ? 0 : weight_rank_;
+  const int64_t world_size = weight_world_size_;
   resolve_weight_quant_method_for_linear_load(
       quant_args_, state_dict, nullptr, resolved_weight_quant_method_);
   ensure_w8a8_params_for_linear_load(
@@ -800,8 +808,8 @@ void ColumnParallelLinearImpl::load_state_dict(
   if (state_dict.size() == 0) {
     return;
   }
-  const int64_t rank = world_size_ == 1 ? 0 : rank_;
-  const int64_t world_size = world_size_;
+  const int64_t rank = weight_world_size_ == 1 ? 0 : weight_rank_;
+  const int64_t world_size = weight_world_size_;
   resolve_weight_quant_method_for_linear_load(
       quant_args_, state_dict, &prefixes, resolved_weight_quant_method_);
   ensure_w8a8_params_for_linear_load(
@@ -940,8 +948,8 @@ void ColumnParallelLinearImpl::load_state_dict(
   if (state_dict.size() == 0) {
     return;
   }
-  const int64_t rank = rank_;
-  const int64_t world_size = world_size_;
+  const int64_t rank = weight_rank_;
+  const int64_t world_size = weight_world_size_;
   resolve_weight_quant_method_for_linear_load(
       quant_args_, state_dict, nullptr, resolved_weight_quant_method_);
   ensure_w8a8_params_for_linear_load(

--- a/xllm/core/layers/common/linear.h
+++ b/xllm/core/layers/common/linear.h
@@ -51,7 +51,8 @@ class ColumnParallelLinearImpl : public torch::nn::Module {
       const QuantArgs& quant_args,
       ProcessGroup* process_group,
       const torch::TensorOptions& options,
-      const LinearExtraArgs& linear_extra_args = LinearExtraArgs());
+      const LinearExtraArgs& linear_extra_args = LinearExtraArgs(),
+      int32_t output_replicas = 1);
 
   ColumnParallelLinearImpl(const ModelContext& context);
 
@@ -92,7 +93,13 @@ class ColumnParallelLinearImpl : public torch::nn::Module {
     return std::nullopt;
   }
 
-  bool is_weight_loaded() const { return weight_is_loaded_; }
+  bool is_weight_loaded() const {
+    if (quant_args_.quant_method() == kQuantMethodSmoothquant) {
+      return qweight_is_loaded_ && per_channel_scale_is_loaded_ &&
+             smooth_is_loaded_;
+    }
+    return weight_is_loaded_;
+  }
 
   // Get FP8 input scale for fused RMSNorm+FP8 quantization
   std::optional<torch::Tensor> get_input_scale() const;
@@ -125,6 +132,8 @@ class ColumnParallelLinearImpl : public torch::nn::Module {
 
   int64_t rank_;
   int64_t world_size_;
+  int64_t weight_rank_;
+  int64_t weight_world_size_;
   // whether to gather the output
   bool gather_output_;
   at::Device device_;

--- a/xllm/core/layers/common/moe_weight_loader_helper.h
+++ b/xllm/core/layers/common/moe_weight_loader_helper.h
@@ -197,10 +197,8 @@ inline bool try_load_down_sq(const StateDict& state_dict,
       start_expert_id,
       num_experts_per_rank);
   torch::Tensor scale = fused_scale;
-  if (fused_scale.dim() == w2_scale.dim() && fused_scale.dim() == 3) {
-    if (!can_shard_last_dim(fused_scale, world_size, w2_scale.size(-1))) {
-      return false;
-    }
+  if (fused_scale.dim() == w2_scale.dim() &&
+      can_shard_last_dim(fused_scale, world_size, w2_scale.size(-1))) {
     scale = shard_last_dim(fused_scale, rank, world_size, w2_scale.size(-1));
   }
   torch::Tensor scale_shard =

--- a/xllm/core/layers/common/moe_weight_loader_helper.h
+++ b/xllm/core/layers/common/moe_weight_loader_helper.h
@@ -1,0 +1,227 @@
+/* Copyright 2026 The xLLM Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://github.com/jd-opensource/xllm/blob/main/LICENSE
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#pragma once
+
+#include <glog/logging.h>
+#include <torch/torch.h>
+
+#include "framework/state_dict/state_dict.h"
+
+namespace xllm {
+namespace layer {
+namespace moe_weight {
+
+inline torch::Tensor slice_experts(const torch::Tensor& tensor,
+                                   int64_t start_expert_id,
+                                   int64_t num_experts_per_rank) {
+  return tensor
+      .slice(/*dim=*/0, start_expert_id, start_expert_id + num_experts_per_rank)
+      .contiguous();
+}
+
+inline torch::Tensor shard_gate_up(const torch::Tensor& tensor,
+                                   int64_t rank,
+                                   int64_t world_size) {
+  if (world_size <= 1) {
+    return tensor;
+  }
+
+  CHECK_GE(tensor.dim(), 2)
+      << "gate_up_proj must have at least 2 dims, got " << tensor.sizes();
+  CHECK_EQ(tensor.size(1) % 2, 0)
+      << "gate_up_proj dim1 must be even, got " << tensor.size(1);
+  const int64_t full_intermediate = tensor.size(1) / 2;
+  CHECK_EQ(full_intermediate % world_size, 0)
+      << "gate_up_proj intermediate dim is not divisible by world_size";
+  const int64_t local_intermediate = full_intermediate / world_size;
+
+  torch::Tensor gate_full = tensor.slice(/*dim=*/1, 0, full_intermediate);
+  torch::Tensor up_full =
+      tensor.slice(/*dim=*/1, full_intermediate, full_intermediate * 2);
+  torch::Tensor gate_shard = gate_full.slice(
+      /*dim=*/1, rank * local_intermediate, (rank + 1) * local_intermediate);
+  torch::Tensor up_shard = up_full.slice(
+      /*dim=*/1, rank * local_intermediate, (rank + 1) * local_intermediate);
+  return torch::cat({gate_shard, up_shard}, /*dim=*/1);
+}
+
+inline torch::Tensor shard_last_dim(const torch::Tensor& tensor,
+                                    int64_t rank,
+                                    int64_t world_size,
+                                    int64_t local_size) {
+  if (world_size <= 1) {
+    return tensor;
+  }
+
+  CHECK_GE(tensor.dim(), 1) << "tensor must have at least 1 dim";
+  CHECK_EQ(tensor.size(-1), local_size * world_size)
+      << "last dim is not divisible by world_size, tensor shape="
+      << tensor.sizes() << ", local_size=" << local_size
+      << ", world_size=" << world_size;
+  return tensor.slice(
+      tensor.dim() - 1, rank * local_size, (rank + 1) * local_size);
+}
+
+inline void copy_expand_vec(const torch::Tensor& src, torch::Tensor& dst) {
+  CHECK_EQ(dst.size(-1), src.numel())
+      << "smooth size mismatch, src=" << src.sizes() << ", dst=" << dst.sizes();
+  torch::Tensor reshaped = src.reshape({1, -1}).expand(dst.sizes());
+  dst.copy_(reshaped);
+}
+
+inline bool can_shard_gate_up(const torch::Tensor& tensor, int64_t world_size) {
+  if (world_size <= 1) {
+    return tensor.defined();
+  }
+  return tensor.defined() && tensor.dim() >= 2 && tensor.size(1) % 2 == 0 &&
+         (tensor.size(1) / 2) % world_size == 0;
+}
+
+inline bool can_shard_last_dim(const torch::Tensor& tensor,
+                               int64_t world_size,
+                               int64_t local_size) {
+  if (world_size <= 1) {
+    return tensor.defined();
+  }
+  return tensor.defined() && tensor.dim() >= 1 &&
+         tensor.size(-1) == local_size * world_size;
+}
+
+inline bool can_slice_experts(const torch::Tensor& tensor,
+                              int64_t start_expert_id,
+                              int64_t num_experts_per_rank) {
+  return tensor.defined() && tensor.dim() >= 1 && start_expert_id >= 0 &&
+         num_experts_per_rank >= 0 &&
+         start_expert_id + num_experts_per_rank <= tensor.size(0);
+}
+
+inline bool can_expand_vec_to(const torch::Tensor& src,
+                              const torch::Tensor& dst) {
+  return src.defined() && dst.defined() && src.dim() >= 1 && dst.dim() >= 1 &&
+         dst.size(-1) == src.numel();
+}
+
+inline bool try_load_gate_up_sq(const StateDict& state_dict,
+                                int64_t rank,
+                                int64_t world_size,
+                                int64_t start_expert_id,
+                                int64_t num_experts_per_rank,
+                                torch::Tensor& w13,
+                                torch::Tensor& w13_scale,
+                                torch::Tensor& input_smooth,
+                                bool& w13_is_loaded,
+                                bool& w13_scale_is_loaded,
+                                bool& input_smooth_is_loaded) {
+  torch::Tensor fused_qweight = state_dict.get_tensor("gate_up_proj.qweight");
+  torch::Tensor fused_scale =
+      state_dict.get_tensor("gate_up_proj.per_channel_scale");
+  torch::Tensor fused_smooth = state_dict.get_tensor("gate_up_proj.smooth");
+  if (!fused_qweight.defined() || !fused_scale.defined() ||
+      !fused_smooth.defined()) {
+    return false;
+  }
+  if (!can_shard_gate_up(fused_qweight, world_size) ||
+      !can_shard_gate_up(fused_scale, world_size) ||
+      !can_slice_experts(
+          fused_qweight, start_expert_id, num_experts_per_rank) ||
+      !can_slice_experts(fused_scale, start_expert_id, num_experts_per_rank) ||
+      !can_expand_vec_to(fused_smooth, input_smooth)) {
+    return false;
+  }
+
+  torch::Tensor qweight_shard =
+      slice_experts(shard_gate_up(fused_qweight, rank, world_size),
+                    start_expert_id,
+                    num_experts_per_rank);
+  torch::Tensor scale_shard =
+      slice_experts(shard_gate_up(fused_scale, rank, world_size),
+                    start_expert_id,
+                    num_experts_per_rank);
+  if (w13.sizes() != qweight_shard.sizes() ||
+      w13_scale.sizes() != scale_shard.sizes()) {
+    return false;
+  }
+
+  w13.copy_(qweight_shard);
+  w13_is_loaded = true;
+  w13_scale.copy_(scale_shard);
+  w13_scale_is_loaded = true;
+
+  copy_expand_vec(fused_smooth, input_smooth);
+  input_smooth_is_loaded = true;
+  return true;
+}
+
+inline bool try_load_down_sq(const StateDict& state_dict,
+                             int64_t rank,
+                             int64_t world_size,
+                             int64_t start_expert_id,
+                             int64_t num_experts_per_rank,
+                             torch::Tensor& w2,
+                             torch::Tensor& w2_scale,
+                             torch::Tensor& act_smooth,
+                             bool& w2_is_loaded,
+                             bool& w2_scale_is_loaded,
+                             bool& act_smooth_is_loaded) {
+  torch::Tensor fused_qweight = state_dict.get_tensor("down_proj.qweight");
+  torch::Tensor fused_scale =
+      state_dict.get_tensor("down_proj.per_channel_scale");
+  torch::Tensor fused_smooth = state_dict.get_tensor("down_proj.smooth");
+  if (!fused_qweight.defined() || !fused_scale.defined() ||
+      !fused_smooth.defined()) {
+    return false;
+  }
+  if (!can_shard_last_dim(fused_qweight, world_size, w2.size(-1)) ||
+      !can_slice_experts(
+          fused_qweight, start_expert_id, num_experts_per_rank) ||
+      !can_slice_experts(fused_scale, start_expert_id, num_experts_per_rank) ||
+      !can_shard_last_dim(fused_smooth, world_size, act_smooth.size(-1))) {
+    return false;
+  }
+
+  torch::Tensor qweight_shard = slice_experts(
+      shard_last_dim(fused_qweight, rank, world_size, w2.size(-1)),
+      start_expert_id,
+      num_experts_per_rank);
+  torch::Tensor scale = fused_scale;
+  if (fused_scale.dim() == w2_scale.dim() && fused_scale.dim() == 3) {
+    if (!can_shard_last_dim(fused_scale, world_size, w2_scale.size(-1))) {
+      return false;
+    }
+    scale = shard_last_dim(fused_scale, rank, world_size, w2_scale.size(-1));
+  }
+  torch::Tensor scale_shard =
+      slice_experts(scale, start_expert_id, num_experts_per_rank);
+  torch::Tensor smooth_shard =
+      shard_last_dim(fused_smooth, rank, world_size, act_smooth.size(-1));
+  if (w2.sizes() != qweight_shard.sizes() ||
+      w2_scale.sizes() != scale_shard.sizes() ||
+      !can_expand_vec_to(smooth_shard, act_smooth)) {
+    return false;
+  }
+
+  w2.copy_(qweight_shard);
+  w2_is_loaded = true;
+  w2_scale.copy_(scale_shard);
+  w2_scale_is_loaded = true;
+  copy_expand_vec(smooth_shard, act_smooth);
+  act_smooth_is_loaded = true;
+  return true;
+}
+
+}  // namespace moe_weight
+}  // namespace layer
+}  // namespace xllm

--- a/xllm/core/layers/mlu/qwen3_5/qwen3_5_attention.cpp
+++ b/xllm/core/layers/mlu/qwen3_5/qwen3_5_attention.cpp
@@ -52,18 +52,56 @@ Qwen3_5AttentionImpl::Qwen3_5AttentionImpl(const ModelArgs& args,
   scaling_ = 1.0f / std::sqrt(static_cast<float>(head_dim_));
   attn_output_gate_ = args.attn_output_gate();
   mrope_cu_seq_lens_ = torch::zeros(2, torch::kInt32).to(options.device());
+  use_split_qkv_ = quant_args.quant_method() == kQuantMethodSmoothquant;
   // 1. QKV linear
-  qkv_proj_ = register_module(
-      "qkv_proj",
-      QKVParallelLinear(args.hidden_size(),
-                        attn_output_gate_ ? num_heads_ * 2 : num_heads_,
-                        num_kv_heads_,
-                        args.head_dim(),
-                        num_kv_head_replicas_,
-                        /*bias=*/args.attention_bias(),
-                        /*gather_output=*/false,
-                        parallel_args,
-                        options));
+  if (use_split_qkv_) {
+    q_proj_ = register_module(
+        "q_proj",
+        ColumnParallelLinear(
+            args.hidden_size(),
+            (attn_output_gate_ ? total_num_heads * 2 : total_num_heads) *
+                args.head_dim(),
+            /*bias=*/args.attention_bias(),
+            /*gather_output=*/false,
+            quant_args,
+            parallel_args.tp_group_,
+            options));
+    k_proj_ = register_module(
+        "k_proj",
+        ColumnParallelLinear(args.hidden_size(),
+                             total_num_kv_heads * args.head_dim(),
+                             /*bias=*/args.attention_bias(),
+                             /*gather_output=*/false,
+                             quant_args,
+                             parallel_args.tp_group_,
+                             options,
+                             LinearExtraArgs(),
+                             num_kv_head_replicas_));
+    v_proj_ = register_module(
+        "v_proj",
+        ColumnParallelLinear(args.hidden_size(),
+                             total_num_kv_heads * args.head_dim(),
+                             /*bias=*/args.attention_bias(),
+                             /*gather_output=*/false,
+                             quant_args,
+                             parallel_args.tp_group_,
+                             options,
+                             LinearExtraArgs(),
+                             num_kv_head_replicas_));
+  } else {
+    qkv_proj_ = register_module(
+        "qkv_proj",
+        QKVParallelLinear(args.hidden_size(),
+                          attn_output_gate_ ? num_heads_ * 2 : num_heads_,
+                          num_kv_heads_,
+                          args.head_dim(),
+                          num_kv_head_replicas_,
+                          /*bias=*/args.attention_bias(),
+                          /*gather_output=*/false,
+                          parallel_args,
+                          options,
+                          quant_args));
+  }
 
   // 2. O proj
   o_proj_ = register_module("o_proj",
@@ -138,19 +176,34 @@ torch::Tensor Qwen3_5AttentionImpl::forward(
     const torch::Tensor& hidden_states,
     const AttentionMetadata& attn_metadata,
     KVCache& kv_cache) {
-  // 1. qkv projection
-  auto qkv = qkv_proj_->forward(hidden_states);
   torch::Tensor q, k, v;
   torch::Tensor gate;
 
+  if (use_split_qkv_) {
+    q = q_proj_->forward(hidden_states);
+    k = k_proj_->forward(hidden_states);
+    v = v_proj_->forward(hidden_states).contiguous();
+  } else {
+    // 1. qkv projection
+    auto qkv = qkv_proj_->forward(hidden_states);
+    if (attn_output_gate_) {
+      // Split qkv for attn_output_gate case: [q_size*2, kv_size, kv_size]
+      q = qkv.slice(/*dim=*/-1, 0, q_size_ * 2);
+      k = qkv.slice(/*dim=*/-1, q_size_ * 2, q_size_ * 2 + kv_size_);
+      v = qkv.slice(
+          /*dim=*/-1, q_size_ * 2 + kv_size_, q_size_ * 2 + kv_size_ * 2);
+      v = v.contiguous();
+    } else {
+      // Normal case: [q_size, kv_size, kv_size]
+      q = qkv.slice(/*dim=*/-1, 0, q_size_);
+      k = qkv.slice(/*dim=*/-1, q_size_, q_size_ + kv_size_);
+      v = qkv.slice(/*dim=*/-1, q_size_ + kv_size_, q_size_ + 2 * kv_size_);
+    }
+  }
+
   if (attn_output_gate_) {
     // Split qkv for attn_output_gate case: [q_size*2, kv_size, kv_size]
-    auto q_gate = qkv.slice(/*dim=*/-1, 0, q_size_ * 2);
-    k = qkv.slice(/*dim=*/-1, q_size_ * 2, q_size_ * 2 + kv_size_);
-    v = qkv.slice(
-        /*dim=*/-1, q_size_ * 2 + kv_size_, q_size_ * 2 + kv_size_ * 2);
-    v = v.contiguous();
-
+    torch::Tensor q_gate = q;
     std::vector<int64_t> orig_shape;
     for (int64_t i = 0; i < q_gate.dim() - 1; i++) {
       orig_shape.push_back(q_gate.size(i));
@@ -170,11 +223,6 @@ torch::Tensor Qwen3_5AttentionImpl::forward(
     std::vector<int64_t> gate_new_shape = orig_shape;
     gate_new_shape.push_back(-1);
     gate = gate.reshape(gate_new_shape);
-  } else {
-    // Normal case: [q_size, kv_size, kv_size]
-    q = qkv.slice(/*dim=*/-1, 0, q_size_);
-    k = qkv.slice(/*dim=*/-1, q_size_, q_size_ + kv_size_);
-    v = qkv.slice(/*dim=*/-1, q_size_ + kv_size_, q_size_ + 2 * kv_size_);
   }
 
   const int64_t T = q.size(0);
@@ -199,7 +247,13 @@ torch::Tensor Qwen3_5AttentionImpl::forward(
 }
 
 void Qwen3_5AttentionImpl::load_state_dict(const StateDict& state_dict) {
-  qkv_proj_->load_state_dict(state_dict, {"q_proj.", "k_proj.", "v_proj."});
+  if (use_split_qkv_) {
+    q_proj_->load_state_dict(state_dict.get_dict_with_prefix("q_proj."));
+    k_proj_->load_state_dict(state_dict.get_dict_with_prefix("k_proj."));
+    v_proj_->load_state_dict(state_dict.get_dict_with_prefix("v_proj."));
+  } else {
+    qkv_proj_->load_state_dict(state_dict, {"q_proj.", "k_proj.", "v_proj."});
+  }
   o_proj_->load_state_dict(state_dict.get_dict_with_prefix("o_proj."));
   if (auto w = state_dict.get_tensor("q_norm.weight"); w.defined()) {
     q_norm_->load_state_dict(StateDict({{"weight", w}}));

--- a/xllm/core/layers/mlu/qwen3_5/qwen3_5_attention.h
+++ b/xllm/core/layers/mlu/qwen3_5/qwen3_5_attention.h
@@ -62,8 +62,12 @@ class Qwen3_5AttentionImpl : public torch::nn::Module {
   bool attn_output_gate_;
   int32_t layer_id_;
   int32_t rank_;
+  bool use_split_qkv_ = false;
 
   QKVParallelLinear qkv_proj_{nullptr};
+  ColumnParallelLinear q_proj_{nullptr};
+  ColumnParallelLinear k_proj_{nullptr};
+  ColumnParallelLinear v_proj_{nullptr};
   RowParallelLinear o_proj_{nullptr};
 
   Qwen3NextRMSNorm q_norm_{nullptr};

--- a/xllm/core/layers/mlu/qwen3_5/qwen3_5_fused_moe.cpp
+++ b/xllm/core/layers/mlu/qwen3_5/qwen3_5_fused_moe.cpp
@@ -19,169 +19,18 @@ limitations under the License.
 
 #include "framework/parallel_state/parallel_state.h"
 #include "framework/state_dict/utils.h"
+#include "layers/common/moe_weight_loader_helper.h"
 
 namespace xllm {
 namespace layer {
 namespace {
 torch::Tensor get_tensor_with_weight_suffix(const StateDict& state_dict,
                                             const std::string& tensor_name) {
-  auto tensor = state_dict.get_tensor(tensor_name);
+  torch::Tensor tensor = state_dict.get_tensor(tensor_name);
   if (!tensor.defined()) {
     tensor = state_dict.get_tensor(tensor_name + ".weight");
   }
   return tensor;
-}
-
-torch::Tensor slice_expert_weights(const torch::Tensor& weight,
-                                   int64_t start_expert_id,
-                                   int64_t num_experts_per_rank) {
-  return weight
-      .slice(0, start_expert_id, start_expert_id + num_experts_per_rank)
-      .contiguous();
-}
-
-torch::Tensor shard_fused_gate_up(const torch::Tensor& fused_gate_up,
-                                  int64_t rank,
-                                  int64_t world_size) {
-  if (world_size <= 1) {
-    return fused_gate_up;
-  }
-
-  CHECK_GE(fused_gate_up.dim(), 2)
-      << "gate_up_proj must have at least 2 dims, got "
-      << fused_gate_up.sizes();
-  CHECK_EQ(fused_gate_up.size(1) % 2, 0)
-      << "gate_up_proj dim1 must be even, got " << fused_gate_up.size(1);
-  const int64_t full_intermediate = fused_gate_up.size(1) / 2;
-  CHECK_EQ(full_intermediate % world_size, 0)
-      << "gate_up_proj intermediate dim is not divisible by world_size";
-  const int64_t inter_shard = full_intermediate / world_size;
-
-  torch::Tensor gate_full = fused_gate_up.slice(1, 0, full_intermediate);
-  torch::Tensor up_full =
-      fused_gate_up.slice(1, full_intermediate, full_intermediate * 2);
-  torch::Tensor gate_shard =
-      gate_full.slice(1, rank * inter_shard, (rank + 1) * inter_shard);
-  torch::Tensor up_shard =
-      up_full.slice(1, rank * inter_shard, (rank + 1) * inter_shard);
-  return torch::cat({gate_shard, up_shard}, 1);
-}
-
-torch::Tensor shard_last_dim(const torch::Tensor& tensor,
-                             int64_t rank,
-                             int64_t world_size,
-                             int64_t local_size) {
-  if (world_size <= 1) {
-    return tensor;
-  }
-  CHECK_EQ(tensor.size(-1), local_size * world_size)
-      << "last dim is not divisible by world_size, tensor shape="
-      << tensor.sizes() << ", local_size=" << local_size
-      << ", world_size=" << world_size;
-  return tensor.slice(
-      tensor.dim() - 1, rank * local_size, (rank + 1) * local_size);
-}
-
-void copy_expanded_vector(const torch::Tensor& src, torch::Tensor& dst) {
-  torch::Tensor reshaped = src.reshape({1, -1}).expand(dst.sizes());
-  dst.copy_(reshaped);
-}
-
-bool load_fused_gate_up_sq(const StateDict& state_dict,
-                           int64_t rank,
-                           int64_t world_size,
-                           int64_t start_expert_id,
-                           int64_t num_experts_per_rank,
-                           torch::Tensor& w13,
-                           torch::Tensor& w13_scale,
-                           torch::Tensor& input_smooth,
-                           bool& w13_is_loaded,
-                           bool& w13_scale_is_loaded,
-                           bool& input_smooth_is_loaded) {
-  torch::Tensor fused_qweight = state_dict.get_tensor("gate_up_proj.qweight");
-  torch::Tensor fused_scale =
-      state_dict.get_tensor("gate_up_proj.per_channel_scale");
-  torch::Tensor fused_smooth = state_dict.get_tensor("gate_up_proj.smooth");
-  if (!fused_qweight.defined() || !fused_scale.defined() ||
-      !fused_smooth.defined()) {
-    return false;
-  }
-
-  torch::Tensor qweight_shard =
-      slice_expert_weights(shard_fused_gate_up(fused_qweight, rank, world_size),
-                           start_expert_id,
-                           num_experts_per_rank);
-  CHECK_EQ(w13.sizes(), qweight_shard.sizes())
-      << "qweight size mismatch for " << state_dict.prefix()
-      << "gate_up_proj.qweight";
-  w13.copy_(qweight_shard);
-  w13_is_loaded = true;
-
-  torch::Tensor scale_shard =
-      slice_expert_weights(shard_fused_gate_up(fused_scale, rank, world_size),
-                           start_expert_id,
-                           num_experts_per_rank);
-  CHECK_EQ(w13_scale.sizes(), scale_shard.sizes())
-      << "per_channel_scale size mismatch for " << state_dict.prefix()
-      << "gate_up_proj.per_channel_scale";
-  w13_scale.copy_(scale_shard);
-  w13_scale_is_loaded = true;
-
-  CHECK_EQ(input_smooth.size(1), fused_smooth.numel())
-      << "smooth size mismatch for " << state_dict.prefix()
-      << "gate_up_proj.smooth";
-  copy_expanded_vector(fused_smooth, input_smooth);
-  input_smooth_is_loaded = true;
-  return true;
-}
-
-bool load_fused_down_sq(const StateDict& state_dict,
-                        int64_t rank,
-                        int64_t world_size,
-                        int64_t start_expert_id,
-                        int64_t num_experts_per_rank,
-                        torch::Tensor& w2,
-                        torch::Tensor& w2_scale,
-                        torch::Tensor& act_smooth,
-                        bool& w2_is_loaded,
-                        bool& w2_scale_is_loaded,
-                        bool& act_smooth_is_loaded) {
-  torch::Tensor fused_qweight = state_dict.get_tensor("down_proj.qweight");
-  torch::Tensor fused_scale =
-      state_dict.get_tensor("down_proj.per_channel_scale");
-  torch::Tensor fused_smooth = state_dict.get_tensor("down_proj.smooth");
-  if (!fused_qweight.defined() || !fused_scale.defined() ||
-      !fused_smooth.defined()) {
-    return false;
-  }
-
-  torch::Tensor qweight_shard = slice_expert_weights(
-      shard_last_dim(fused_qweight, rank, world_size, w2.size(-1)),
-      start_expert_id,
-      num_experts_per_rank);
-  CHECK_EQ(w2.sizes(), qweight_shard.sizes())
-      << "qweight size mismatch for " << state_dict.prefix()
-      << "down_proj.qweight";
-  w2.copy_(qweight_shard);
-  w2_is_loaded = true;
-
-  torch::Tensor scale = fused_scale;
-  if (fused_scale.dim() == w2_scale.dim() && fused_scale.dim() == 3) {
-    scale = shard_last_dim(fused_scale, rank, world_size, w2_scale.size(-1));
-  }
-  torch::Tensor scale_shard =
-      slice_expert_weights(scale, start_expert_id, num_experts_per_rank);
-  CHECK_EQ(w2_scale.sizes(), scale_shard.sizes())
-      << "per_channel_scale size mismatch for " << state_dict.prefix()
-      << "down_proj.per_channel_scale";
-  w2_scale.copy_(scale_shard);
-  w2_scale_is_loaded = true;
-
-  torch::Tensor smooth_shard =
-      shard_last_dim(fused_smooth, rank, world_size, act_smooth.size(-1));
-  copy_expanded_vector(smooth_shard, act_smooth);
-  act_smooth_is_loaded = true;
-  return true;
 }
 
 bool load_fused_gate_up_fallback(const StateDict& state_dict,
@@ -190,32 +39,16 @@ bool load_fused_gate_up_fallback(const StateDict& state_dict,
                                  int64_t start_expert_id,
                                  int64_t num_experts_per_rank,
                                  torch::Tensor& w13) {
-  auto fused_gate_up =
+  torch::Tensor fused_gate_up =
       get_tensor_with_weight_suffix(state_dict, "gate_up_proj");
   if (!fused_gate_up.defined()) {
     return false;
   }
 
-  if (world_size > 1) {
-    CHECK_EQ(fused_gate_up.size(1) % 2, 0)
-        << "gate_up_proj dim1 must be even, got " << fused_gate_up.size(1);
-    const int64_t full_intermediate = fused_gate_up.size(1) / 2;
-    CHECK_EQ(full_intermediate % world_size, 0)
-        << "gate_up_proj intermediate dim is not divisible by world_size";
-    const int64_t inter_shard = full_intermediate / world_size;
-
-    auto gate_full = fused_gate_up.slice(1, 0, full_intermediate);
-    auto up_full =
-        fused_gate_up.slice(1, full_intermediate, full_intermediate * 2);
-    auto gate_shard =
-        gate_full.slice(1, rank * inter_shard, (rank + 1) * inter_shard);
-    auto up_shard =
-        up_full.slice(1, rank * inter_shard, (rank + 1) * inter_shard);
-    fused_gate_up = torch::cat({gate_shard, up_shard}, 1);
-  }
-
-  auto gate_up_slice = slice_expert_weights(
-      fused_gate_up, start_expert_id, num_experts_per_rank);
+  torch::Tensor gate_up_slice = moe_weight::slice_experts(
+      moe_weight::shard_gate_up(fused_gate_up, rank, world_size),
+      start_expert_id,
+      num_experts_per_rank);
   CHECK_EQ(w13.sizes(), gate_up_slice.sizes())
       << "weight size mismatch for " << state_dict.prefix()
       << "experts.gate_up_proj";
@@ -229,21 +62,16 @@ bool load_fused_down_fallback(const StateDict& state_dict,
                               int64_t start_expert_id,
                               int64_t num_experts_per_rank,
                               torch::Tensor& w2) {
-  auto fused_down = get_tensor_with_weight_suffix(state_dict, "down_proj");
+  torch::Tensor fused_down =
+      get_tensor_with_weight_suffix(state_dict, "down_proj");
   if (!fused_down.defined()) {
     return false;
   }
 
-  if (world_size > 1) {
-    CHECK_EQ(fused_down.size(2) % world_size, 0)
-        << "down_proj dim2 is not divisible by world_size";
-    const int64_t down_shard = fused_down.size(2) / world_size;
-    fused_down =
-        fused_down.slice(2, rank * down_shard, (rank + 1) * down_shard);
-  }
-
-  auto down_slice =
-      slice_expert_weights(fused_down, start_expert_id, num_experts_per_rank);
+  torch::Tensor down_slice = moe_weight::slice_experts(
+      moe_weight::shard_last_dim(fused_down, rank, world_size, w2.size(-1)),
+      start_expert_id,
+      num_experts_per_rank);
   CHECK_EQ(w2.sizes(), down_slice.sizes())
       << "weight size mismatch for " << state_dict.prefix()
       << "experts.down_proj";
@@ -272,28 +100,28 @@ void Qwen3_5FusedMoEImpl::load_experts(const StateDict& state_dict) {
   FusedMoEImpl::load_experts(state_dict);
 
   if (is_smoothquant_) {
-    load_fused_gate_up_sq(state_dict,
-                          tp_pg_->rank(),
-                          tp_pg_->world_size(),
-                          start_expert_id_,
-                          num_experts_per_rank_,
-                          w13_,
-                          w13_scale_,
-                          input_smooth_,
-                          w13_is_loaded_,
-                          w13_scale_is_loaded_,
-                          input_smooth_is_loaded_);
-    load_fused_down_sq(state_dict,
-                       tp_pg_->rank(),
-                       tp_pg_->world_size(),
-                       start_expert_id_,
-                       num_experts_per_rank_,
-                       w2_,
-                       w2_scale_,
-                       act_smooth_,
-                       w2_is_loaded_,
-                       w2_scale_is_loaded_,
-                       act_smooth_is_loaded_);
+    moe_weight::try_load_gate_up_sq(state_dict,
+                                    tp_pg_->rank(),
+                                    tp_pg_->world_size(),
+                                    start_expert_id_,
+                                    num_experts_per_rank_,
+                                    w13_,
+                                    w13_scale_,
+                                    input_smooth_,
+                                    w13_is_loaded_,
+                                    w13_scale_is_loaded_,
+                                    input_smooth_is_loaded_);
+    moe_weight::try_load_down_sq(state_dict,
+                                 tp_pg_->rank(),
+                                 tp_pg_->world_size(),
+                                 start_expert_id_,
+                                 num_experts_per_rank_,
+                                 w2_,
+                                 w2_scale_,
+                                 act_smooth_,
+                                 w2_is_loaded_,
+                                 w2_scale_is_loaded_,
+                                 act_smooth_is_loaded_);
   } else {
     if (!w13_is_loaded_) {
       w13_is_loaded_ = load_fused_gate_up_fallback(state_dict,

--- a/xllm/core/layers/mlu/qwen3_5/qwen3_5_fused_moe.cpp
+++ b/xllm/core/layers/mlu/qwen3_5/qwen3_5_fused_moe.cpp
@@ -40,6 +40,150 @@ torch::Tensor slice_expert_weights(const torch::Tensor& weight,
       .contiguous();
 }
 
+torch::Tensor shard_fused_gate_up(const torch::Tensor& fused_gate_up,
+                                  int64_t rank,
+                                  int64_t world_size) {
+  if (world_size <= 1) {
+    return fused_gate_up;
+  }
+
+  CHECK_GE(fused_gate_up.dim(), 2)
+      << "gate_up_proj must have at least 2 dims, got "
+      << fused_gate_up.sizes();
+  CHECK_EQ(fused_gate_up.size(1) % 2, 0)
+      << "gate_up_proj dim1 must be even, got " << fused_gate_up.size(1);
+  const int64_t full_intermediate = fused_gate_up.size(1) / 2;
+  CHECK_EQ(full_intermediate % world_size, 0)
+      << "gate_up_proj intermediate dim is not divisible by world_size";
+  const int64_t inter_shard = full_intermediate / world_size;
+
+  torch::Tensor gate_full = fused_gate_up.slice(1, 0, full_intermediate);
+  torch::Tensor up_full =
+      fused_gate_up.slice(1, full_intermediate, full_intermediate * 2);
+  torch::Tensor gate_shard =
+      gate_full.slice(1, rank * inter_shard, (rank + 1) * inter_shard);
+  torch::Tensor up_shard =
+      up_full.slice(1, rank * inter_shard, (rank + 1) * inter_shard);
+  return torch::cat({gate_shard, up_shard}, 1);
+}
+
+torch::Tensor shard_last_dim(const torch::Tensor& tensor,
+                             int64_t rank,
+                             int64_t world_size,
+                             int64_t local_size) {
+  if (world_size <= 1) {
+    return tensor;
+  }
+  CHECK_EQ(tensor.size(-1), local_size * world_size)
+      << "last dim is not divisible by world_size, tensor shape="
+      << tensor.sizes() << ", local_size=" << local_size
+      << ", world_size=" << world_size;
+  return tensor.slice(
+      tensor.dim() - 1, rank * local_size, (rank + 1) * local_size);
+}
+
+void copy_expanded_vector(const torch::Tensor& src, torch::Tensor& dst) {
+  torch::Tensor reshaped = src.reshape({1, -1}).expand(dst.sizes());
+  dst.copy_(reshaped);
+}
+
+bool load_fused_gate_up_sq(const StateDict& state_dict,
+                           int64_t rank,
+                           int64_t world_size,
+                           int64_t start_expert_id,
+                           int64_t num_experts_per_rank,
+                           torch::Tensor& w13,
+                           torch::Tensor& w13_scale,
+                           torch::Tensor& input_smooth,
+                           bool& w13_is_loaded,
+                           bool& w13_scale_is_loaded,
+                           bool& input_smooth_is_loaded) {
+  torch::Tensor fused_qweight = state_dict.get_tensor("gate_up_proj.qweight");
+  torch::Tensor fused_scale =
+      state_dict.get_tensor("gate_up_proj.per_channel_scale");
+  torch::Tensor fused_smooth = state_dict.get_tensor("gate_up_proj.smooth");
+  if (!fused_qweight.defined() || !fused_scale.defined() ||
+      !fused_smooth.defined()) {
+    return false;
+  }
+
+  torch::Tensor qweight_shard =
+      slice_expert_weights(shard_fused_gate_up(fused_qweight, rank, world_size),
+                           start_expert_id,
+                           num_experts_per_rank);
+  CHECK_EQ(w13.sizes(), qweight_shard.sizes())
+      << "qweight size mismatch for " << state_dict.prefix()
+      << "gate_up_proj.qweight";
+  w13.copy_(qweight_shard);
+  w13_is_loaded = true;
+
+  torch::Tensor scale_shard =
+      slice_expert_weights(shard_fused_gate_up(fused_scale, rank, world_size),
+                           start_expert_id,
+                           num_experts_per_rank);
+  CHECK_EQ(w13_scale.sizes(), scale_shard.sizes())
+      << "per_channel_scale size mismatch for " << state_dict.prefix()
+      << "gate_up_proj.per_channel_scale";
+  w13_scale.copy_(scale_shard);
+  w13_scale_is_loaded = true;
+
+  CHECK_EQ(input_smooth.size(1), fused_smooth.numel())
+      << "smooth size mismatch for " << state_dict.prefix()
+      << "gate_up_proj.smooth";
+  copy_expanded_vector(fused_smooth, input_smooth);
+  input_smooth_is_loaded = true;
+  return true;
+}
+
+bool load_fused_down_sq(const StateDict& state_dict,
+                        int64_t rank,
+                        int64_t world_size,
+                        int64_t start_expert_id,
+                        int64_t num_experts_per_rank,
+                        torch::Tensor& w2,
+                        torch::Tensor& w2_scale,
+                        torch::Tensor& act_smooth,
+                        bool& w2_is_loaded,
+                        bool& w2_scale_is_loaded,
+                        bool& act_smooth_is_loaded) {
+  torch::Tensor fused_qweight = state_dict.get_tensor("down_proj.qweight");
+  torch::Tensor fused_scale =
+      state_dict.get_tensor("down_proj.per_channel_scale");
+  torch::Tensor fused_smooth = state_dict.get_tensor("down_proj.smooth");
+  if (!fused_qweight.defined() || !fused_scale.defined() ||
+      !fused_smooth.defined()) {
+    return false;
+  }
+
+  torch::Tensor qweight_shard = slice_expert_weights(
+      shard_last_dim(fused_qweight, rank, world_size, w2.size(-1)),
+      start_expert_id,
+      num_experts_per_rank);
+  CHECK_EQ(w2.sizes(), qweight_shard.sizes())
+      << "qweight size mismatch for " << state_dict.prefix()
+      << "down_proj.qweight";
+  w2.copy_(qweight_shard);
+  w2_is_loaded = true;
+
+  torch::Tensor scale = fused_scale;
+  if (fused_scale.dim() == w2_scale.dim() && fused_scale.dim() == 3) {
+    scale = shard_last_dim(fused_scale, rank, world_size, w2_scale.size(-1));
+  }
+  torch::Tensor scale_shard =
+      slice_expert_weights(scale, start_expert_id, num_experts_per_rank);
+  CHECK_EQ(w2_scale.sizes(), scale_shard.sizes())
+      << "per_channel_scale size mismatch for " << state_dict.prefix()
+      << "down_proj.per_channel_scale";
+  w2_scale.copy_(scale_shard);
+  w2_scale_is_loaded = true;
+
+  torch::Tensor smooth_shard =
+      shard_last_dim(fused_smooth, rank, world_size, act_smooth.size(-1));
+  copy_expanded_vector(smooth_shard, act_smooth);
+  act_smooth_is_loaded = true;
+  return true;
+}
+
 bool load_fused_gate_up_fallback(const StateDict& state_dict,
                                  int64_t rank,
                                  int64_t world_size,
@@ -127,7 +271,30 @@ Qwen3_5FusedMoEImpl::Qwen3_5FusedMoEImpl(const ModelArgs& model_args,
 void Qwen3_5FusedMoEImpl::load_experts(const StateDict& state_dict) {
   FusedMoEImpl::load_experts(state_dict);
 
-  if (!is_smoothquant_) {
+  if (is_smoothquant_) {
+    load_fused_gate_up_sq(state_dict,
+                          tp_pg_->rank(),
+                          tp_pg_->world_size(),
+                          start_expert_id_,
+                          num_experts_per_rank_,
+                          w13_,
+                          w13_scale_,
+                          input_smooth_,
+                          w13_is_loaded_,
+                          w13_scale_is_loaded_,
+                          input_smooth_is_loaded_);
+    load_fused_down_sq(state_dict,
+                       tp_pg_->rank(),
+                       tp_pg_->world_size(),
+                       start_expert_id_,
+                       num_experts_per_rank_,
+                       w2_,
+                       w2_scale_,
+                       act_smooth_,
+                       w2_is_loaded_,
+                       w2_scale_is_loaded_,
+                       act_smooth_is_loaded_);
+  } else {
     if (!w13_is_loaded_) {
       w13_is_loaded_ = load_fused_gate_up_fallback(state_dict,
                                                    tp_pg_->rank(),

--- a/xllm/core/layers/mlu/qwen3_5/qwen3_5_fused_moe.cpp
+++ b/xllm/core/layers/mlu/qwen3_5/qwen3_5_fused_moe.cpp
@@ -100,28 +100,41 @@ void Qwen3_5FusedMoEImpl::load_experts(const StateDict& state_dict) {
   FusedMoEImpl::load_experts(state_dict);
 
   if (is_smoothquant_) {
-    moe_weight::try_load_gate_up_sq(state_dict,
-                                    tp_pg_->rank(),
-                                    tp_pg_->world_size(),
-                                    start_expert_id_,
-                                    num_experts_per_rank_,
-                                    w13_,
-                                    w13_scale_,
-                                    input_smooth_,
-                                    w13_is_loaded_,
-                                    w13_scale_is_loaded_,
-                                    input_smooth_is_loaded_);
-    moe_weight::try_load_down_sq(state_dict,
-                                 tp_pg_->rank(),
-                                 tp_pg_->world_size(),
-                                 start_expert_id_,
-                                 num_experts_per_rank_,
-                                 w2_,
-                                 w2_scale_,
-                                 act_smooth_,
-                                 w2_is_loaded_,
-                                 w2_scale_is_loaded_,
-                                 act_smooth_is_loaded_);
+    const bool gate_up_loaded =
+        w13_is_loaded_ && w13_scale_is_loaded_ && input_smooth_is_loaded_;
+    if (!gate_up_loaded) {
+      CHECK(moe_weight::try_load_gate_up_sq(state_dict,
+                                            tp_pg_->rank(),
+                                            tp_pg_->world_size(),
+                                            start_expert_id_,
+                                            num_experts_per_rank_,
+                                            w13_,
+                                            w13_scale_,
+                                            input_smooth_,
+                                            w13_is_loaded_,
+                                            w13_scale_is_loaded_,
+                                            input_smooth_is_loaded_))
+          << "failed to load gate_up smoothquant weights for "
+          << state_dict.prefix();
+    }
+
+    const bool down_loaded =
+        w2_is_loaded_ && w2_scale_is_loaded_ && act_smooth_is_loaded_;
+    if (!down_loaded) {
+      CHECK(moe_weight::try_load_down_sq(state_dict,
+                                         tp_pg_->rank(),
+                                         tp_pg_->world_size(),
+                                         start_expert_id_,
+                                         num_experts_per_rank_,
+                                         w2_,
+                                         w2_scale_,
+                                         act_smooth_,
+                                         w2_is_loaded_,
+                                         w2_scale_is_loaded_,
+                                         act_smooth_is_loaded_))
+          << "failed to load down smoothquant weights for "
+          << state_dict.prefix();
+    }
   } else {
     if (!w13_is_loaded_) {
       w13_is_loaded_ = load_fused_gate_up_fallback(state_dict,


### PR DESCRIPTION
## Description
bugfix qwen3.5 w8a8 weight loading.

## Related Issues

<!-- Link related issues here. Use "Fixes #123" when this PR closes an issue. -->

## Change Type

- [x] Bug fix
- [ ] New feature
- [ ] Performance improvement
- [ ] Refactor
- [ ] Documentation
- [ ] Test
- [ ] Build or CI

## Pull Request Checklist

Thank you for contributing to xLLM. Before requesting review, please make sure the following items are complete.

### PR Title and Commit Messages

- [ ] The PR title and each commit message follow the xLLM commit format: `<type>: <subject>`.

> Allowed types: feat, bugfix, docs, test, refactor, chore, style, revert, perf, model, build, release.
> The subject should use clear English, start with a verb, include at least 4 words, and end with `.`.

### Pre-commit Checks

- [ ] I have installed `pre-commit` by running `pip install pre-commit` or an equivalent command.
- [ ] I have installed the hooks with `pre-commit install`.
- [ ] I have run `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

### Self Review

- [ ] I have self-reviewed the code according to `.agents/skills/code-review/references/custom-code-style.md`, especially code written or assisted by AI.
- [ ] I have rebased this PR onto the latest `main` branch.

### Build and Test Coverage

- [ ] Tests have been added or updated as needed.
- [ ] CUDA: `python setup.py build test` has passed on a CUDA machine.
- [ ] NPU: `python setup.py build test` has passed on an NPU machine.
- [x] MLU: `python setup.py build test` has passed on an MLU machine.

## Reviewer Notes

<!-- Optional: anything reviewers should focus on, known risks, follow-ups, or validation gaps. -->
