### PR TITLE
feat: add TileLang FSGDR kernel for NPU.

### DIFF
--- a/tests/core/kernels/npu/tilelang/CMakeLists.txt
+++ b/tests/core/kernels/npu/tilelang/CMakeLists.txt
@@ -28,6 +28,19 @@ cc_test(
 
 cc_test(
   NAME
+    fused_sigmoid_gating_delta_rule_wrapper_test
+  SRCS
+    fused_sigmoid_gating_delta_rule_wrapper_test.cpp
+  DEPS
+    :tilelang_kernels
+    torch
+    GTest::gtest_main
+    glog::glog
+    unified_dlog
+)
+
+cc_test(
+  NAME
     split_qkv_rmsnorm_mrope_wrapper_test
   SRCS
     split_qkv_rmsnorm_mrope_wrapper_test.cpp

--- a/tests/core/kernels/npu/tilelang/fused_sigmoid_gating_delta_rule_wrapper_test.cpp
+++ b/tests/core/kernels/npu/tilelang/fused_sigmoid_gating_delta_rule_wrapper_test.cpp
@@ -1,0 +1,281 @@
+/* Copyright 2026 The xLLM Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://github.com/jd-opensource/xllm/blob/main/LICENSE
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include <gtest/gtest.h>
+#include <torch/torch.h>
+#include <torch_npu/torch_npu.h>
+
+#include <string>
+#include <tuple>
+#include <utility>
+#include <vector>
+
+#include "core/kernels/npu/tilelang/tilelang_ops_api.h"
+
+namespace xllm::kernel::npu::tilelang {
+namespace {
+
+class TileLangFusedSigmoidGatingDeltaRuleWrapperTest : public ::testing::Test {
+ protected:
+  static void SetUpTestSuite() { torch_npu::init_npu("npu:0"); }
+
+  static void TearDownTestSuite() { torch_npu::finalize_npu(); }
+};
+
+struct FusedSigmoidGatingDeltaRuleTestCase {
+  std::string name;
+  std::vector<int64_t> seqlens;
+  int64_t nk;
+  int64_t nv;
+  int64_t dk;
+  int64_t dv;
+  int64_t seed;
+  float softplus_beta = 1.0F;
+  torch::ScalarType init_state_dtype = torch::kFloat32;
+};
+
+std::tuple<torch::Tensor, torch::Tensor> torch_fused_sigmoid_gating_delta_rule(
+    const torch::Tensor& A_log,
+    const torch::Tensor& a,
+    const torch::Tensor& dt_bias,
+    const torch::Tensor& query,
+    const torch::Tensor& key,
+    const torch::Tensor& value,
+    const torch::Tensor& beta,
+    const torch::Tensor& init_state,
+    const torch::Tensor& ssm_state_indices,
+    const torch::Tensor& cu_seqlens,
+    float softplus_beta = 1.0F) {
+  const int64_t total_tokens = query.size(1);
+  const int64_t nk = query.size(2);
+  const int64_t dk = query.size(3);
+  const int64_t nv = value.size(2);
+  const int64_t dv = value.size(3);
+  const int64_t num_seqs = cu_seqlens.size(0) - 1;
+  const float scale = 1.0F / std::sqrt(static_cast<float>(dk));
+  const float l2_norm_eps = 1e-6F;
+  const int64_t v_per_k = nv / nk;
+  const auto fp32_opts = query.options().dtype(torch::kFloat32);
+
+  auto state = torch::zeros({num_seqs, nv, dk, dv}, fp32_opts);
+  for (int64_t i = 0; i < num_seqs; ++i) {
+    int64_t state_idx = ssm_state_indices[i].item<int64_t>();
+    if (state_idx >= 0) {
+      state[i] = init_state[state_idx].to(torch::kFloat32);
+    }
+  }
+
+  auto A_log_f = A_log.to(torch::kFloat32);
+  auto dt_bias_f = dt_bias.to(torch::kFloat32);
+  auto a_f = a.to(torch::kFloat32);
+  auto beta_f = beta.to(torch::kFloat32);
+  auto query_f = query.to(torch::kFloat32);
+  auto key_f = key.to(torch::kFloat32);
+  auto value_f = value.to(torch::kFloat32);
+
+  auto exp_A = torch::exp(A_log_f);
+  auto out = torch::empty({1, total_tokens, nv, dv}, query.options());
+
+  for (int64_t seq_idx = 0; seq_idx < num_seqs; ++seq_idx) {
+    int64_t seq_start = cu_seqlens[seq_idx].item<int64_t>();
+    int64_t seq_end = cu_seqlens[seq_idx + 1].item<int64_t>();
+    for (int64_t v_head_idx = 0; v_head_idx < nv; ++v_head_idx) {
+      auto h = state[seq_idx][v_head_idx];
+      int64_t k_head_idx = v_head_idx / v_per_k;
+      for (int64_t token = seq_start; token < seq_end; ++token) {
+        auto q_t = query_f[0][token][k_head_idx];
+        auto k_t = key_f[0][token][k_head_idx];
+        auto v_t = value_f[0][token][v_head_idx];
+
+        {
+          auto q_norm = q_t / torch::sqrt((q_t * q_t).sum() + l2_norm_eps);
+          auto k_norm = k_t / torch::sqrt((k_t * k_t).sum() + l2_norm_eps);
+          q_t = q_norm;
+          k_t = k_norm;
+        }
+
+        auto x = a_f[token][v_head_idx] + dt_bias_f[v_head_idx];
+        auto beta_x = softplus_beta * x;
+        auto sp =
+            torch::where(beta_x > 20.0F,
+                         x,
+                         torch::log1p(torch::exp(beta_x)) / softplus_beta);
+
+        h = h * torch::exp(-exp_A[v_head_idx] * sp);
+        auto pred = torch::matmul(k_t.unsqueeze(0), h).squeeze(0);
+        h = h +
+            torch::outer(
+                k_t, (v_t - pred) * torch::sigmoid(beta_f[token][v_head_idx]));
+        out[0][token][v_head_idx] =
+            torch::matmul((q_t * scale).unsqueeze(0), h).squeeze(0);
+      }
+      state[seq_idx][v_head_idx] = h;
+    }
+  }
+
+  return {out.to(query.scalar_type()), state};
+}
+
+void run_fused_sigmoid_gating_delta_rule_case(
+    const FusedSigmoidGatingDeltaRuleTestCase& test_case) {
+  const auto device = torch::Device("npu:0");
+  torch::manual_seed(test_case.seed);
+
+  const int64_t num_seqs = static_cast<int64_t>(test_case.seqlens.size());
+  ASSERT_GT(num_seqs, 0);
+
+  int64_t total_tokens = 0;
+  std::vector<int32_t> cu_seqlens_vec;
+  cu_seqlens_vec.push_back(0);
+  for (int64_t len : test_case.seqlens) {
+    total_tokens += len;
+    cu_seqlens_vec.push_back(static_cast<int32_t>(total_tokens));
+  }
+
+  const auto bf16_opts =
+      torch::TensorOptions().dtype(torch::kBFloat16).device(device);
+  const auto fp32_opts =
+      torch::TensorOptions().dtype(torch::kFloat32).device(device);
+  const auto i32_opts =
+      torch::TensorOptions().dtype(torch::kInt32).device(device);
+
+  const int64_t nk = test_case.nk;
+  const int64_t nv = test_case.nv;
+  const int64_t dk = test_case.dk;
+  const int64_t dv = test_case.dv;
+
+  auto A_log = torch::randn({nv}, fp32_opts);
+  auto a = torch::randn({total_tokens, nv}, bf16_opts);
+  auto dt_bias = torch::randn({nv}, fp32_opts);
+  const int64_t q_width = nk * dk;
+  const int64_t k_width = nk * dk;
+  const int64_t v_width = nv * dv;
+  auto qkv =
+      torch::randn({total_tokens, q_width + k_width + v_width}, bf16_opts);
+  auto query = qkv.narrow(1, 0, q_width).view({total_tokens, nk, dk});
+  auto key = qkv.narrow(1, q_width, k_width).view({total_tokens, nk, dk});
+  auto value =
+      qkv.narrow(1, q_width + k_width, v_width).view({total_tokens, nv, dv});
+  auto beta = torch::randn({total_tokens, nv}, bf16_opts);
+  ASSERT_GT(query.stride(0), nk * dk);
+  ASSERT_GT(key.stride(0), nk * dk);
+  ASSERT_GT(value.stride(0), nv * dv);
+
+  int64_t num_cache_slots = num_seqs * 2;
+  auto init_state = torch::randn(
+      {num_cache_slots, nv, dk, dv},
+      torch::TensorOptions().dtype(test_case.init_state_dtype).device(device));
+  auto ssm_state_indices = torch::arange(num_seqs, i32_opts);
+  auto cu_seqlens = torch::tensor(cu_seqlens_vec, i32_opts);
+
+  auto [out_ref, final_state_ref] =
+      torch_fused_sigmoid_gating_delta_rule(A_log,
+                                            a,
+                                            dt_bias,
+                                            query.unsqueeze(0),
+                                            key.unsqueeze(0),
+                                            value.unsqueeze(0),
+                                            beta,
+                                            init_state,
+                                            ssm_state_indices,
+                                            cu_seqlens,
+                                            test_case.softplus_beta);
+
+  // TileLang kernel.
+  const float scale_val = 1.0F / std::sqrt(static_cast<float>(dk));
+  auto [out_out, final_state_out] =
+      fused_sigmoid_gating_delta_rule(A_log,
+                                      a,
+                                      dt_bias,
+                                      query,
+                                      key,
+                                      value,
+                                      beta,
+                                      init_state,
+                                      ssm_state_indices,
+                                      cu_seqlens,
+                                      scale_val,
+                                      /*use_qk_l2norm_in_kernel=*/true,
+                                      test_case.softplus_beta,
+                                      /*softplus_threshold=*/20.0F);
+
+  auto out_sliced = out_out.unsqueeze(0);
+  auto final_state_sliced = final_state_out.slice(0, 0, num_seqs);
+
+  EXPECT_TRUE(
+      torch::allclose(out_sliced, out_ref, /*rtol=*/2e-2, /*atol=*/2e-2))
+      << "out mismatch for case " << test_case.name;
+  EXPECT_TRUE(torch::allclose(final_state_sliced,
+                              final_state_ref,
+                              /*rtol=*/2e-2,
+                              /*atol=*/2e-2))
+      << "final_state mismatch for case " << test_case.name;
+  EXPECT_TRUE(
+      torch::allclose(init_state.narrow(0, 0, num_seqs).to(torch::kFloat32),
+                      final_state_ref,
+                      /*rtol=*/2e-2,
+                      /*atol=*/2e-2))
+      << "in-place cache update mismatch for case " << test_case.name;
+}
+
+TEST_F(TileLangFusedSigmoidGatingDeltaRuleWrapperTest, MatchesTorchReference) {
+  const std::vector<FusedSigmoidGatingDeltaRuleTestCase> cases = {
+      {
+          .name = "small_4x8_d128",
+          .seqlens = {4, 8, 6, 3},
+          .nk = 4,
+          .nv = 8,
+          .dk = 128,
+          .dv = 128,
+          .seed = 20260421,
+      },
+      {
+          .name = "medium_16x32_d128",
+          .seqlens = {4, 8, 12, 6, 3, 7, 5, 9},
+          .nk = 16,
+          .nv = 32,
+          .dk = 128,
+          .dv = 128,
+          .seed = 20260422,
+      },
+      {
+          .name = "oversized_40x32_decode_d128",
+          .seqlens = std::vector<int64_t>(40, 1),
+          .nk = 16,
+          .nv = 32,
+          .dk = 128,
+          .dv = 128,
+          .seed = 20260703,
+      },
+      {
+          .name = "bf16_cache_4x8_decode_d128",
+          .seqlens = std::vector<int64_t>(4, 1),
+          .nk = 4,
+          .nv = 8,
+          .dk = 128,
+          .dv = 128,
+          .seed = 20260704,
+          .init_state_dtype = torch::kBFloat16,
+      },
+  };
+
+  for (const auto& test_case : cases) {
+    SCOPED_TRACE(::testing::Message() << "case=" << test_case.name);
+    run_fused_sigmoid_gating_delta_rule_case(test_case);
+  }
+}
+
+}  // namespace
+}  // namespace xllm::kernel::npu::tilelang

--- a/xllm/compiler/tilelang/targets/ascend/kernels/fused_sigmoid_gating_delta_rule.py
+++ b/xllm/compiler/tilelang/targets/ascend/kernels/fused_sigmoid_gating_delta_rule.py
@@ -1,0 +1,692 @@
+#!/usr/bin/env python3
+
+import argparse
+from pathlib import Path
+import math
+
+import tilelang
+import tilelang.language as T
+
+from .utils import DEFAULT_ASCEND_PASS_CONFIGS
+from ....common.spec import DispatchField, TilelangKernel, register_kernel
+
+# Per-kernel pass_configs matching the original tuned kernel.
+_SIGMOID_PASS_CONFIGS = {
+    "tl.ascend_memory_planning": True,
+    "tl.ascend_auto_cv_combine": True,
+}
+
+SOFTPLUS_THRESHOLD = 20.0
+VEC_NUM = 2
+L2_NORM_EPS = 1e-6
+DEFAULT_DTYPE = "bf16"
+# TVM/TileLang knows "bfloat16" for tensor buffers but the dispatch
+# system uses the compact "bf16" string to map to TilelangDType::kBF16.
+_INTERNAL_DTYPE = "bfloat16"
+DEFAULT_ACCUM_DTYPE = "float"
+DEFAULT_USE_QK_L2NORM = 1
+DEFAULT_SOFTPLUS_BETA = 1.0
+DEFAULT_NUM_CORES = 24
+DEFAULT_NK = 16
+DEFAULT_NV = 32
+DEFAULT_DK = 128
+DEFAULT_DV = 128
+
+NUM_SEQS_SPECIALIZATION_MIN = 1
+NUM_SEQS_SPECIALIZATION_MAX = 32
+NUM_SEQS_SPECIALIZATION_STEP = 1
+NUM_SEQS_SPECIALIZATIONS = tuple(
+    range(
+        NUM_SEQS_SPECIALIZATION_MIN,
+        NUM_SEQS_SPECIALIZATION_MAX + 1,
+        NUM_SEQS_SPECIALIZATION_STEP,
+    )
+)
+
+REF_CHECK_NUM_SEQS = 32
+REF_CHECK_MAX_SEQ_LEN = 64
+
+
+def _auto_block_v(dv: int) -> int:
+    return min(dv, 128)
+
+
+def build_fused_sigmoid_gating_delta_rule_kernel(
+    nk: int,
+    nv: int,
+    dk: int,
+    dv: int,
+    block_v: int,
+    max_num_seqs: int,
+    use_qk_l2norm: bool,
+    softplus_beta: float,
+    dtype: str,
+    accum_dtype: str,
+    num_cores: int = DEFAULT_NUM_CORES,
+):
+    if nv % nk != 0:
+        raise ValueError("nv must be divisible by nk")
+    if block_v % VEC_NUM != 0:
+        raise ValueError(f"block_v must be divisible by VEC_NUM={VEC_NUM}")
+    if dv % block_v != 0:
+        raise ValueError("dv must be divisible by block_v")
+
+    num_v_tiles = math.ceil(dv / block_v)
+    v_per_k = nv // nk
+    vec_block_v = block_v // VEC_NUM
+    total_tokens_padded = T.symbolic("total_tokens_padded")
+    num_cache_slots = T.symbolic("num_cache_slots")
+    max_token_stride = 2 * nk * dk + nv * dv
+    qkv_flat_size = total_tokens_padded * max_token_stride
+    input_dtype = _INTERNAL_DTYPE  # "bfloat16" — TVM-supported name
+
+    block_num = max_num_seqs * nv * num_v_tiles
+    q_tasks = block_num // num_cores
+    r_tasks = block_num % num_cores
+    max_work_per_block = q_tasks + 1
+    inv_beta = 1.0 / softplus_beta
+
+    @T.prim_func
+    def main(
+        A_log: T.Tensor([nv], accum_dtype),
+        a: T.Tensor([total_tokens_padded, nv], input_dtype),
+        dt_bias: T.Tensor([nv], accum_dtype),
+        query: T.Tensor([1, qkv_flat_size], input_dtype),
+        key: T.Tensor([1, qkv_flat_size], input_dtype),
+        value: T.Tensor([1, qkv_flat_size], input_dtype),
+        beta: T.Tensor([total_tokens_padded, nv], input_dtype),
+        init_state: T.Tensor([num_cache_slots, nv, dk, dv], accum_dtype),
+        # init_state: T.Tensor([num_cache_slots, nv, dk, dv], input_dtype),
+        ssm_state_indices: T.Tensor([max_num_seqs], "int32"),
+        cu_seqlens: T.Tensor([max_num_seqs + 1], "int32"),
+        out: T.Tensor([total_tokens_padded, nv, dv], input_dtype),
+        final_state: T.Tensor([num_cache_slots, nv, dk, dv], accum_dtype),
+        softplus_beta: T.float32,
+        scale: T.float32,
+        use_qk_l2norm: T.int32,
+        softplus_threshold: T.float32,
+        query_stride_t: T.int32,
+        key_stride_t: T.int32,
+        value_stride_t: T.int32,
+    ):
+        with T.Kernel(num_cores, is_npu=True) as (cid, vid):
+            start_work = cid * q_tasks + T.if_then_else(cid < r_tasks, cid, r_tasks)
+            count_work = q_tasks + T.if_then_else(cid < r_tasks, 1, 0)
+
+            q_buf = T.alloc_ub([2, dk], input_dtype)
+            k_buf = T.alloc_ub([2, dk], input_dtype)
+            v_buf = T.alloc_ub([2, vec_block_v], input_dtype)
+
+            q_f = T.alloc_ub([dk], accum_dtype)
+            k_f = T.alloc_ub([dk], accum_dtype)
+            k_1d = T.alloc_ub([dk, 1], accum_dtype)
+            v_f = T.alloc_ub([vec_block_v], accum_dtype)
+            k_broadcasted = T.alloc_ub([dk, vec_block_v], accum_dtype)
+            compute_buffer = T.alloc_ub([dk, vec_block_v], accum_dtype)
+
+            h_vec = T.alloc_ub([dk, vec_block_v], accum_dtype)
+            # h_load_vec = T.alloc_ub([dk, vec_block_v], input_dtype)
+            # h_store_vec = T.alloc_ub([dk, vec_block_v], input_dtype)
+
+            pred_vec = T.alloc_ub([vec_block_v], accum_dtype)
+            pred_1d = T.alloc_ub([1, vec_block_v], accum_dtype)
+            delta_vec = T.alloc_ub([vec_block_v], accum_dtype)
+            delta_1d = T.alloc_ub([1, vec_block_v], accum_dtype)
+            o_half_buf = T.alloc_ub([2, vec_block_v], input_dtype)
+
+            scalar_fp32 = T.alloc_ub([1], accum_dtype)
+            scalar_fp16 = T.alloc_ub([1], input_dtype)
+            scalar2_fp32 = T.alloc_ub([1], accum_dtype)
+            scalar2_fp16 = T.alloc_ub([1], input_dtype)
+            softplus_val = T.alloc_ub([1], accum_dtype)
+            alpha_val = T.alloc_ub([1], accum_dtype)
+
+            norm_sq = T.alloc_ub([1, dk], accum_dtype)
+            norm_val = T.alloc_ub([1], accum_dtype)
+
+            for work_i in T.serial(max_work_per_block):
+                if work_i < count_work:
+                    flat_idx = start_work + work_i
+                    v_tile_idx = flat_idx % num_v_tiles
+                    v_head_idx = (flat_idx // num_v_tiles) % nv
+                    seq_idx = flat_idx // (num_v_tiles * nv)
+
+                    k_head_idx = v_head_idx // v_per_k
+                    v_offset = v_tile_idx * block_v + vid * vec_block_v
+
+                    seq_start = cu_seqlens[seq_idx]
+                    seq_end = cu_seqlens[seq_idx + 1]
+                    seq_len = seq_end - seq_start
+
+                    state_idx = ssm_state_indices[seq_idx]
+                    T.tile.fill(h_vec, 0.0)
+                    T.barrier_all()
+                    if state_idx >= 0:
+                        T.copy(
+                            init_state[
+                                state_idx,
+                                v_head_idx,
+                                :,
+                                v_offset : v_offset + vec_block_v,
+                            ],
+                            # h_load_vec,
+                            h_vec
+                        )
+                        # T.set_flag("mte2", "v", 1)
+                        # T.wait_flag("mte2", "v", 1)
+                        # T.tile.cast(h_vec, h_load_vec, "CAST_NONE", vec_block_v * dk)
+                        T.barrier_all()
+
+                    T.copy(A_log[v_head_idx : v_head_idx + 1], scalar_fp32)
+                    T.set_flag("mte2", "v", 2)
+                    T.wait_flag("mte2", "v", 2)
+                    T.tile.exp(softplus_val, scalar_fp32)
+                    exp_A = softplus_val[0]
+
+                    T.set_flag("v", "mte2", 3)
+                    T.wait_flag("v", "mte2", 3)
+                    T.copy(dt_bias[v_head_idx : v_head_idx + 1], scalar_fp32)
+                    T.set_flag("mte2", "v", 4)
+                    T.wait_flag("mte2", "v", 4)
+                    dt_val = scalar_fp32[0]
+
+                    if seq_len > 0:
+                        q_offset = seq_start * query_stride_t + k_head_idx * dk
+                        k_offset = seq_start * key_stride_t + k_head_idx * dk
+                        v_offset_gm = (
+                            seq_start * value_stride_t + v_head_idx * dv + v_offset
+                        )
+                        T.copy(query[0, q_offset], q_buf[0, :])
+                        T.copy(key[0, k_offset], k_buf[0, :])
+                        T.copy(
+                            value[0, v_offset_gm],
+                            v_buf[0, :],
+                        )
+                        T.set_flag("mte2", "v", 6)
+
+                    for t in T.serial(seq_len):
+                        token_idx = seq_start + t
+                        buf_idx = t % 2
+
+                        T.wait_flag("mte2", "v", 6)
+
+                        T.copy(a[token_idx, v_head_idx : v_head_idx + 1], scalar_fp16)
+                        T.copy(
+                            beta[token_idx, v_head_idx : v_head_idx + 1], scalar2_fp16
+                        )
+                        T.set_flag("mte2", "v", 5)
+                        T.wait_flag("mte2", "v", 5)
+                        T.tile.cast(scalar_fp32, scalar_fp16, "CAST_NONE", 1)
+                        T.tile.cast(scalar2_fp32, scalar2_fp16, "CAST_NONE", 1)
+                        a_val = scalar_fp32[0]
+                        b_val = scalar2_fp32[0]
+
+                        x = a_val + dt_val
+                        beta_x = x * softplus_beta
+
+                        if beta_x > softplus_threshold:
+                            softplus_val[0] = x
+                        else:
+                            scalar_fp32[0] = beta_x
+                            T.tile.exp(alpha_val, scalar_fp32)
+                            T.tile.add(alpha_val, alpha_val, 1.0)
+                            T.tile.ln(alpha_val, alpha_val)
+                            softplus_val[0] = alpha_val[0] * inv_beta
+
+                        scalar_fp32[0] = -exp_A * softplus_val[0]
+                        T.tile.exp(alpha_val, scalar_fp32)
+
+                        scalar_fp32[0] = b_val
+                        T.tile.sigmoid(scalar_fp32, scalar_fp32)
+                        beta_gate_scalar = scalar_fp32[0]
+
+                        T.tile.cast(q_f, q_buf[buf_idx, :], "CAST_NONE", dk)
+                        T.tile.cast(k_f, k_buf[buf_idx, :], "CAST_NONE", dk)
+                        T.tile.cast(v_f, v_buf[buf_idx, :], "CAST_NONE", vec_block_v)
+
+                        if t + 1 < seq_len:
+                            next_token_idx = seq_start + t + 1
+                            next_buf_idx = (t + 1) % 2
+                            q_offset = (
+                                next_token_idx * query_stride_t + k_head_idx * dk
+                            )
+                            k_offset = (
+                                next_token_idx * key_stride_t + k_head_idx * dk
+                            )
+                            v_offset_gm = (
+                                next_token_idx * value_stride_t
+                                + v_head_idx * dv
+                                + v_offset
+                            )
+                            T.copy(query[0, q_offset], q_buf[next_buf_idx, :])
+                            T.copy(key[0, k_offset], k_buf[next_buf_idx, :])
+                            T.copy(value[0, v_offset_gm], v_buf[next_buf_idx, :])
+                            T.set_flag("mte2", "v", 6)
+
+                        if use_qk_l2norm:
+                            T.tile.mul(norm_sq[0, :], q_f, q_f)
+                            T.reduce_sum(norm_sq, norm_val, dim=-1)
+                            T.tile.add(norm_val, norm_val, L2_NORM_EPS)
+                            T.tile.sqrt(norm_val, norm_val)
+                            norm_scalar = norm_val[0]
+                            T.tile.div(q_f, q_f, norm_scalar)
+
+                            T.tile.mul(norm_sq[0, :], k_f, k_f)
+                            T.reduce_sum(norm_sq, norm_val, dim=-1)
+                            T.tile.add(norm_val, norm_val, L2_NORM_EPS)
+                            T.tile.sqrt(norm_val, norm_val)
+                            norm_scalar = norm_val[0]
+                            T.tile.div(k_f, k_f, norm_scalar)
+
+                        T.tile.mul(q_f, q_f, scale)
+
+                        T.tile.mul(h_vec, h_vec, alpha_val[0])
+
+                        T.copy(k_f, k_1d[:, 0])
+                        T.tile.broadcast(k_broadcasted, k_1d)
+                        T.tile.mul(compute_buffer, h_vec, k_broadcasted)
+                        T.reduce_sum(compute_buffer, pred_1d[0, :], dim=0)
+                        T.copy(pred_1d[0, :], pred_vec)
+
+                        T.tile.sub(delta_vec, v_f, pred_vec)
+                        T.tile.mul(delta_vec, delta_vec, beta_gate_scalar)
+
+                        T.copy(delta_vec, delta_1d[0, :])
+                        T.tile.broadcast(compute_buffer, delta_1d)
+                        T.tile.mul_add_dst(h_vec, k_broadcasted, compute_buffer)
+
+                        T.copy(q_f, k_1d[:, 0])
+                        T.tile.broadcast(k_broadcasted, k_1d)
+                        T.tile.mul(compute_buffer, h_vec, k_broadcasted)
+                        T.reduce_sum(compute_buffer, pred_1d[0, :], dim=0)
+                        T.tile.cast(
+                            o_half_buf[buf_idx, :],
+                            pred_1d[0, :],
+                            "CAST_RINT",
+                            vec_block_v,
+                        )
+
+                        T.set_flag("v", "mte3", 0)
+                        T.wait_flag("v", "mte3", 0)
+                        T.copy(
+                            o_half_buf[buf_idx, :],
+                            out[
+                                token_idx, v_head_idx, v_offset : v_offset + vec_block_v
+                            ],
+                        )
+
+                    T.set_flag("v", "mte3", 5)
+                    T.wait_flag("v", "mte3", 5)
+                    if state_idx >= 0:
+                        T.copy(
+                            h_vec,
+                            final_state[
+                                state_idx,
+                                v_head_idx,
+                                :,
+                                v_offset : v_offset + vec_block_v,
+                            ],
+                        )
+                    T.set_flag("mte3", "v", 6)
+                    T.wait_flag("mte3", "v", 6)
+
+    return main
+
+
+@tilelang.jit(out_idx=[10, 11], pass_configs=_SIGMOID_PASS_CONFIGS)
+def fused_sigmoid_gating_delta_rule_kernel_jit(
+    nk: int,
+    nv: int,
+    dk: int,
+    dv: int,
+    block_v: int,
+    max_num_seqs: int,
+    use_qk_l2norm: int,
+    softplus_beta: float,
+    dtype: str,
+    accum_dtype: str,
+):
+    return build_fused_sigmoid_gating_delta_rule_kernel(
+        nk=nk,
+        nv=nv,
+        dk=dk,
+        dv=dv,
+        block_v=block_v,
+        max_num_seqs=max_num_seqs,
+        use_qk_l2norm=bool(use_qk_l2norm),
+        softplus_beta=softplus_beta,
+        dtype=dtype,
+        accum_dtype=accum_dtype,
+        num_cores=DEFAULT_NUM_CORES,
+    )
+
+
+@register_kernel
+class FusedSigmoidGatingDeltaRuleKernel(TilelangKernel):
+    DISPATCH_SCHEMA = [
+        DispatchField("max_num_seqs", "int32"),
+        DispatchField("nk", "int32"),
+        DispatchField("nv", "int32"),
+        DispatchField("dk", "int32"),
+        DispatchField("dv", "int32"),
+        DispatchField("block_v", "int32"),
+        DispatchField("use_qk_l2norm", "int32"),
+        DispatchField("dtype", "dtype"),
+    ]
+    SPECIALIZATIONS = [
+        {
+            "variant_key": (
+                f"ns{num_seqs}_nk{nk}_nv{nv}_dk{dk}_dv{dv}"
+                f"_bv{block_v}_l2{int(use_qk_l2norm)}_bf16"
+            ),
+            "max_num_seqs": num_seqs,
+            "nk": nk,
+            "nv": nv,
+            "dk": dk,
+            "dv": dv,
+            "block_v": block_v,
+            "use_qk_l2norm": int(use_qk_l2norm),
+            "dtype": DEFAULT_DTYPE,
+        }
+        for num_seqs in NUM_SEQS_SPECIALIZATIONS
+        for nk, nv, dk, dv, use_qk_l2norm in sorted(
+            {
+                (nk // tp, nv // tp, dk, dv, use_qk_l2norm)
+                for nk, nv, dk, dv, use_qk_l2norm in [
+                    (16, 16, 128, 128, True),
+                    (16, 32, 128, 128, True),
+                    (16, 48, 128, 128, True),
+                    (16, 64, 128, 128, True),
+                ]
+                for tp in [1, 2, 4, 8]
+                if nk % tp == 0 and nv % tp == 0
+            }
+        )
+        for block_v in [_auto_block_v(dv)]
+    ]
+
+    @staticmethod
+    def generate_source(
+        max_num_seqs: int,
+        nk: int,
+        nv: int,
+        dk: int,
+        dv: int,
+        block_v: int,
+        use_qk_l2norm: int,
+        dtype: str,
+    ) -> str:
+        if dtype != DEFAULT_DTYPE:
+            raise ValueError(
+                f"fused_sigmoid_gating_delta_rule only supports dtype={DEFAULT_DTYPE}, "
+                f"got {dtype}"
+            )
+        tilelang.disable_cache()
+        tilelang_kernel = build_fused_sigmoid_gating_delta_rule_kernel(
+            nk=nk,
+            nv=nv,
+            dk=dk,
+            dv=dv,
+            block_v=block_v,
+            max_num_seqs=max_num_seqs,
+            use_qk_l2norm=bool(use_qk_l2norm),
+            softplus_beta=DEFAULT_SOFTPLUS_BETA,
+            dtype=dtype,
+            accum_dtype=DEFAULT_ACCUM_DTYPE,
+            num_cores=DEFAULT_NUM_CORES,
+        )
+        with tilelang.tvm.transform.PassContext(
+            opt_level=3, config=_SIGMOID_PASS_CONFIGS
+        ):
+            kernel = tilelang.engine.lower(tilelang_kernel)
+        return kernel.kernel_source
+
+
+def golden(
+    A_log,
+    a,
+    dt_bias,
+    query,
+    key,
+    value,
+    beta,
+    init_state,
+    ssm_state_indices,
+    cu_seqlens,
+    scale=None,
+    use_qk_l2norm=True,
+    softplus_beta=1.0,
+):
+    import torch
+
+    _, total_tokens, nk, dk = query.shape
+    _, _, nv, dv = value.shape
+    num_seqs = len(cu_seqlens) - 1
+    scale = dk**-0.5 if scale is None else scale
+    v_per_k = nv // nk
+
+    state = torch.zeros(
+        (num_seqs, nv, dk, dv), dtype=torch.float32, device=query.device
+    )
+    for i in range(num_seqs):
+        state_idx = ssm_state_indices[i].item()
+        if state_idx >= 0:
+            state[i] = init_state[state_idx].float().clone()
+    out = torch.empty(
+        (1, total_tokens, nv, dv), dtype=torch.float32, device=query.device
+    )
+
+    exp_A = torch.exp(A_log.float())
+    for seq_idx in range(num_seqs):
+        seq_start = cu_seqlens[seq_idx].item()
+        seq_end = cu_seqlens[seq_idx + 1].item()
+        for v_head_idx in range(nv):
+            h = state[seq_idx, v_head_idx]
+            k_head_idx = v_head_idx // v_per_k
+            for t in range(seq_end - seq_start):
+                token_idx = seq_start + t
+                q_t = query[0, token_idx, k_head_idx].float()
+                k_t = key[0, token_idx, k_head_idx].float()
+                v_t = value[0, token_idx, v_head_idx].float()
+
+                if use_qk_l2norm:
+                    q_t = q_t / torch.sqrt((q_t**2).sum() + L2_NORM_EPS)
+                    k_t = k_t / torch.sqrt((k_t**2).sum() + L2_NORM_EPS)
+
+                x = a[token_idx, v_head_idx].float() + dt_bias[v_head_idx].float()
+                beta_x = softplus_beta * x
+                if beta_x > 20:
+                    sp = x
+                else:
+                    sp = torch.log1p(torch.exp(beta_x)) / softplus_beta
+
+                h = h * torch.exp(-exp_A[v_head_idx] * sp)
+                pred = k_t @ h
+                h = h + torch.outer(
+                    k_t,
+                    (v_t - pred) * torch.sigmoid(beta[token_idx, v_head_idx].float()),
+                )
+                out[0, token_idx, v_head_idx] = (q_t * scale) @ h
+            state[seq_idx, v_head_idx] = h
+
+    return out.to(query.dtype), state.to(init_state.dtype)
+
+
+def main(
+    seqlens=None,
+    batch_size=1,
+    seq_len=256,
+    nk=DEFAULT_NK,
+    nv=DEFAULT_NV,
+    dk=DEFAULT_DK,
+    dv=DEFAULT_DV,
+    use_qk_l2norm=True,
+    softplus_beta=1.0,
+    block_v=None,
+):
+    import torch
+
+    torch.manual_seed(41)
+    device = "npu"
+
+    if seqlens:
+        total_tokens = sum(seqlens)
+        num_seqs = len(seqlens)
+        cu_seqlens_cpu = torch.tensor(
+            [0] + [sum(seqlens[: i + 1]) for i in range(num_seqs)], dtype=torch.int32
+        )
+        query_cpu = torch.randn((1, total_tokens, nk, dk), dtype=torch.float16)
+        key_cpu = torch.randn((1, total_tokens, nk, dk), dtype=torch.float16)
+        value_cpu = torch.randn((1, total_tokens, nv, dv), dtype=torch.float16)
+        a_cpu = torch.randn((total_tokens, nv), dtype=torch.float16)
+        beta_cpu = torch.randn((total_tokens, nv), dtype=torch.float16)
+    else:
+        total_tokens = batch_size * seq_len
+        num_seqs = batch_size
+        cu_seqlens_cpu = torch.arange(0, total_tokens + 1, seq_len, dtype=torch.int32)
+        query_cpu = torch.randn((batch_size, seq_len, nk, dk), dtype=torch.float16)
+        key_cpu = torch.randn((batch_size, seq_len, nk, dk), dtype=torch.float16)
+        value_cpu = torch.randn((batch_size, seq_len, nv, dv), dtype=torch.float16)
+        a_cpu = torch.randn((batch_size, seq_len, nv), dtype=torch.float16)
+        beta_cpu = torch.randn((batch_size, seq_len, nv), dtype=torch.float16)
+        query_cpu = query_cpu.reshape(1, total_tokens, nk, dk)
+        key_cpu = key_cpu.reshape(1, total_tokens, nk, dk)
+        value_cpu = value_cpu.reshape(1, total_tokens, nv, dv)
+        a_cpu = a_cpu.reshape(total_tokens, nv)
+        beta_cpu = beta_cpu.reshape(total_tokens, nv)
+
+    num_cache_slots = num_seqs * 10
+    init_state_cpu = torch.randn((num_cache_slots, nv, dk, dv), dtype=torch.bfloat16)
+    ssm_state_indices_cpu = torch.arange(num_seqs, dtype=torch.int32)
+    A_log_cpu = torch.randn((nv,), dtype=torch.float32)
+    dt_bias_cpu = torch.randn((nv,), dtype=torch.float32)
+
+    if block_v is None:
+        block_v = _auto_block_v(dv)
+
+    dtype_str = DEFAULT_DTYPE
+
+    ker = fused_sigmoid_gating_delta_rule_kernel_jit(
+        nk=nk,
+        nv=nv,
+        dk=dk,
+        dv=dv,
+        block_v=block_v,
+        max_num_seqs=num_seqs,
+        use_qk_l2norm=int(use_qk_l2norm),
+        softplus_beta=softplus_beta,
+        dtype=dtype_str,
+        accum_dtype=DEFAULT_ACCUM_DTYPE,
+    )
+
+    A_log = A_log_cpu.to(device)
+    a = a_cpu.to(device)
+    dt_bias = dt_bias_cpu.to(device)
+    query = query_cpu.squeeze(0).to(device)
+    key = key_cpu.squeeze(0).to(device)
+    value = value_cpu.squeeze(0).to(device)
+    beta = beta_cpu.to(device)
+    init_state = init_state_cpu.to(device)
+    ssm_state_indices = ssm_state_indices_cpu.to(device)
+    cu_seqlens = cu_seqlens_cpu.to(device)
+
+    out, final_state = ker(
+        A_log,
+        a,
+        dt_bias,
+        query.reshape(1, -1),
+        key.reshape(1, -1),
+        value.reshape(1, -1),
+        beta,
+        init_state,
+        ssm_state_indices,
+        cu_seqlens,
+        query.stride(0),
+        key.stride(0),
+        value.stride(0),
+    )
+    out = out[:total_tokens].unsqueeze(0)
+    final_state = final_state[:num_seqs]
+
+    out_golden, final_state_golden = golden(
+        A_log_cpu,
+        a_cpu,
+        dt_bias_cpu,
+        query_cpu,
+        key_cpu,
+        value_cpu,
+        beta_cpu,
+        init_state_cpu,
+        ssm_state_indices_cpu,
+        cu_seqlens_cpu,
+        use_qk_l2norm=use_qk_l2norm,
+        softplus_beta=softplus_beta,
+    )
+
+    torch.testing.assert_close(out.cpu(), out_golden, rtol=2e-2, atol=2e-2)
+    torch.testing.assert_close(
+        final_state.cpu(), final_state_golden, rtol=2e-2, atol=2e-2
+    )
+    from scripts.logger import logger
+    logger.info("Kernel Output Match!")
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Generate TileLang AscendC source for fused_sigmoid_gating_delta_rule AOT kernel."
+    )
+    parser.add_argument(
+        "--output", type=Path, required=True, help="Output AscendC .cpp file"
+    )
+    parser.add_argument("--nk", type=int, default=DEFAULT_NK)
+    parser.add_argument("--nv", type=int, default=DEFAULT_NV)
+    parser.add_argument("--dk", type=int, default=DEFAULT_DK)
+    parser.add_argument("--dv", type=int, default=DEFAULT_DV)
+    parser.add_argument("--block-v", type=int, default=None)
+    parser.add_argument(
+        "--max-num-seqs", type=int, default=NUM_SEQS_SPECIALIZATIONS[-1]
+    )
+    parser.add_argument("--use-qk-l2norm", type=int, default=DEFAULT_USE_QK_L2NORM)
+    parser.add_argument("--dtype", type=str, default=DEFAULT_DTYPE)
+    parser.add_argument(
+        "--skip-ref-check",
+        action="store_true",
+        help="Skip runtime torch-reference check.",
+    )
+    return parser.parse_args()
+
+
+def main_cli() -> None:
+    args = parse_args()
+    block_v = args.block_v if args.block_v is not None else _auto_block_v(args.dv)
+    output = Path(args.output).resolve()
+    output.parent.mkdir(parents=True, exist_ok=True)
+    output.write_text(
+        FusedSigmoidGatingDeltaRuleKernel.generate_source(
+            max_num_seqs=args.max_num_seqs,
+            nk=args.nk,
+            nv=args.nv,
+            dk=args.dk,
+            dv=args.dv,
+            block_v=block_v,
+            use_qk_l2norm=args.use_qk_l2norm,
+            dtype=args.dtype,
+        ),
+        encoding="utf-8",
+    )
+
+    if not args.skip_ref_check:
+        main(
+            seqlens=[4, 8] * (REF_CHECK_NUM_SEQS // 2),
+            nk=args.nk,
+            nv=args.nv,
+            dk=args.dk,
+            dv=args.dv,
+            block_v=block_v,
+            use_qk_l2norm=bool(args.use_qk_l2norm),
+            softplus_beta=DEFAULT_SOFTPLUS_BETA,
+        )
+
+
+if __name__ == "__main__":
+    main_cli()

--- a/xllm/core/kernels/npu/tilelang/CMakeLists.txt
+++ b/xllm/core/kernels/npu/tilelang/CMakeLists.txt
@@ -152,6 +152,11 @@ tilelang_register_runtime_kernel(
   WRAPPER_SRCS causal_conv1d_wrapper.cpp
 )
 
+tilelang_register_runtime_kernel(
+  NAME fused_sigmoid_gating_delta_rule
+  WRAPPER_SRCS fused_sigmoid_gating_delta_rule_wrapper.cpp
+)
+
 cc_library(
   NAME
     tilelang_kernels

--- a/xllm/core/kernels/npu/tilelang/fused_sigmoid_gating_delta_rule_wrapper.cpp
+++ b/xllm/core/kernels/npu/tilelang/fused_sigmoid_gating_delta_rule_wrapper.cpp
@@ -1,0 +1,577 @@
+/* Copyright 2026 The xLLM Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://github.com/jd-opensource/xllm/blob/main/LICENSE
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include <c10/core/DeviceType.h>
+#include <glog/logging.h>
+#include <torch_npu/csrc/core/npu/NPUStream.h>
+#include <torch_npu/torch_npu.h>
+
+#include <algorithm>
+#include <cstdint>
+#include <limits>
+#include <tuple>
+#include <utility>
+
+#include "acl/acl.h"
+#include "core/kernels/npu/tilelang/dispatch_registry.h"
+#include "core/kernels/npu/tilelang/tilelang_ops_api.h"
+
+#ifndef XLLM_TL_FUSED_SIGMOID_GATING_DELTA_RULE_REGISTRY_INC
+#error "XLLM_TL_FUSED_SIGMOID_GATING_DELTA_RULE_REGISTRY_INC is not defined"
+#endif
+
+namespace xllm::kernel::npu::tilelang {
+namespace {
+
+constexpr int32_t kVEC_NUM = 2;
+constexpr int32_t kNSpecializationMin = 1;
+constexpr int32_t kNSpecializationStep = 1;
+constexpr int32_t kUseQkL2norm = 1;
+
+#include XLLM_TL_FUSED_SIGMOID_GATING_DELTA_RULE_REGISTRY_INC
+
+int32_t auto_block_v(int32_t dv) {
+  int32_t block_v = std::min(dv, 128);
+  if (block_v >= 32) {
+    block_v = (block_v / 32) * 32;
+  }
+  if (block_v < kVEC_NUM) {
+    block_v = (dv >= kVEC_NUM) ? kVEC_NUM : dv;
+  }
+  if (block_v % kVEC_NUM != 0) {
+    block_v = (block_v / kVEC_NUM) * kVEC_NUM;
+  }
+  while (block_v > 0 && dv % block_v != 0) {
+    block_v -= kVEC_NUM;
+  }
+  if (block_v <= 0) {
+    block_v = std::min(dv, kVEC_NUM);
+    if (block_v % kVEC_NUM != 0) {
+      block_v = (block_v / kVEC_NUM) * kVEC_NUM;
+    }
+  }
+  CHECK_GT(block_v, 0) << "TileLang fused_sigmoid_gating_delta_rule: "
+                       << "could not auto-derive block_v for dv=" << dv;
+  CHECK_LE(block_v, dv);
+  CHECK_EQ(block_v % kVEC_NUM, 0);
+  CHECK_EQ(dv % block_v, 0);
+  return block_v;
+}
+
+int32_t max_compiled_num_seqs(int32_t nk,
+                              int32_t nv,
+                              int32_t dk,
+                              int32_t dv,
+                              int32_t block_v,
+                              TilelangDType dtype) {
+  int32_t max_n = 0;
+  for (const auto& entry : kFusedSigmoidGatingDeltaRuleRegistry) {
+    const auto& spec = entry.spec;
+    if (spec.nk == nk && spec.nv == nv && spec.dk == dk && spec.dv == dv &&
+        spec.block_v == block_v && spec.use_qk_l2norm == kUseQkL2norm &&
+        spec.dtype == dtype) {
+      max_n = std::max(max_n, spec.max_num_seqs);
+    }
+  }
+  return max_n;
+}
+
+int32_t select_launch_num_seqs(int64_t actual_n,
+                               int32_t nk,
+                               int32_t nv,
+                               int32_t dk,
+                               int32_t dv,
+                               int32_t block_v,
+                               TilelangDType dtype) {
+  CHECK_GT(actual_n, 0)
+      << "TileLang fused_sigmoid_gating_delta_rule: actual_n must be > 0";
+  const int32_t max_n = max_compiled_num_seqs(nk, nv, dk, dv, block_v, dtype);
+  CHECK_GT(max_n, 0)
+      << "TileLang fused_sigmoid_gating_delta_rule: no compiled num_seqs "
+      << "variant for nk=" << nk << ", nv=" << nv << ", dk=" << dk
+      << ", dv=" << dv << ", dtype=" << static_cast<int>(dtype);
+  CHECK_GE(max_n, kNSpecializationMin)
+      << "TileLang fused_sigmoid_gating_delta_rule: compiled num_seqs "
+      << "variants must be >= " << kNSpecializationMin;
+  CHECK_LE(actual_n, static_cast<int64_t>(max_n))
+      << "TileLang fused_sigmoid_gating_delta_rule: actual_n=" << actual_n
+      << " exceeds max compiled num_seqs=" << max_n;
+
+  int64_t rounded_up =
+      ((actual_n + kNSpecializationStep - 1) / kNSpecializationStep) *
+      kNSpecializationStep;
+  rounded_up = std::max<int64_t>(rounded_up, kNSpecializationMin);
+  rounded_up = std::min<int64_t>(rounded_up, max_n);
+  return static_cast<int32_t>(rounded_up);
+}
+
+void check_supported(const torch::Tensor& A_log,
+                     const torch::Tensor& a,
+                     const torch::Tensor& dt_bias,
+                     const torch::Tensor& query,
+                     const torch::Tensor& key,
+                     const torch::Tensor& value,
+                     const torch::Tensor& beta,
+                     const torch::Tensor& init_state,
+                     const torch::Tensor& ssm_state_indices,
+                     const torch::Tensor& cu_seqlens) {
+  CHECK(A_log.defined())
+      << "TileLang fused_sigmoid_gating_delta_rule: A_log must be defined";
+  CHECK(a.defined())
+      << "TileLang fused_sigmoid_gating_delta_rule: a must be defined";
+  CHECK(dt_bias.defined())
+      << "TileLang fused_sigmoid_gating_delta_rule: dt_bias must be defined";
+  CHECK(query.defined())
+      << "TileLang fused_sigmoid_gating_delta_rule: query must be defined";
+  CHECK(key.defined())
+      << "TileLang fused_sigmoid_gating_delta_rule: key must be defined";
+  CHECK(value.defined())
+      << "TileLang fused_sigmoid_gating_delta_rule: value must be defined";
+  CHECK(beta.defined())
+      << "TileLang fused_sigmoid_gating_delta_rule: beta must be defined";
+  CHECK(init_state.defined())
+      << "TileLang fused_sigmoid_gating_delta_rule: init_state must be defined";
+  CHECK(ssm_state_indices.defined())
+      << "TileLang fused_sigmoid_gating_delta_rule: ssm_state_indices must be "
+         "defined";
+  CHECK(cu_seqlens.defined())
+      << "TileLang fused_sigmoid_gating_delta_rule: cu_seqlens must be defined";
+
+  CHECK(A_log.device().type() == c10::DeviceType::PrivateUse1 &&
+        a.device().type() == c10::DeviceType::PrivateUse1 &&
+        dt_bias.device().type() == c10::DeviceType::PrivateUse1 &&
+        query.device().type() == c10::DeviceType::PrivateUse1 &&
+        key.device().type() == c10::DeviceType::PrivateUse1 &&
+        value.device().type() == c10::DeviceType::PrivateUse1 &&
+        beta.device().type() == c10::DeviceType::PrivateUse1 &&
+        init_state.device().type() == c10::DeviceType::PrivateUse1 &&
+        ssm_state_indices.device().type() == c10::DeviceType::PrivateUse1 &&
+        cu_seqlens.device().type() == c10::DeviceType::PrivateUse1)
+      << "TileLang fused_sigmoid_gating_delta_rule: all tensors must be on NPU";
+
+  CHECK_EQ(A_log.dim(), 1)
+      << "TileLang fused_sigmoid_gating_delta_rule: A_log must be 1D [nv]";
+  CHECK_EQ(dt_bias.dim(), 1)
+      << "TileLang fused_sigmoid_gating_delta_rule: dt_bias must be 1D [nv]";
+  CHECK_EQ(a.dim(), 2)
+      << "TileLang fused_sigmoid_gating_delta_rule: a must be 2D [T, nv]";
+  CHECK_EQ(beta.dim(), 2)
+      << "TileLang fused_sigmoid_gating_delta_rule: beta must be 2D [T, nv]";
+  CHECK_EQ(a.sizes(), beta.sizes())
+      << "TileLang fused_sigmoid_gating_delta_rule: a/beta shape mismatch";
+
+  CHECK_EQ(query.dim(), 3)
+      << "TileLang fused_sigmoid_gating_delta_rule: query must be 3D [T, nk, "
+         "dk]";
+  CHECK_EQ(key.dim(), 3)
+      << "TileLang fused_sigmoid_gating_delta_rule: key must be 3D [T, nk, dk]";
+  CHECK_EQ(query.sizes(), key.sizes())
+      << "TileLang fused_sigmoid_gating_delta_rule: query/key shape mismatch";
+
+  CHECK_EQ(value.dim(), 3)
+      << "TileLang fused_sigmoid_gating_delta_rule: value must be 3D [T, nv, "
+         "dv]";
+  CHECK_EQ(value.size(0), query.size(0))
+      << "TileLang fused_sigmoid_gating_delta_rule: token dim mismatch between "
+         "value and query";
+
+  const int64_t nv = value.size(1);
+  const int64_t nk = query.size(1);
+  const int64_t dk = query.size(2);
+  const int64_t dv = value.size(2);
+
+  CHECK_EQ(A_log.size(0), nv)
+      << "TileLang fused_sigmoid_gating_delta_rule: A_log head size mismatch";
+  CHECK_EQ(dt_bias.size(0), nv)
+      << "TileLang fused_sigmoid_gating_delta_rule: dt_bias head size mismatch";
+  CHECK_EQ(a.size(1), nv)
+      << "TileLang fused_sigmoid_gating_delta_rule: a head size mismatch";
+  CHECK_EQ(beta.size(1), nv)
+      << "TileLang fused_sigmoid_gating_delta_rule: beta head size mismatch";
+  CHECK_EQ(nv % nk, 0)
+      << "TileLang fused_sigmoid_gating_delta_rule: nv must be divisible by nk";
+  CHECK_GT(nk, 0);
+  CHECK_GT(nv, 0);
+  CHECK_GT(dk, 0);
+  CHECK_GT(dv, 0);
+
+  CHECK_EQ(init_state.dim(), 4)
+      << "TileLang fused_sigmoid_gating_delta_rule: init_state must be 4D [C, "
+         "nv, dk, dv]";
+  CHECK_EQ(init_state.size(1), nv);
+  CHECK_EQ(init_state.size(2), dk);
+  CHECK_EQ(init_state.size(3), dv);
+
+  CHECK_EQ(ssm_state_indices.dim(), 1)
+      << "TileLang fused_sigmoid_gating_delta_rule: ssm_state_indices must be "
+         "1D";
+  CHECK_EQ(cu_seqlens.dim(), 1)
+      << "TileLang fused_sigmoid_gating_delta_rule: cu_seqlens must be 1D";
+  CHECK_EQ(ssm_state_indices.size(0), cu_seqlens.size(0) - 1)
+      << "TileLang fused_sigmoid_gating_delta_rule: ssm_state_indices / "
+         "cu_seqlens length mismatch";
+
+  CHECK_EQ(ssm_state_indices.scalar_type(), torch::kInt32);
+  CHECK_EQ(cu_seqlens.scalar_type(), torch::kInt32);
+
+  CHECK_EQ(a.scalar_type(), torch::kBFloat16)
+      << "TileLang fused_sigmoid_gating_delta_rule: a/q/k/v/beta must be bf16";
+  CHECK_EQ(A_log.dtype(), torch::kFloat32)
+      << "TileLang fused_sigmoid_gating_delta_rule: A_log must be float32";
+  CHECK_EQ(dt_bias.dtype(), torch::kFloat32)
+      << "TileLang fused_sigmoid_gating_delta_rule: dt_bias must be float32";
+  CHECK(init_state.scalar_type() == torch::kFloat32 ||
+        init_state.scalar_type() == torch::kBFloat16)
+      << "TileLang fused_sigmoid_gating_delta_rule: init_state must be float32 "
+         "or bf16";
+  CHECK_EQ(a.dtype(), query.dtype());
+  CHECK_EQ(a.dtype(), key.dtype());
+  CHECK_EQ(a.dtype(), value.dtype());
+  CHECK_EQ(a.dtype(), beta.dtype());
+
+  CHECK(A_log.is_contiguous());
+  CHECK(dt_bias.is_contiguous());
+  CHECK(ssm_state_indices.is_contiguous());
+  CHECK(cu_seqlens.is_contiguous());
+
+  CHECK_EQ(a.stride(1), 1);
+  CHECK_EQ(a.stride(0), a.size(1));
+  CHECK_EQ(beta.stride(1), 1);
+  CHECK_EQ(beta.stride(0), beta.size(1));
+
+  CHECK_EQ(query.stride(2), 1);
+  CHECK_EQ(query.stride(1), dk);
+  CHECK_EQ(key.stride(2), 1);
+  CHECK_EQ(key.stride(1), dk);
+  CHECK_EQ(value.stride(2), 1);
+  CHECK_EQ(value.stride(1), dv);
+
+  CHECK_EQ(init_state.stride(3), 1);
+  CHECK_EQ(init_state.stride(2), dv);
+  CHECK_EQ(init_state.stride(1), dk * dv);
+  CHECK_EQ(a.size(0), query.size(0))
+      << "TileLang fused_sigmoid_gating_delta_rule: a/query token dim mismatch";
+  CHECK_EQ(beta.size(0), query.size(0))
+      << "TileLang fused_sigmoid_gating_delta_rule: beta/query token dim "
+         "mismatch";
+}
+
+FusedSigmoidGatingDeltaRuleSpecialization build_runtime_specialization(
+    int32_t compiled_num_seqs,
+    const torch::Tensor& query,
+    const torch::Tensor& value) {
+  CHECK_EQ(query.dim(), 3);
+  CHECK_EQ(value.dim(), 3);
+  const int32_t nk = static_cast<int32_t>(query.size(1));
+  const int32_t nv = static_cast<int32_t>(value.size(1));
+  const int32_t dk = static_cast<int32_t>(query.size(2));
+  const int32_t dv = static_cast<int32_t>(value.size(2));
+  const int32_t block_v = auto_block_v(dv);
+  const TilelangDType dtype = to_tilelang_dtype(query.scalar_type());
+
+  return make_fused_sigmoid_gating_delta_rule_specialization(
+      FusedSigmoidGatingDeltaRuleMaxNumSeqs{compiled_num_seqs},
+      FusedSigmoidGatingDeltaRuleNk{nk},
+      FusedSigmoidGatingDeltaRuleNv{nv},
+      FusedSigmoidGatingDeltaRuleDk{dk},
+      FusedSigmoidGatingDeltaRuleDv{dv},
+      FusedSigmoidGatingDeltaRuleBlockV{block_v},
+      FusedSigmoidGatingDeltaRuleUseQkL2norm{kUseQkL2norm},
+      FusedSigmoidGatingDeltaRuleDType{dtype});
+}
+
+const auto* find_entry_with_fallback(
+    FusedSigmoidGatingDeltaRuleSpecialization specialization) {
+  const auto* entry =
+      find_fused_sigmoid_gating_delta_rule_kernel_entry(specialization);
+  if (entry != nullptr) {
+    return entry;
+  }
+  int32_t fallback_n = specialization.max_num_seqs - kNSpecializationStep;
+  while (fallback_n >= kNSpecializationMin && entry == nullptr) {
+    specialization = make_fused_sigmoid_gating_delta_rule_specialization(
+        FusedSigmoidGatingDeltaRuleMaxNumSeqs{fallback_n},
+        FusedSigmoidGatingDeltaRuleNk{specialization.nk},
+        FusedSigmoidGatingDeltaRuleNv{specialization.nv},
+        FusedSigmoidGatingDeltaRuleDk{specialization.dk},
+        FusedSigmoidGatingDeltaRuleDv{specialization.dv},
+        FusedSigmoidGatingDeltaRuleBlockV{specialization.block_v},
+        FusedSigmoidGatingDeltaRuleUseQkL2norm{specialization.use_qk_l2norm},
+        FusedSigmoidGatingDeltaRuleDType{specialization.dtype});
+    entry = find_fused_sigmoid_gating_delta_rule_kernel_entry(specialization);
+    fallback_n -= kNSpecializationStep;
+  }
+  return entry;
+}
+
+int32_t checked_i32_stride(int64_t stride,
+                           int64_t max_stride,
+                           const char* name) {
+  CHECK_GT(stride, 0) << "TileLang fused_sigmoid_gating_delta_rule: " << name
+                      << " must be positive";
+  CHECK_LE(stride, max_stride)
+      << "TileLang fused_sigmoid_gating_delta_rule: " << name
+      << " exceeds supported qkv token stride";
+  CHECK_LE(stride, static_cast<int64_t>(std::numeric_limits<int32_t>::max()))
+      << "TileLang fused_sigmoid_gating_delta_rule: " << name
+      << " exceeds int32";
+  return static_cast<int32_t>(stride);
+}
+
+void launch_tilelang_fused_sigmoid_gating_delta_rule(
+    const torch::Tensor& A_log,
+    const torch::Tensor& a,
+    const torch::Tensor& dt_bias,
+    const torch::Tensor& query,
+    const torch::Tensor& key,
+    const torch::Tensor& value,
+    const torch::Tensor& beta,
+    const torch::Tensor& init_state_accum,
+    const torch::Tensor& ssm_state_indices,
+    const torch::Tensor& cu_seqlens,
+    const torch::Tensor& out,
+    const torch::Tensor& final_state,
+    int32_t query_stride_t,
+    int32_t key_stride_t,
+    int32_t value_stride_t,
+    float softplus_beta,
+    float scale,
+    bool use_qk_l2norm,
+    float softplus_threshold) {
+  const int64_t actual_n = ssm_state_indices.size(0);
+  CHECK_GT(actual_n, 0)
+      << "TileLang fused_sigmoid_gating_delta_rule: actual_n must be > 0";
+  CHECK_EQ(cu_seqlens.size(0), actual_n + 1)
+      << "TileLang fused_sigmoid_gating_delta_rule: chunked cu_seqlens length "
+      << "mismatch";
+
+  const int32_t nk = static_cast<int32_t>(query.size(1));
+  const int32_t nv = static_cast<int32_t>(value.size(1));
+  const int32_t dk = static_cast<int32_t>(query.size(2));
+  const int32_t dv = static_cast<int32_t>(value.size(2));
+  const int32_t block_v = auto_block_v(dv);
+  const TilelangDType dtype = to_tilelang_dtype(query.scalar_type());
+  const int32_t compiled_n =
+      select_launch_num_seqs(actual_n, nk, nv, dk, dv, block_v, dtype);
+
+  // Pad per-launch metadata to the compiled num_seqs. The cu_seqlens values are
+  // absolute token offsets into the full q/k/v/out tensors, so chunks do not
+  // need q/k/v copies or token-offset rebasing.
+  torch::Tensor indices_prepared;
+  if (static_cast<int64_t>(compiled_n) > actual_n) {
+    indices_prepared = torch::empty({compiled_n}, ssm_state_indices.options());
+    indices_prepared.narrow(0, 0, actual_n).copy_(ssm_state_indices);
+    indices_prepared.narrow(0, actual_n, compiled_n - actual_n).fill_(-1);
+  } else {
+    indices_prepared = ssm_state_indices;
+  }
+
+  torch::Tensor cu_prepared;
+  if (static_cast<int64_t>(compiled_n) > actual_n) {
+    cu_prepared = torch::empty({compiled_n + 1}, cu_seqlens.options());
+    cu_prepared.narrow(0, 0, actual_n + 1).copy_(cu_seqlens);
+    const int64_t num_dummy = compiled_n - actual_n;
+    cu_prepared.narrow(0, actual_n + 1, num_dummy)
+        .copy_(cu_seqlens.narrow(0, actual_n, 1).expand({num_dummy}));
+  } else {
+    cu_prepared = cu_seqlens;
+  }
+
+  auto specialization = build_runtime_specialization(compiled_n, query, value);
+  const auto* entry = find_entry_with_fallback(specialization);
+  CHECK(entry != nullptr)
+      << "TileLang fused_sigmoid_gating_delta_rule: no compiled variant. "
+      << "Available variants: "
+      << available_fused_sigmoid_gating_delta_rule_variant_keys();
+  CHECK_GE(entry->spec.max_num_seqs, actual_n)
+      << "TileLang fused_sigmoid_gating_delta_rule: selected compiled "
+      << "num_seqs=" << entry->spec.max_num_seqs
+      << " is smaller than actual_n=" << actual_n;
+
+  const int32_t device_id = query.device().index();
+  aclrtStream stream = c10_npu::getCurrentNPUStream(device_id).stream();
+
+  entry->fn(static_cast<uint8_t*>(A_log.data_ptr()),
+            static_cast<uint8_t*>(a.data_ptr()),
+            static_cast<uint8_t*>(dt_bias.data_ptr()),
+            static_cast<uint8_t*>(query.data_ptr()),
+            static_cast<uint8_t*>(key.data_ptr()),
+            static_cast<uint8_t*>(value.data_ptr()),
+            static_cast<uint8_t*>(beta.data_ptr()),
+            static_cast<uint8_t*>(init_state_accum.data_ptr()),
+            static_cast<uint8_t*>(indices_prepared.data_ptr()),
+            static_cast<uint8_t*>(cu_prepared.data_ptr()),
+            static_cast<uint8_t*>(out.data_ptr()),
+            static_cast<uint8_t*>(final_state.data_ptr()),
+            softplus_beta,
+            scale,
+            static_cast<int32_t>(use_qk_l2norm ? 1 : 0),
+            softplus_threshold,
+            query_stride_t,
+            key_stride_t,
+            value_stride_t,
+            static_cast<int32_t>(query.size(0)),
+            static_cast<int32_t>(init_state_accum.size(0)),
+            stream);
+}
+
+std::tuple<torch::Tensor, torch::Tensor>
+run_tilelang_fused_sigmoid_gating_delta_rule(
+    const torch::Tensor& A_log,
+    const torch::Tensor& a,
+    const torch::Tensor& dt_bias,
+    const torch::Tensor& query,
+    const torch::Tensor& key,
+    const torch::Tensor& value,
+    const torch::Tensor& beta,
+    const torch::Tensor& init_state,
+    const torch::Tensor& ssm_state_indices,
+    const torch::Tensor& cu_seqlens,
+    float softplus_beta,
+    float scale,
+    bool use_qk_l2norm,
+    float softplus_threshold) {
+  const int64_t actual_n = ssm_state_indices.size(0);
+  CHECK_GT(actual_n, 0)
+      << "TileLang fused_sigmoid_gating_delta_rule: actual_n must be > 0";
+
+  const int32_t nk = static_cast<int32_t>(query.size(1));
+  const int32_t nv = static_cast<int32_t>(value.size(1));
+  const int32_t dk = static_cast<int32_t>(query.size(2));
+  const int32_t dv = static_cast<int32_t>(value.size(2));
+  const int32_t block_v = auto_block_v(dv);
+  const TilelangDType dtype = to_tilelang_dtype(query.scalar_type());
+  const int32_t max_compiled_n =
+      max_compiled_num_seqs(nk, nv, dk, dv, block_v, dtype);
+  CHECK_GT(max_compiled_n, 0)
+      << "TileLang fused_sigmoid_gating_delta_rule: no compiled num_seqs "
+      << "variant for nk=" << nk << ", nv=" << nv << ", dk=" << dk
+      << ", dv=" << dv << ", dtype=" << static_cast<int>(dtype);
+  const int64_t max_qkv_token_stride =
+      static_cast<int64_t>(2) * nk * dk + static_cast<int64_t>(nv) * dv;
+  const int32_t query_stride_t = checked_i32_stride(
+      query.stride(0), max_qkv_token_stride, "query stride(0)");
+  const int32_t key_stride_t =
+      checked_i32_stride(key.stride(0), max_qkv_token_stride, "key stride(0)");
+  const int32_t value_stride_t = checked_i32_stride(
+      value.stride(0), max_qkv_token_stride, "value stride(0)");
+
+  const auto options = query.options();
+  const auto init_state_accum = init_state.scalar_type() == torch::kFloat32
+                                    ? init_state
+                                    : init_state.to(torch::kFloat32);
+
+  auto out = torch::empty({query.size(0), nv, dv}, options);
+  auto final_state = init_state_accum;
+  CHECK_EQ(out.stride(2), 1);
+  CHECK_EQ(out.stride(1), dv);
+  CHECK_EQ(final_state.stride(3), 1);
+  CHECK_EQ(final_state.stride(2), dv);
+  CHECK_EQ(final_state.stride(1), dk * dv);
+
+  for (int64_t seq_start = 0; seq_start < actual_n;
+       seq_start += max_compiled_n) {
+    const int64_t chunk_n =
+        std::min<int64_t>(max_compiled_n, actual_n - seq_start);
+    auto indices_chunk =
+        ssm_state_indices.narrow(0, seq_start, chunk_n).contiguous();
+    auto cu_chunk = cu_seqlens.narrow(0, seq_start, chunk_n + 1).contiguous();
+    launch_tilelang_fused_sigmoid_gating_delta_rule(A_log,
+                                                    a,
+                                                    dt_bias,
+                                                    query,
+                                                    key,
+                                                    value,
+                                                    beta,
+                                                    init_state_accum,
+                                                    indices_chunk,
+                                                    cu_chunk,
+                                                    out,
+                                                    final_state,
+                                                    query_stride_t,
+                                                    key_stride_t,
+                                                    value_stride_t,
+                                                    softplus_beta,
+                                                    scale,
+                                                    use_qk_l2norm,
+                                                    softplus_threshold);
+  }
+
+  if (init_state.scalar_type() != torch::kFloat32) {
+    // The update API only returns out, so a fp32 accumulation copy must be
+    // written back to the original bf16 cache before returning.
+    auto valid_indices_i32 =
+        ssm_state_indices.masked_select(ssm_state_indices.ge(0));
+    if (valid_indices_i32.numel() > 0) {
+      auto valid_indices = valid_indices_i32.to(torch::kLong);
+      auto updated_state = final_state.index_select(0, valid_indices)
+                               .to(init_state.scalar_type());
+      init_state.index_put_({valid_indices}, updated_state);
+    }
+  }
+
+  auto final_state_sliced = final_state.narrow(0, 0, actual_n);
+  return {out, final_state_sliced};
+}
+
+}  // namespace
+
+std::tuple<torch::Tensor, torch::Tensor> fused_sigmoid_gating_delta_rule(
+    const torch::Tensor& A_log,
+    const torch::Tensor& a,
+    const torch::Tensor& dt_bias,
+    const torch::Tensor& query,
+    const torch::Tensor& key,
+    const torch::Tensor& value,
+    const torch::Tensor& beta,
+    const torch::Tensor& init_state,
+    const torch::Tensor& ssm_state_indices,
+    const torch::Tensor& cu_seqlens,
+    std::optional<float> scale,
+    bool use_qk_l2norm_in_kernel,
+    float softplus_beta,
+    float softplus_threshold) {
+  check_supported(A_log,
+                  a,
+                  dt_bias,
+                  query,
+                  key,
+                  value,
+                  beta,
+                  init_state,
+                  ssm_state_indices,
+                  cu_seqlens);
+
+  const float runtime_scale =
+      scale.has_value() ? scale.value()
+                        : 1.0f / std::sqrt(static_cast<float>(query.size(2)));
+
+  return run_tilelang_fused_sigmoid_gating_delta_rule(A_log,
+                                                      a,
+                                                      dt_bias,
+                                                      query,
+                                                      key,
+                                                      value,
+                                                      beta,
+                                                      init_state,
+                                                      ssm_state_indices,
+                                                      cu_seqlens,
+                                                      softplus_beta,
+                                                      runtime_scale,
+                                                      use_qk_l2norm_in_kernel,
+                                                      softplus_threshold);
+}
+
+}  // namespace xllm::kernel::npu::tilelang

--- a/xllm/core/kernels/npu/tilelang/tilelang_ops_api.h
+++ b/xllm/core/kernels/npu/tilelang/tilelang_ops_api.h
@@ -143,4 +143,25 @@ torch::Tensor causal_conv1d(torch::Tensor& conv_state,
                             const torch::Tensor& initial_state_mode,
                             bool has_silu);
 
+// Run fused sigmoid-gating delta-rule SSM scan on NPU.
+// Returns (out, final_state).
+//   out: [T_padded, nv, dv] (padded token dim; caller strips padding)
+//   final_state: [num_seqs, nv, dk, dv], float32 accumulator state
+// Invalid inputs trigger CHECK failures.
+std::tuple<torch::Tensor, torch::Tensor> fused_sigmoid_gating_delta_rule(
+    const torch::Tensor& A_log,
+    const torch::Tensor& a,
+    const torch::Tensor& dt_bias,
+    const torch::Tensor& query,
+    const torch::Tensor& key,
+    const torch::Tensor& value,
+    const torch::Tensor& beta,
+    const torch::Tensor& init_state,
+    const torch::Tensor& ssm_state_indices,
+    const torch::Tensor& cu_seqlens,
+    std::optional<float> scale,
+    bool use_qk_l2norm_in_kernel,
+    float softplus_beta,
+    float softplus_threshold);
+
 }  // namespace xllm::kernel::npu::tilelang


### PR DESCRIPTION
## Description

This PR adds an Ascend TileLang backend for the existing `fused_sigmoid_gating_delta_rule` operator and routes the Qwen3.5 Gated Delta Net FSGDR update path from the Triton implementation to the TileLang implementation.

The operator was already used in the Qwen3.5 model through the Triton NPU path. This change keeps the same model-level semantics while introducing a TileLang AOT kernel, runtime wrapper, build registration, and test coverage.

Main changes include:

- Add the TileLang Ascend kernel generator for `fused_sigmoid_gating_delta_rule`.
- Register TileLang AOT specializations for Qwen3.5-style FSGDR shapes and sequence-count variants.
- Add the TileLang NPU runtime wrapper, including shape/dtype checks, compiled-variant dispatch, SSM state index handling, and `cu_seqlens` metadata handling.
- Route the existing `fused_sigmoid_gating_delta_rule_update` ops API to the TileLang backend on NPU.
- Update the Qwen3.5 Gated Delta Net FSGDR path to pass reshaped q/k/v/a/b tensors into the existing fused update API.
- Add NPU wrapper tests against a Torch reference.

Performance data will be added after benchmarking.

## Related Issues

N/A

## Change Type

- [ ] Bug fix
- [x] New feature
- [x] Performance improvement
- [ ] Refactor
- [ ] Documentation
- [x] Test
- [ ] Build or CI

## Pull Request Checklist

Thank you for contributing to xLLM. Before requesting review, please make sure the following items are complete.

### PR Title and Commit Messages

- [x] The PR title and each commit message follow the xLLM commit format: `<type>: <subject>`.

> Allowed types: feat, bugfix, docs, test, refactor, chore, style, revert, perf, model, build, release.
> The subject should use clear English, start with a verb, include at least 4 words, and end with `.`.

### Pre-commit Checks

- [x] I have installed `pre-commit` by running `pip install pre-commit` or an equivalent command.
- [x] I have installed the hooks with `pre-commit install`.
- [x] I have run `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

### Self Review

- [x] I have self-reviewed the code according to `.agents/skills/code-review/references/custom-code-style.md`, especially code written or assisted by AI.
- [x] I have rebased this PR onto the latest `main` branch.

### Build and Test Coverage

- [x] Tests have been added or updated as needed.
- [ ] CUDA: `python setup.py build test` has passed on a CUDA machine.
- [x] NPU: `python setup.py build test` has passed on an NPU machine.
- [ ] MLU: `python setup.py build test` has passed on an MLU machine.

## Reviewer Notes

Please focus review on the TileLang FSGDR kernel semantics, compiled sequence-count dispatch, SSM state index mapping, and Qwen3.5 model integration.

Benchmark results and final end-to-end performance numbers are still being collected and will be added later.