### PR TITLE
feat: add VAE parallel for wan22 and QwenImageEdit.

### DIFF
--- a/xllm/core/framework/parallel_state/process_group.cpp
+++ b/xllm/core/framework/parallel_state/process_group.cpp
@@ -209,6 +209,20 @@ void ProcessGroup::all_to_all_single(
   }
 }
 
+void ProcessGroup::send(const torch::Tensor& tensor, int dst, int tag) {
+  CHECK(pg_ != nullptr) << "Process group is not initialized.";
+  CHECK(tensor.defined()) << "send tensor is not defined";
+  std::vector<torch::Tensor> tensors = {tensor};
+  pg_->send(tensors, dst, tag)->wait();
+}
+
+void ProcessGroup::recv(torch::Tensor& tensor, int src, int tag) {
+  CHECK(pg_ != nullptr) << "Process group is not initialized.";
+  CHECK(tensor.defined()) << "recv tensor is not defined";
+  std::vector<torch::Tensor> tensors = {tensor};
+  pg_->recv(tensors, src, tag)->wait();
+}
+
 std::string ProcessGroup::hccl_comm_name(bool init_comm) {
   (void)init_comm;
   CHECK(false) << "hccl_comm_name is only supported on NPU HCCL process group.";

--- a/xllm/core/framework/parallel_state/process_group.h
+++ b/xllm/core/framework/parallel_state/process_group.h
@@ -106,6 +106,12 @@ class ProcessGroup {
       bool async_op = false,
       c10::intrusive_ptr<c10d::Work>* async_work = nullptr);
 
+  // Point-to-point: send tensor to dst rank, recv tensor from src rank.
+  // Both are synchronous (block until complete).
+  // src/dst are group-local ranks.
+  virtual void send(const torch::Tensor& tensor, int dst, int tag = 0);
+  virtual void recv(torch::Tensor& tensor, int src, int tag = 0);
+
   virtual std::string hccl_comm_name(bool init_comm = true);
 
  private:

--- a/xllm/models/dit/autoencoders/autoencoder_kl_qwenimage.h
+++ b/xllm/models/dit/autoencoders/autoencoder_kl_qwenimage.h
@@ -36,6 +36,7 @@ limitations under the License.
 #include "models/dit/autoencoders/autoencoder_kl.h"
 #include "models/dit/utils/diagonal_gaussian_distribution.h"
 #include "models/dit/utils/util.h"
+#include "models/dit/utils/vae_spatial_parallel.h"
 #include "models/model_registry.h"
 
 #ifdef TORCH_HIGHER_THAN_PTA6
@@ -51,12 +52,15 @@ limitations under the License.
 
 namespace xllm {
 
+using xllm::dit::VaeSpatialParallel;
+
 class QwenImageBaseModule : public torch::nn::Module {
  public:
   virtual torch::Tensor forward(
       const torch::Tensor& x,
-      std::shared_ptr<std::vector<torch::Tensor>> feat_cache = nullptr,
-      std::shared_ptr<std::vector<int64_t>> feat_idx = nullptr) = 0;
+      std::shared_ptr<std::vector<torch::Tensor>> feat_cache,
+      std::shared_ptr<std::vector<int64_t>> feat_idx,
+      VaeSpatialParallel& ctx) = 0;
   virtual ~QwenImageBaseModule() = default;
 };
 
@@ -83,22 +87,45 @@ class QwenImageCausalConv3dImpl : public torch::nn::Module {
                  : std::vector<int64_t>(padding.begin(), padding.end());
 
     padding_ = {p[2], p[2], p[1], p[1], 2 * p[0], 0};
+    stride_ = stride.vec();
   }
 
   torch::Tensor forward(const torch::Tensor& x,
+                        VaeSpatialParallel& ctx,
                         const torch::Tensor& cache_x = torch::Tensor()) {
     auto padding_vec = padding_;
     auto result_x = x;
 
-    if (cache_x.defined() && padding_[4] > 0) {
+    // Halo exchange is only needed for 3×3 spatial convolutions (kernel=3,
+    // pad=1). For 1×1 convolutions (e.g. quant_conv) the padding is {0,0,0}
+    // so this condition is false and no exchange occurs.
+    // padding_ is the 6-element F::pad format:
+    //   {W_left, W_right, H_top, H_bottom, T_front, T_back}
+    // padding_[1] is W_right padding, padding_[2] is H_top padding.
+    // Both == 1 means spatial kernel is 3×3 with padding=1.
+    bool use_halo = (ctx.is_parallel() && padding_[1] == 1 && padding_[2] == 1);
+
+    // Temporal padding (causal) — must come BEFORE halo exchange so cache
+    // and input have matching spatial dims.
+    if (cache_x.defined() && padding_vec[4] > 0) {
       auto device_x = result_x.device();
       auto cache_device = cache_x.to(device_x);
       result_x = torch::cat({cache_device, result_x}, 2);
       padding_vec[4] -= cache_x.size(2);
     }
 
+    // Spatial parallel: halo exchange provides W neighbors.
+    // Zero W padding from F::pad (exchange already handles it).
+    // H padding stays in F::pad since conv3d has padding=0.
+    if (use_halo) {
+      result_x = ctx.exchange(result_x, /*pad=*/true);
+      padding_vec[0] = 0;  // W left  — handled by exchange
+      padding_vec[1] = 0;  // W right — handled by exchange
+    }
+
     result_x = torch::nn::functional::pad(
         result_x, torch::nn::functional::PadFuncOptions(padding_vec));
+
     return conv_(result_x);
   }
 
@@ -118,6 +145,7 @@ class QwenImageCausalConv3dImpl : public torch::nn::Module {
   bool is_bias_loaded_{false};
   torch::nn::Conv3d conv_ = nullptr;
   std::vector<int64_t> padding_;
+  std::vector<int64_t> stride_;
 };
 
 TORCH_MODULE(QwenImageCausalConv3d);
@@ -303,10 +331,10 @@ class QwenImageResampleImpl : public QwenImageBaseModule {
     rep_tensor_ = register_parameter("rep_tensor", torch::tensor({-999.0}));
   }
 
-  torch::Tensor forward(
-      const torch::Tensor& x,
-      std::shared_ptr<std::vector<torch::Tensor>> feat_cache = nullptr,
-      std::shared_ptr<std::vector<int64_t>> feat_idx = nullptr) override {
+  torch::Tensor forward(const torch::Tensor& x,
+                        std::shared_ptr<std::vector<torch::Tensor>> feat_cache,
+                        std::shared_ptr<std::vector<int64_t>> feat_idx,
+                        VaeSpatialParallel& ctx) override {
     if (feat_idx == nullptr) {
       feat_idx =
           std::make_shared<std::vector<int64_t>>(std::vector<int64_t>{0});
@@ -343,9 +371,9 @@ class QwenImageResampleImpl : public QwenImageBaseModule {
               {torch::zeros_like(cache_x).to(cache_x.device()), cache_x}, 2);
         }
         if (torch::equal(rep_tensor_, feat_cache->at(idx))) {
-          result_x = time_conv_->forward(result_x);
+          result_x = time_conv_->forward(result_x, ctx);
         } else {
-          result_x = time_conv_->forward(result_x, feat_cache->at(idx));
+          result_x = time_conv_->forward(result_x, ctx, feat_cache->at(idx));
         }
         feat_cache->at(idx) = cache_x;
         (*feat_idx)[0]++;
@@ -362,12 +390,53 @@ class QwenImageResampleImpl : public QwenImageBaseModule {
     }
 
     t = result_x.size(2);
+
+    bool is_upsample = (mode_ == "upsample2d" || mode_ == "upsample3d");
+    bool is_downsample = (mode_ == "downsample2d" || mode_ == "downsample3d");
+
+    // Upsample: exchange halo columns before spatial upsampling
+    if (ctx.is_parallel() && is_upsample) {
+      result_x = ctx.exchange(result_x, /*pad=*/false);
+      w = result_x.size(-1);
+    }
+    // Downsample: merge spatial slices before spatial downsampling
+    if (ctx.is_parallel() && is_downsample) {
+      result_x = ctx.merge(result_x);
+      w = result_x.size(-1);
+      h = result_x.size(-2);
+    }
+
     result_x = result_x.permute({0, 2, 1, 3, 4}).reshape({b * t, c, h, w});
     result_x = resample_->forward(result_x);
     result_x =
         result_x
             .view({b, t, result_x.size(1), result_x.size(2), result_x.size(3)})
             .permute({0, 2, 1, 3, 4});
+
+    // Upsample: trim excess columns introduced by halo exchange.
+    //
+    // Before upsample: exchange(pad=false) adds 1 neighbor column per side.
+    // The interpolate 2× doubles each column, and the following Conv2d(k=3,
+    // pad=1) preserves size. So each halo column produces 2 excess columns.
+    //
+    // Trim 2 from each side where a neighbor contributed halo:
+    //   - middle rank (has_left && has_right): trim 2 from each side
+    //   - first rank  (!has_left):           trim 2 from right only
+    //   - last rank   (!has_right):          trim 2 from left only
+    if (ctx.is_parallel() && is_upsample) {
+      auto cur_w = result_x.size(-1);
+      if (ctx.has_left() && ctx.has_right()) {
+        result_x = result_x.slice(/*dim=*/-1, 2, cur_w - 2);
+      } else if (!ctx.has_left()) {
+        result_x = result_x.slice(/*dim=*/-1, 0, cur_w - 2);
+      } else {
+        result_x = result_x.slice(/*dim=*/-1, 2, cur_w);
+      }
+    }
+    // Downsample: split full result back to local slices
+    if (ctx.is_parallel() && is_downsample) {
+      result_x = ctx.split(result_x);
+    }
 
     if (mode_ == "downsample3d" && feat_cache && feat_idx) {
       auto idx = (*feat_idx)[0];
@@ -388,7 +457,7 @@ class QwenImageResampleImpl : public QwenImageBaseModule {
              result_x},
             2);
 
-        result_x = time_conv_->forward(concat_x);
+        result_x = time_conv_->forward(concat_x, ctx);
         feat_cache->at(idx) = cache_x;
         (*feat_idx)[0]++;
       } else {
@@ -495,17 +564,17 @@ class QwenImageResidualBlockImpl : public QwenImageBaseModule {
     }
   }
 
-  torch::Tensor forward(
-      const torch::Tensor& x,
-      std::shared_ptr<std::vector<torch::Tensor>> feat_cache = nullptr,
-      std::shared_ptr<std::vector<int64_t>> feat_idx = nullptr) override {
+  torch::Tensor forward(const torch::Tensor& x,
+                        std::shared_ptr<std::vector<torch::Tensor>> feat_cache,
+                        std::shared_ptr<std::vector<int64_t>> feat_idx,
+                        VaeSpatialParallel& ctx) override {
     if (feat_idx == nullptr) {
       feat_idx =
           std::make_shared<std::vector<int64_t>>(std::vector<int64_t>{0});
     }
     torch::Tensor h = torch::empty({0});
     if (conv_shortcut_) {
-      h = conv_shortcut_->forward(x);
+      h = conv_shortcut_->forward(x, ctx);
     } else {
       h = identity_->forward(x);
     }
@@ -533,11 +602,11 @@ class QwenImageResidualBlockImpl : public QwenImageBaseModule {
         cache_x = torch::cat({last_frame, cache_x}, 2);
       }
 
-      result_x = conv1_->forward(result_x, feat_cache->at(idx));
+      result_x = conv1_->forward(result_x, ctx, feat_cache->at(idx));
       feat_cache->at(idx) = cache_x;
       (*feat_idx)[0]++;
     } else {
-      result_x = conv1_->forward(result_x);
+      result_x = conv1_->forward(result_x, ctx);
     }
     result_x = norm2_->forward(result_x);
     result_x = activation_->forward(result_x);
@@ -562,11 +631,11 @@ class QwenImageResidualBlockImpl : public QwenImageBaseModule {
                 .to(cache_x.device());
         cache_x = torch::cat({last_frame, cache_x}, 2);
       }
-      result_x = conv2_->forward(result_x, feat_cache->at(idx));
+      result_x = conv2_->forward(result_x, ctx, feat_cache->at(idx));
       feat_cache->at(idx) = cache_x;
       (*feat_idx)[0]++;
     } else {
-      result_x = conv2_->forward(result_x);
+      result_x = conv2_->forward(result_x, ctx);
     }
 
     return result_x + h;
@@ -631,10 +700,11 @@ class QwenImageAttentionBlockImpl : public QwenImageBaseModule {
                                                    /*kernel_size=*/1)));
   }
 
-  torch::Tensor forward(
-      const torch::Tensor& x,
-      std::shared_ptr<std::vector<torch::Tensor>> feat_cache = nullptr,
-      std::shared_ptr<std::vector<int64_t>> feat_idx = nullptr) override {
+  torch::Tensor forward(const torch::Tensor& x,
+                        std::shared_ptr<std::vector<torch::Tensor>> feat_cache,
+                        std::shared_ptr<std::vector<int64_t>> feat_idx,
+                        VaeSpatialParallel& ctx) override {
+    (void)ctx;  // attention block has no conv3d sub-calls
     if (feat_idx == nullptr) {
       feat_idx =
           std::make_shared<std::vector<int64_t>>(std::vector<int64_t>{0});
@@ -647,11 +717,32 @@ class QwenImageAttentionBlockImpl : public QwenImageBaseModule {
     reshaped_x = norm_->forward(reshaped_x);
 
     auto qkv = to_qkv_->forward(reshaped_x);
-    qkv = qkv.reshape({b * t, 1, c * 3, h * w});
-    qkv = qkv.permute({0, 1, 3, 2}).contiguous();
 
-    auto chunks = qkv.chunk(3, -1);
-    auto q = chunks[0], k = chunks[1], v = chunks[2];
+    torch::Tensor q, k, v;
+    if (ctx.is_parallel()) {
+      // Gather K/V in spatial domain before BNSD reshape
+      auto spatial_chunks = qkv.chunk(3, 1);
+      auto k_sp = ctx.merge(spatial_chunks[1].unsqueeze(2)).squeeze(2);
+      auto v_sp = ctx.merge(spatial_chunks[2].unsqueeze(2)).squeeze(2);
+      int64_t W_global = k_sp.size(-1);
+      q = spatial_chunks[0]
+              .reshape({b * t, 1, c, h * w})
+              .permute({0, 1, 3, 2})
+              .contiguous();
+      k = k_sp.reshape({b * t, 1, c, h * W_global})
+              .permute({0, 1, 3, 2})
+              .contiguous();
+      v = v_sp.reshape({b * t, 1, c, h * W_global})
+              .permute({0, 1, 3, 2})
+              .contiguous();
+    } else {
+      qkv = qkv.reshape({b * t, 1, c * 3, h * w});
+      qkv = qkv.permute({0, 1, 3, 2}).contiguous();
+      auto chunks = qkv.chunk(3, -1);
+      q = chunks[0];
+      k = chunks[1];
+      v = chunks[2];
+    }
 
     auto results = at_npu::native::custom_ops::npu_fusion_attention(
         q,
@@ -741,10 +832,10 @@ class QwenImageMidBlockImpl : public torch::nn::Module {
     }
   }
 
-  torch::Tensor forward(
-      const torch::Tensor& x,
-      std::shared_ptr<std::vector<torch::Tensor>> feat_cache = nullptr,
-      std::shared_ptr<std::vector<int64_t>> feat_idx = nullptr) {
+  torch::Tensor forward(const torch::Tensor& x,
+                        std::shared_ptr<std::vector<torch::Tensor>> feat_cache,
+                        std::shared_ptr<std::vector<int64_t>> feat_idx,
+                        VaeSpatialParallel& ctx) {
     if (feat_idx == nullptr) {
       feat_idx =
           std::make_shared<std::vector<int64_t>>(std::vector<int64_t>{0});
@@ -752,13 +843,13 @@ class QwenImageMidBlockImpl : public torch::nn::Module {
     auto result_x = x;
 
     result_x = resnets_[0]->as<QwenImageResidualBlock>()->forward(
-        result_x, feat_cache, feat_idx);
+        result_x, feat_cache, feat_idx, ctx);
 
     for (size_t i = 0; i < attentions_->size(); i++) {
-      result_x =
-          attentions_[i]->as<QwenImageAttentionBlock>()->forward(result_x);
+      result_x = attentions_[i]->as<QwenImageAttentionBlock>()->forward(
+          result_x, nullptr, nullptr, ctx);
       result_x = resnets_[i + 1]->as<QwenImageResidualBlock>()->forward(
-          result_x, feat_cache, feat_idx);
+          result_x, feat_cache, feat_idx, ctx);
     }
 
     return result_x;
@@ -894,10 +985,10 @@ class QwenImageEncoder3dImpl : public torch::nn::Module {
                               /*padding=*/torch::IntArrayRef{1, 1, 1}));
   }
 
-  torch::Tensor forward(
-      const torch::Tensor& x,
-      std::shared_ptr<std::vector<torch::Tensor>> feat_cache = nullptr,
-      std::shared_ptr<std::vector<int64_t>> feat_idx = nullptr) {
+  torch::Tensor forward(const torch::Tensor& x,
+                        std::shared_ptr<std::vector<torch::Tensor>> feat_cache,
+                        std::shared_ptr<std::vector<int64_t>> feat_idx,
+                        VaeSpatialParallel& ctx) {
     if (feat_idx == nullptr) {
       feat_idx =
           std::make_shared<std::vector<int64_t>>(std::vector<int64_t>{0});
@@ -922,11 +1013,11 @@ class QwenImageEncoder3dImpl : public torch::nn::Module {
                 .to(cache_x.device());
         cache_x = torch::cat({last_frame, cache_x}, 2);
       }
-      result_x = conv_in_->forward(x, feat_cache->at(idx));
+      result_x = conv_in_->forward(x, ctx, feat_cache->at(idx));
       feat_cache->at(idx) = cache_x;
       (*feat_idx)[0]++;
     } else {
-      result_x = conv_in_->forward(x);
+      result_x = conv_in_->forward(x, ctx);
     }
 
     int64_t counter = 0;
@@ -935,18 +1026,18 @@ class QwenImageEncoder3dImpl : public torch::nn::Module {
         counter = counter + 1;
         result_x =
             std::dynamic_pointer_cast<QwenImageBaseModule>(layer)->forward(
-                result_x, feat_cache, feat_idx);
+                result_x, feat_cache, feat_idx, ctx);
       } else {
         result_x =
             std::dynamic_pointer_cast<QwenImageBaseModule>(layer)->forward(
                 result_x,
                 nullptr,
-                std::make_shared<std::vector<int64_t>>(
-                    std::vector<int64_t>{0}));
+                std::make_shared<std::vector<int64_t>>(std::vector<int64_t>{0}),
+                ctx);
       }
     }
 
-    result_x = mid_block_->forward(result_x, feat_cache, feat_idx);
+    result_x = mid_block_->forward(result_x, feat_cache, feat_idx, ctx);
 
     result_x = norm_out_->forward(result_x);
     result_x = nonlinearity_->forward(result_x);
@@ -972,11 +1063,11 @@ class QwenImageEncoder3dImpl : public torch::nn::Module {
         cache_x = torch::cat({last_frame, cache_x}, 2);
       }
 
-      result_x = conv_out_->forward(result_x, feat_cache->at(idx));
+      result_x = conv_out_->forward(result_x, ctx, feat_cache->at(idx));
       feat_cache->at(idx) = cache_x;
       (*feat_idx)[0]++;
     } else {
-      result_x = conv_out_->forward(result_x);
+      result_x = conv_out_->forward(result_x, ctx);
     }
 
     return result_x;
@@ -1080,10 +1171,10 @@ class QwenImageUpBlockImpl : public torch::nn::Module {
     }
   }
 
-  torch::Tensor forward(
-      const torch::Tensor& x,
-      std::shared_ptr<std::vector<torch::Tensor>> feat_cache = nullptr,
-      std::shared_ptr<std::vector<int64_t>> feat_idx = nullptr) {
+  torch::Tensor forward(const torch::Tensor& x,
+                        std::shared_ptr<std::vector<torch::Tensor>> feat_cache,
+                        std::shared_ptr<std::vector<int64_t>> feat_idx,
+                        VaeSpatialParallel& ctx) {
     if (feat_idx == nullptr) {
       feat_idx =
           std::make_shared<std::vector<int64_t>>(std::vector<int64_t>{0});
@@ -1095,14 +1186,14 @@ class QwenImageUpBlockImpl : public torch::nn::Module {
       if (feat_cache && feat_idx) {
         result_x =
             std::dynamic_pointer_cast<QwenImageBaseModule>(resnet)->forward(
-                result_x, feat_cache, feat_idx);
+                result_x, feat_cache, feat_idx, ctx);
       } else {
         result_x =
             std::dynamic_pointer_cast<QwenImageBaseModule>(resnet)->forward(
                 result_x,
                 nullptr,
-                std::make_shared<std::vector<int64_t>>(
-                    std::vector<int64_t>{0}));
+                std::make_shared<std::vector<int64_t>>(std::vector<int64_t>{0}),
+                ctx);
       }
     }
 
@@ -1110,14 +1201,15 @@ class QwenImageUpBlockImpl : public torch::nn::Module {
       if (feat_cache && feat_idx) {
         result_x =
             std::dynamic_pointer_cast<QwenImageBaseModule>(upsamplers_[0])
-                ->forward(result_x, feat_cache, feat_idx);
+                ->forward(result_x, feat_cache, feat_idx, ctx);
       } else {
         result_x =
             std::dynamic_pointer_cast<QwenImageBaseModule>(upsamplers_[0])
                 ->forward(result_x,
                           nullptr,
                           std::make_shared<std::vector<int64_t>>(
-                              std::vector<int64_t>{0}));
+                              std::vector<int64_t>{0}),
+                          ctx);
       }
     }
 
@@ -1241,10 +1333,10 @@ class QwenImageDecoder3dImpl : public torch::nn::Module {
                               /*padding=*/torch::IntArrayRef{1, 1, 1}));
   }
 
-  torch::Tensor forward(
-      const torch::Tensor& x,
-      std::shared_ptr<std::vector<torch::Tensor>> feat_cache = nullptr,
-      std::shared_ptr<std::vector<int64_t>> feat_idx = nullptr) {
+  torch::Tensor forward(const torch::Tensor& x,
+                        std::shared_ptr<std::vector<torch::Tensor>> feat_cache,
+                        std::shared_ptr<std::vector<int64_t>> feat_idx,
+                        VaeSpatialParallel& ctx) {
     if (feat_idx == nullptr) {
       feat_idx =
           std::make_shared<std::vector<int64_t>>(std::vector<int64_t>{0});
@@ -1271,18 +1363,18 @@ class QwenImageDecoder3dImpl : public torch::nn::Module {
         cache_x = torch::cat({last_frame, cache_x}, 2);
       }
 
-      result_x = conv_in_->forward(result_x, feat_cache->at(idx));
+      result_x = conv_in_->forward(result_x, ctx, feat_cache->at(idx));
       feat_cache->at(idx) = cache_x;
       (*feat_idx)[0]++;
     } else {
-      result_x = conv_in_->forward(result_x);
+      result_x = conv_in_->forward(result_x, ctx);
     }
 
-    result_x = mid_block_->forward(result_x, feat_cache, feat_idx);
+    result_x = mid_block_->forward(result_x, feat_cache, feat_idx, ctx);
 
     for (auto& up_block : *up_blocks_) {
       result_x = up_block->as<QwenImageUpBlock>()->forward(
-          result_x, feat_cache, feat_idx);
+          result_x, feat_cache, feat_idx, ctx);
     }
 
     result_x = norm_out_->forward(result_x);
@@ -1309,11 +1401,11 @@ class QwenImageDecoder3dImpl : public torch::nn::Module {
         cache_x = torch::cat({last_frame, cache_x}, 2);
       }
 
-      result_x = conv_out_->forward(result_x, feat_cache->at(idx));
+      result_x = conv_out_->forward(result_x, ctx, feat_cache->at(idx));
       feat_cache->at(idx) = cache_x;
       (*feat_idx)[0]++;
     } else {
-      result_x = conv_out_->forward(result_x);
+      result_x = conv_out_->forward(result_x, ctx);
     }
     return result_x;
   }
@@ -1377,7 +1469,13 @@ class AutoencoderKLQwenImageImpl : public torch::nn::Module {
         dim_mult_(context.get_model_args().dim_mult()),
         num_res_blocks_(context.get_model_args().num_res_blocks()),
         attn_scales_(context.get_model_args().attn_scales()),
-        dropout_(context.get_model_args().dropout()) {
+        dropout_(context.get_model_args().dropout()),
+        // VAE spatial parallel context (always constructed, even w_split=1).
+        // VaeSpatialParallel's own constructor CHECKs that a process group is
+        // provided whenever vae_size > 1.
+        parallel_ctx_(context.get_parallel_args().vae_size(),
+                      context.get_parallel_args().dit_vae_group_,
+                      context.get_tensor_options().device()) {
     temperal_upsample_ = std::vector<bool>(temperal_downsample_.rbegin(),
                                            temperal_downsample_.rend());
 
@@ -1434,6 +1532,11 @@ class AutoencoderKLQwenImageImpl : public torch::nn::Module {
 
     cached_conv_counts_ = {{"decoder", count_conv3d_modules(*decoder_)},
                            {"encoder", count_conv3d_modules(*encoder_)}};
+
+    if (parallel_ctx_.is_parallel()) {
+      LOG(INFO) << "VAE spatial parallel enabled: w_split="
+                << parallel_ctx_.w_split();
+    }
   }
 
   void enable_tiling(int64_t tile_sample_min_height = -1,
@@ -1464,10 +1567,16 @@ class AutoencoderKLQwenImageImpl : public torch::nn::Module {
         std::vector<torch::Tensor>(enc_conv_num_));
   }
 
-  torch::Tensor _encode(const torch::Tensor& x) {
+  torch::Tensor _encode(const torch::Tensor& x_input) {
+    auto x = x_input;
     auto sizes = x.sizes();
     auto b = sizes[0], c = sizes[1], num_frame = sizes[2], height = sizes[3],
          width = sizes[4];
+
+    if (parallel_ctx_.is_parallel()) {
+      x = parallel_ctx_.split(x);
+      width = x.size(-1);
+    }
 
     if (use_tiling_ &&
         (width > tile_sample_min_width_ || height > tile_sample_min_height_)) {
@@ -1476,8 +1585,9 @@ class AutoencoderKLQwenImageImpl : public torch::nn::Module {
 
     clear_cache();
     auto iter = 1 + (num_frame - 1) / 4;
-    torch::Tensor out;
 
+    std::vector<torch::Tensor> enc_outputs;
+    enc_outputs.reserve(iter);
     for (int64_t i = 0; i < iter; i++) {
       enc_conv_idx_->at(0) = 0;
       torch::Tensor tile;
@@ -1496,16 +1606,16 @@ class AutoencoderKLQwenImageImpl : public torch::nn::Module {
                         torch::indexing::Slice()});
       }
 
-      auto encoded_tile = encoder_->forward(tile, enc_feat_map_, enc_conv_idx_);
-
-      if (i == 0) {
-        out = encoded_tile;
-      } else {
-        out = torch::cat({out, encoded_tile}, 2);
-      }
+      enc_outputs.push_back(
+          encoder_->forward(tile, enc_feat_map_, enc_conv_idx_, parallel_ctx_));
     }
+    torch::Tensor out = torch::cat(enc_outputs, 2);
 
-    auto enc = quant_conv_->forward(out);
+    auto enc = quant_conv_->forward(out, parallel_ctx_);
+    // Merge latent back to global W before passing to DiT transformer
+    if (parallel_ctx_.is_parallel()) {
+      enc = parallel_ctx_.merge(enc);
+    }
     clear_cache();
     return enc;
   }
@@ -1534,10 +1644,16 @@ class AutoencoderKLQwenImageImpl : public torch::nn::Module {
     return output;
   }
 
-  DecoderOutput _decode(const torch::Tensor& z, bool return_dict = true) {
+  DecoderOutput _decode(const torch::Tensor& z_input, bool return_dict = true) {
+    auto z = z_input;
     auto sizes = z.sizes();
     auto b = sizes[0], c = sizes[1], num_frame = sizes[2], height = sizes[3],
          width = sizes[4];
+
+    if (parallel_ctx_.is_parallel()) {
+      z = parallel_ctx_.split(z);
+      width = z.size(-1);
+    }
 
     auto tile_latent_min_height =
         tile_sample_min_height_ / spatial_compression_ratio_;
@@ -1550,24 +1666,20 @@ class AutoencoderKLQwenImageImpl : public torch::nn::Module {
     }
 
     clear_cache();
-    auto x = post_quant_conv_->forward(z);
-    torch::Tensor out;
+    auto x = post_quant_conv_->forward(z, parallel_ctx_);
 
+    std::vector<torch::Tensor> dec_outputs;
+    dec_outputs.reserve(num_frame);
     for (int64_t i = 0; i < num_frame; i++) {
       conv_idx_->at(0) = 0;
-      auto frame = x.index({torch::indexing::Slice(),
-                            torch::indexing::Slice(),
-                            torch::indexing::Slice(i, i + 1),
-                            torch::indexing::Slice(),
-                            torch::indexing::Slice()});
+      auto frame = x.slice(/*dim=*/2, i, i + 1);
+      dec_outputs.push_back(
+          decoder_->forward(frame, feat_map_, conv_idx_, parallel_ctx_));
+    }
+    torch::Tensor out = torch::cat(dec_outputs, 2);
 
-      auto decoded_frame = decoder_->forward(frame, feat_map_, conv_idx_);
-
-      if (i == 0) {
-        out = decoded_frame;
-      } else {
-        out = torch::cat({out, decoded_frame}, 2);
-      }
+    if (parallel_ctx_.is_parallel()) {
+      out = parallel_ctx_.merge(out);
     }
 
     out = torch::clamp(out, -1.0, 1.0);
@@ -1723,9 +1835,10 @@ class AutoencoderKLQwenImageImpl : public torch::nn::Module {
                  torch::indexing::Slice(j, j + tile_sample_min_width_)});
           }
 
-          auto encoded_tile =
-              encoder_->forward(tile, enc_feat_map_, enc_conv_idx_);
-          auto quantized_tile = quant_conv_->forward(encoded_tile);
+          auto encoded_tile = encoder_->forward(
+              tile, enc_feat_map_, enc_conv_idx_, parallel_ctx_);
+          auto quantized_tile =
+              quant_conv_->forward(encoded_tile, parallel_ctx_);
           time_frames.push_back(quantized_tile);
         }
 
@@ -1809,9 +1922,9 @@ class AutoencoderKLQwenImageImpl : public torch::nn::Module {
                        torch::indexing::Slice(i, i + tile_latent_min_height),
                        torch::indexing::Slice(j, j + tile_latent_min_width)});
 
-          auto post_quant_tile = post_quant_conv_->forward(tile);
-          auto decoded_tile =
-              decoder_->forward(post_quant_tile, feat_map_, conv_idx_);
+          auto post_quant_tile = post_quant_conv_->forward(tile, parallel_ctx_);
+          auto decoded_tile = decoder_->forward(
+              post_quant_tile, feat_map_, conv_idx_, parallel_ctx_);
           time_frames.push_back(decoded_tile);
         }
 
@@ -1944,6 +2057,7 @@ class AutoencoderKLQwenImageImpl : public torch::nn::Module {
   QwenImageDecoder3d decoder_{nullptr};
 
   ModelArgs args_;
+  VaeSpatialParallel parallel_ctx_;
 };
 
 TORCH_MODULE(AutoencoderKLQwenImage);

--- a/xllm/models/dit/autoencoders/autoencoder_kl_wan.h
+++ b/xllm/models/dit/autoencoders/autoencoder_kl_wan.h
@@ -33,9 +33,11 @@ limitations under the License.
 #include "core/framework/state_dict/state_dict.h"
 #include "framework/model_context.h"
 #include "models/dit/autoencoders/autoencoder_kl.h"
+#include "models/dit/utils/vae_spatial_parallel.h"
 #include "models/model_registry.h"
 
 namespace xllm {
+using xllm::dit::VaeSpatialParallel;
 
 class AvgDown3DImpl : public torch::nn::Module {
  public:
@@ -157,24 +159,59 @@ class WanCausalConv3DImpl : public torch::nn::Module {
         torch::nn::Conv3d(
             torch::nn::Conv3dOptions(in_channels, out_channels, kernel_size)
                 .stride(stride)
+                // Conv3d always gets 0 for temporal padding — causal temporal
+                // padding is handled separately via cache_x concatenation.
+                // padding_ layout: {temporal_pad, height_pad, width_pad}
                 .padding({0, padding[1], padding[2]})
                 .bias(true)));
+    // _padding_ is the 6-element format for F::pad:
+    //   {dim4_left, dim4_right, dim3_left, dim3_right, dim2_left, dim2_right}
+    // (dim4=W, dim3=H, dim2=T). Only the temporal (dim2) front padding is
+    // non-zero (2 * pad_t) for causal convolution; spatial padding is handled
+    // by Conv3d directly above.
     _padding_ = {0, 0, 0, 0, 2 * padding[0], 0};
   }
 
   torch::Tensor forward(
       const torch::Tensor& x,
+      VaeSpatialParallel& ctx,
       const torch::optional<torch::Tensor>& cache_x = torch::nullopt) {
     std::vector<int64_t> padding = _padding_;
     torch::Tensor input = x;
+
+    // Halo exchange is only needed for 3×3 spatial convolutions (kernel=3,
+    // pad=1). For 1×1 convolutions (e.g. quant_conv) padding_ is {0,0,0}
+    // so this condition is false and no exchange occurs.
+    // padding_ layout: {pad_temporal, pad_height, pad_width}
+    bool use_halo = (ctx.is_parallel() && padding_[1] == 1 && padding_[2] == 1);
+
+    // Temporal padding (causal) — must come BEFORE halo exchange so cache
+    // and input have matching spatial dims.
     if (cache_x.has_value() && cache_x.value().defined() && padding[4] > 0) {
       torch::Tensor cache = cache_x.value().to(x.device());
       input = torch::cat({cache, input}, 2);
       padding[4] -= cache.size(2);
     }
+
+    // Spatial parallel: halo exchange for conv3d with spatial padding
+    if (use_halo) {
+      input = ctx.exchange(input, /*pad=*/true);
+    }
+
     input = torch::nn::functional::pad(
         input, torch::nn::functional::PadFuncOptions(padding));
-    return conv_->forward(input);
+
+    auto out = conv_->forward(input);
+
+    // Trim halo columns after conv:
+    //   exchange() added 1 column from left neighbor and 1 from right neighbor
+    //   (2 extra columns total). Conv3d with kernel=3, spatial pad=1 preserves
+    //   spatial size, so the output is 2 columns wider in W than the true local
+    //   result. Trim 1 column from each side (slice from column 1 to W-1).
+    if (use_halo) {
+      out = out.slice(/*dim=*/-1, 1, out.size(-1) - 1);
+    }
+    return out;
   }
 
   void load_state_dict(const StateDict& state_dict) {
@@ -192,6 +229,10 @@ class WanCausalConv3DImpl : public torch::nn::Module {
   bool is_weight_loaded_{false};
   bool is_bias_loaded_{false};
   int64_t in_channels_, out_channels_;
+  // padding_ layout: {temporal_pad, height_pad, width_pad}
+  // _padding_ layout: 6-element F::pad format {W_left, W_right, H_left,
+  // H_right, T_front, T_back}, where only T_front (2 * temporal_pad) is
+  // non-zero for causal temporal padding.
   std::vector<int64_t> kernel_size_, stride_, padding_, _padding_;
   torch::nn::Conv3d conv_{nullptr};
 };
@@ -340,15 +381,18 @@ class WanResampleImpl : public torch::nn::Module {
     rep_tensor_ = register_parameter("rep_tensor", torch::tensor({-999.0}));
   }
 
-  torch::Tensor forward(
-      torch::Tensor x,
-      std::shared_ptr<std::vector<torch::Tensor>> feat_cache = nullptr,
-      std::shared_ptr<std::vector<int64_t>> feat_idx = nullptr) {
+  torch::Tensor forward(torch::Tensor x,
+                        std::shared_ptr<std::vector<torch::Tensor>> feat_cache,
+                        std::shared_ptr<std::vector<int64_t>> feat_idx,
+                        VaeSpatialParallel& ctx) {
     if (!feat_idx) feat_idx = std::make_shared<std::vector<int64_t>>(1, 0);
 
     auto sizes = x.sizes();
     int64_t b = sizes[0], c = sizes[1], t = sizes[2], h = sizes[3],
             w = sizes[4];
+
+    bool is_upsample = (mode_ == "upsample2d" || mode_ == "upsample3d");
+    bool is_downsample = (mode_ == "downsample2d" || mode_ == "downsample3d");
 
     if (mode_ == "upsample3d" && feat_cache) {
       int64_t idx = (*feat_idx)[0];
@@ -382,9 +426,9 @@ class WanResampleImpl : public torch::nn::Module {
               {torch::zeros_like(cache_x).to(cache_x.device()), cache_x}, 2);
         }
         if (torch::equal(rep_tensor_, feat_cache->at(idx))) {
-          x = time_conv_->forward(x);
+          x = time_conv_->forward(x, ctx);
         } else {
-          x = time_conv_->forward(x, (*feat_cache)[idx]);
+          x = time_conv_->forward(x, ctx, (*feat_cache)[idx]);
         }
         (*feat_cache)[idx] = cache_x;
         (*feat_idx)[0] += 1;
@@ -407,11 +451,51 @@ class WanResampleImpl : public torch::nn::Module {
       }
     }
     t = x.size(2);
+
+    // Upsample: exchange halo columns before spatial upsampling
+    if (ctx.is_parallel() && is_upsample) {
+      x = ctx.exchange(x, /*pad=*/false);
+      w = x.size(-1);  // recalc after halo exchange changed width
+    }
+    // Downsample: merge spatial slices before spatial downsampling
+    if (ctx.is_parallel() && is_downsample) {
+      x = ctx.merge(x);
+      w = x.size(-1);  // recalc after merge: W is now global
+      h = x.size(-2);  // recalc H too (may change with 2D split)
+    }
+
     x = x.permute({0, 2, 1, 3, 4}).reshape({b * t, c, h, w});
 
     x = resample_->forward(x);
     x = x.view({b, t, x.size(1), x.size(2), x.size(3)})
             .permute({0, 2, 1, 3, 4});
+
+    // Upsample: trim excess columns introduced by halo exchange.
+    //
+    // Before upsample: exchange(pad=false) adds 1 neighbor column per side,
+    // making W_local → W_local + (has_left ? 1 : 0) + (has_right ? 1 : 0).
+    // The interpolate 2× doubles each column, and the following Conv2d(k=3,
+    // pad=1) preserves size. So the halo columns produce 2 excess columns per
+    // side in the output.
+    //
+    // Trim 2 columns from each side where a neighbor contributed halo:
+    //   - middle rank (has_left && has_right): trim 2 from left, 2 from right
+    //   - first rank  (!has_left):           trim 2 from right only
+    //   - last rank   (!has_right):          trim 2 from left only
+    if (ctx.is_parallel() && is_upsample) {
+      auto cur_w = x.size(-1);
+      if (ctx.has_left() && ctx.has_right()) {
+        x = x.slice(/*dim=*/-1, 2, cur_w - 2);  // trim 2 from each side
+      } else if (!ctx.has_left()) {
+        x = x.slice(/*dim=*/-1, 0, cur_w - 2);  // trim 2 from right only
+      } else {
+        x = x.slice(/*dim=*/-1, 2, cur_w);  // trim 2 from left only
+      }
+    }
+    // Downsample: split full result back to local slices
+    if (ctx.is_parallel() && is_downsample) {
+      x = ctx.split(x);
+    }
 
     if (mode_ == "downsample3d" && feat_cache) {
       int64_t idx = (*feat_idx)[0];
@@ -434,7 +518,8 @@ class WanResampleImpl : public torch::nn::Module {
                              torch::indexing::Slice(),
                              torch::indexing::Slice()}),
                         x},
-                       2));
+                       2),
+            ctx);
         (*feat_cache)[idx] = cache_x;
         (*feat_idx)[0] += 1;
       }
@@ -512,15 +597,15 @@ class WanResidualBlockImpl : public torch::nn::Module {
     }
   }
 
-  torch::Tensor forward(
-      torch::Tensor x,
-      std::shared_ptr<std::vector<torch::Tensor>> feat_cache = nullptr,
-      std::shared_ptr<std::vector<int64_t>> feat_idx = nullptr) {
+  torch::Tensor forward(torch::Tensor x,
+                        std::shared_ptr<std::vector<torch::Tensor>> feat_cache,
+                        std::shared_ptr<std::vector<int64_t>> feat_idx,
+                        VaeSpatialParallel& ctx) {
     if (!feat_idx) feat_idx = std::make_shared<std::vector<int64_t>>(1, 0);
 
     torch::Tensor h;
     if (in_dim_ != out_dim_) {
-      h = conv_shortcut_->forward(x);
+      h = conv_shortcut_->forward(x, ctx);
     } else {
       h = x;
     }
@@ -549,11 +634,11 @@ class WanResidualBlockImpl : public torch::nn::Module {
                               cache_x},
                              2);
       }
-      x = conv1_->forward(x, (*feat_cache)[idx]);
+      x = conv1_->forward(x, ctx, (*feat_cache)[idx]);
       (*feat_cache)[idx] = cache_x;
       (*feat_idx)[0] += 1;
     } else {
-      x = conv1_->forward(x);
+      x = conv1_->forward(x, ctx);
     }
 
     x = norm2_->forward(x);
@@ -583,11 +668,11 @@ class WanResidualBlockImpl : public torch::nn::Module {
                               cache_x},
                              2);
       }
-      x = conv2_->forward(x, (*feat_cache)[idx]);
+      x = conv2_->forward(x, ctx, (*feat_cache)[idx]);
       (*feat_cache)[idx] = cache_x;
       (*feat_idx)[0] += 1;
     } else {
-      x = conv2_->forward(x);
+      x = conv2_->forward(x, ctx);
     }
 
     return x + h;
@@ -636,7 +721,7 @@ class WanAttentionBlockImpl : public torch::nn::Module {
         "proj", torch::nn::Conv2d(torch::nn::Conv2dOptions(dim, dim, 1)));
   }
 
-  torch::Tensor forward(torch::Tensor x) {
+  torch::Tensor forward(torch::Tensor x, VaeSpatialParallel& ctx) {
     torch::Tensor identity = x;
     auto sizes = x.sizes();
     int64_t batch_size = sizes[0];
@@ -650,12 +735,32 @@ class WanAttentionBlockImpl : public torch::nn::Module {
     x = norm_->forward(x);
 
     auto qkv = to_qkv_->forward(x);
-    qkv = qkv.reshape({batch_size * time, 1, channels * 3, height * width});
-    qkv = qkv.permute({0, 1, 3, 2}).contiguous();
-    auto chunks = qkv.chunk(3, -1);
-    torch::Tensor q = chunks[0];
-    torch::Tensor k = chunks[1];
-    torch::Tensor v = chunks[2];
+
+    torch::Tensor q, k, v;
+    if (ctx.is_parallel()) {
+      // Gather K/V in spatial domain before BNSD reshape
+      auto spatial_chunks = qkv.chunk(3, 1);
+      auto k_sp = ctx.merge(spatial_chunks[1].unsqueeze(2)).squeeze(2);
+      auto v_sp = ctx.merge(spatial_chunks[2].unsqueeze(2)).squeeze(2);
+      int64_t W_global = k_sp.size(-1);
+      q = spatial_chunks[0]
+              .reshape({batch_size * time, 1, channels, height * width})
+              .permute({0, 1, 3, 2})
+              .contiguous();
+      k = k_sp.reshape({batch_size * time, 1, channels, height * W_global})
+              .permute({0, 1, 3, 2})
+              .contiguous();
+      v = v_sp.reshape({batch_size * time, 1, channels, height * W_global})
+              .permute({0, 1, 3, 2})
+              .contiguous();
+    } else {
+      qkv = qkv.reshape({batch_size * time, 1, channels * 3, height * width});
+      qkv = qkv.permute({0, 1, 3, 2}).contiguous();
+      auto chunks = qkv.chunk(3, -1);
+      q = chunks[0];
+      k = chunks[1];
+      v = chunks[2];
+    }
 
     auto results = at_npu::native::custom_ops::npu_fusion_attention(
         q,
@@ -732,20 +837,21 @@ class WanMidBlockImpl : public torch::nn::Module {
     }
   }
 
-  torch::Tensor forward(
-      torch::Tensor x,
-      std::shared_ptr<std::vector<torch::Tensor>> feat_cache = nullptr,
-      std::shared_ptr<std::vector<int64_t>> feat_idx = nullptr) {
+  torch::Tensor forward(torch::Tensor x,
+                        std::shared_ptr<std::vector<torch::Tensor>> feat_cache,
+                        std::shared_ptr<std::vector<int64_t>> feat_idx,
+                        VaeSpatialParallel& ctx) {
     if (!feat_idx) feat_idx = std::make_shared<std::vector<int64_t>>(1, 0);
 
-    x = resnets_[0]->as<WanResidualBlock>()->forward(x, feat_cache, feat_idx);
+    x = resnets_[0]->as<WanResidualBlock>()->forward(
+        x, feat_cache, feat_idx, ctx);
     for (size_t i = 0; i < attentions_->size(); ++i) {
       auto attn = attentions_[i]->as<WanAttentionBlock>();
       if (attn) {
-        x = attn->forward(x);
+        x = attn->forward(x, ctx);
       }
       auto resnet = resnets_[i + 1]->as<WanResidualBlock>();
-      x = resnet->forward(x, feat_cache, feat_idx);
+      x = resnet->forward(x, feat_cache, feat_idx, ctx);
     }
     return x;
   }
@@ -816,18 +922,19 @@ class WanResidualDownBlockImpl : public torch::nn::Module {
     }
   }
 
-  torch::Tensor forward(
-      torch::Tensor x,
-      std::shared_ptr<std::vector<torch::Tensor>> feat_cache = nullptr,
-      std::shared_ptr<std::vector<int64_t>> feat_idx = nullptr) {
+  torch::Tensor forward(torch::Tensor x,
+                        std::shared_ptr<std::vector<torch::Tensor>> feat_cache,
+                        std::shared_ptr<std::vector<int64_t>> feat_idx,
+                        VaeSpatialParallel& ctx) {
     if (!feat_idx) feat_idx = std::make_shared<std::vector<int64_t>>(1, 0);
 
     torch::Tensor x_copy = x.clone();
     for (size_t i = 0; i < resnets_->size(); ++i) {
-      x = resnets_[i]->as<WanResidualBlock>()->forward(x, feat_cache, feat_idx);
+      x = resnets_[i]->as<WanResidualBlock>()->forward(
+          x, feat_cache, feat_idx, ctx);
     }
     if (downsampler_) {
-      x = downsampler_->forward(x, feat_cache, feat_idx);
+      x = downsampler_->forward(x, feat_cache, feat_idx, ctx);
     }
 
     if (avg_shortcut_) {
@@ -934,10 +1041,10 @@ class WanVAEEncoder3DImpl : public torch::nn::Module {
                                                 std::vector<int64_t>{1, 1, 1}));
   }
 
-  torch::Tensor forward(
-      torch::Tensor x,
-      std::shared_ptr<std::vector<torch::Tensor>> feat_cache = nullptr,
-      std::shared_ptr<std::vector<int64_t>> feat_idx = nullptr) {
+  torch::Tensor forward(torch::Tensor x,
+                        std::shared_ptr<std::vector<torch::Tensor>> feat_cache,
+                        std::shared_ptr<std::vector<int64_t>> feat_idx,
+                        VaeSpatialParallel& ctx) {
     if (!feat_idx) feat_idx = std::make_shared<std::vector<int64_t>>(1, 0);
     if (feat_cache) {
       int64_t idx = (*feat_idx)[0];
@@ -960,29 +1067,29 @@ class WanVAEEncoder3DImpl : public torch::nn::Module {
                               cache_x},
                              2);
       }
-      x = conv_in_->forward(x, (*feat_cache)[idx]);
+      x = conv_in_->forward(x, ctx, (*feat_cache)[idx]);
       (*feat_cache)[idx] = cache_x;
       (*feat_idx)[0] += 1;
     } else {
-      x = conv_in_->forward(x);
+      x = conv_in_->forward(x, ctx);
     }
 
     // Type-safe forward call for down_blocks_
     for (size_t i = 0; i < down_blocks_->size(); ++i) {
       if (auto res_down = down_blocks_[i]->as<WanResidualDownBlock>()) {
-        x = res_down->forward(x, feat_cache, feat_idx);
+        x = res_down->forward(x, feat_cache, feat_idx, ctx);
       } else if (auto down = down_blocks_[i]->as<WanResidualBlock>()) {
-        x = feat_cache ? down->forward(x, feat_cache, feat_idx)
-                       : down->forward(x);
+        x = feat_cache ? down->forward(x, feat_cache, feat_idx, ctx)
+                       : down->forward(x, nullptr, nullptr, ctx);
       } else if (auto attn = down_blocks_[i]->as<WanAttentionBlock>()) {
-        x = attn->forward(x);
+        x = attn->forward(x, ctx);
       } else if (auto resample = down_blocks_[i]->as<WanResample>()) {
-        x = feat_cache ? resample->forward(x, feat_cache, feat_idx)
-                       : resample->forward(x);
+        x = feat_cache ? resample->forward(x, feat_cache, feat_idx, ctx)
+                       : resample->forward(x, nullptr, nullptr, ctx);
       }
     }
 
-    x = mid_block_->forward(x, feat_cache, feat_idx);
+    x = mid_block_->forward(x, feat_cache, feat_idx, ctx);
     x = norm_out_->forward(x);
     x = nonlinearity_(x);
     if (feat_cache) {
@@ -1006,11 +1113,11 @@ class WanVAEEncoder3DImpl : public torch::nn::Module {
                               cache_x},
                              2);
       }
-      x = conv_out_->forward(x, (*feat_cache)[idx]);
+      x = conv_out_->forward(x, ctx, (*feat_cache)[idx]);
       (*feat_cache)[idx] = cache_x;
       (*feat_idx)[0] += 1;
     } else {
-      x = conv_out_->forward(x);
+      x = conv_out_->forward(x, ctx);
     }
     return x;
   }
@@ -1104,27 +1211,29 @@ class WanResidualUpBlockImpl : public torch::nn::Module {
     }
   }
 
-  torch::Tensor forward(
-      torch::Tensor x,
-      std::shared_ptr<std::vector<torch::Tensor>> feat_cache = nullptr,
-      std::shared_ptr<std::vector<int64_t>> feat_idx = nullptr,
-      bool first_chunk = false) {
+  torch::Tensor forward(torch::Tensor x,
+                        std::shared_ptr<std::vector<torch::Tensor>> feat_cache,
+                        std::shared_ptr<std::vector<int64_t>> feat_idx,
+                        bool first_chunk,
+                        VaeSpatialParallel& ctx) {
     if (!feat_idx) feat_idx = std::make_shared<std::vector<int64_t>>(1, 0);
 
     torch::Tensor x_copy = x.clone();
     for (size_t i = 0; i < resnets_->size(); ++i) {
       if (feat_cache) {
         x = resnets_[i]->as<WanResidualBlock>()->forward(
-            x, feat_cache, feat_idx);
+            x, feat_cache, feat_idx, ctx);
       } else {
-        x = resnets_[i]->as<WanResidualBlock>()->forward(x);
+        x = resnets_[i]->as<WanResidualBlock>()->forward(
+            x, nullptr, nullptr, ctx);
       }
     }
     if (upsampler_) {
       if (feat_cache) {
-        x = upsampler_->as<WanResample>()->forward(x, feat_cache, feat_idx);
+        x = upsampler_->as<WanResample>()->forward(
+            x, feat_cache, feat_idx, ctx);
       } else {
-        x = upsampler_->as<WanResample>()->forward(x);
+        x = upsampler_->as<WanResample>()->forward(x, nullptr, nullptr, ctx);
       }
     }
     if (avg_shortcut_) {
@@ -1185,27 +1294,27 @@ class WanUpBlockImpl : public torch::nn::Module {
     }
   }
 
-  torch::Tensor forward(
-      torch::Tensor x,
-      std::shared_ptr<std::vector<torch::Tensor>> feat_cache = nullptr,
-      std::shared_ptr<std::vector<int64_t>> feat_idx = nullptr) {
+  torch::Tensor forward(torch::Tensor x,
+                        std::shared_ptr<std::vector<torch::Tensor>> feat_cache,
+                        std::shared_ptr<std::vector<int64_t>> feat_idx,
+                        VaeSpatialParallel& ctx) {
     if (!feat_idx) feat_idx = std::make_shared<std::vector<int64_t>>(1, 0);
 
     torch::Tensor h = x;
     for (size_t i = 0; i < resnets_->size(); ++i) {
       auto resnet = resnets_[i]->as<WanResidualBlock>();
       if (feat_cache) {
-        h = resnet->forward(h, feat_cache, feat_idx);
+        h = resnet->forward(h, feat_cache, feat_idx, ctx);
       } else {
-        h = resnet->forward(h);
+        h = resnet->forward(h, nullptr, nullptr, ctx);
       }
     }
     if (upsamplers_ && upsamplers_->size() > 0) {
       auto upsampler = upsamplers_[0]->as<WanResample>();
       if (feat_cache) {
-        h = upsampler->forward(h, feat_cache, feat_idx);
+        h = upsampler->forward(h, feat_cache, feat_idx, ctx);
       } else {
-        h = upsampler->forward(h);
+        h = upsampler->forward(h, nullptr, nullptr, ctx);
       }
     }
     return h;
@@ -1317,11 +1426,11 @@ class WanVAEDecoder3DImpl : public torch::nn::Module {
                                                 std::vector<int64_t>{1, 1, 1}));
   }
 
-  torch::Tensor forward(
-      torch::Tensor x,
-      std::shared_ptr<std::vector<torch::Tensor>> feat_cache = nullptr,
-      std::shared_ptr<std::vector<int64_t>> feat_idx = nullptr,
-      bool first_chunk = false) {
+  torch::Tensor forward(torch::Tensor x,
+                        std::shared_ptr<std::vector<torch::Tensor>> feat_cache,
+                        std::shared_ptr<std::vector<int64_t>> feat_idx,
+                        bool first_chunk,
+                        VaeSpatialParallel& ctx) {
     if (!feat_idx) feat_idx = std::make_shared<std::vector<int64_t>>(1, 0);
 
     // conv_in
@@ -1346,22 +1455,22 @@ class WanVAEDecoder3DImpl : public torch::nn::Module {
                               cache_x},
                              2);
       }
-      x = conv_in_->forward(x, (*feat_cache)[idx]);
+      x = conv_in_->forward(x, ctx, (*feat_cache)[idx]);
       (*feat_cache)[idx] = cache_x;
       (*feat_idx)[0] += 1;
     } else {
-      x = conv_in_->forward(x);
+      x = conv_in_->forward(x, ctx);
     }
 
     // mid_block
-    x = mid_block_->forward(x, feat_cache, feat_idx);
+    x = mid_block_->forward(x, feat_cache, feat_idx, ctx);
 
-    // up_blocks : pass 'first_chunk'  to WanResidualUpBlock
+    // up_blocks : pass 'first_chunk' and ctx to WanResidualUpBlock
     for (size_t i = 0; i < up_blocks_->size(); ++i) {
       if (auto res_up = up_blocks_[i]->as<WanResidualUpBlock>()) {
-        x = res_up->forward(x, feat_cache, feat_idx, first_chunk);
+        x = res_up->forward(x, feat_cache, feat_idx, first_chunk, ctx);
       } else if (auto up = up_blocks_[i]->as<WanUpBlock>()) {
-        x = up->forward(x, feat_cache, feat_idx);
+        x = up->forward(x, feat_cache, feat_idx, ctx);
       }
     }
 
@@ -1391,11 +1500,11 @@ class WanVAEDecoder3DImpl : public torch::nn::Module {
              cache_x},
             2);
       }
-      x = conv_out_->forward(x, (*feat_cache)[idx]);
+      x = conv_out_->forward(x, ctx, (*feat_cache)[idx]);
       (*feat_cache)[idx] = cache_x;
       (*feat_idx)[0] += 1;
     } else {
-      x = conv_out_->forward(x);
+      x = conv_out_->forward(x, ctx);
     }
     return x;
   }
@@ -1451,7 +1560,17 @@ class AutoencoderKLWanImpl : public torch::nn::Module {
   AutoencoderKLWanImpl(const ModelContext& context)
       : args_(context.get_model_args()),
         device_(context.get_tensor_options().device()),
-        dtype_(context.get_tensor_options().dtype().toScalarType()) {
+        dtype_(context.get_tensor_options().dtype().toScalarType()),
+        // VAE spatial parallel context (always constructed, even w_split=1).
+        // VaeSpatialParallel's own constructor CHECKs that a process group is
+        // provided whenever vae_size > 1.
+        parallel_ctx_(context.get_parallel_args().vae_size(),
+                      context.get_parallel_args().dit_vae_group_,
+                      context.get_tensor_options().device()) {
+    if (parallel_ctx_.is_parallel()) {
+      LOG(INFO) << "VAE spatial parallel enabled: w_split="
+                << parallel_ctx_.w_split();
+    }
     encoder_ = register_module("encoder",
                                WanVAEEncoder3D(args_.in_channels(),
                                                args_.base_dim(),
@@ -1506,15 +1625,19 @@ class AutoencoderKLWanImpl : public torch::nn::Module {
   torch::Tensor encode_(const torch::Tensor& videos) {
     auto orig_dtype = videos.dtype();
     auto x = videos.to(torch::kFloat32);
+    if (parallel_ctx_.is_parallel()) {
+      x = parallel_ctx_.split(x);
+    }
     int64_t num_frame = x.size(2);
     int64_t height = x.size(3);
     int64_t width = x.size(4);
     int64_t iter_ = 1 + (num_frame - 1) / 4;
     clear_cache();
-    torch::Tensor out;
     feat_map_ = std::make_shared<std::vector<torch::Tensor>>(
         std::vector<torch::Tensor>(conv_num_));
 
+    std::vector<torch::Tensor> enc_outputs;
+    enc_outputs.reserve(iter_);
     for (int64_t i = 0; i < iter_; ++i) {
       enc_conv_idx_ = {0};
       if (i == 0) {
@@ -1523,7 +1646,8 @@ class AutoencoderKLWanImpl : public torch::nn::Module {
                                 torch::indexing::Slice(0, 1),
                                 torch::indexing::Slice(),
                                 torch::indexing::Slice()});
-        out = encoder_(x_slice, enc_feat_map_, enc_conv_idx_);
+        enc_outputs.push_back(
+            encoder_(x_slice, enc_feat_map_, enc_conv_idx_, parallel_ctx_));
       } else {
         int64_t start = 1 + 4 * (i - 1);
         int64_t end = std::min(1 + 4 * i, num_frame);
@@ -1532,11 +1656,16 @@ class AutoencoderKLWanImpl : public torch::nn::Module {
                                 torch::indexing::Slice(start, end),
                                 torch::indexing::Slice(),
                                 torch::indexing::Slice()});
-        auto out_ = encoder_(x_slice, enc_feat_map_, enc_conv_idx_);
-        out = torch::cat({out, out_}, 2);
+        enc_outputs.push_back(
+            encoder_(x_slice, enc_feat_map_, enc_conv_idx_, parallel_ctx_));
       }
     }
-    out = quant_conv_(out);
+    torch::Tensor out = torch::cat(enc_outputs, 2);
+    out = quant_conv_->forward(out, parallel_ctx_);
+    // Merge latent back to global W before passing to DiT transformer
+    if (parallel_ctx_.is_parallel()) {
+      out = parallel_ctx_.merge(out);
+    }
     clear_cache();
     return out.to(orig_dtype);
   }
@@ -1550,32 +1679,29 @@ class AutoencoderKLWanImpl : public torch::nn::Module {
   DecoderOutput decode_(const torch::Tensor& latents) {
     auto orig_dtype = latents.dtype();
     torch::Tensor processed_latents = latents.to(torch::kFloat32);
+    if (parallel_ctx_.is_parallel()) {
+      processed_latents = parallel_ctx_.split(processed_latents);
+    }
     int64_t num_frame = processed_latents.size(2);
     int64_t height = processed_latents.size(3);
     int64_t width = processed_latents.size(4);
     clear_cache();
-    torch::Tensor out;
-    processed_latents = post_quant_conv_(processed_latents);
+    processed_latents =
+        post_quant_conv_->forward(processed_latents, parallel_ctx_);
+    std::vector<torch::Tensor> dec_outputs;
+    dec_outputs.reserve(num_frame);
     for (int64_t i = 0; i < num_frame; ++i) {
       conv_idx_ = {0};
-      if (i == 0) {
-        auto x_slice =
-            processed_latents.index({torch::indexing::Slice(),
-                                     torch::indexing::Slice(),
-                                     torch::indexing::Slice(i, i + 1),
-                                     torch::indexing::Slice(),
-                                     torch::indexing::Slice()});
-        out = decoder_(x_slice, feat_map_, conv_idx_, true);  // first_chunk
-      } else {
-        auto x_slice =
-            processed_latents.index({torch::indexing::Slice(),
-                                     torch::indexing::Slice(),
-                                     torch::indexing::Slice(i, i + 1),
-                                     torch::indexing::Slice(),
-                                     torch::indexing::Slice()});
-        auto out_ = decoder_(x_slice, feat_map_, conv_idx_);
-        out = torch::cat({out, out_}, 2);
-      }
+      auto x_slice = processed_latents.slice(/*dim=*/2, i, i + 1);
+      dec_outputs.push_back(decoder_(x_slice,
+                                     feat_map_,
+                                     conv_idx_,
+                                     /*first_chunk=*/(i == 0),
+                                     parallel_ctx_));
+    }
+    torch::Tensor out = torch::cat(dec_outputs, 2);
+    if (parallel_ctx_.is_parallel()) {
+      out = parallel_ctx_.merge(out);
     }
     auto dec = torch::clamp(out, -1.0f, 1.0f);
 
@@ -1637,6 +1763,7 @@ class AutoencoderKLWanImpl : public torch::nn::Module {
   ModelArgs args_;
   torch::Device device_;
   torch::ScalarType dtype_;
+  VaeSpatialParallel parallel_ctx_;
   int64_t tile_sample_min_height_ = 256;
   int64_t tile_sample_min_width_ = 256;
   int64_t tile_sample_stride_height_ = 192;

--- a/xllm/models/dit/utils/vae_spatial_parallel.h
+++ b/xllm/models/dit/utils/vae_spatial_parallel.h
@@ -1,0 +1,224 @@
+/* Copyright 2026 The xLLM Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://github.com/jd-opensource/xllm/blob/main/LICENSE
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#pragma once
+
+#include <glog/logging.h>
+#include <torch/torch.h>
+
+#include <algorithm>
+#include <string>
+#include <vector>
+
+#include "core/framework/parallel_state/process_group.h"
+
+namespace xllm {
+namespace dit {
+
+/// @brief 1D spatial-parallel helper for VAE encode/decode.
+///
+/// Splits the global W dimension across w_split ranks. Each rank owns a
+/// contiguous W-local slice. Conv layers obtain neighbour columns through
+/// exchange(). Operations that need the full global tensor (e.g. down-sampling)
+/// use merge() followed by split() to restore the local view.
+///
+/// When w_split == 1 every method returns the input unchanged.
+class VaeSpatialParallel final {
+ public:
+  /// @param w_split  number of ranks over which W is partitioned
+  /// @param pg       process group (may be nullptr iff w_split == 1)
+  /// @param device   torch device for communication buffers
+  VaeSpatialParallel(int64_t w_split,
+                     ProcessGroup* pg,
+                     const torch::Device& device)
+      : w_split_(w_split),
+        pg_(pg),
+        device_(device),
+        rank_(pg ? pg->rank() : 0) {
+    CHECK(w_split_ > 0) << "w_split must be positive";
+    CHECK(w_split_ == 1 || pg != nullptr)
+        << "ProcessGroup must be provided when w_split > 1";
+    if (pg) {
+      CHECK(w_split_ == pg->world_size())
+          << "w_split must equal ProcessGroup world_size";
+    }
+  }
+
+  // ---- queries ------------------------------------------------------------
+
+  bool is_parallel() const { return w_split_ > 1; }
+  int64_t w_split() const { return w_split_; }
+  int64_t rank() const { return rank_; }
+  int64_t world_size() const { return w_split_; }
+  bool has_left() const { return rank_ > 0; }
+  bool has_right() const { return rank_ < w_split_ - 1; }
+
+  // ---- operations (identity when !is_parallel()) --------------------------
+
+  /// Split global tensor along the last (W) dimension.
+  torch::Tensor split(torch::Tensor x) {
+    if (!is_parallel()) {
+      return x;
+    }
+    int64_t width = x.size(-1);
+    int64_t base_w = width / w_split_;
+    int64_t rem_w = width % w_split_;
+    int64_t start_w = rank_ * base_w + std::min<int64_t>(rank_, rem_w);
+    int64_t w_local = base_w + (rank_ < rem_w ? 1 : 0);
+    return x.slice(/*dim=*/-1, start_w, start_w + w_local).contiguous();
+  }
+
+  /// All-gather local slices along W, concatenate back to global tensor.
+  torch::Tensor merge(const torch::Tensor& local_patch) {
+    if (!is_parallel()) {
+      return local_patch;
+    }
+
+    auto orig_sizes = local_patch.sizes();
+
+    // All-gather local widths first (may differ across ranks).
+    auto local_w = torch::tensor(
+        {local_patch.size(-1)},
+        torch::TensorOptions().dtype(torch::kInt64).device(device_));
+    std::vector<torch::Tensor> w_list(w_split_);
+    for (int64_t i = 0; i < w_split_; ++i) {
+      w_list[i] = torch::empty(
+          {1}, torch::TensorOptions().dtype(torch::kInt64).device(device_));
+    }
+    pg_->allgather(local_w, w_list);
+
+    std::vector<int64_t> widths(w_split_);
+    std::vector<std::vector<int64_t>> target_shapes(w_split_);
+    for (int64_t i = 0; i < w_split_; ++i) {
+      widths[i] = w_list[i][0].item<int64_t>();
+      target_shapes[i] =
+          std::vector<int64_t>(orig_sizes.begin(), orig_sizes.end());
+      target_shapes[i].back() = widths[i];
+    }
+
+    return allgather_variable_width(local_patch, widths, target_shapes);
+  }
+
+  /// Halo exchange. If @p pad is true, missing neighbours are zero-padded;
+  /// otherwise omitted (for up-sampling trim-exchange).
+  torch::Tensor exchange(torch::Tensor local_patch, bool pad) {
+    if (!is_parallel()) {
+      return local_patch;
+    }
+
+    auto left_col = local_patch.slice(/*dim=*/-1, 0, 1).contiguous();
+    auto right_col =
+        local_patch
+            .slice(/*dim=*/-1, local_patch.size(-1) - 1, local_patch.size(-1))
+            .contiguous();
+
+    torch::Tensor left_recv, right_recv;
+    if (has_left()) {
+      left_recv = torch::empty_like(right_col);
+    }
+    if (has_right()) {
+      right_recv = torch::empty_like(left_col);
+    }
+
+    // Even/odd ordering avoids deadlock in blocking send/recv ring.
+    if (rank_ % 2 == 0) {
+      if (has_right()) {
+        pg_->send(right_col, rank_ + 1);
+      }
+      if (has_right()) {
+        pg_->recv(right_recv, rank_ + 1);
+      }
+      if (has_left()) {
+        pg_->send(left_col, rank_ - 1);
+      }
+      if (has_left()) {
+        pg_->recv(left_recv, rank_ - 1);
+      }
+    } else {
+      if (has_left()) {
+        pg_->recv(left_recv, rank_ - 1);
+      }
+      if (has_left()) {
+        pg_->send(left_col, rank_ - 1);
+      }
+      if (has_right()) {
+        pg_->recv(right_recv, rank_ + 1);
+      }
+      if (has_right()) {
+        pg_->send(right_col, rank_ + 1);
+      }
+    }
+
+    if (pad) {
+      auto left_pad = has_left() ? left_recv : torch::zeros_like(left_col);
+      auto right_pad = has_right() ? right_recv : torch::zeros_like(right_col);
+      return torch::cat({left_pad, local_patch, right_pad}, -1).contiguous();
+    } else {
+      if (!has_left()) {
+        return torch::cat({local_patch, right_recv}, -1).contiguous();
+      }
+      if (!has_right()) {
+        return torch::cat({left_recv, local_patch}, -1).contiguous();
+      }
+      return torch::cat({left_recv, local_patch, right_recv}, -1).contiguous();
+    }
+  }
+
+ private:
+  /// All-gather variable-width tensors, then unpad and cat along last dim.
+  torch::Tensor allgather_variable_width(
+      const torch::Tensor& local,
+      const std::vector<int64_t>& widths,
+      const std::vector<std::vector<int64_t>>& target_shapes) {
+    int64_t prefix_numel = 1;
+    for (int64_t d = 0; d < local.dim() - 1; ++d) {
+      prefix_numel *= local.size(d);
+    }
+
+    std::vector<int64_t> flat_sizes(w_split_);
+    int64_t max_flat_size = 0;
+    for (int64_t i = 0; i < w_split_; ++i) {
+      flat_sizes[i] = prefix_numel * widths[i];
+      max_flat_size = std::max(max_flat_size, flat_sizes[i]);
+    }
+
+    auto local_flat = local.reshape({-1});
+    auto padded_flat = torch::zeros({max_flat_size}, local.options());
+    padded_flat.slice(/*dim=*/0, 0, local_flat.size(0)).copy_(local_flat);
+
+    std::vector<torch::Tensor> gathered_flat(w_split_);
+    for (int64_t i = 0; i < w_split_; ++i) {
+      gathered_flat[i] = torch::empty({max_flat_size}, local.options());
+    }
+    pg_->allgather(padded_flat, gathered_flat);
+
+    std::vector<torch::Tensor> gathered_tensors;
+    gathered_tensors.reserve(w_split_);
+    for (int64_t i = 0; i < w_split_; ++i) {
+      gathered_tensors.emplace_back(gathered_flat[i]
+                                        .slice(/*dim=*/0, 0, flat_sizes[i])
+                                        .reshape(target_shapes[i]));
+    }
+    return torch::cat(gathered_tensors, -1);
+  }
+
+  int64_t w_split_;
+  ProcessGroup* pg_;
+  torch::Device device_;
+  int64_t rank_;
+};
+
+}  // namespace dit
+}  // namespace xllm


### PR DESCRIPTION
wan22:
1.  4sp * 2cfg, after vae parallel, 117.8s --> 112.72s
2.  after vae parallel, percison : guidance=1.5 0.99564, guidance=5.0 0.958248

qwen_image_edit:
1.  3 pictures with 4 sp, before vae parallel: time consuming 62.30s
     3 pictures with 4 sp, after vae parallel: time consuming 61.92s
2.  percision with vae parallel 0.99750