### PR TITLE
perf: disable qwen3 split rmsnorm rope in prefill, keep decode path.

### DIFF
--- a/xllm/core/layers/npu/npu_qwen3_decoder_layer_impl.cpp
+++ b/xllm/core/layers/npu/npu_qwen3_decoder_layer_impl.cpp
@@ -128,7 +128,10 @@ void NpuQwen3DecoderLayerImpl::param_from_args(
         ::xllm::KVCacheConfig::get_instance().block_size() == 128;
   }
   num_hidden_layers_ = args.n_layers();
-  if (kernel_config.enable_split_rmsnorm_rope()) {
+  // TODO: optimize the split rmsnorm rope path for prefill before enabling it
+  // there again. It regresses long-prompt TTFT today, while decode still
+  // benefits from this fused path.
+  if (kernel_config.enable_split_rmsnorm_rope() && !isPrefill) {
     param.enableSplitRmsNormRope = true;
   }
 }


### PR DESCRIPTION
## 背景

Qwen3 1.7B 在当前调优配置下，prefill 阶段启用 split rmsnorm rope 路径时 TTFT 偏高。本次 PR 只提交 prefill TTFT 优化改动，不包含本地权重加载补丁，也不包含采样路径优化或后续 2B 继续优化中的改动。

## 修改内容

- prefill 阶段关闭 Qwen3 split rmsnorm rope 路径。
- decode 阶段仍保留 split rmsnorm rope 开关生效，避免影响已调优的 decode 路径。

## TODO

- 当前增加 `!isPrefill` 分支是阶段性处理：已有验证显示该 split rmsnorm rope 路径在 prefill 场景会拉高 TTFT，而 decode 场景仍有收益，因此先将触发范围收窄到 decode。
- 后续需要继续针对 prefill 阶段优化该算子路径，确认其在长 prompt prefill 下的算子耗时、融合收益和调度开销，再决定是否重新接入 prefill。

## 测试场景

- 模型：Qwen3 1.7B。
- 接口：Chat Completions stream 请求。
- 请求集：同一批 20 条正式请求，warmup 请求不计入结果。
- 输入长度：请求 prompt 文本长度约 2.8k 到 9.0k 字符，中位数约 6.5k 字符。
- 输出设置：测试脚本固定 max_tokens=128，ignore_eos=true。
- 采样设置：请求携带 top_k=1，测试脚本设置 temperature=1，未显式设置 do_sample；PR 前后采样参数保持一致，本 PR 不修改采样逻辑。

## 验证结果

- 修改前：avg TTFT 约 111ms。
- 修改后：avg TTFT 约 91ms。
- TTFT 收益：约 20ms。
- 同场景下 decode TPOT 维持在约 4.9ms，未破坏此前 decode 调优结果。

当前 PR diff 仅包含 prefill TTFT 相关改动。
