### PR TITLE
feat: add RainFusion sparse attention for wan2.2.

### DIFF
--- a/xllm/core/common/global_flags.h
+++ b/xllm/core/common/global_flags.h
@@ -362,6 +362,18 @@ DECLARE_bool(dit_debug_print);
 
 DECLARE_bool(dit_enable_vae_tiling);
 
+DECLARE_bool(dit_sparse_attention_enabled);
+
+DECLARE_double(dit_sparse_attention_sparsity);
+
+DECLARE_int64(dit_sparse_attention_pool_size);
+
+DECLARE_int64(dit_sparse_attention_sparse_start_step);
+
+DECLARE_string(dit_sparse_attention_version);
+
+DECLARE_int64(dit_sparse_attention_mask_refresh_steps);
+
 DECLARE_bool(use_audio_in_video);
 
 // --- kernel config ---

--- a/xllm/core/framework/config/dit_config.cpp
+++ b/xllm/core/framework/config/dit_config.cpp
@@ -77,6 +77,37 @@ DEFINE_int64(
     1048576,
     "Qwen Image Edit Plus VAE image size used to calculate dimensions.");
 
+DEFINE_bool(dit_sparse_attention_enabled,
+            false,
+            "Enable block-wise sparse attention / RainFusion for WAN.");
+
+DEFINE_double(dit_sparse_attention_sparsity,
+              0.5,
+              "Sparse attention sparsity ratio in [0.0, 1.0). 0.0 = dense "
+              "attention, 0.5 = drop 50 percent blocks.");
+
+DEFINE_int64(
+    dit_sparse_attention_pool_size,
+    128,
+    "Sparse attention pooling window size for block-wise mask generation.");
+
+DEFINE_int64(dit_sparse_attention_sparse_start_step,
+             0,
+             "Sparse attention step index to start sparse attention. "
+             "Steps before this use dense attention.");
+
+DEFINE_string(
+    dit_sparse_attention_version,
+    "rain_fusion",
+    "Sparse attention version: 'rain_fusion' (frame-pairing + "
+    "aclnnRainFusionAttention) or 'sparse_attention' (block-decompose + "
+    "aclnnBlockSparseAttention).");
+
+DEFINE_int64(dit_sparse_attention_mask_refresh_steps,
+             1,
+             "Sparse attention: recompute block sparse mask every N diffusion "
+             "steps. 1 = every step (default), higher = reuse mask longer.");
+
 namespace xllm {
 
 void DiTConfig::from_flags() {
@@ -95,6 +126,12 @@ void DiTConfig::from_flags() {
   XLLM_CONFIG_ASSIGN_FROM_FLAG(dit_generation_image_area_max);
   XLLM_CONFIG_ASSIGN_FROM_FLAG(dit_vae_image_size);
   XLLM_CONFIG_ASSIGN_FROM_FLAG(dit_enable_vae_tiling);
+  XLLM_CONFIG_ASSIGN_FROM_FLAG(dit_sparse_attention_enabled);
+  XLLM_CONFIG_ASSIGN_FROM_FLAG(dit_sparse_attention_sparsity);
+  XLLM_CONFIG_ASSIGN_FROM_FLAG(dit_sparse_attention_pool_size);
+  XLLM_CONFIG_ASSIGN_FROM_FLAG(dit_sparse_attention_sparse_start_step);
+  XLLM_CONFIG_ASSIGN_FROM_FLAG(dit_sparse_attention_version);
+  XLLM_CONFIG_ASSIGN_FROM_FLAG(dit_sparse_attention_mask_refresh_steps);
 }
 
 void DiTConfig::from_json(const JsonReader& json) {
@@ -113,6 +150,12 @@ void DiTConfig::from_json(const JsonReader& json) {
   XLLM_CONFIG_ASSIGN_FROM_JSON(dit_generation_image_area_max);
   XLLM_CONFIG_ASSIGN_FROM_JSON(dit_vae_image_size);
   XLLM_CONFIG_ASSIGN_FROM_JSON(dit_enable_vae_tiling);
+  XLLM_CONFIG_ASSIGN_FROM_JSON(dit_sparse_attention_enabled);
+  XLLM_CONFIG_ASSIGN_FROM_JSON(dit_sparse_attention_sparsity);
+  XLLM_CONFIG_ASSIGN_FROM_JSON(dit_sparse_attention_pool_size);
+  XLLM_CONFIG_ASSIGN_FROM_JSON(dit_sparse_attention_sparse_start_step);
+  XLLM_CONFIG_ASSIGN_FROM_JSON(dit_sparse_attention_version);
+  XLLM_CONFIG_ASSIGN_FROM_JSON(dit_sparse_attention_mask_refresh_steps);
 }
 
 void DiTConfig::append_config_json(nlohmann::ordered_json& config_json) const {
@@ -147,6 +190,18 @@ void DiTConfig::append_config_json(nlohmann::ordered_json& config_json) const {
       config_json, default_config, dit_vae_image_size);
   APPEND_CONFIG_JSON_VALUE_IF_NOT_DEFAULT(
       config_json, default_config, dit_enable_vae_tiling);
+  APPEND_CONFIG_JSON_VALUE_IF_NOT_DEFAULT(
+      config_json, default_config, dit_sparse_attention_enabled);
+  APPEND_CONFIG_JSON_VALUE_IF_NOT_DEFAULT(
+      config_json, default_config, dit_sparse_attention_sparsity);
+  APPEND_CONFIG_JSON_VALUE_IF_NOT_DEFAULT(
+      config_json, default_config, dit_sparse_attention_pool_size);
+  APPEND_CONFIG_JSON_VALUE_IF_NOT_DEFAULT(
+      config_json, default_config, dit_sparse_attention_sparse_start_step);
+  APPEND_CONFIG_JSON_VALUE_IF_NOT_DEFAULT(
+      config_json, default_config, dit_sparse_attention_version);
+  APPEND_CONFIG_JSON_VALUE_IF_NOT_DEFAULT(
+      config_json, default_config, dit_sparse_attention_mask_refresh_steps);
 }
 
 DiTConfig& DiTConfig::get_instance() {

--- a/xllm/core/framework/config/dit_config.h
+++ b/xllm/core/framework/config/dit_config.h
@@ -55,7 +55,13 @@ class DiTConfig final {
          "dit_debug_print",
          "dit_generation_image_area_max",
          "dit_vae_image_size",
-         "dit_enable_vae_tiling"}};
+         "dit_enable_vae_tiling",
+         "dit_sparse_attention_enabled",
+         "dit_sparse_attention_sparsity",
+         "dit_sparse_attention_pool_size",
+         "dit_sparse_attention_sparse_start_step",
+         "dit_sparse_attention_version",
+         "dit_sparse_attention_mask_refresh_steps"}};
     return kOptionCategory;
   }
 
@@ -88,6 +94,18 @@ class DiTConfig final {
   PROPERTY(int64_t, dit_vae_image_size) = 1048576;
 
   PROPERTY(bool, dit_enable_vae_tiling) = false;
+
+  PROPERTY(bool, dit_sparse_attention_enabled) = false;
+
+  PROPERTY(double, dit_sparse_attention_sparsity) = 0.5;
+
+  PROPERTY(int64_t, dit_sparse_attention_pool_size) = 128;
+
+  PROPERTY(int64_t, dit_sparse_attention_sparse_start_step) = 0;
+
+  PROPERTY(std::string, dit_sparse_attention_version) = "rain_fusion";
+
+  PROPERTY(int64_t, dit_sparse_attention_mask_refresh_steps) = 1;
 };
 
 }  // namespace xllm

--- a/xllm/core/kernels/npu/CMakeLists.txt
+++ b/xllm/core/kernels/npu/CMakeLists.txt
@@ -18,6 +18,8 @@ cc_library(
     npu_causal_conv1d.cpp
     npu_fused_infer_attention.cpp
     npu_gemma_rms_norm.cpp
+    npu_block_sparse_attention.cpp
+    npu_rain_fusion_attention.cpp
     npu_grouped_matmul.cpp
     npu_moe_gating_topk_softmax.cpp
     npu_dispatch_ffn_combine.cpp

--- a/xllm/core/kernels/npu/npu_block_sparse_attention.cpp
+++ b/xllm/core/kernels/npu/npu_block_sparse_attention.cpp
@@ -1,0 +1,108 @@
+/* Copyright 2026 The xLLM Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://github.com/jd-opensource/xllm/blob/main/LICENSE
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include <glog/logging.h>
+
+#include "core/kernels/npu/aclnn/pytorch_npu_helper.hpp"
+#include "core/kernels/npu/npu_ops_api.h"
+
+namespace xllm::kernel::npu {
+
+namespace {
+constexpr int64_t kMaskType = 0;
+constexpr int64_t kPreTokens = 2147483647;
+constexpr int64_t kNextTokens = 2147483647;
+constexpr int64_t kBlockSize = 0;
+}  // namespace
+
+std::tuple<torch::Tensor, torch::Tensor> npu_block_sparse_attention(
+    const torch::Tensor& query,
+    const torch::Tensor& key,
+    const torch::Tensor& value,
+    const torch::Tensor& block_sparse_mask,
+    torch::IntArrayRef block_shape,
+    const std::string& q_input_layout,
+    const std::string& kv_input_layout,
+    int64_t num_key_value_heads,
+    double scale_value,
+    int64_t inner_precise,
+    int64_t softmax_lse_flag,
+    std::optional<torch::IntArrayRef> actual_seq_lengths,
+    std::optional<torch::IntArrayRef> actual_seq_lengths_kv) {
+  CHECK(q_input_layout == "BNSD" || q_input_layout == "TND")
+      << "q_input_layout only supports 'BNSD' and 'TND', got "
+      << q_input_layout;
+  CHECK(kv_input_layout == q_input_layout)
+      << "q_input_layout and kv_input_layout must be consistent";
+
+  // TND layout requires actual_seq_lengths for correct batch handling.
+  CHECK(q_input_layout != "TND" ||
+        (actual_seq_lengths.has_value() && actual_seq_lengths_kv.has_value()))
+      << "actual_seq_lengths and actual_seq_lengths_kv are required for TND "
+         "layout.";
+
+  const char* q_layout_ptr = q_input_layout.c_str();
+  const char* kv_layout_ptr = kv_input_layout.c_str();
+
+  // attenMaskOptional and blockTableOptional: always nullptr.
+  std::optional<torch::Tensor> null_tensor = std::nullopt;
+
+  auto attention_out = torch::empty(query.sizes(), query.options());
+
+  // softmaxLse shape depends on layout.
+  //   TND:  [T, N, 1]      — batched by token (T).
+  //   BNSD: [B, N, S, 1]   — batched by batch (B).
+  // When softmax_lse_flag == 0, pass nullptr so the op skips the LSE write.
+  torch::Tensor softmax_lse;
+  std::optional<torch::Tensor> softmax_lse_opt = std::nullopt;
+  if (softmax_lse_flag != 0) {
+    if (q_input_layout == "TND") {
+      softmax_lse = torch::empty({query.size(0), query.size(1), 1},
+                                 query.options().dtype(torch::kFloat));
+    } else {
+      softmax_lse =
+          torch::empty({query.size(0), query.size(1), query.size(2), 1},
+                       query.options().dtype(torch::kFloat));
+    }
+    softmax_lse_opt = softmax_lse;
+  }
+
+  EXEC_NPU_CMD(aclnnBlockSparseAttention,
+               query,
+               key,
+               value,
+               block_sparse_mask,
+               null_tensor,  // attenMaskOptional
+               block_shape,
+               actual_seq_lengths,
+               actual_seq_lengths_kv,
+               null_tensor,  // blockTableOptional
+               q_layout_ptr,
+               kv_layout_ptr,
+               num_key_value_heads,
+               kMaskType,
+               scale_value,
+               inner_precise,
+               kBlockSize,
+               kPreTokens,
+               kNextTokens,
+               softmax_lse_flag,
+               attention_out,
+               softmax_lse_opt);  // nullptr when flag==0
+
+  return std::make_tuple(attention_out, softmax_lse);
+}
+
+}  // namespace xllm::kernel::npu

--- a/xllm/core/kernels/npu/npu_ops_api.h
+++ b/xllm/core/kernels/npu/npu_ops_api.h
@@ -107,6 +107,36 @@ void npu_gemma_rms_norm(const torch::Tensor& x,
                         torch::Tensor& rstd_out,
                         torch::Tensor& y_out);
 
+std::tuple<torch::Tensor, torch::Tensor> npu_block_sparse_attention(
+    const torch::Tensor& query,
+    const torch::Tensor& key,
+    const torch::Tensor& value,
+    const torch::Tensor& block_sparse_mask,
+    torch::IntArrayRef block_shape,
+    const std::string& q_input_layout,
+    const std::string& kv_input_layout,
+    int64_t num_key_value_heads,
+    double scale_value,
+    int64_t inner_precise,
+    int64_t softmax_lse_flag = 0,
+    std::optional<torch::IntArrayRef> actual_seq_lengths = std::nullopt,
+    std::optional<torch::IntArrayRef> actual_seq_lengths_kv = std::nullopt);
+
+std::tuple<torch::Tensor, torch::Tensor> npu_rain_fusion_attention(
+    const torch::Tensor& query,
+    const torch::Tensor& key,
+    const torch::Tensor& value,
+    const torch::Tensor& select_idx,
+    const torch::Tensor& select_num_idx,
+    torch::IntArrayRef blockshape,
+    const std::string& q_input_layout,
+    const std::string& kv_input_layout,
+    int64_t head_num,
+    double scale,
+    int64_t inner_precise,
+    std::optional<torch::IntArrayRef> actual_seq_lengths = std::nullopt,
+    std::optional<torch::IntArrayRef> actual_seq_lengths_kv = std::nullopt);
+
 std::tuple<torch::Tensor, torch::Tensor, torch::Tensor> add_rms_norm(
     const torch::Tensor& x1,
     const torch::Tensor& x2,

--- a/xllm/core/kernels/npu/npu_rain_fusion_attention.cpp
+++ b/xllm/core/kernels/npu/npu_rain_fusion_attention.cpp
@@ -1,0 +1,94 @@
+/* Copyright 2026 The xLLM Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://github.com/jd-opensource/xllm/blob/main/LICENSE
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include <glog/logging.h>
+
+#include "core/kernels/npu/aclnn/pytorch_npu_helper.hpp"
+#include "core/kernels/npu/npu_ops_api.h"
+
+namespace xllm::kernel::npu {
+
+namespace {
+constexpr int64_t kMaskType = 0;
+constexpr int64_t kBlockSize = 0;
+}  // namespace
+
+std::tuple<torch::Tensor, torch::Tensor> npu_rain_fusion_attention(
+    const torch::Tensor& query,
+    const torch::Tensor& key,
+    const torch::Tensor& value,
+    const torch::Tensor& select_idx,
+    const torch::Tensor& select_num_idx,
+    torch::IntArrayRef blockshape,
+    const std::string& q_input_layout,
+    const std::string& kv_input_layout,
+    int64_t head_num,
+    double scale,
+    int64_t inner_precise,
+    std::optional<torch::IntArrayRef> actual_seq_lengths,
+    std::optional<torch::IntArrayRef> actual_seq_lengths_kv) {
+  CHECK(q_input_layout == "BNSD" || q_input_layout == "TND")
+      << "q_input_layout only supports 'BNSD' and 'TND', got "
+      << q_input_layout;
+  CHECK(kv_input_layout == q_input_layout)
+      << "q_input_layout and kv_input_layout must be consistent";
+
+  const char* q_layout_ptr = q_input_layout.c_str();
+  const char* kv_layout_ptr = kv_input_layout.c_str();
+
+  // attenMask and blockTable: always nullptr for RainFusion.
+  std::optional<torch::Tensor> null_tensor = std::nullopt;
+
+  // actual_seq_lengths: empty IntArrayRef when not set.
+  auto opt_seq_lens = actual_seq_lengths.value_or(torch::IntArrayRef{});
+  auto opt_seq_lens_kv = actual_seq_lengths_kv.value_or(torch::IntArrayRef{});
+
+  auto attention_out = torch::empty(query.sizes(), query.options());
+
+  // softmaxLse: aclnnRainFusionAttention requires non-null output.
+  torch::Tensor softmax_lse;
+  if (q_input_layout == "TND") {
+    softmax_lse = torch::empty({query.size(0), query.size(1)},
+                               query.options().dtype(torch::kFloat));
+  } else {
+    softmax_lse = torch::empty({query.size(0), query.size(1), query.size(2)},
+                               query.options().dtype(torch::kFloat));
+  }
+
+  EXEC_NPU_CMD(aclnnRainFusionAttention,
+               query,
+               key,
+               value,
+               select_idx,
+               select_num_idx,
+               blockshape,
+               null_tensor,      // attenMaskOptional (nullptr)
+               opt_seq_lens,     // actual_seq_lengths
+               opt_seq_lens_kv,  // actual_seq_lengths_kv
+               null_tensor,      // blockTableOptional (nullptr)
+               q_layout_ptr,
+               kv_layout_ptr,
+               head_num,
+               kMaskType,
+               scale,
+               inner_precise,
+               kBlockSize,
+               attention_out,
+               softmax_lse);
+
+  return std::make_tuple(attention_out, softmax_lse);
+}
+
+}  // namespace xllm::kernel::npu

--- a/xllm/models/dit/pipelines/pipeline_wan_i2v.h
+++ b/xllm/models/dit/pipelines/pipeline_wan_i2v.h
@@ -19,6 +19,7 @@ limitations under the License.
 #include <cstring>
 #include <memory>
 
+#include "core/framework/config/dit_config.h"
 #include "core/framework/config/load_config.h"
 #include "core/framework/config/parallel_config.h"
 #include "core/framework/dit_model_loader.h"
@@ -55,12 +56,26 @@ class WanImageToVideoPipelineImpl : public torch::nn::Module {
     const auto& scheduler_args = context.get_model_args("scheduler");
     num_train_timesteps_ = scheduler_args.num_train_timesteps();
 
+    // RainFusion config is static (derived from flags) — build it once here
+    // and pass to the transformers via constructor. It never changes per
+    // request, unlike RainFusionState which is per-inference dynamic state.
+    auto& dit_config = DiTConfig::get_instance();
+    rf_config_.enabled = dit_config.dit_sparse_attention_enabled();
+    rf_config_.sparsity =
+        static_cast<float>(dit_config.dit_sparse_attention_sparsity());
+    rf_config_.pool_size = dit_config.dit_sparse_attention_pool_size();
+    rf_config_.sparse_start_step =
+        dit_config.dit_sparse_attention_sparse_start_step();
+    rf_config_.version = dit_config.dit_sparse_attention_version();
+    rf_config_.mask_refresh_steps =
+        dit_config.dit_sparse_attention_mask_refresh_steps();
+
     LOG(INFO) << "Initializing Wan2_2I2V pipeline...";
     vae_ = AutoencoderKLWan(context.get_model_context("vae"));
-    transformer_ =
-        WanTransformer3DModel(context.get_model_context("transformer"));
-    transformer_2_ =
-        WanTransformer3DModel(context.get_model_context("transformer_2"));
+    transformer_ = WanTransformer3DModel(
+        context.get_model_context("transformer"), rf_config_);
+    transformer_2_ = WanTransformer3DModel(
+        context.get_model_context("transformer_2"), rf_config_);
     umt5_ = UMT5EncoderModel(context.get_model_context("text_encoder"));
     scheduler_ =
         UniPCMultistepScheduler(context.get_model_context("scheduler"));
@@ -481,6 +496,10 @@ class WanImageToVideoPipelineImpl : public torch::nn::Module {
     float boundary_timestep =
         boundary_ratio_ > 0.0f ? boundary_ratio_ * num_train_timesteps_ : -1.0f;
 
+    // RainFusion config is static and already bound to the transformers in the
+    // constructor. Only the per-inference dynamic state lives here.
+    xllm::dit::RainFusionState rf_state;
+
     for (int64_t i = 0; i < timesteps.numel(); ++i) {
       torch::Tensor t = timesteps[i];
       int64_t total_steps = timesteps.numel();
@@ -496,6 +515,7 @@ class WanImageToVideoPipelineImpl : public torch::nn::Module {
         current_guidance = guidance_scale_2;
       }
 
+      rf_state.current_step = i;
       torch::Tensor latent_model_input;
       torch::Tensor timestep_input;
 
@@ -532,6 +552,7 @@ class WanImageToVideoPipelineImpl : public torch::nn::Module {
             timestep_input,
             embeds,
             torch::Tensor(),
+            rf_state,
             [&rolling](int32_t i) { rolling.wait_h2d(i); },
             [&rolling](int32_t i) { rolling.schedule_next_h2d(i); });
       };
@@ -552,7 +573,9 @@ class WanImageToVideoPipelineImpl : public torch::nn::Module {
                   : current_model->forward(latent_model_input,
                                            timestep_input,
                                            rank == 0 ? encoded_prompt_embeds
-                                                     : encoded_negative_embeds);
+                                                     : encoded_negative_embeds,
+                                           torch::Tensor(),
+                                           rf_state);
           auto gathered = xllm::parallel_state::gather(
               noise_pred, parallel_args_.dit_cfg_group_, /*dim=*/0);
           auto chunks = torch::chunk(gathered, 2, 0);
@@ -563,10 +586,16 @@ class WanImageToVideoPipelineImpl : public torch::nn::Module {
             noise_pred = rolling_forward(encoded_prompt_embeds);
             noise_uncond = rolling_forward(encoded_negative_embeds);
           } else {
-            noise_pred = current_model->forward(
-                latent_model_input, timestep_input, encoded_prompt_embeds);
-            noise_uncond = current_model->forward(
-                latent_model_input, timestep_input, encoded_negative_embeds);
+            noise_pred = current_model->forward(latent_model_input,
+                                                timestep_input,
+                                                encoded_prompt_embeds,
+                                                torch::Tensor(),
+                                                rf_state);
+            noise_uncond = current_model->forward(latent_model_input,
+                                                  timestep_input,
+                                                  encoded_negative_embeds,
+                                                  torch::Tensor(),
+                                                  rf_state);
           }
         }
 
@@ -580,7 +609,9 @@ class WanImageToVideoPipelineImpl : public torch::nn::Module {
                          ? rolling_forward(encoded_prompt_embeds)
                          : current_model->forward(latent_model_input,
                                                   timestep_input,
-                                                  encoded_prompt_embeds);
+                                                  encoded_prompt_embeds,
+                                                  torch::Tensor(),
+                                                  rf_state);
       }
       auto prev_latents = scheduler_->step(noise_pred, t, prepared_latents);
       prepared_latents = prev_latents.detach();
@@ -616,7 +647,6 @@ class WanImageToVideoPipelineImpl : public torch::nn::Module {
     prepared_latents = prepared_latents + latents_mean;
     video = vae_->decode(prepared_latents.to(torch::kFloat32)).sample;
     video = video_processor_->postprocess_video(video);
-
     return video;
   }
 
@@ -722,6 +752,7 @@ class WanImageToVideoPipelineImpl : public torch::nn::Module {
   std::vector<double> latents_std_;
   torch::TensorOptions options_;
   const ParallelArgs parallel_args_;
+  xllm::dit::RainFusionConfig rf_config_;
 };
 TORCH_MODULE(WanImageToVideoPipeline);
 

--- a/xllm/models/dit/transformers/transformer_wan.h
+++ b/xllm/models/dit/transformers/transformer_wan.h
@@ -35,6 +35,7 @@ limitations under the License.
 #include "core/layers/common/add_matmul.h"
 #include "core/layers/common/rms_norm.h"
 #include "models/dit/utils/dit_parallel_linear.h"
+#include "models/dit/utils/sparse_attention.h"
 
 using xllm::dit::DiTParallelLinear;
 using xllm::dit::SpOptions;
@@ -520,10 +521,14 @@ TORCH_MODULE(WanPixArtAlphaTextProjection);
 
 class WanAttentionImpl : public torch::nn::Module {
  public:
-  explicit WanAttentionImpl(const ModelContext& context,
-                            const ParallelArgs& parallel_args,
-                            int64_t cross_attention_dim_head = -1)
-      : options_(context.get_tensor_options()), parallel_args_(parallel_args) {
+  explicit WanAttentionImpl(
+      const ModelContext& context,
+      const ParallelArgs& parallel_args,
+      int64_t cross_attention_dim_head = -1,
+      const xllm::dit::RainFusionConfig& rainfusion_config = {})
+      : options_(context.get_tensor_options()),
+        parallel_args_(parallel_args),
+        rainfusion_config_(rainfusion_config) {
     auto model_args = context.get_model_args();
     dim_ = model_args.head_dim() * model_args.n_heads();
     heads_ = model_args.n_heads();
@@ -623,12 +628,45 @@ class WanAttentionImpl : public torch::nn::Module {
 
   torch::Tensor at_npu_attention(const torch::Tensor& q,
                                  const torch::Tensor& k,
-                                 const torch::Tensor& v) {
+                                 const torch::Tensor& v,
+                                 xllm::dit::RainFusionState& rf_state) {
     const auto q_t = q.transpose(1, 2);
     const auto k_t = k.transpose(1, 2);
     const auto v_t = v.transpose(1, 2);
 
 #if defined(USE_NPU)
+    if (rainfusion_config_.enabled &&
+        rf_state.current_step >= rainfusion_config_.sparse_start_step &&
+        q_t.size(2) == k_t.size(2)) {
+      // Strip SP padding: latent_shape uses the unpadded seq_len,
+      // but SP may have padded the sequence to be divisible by sp_size.
+      auto q_use = q_t;
+      auto k_use = k_t;
+      auto v_use = v_t;
+      int64_t pad_len = 0;
+      if (rf_state.seq_len > 0 && q_t.size(2) > rf_state.seq_len) {
+        pad_len = q_t.size(2) - rf_state.seq_len;
+        q_use = q_t.slice(2, 0, rf_state.seq_len);
+        k_use = k_t.slice(2, 0, rf_state.seq_len);
+        v_use = v_t.slice(2, 0, rf_state.seq_len);
+      }
+      auto [out_bnsd, unused] = [&]() {
+        if (rainfusion_config_.version == "sparse_attention") {
+          return xllm::dit::sparse_attention::attention(
+              q_use, k_use, v_use, rainfusion_config_, rf_state);
+        }
+        return xllm::dit::rain_fusion::attention(
+            q_use, k_use, v_use, rainfusion_config_, rf_state);
+      }();
+      // RainFusionState cache (cached_select_idx/_num_idx) managed internally
+      if (pad_len > 0) {
+        out_bnsd = torch::nn::functional::pad(
+            out_bnsd,
+            torch::nn::functional::PadFuncOptions({0, 0, 0, pad_len}));
+      }
+      return out_bnsd.transpose(1, 2).flatten(2, 3).to(q.dtype());
+    }
+
     const int64_t head_num = q_t.size(1);
     const int64_t head_dim = q_t.size(-1);
     const auto results = at_npu::native::custom_ops::npu_fusion_attention(
@@ -656,9 +694,9 @@ class WanAttentionImpl : public torch::nn::Module {
 
   torch::Tensor forward(
       const torch::Tensor& hidden_states_in,
-      const torch::Tensor& encoder_hidden_states = torch::Tensor(),
-      std::optional<std::pair<torch::Tensor, torch::Tensor>> rotary_emb =
-          std::nullopt) {
+      const torch::Tensor& encoder_hidden_states,
+      std::optional<std::pair<torch::Tensor, torch::Tensor>> rotary_emb,
+      xllm::dit::RainFusionState& rf_state) {
     torch::Tensor hidden_states = hidden_states_in;
     bool is_self_attention =
         !encoder_hidden_states.defined() ||
@@ -765,9 +803,9 @@ class WanAttentionImpl : public torch::nn::Module {
 
       key_img = key_img.view({batch_size, -1, n_heads, dim_head_});
       value_img = value_img.view({batch_size, -1, n_heads, dim_head_});
-      hidden_states_img = at_npu_attention(query, key_img, value_img);
+      hidden_states_img = at_npu_attention(query, key_img, value_img, rf_state);
     }
-    hidden_states = at_npu_attention(query, key, value);
+    hidden_states = at_npu_attention(query, key, value, rf_state);
     if (hidden_states_img.defined()) {
       hidden_states = hidden_states + hidden_states_img;
     }
@@ -832,6 +870,9 @@ class WanAttentionImpl : public torch::nn::Module {
   layer::RMSNorm norm_added_k_{nullptr};
 
   torch::TensorOptions options_;
+
+  // RainFusionV3 configuration (static, same for all requests)
+  xllm::dit::RainFusionConfig rainfusion_config_;
 };
 TORCH_MODULE(WanAttention);
 
@@ -1165,9 +1206,11 @@ TORCH_MODULE(WanRotaryPosEmbed);
 
 class WanTransformerBlockImpl : public torch::nn::Module {
  public:
-  explicit WanTransformerBlockImpl(const ModelContext& context,
-                                   const ParallelArgs& parallel_args,
-                                   int64_t block_idx = 0)
+  explicit WanTransformerBlockImpl(
+      const ModelContext& context,
+      const ParallelArgs& parallel_args,
+      int64_t block_idx = 0,
+      const xllm::dit::RainFusionConfig& rainfusion_config = {})
       : options_(context.get_tensor_options()),
         parallel_args_(parallel_args),
         block_idx_(block_idx) {
@@ -1182,9 +1225,12 @@ class WanTransformerBlockImpl : public torch::nn::Module {
 
     norm1_ =
         register_module("norm1", FP32LayerNorm(context, dim_, eps_, false));
-    attn1_ = register_module("attn1", WanAttention(context, parallel_args));
+    attn1_ = register_module(
+        "attn1", WanAttention(context, parallel_args, -1, rainfusion_config));
     attn2_ = register_module(
-        "attn2", WanAttention(context, parallel_args, dim_ / num_heads_));
+        "attn2",
+        WanAttention(
+            context, parallel_args, dim_ / num_heads_, rainfusion_config));
     if (cross_attn_norm_) {
       norm2_ =
           register_module("norm2", FP32LayerNorm(context, dim_, eps_, true));
@@ -1208,11 +1254,12 @@ class WanTransformerBlockImpl : public torch::nn::Module {
                                std::sqrt(static_cast<float>(dim_)));
   }
 
-  torch::Tensor forward(const torch::Tensor& hidden_states_in,
-                        const torch::Tensor& encoder_hidden_states,
-                        const torch::Tensor& timestep_proj,
-                        std::optional<std::pair<torch::Tensor, torch::Tensor>>
-                            rotary_emb = std::nullopt) {
+  torch::Tensor forward(
+      const torch::Tensor& hidden_states_in,
+      const torch::Tensor& encoder_hidden_states,
+      const torch::Tensor& timestep_proj,
+      std::optional<std::pair<torch::Tensor, torch::Tensor>> rotary_emb,
+      xllm::dit::RainFusionState& rf_state) {
     torch::Tensor hidden_states = hidden_states_in;
     torch::Tensor shift_msa, scale_msa, gate_msa, c_shift_msa, c_scale_msa,
         c_gate_msa;
@@ -1243,8 +1290,8 @@ class WanTransformerBlockImpl : public torch::nn::Module {
     torch::Tensor norm1_result = norm1_->forward(hidden_states);
     torch::Tensor norm_hidden_states =
         (norm1_result.to(hidden_states.dtype()) * (1 + scale_msa) + shift_msa);
-    torch::Tensor attn_output =
-        attn1_->forward(norm_hidden_states, norm_hidden_states, rotary_emb);
+    torch::Tensor attn_output = attn1_->forward(
+        norm_hidden_states, norm_hidden_states, rotary_emb, rf_state);
     hidden_states = hidden_states + attn_output * gate_msa;
 
     if (cross_attn_norm_) {
@@ -1254,7 +1301,7 @@ class WanTransformerBlockImpl : public torch::nn::Module {
     }
 
     attn_output = attn2_->forward(
-        norm_hidden_states, encoder_hidden_states, std::nullopt);
+        norm_hidden_states, encoder_hidden_states, std::nullopt, rf_state);
     hidden_states = hidden_states + attn_output;
     torch::Tensor norm2_result = norm3_->forward(hidden_states);
     norm_hidden_states = (norm2_result * (1 + c_scale_msa) + c_shift_msa);
@@ -1328,7 +1375,9 @@ TORCH_MODULE(WanTransformerBlock);
 
 class WanTransformer3DModelImpl : public torch::nn::Module {
  public:
-  explicit WanTransformer3DModelImpl(const ModelContext& context)
+  explicit WanTransformer3DModelImpl(
+      const ModelContext& context,
+      const xllm::dit::RainFusionConfig& rainfusion_config = {})
       : options_(context.get_tensor_options()) {
     auto model_args = context.get_model_args();
     auto parallel_args = context.get_parallel_args();
@@ -1370,8 +1419,8 @@ class WanTransformer3DModelImpl : public torch::nn::Module {
     blocks_ = register_module("blocks", torch::nn::ModuleList());
     transformer_layers_.reserve(num_layers_);
     for (int64_t i = 0; i < num_layers_; ++i) {
-      auto block =
-          WanTransformerBlock(context, parallel_args, static_cast<int64_t>(i));
+      auto block = WanTransformerBlock(
+          context, parallel_args, static_cast<int64_t>(i), rainfusion_config);
       blocks_->push_back(block);
       transformer_layers_.push_back(block);
     }
@@ -1395,13 +1444,13 @@ class WanTransformer3DModelImpl : public torch::nn::Module {
     }
   }
 
-  torch::Tensor forward(
-      const torch::Tensor& hidden_states_in,
-      const torch::Tensor& timestep,
-      const torch::Tensor& encoder_hidden_states,
-      const torch::Tensor& encoder_hidden_states_image = torch::Tensor(),
-      std::function<void(int32_t)> before_layer_cb = nullptr,
-      std::function<void(int32_t)> after_layer_cb = nullptr) {
+  torch::Tensor forward(const torch::Tensor& hidden_states_in,
+                        const torch::Tensor& timestep,
+                        const torch::Tensor& encoder_hidden_states,
+                        const torch::Tensor& encoder_hidden_states_image,
+                        xllm::dit::RainFusionState& rf_state,
+                        std::function<void(int32_t)> before_layer_cb = nullptr,
+                        std::function<void(int32_t)> after_layer_cb = nullptr) {
     int64_t batch_size = hidden_states_in.size(0);
     int64_t num_frames = hidden_states_in.size(2);
     int64_t height = hidden_states_in.size(3);
@@ -1413,6 +1462,9 @@ class WanTransformer3DModelImpl : public torch::nn::Module {
     int64_t post_patch_num_frames = num_frames / p_t;
     int64_t post_patch_height = height / p_h;
     int64_t post_patch_width = width / p_w;
+
+    std::vector<int64_t> latent_shape = {
+        post_patch_num_frames, post_patch_height, post_patch_width};
 
     torch::Tensor hidden_states = hidden_states_in;
 
@@ -1427,6 +1479,9 @@ class WanTransformer3DModelImpl : public torch::nn::Module {
     int64_t seq_len = hidden_states.size(1);
     int64_t pad_seq_len = sp_pad_sequence(
         hidden_states, freqs_cos, freqs_sin, rotary_emb, sp_group_);
+
+    rf_state.latent_shape = latent_shape;
+    rf_state.seq_len = seq_len;
 
     torch::Tensor timestep_input = timestep;
     int64_t ts_seq_len_val = hidden_states.size(1);
@@ -1476,7 +1531,8 @@ class WanTransformer3DModelImpl : public torch::nn::Module {
           transformer_layers_[i]->forward(hidden_states,
                                           encoder_hidden_states_embedded,
                                           timestep_proj,
-                                          rotary_emb);
+                                          rotary_emb,
+                                          rf_state);
       if (after_layer_cb) {
         after_layer_cb(static_cast<int32_t>(i));
       }

--- a/xllm/models/dit/utils/sparse_attention.h
+++ b/xllm/models/dit/utils/sparse_attention.h
@@ -1,0 +1,781 @@
+/* Copyright 2026 The xLLM Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://github.com/jd-opensource/xllm/blob/main/LICENSE
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#pragma once
+
+#include <torch/torch.h>
+
+#include <cmath>
+#include <tuple>
+#include <vector>
+
+#include "core/kernels/npu/npu_ops_api.h"
+
+namespace xllm::dit {
+
+struct RainFusionConfig {
+  float sparsity = 0.5;
+  int64_t pool_size = 128;
+  int64_t sparse_start_step = 0;  // skip_timesteps
+  bool enabled = false;
+  std::string version = "rain_fusion";  // "rain_fusion" or "sparse_attention"
+  int64_t inner_precise = 0;  // sparse_attention: 0=float32 softmax, 1=fp16
+  int64_t mask_refresh_steps =
+      1;  // sparse_attention: recompute mask every N steps
+};
+
+// Per-request dynamic state for sparse / RainFusion attention.
+struct RainFusionState {
+  int64_t current_step = 0;
+  std::vector<int64_t> latent_shape = {1, 1, 1};
+  int64_t seq_len = -1;
+  torch::Tensor
+      cached_mask;  // sparse_attention: cached binary int8 block_sparse_mask
+};
+
+// =========================================================================
+//  Common helpers (shared by both rain_fusion and sparse_attention)
+// =========================================================================
+
+inline torch::Tensor avgpool(const torch::Tensor& input,
+                             int64_t pool_size,
+                             const std::string& input_layout) {
+  std::vector<torch::Tensor> pooled_parts;
+  if (input_layout == "BSND") {
+    int64_t batch = input.size(0);
+    int64_t seqlen = input.size(1);
+    int64_t headnum = input.size(2);
+    int64_t dim = input.size(3);
+    int64_t num_full_blocks = seqlen / pool_size;
+    int64_t tail_size = seqlen % pool_size;
+
+    if (num_full_blocks > 0) {
+      auto full_blocks = input.slice(1, 0, num_full_blocks * pool_size);
+      full_blocks = full_blocks.reshape(
+          {batch, num_full_blocks, pool_size, headnum, dim});
+      pooled_parts.emplace_back(full_blocks.mean(2));
+    }
+    if (tail_size > 0) {
+      auto tail_block = input.slice(1, num_full_blocks * pool_size, seqlen);
+      tail_block = tail_block.reshape({batch, 1, tail_size, headnum, dim});
+      pooled_parts.emplace_back(tail_block.mean(2));
+    }
+  } else {
+    // BNSD: [B, N, S, D]
+    int64_t batch = input.size(0);
+    int64_t headnum = input.size(1);
+    int64_t seqlen = input.size(2);
+    int64_t dim = input.size(3);
+    int64_t num_full_blocks = seqlen / pool_size;
+    int64_t tail_size = seqlen % pool_size;
+
+    if (num_full_blocks > 0) {
+      auto full_blocks = input.slice(2, 0, num_full_blocks * pool_size);
+      full_blocks = full_blocks.reshape(
+          {batch, headnum, num_full_blocks, pool_size, dim});
+      pooled_parts.emplace_back(full_blocks.mean(3));
+    }
+    if (tail_size > 0) {
+      auto tail_block = input.slice(2, num_full_blocks * pool_size, seqlen);
+      tail_block = tail_block.reshape({batch, headnum, 1, tail_size, dim});
+      pooled_parts.emplace_back(tail_block.mean(3));
+    }
+  }
+  if (pooled_parts.size() > 1) {
+    int64_t cat_dim = (input_layout == "BSND") ? 1 : 2;
+    return torch::cat(pooled_parts, cat_dim);
+  }
+  return pooled_parts[0];
+}
+
+// =========================================================================
+//  RainFusion attention (V2) — frame-pairing + aclnnRainFusionAttention
+//  Internal helpers live in the rain_fusion namespace to scope
+//  preprocessing from the sparse_attention variant.
+// =========================================================================
+namespace rain_fusion {
+
+// Layout helpers: merge B*N for NPU 8-dim compliance.
+// The reference Wan2.2 code uses einops with (b n) pre-merge:
+//   rearrange(tensor, 'b (f h w) n d -> (b n) f h w d', ...)
+// This keeps all intermediate tensors ≤ 8 dims and eliminates
+// per-layout code branches.
+
+inline torch::Tensor to_flat(const torch::Tensor& t,
+                             const std::string& layout) {
+  if (layout == "BNSD") {
+    // .contiguous() needed: SP padding strip via slice() makes tensor
+    // non-contiguous; without it reshape does a hidden device copy.
+    auto ct = t.contiguous();
+    return ct.view({ct.size(0) * ct.size(1), ct.size(2), ct.size(3)});
+  }
+  // BSND: [B, S, N, D] → [B*N, S, D]
+  auto ct = t.permute({0, 2, 1, 3}).contiguous();
+  return ct.view({ct.size(0), ct.size(1), ct.size(2)});
+}
+
+inline torch::Tensor from_flat(const torch::Tensor& t, int64_t B, int64_t N) {
+  // view requires contiguous; aclnn output may be non-contiguous
+  auto ct = t.contiguous();
+  return ct.view({B, N, ct.size(1), ct.size(2)});  // → [B, N, S, D]
+}
+
+// ---- Frame-pairing rearrange ----
+// Splits first frame (placed at END), pairs remaining frames (fn=tq/2, fb=2).
+// All internal ops work on [B*N, S, D] — max 8 dims after splitting.
+// Output: [B, N, rearranged_rest+first_frame, D]
+inline torch::Tensor rearrange_with_remaining(const torch::Tensor& tensor,
+                                              int64_t tq,
+                                              int64_t hq,
+                                              int64_t wq,
+                                              const std::string& input_layout) {
+  int64_t B = (input_layout == "BNSD") ? tensor.size(0) : tensor.size(0);
+  int64_t N = (input_layout == "BNSD") ? tensor.size(1) : tensor.size(2);
+  int64_t D = (input_layout == "BNSD") ? tensor.size(3) : tensor.size(3);
+  int64_t first_frame_len = hq * wq;
+  int64_t rest_frames = tq - 1;
+  int64_t fn = tq / 2;
+  int64_t fb = 2;
+  int64_t hn = hq / 8;
+  int64_t wn = wq / 8;
+  CHECK(tq % 2 == 1) << "V2 frame-pairing requires odd tq, got " << tq;
+
+  // Flatten to [B*N, S, D], split first frame
+  auto t = to_flat(tensor, input_layout);
+  auto t_first = t.slice(1, 0, first_frame_len);
+  auto t_rest = t.slice(1, first_frame_len, t.size(1));
+
+  if (hq % 8 == 0 && wq % 8 == 0) {
+    // Aligned: single-step frame-pairing (8 dims: B*N,fn,fb,hn,8,wn,8,D)
+    t_rest = t_rest.reshape({B * N, fn, fb, hn, 8, wn, 8, D})
+                 .permute({0, 1, 3, 5, 2, 4, 6, 7})
+                 .contiguous()
+                 .reshape({B * N, -1, D});
+  } else {
+    // Remainder: split h/w remainders, pair only aligned portion
+    int64_t hq_block = (hq / 8) * 8;
+    int64_t wq_block = (wq / 8) * 8;
+    int64_t hq_rem = hq % 8;
+    int64_t wq_rem = wq % 8;
+    int64_t hn_a = hq_block / 8;
+    int64_t wn_a = wq_block / 8;
+
+    t_rest = t_rest.reshape({B * N, rest_frames, hq, wq, D});
+    torch::Tensor t_h_r, t_w_r;
+    if (hq_rem > 0) {
+      auto s = t_rest.split({hq_block, hq_rem}, 2);
+      t_rest = s[0];
+      t_h_r = s[1].reshape({B * N, rest_frames, -1, wq, D});
+    }
+    if (wq_rem > 0) {
+      auto s = t_rest.split({wq_block, wq_rem}, 3);
+      t_rest = s[0];
+      t_w_r = s[1].reshape({B * N, rest_frames, hq_block, -1, D});
+    }
+    // Frame-pairing aligned portion (8 dims)
+    t_rest = t_rest.reshape({B * N, fn, fb, hn_a, 8, wn_a, 8, D})
+                 .permute({0, 1, 3, 5, 2, 4, 6, 7})
+                 .contiguous()
+                 .reshape({B * N, -1, D});
+    if (hq_rem > 0) {
+      t_rest = torch::cat({t_rest, t_h_r.reshape({B * N, -1, D})}, 1);
+    }
+    if (wq_rem > 0) {
+      t_rest = torch::cat({t_rest, t_w_r.reshape({B * N, -1, D})}, 1);
+    }
+  }
+  t = torch::cat({t_rest, t_first}, 1);
+  return from_flat(t, B, N);
+}
+
+// ---- Inverse rearrange ----
+// Reverses frame-pairing: [B*N, paired_rest+first_frame, D] → [B,N,S,D]
+// Works on flat layout; max 8 dims.
+inline torch::Tensor bsa_inv_rearrange(const torch::Tensor& out,
+                                       int64_t tq,
+                                       int64_t hq,
+                                       int64_t wq,
+                                       const std::string& input_layout) {
+  int64_t B = (input_layout == "BNSD") ? out.size(0) : out.size(0);
+  int64_t N = (input_layout == "BNSD") ? out.size(1) : out.size(2);
+  int64_t D = (input_layout == "BNSD") ? out.size(3) : out.size(3);
+  int64_t first_frame_len = hq * wq;
+  int64_t rest_frames = tq - 1;
+  int64_t fn = tq / 2;
+  int64_t fb = 2;
+  int64_t hn = hq / 8;
+  int64_t wn = wq / 8;
+
+  auto t = to_flat(out, input_layout);
+  auto t_first = t.slice(1, -first_frame_len, t.size(1));
+  auto t_rest = t.slice(1, 0, -first_frame_len);
+
+  if (hq % 8 == 0 && wq % 8 == 0) {
+    // Aligned: un-pair (8 dims)
+    t_rest = t_rest.reshape({B * N, fn, hn, wn, fb, 8, 8, D})
+                 .permute({0, 1, 4, 2, 5, 3, 6, 7})
+                 .contiguous()
+                 .reshape({B * N, rest_frames * hq * wq, D});
+  } else {
+    // Remainder
+    int64_t hq_block = (hq / 8) * 8;
+    int64_t wq_block = (wq / 8) * 8;
+    int64_t hq_rem = hq % 8;
+    int64_t wq_rem = wq % 8;
+    int64_t hn_a = hq_block / 8;
+    int64_t wn_a = wq_block / 8;
+    int64_t h_rem_size = hq_rem * wq;
+    int64_t block_tokens = fn * hn_a * wn_a * 128;
+
+    t_rest = t_rest.reshape({B * N, rest_frames * hq * wq, D});
+    auto t_block = t_rest.slice(1, 0, block_tokens);
+    torch::Tensor t_h_r, t_w_r;
+    int64_t offset = block_tokens;
+    if (hq_rem > 0) {
+      t_h_r = t_rest.slice(1, offset, offset + h_rem_size * rest_frames);
+      offset += h_rem_size * rest_frames;
+    }
+    if (wq_rem > 0) {
+      t_w_r = t_rest.slice(1, offset);
+    }
+
+    t_block = t_block.reshape({B * N, fn, hn_a, wn_a, fb, 8, 8, D})
+                  .permute({0, 1, 4, 2, 5, 3, 6, 7})
+                  .contiguous()
+                  .reshape({B * N, rest_frames, hq_block, wq_block, D});
+    if (wq_rem > 0) {
+      t_block = torch::cat(
+          {t_block, t_w_r.reshape({B * N, rest_frames, hq_block, wq_rem, D})},
+          3);
+    }
+    if (hq_rem > 0) {
+      t_block = torch::cat(
+          {t_block, t_h_r.reshape({B * N, rest_frames, hq_rem, wq, D})}, 2);
+    }
+    t_rest = t_block.reshape({B * N, rest_frames * hq * wq, D});
+  }
+  // Restore original order: [first_frame, un-rearranged_rest]
+  // (matches reference do_tensor_inv_rearrange: concat(tensor_f, tensor_i))
+  t = torch::cat({t_first, t_rest}, 1);
+  return from_flat(t, B, N);
+}
+
+// ---- Mask helpers ----
+
+inline std::pair<torch::Tensor, torch::Tensor> mask_to_select_idx(
+    const torch::Tensor& mask_b0) {
+  int64_t N = mask_b0.size(0);
+  int64_t q_blocks = mask_b0.size(1);
+  int64_t kv_blocks = mask_b0.size(2);
+
+  auto row_indices =
+      torch::arange(kv_blocks, mask_b0.options().dtype(torch::kInt64))
+          .view({1, 1, kv_blocks})
+          .expand({N, q_blocks, kv_blocks});
+
+  auto sorted_vals =
+      torch::where(mask_b0,
+                   row_indices,
+                   torch::full({}, 1000000000LL, row_indices.options()));
+  auto sorted_sorted = std::get<0>(torch::sort(sorted_vals, -1));
+
+  auto valid_count = mask_b0.sum(-1);
+  auto keep_mask = row_indices < valid_count.unsqueeze(-1);
+
+  auto select_idx = torch::where(keep_mask,
+                                 sorted_sorted.to(torch::kInt64),
+                                 torch::full({}, -1LL, row_indices.options()));
+  auto select_num_idx = valid_count.to(torch::kInt64);
+  return {select_idx, select_num_idx};
+}
+
+inline std::pair<torch::Tensor, torch::Tensor> get_blockwise_mask(
+    const torch::Tensor& q_pool,
+    const torch::Tensor& k_pool,
+    int64_t txt_len,
+    float sparsity,
+    double scale,
+    int64_t pool_size,
+    int64_t tq,
+    int64_t hq,
+    int64_t wq,
+    const std::string& input_layout) {
+  torch::Tensor attn_scores;
+  if (input_layout == "BSND") {
+    attn_scores = torch::einsum("blnd,bsnd->bnls", {q_pool, k_pool}) * scale;
+  } else {
+    attn_scores = torch::einsum("bnld,bnsd->bnls", {q_pool, k_pool}) * scale;
+  }
+
+  auto score_matrix = torch::softmax(attn_scores, -1);
+  int64_t cols = score_matrix.size(-1);
+  int64_t keep_len =
+      std::max(static_cast<int64_t>(std::ceil(cols * (1.0 - sparsity))),
+               static_cast<int64_t>(1));
+
+  auto topk_result = score_matrix.topk(keep_len, -1);
+  auto thresholds = std::get<0>(topk_result).slice(-1, keep_len - 1, keep_len);
+  auto mask = score_matrix >= thresholds;
+
+  // RainFusion: first frame at END → protect LAST blocks
+  int64_t first_frame_len = hq * wq;
+  int64_t protect_len = (first_frame_len + txt_len + pool_size - 1) / pool_size;
+  if (protect_len > 0) {
+    mask.index_put_(
+        {torch::indexing::Slice(),
+         torch::indexing::Slice(),
+         torch::indexing::Slice(-protect_len, torch::indexing::None),
+         torch::indexing::Slice()},
+        true);
+    mask.index_put_(
+        {torch::indexing::Slice(),
+         torch::indexing::Slice(),
+         torch::indexing::Slice(),
+         torch::indexing::Slice(-protect_len, torch::indexing::None)},
+        true);
+  }
+  // Reference transposes to [q_blocks, N, max_select] before passing to
+  // aclnnRainFusionAttention (see Wan2.2 get_blockwise_mask).
+  auto [si, sn] = mask_to_select_idx(mask[0]);      // [N, q_blocks, kv_blocks]
+  return {si.transpose(0, 1), sn.transpose(0, 1)};  // → [q_blocks, N, ...]
+}
+
+// RainFusion block sparse attention — main entry point.
+inline std::tuple<torch::Tensor, torch::Tensor> attention(
+    const torch::Tensor& query,
+    const torch::Tensor& key,
+    const torch::Tensor& value,
+    const RainFusionConfig& config,
+    RainFusionState& state) {
+  CHECK(query.dim() == 4) << "query must be 4D [B, N, S, D]";
+  CHECK(query.dtype() == torch::kHalf || query.dtype() == torch::kBFloat16)
+      << "query must be fp16 or bf16";
+  CHECK(config.sparsity >= 0.0f && config.sparsity < 1.0f)
+      << "sparsity must be in [0.0, 1.0)";
+  CHECK(config.pool_size > 0 && config.pool_size % 128 == 0)
+      << "pool_size must be positive multiple of 128";
+  int64_t tq = state.latent_shape[0];
+  int64_t hq = state.latent_shape[1];
+  int64_t wq = state.latent_shape[2];
+  int64_t num_heads = query.size(1);
+  double scale = std::pow(static_cast<double>(query.size(-1)), -0.5);
+
+  // Step 1: Cat QKV → rearrange once → chunk (matches reference:
+  //   rainfusion_blockwise.py cat(q,k,v) → do_tensor_rearrange_pooling)
+  auto qkv = torch::cat({query, key, value}, 0);
+  auto qkv_r = rearrange_with_remaining(qkv, tq, hq, wq, "BNSD");
+  auto qkv_chunks = qkv_r.chunk(3, 0);  // Q', K', V'
+  auto q_r = qkv_chunks[0];
+  auto k_r = qkv_chunks[1];
+  auto v_r = qkv_chunks[2];
+
+  // Step 2: Cat Q'+K' → avgpool together → compute mask
+  auto qk = torch::cat({q_r, k_r}, 0);
+  auto qk_pool = avgpool(qk, config.pool_size, "BNSD");
+  auto pool_chunks = qk_pool.chunk(2, 0);
+  auto [sel_idx, sel_num] = get_blockwise_mask(pool_chunks[0],
+                                               pool_chunks[1],
+                                               /*txt_len=*/0,
+                                               config.sparsity,
+                                               scale,
+                                               config.pool_size,
+                                               tq,
+                                               hq,
+                                               wq,
+                                               "BNSD");
+
+  // Step 3: RainFusion block sparse attention
+  int64_t batch_size = query.size(0);
+  std::vector<int64_t> seq_lens(batch_size, q_r.size(2));
+  constexpr int64_t kInnerPrecise = 0;
+
+  auto [attn_out, lse] = xllm::kernel::npu::npu_rain_fusion_attention(
+      q_r,
+      k_r,
+      v_r,
+      sel_idx,
+      sel_num,
+      {config.pool_size, config.pool_size},
+      "BNSD",
+      "BNSD",
+      num_heads,
+      scale,
+      kInnerPrecise,
+      std::optional<torch::IntArrayRef>(seq_lens),
+      std::optional<torch::IntArrayRef>(seq_lens));
+
+  // Step 4: Inverse rearrange
+  auto out = bsa_inv_rearrange(attn_out, tq, hq, wq, "BNSD");
+
+  return std::make_tuple(out, sel_idx);
+}
+
+}  // namespace rain_fusion
+
+// =========================================================================
+//  Sparse attention (V3) — block-decompose + aclnnBlockSparseAttention
+//  Internal helpers live in the sparse_attention namespace to scope
+//  preprocessing from the rain_fusion variant.
+// =========================================================================
+namespace sparse_attention {
+
+// Rearrange: block-decompose (f hn hb wn wb) → (f hn wn hb wb).
+// Remainder: first frame kept raw, rest block-decomposed per-frame.
+inline torch::Tensor rearrange_v3(const torch::Tensor& tensor,
+                                  int64_t tq,
+                                  int64_t hq,
+                                  int64_t wq,
+                                  const std::string& input_layout) {
+  int64_t first_frame_len = hq * wq;
+  int64_t frame_num = tq;
+
+  if (hq % 8 == 0 && wq % 8 == 0) {
+    int64_t hn = hq / 8, wn = wq / 8;
+    if (input_layout == "BSND") {
+      return tensor
+          .reshape({tensor.size(0),
+                    frame_num,
+                    hn,
+                    8,
+                    wn,
+                    8,
+                    tensor.size(2),
+                    tensor.size(3)})
+          .permute({0, 1, 2, 4, 3, 5, 6, 7})
+          .contiguous()
+          .reshape({tensor.size(0), -1, tensor.size(2), tensor.size(3)});
+    }
+    return tensor
+        .reshape({tensor.size(0),
+                  tensor.size(1),
+                  frame_num,
+                  hn,
+                  8,
+                  wn,
+                  8,
+                  tensor.size(3)})
+        .permute({0, 1, 2, 3, 5, 4, 6, 7})
+        .contiguous()
+        .reshape({tensor.size(0), tensor.size(1), -1, tensor.size(3)});
+  }
+
+  int64_t hq_block = (hq / 8) * 8, wq_block = (wq / 8) * 8;
+  int64_t hq_rem = hq % 8, wq_rem = wq % 8;
+  int64_t hn = hq_block / 8, wn = wq_block / 8;
+
+  if (input_layout == "BSND") {
+    auto t_first = tensor.slice(1, 0, first_frame_len);
+    auto t_rest = tensor.slice(1, first_frame_len);
+    t_rest = t_rest.reshape({tensor.size(0),
+                             frame_num - 1,
+                             hq,
+                             wq,
+                             tensor.size(2),
+                             tensor.size(3)});
+    torch::Tensor t_h_r, t_w_r;
+    if (hq_rem > 0) {
+      auto s = t_rest.split({hq_block, hq_rem}, 2);
+      t_rest = s[0];
+      t_h_r = s[1].reshape(
+          {tensor.size(0), frame_num - 1, -1, tensor.size(2), tensor.size(3)});
+    }
+    if (wq_rem > 0) {
+      auto s = t_rest.split({wq_block, wq_rem}, 3);
+      t_rest = s[0];
+      t_w_r = s[1].reshape(
+          {tensor.size(0), frame_num - 1, -1, tensor.size(2), tensor.size(3)});
+    }
+    t_rest = t_rest
+                 .reshape({tensor.size(0),
+                           frame_num - 1,
+                           hn,
+                           8,
+                           wn,
+                           8,
+                           tensor.size(2),
+                           tensor.size(3)})
+                 .permute({0, 1, 2, 4, 3, 5, 6, 7})
+                 .contiguous()
+                 .reshape({tensor.size(0),
+                           frame_num - 1,
+                           hn * wn * 64,
+                           tensor.size(2),
+                           tensor.size(3)});
+    if (hq_rem > 0) t_rest = torch::cat({t_rest, t_h_r}, 2);
+    if (wq_rem > 0) t_rest = torch::cat({t_rest, t_w_r}, 2);
+    t_rest =
+        t_rest.reshape({tensor.size(0), -1, tensor.size(2), tensor.size(3)});
+    return torch::cat({t_first, t_rest}, 1);
+  }
+
+  // BNSD remainder
+  auto t_first = tensor.slice(2, 0, first_frame_len);
+  auto t_rest = tensor.slice(2, first_frame_len);
+  t_rest = t_rest.reshape(
+      {tensor.size(0), tensor.size(1), frame_num - 1, hq, wq, tensor.size(3)});
+  torch::Tensor t_h_r, t_w_r;
+  if (hq_rem > 0) {
+    auto s = t_rest.split({hq_block, hq_rem}, 3);
+    t_rest = s[0];
+    t_h_r = s[1].reshape(
+        {tensor.size(0), tensor.size(1), frame_num - 1, -1, tensor.size(3)});
+  }
+  if (wq_rem > 0) {
+    auto s = t_rest.split({wq_block, wq_rem}, 4);
+    t_rest = s[0];
+    t_w_r = s[1].reshape(
+        {tensor.size(0), tensor.size(1), frame_num - 1, -1, tensor.size(3)});
+  }
+  t_rest = t_rest
+               .reshape({tensor.size(0),
+                         tensor.size(1),
+                         frame_num - 1,
+                         hn,
+                         8,
+                         wn,
+                         8,
+                         tensor.size(3)})
+               .permute({0, 1, 2, 3, 5, 4, 6, 7})
+               .contiguous()
+               .reshape({tensor.size(0),
+                         tensor.size(1),
+                         frame_num - 1,
+                         hn * wn * 64,
+                         tensor.size(3)});
+  if (hq_rem > 0) t_rest = torch::cat({t_rest, t_h_r}, 3);
+  if (wq_rem > 0) t_rest = torch::cat({t_rest, t_w_r}, 3);
+  t_rest = t_rest.reshape({tensor.size(0), tensor.size(1), -1, tensor.size(3)});
+  return torch::cat({t_first, t_rest}, 2);
+}
+
+// Inverse rearrange — reverses rearrange_v3.
+inline torch::Tensor bsa_inv_rearrange_v3(const torch::Tensor& out,
+                                          int64_t tq,
+                                          int64_t hq,
+                                          int64_t wq,
+                                          const std::string& input_layout) {
+  int64_t hn = hq / 8, wn = wq / 8;
+
+  if (hq % 8 == 0 && wq % 8 == 0) {
+    if (input_layout == "BNSD") {
+      int64_t n = out.size(1);
+      return out.reshape({out.size(0), n, tq, hn, wn, 8, 8, out.size(3)})
+          .permute({0, 1, 2, 3, 5, 4, 6, 7})
+          .contiguous()
+          .reshape({out.size(0), n, tq * hq * wq, out.size(3)});
+    }
+    int64_t n = out.size(2);
+    return out.reshape({out.size(0), tq, hn, wn, 8, 8, n, out.size(3)})
+        .permute({0, 1, 2, 4, 3, 5, 6, 7})
+        .contiguous()
+        .reshape({out.size(0), tq * hq * wq, n, out.size(3)});
+  }
+
+  int64_t first_frame_len = hq * wq;
+  int64_t hq_block = (hq / 8) * 8, wq_block = (wq / 8) * 8;
+  int64_t hq_rem = hq % 8, wq_rem = wq % 8;
+  int64_t block_size = hn * wn * 64;
+  int64_t h_rem_size = hq_rem * wq;
+
+  if (input_layout == "BNSD") {
+    int64_t n = out.size(1);
+    auto o_first = out.slice(2, 0, first_frame_len);
+    auto o_rest = out.slice(2, first_frame_len);
+    o_rest = o_rest.reshape({out.size(0), n, tq - 1, hq * wq, out.size(3)});
+
+    auto t_block = o_rest.slice(3, 0, block_size);
+    torch::Tensor t_h_r, t_w_r;
+    if (hq_rem > 0)
+      t_h_r = o_rest.slice(3, block_size, block_size + h_rem_size);
+    if (wq_rem > 0) t_w_r = o_rest.slice(3, block_size + h_rem_size);
+
+    t_block =
+        t_block.reshape({out.size(0), n, tq - 1, hn, wn, 8, 8, out.size(3)})
+            .permute({0, 1, 2, 3, 5, 4, 6, 7})
+            .contiguous()
+            .reshape({out.size(0), n, tq - 1, hq_block, wq_block, out.size(3)});
+    if (wq_rem > 0)
+      t_block = torch::cat(
+          {t_block,
+           t_w_r.reshape(
+               {out.size(0), n, tq - 1, hq_block, wq_rem, out.size(3)})},
+          4);
+    if (hq_rem > 0)
+      t_block = torch::cat(
+          {t_block,
+           t_h_r.reshape({out.size(0), n, tq - 1, hq_rem, wq, out.size(3)})},
+          3);
+    auto o_rest_out =
+        t_block.reshape({out.size(0), n, (tq - 1) * hq * wq, out.size(3)});
+    return torch::cat({o_first, o_rest_out}, 2);
+  }
+
+  // BSND remainder
+  int64_t n = out.size(2);
+  auto o_first = out.slice(1, 0, first_frame_len);
+  auto o_rest = out.slice(1, first_frame_len);
+  o_rest = o_rest.reshape({out.size(0), tq - 1, hq * wq, n, out.size(3)});
+
+  auto t_block = o_rest.slice(2, 0, block_size);
+  torch::Tensor t_h_r, t_w_r;
+  if (hq_rem > 0) t_h_r = o_rest.slice(2, block_size, block_size + h_rem_size);
+  if (wq_rem > 0) t_w_r = o_rest.slice(2, block_size + h_rem_size);
+
+  t_block =
+      t_block.reshape({out.size(0), tq - 1, hn, wn, 8, 8, n, out.size(3)})
+          .permute({0, 1, 2, 4, 3, 5, 6, 7})
+          .contiguous()
+          .reshape({out.size(0), tq - 1, hq_block, wq_block, n, out.size(3)});
+  if (wq_rem > 0)
+    t_block = torch::cat(
+        {t_block,
+         t_w_r.reshape(
+             {out.size(0), tq - 1, hq_block, wq_rem, n, out.size(3)})},
+        3);
+  if (hq_rem > 0)
+    t_block = torch::cat(
+        {t_block,
+         t_h_r.reshape({out.size(0), tq - 1, hq_rem, wq, n, out.size(3)})},
+        2);
+  auto o_rest_out =
+      t_block.reshape({out.size(0), (tq - 1) * hq * wq, n, out.size(3)});
+  return torch::cat({o_first, o_rest_out}, 1);
+}
+
+// Binary mask for aclnnBlockSparseAttention.  Returns int8
+// [B,N,q_blocks,kv_blocks].
+inline torch::Tensor get_blockwise_mask_v3(const torch::Tensor& q_pool,
+                                           const torch::Tensor& k_pool,
+                                           int64_t txt_len,
+                                           float sparsity,
+                                           double scale,
+                                           int64_t pool_size,
+                                           int64_t tq,
+                                           int64_t hq,
+                                           int64_t wq,
+                                           const std::string& input_layout,
+                                           bool protect_first_frame) {
+  torch::Tensor attn_scores;
+  if (input_layout == "BSND")
+    attn_scores = torch::einsum("blnd,bsnd->bnls", {q_pool, k_pool}) * scale;
+  else
+    attn_scores = torch::einsum("bnld,bnsd->bnls", {q_pool, k_pool}) * scale;
+
+  auto score_matrix = torch::softmax(attn_scores, -1);
+  int64_t cols = score_matrix.size(-1);
+  int64_t keep_len = std::max(
+      static_cast<int64_t>(std::ceil(cols * (1.0 - sparsity))), int64_t(1));
+  auto topk_result = score_matrix.topk(keep_len, -1);
+  auto thresholds = std::get<0>(topk_result).slice(-1, keep_len - 1, keep_len);
+  auto mask = score_matrix >= thresholds;
+
+  int64_t text_block_num = (txt_len + pool_size - 1) / pool_size;
+  if (text_block_num > 0) {
+    mask.index_put_(
+        {torch::indexing::Slice(),
+         torch::indexing::Slice(),
+         torch::indexing::Slice(-text_block_num, torch::indexing::None),
+         torch::indexing::Slice()},
+        true);
+    mask.index_put_(
+        {torch::indexing::Slice(),
+         torch::indexing::Slice(),
+         torch::indexing::Slice(),
+         torch::indexing::Slice(-text_block_num, torch::indexing::None)},
+        true);
+  }
+  if (protect_first_frame) {
+    int64_t nblocks = (hq * wq + pool_size - 1) / pool_size;
+    if (nblocks > 0) {
+      mask.index_put_({torch::indexing::Slice(),
+                       torch::indexing::Slice(),
+                       torch::indexing::Slice(0, nblocks),
+                       torch::indexing::Slice()},
+                      true);
+      mask.index_put_({torch::indexing::Slice(),
+                       torch::indexing::Slice(),
+                       torch::indexing::Slice(),
+                       torch::indexing::Slice(0, nblocks)},
+                      true);
+    }
+  }
+  return mask.to(torch::kInt8);
+}
+
+// Sparse attention — main entry point. Ported from wan22_rainfusion.
+inline std::tuple<torch::Tensor, torch::Tensor> attention(
+    const torch::Tensor& query,
+    const torch::Tensor& key,
+    const torch::Tensor& value,
+    const RainFusionConfig& config,
+    RainFusionState& state) {
+  CHECK(query.dim() == 4) << "query must be 4D [B, N, S, D]";
+  int64_t tq = state.latent_shape[0], hq = state.latent_shape[1],
+          wq = state.latent_shape[2];
+  int64_t num_heads = query.size(1);
+  double scale = std::pow(static_cast<double>(query.size(-1)), -0.5);
+  int64_t batch_size = query.size(0);
+
+  auto q_r = rearrange_v3(query, tq, hq, wq, "BNSD");
+  auto k_r = rearrange_v3(key, tq, hq, wq, "BNSD");
+  auto v_r = rearrange_v3(value, tq, hq, wq, "BNSD");
+
+  torch::Tensor new_mask;
+  bool use_cached = state.cached_mask.defined() &&
+                    (config.mask_refresh_steps <= 0 ||
+                     (state.current_step % config.mask_refresh_steps != 0));
+  if (!use_cached) {
+    auto qk = torch::cat({q_r, k_r}, 0);
+    auto qk_pool = avgpool(qk, config.pool_size, "BNSD");
+    auto chunks = qk_pool.chunk(2, 0);
+    new_mask = get_blockwise_mask_v3(chunks[0],
+                                     chunks[1],
+                                     /*txt_len=*/0,
+                                     config.sparsity,
+                                     scale,
+                                     config.pool_size,
+                                     tq,
+                                     hq,
+                                     wq,
+                                     "BNSD",
+                                     /*protect_first_frame=*/true);
+    state.cached_mask = new_mask;
+  } else {
+    new_mask = state.cached_mask;
+  }
+
+  std::vector<int64_t> seq_lens(batch_size, q_r.size(2));
+  auto [attn_out, lse] = xllm::kernel::npu::npu_block_sparse_attention(
+      q_r,
+      k_r,
+      v_r,
+      new_mask,
+      {config.pool_size, config.pool_size},
+      "BNSD",
+      "BNSD",
+      num_heads,
+      scale,
+      config.inner_precise,
+      /*softmax_lse_flag=*/0,
+      std::optional<torch::IntArrayRef>(seq_lens),
+      std::optional<torch::IntArrayRef>(seq_lens));
+
+  auto out = bsa_inv_rearrange_v3(attn_out, tq, hq, wq, "BNSD");
+  return std::make_tuple(out, new_mask);
+}
+
+}  // namespace sparse_attention
+
+}  // namespace xllm::dit


### PR DESCRIPTION
1.  add two new aclnn op:  aclnnRainFusionAttention and aclnnBlockSparseAttention(for future A5, currently not actual used.)
2.  6 new dit configs: 
     a. rainfusion_enabled , bool, whethen enable rainfusion attention or not.
     b. rainfusion_sparsity , double 0.5~0.9 ; with value higher, faster and lower percision.
     c. rainfusion_pool_size , int , block size default 128. 
     d. rainfusion_sparse_start_step , int,  decide which step to start use sparsity ; with higher value faster and lower percision.
     e. rainfusion_version, default v2 means aclnnRainFusionAttention , v3 means aclnnBlockSparseAttention
     f.  rainfusion_mask_refresh_steps, int, how many steps to refresh mask. used with v3.f
3.  with or without sparsity=0.8 , start_step=15: mindiesd percision compare result is 0.9547, xllm percision compare result is 0.9556
