### PR TITLE
feat: add qwen image edit dcu batch support.

### DIFF
--- a/xllm/core/distributed_runtime/spawn_worker_server/spawn_worker_server.cpp
+++ b/xllm/core/distributed_runtime/spawn_worker_server/spawn_worker_server.cpp
@@ -83,12 +83,19 @@ SpawnWorkerServer::SpawnWorkerServer(const std::string& master_node_addr,
                                      bool enable_graph_mode_decode_no_padding,
                                      bool enable_prefill_piecewise_graph,
                                      int32_t max_tokens_for_graph_mode,
-                                     int64_t max_encoder_cache_size) {
+                                     int64_t max_encoder_cache_size,
+                                     int32_t dp_size,
+                                     int32_t tp_size,
+                                     int32_t sp_size,
+                                     int32_t cfg_size) {
   // TODO: pass whole xllm::runtime::Options here from main process.
   xllm::runtime::Options runner_options;
   const std::string backend = get_backend_from_worker_type(worker_type);
   CHECK(!backend.empty()) << "Unsupported worker_type for backend mapping: "
                           << worker_type;
+  const bool is_dit_backend = backend == "dit";
+  const int32_t effective_sp_size = is_dit_backend ? sp_size : 1;
+  const int32_t effective_cfg_size = is_dit_backend ? cfg_size : 1;
   runner_options.block_size(block_size)
       .backend(backend)
       .world_size(world_size)
@@ -102,6 +109,10 @@ SpawnWorkerServer::SpawnWorkerServer(const std::string& master_node_addr,
       .enable_schedule_overlap(/*enable_schedule_overlap=*/false)
       .enable_offline_inference(/*enable_offline_inference=*/true)
       .master_node_addr(master_node_addr)
+      .dp_size(dp_size)
+      .tp_size(tp_size)
+      .sp_size(effective_sp_size)
+      .cfg_size(effective_cfg_size)
       .enable_shm(enable_shm)
       .input_shm_size(input_shm_size)
       .output_shm_size(output_shm_size)
@@ -119,6 +130,10 @@ SpawnWorkerServer::SpawnWorkerServer(const std::string& master_node_addr,
       .enable_schedule_overlap(false);
   ParallelConfig::get_instance()
       .enable_prefill_sp(enable_prefill_sp)
+      .dp_size(dp_size)
+      .tp_size(tp_size)
+      .sp_size(effective_sp_size)
+      .cfg_size(effective_cfg_size)
       .communication_backend(communication_backend);
   DistributedConfig::get_instance().master_node_addr(master_node_addr);
   KVCacheConfig::get_instance().block_size(block_size);
@@ -153,7 +168,7 @@ SpawnWorkerServer::SpawnWorkerServer(const std::string& master_node_addr,
 
   ParallelArgs parallel_args(global_rank,
                              world_size,
-                             /* dp_size = */ 1,
+                             dp_size,
                              /* cp_size = */ 1,
                              /* process_group = */ nullptr,
                              /* ep_size = */ 1);

--- a/xllm/core/distributed_runtime/spawn_worker_server/spawn_worker_server.h
+++ b/xllm/core/distributed_runtime/spawn_worker_server/spawn_worker_server.h
@@ -52,7 +52,11 @@ class SpawnWorkerServer final {
                              bool enable_graph_mode_decode_no_padding,
                              bool enable_prefill_piecewise_graph,
                              int32_t max_tokens_for_graph_mode,
-                             int64_t max_encoder_cache_size);
+                             int64_t max_encoder_cache_size,
+                             int32_t dp_size,
+                             int32_t tp_size,
+                             int32_t sp_size,
+                             int32_t cfg_size);
 
   ~SpawnWorkerServer();
 

--- a/xllm/core/distributed_runtime/spawn_worker_server/spawn_worker_server_process.cpp
+++ b/xllm/core/distributed_runtime/spawn_worker_server/spawn_worker_server_process.cpp
@@ -49,10 +49,14 @@ limitations under the License.
 // @enable_prefill_piecewise_graph
 // @max_tokens_for_graph_mode
 // @max_encoder_cache_size
+// @dp_size
+// @tp_size
+// @sp_size
+// @cfg_size
 int main(int argc, char* argv[]) {
-  if (argc < 28) {
+  if (argc < 32) {
     LOG(ERROR)
-        << "Spawn worker process receive wrong args. Need 28 args, receive "
+        << "Spawn worker process receive wrong args. Need 32 args, receive "
         << argc;
     return 1;
   }
@@ -86,6 +90,10 @@ int main(int argc, char* argv[]) {
       static_cast<int32_t>(atoi(argv[25])) > 0;
   int32_t max_tokens_for_graph_mode = static_cast<int32_t>(atoi(argv[26]));
   int64_t max_encoder_cache_size = static_cast<int64_t>(atoll(argv[27]));
+  int32_t dp_size = static_cast<int32_t>(atoi(argv[28]));
+  int32_t tp_size = static_cast<int32_t>(atoi(argv[29]));
+  int32_t sp_size = static_cast<int32_t>(atoi(argv[30]));
+  int32_t cfg_size = static_cast<int32_t>(atoi(argv[31]));
 
   LOG(INFO) << "Spawn worker: "
             << "master_node_addr = " << master_node_addr
@@ -116,7 +124,9 @@ int main(int argc, char* argv[]) {
             << ", enable_prefill_piecewise_graph = "
             << enable_prefill_piecewise_graph
             << ", max_tokens_for_graph_mode = " << max_tokens_for_graph_mode
-            << ", max_encoder_cache_size = " << max_encoder_cache_size << "\n";
+            << ", max_encoder_cache_size = " << max_encoder_cache_size
+            << ", dp_size = " << dp_size << ", tp_size = " << tp_size
+            << ", sp_size = " << sp_size << ", cfg_size = " << cfg_size << "\n";
 
   xllm::SpawnWorkerServer worker(master_node_addr,
                                  local_rank,
@@ -144,7 +154,11 @@ int main(int argc, char* argv[]) {
                                  enable_graph_mode_decode_no_padding,
                                  enable_prefill_piecewise_graph,
                                  max_tokens_for_graph_mode,
-                                 max_encoder_cache_size);
+                                 max_encoder_cache_size,
+                                 dp_size,
+                                 tp_size,
+                                 sp_size,
+                                 cfg_size);
 
   worker.run();
 

--- a/xllm/core/distributed_runtime/worker_server.cpp
+++ b/xllm/core/distributed_runtime/worker_server.cpp
@@ -281,6 +281,14 @@ void WorkerServer::create_spawn_server(int32_t local_rank,
   std::string max_encoder_cache_size_str =
       std::to_string(options.max_encoder_cache_size());
   const char* max_encoder_cache_size_ptr = max_encoder_cache_size_str.c_str();
+  std::string dp_size_str = std::to_string(options.dp_size());
+  const char* dp_size_ptr = dp_size_str.c_str();
+  std::string tp_size_str = std::to_string(options.tp_size());
+  const char* tp_size_ptr = tp_size_str.c_str();
+  std::string sp_size_str = std::to_string(options.sp_size());
+  const char* sp_size_ptr = sp_size_str.c_str();
+  std::string cfg_size_str = std::to_string(options.cfg_size());
+  const char* cfg_size_ptr = cfg_size_str.c_str();
   const char* worker_type_ptr = worker_type.to_string();
   std::string spawn_worker_bin_path =
       options.spawn_worker_path() + "/spawn_worker";
@@ -313,6 +321,10 @@ void WorkerServer::create_spawn_server(int32_t local_rank,
                         enable_prefill_piecewise_graph_ptr,
                         max_tokens_for_graph_mode_ptr,
                         max_encoder_cache_size_ptr,
+                        dp_size_ptr,
+                        tp_size_ptr,
+                        sp_size_ptr,
+                        cfg_size_ptr,
                         nullptr};
   pid_t pid;
   int status = posix_spawnp(

--- a/xllm/core/distributed_runtime/worker_service.cpp
+++ b/xllm/core/distributed_runtime/worker_service.cpp
@@ -340,18 +340,20 @@ void WorkerService::create_polling_shm_thread(
                out_tokens,
                out_logprobs);
 
-          output_shm_manager->raw_output_write(next_tokens,
-                                               logprobs,
-                                               top_tokens,
-                                               top_logprobs,
-                                               embeddings,
-                                               mm_embeddings,
-                                               dit_images,
-                                               expert_load_data,
-                                               prepared_layer_id,
-                                               src_seq_idxes,
-                                               out_tokens,
-                                               out_logprobs);
+          const bool shm_write_ok =
+              output_shm_manager->raw_output_write(next_tokens,
+                                                   logprobs,
+                                                   top_tokens,
+                                                   top_logprobs,
+                                                   embeddings,
+                                                   mm_embeddings,
+                                                   dit_images,
+                                                   expert_load_data,
+                                                   prepared_layer_id,
+                                                   src_seq_idxes,
+                                                   out_tokens,
+                                                   out_logprobs);
+          CHECK(shm_write_ok) << "Worker output shared memory write failed.";
           COUNTER_ADD(worker_service_latency_seconds, timer.elapsed_seconds());
         }
       });

--- a/xllm/core/framework/batch/dit_batch.cpp
+++ b/xllm/core/framework/batch/dit_batch.cpp
@@ -17,9 +17,12 @@ limitations under the License.
 #include "dit_batch.h"
 
 #include <c10/core/DeviceType.h>
+#include <glog/logging.h>
 #include <torch/torch.h>
 
 #include <vector>
+
+#include "core/framework/config/dit_config.h"
 
 namespace {
 
@@ -49,6 +52,9 @@ namespace xllm {
 
 DiTForwardInput DiTBatch::prepare_forward_input() {
   CHECK(!request_vec_.empty());
+  if (::xllm::DiTConfig::get_instance().dit_debug_print()) {
+    LOG(INFO) << "DiT batch_size=" << request_vec_.size();
+  }
 
   DiTForwardInput input;
   input.batch_size = request_vec_.size();
@@ -66,6 +72,7 @@ DiTForwardInput DiTBatch::prepare_forward_input() {
   std::vector<torch::Tensor> latents;
   std::vector<torch::Tensor> masked_image_latents;
   std::vector<torch::Tensor> last_images;
+  std::vector<std::vector<torch::Tensor>> per_request_images;
   const auto batch_size = request_vec_.size();
   prompt_embeds.reserve(batch_size);
   pooled_prompt_embeds.reserve(batch_size);
@@ -77,15 +84,16 @@ DiTForwardInput DiTBatch::prepare_forward_input() {
   latents.reserve(batch_size);
   masked_image_latents.reserve(batch_size);
   last_images.reserve(batch_size);
+  per_request_images.reserve(batch_size);
 
   std::vector<torch::Tensor> images_list;
-  size_t images_size = request_vec_[0]->state().input_params().images.size();
-  bool images_size_valid = images_size > 0;
+  size_t images_size = 0;
+  bool images_size_valid = true;
+  bool images_size_initialized = false;
   for (const auto& request : request_vec_) {
     const auto& generation_params = request->state().generation_params();
-    if (input.generation_params != generation_params) {
-      LOG(WARNING) << " dit generation params not equal";
-    }
+    CHECK(input.generation_params == generation_params)
+        << "DiT generation params must be equal in the same batch";
 
     const auto& input_params = request->state().input_params();
     if (!input_params.prompt.empty())
@@ -115,9 +123,18 @@ DiTForwardInput DiTBatch::prepare_forward_input() {
     control_images.emplace_back(input_params.control_image);
     last_images.emplace_back(input_params.last_image);
 
-    if (input_params.images.size() != images_size) {
+    std::vector<torch::Tensor> request_images = input_params.images;
+    if (request_images.empty() && input_params.image.defined()) {
+      request_images.emplace_back(input_params.image);
+    }
+    if (!images_size_initialized) {
+      images_size = request_images.size();
+      images_size_valid = images_size > 0;
+      images_size_initialized = true;
+    } else if (request_images.size() != images_size) {
       images_size_valid = false;
     }
+    per_request_images.emplace_back(std::move(request_images));
 
     // Voice cloning: prompt_audio is per-request (batch_size==1 in practice).
     // Forward the first defined tensor; multi-batch voice cloning is not
@@ -139,7 +156,9 @@ DiTForwardInput DiTBatch::prepare_forward_input() {
     input.prompts_2.clear();
   }
 
-  if (input.negative_prompts.size() != request_vec_.size()) {
+  const bool has_full_negative_prompts =
+      input.negative_prompts.size() == request_vec_.size();
+  if (!has_full_negative_prompts) {
     input.negative_prompts.clear();
   }
 
@@ -159,8 +178,8 @@ DiTForwardInput DiTBatch::prepare_forward_input() {
     bool all_valid = true;
     for (size_t idx = 0; idx < images_size; ++idx) {
       vec.clear();
-      for (const auto& req : request_vec_) {
-        vec.emplace_back(req->state().input_params().images[idx]);
+      for (const auto& request_images : per_request_images) {
+        vec.emplace_back(request_images[idx]);
       }
       if (!check_tensors_valid(vec)) {
         all_valid = false;

--- a/xllm/core/framework/dit_model_loader.cpp
+++ b/xllm/core/framework/dit_model_loader.cpp
@@ -153,6 +153,7 @@ bool DiTFolderLoader::load_model_args(const std::string& model_weights_path) {
     std::filesystem::path tokenizer_config_path =
         model_dir / "tokenizer_config.json";
     if (std::filesystem::exists(tokenizer_config_path)) {
+      load_image_preprocessor_args(model_weights_path);
       return true;
     }
     std::vector<std::filesystem::path> json_file_paths;

--- a/xllm/core/framework/model/model_input_params.h
+++ b/xllm/core/framework/model/model_input_params.h
@@ -883,6 +883,9 @@ struct ExpertInput {
 struct GraphInput {
   torch::Tensor attn_mask;
   torch::Tensor tiling_data;
+#if defined(USE_DCU)
+  bool use_dense_flash_attention = false;
+#endif
   bool use_expanded_decode_for_spec_verify_attention = false;
   torch::Tensor expanded_kv_seq_lens;
   torch::Tensor expanded_block_tables;
@@ -897,6 +900,9 @@ struct GraphInput {
     GraphInput out;
     out.attn_mask = safe_to(attn_mask, device, true);
     out.tiling_data = safe_to(tiling_data, device, true);
+#if defined(USE_DCU)
+    out.use_dense_flash_attention = use_dense_flash_attention;
+#endif
     out.use_expanded_decode_for_spec_verify_attention =
         use_expanded_decode_for_spec_verify_attention;
     out.expanded_kv_seq_lens = safe_to(expanded_kv_seq_lens, device, true);

--- a/xllm/core/framework/parallel_state/cuda_process_group.h
+++ b/xllm/core/framework/parallel_state/cuda_process_group.h
@@ -34,10 +34,7 @@ class ProcessGroupImpl : public ProcessGroup {
       : ProcessGroup(global_rank, world_size, device) {
     c10::intrusive_ptr<c10d::ProcessGroupNCCL::Options> pg_options =
         c10d::ProcessGroupNCCL::Options::create();
-#if TORCH_VERSION_MAJOR > 2 || \
-    (TORCH_VERSION_MAJOR == 2 && TORCH_VERSION_MINOR >= 7)
     pg_options->group_name = group_name;
-#endif
     int32_t rank = global_rank;
     if (world_size != rank_size) {
       auto [local_rank, group_ranks] =
@@ -49,6 +46,31 @@ class ProcessGroupImpl : public ProcessGroup {
     auto store = create_tcp_store(host, port, rank);
     pg_ = std::make_unique<c10d::ProcessGroupNCCL>(
         store, rank, rank_size, pg_options);
+  }
+
+  ProcessGroupImpl(int32_t global_rank,
+                   int32_t local_rank,
+                   const std::vector<int32_t>& group_ranks,
+                   int32_t world_size,
+                   int32_t rank_size,
+                   int32_t port,
+                   const std::string& host,
+                   const std::string& group_name,
+                   const torch::Device& device)
+      : ProcessGroup(global_rank, world_size, device) {
+    c10::intrusive_ptr<c10d::ProcessGroupNCCL::Options> pg_options =
+        c10d::ProcessGroupNCCL::Options::create();
+    pg_options->group_name = group_name;
+    std::vector<uint64_t> ranks_unsigned;
+    ranks_unsigned.reserve(group_ranks.size());
+    for (int32_t rank : group_ranks) {
+      ranks_unsigned.push_back(static_cast<uint64_t>(rank));
+    }
+    pg_options->global_ranks_in_group = ranks_unsigned;
+
+    auto store = create_tcp_store(host, port, local_rank);
+    pg_ = std::make_unique<c10d::ProcessGroupNCCL>(
+        store, local_rank, rank_size, pg_options);
   }
 };
 

--- a/xllm/core/framework/parallel_state/dit_collective_communicator.cpp
+++ b/xllm/core/framework/parallel_state/dit_collective_communicator.cpp
@@ -102,7 +102,7 @@ ProcessGroup* DiTCollectiveCommunicator::create_process_group_by_type(
     auto local_rank = parallel_info.rank();
     auto& rank_per_group = parallel_info.rank_per_group()[group_id];
     int port_offset = group_id + 1;
-#if defined(USE_NPU) || defined(USE_MLU)
+#if defined(USE_NPU) || defined(USE_MLU) || defined(USE_DCU)
     member_group = std::move(create_process_group(global_rank_,
                                                   local_rank,
                                                   rank_per_group,

--- a/xllm/core/framework/parallel_state/process_group.cpp
+++ b/xllm/core/framework/parallel_state/process_group.cpp
@@ -228,8 +228,8 @@ std::unique_ptr<ProcessGroup> create_process_group(
       rank, world_size, rank_size, port, trans, host, group_name, device);
 }
 
-#if defined(USE_NPU) || defined(USE_MLU)
-// we only support DiT models onNPU and MLU for now.
+#if defined(USE_NPU) || defined(USE_MLU) || defined(USE_DCU)
+// We currently support explicit DiT communication groups on NPU, MLU, and DCU.
 // TODO: This function is used by DiT models, since the DiT communication group
 // info have already been calculated by rank_generator, we only need to pass the
 // info to create the process groups. For any device that want to reuse the

--- a/xllm/core/framework/parallel_state/process_group.h
+++ b/xllm/core/framework/parallel_state/process_group.h
@@ -20,6 +20,7 @@ limitations under the License.
 #include <string>
 #include <torch/csrc/distributed/c10d/Backend.hpp>
 #include <torch/csrc/distributed/c10d/TCPStore.hpp>
+#include <vector>
 
 #if defined(USE_NPU)
 #include <torch_npu/csrc/distributed/ProcessGroupHCCL.hpp>
@@ -143,7 +144,7 @@ std::unique_ptr<xllm::ProcessGroup> create_process_group(
     const std::string& group_name,
     const torch::Device& device);
 
-#if defined(USE_NPU) || defined(USE_MLU)
+#if defined(USE_NPU) || defined(USE_MLU) || defined(USE_DCU)
 // for DiT models
 std::unique_ptr<xllm::ProcessGroup> create_process_group(
     int32_t global_rank,

--- a/xllm/core/framework/request/dit_request_state.h
+++ b/xllm/core/framework/request/dit_request_state.h
@@ -171,7 +171,11 @@ struct DiTRequestState {
         call_(call) {}
   DiTRequestState() {}
   DiTInputParams& input_params() { return input_params_; }
+  const DiTInputParams& input_params() const { return input_params_; }
   DiTGenerationParams& generation_params() { return generation_params_; }
+  const DiTGenerationParams& generation_params() const {
+    return generation_params_;
+  }
   DiTOutputFunc& output_func() { return output_func_; }
   DiTOutputsFunc& outputs_func() { return outputs_func_; }
   std::optional<Call*>& call() { return call_; }

--- a/xllm/core/layers/common/attention_metadata.h
+++ b/xllm/core/layers/common/attention_metadata.h
@@ -88,6 +88,9 @@ struct AttentionMetadata {
   bool is_dummy;
   // Whether to apply causal mask. Default: true.
   bool is_causal = true;
+#if defined(USE_DCU)
+  bool use_dense_flash_attention = false;
+#endif
 
   // Spec-verify ACL graph can run full attention as expanded decode while GDN
   // layers keep the original spec-verify metadata.

--- a/xllm/core/layers/common/attention_metadata_builder.cpp
+++ b/xllm/core/layers/common/attention_metadata_builder.cpp
@@ -72,6 +72,10 @@ AttentionMetadata build_attention_metadata(
   attn_metadata.q_seq_lens_vec = params.attention.host.q_seq_lens;
   attn_metadata.slot_mapping = params.attention.device.new_cache_slots;
   attn_metadata.compute_dtype = compute_dtype;
+#if defined(USE_DCU)
+  attn_metadata.use_dense_flash_attention =
+      params.graph.use_dense_flash_attention;
+#endif
 
   // for flashinfer
   attn_metadata.paged_kv_indptr = params.attention.device.paged_kv_indptr;
@@ -84,7 +88,8 @@ AttentionMetadata build_attention_metadata(
   attn_metadata.unshared_plan_info = std::make_shared<PlanInfo>();
 #endif
 
-#if defined(USE_CUDA) || defined(USE_NPU) || defined(USE_MLU)
+#if defined(USE_CUDA) || defined(USE_DCU) || defined(USE_NPU) || \
+    defined(USE_MLU)
   // Use explicit attn_mask if provided; otherwise fall back to
   // graph_buffer.attn_mask (e.g. Qwen2_5_VL sets graph_buffer.attn_mask for
   // LongCat text encoding)

--- a/xllm/core/layers/common/qwen2_vision_attention.cpp
+++ b/xllm/core/layers/common/qwen2_vision_attention.cpp
@@ -115,9 +115,9 @@ int32_t Qwen2VisionAttentionImpl::get_max_sequence_length(
 
 namespace {
 
-#if defined(USE_CUDA)
+#if defined(USE_CUDA) || defined(USE_DCU)
 // Pure PyTorch scaled dot-product attention for Qwen2 vision.
-void compute_qwen2_vision_attention_cuda(
+void compute_qwen2_vision_attention_torch(
     torch::Tensor& q,
     torch::Tensor& k,
     torch::Tensor& v,
@@ -155,7 +155,7 @@ void compute_qwen2_vision_attention_cuda(
     output.slice(/*dim=*/0, /*start=*/start, /*end=*/end).copy_(out_i);
   }
 }
-#endif  // defined(USE_CUDA)
+#endif  // defined(USE_CUDA) || defined(USE_DCU)
 
 }  // namespace
 
@@ -199,7 +199,16 @@ torch::Tensor Qwen2VisionAttentionImpl::forward(
   rotary_params.cos = m_cos_pos;
   rotary_params.interleaved = false;
   rotary_params.discrete = false;
+#if defined(USE_CUDA) || defined(USE_DCU) || defined(USE_MUSA)
+  rotary_params.position_ids =
+      torch::arange(
+          q.size(0),
+          torch::TensorOptions().dtype(torch::kInt64).device(q.device()))
+          .contiguous();
+  rotary_params.cu_query_lens = std::nullopt;
+#else
   rotary_params.cu_query_lens = cu_seq_len;
+#endif
   rotary_params.max_query_len = max_seqlen;
   xllm::kernel::apply_rotary(rotary_params);
   q = rotary_params.q.reshape(
@@ -239,12 +248,12 @@ torch::Tensor Qwen2VisionAttentionImpl::forward(
                                    /*window_size_right=*/-1,
                                    /*compute_dtype=*/"half",
                                    /*return_lse=*/false);
-#elif defined(USE_CUDA)
-  // CUDA path: use a pure PyTorch vision attention implementation that matches
-  // Transformers Qwen2.5-VL VisionAttention. FlashInfer's precompiled AOT
-  // kernels in this project do not support head_dim=80, so we intentionally do
-  // not call FlashInfer here and run attention entirely in PyTorch instead.
-  compute_qwen2_vision_attention_cuda(q, k, v, output, cu_seq_len_vec, scale_);
+#elif defined(USE_CUDA) || defined(USE_DCU)
+  // CUDA/DCU path: use a pure PyTorch vision attention implementation that
+  // matches Transformers Qwen2.5-VL VisionAttention. FlashInfer's precompiled
+  // AOT kernels in this project do not support head_dim=80, so we intentionally
+  // do not call FlashInfer here and run attention entirely in PyTorch instead.
+  compute_qwen2_vision_attention_torch(q, k, v, output, cu_seq_len_vec, scale_);
 #endif
 
   // context_layer = rearrange(output, "(b s) h d -> s b (h d)", b=batch_size)

--- a/xllm/core/layers/dcu/flash_attention.cpp
+++ b/xllm/core/layers/dcu/flash_attention.cpp
@@ -18,8 +18,12 @@ limitations under the License.
 #include <glog/logging.h>
 #include <torch/torch.h>
 
+#include <algorithm>
 #include <cstdint>
+#include <limits>
 #include <optional>
+#include <utility>
+#include <vector>
 
 #include "framework/kv_cache/kv_cache.h"
 #include "kernels/dcu/attention_runner.h"
@@ -93,6 +97,36 @@ std::vector<torch::Tensor> prefix_decode_varlen_fwd(
     const bool return_softmax,
     const int32_t layout);
 
+// Dense varlen forward kernel from flash_api.cpp. This is the non-KV-cache
+// path used by full-sequence DiT attention.
+std::vector<torch::Tensor> varlen_fwd(
+    const torch::Tensor& q,
+    const torch::Tensor& k,
+    const torch::Tensor& v,
+    const int32_t num_heads,
+    const int32_t num_heads_k,
+    std::optional<torch::Tensor>& out_,
+    const torch::Tensor& cu_seqlens_q,
+    const torch::Tensor& cu_seqlens_k,
+    std::optional<torch::Tensor>& seqused_k,
+    std::optional<torch::Tensor>& alibi_slopes_,
+    const int32_t max_seqlen_q,
+    const int32_t max_seqlen_k,
+    const float p_dropout,
+    const float softmax_scale,
+    const bool zero_tensors,
+    const bool is_causal,
+    int32_t window_size_left,
+    int32_t window_size_right,
+    const float softcap,
+    const bool return_softmax,
+    std::optional<at::Generator> gen_,
+    const int32_t layout,
+    std::optional<torch::Tensor> q_descale_ = std::nullopt,
+    std::optional<torch::Tensor> k_descale_ = std::nullopt,
+    std::optional<torch::Tensor> v_descale_ = std::nullopt,
+    const bool is_bf16_output = true);
+
 namespace xllm {
 namespace layer {
 
@@ -151,7 +185,134 @@ torch::Tensor get_or_build_block_table(const torch::Tensor& block_table,
       paged_kv_indptr, paged_kv_indices);
 }
 
+struct VarlenSeqlenInfo {
+  int64_t batch_size = 0;
+  int64_t total_len = 0;
+  int64_t max_seq_len = 0;
+  std::vector<int64_t> seq_lens;
+};
+
+VarlenSeqlenInfo validate_cu_seqlens(const torch::Tensor& cu_seqlens,
+                                     const char* name) {
+  CHECK(cu_seqlens.defined()) << name << " must be defined";
+  CHECK_EQ(cu_seqlens.dim(), 1) << name << " must be 1D";
+  CHECK_GE(cu_seqlens.numel(), 2) << name << " must include batch + 1 items";
+
+  auto cu_cpu = cu_seqlens.to(torch::kCPU).to(torch::kInt64).contiguous();
+  const auto* data = cu_cpu.data_ptr<int64_t>();
+  VarlenSeqlenInfo info;
+  info.batch_size = cu_cpu.numel() - 1;
+  info.seq_lens.reserve(static_cast<size_t>(info.batch_size));
+  CHECK_EQ(data[0], 0) << name << " must start at 0";
+
+  for (int64_t i = 0; i < info.batch_size; ++i) {
+    const int64_t current_len = data[i + 1] - data[i];
+    CHECK_GT(current_len, 0)
+        << name << " sequence length must be positive, batch index=" << i;
+    info.seq_lens.push_back(current_len);
+    info.max_seq_len = std::max(info.max_seq_len, current_len);
+  }
+  info.total_len = data[info.batch_size];
+  return info;
+}
+
+int32_t checked_int32(int64_t value, const char* name) {
+  CHECK_LE(value, static_cast<int64_t>(std::numeric_limits<int32_t>::max()))
+      << name << " exceeds int32 range: " << value;
+  CHECK_GE(value, static_cast<int64_t>(std::numeric_limits<int32_t>::min()))
+      << name << " is below int32 range: " << value;
+  return static_cast<int32_t>(value);
+}
+
 }  // namespace
+
+torch::Tensor dense_varlen_flash_attention(torch::Tensor query,
+                                           torch::Tensor key,
+                                           torch::Tensor value,
+                                           const torch::Tensor& cu_seqlens_q,
+                                           const torch::Tensor& cu_seqlens_k,
+                                           double softmax_scale,
+                                           bool is_causal) {
+  CHECK_EQ(query.dim(), 3) << "query must be [total, heads, dim]";
+  CHECK_EQ(key.dim(), 3) << "key must be [total, heads, dim]";
+  CHECK_EQ(value.dim(), 3) << "value must be [total, heads, dim]";
+  CHECK(query.device() == key.device() && query.device() == value.device())
+      << "query/key/value must be on the same device";
+  CHECK(query.scalar_type() == key.scalar_type() &&
+        query.scalar_type() == value.scalar_type())
+      << "query/key/value must have the same dtype";
+  CHECK_EQ(key.size(0), value.size(0)) << "key/value token counts must match";
+  CHECK_EQ(key.size(1), value.size(1)) << "key/value head counts must match";
+  CHECK_EQ(query.size(2), key.size(2))
+      << "query/key head dimensions must match";
+  CHECK_EQ(query.size(2), value.size(2))
+      << "query/value head dimensions must match";
+  CHECK_GT(query.size(0), 0) << "query token count must be positive";
+  CHECK_GT(key.size(0), 0) << "key token count must be positive";
+
+  const VarlenSeqlenInfo q_info =
+      validate_cu_seqlens(cu_seqlens_q, "cu_seqlens_q");
+  const VarlenSeqlenInfo k_info =
+      validate_cu_seqlens(cu_seqlens_k, "cu_seqlens_k");
+  CHECK_EQ(q_info.batch_size, k_info.batch_size)
+      << "q/k batch sizes must match";
+  CHECK_EQ(query.size(0), q_info.total_len)
+      << "query length does not match cu_seqlens_q";
+  CHECK_EQ(key.size(0), k_info.total_len)
+      << "key length does not match cu_seqlens_k";
+  checked_int32(q_info.total_len, "cu_seqlens_q total length");
+  checked_int32(k_info.total_len, "cu_seqlens_k total length");
+  if (is_causal) {
+    CHECK(q_info.seq_lens == k_info.seq_lens)
+        << "causal dense flash-attn C API requires per-sequence q_len == "
+           "kv_len";
+  }
+
+  const int64_t num_heads = query.size(1);
+  const int64_t num_heads_k = key.size(1);
+
+  const int32_t num_heads_i32 = checked_int32(num_heads, "num_heads");
+  const int32_t num_heads_k_i32 = checked_int32(num_heads_k, "num_heads_k");
+  const int32_t max_seqlen_q_i32 =
+      checked_int32(q_info.max_seq_len, "max_seqlen_q");
+  const int32_t max_seqlen_k_i32 =
+      checked_int32(k_info.max_seq_len, "max_seqlen_k");
+
+  std::optional<torch::Tensor> out_opt = std::nullopt;
+  std::optional<torch::Tensor> seqused_k_opt = std::nullopt;
+  std::optional<torch::Tensor> alibi_opt = std::nullopt;
+  std::optional<at::Generator> gen_opt = std::nullopt;
+
+  std::vector<torch::Tensor> result =
+      varlen_fwd(query.contiguous(),
+                 key.contiguous(),
+                 value.contiguous(),
+                 num_heads_i32,
+                 num_heads_k_i32,
+                 out_opt,
+                 cu_seqlens_q.to(query.device()).to(torch::kInt32).contiguous(),
+                 cu_seqlens_k.to(query.device()).to(torch::kInt32).contiguous(),
+                 seqused_k_opt,
+                 alibi_opt,
+                 max_seqlen_q_i32,
+                 max_seqlen_k_i32,
+                 /*p_dropout=*/0.0f,
+                 /*softmax_scale=*/static_cast<float>(softmax_scale),
+                 /*zero_tensors=*/false,
+                 /*is_causal=*/is_causal,
+                 /*window_size_left=*/-1,
+                 /*window_size_right=*/is_causal ? 0 : -1,
+                 /*softcap=*/0.0f,
+                 /*return_softmax=*/false,
+                 gen_opt,
+                 /*layout=*/1,
+                 /*q_descale_=*/std::nullopt,
+                 /*k_descale_=*/std::nullopt,
+                 /*v_descale_=*/std::nullopt,
+                 /*is_bf16_output=*/query.scalar_type() == at::kBFloat16);
+
+  return result[0];
+}
 
 FlashAttentionImpl::FlashAttentionImpl(int64_t num_heads,
                                        int64_t head_size,
@@ -171,6 +332,12 @@ void FlashAttentionImpl::prefill_forward(const AttentionMetadata& attn_metadata,
                                          torch::Tensor& output,
                                          torch::Tensor k_cache,
                                          torch::Tensor v_cache) {
+  const bool has_paged_kv_cache = k_cache.defined() && k_cache.dim() >= 2 &&
+                                  v_cache.defined() && v_cache.dim() >= 2;
+  CHECK(has_paged_kv_cache)
+      << "FlashAttentionImpl requires paged KV cache for prefill. "
+      << "Set use_dense_flash_attention for uncached dense prefill.";
+
   // Prefill: KV has been stored into paged cache by reshape_paged_cache.
   // Q is already in packed format [total_tokens, nh, hd], no padding needed.
   // prefix_prefill_varlen_fwd reads Q, K/V cache, cu_seqlens_q, seqused_k,
@@ -306,6 +473,22 @@ FlashAttentionImpl::forward(const AttentionMetadata& attn_metadata,
   key = key.view({-1, num_kv_heads_, head_size_});
   value = value.view({-1, num_kv_heads_, head_size_});
   output = output.view({-1, num_heads_, head_size_});
+
+  if (attn_metadata.use_dense_flash_attention) {
+    CHECK(attn_metadata.is_prefill)
+        << "dense flash-attn C API is only supported for prefill";
+    auto dense_output =
+        dense_varlen_flash_attention(query,
+                                     key,
+                                     value,
+                                     attn_metadata.q_cu_seq_lens,
+                                     attn_metadata.kv_cu_seq_lens,
+                                     /*softmax_scale=*/scale_,
+                                     attn_metadata.is_causal);
+    output.copy_(dense_output);
+    output = output.view({-1, num_heads_ * head_size_});
+    return {output, output_lse};
+  }
 
   torch::Tensor k_cache = kv_cache.get_k_cache();
   torch::Tensor v_cache = kv_cache.get_v_cache();

--- a/xllm/core/layers/dcu/flash_attention.h
+++ b/xllm/core/layers/dcu/flash_attention.h
@@ -26,6 +26,14 @@ limitations under the License.
 namespace xllm {
 namespace layer {
 
+torch::Tensor dense_varlen_flash_attention(torch::Tensor query,
+                                           torch::Tensor key,
+                                           torch::Tensor value,
+                                           const torch::Tensor& cu_seqlens_q,
+                                           const torch::Tensor& cu_seqlens_k,
+                                           double softmax_scale,
+                                           bool is_causal);
+
 // FlashAttentionImpl uses the mha_fwd_kvcache_bshd HIP kernel from
 // libflash_attention to compute paged attention directly from KV cache,
 // with zero intermediate tensor copies.

--- a/xllm/core/layers/dcu/torch_attention.cpp
+++ b/xllm/core/layers/dcu/torch_attention.cpp
@@ -42,10 +42,7 @@ std::pair<torch::Tensor, torch::Tensor> TorchAttentionImpl::expand_kv_for_mqa(
     const torch::Tensor& value) {
   // key: [seq_len, num_kv_heads, head_size]
   // value: [seq_len, num_kv_heads, head_size]
-  // For multi-query attention (MQA), expand kv_heads to match num_heads.
-
   if (num_kv_heads_ == num_heads_) {
-    // Already have enough heads, no expansion needed.
     return {key, value};
   }
   CHECK_GT(num_kv_heads_, 0) << "num_kv_heads must be positive";
@@ -54,58 +51,62 @@ std::pair<torch::Tensor, torch::Tensor> TorchAttentionImpl::expand_kv_for_mqa(
 
   const int64_t expansion_factor = num_heads_ / num_kv_heads_;
   const int64_t seq_len = key.size(0);
-  const int64_t head_size = key.size(2);
 
-  // Expand: [seq_len, num_kv_heads, head_size] -> [seq_len, num_heads,
-  // head_size] by repeating each head expansion_factor times.
   torch::Tensor key_expanded =
       key.unsqueeze(2)
-          .expand({seq_len, num_kv_heads_, expansion_factor, head_size})
-          .reshape({seq_len, num_heads_, head_size});
-
+          .expand({seq_len, num_kv_heads_, expansion_factor, head_size_})
+          .reshape({seq_len, num_heads_, head_size_});
   torch::Tensor value_expanded =
       value.unsqueeze(2)
-          .expand({seq_len, num_kv_heads_, expansion_factor, head_size})
-          .reshape({seq_len, num_heads_, head_size});
+          .expand({seq_len, num_kv_heads_, expansion_factor, head_size_})
+          .reshape({seq_len, num_heads_, head_size_});
 
   return {key_expanded, value_expanded};
 }
 
-torch::Tensor TorchAttentionImpl::compute_attention(const torch::Tensor& query,
-                                                    const torch::Tensor& key,
-                                                    const torch::Tensor& value,
-                                                    bool is_causal) {
-  // query: [seq_len_q, num_heads, head_size]
-  // key: [seq_len_kv, num_heads, head_size]
-  // value: [seq_len_kv, num_heads, head_size]
-
-  // scaled_dot_product_attention expects 4D tensors:
-  // [batch_size, num_heads, seq_len, head_size]
-
-  // [seq_len_q, num_heads, head_size] -> [1, seq_len_q, num_heads, head_size]
-  // -> [1, num_heads, seq_len_q, head_size]
+torch::Tensor TorchAttentionImpl::compute_attention(
+    const torch::Tensor& query,
+    const torch::Tensor& key,
+    const torch::Tensor& value,
+    bool is_causal,
+    const std::optional<torch::Tensor>& attn_mask) {
   torch::Tensor query_4d = query.unsqueeze(0).permute({0, 2, 1, 3});
   torch::Tensor key_4d = key.unsqueeze(0).permute({0, 2, 1, 3});
   torch::Tensor value_4d = value.unsqueeze(0).permute({0, 2, 1, 3});
 
-  // Apply scaled dot product attention.
-  // For causal attention, we need to handle it differently in chunked/decode
-  // scenarios.
-  torch::Tensor attn_output = at::scaled_dot_product_attention(
-      query_4d,      // [1, num_heads, seq_len_q, head_size]
-      key_4d,        // [1, num_heads, seq_len_kv, head_size]
-      value_4d,      // [1, num_heads, seq_len_kv, head_size]
-      c10::nullopt,  // attn_mask: optional
-      0.0,           // dropout_p
-      is_causal      // is_causal: apply causal mask if true
-  );
+  std::optional<torch::Tensor> sdpa_mask = std::nullopt;
+  bool sdpa_is_causal = is_causal;
+  if (attn_mask.has_value() && attn_mask.value().defined()) {
+    torch::Tensor key_mask = attn_mask.value()
+                                 .to(query.device())
+                                 .to(torch::kBool)
+                                 .view({1, 1, 1, key.size(0)});
+    torch::Tensor combined_mask =
+        key_mask.expand({1, 1, query.size(0), key.size(0)});
+    if (is_causal) {
+      CHECK_LE(query.size(0), key.size(0))
+          << "masked causal torch attention expects q_len <= kv_len";
+      auto causal_mask =
+          torch::ones(
+              {query.size(0), key.size(0)},
+              torch::TensorOptions().dtype(torch::kBool).device(query.device()))
+              .tril(key.size(0) - query.size(0))
+              .view({1, 1, query.size(0), key.size(0)});
+      combined_mask = combined_mask.logical_and(causal_mask);
+      sdpa_is_causal = false;
+    }
+    sdpa_mask = combined_mask;
+  }
 
-  // Reshape back to [seq_len_q, num_heads, head_size].
-  attn_output = attn_output.permute(
-      {0, 2, 1, 3});                     // [1, seq_len_q, num_heads, head_size]
-  attn_output = attn_output.squeeze(0);  // [seq_len_q, num_heads, head_size]
+  torch::Tensor attn_output =
+      at::scaled_dot_product_attention(query_4d,
+                                       key_4d,
+                                       value_4d,
+                                       sdpa_mask,
+                                       /*dropout_p=*/0.0,
+                                       sdpa_is_causal);
 
-  return attn_output;
+  return attn_output.permute({0, 2, 1, 3}).squeeze(0);
 }
 
 std::tuple<torch::Tensor, std::optional<torch::Tensor>>
@@ -197,9 +198,16 @@ TorchAttentionImpl::forward(const AttentionMetadata& attn_metadata,
             torch::Tensor q_seq = query.slice(0, q_start, q_end);
             torch::Tensor k_seq = key_expanded.slice(0, kv_start, kv_end);
             torch::Tensor v_seq = value_expanded.slice(0, kv_start, kv_end);
+            std::optional<torch::Tensor> attn_mask_seq = std::nullopt;
+            if (replay_metadata.attn_mask.defined()) {
+              CHECK_GE(replay_metadata.attn_mask.numel(), kv_end)
+                  << "attention mask is shorter than kv sequence";
+              attn_mask_seq =
+                  replay_metadata.attn_mask.slice(0, kv_start, kv_end);
+            }
 
             torch::Tensor attn_out = compute_attention(
-                q_seq, k_seq, v_seq, replay_metadata.is_causal);
+                q_seq, k_seq, v_seq, replay_metadata.is_causal, attn_mask_seq);
 
             output.slice(0, q_start, q_end).copy_(attn_out);
           }

--- a/xllm/core/layers/dcu/torch_attention.h
+++ b/xllm/core/layers/dcu/torch_attention.h
@@ -17,6 +17,7 @@ limitations under the License.
 
 #include <torch/torch.h>
 
+#include <optional>
 #include <tuple>
 #include <utility>
 
@@ -52,7 +53,8 @@ class TorchAttentionImpl final : public BaseAttentionImpl {
       const torch::Tensor& query,  // [seq_len, num_heads, head_size]
       const torch::Tensor& key,    // [seq_len, num_kv_heads, head_size]
       const torch::Tensor& value,  // [seq_len, num_kv_heads, head_size]
-      bool is_causal);
+      bool is_causal,
+      const std::optional<torch::Tensor>& attn_mask = std::nullopt);
 
   // Helper function to expand kv heads to match query heads.
   std::pair<torch::Tensor, torch::Tensor> expand_kv_for_mqa(

--- a/xllm/core/runtime/dit_forward_params.h
+++ b/xllm/core/runtime/dit_forward_params.h
@@ -28,8 +28,9 @@ namespace xllm {
 // dit related forward input params
 struct DiTForwardInput {
   bool valid() const {
-    return prompts.size() > 0 || prompt_embeds.defined() ||
-           pooled_prompt_embeds.defined();
+    return batch_size > 0 || prompts.size() > 0 || prompt_embeds.defined() ||
+           pooled_prompt_embeds.defined() || images.defined() ||
+           !images_list.empty();
   }
 
   void save_with_prefix(std::string prefix) const {

--- a/xllm/core/runtime/forward_shared_memory_manager.cpp
+++ b/xllm/core/runtime/forward_shared_memory_manager.cpp
@@ -366,6 +366,8 @@ inline size_t get_dit_forward_input_size(const DiTForwardInput& input) {
   size += get_tensor_size(input.negative_pooled_prompt_embeds);
   size += get_tensor_size(input.latents);
   size += get_tensor_size(input.last_images);
+  size += get_tensor_size(input.prompt_audio);
+  size += get_string_size(input.audio_prompt_text);
 
   // Generation params
   size += get_dit_generation_params_size(input.generation_params);
@@ -1044,6 +1046,8 @@ inline void write_dit_forward_input(char*& buffer,
   write_tensor(buffer, input.negative_pooled_prompt_embeds);
   write_tensor(buffer, input.latents);
   write_tensor(buffer, input.last_images);
+  write_tensor(buffer, input.prompt_audio);
+  write_string(buffer, input.audio_prompt_text);
 
   write_dit_generation_params(buffer, input.generation_params);
 }
@@ -1067,6 +1071,9 @@ inline void write_dit_forward_input(RawInputSerializeContext& context,
   write_tensor(context, input.negative_prompt_embeds);
   write_tensor(context, input.negative_pooled_prompt_embeds);
   write_tensor(context, input.latents);
+  write_tensor(context, input.last_images);
+  write_tensor(context, input.prompt_audio);
+  write_string(context.descriptor, input.audio_prompt_text);
 
   write_dit_generation_params(context, input.generation_params);
 }
@@ -1934,8 +1941,37 @@ inline void read_dit_generation_params(ReadContext& context,
   read_data(context, params.num_videos_per_prompt);
 }
 
+inline void clone_tensor_if_defined(torch::Tensor& tensor) {
+  if (tensor.defined()) {
+    tensor = tensor.clone();
+  }
+}
+
+inline void clone_vector_tensor_if_defined(
+    std::vector<torch::Tensor>& tensors) {
+  for (auto& tensor : tensors) {
+    clone_tensor_if_defined(tensor);
+  }
+}
+
+inline void stabilize_dit_forward_input_tensors(DiTForwardInput& input) {
+  clone_tensor_if_defined(input.images);
+  clone_vector_tensor_if_defined(input.images_list);
+  clone_tensor_if_defined(input.mask_images);
+  clone_tensor_if_defined(input.control_image);
+  clone_tensor_if_defined(input.masked_image_latents);
+  clone_tensor_if_defined(input.prompt_embeds);
+  clone_tensor_if_defined(input.pooled_prompt_embeds);
+  clone_tensor_if_defined(input.negative_prompt_embeds);
+  clone_tensor_if_defined(input.negative_pooled_prompt_embeds);
+  clone_tensor_if_defined(input.latents);
+  clone_tensor_if_defined(input.last_images);
+  clone_tensor_if_defined(input.prompt_audio);
+}
+
 inline void read_dit_forward_input(const char*& buffer,
-                                   DiTForwardInput& input) {
+                                   DiTForwardInput& input,
+                                   bool stabilize_host_tensors = false) {
   read_data(buffer, input.batch_size);
 
   read_string_vector(buffer, input.prompts);
@@ -1954,12 +1990,18 @@ inline void read_dit_forward_input(const char*& buffer,
   read_tensor(buffer, input.negative_pooled_prompt_embeds);
   read_tensor(buffer, input.latents);
   read_tensor(buffer, input.last_images);
+  read_tensor(buffer, input.prompt_audio);
+  read_string(buffer, input.audio_prompt_text);
 
   read_dit_generation_params(buffer, input.generation_params);
+  if (stabilize_host_tensors) {
+    stabilize_dit_forward_input_tensors(input);
+  }
 }
 
 inline void read_dit_forward_input(ReadContext& context,
-                                   DiTForwardInput& input) {
+                                   DiTForwardInput& input,
+                                   bool stabilize_host_tensors = false) {
   read_data(context, input.batch_size);
 
   read_string_vector(context, input.prompts);
@@ -2007,13 +2049,30 @@ inline void read_dit_forward_input(ReadContext& context,
               input.latents,
               /*stream=*/nullptr,
               /*force_host_materialize=*/true);
+  read_tensor(context,
+              input.last_images,
+              /*stream=*/nullptr,
+              /*force_host_materialize=*/true);
+  read_tensor(context,
+              input.prompt_audio,
+              /*stream=*/nullptr,
+              /*force_host_materialize=*/true);
+  read_string(context, input.audio_prompt_text);
 
   read_dit_generation_params(context, input.generation_params);
+  if (stabilize_host_tensors) {
+    stabilize_dit_forward_input_tensors(input);
+  }
 }
 
 inline void read_dit_forward_output(const char*& buffer,
                                     DiTForwardOutput& output) {
   read_vector_tensor(buffer, output.tensors);
+  for (auto& tensor : output.tensors) {
+    if (tensor.defined()) {
+      tensor = tensor.clone();
+    }
+  }
 }
 
 inline void initialize_device_buffer_session(ReadContext& context,
@@ -2113,7 +2172,8 @@ inline void deserialize_forward_input_payload(
     ForwardInput& forward_input,
     const torch::Device& device,
     Stream* stream,
-    bool materialize_device_buffer = true) {
+    bool materialize_device_buffer = true,
+    bool stabilize_dit_host_tensors = false) {
   const char* payload_base = buffer;
   RawInputLayoutHeader layout;
   read_data(buffer, layout.descriptor_bytes);
@@ -2268,8 +2328,11 @@ inline void deserialize_forward_input_payload(
     input_params.multi_block_tables.emplace_back(manager_table.clone());
   }
 
-  if (::xllm::ModelConfig::get_instance().backend() == "dit") {
-    read_dit_forward_input(context, input_params.dit_forward_input);
+  bool has_dit_forward_input = false;
+  read_data(context, has_dit_forward_input);
+  if (has_dit_forward_input) {
+    read_dit_forward_input(
+        context, input_params.dit_forward_input, stabilize_dit_host_tensors);
   }
 
   finalize_device_buffer_session(device_session, stream);
@@ -2348,8 +2411,10 @@ size_t calculate_raw_forward_output_size(const RawForwardOutput& output) {
   size += type_size<int32_t>;  // prepared_layer_id
   // mm_embedding_data
   size += get_vector_tensor_size(output.mm_embeddings);
-  // dit output data
-  if (::xllm::ModelConfig::get_instance().backend() == "dit") {
+  const bool has_dit_forward_output =
+      !output.dit_forward_output.tensors.empty();
+  size += type_size<bool>;
+  if (has_dit_forward_output) {
     size += get_dit_forward_output_size(output.dit_forward_output);
   }
 
@@ -2413,13 +2478,17 @@ void deserialize_raw_forward_output(const char* buffer,
   }
 
   read_vector(buffer, output.expert_load_data);
+  read_vector(buffer, output.src_seq_idxes);
+  read_vector(buffer, output.out_tokens);
+  read_vector(buffer, output.out_logprobs);
 
   read_data(buffer, output.prepared_layer_id);
 
   read_vector_tensor(buffer, output.mm_embeddings);
 
-  // read dit output
-  if (::xllm::ModelConfig::get_instance().backend() == "dit") {
+  bool has_dit_forward_output = false;
+  read_data(buffer, has_dit_forward_output);
+  if (has_dit_forward_output) {
     read_dit_forward_output(buffer, output.dit_forward_output);
   }
 }
@@ -2432,12 +2501,17 @@ void serialize_raw_forward_output(const RawForwardOutput& output,
   }
 
   write_vector(buffer, output.expert_load_data);
+  write_vector(buffer, output.src_seq_idxes);
+  write_vector(buffer, output.out_tokens);
+  write_vector(buffer, output.out_logprobs);
 
   write_data(buffer, output.prepared_layer_id);
 
   write_vector_tensor(buffer, output.mm_embeddings);
-  // write dit output
-  if (::xllm::ModelConfig::get_instance().backend() == "dit") {
+  const bool has_dit_forward_output =
+      !output.dit_forward_output.tensors.empty();
+  write_data(buffer, has_dit_forward_output);
+  if (has_dit_forward_output) {
     write_dit_forward_output(buffer, output.dit_forward_output);
   }
 }
@@ -2595,7 +2669,9 @@ inline void serialize_forward_input_sections(
     write_tensor(context, manager_table);
   }
 
-  if (::xllm::ModelConfig::get_instance().backend() == "dit") {
+  const bool has_dit_forward_input = input_params.dit_forward_input.valid();
+  write_data(context.descriptor, has_dit_forward_input);
+  if (has_dit_forward_input) {
     write_dit_forward_input(context, input_params.dit_forward_input);
   }
 }
@@ -2961,7 +3037,8 @@ void ForwardSharedMemoryManager::input_read(ForwardInput& input,
                                     input,
                                     device,
                                     stream_.get(),
-                                    materialize_device_buffer);
+                                    materialize_device_buffer,
+                                    /*stabilize_dit_host_tensors=*/true);
 
   return;
 }
@@ -3003,7 +3080,6 @@ bool ForwardSharedMemoryManager::raw_output_write(
 
   char* data_ptr = static_cast<char*>(base_address()) + sizeof(ControlMetadata);
   serialize_raw_forward_output(output, data_ptr);
-  char* test = static_cast<char*>(base_address()) + sizeof(ControlMetadata);
   std::atomic_thread_fence(std::memory_order_release);
   control_ptr_->version = ++last_version_;
   return true;
@@ -3021,7 +3097,6 @@ void ForwardSharedMemoryManager::raw_output_read(RawForwardOutput& output) {
 
   const char* data_ptr =
       static_cast<char*>(base_address()) + sizeof(ControlMetadata);
-  char* test = static_cast<char*>(base_address()) + sizeof(ControlMetadata);
   deserialize_raw_forward_output(data_ptr, output);
 
   return;

--- a/xllm/core/scheduler/dit_scheduler.cpp
+++ b/xllm/core/scheduler/dit_scheduler.cpp
@@ -23,16 +23,92 @@ limitations under the License.
 #include <atomic>
 #include <cstdint>
 #include <memory>
+#include <vector>
 
 #include "common/metrics.h"
 #include "distributed_runtime/dit_engine.h"
 #include "framework/request/dit_request.h"
+#include "util/tensor_helper.h"
 #include "util/utils.h"
 
 namespace xllm {
 
 namespace {
 constexpr size_t kRequestQueueSize = 100;
+
+bool image_batch_signature_matches(const DiTInputParams& lhs,
+                                   const DiTInputParams& rhs) {
+  if (!tensor_batch_signature_matches(lhs.image, rhs.image)) {
+    return false;
+  }
+  if (lhs.images.size() != rhs.images.size()) {
+    return false;
+  }
+  for (size_t i = 0; i < lhs.images.size(); ++i) {
+    if (!tensor_batch_signature_matches(lhs.images[i], rhs.images[i])) {
+      return false;
+    }
+  }
+  return true;
+}
+
+bool stacked_tensor_inputs_match(const DiTInputParams& lhs,
+                                 const DiTInputParams& rhs) {
+  return tensor_batch_signature_matches(lhs.prompt_embed, rhs.prompt_embed) &&
+         tensor_batch_signature_matches(lhs.pooled_prompt_embed,
+                                        rhs.pooled_prompt_embed) &&
+         tensor_batch_signature_matches(lhs.negative_prompt_embed,
+                                        rhs.negative_prompt_embed) &&
+         tensor_batch_signature_matches(lhs.negative_pooled_prompt_embed,
+                                        rhs.negative_pooled_prompt_embed) &&
+         tensor_batch_signature_matches(lhs.latent, rhs.latent) &&
+         tensor_batch_signature_matches(lhs.mask_image, rhs.mask_image) &&
+         tensor_batch_signature_matches(lhs.control_image, rhs.control_image) &&
+         tensor_batch_signature_matches(lhs.masked_image_latent,
+                                        rhs.masked_image_latent) &&
+         tensor_batch_signature_matches(lhs.last_image, rhs.last_image);
+}
+
+bool prompt_audio_allows_batching(const DiTInputParams& lhs,
+                                  const DiTInputParams& rhs) {
+  return !lhs.prompt_audio.defined() && !rhs.prompt_audio.defined() &&
+         lhs.audio_prompt_text.empty() && rhs.audio_prompt_text.empty();
+}
+
+int32_t true_cfg_condition_type(const std::shared_ptr<DiTRequest>& request) {
+  const auto& generation_params = request->state().generation_params();
+  if (generation_params.true_cfg_scale <= 1.0) {
+    return 0;
+  }
+
+  const auto& input_params = request->state().input_params();
+  if (!input_params.negative_prompt.empty()) {
+    return 1;
+  }
+  if (input_params.negative_prompt_embed.defined()) {
+    return 2;
+  }
+  return 3;
+}
+
+bool is_compatible_dit_batch_request(
+    const std::shared_ptr<DiTRequest>& batch_request,
+    const std::shared_ptr<DiTRequest>& candidate_request) {
+  const auto& batch_state = batch_request->state();
+  const auto& candidate_state = candidate_request->state();
+  if (candidate_state.generation_params() != batch_state.generation_params()) {
+    return false;
+  }
+  if (true_cfg_condition_type(candidate_request) !=
+      true_cfg_condition_type(batch_request)) {
+    return false;
+  }
+  const auto& batch_input = batch_state.input_params();
+  const auto& candidate_input = candidate_state.input_params();
+  return image_batch_signature_matches(batch_input, candidate_input) &&
+         stacked_tensor_inputs_match(batch_input, candidate_input) &&
+         prompt_audio_allows_batching(batch_input, candidate_input);
+}
 }  // namespace
 
 void DiTAsyncResponseProcessor::process_completed_request(
@@ -107,10 +183,30 @@ std::vector<DiTBatch> DiTDynamicBatchScheduler::prepare_batch() {
 
   int count = 0;
   std::shared_ptr<DiTRequest> request;
-  while (request_queue_.read(request)) {
-    running_requests_.emplace_back(request);
+  auto read_next_request = [this](std::shared_ptr<DiTRequest>& next_request) {
+    if (!deferred_requests_.empty()) {
+      next_request = std::move(deferred_requests_.front());
+      deferred_requests_.pop_front();
+      return true;
+    }
+    return request_queue_.read(next_request);
+  };
 
-    if (++count == options_.max_request_per_batch()) break;
+  if (read_next_request(request)) {
+    std::shared_ptr<DiTRequest> batch_request = request;
+    running_requests_.emplace_back(request);
+    count = 1;
+
+    while (count < options_.max_request_per_batch() &&
+           read_next_request(request)) {
+      if (!is_compatible_dit_batch_request(batch_request, request)) {
+        deferred_requests_.emplace_back(std::move(request));
+        break;
+      }
+
+      running_requests_.emplace_back(request);
+      ++count;
+    }
   }
 
   DiTBatch batches;
@@ -122,7 +218,8 @@ std::vector<DiTBatch> DiTDynamicBatchScheduler::prepare_batch() {
   GAUGE_SET(num_pending_requests,
             pending_requests_.load(std::memory_order_relaxed));
   GAUGE_SET(num_running_requests, running_requests_.size());
-  GAUGE_SET(num_waiting_requests, request_queue_.size());
+  GAUGE_SET(num_waiting_requests,
+            request_queue_.size() + deferred_requests_.size());
 
   return {batches};
 }

--- a/xllm/core/scheduler/dit_scheduler.h
+++ b/xllm/core/scheduler/dit_scheduler.h
@@ -19,6 +19,7 @@ limitations under the License.
 #include <folly/MPMCQueue.h>
 #include <folly/futures/Future.h>
 
+#include <deque>
 #include <limits>
 #include <memory>
 #include <queue>
@@ -113,6 +114,10 @@ class DiTDynamicBatchScheduler : public DiTScheduler {
 
   // a batch of requests in running state
   std::vector<std::shared_ptr<DiTRequest>> running_requests_;
+
+  // requests popped from request_queue_ but deferred because they are not
+  // compatible with the current DiT batch.
+  std::deque<std::shared_ptr<DiTRequest>> deferred_requests_;
 
   // response handler
   std::unique_ptr<DiTAsyncResponseProcessor> response_handler_;

--- a/xllm/core/util/tensor_helper.h
+++ b/xllm/core/util/tensor_helper.h
@@ -129,6 +129,23 @@ inline bool file_exists(const std::string& path) {
   return file.good();
 }
 
+inline bool tensor_batch_signature_matches(const torch::Tensor& lhs,
+                                           const torch::Tensor& rhs) {
+  if (!lhs.defined() || !rhs.defined()) {
+    return lhs.defined() == rhs.defined();
+  }
+  if (lhs.scalar_type() != rhs.scalar_type() || lhs.device() != rhs.device() ||
+      lhs.dim() != rhs.dim()) {
+    return false;
+  }
+  for (int64_t i = 0; i < lhs.dim(); ++i) {
+    if (lhs.size(i) != rhs.size(i)) {
+      return false;
+    }
+  }
+  return true;
+}
+
 inline torch::Tensor safe_concat(const torch::Tensor& t1,
                                  const torch::Tensor& t2,
                                  const uint32_t dim) {

--- a/xllm/models/dit/autoencoders/autoencoder_kl_qwenimage.h
+++ b/xllm/models/dit/autoencoders/autoencoder_kl_qwenimage.h
@@ -18,8 +18,10 @@ limitations under the License.
 #include <torch/nn/modules/linear.h>
 #include <torch/nn/modules/normalization.h>
 #include <torch/torch.h>
+#if defined(USE_NPU)
 #include <torch_npu/csrc/aten/CustomFunctions.h>
 #include <torch_npu/csrc/libs/init_npu.h>
+#endif
 
 #include <iostream>
 #include <memory>
@@ -38,11 +40,13 @@ limitations under the License.
 #include "models/dit/utils/util.h"
 #include "models/model_registry.h"
 
+#if defined(USE_NPU)
 #ifdef TORCH_HIGHER_THAN_PTA6
 #include <torch_npu/csrc/framework/OpCommand.h>
 #else
 #include <torch_npu/csrc/aten/NPUNativeFunctions.h>
 #include <torch_npu/csrc/framework/utils/OpPreparation.h>
+#endif
 #endif
 
 // VAE model compatible with huggingface weights
@@ -149,6 +153,7 @@ class QwenImageRMS_normImpl : public torch::nn::Module {
 
   torch::Tensor forward(const torch::Tensor& x) {
     if (fused_) {
+#if defined(USE_NPU)
       auto [output, rstd] =
           at_npu::native::custom_ops::npu_rms_norm(x, weight_, 0);
 
@@ -156,6 +161,18 @@ class QwenImageRMS_normImpl : public torch::nn::Module {
         output = output + bias_.to(output.device());
       }
       return output;
+#else
+      torch::Tensor normalized =
+          torch::nn::functional::normalize(
+              x.to(torch::kFloat),
+              torch::nn::functional::NormalizeFuncOptions().dim(
+                  channel_first_ ? 1 : -1))
+              .to(x.dtype());
+      if (is_bias_) {
+        return normalized * scale_ * weight_ + bias_;
+      }
+      return normalized * scale_ * weight_;
+#endif
     } else {
       torch::Tensor normalized =
           torch::nn::functional::normalize(
@@ -653,6 +670,7 @@ class QwenImageAttentionBlockImpl : public QwenImageBaseModule {
     auto chunks = qkv.chunk(3, -1);
     auto q = chunks[0], k = chunks[1], v = chunks[2];
 
+#if defined(USE_NPU)
     auto results = at_npu::native::custom_ops::npu_fusion_attention(
         q,
         k,
@@ -666,7 +684,16 @@ class QwenImageAttentionBlockImpl : public QwenImageBaseModule {
         /*keep_prob=*/1.0,
         /*pre_tockens=*/65535,
         /*next_tockens=*/65535);
-    auto attn_output = std::get<0>(results);
+    torch::Tensor attn_output = std::get<0>(results);
+#else
+    torch::Tensor attn_output =
+        torch::scaled_dot_product_attention(q,
+                                            k,
+                                            v,
+                                            torch::nullopt,
+                                            /*dropout_p=*/0.0,
+                                            /*is_causal=*/false);
+#endif
     attn_output =
         attn_output.squeeze(1).permute({0, 2, 1}).reshape({b * t, c, h, w});
 

--- a/xllm/models/dit/autoencoders/autoencoder_kl_wan.h
+++ b/xllm/models/dit/autoencoders/autoencoder_kl_wan.h
@@ -657,6 +657,7 @@ class WanAttentionBlockImpl : public torch::nn::Module {
     torch::Tensor k = chunks[1];
     torch::Tensor v = chunks[2];
 
+#if defined(USE_NPU)
     auto results = at_npu::native::custom_ops::npu_fusion_attention(
         q,
         k,
@@ -670,7 +671,16 @@ class WanAttentionBlockImpl : public torch::nn::Module {
         /*keep_prob=*/1.0,
         /*pre_tockens=*/65535,
         /*next_tockens=*/65535);
-    auto attn_output = std::get<0>(results);
+    torch::Tensor attn_output = std::get<0>(results);
+#else
+    torch::Tensor attn_output =
+        torch::scaled_dot_product_attention(q,
+                                            k,
+                                            v,
+                                            torch::nullopt,
+                                            /*dropout_p=*/0.0,
+                                            /*is_causal=*/false);
+#endif
 
     auto attn_out = attn_output.squeeze(1).permute({0, 2, 1}).reshape(
         {batch_size * time, channels, height, width});

--- a/xllm/models/dit/pipelines/pipeline_longcat_image.h
+++ b/xllm/models/dit/pipelines/pipeline_longcat_image.h
@@ -26,7 +26,9 @@ limitations under the License.
 #include "core/framework/parallel_state/process_group.h"
 #include "core/framework/request/dit_request_state.h"
 #include "core/framework/tokenizer/tokenizer.h"
+#if defined(USE_CUDA)
 #include "core/layers/cuda/flashinfer_workspace.h"
+#endif
 #include "models/dit/autoencoders/autoencoder_kl.h"
 #include "models/dit/schedulers/flowmatch_euler_discrete_scheduler.h"
 #include "models/dit/transformers/transformer_longcat_image.h"
@@ -39,7 +41,7 @@ namespace xllm {
 class LongCatImagePipelineImpl;
 
 // Utility constants
-constexpr int64_t ROPE_SCALE_BASE = 10000;
+constexpr int64_t kLongCatRopeScaleBase = 10000;
 // FlowMatch/Euler scheduler timestep scaling (model expects [0, 1000])
 constexpr float kLongCatTimestepScale = 1000.0f;
 
@@ -53,11 +55,11 @@ constexpr const char* PROMPT_TEMPLATE_ENCODE_PREFIX =
 constexpr const char* PROMPT_TEMPLATE_ENCODE_SUFFIX =
     "<|im_end|>\n<|im_start|>assistant\n";
 
-float calculate_shift(int64_t image_seq_len,
-                      int64_t base_seq_len = 256,
-                      int64_t max_seq_len = 4096,
-                      float base_shift = 0.5f,
-                      float max_shift = 1.15f) {
+inline float calculate_longcat_shift(int64_t image_seq_len,
+                                     int64_t base_seq_len = 256,
+                                     int64_t max_seq_len = 4096,
+                                     float base_shift = 0.5f,
+                                     float max_shift = 1.15f) {
   float m =
       (max_shift - base_shift) / static_cast<float>(max_seq_len - base_seq_len);
   float b = base_shift - m * static_cast<float>(base_seq_len);
@@ -65,7 +67,7 @@ float calculate_shift(int64_t image_seq_len,
   return mu;
 }
 
-std::pair<torch::Tensor, int64_t> retrieve_timesteps(
+inline std::pair<torch::Tensor, int64_t> retrieve_longcat_timesteps(
     FlowMatchEulerDiscreteScheduler scheduler,
     int64_t num_inference_steps = 0,
     torch::Device device = torch::kCPU,
@@ -93,10 +95,11 @@ class LongCatImagePipelineImpl : public torch::nn::Module {
     const auto& model_args = context.get_model_args("vae");
     options_ = context.get_tensor_options();
 
-    // Initialize FlashinferWorkspace for attention operations
-    // This is required for batch_prefill to work correctly
+#if defined(USE_CUDA)
+    // Initialize FlashinferWorkspace for CUDA attention operations.
     layer::flashinfer::FlashinferWorkspace::get_instance().initialize(
         options_.device());
+#endif
 
     vae_scale_factor_ = 1 << (model_args.block_out_channels().size() - 1);
     vae_shift_factor_ = model_args.shift_factor();
@@ -120,7 +123,7 @@ class LongCatImagePipelineImpl : public torch::nn::Module {
     pos_embed_ = register_module(
         "pos_embed",
         LongCatImagePosEmbed(
-            ROPE_SCALE_BASE,
+            kLongCatRopeScaleBase,
             context.get_model_args("transformer").axes_dims_rope()));
     transformer_ = LongCatImageTransformer2DModel(
         ModelContext(context.get_parallel_args(),
@@ -744,12 +747,12 @@ class LongCatImagePipelineImpl : public torch::nn::Module {
     }
 
     int64_t image_seq_len = prepared_latents.size(1);
-    float mu = calculate_shift(image_seq_len,
-                               scheduler_->base_image_seq_len(),
-                               scheduler_->max_image_seq_len(),
-                               scheduler_->base_shift(),
-                               scheduler_->max_shift());
-    auto [timesteps, _] = retrieve_timesteps(
+    float mu = calculate_longcat_shift(image_seq_len,
+                                       scheduler_->base_image_seq_len(),
+                                       scheduler_->max_image_seq_len(),
+                                       scheduler_->base_shift(),
+                                       scheduler_->max_shift());
+    auto [timesteps, _] = retrieve_longcat_timesteps(
         scheduler_, num_inference_steps, options_.device(), new_sigmas, mu);
 
     scheduler_->set_begin_index(0);

--- a/xllm/models/dit/pipelines/pipeline_longcat_image_edit.h
+++ b/xllm/models/dit/pipelines/pipeline_longcat_image_edit.h
@@ -118,7 +118,7 @@ class LongCatImageEditPipelineImpl : public torch::nn::Module {
     pos_embed_ = register_module(
         "pos_embed",
         LongCatImagePosEmbed(
-            ROPE_SCALE_BASE,
+            kLongCatRopeScaleBase,
             context.get_model_args("transformer").axes_dims_rope()));
     transformer_ = LongCatImageTransformer2DModel(
         ModelContext(context.get_parallel_args(),
@@ -974,13 +974,13 @@ class LongCatImageEditPipelineImpl : public torch::nn::Module {
     }
 
     int64_t image_seq_len = prepared_latents.size(1);
-    float mu = calculate_shift(image_seq_len,
-                               scheduler_->base_image_seq_len(),
-                               scheduler_->max_image_seq_len(),
-                               scheduler_->base_shift(),
-                               scheduler_->max_shift());
+    float mu = calculate_longcat_shift(image_seq_len,
+                                       scheduler_->base_image_seq_len(),
+                                       scheduler_->max_image_seq_len(),
+                                       scheduler_->base_shift(),
+                                       scheduler_->max_shift());
 
-    auto [timesteps, _] = retrieve_timesteps(
+    auto [timesteps, _] = retrieve_longcat_timesteps(
         scheduler_, num_inference_steps, options_.device(), sigmas, mu);
 
     scheduler_->set_begin_index(0);

--- a/xllm/models/dit/pipelines/pipeline_qwenimage_edit_plus.h
+++ b/xllm/models/dit/pipelines/pipeline_qwenimage_edit_plus.h
@@ -14,12 +14,15 @@ limitations under the License.
 ==============================================================================*/
 #pragma once
 
-#include <acl/acl.h>
 #include <torch/torch.h>
 
 #include <algorithm>
+#include <limits>
 #include <memory>
 #include <string>
+#include <utility>
+#include <variant>
+#include <vector>
 
 #include "core/common/global_flags.h"
 #include "core/framework/config/dit_config.h"
@@ -28,6 +31,7 @@ limitations under the License.
 #include "core/framework/dit_model_loader.h"
 #include "core/framework/model/model_input_params.h"
 #include "core/framework/model_context.h"
+#include "core/framework/parallel_state/process_group.h"
 #include "core/framework/request/dit_request_state.h"
 #include "core/framework/state_dict/state_dict.h"
 #include "core/framework/state_dict/utils.h"
@@ -38,16 +42,51 @@ limitations under the License.
 #include "models/dit/transformers/transformer_qwen_image.h"
 #include "models/dit/utils/util.h"
 #include "models/model_registry.h"
+#if defined(USE_DCU)
+#include "models/vlm/qwen2_5_vl.h"
+#endif
 #include "processors/qwen2_vl_image_processor.h"
 #include "util/tensor_helper.h"
 
 #define CONDITION_IMAGE_SIZE 147456
 
 namespace xllm {
+
+#if defined(USE_DCU)
+using QwenImageEditTextEncoder = Qwen2_5_VLForConditionalGeneration;
+#endif
+
+inline int32_t get_qwen_image_edit_vlm_tp_port(int32_t rank) {
+  constexpr int32_t kQwenImageEditVlmTpBasePort = 29502;
+  const int32_t port = kQwenImageEditVlmTpBasePort + rank;
+  CHECK_LE(port, 65535)
+      << "Qwen-Image-Edit VLM ProcessGroup port overflow: base_port="
+      << kQwenImageEditVlmTpBasePort << ", rank=" << rank;
+  return port;
+}
+
+inline int64_t get_qwen_image_edit_vae_target_area(int64_t height,
+                                                   int64_t width) {
+  constexpr int64_t kDefaultVaeTargetArea = 1024 * 1024;
+  int64_t request_area =
+      height > 0 && width > 0 ? height * width : kDefaultVaeTargetArea;
+
+  const int64_t config_area =
+      ::xllm::DiTConfig::get_instance().dit_vae_image_size();
+  if (config_area > 0 && config_area != kDefaultVaeTargetArea) {
+    return config_area;
+  }
+  return request_area;
+}
+
 class QwenImageEditPlusPipelineImpl : public torch::nn::Module {
  public:
   QwenImageEditPlusPipelineImpl(const DiTModelContext& context)
-      : parallel_args_(context.get_parallel_args()),
+      : context_(context),
+        parallel_args_(context.get_parallel_args()),
+#if defined(USE_DCU)
+        vl_image_processor_(context.get_model_args("processor")),
+#endif
         vae_model_args_(context.get_model_args("vae")) {
     options_ = context.get_tensor_options();
     dtype_ = options_.dtype().toScalarType();
@@ -82,6 +121,36 @@ class QwenImageEditPlusPipelineImpl : public torch::nn::Module {
     scheduler_ =
         FlowMatchEulerDiscreteScheduler(context.get_model_context("scheduler"));
 
+#if defined(USE_DCU)
+    const auto& original_parallel_args = context.get_parallel_args();
+    ParallelArgs vlm_parallel_args = original_parallel_args;
+    if (original_parallel_args.tp_group_ == nullptr) {
+      if (original_parallel_args.dit_tp_group_ != nullptr) {
+        vlm_parallel_args.tp_group_ = original_parallel_args.dit_tp_group_;
+      } else {
+        const int32_t vlm_tp_port =
+            get_qwen_image_edit_vlm_tp_port(original_parallel_args.rank());
+        LOG(INFO) << "Creating single-rank Qwen-Image-Edit VLM ProcessGroup on "
+                  << "127.0.0.1:" << vlm_tp_port;
+        vlm_tp_group_ =
+            create_process_group(/*rank=*/0,
+                                 /*world_size=*/1,
+                                 /*rank_size=*/1,
+                                 vlm_tp_port,
+                                 /*trans=*/false,
+                                 /*host=*/"127.0.0.1",
+                                 /*group_name=*/"vlm_tp_group_qwen_image_edit",
+                                 options_.device());
+        vlm_parallel_args.tp_group_ = vlm_tp_group_.get();
+      }
+    }
+    text_encoder_ = QwenImageEditTextEncoder(
+        ModelContext(vlm_parallel_args,
+                     context.get_model_args("text_encoder"),
+                     context.get_quant_args("text_encoder"),
+                     context.get_tensor_options()));
+#endif
+
     vae_image_processor_ =
         xllm::VAEImageProcessor(context.get_model_context("vae"),
                                 /*do_resize=*/true,
@@ -95,6 +164,9 @@ class QwenImageEditPlusPipelineImpl : public torch::nn::Module {
     register_module("vae", vae_);
     register_module("scheduler", scheduler_);
     register_module("transformer", transformer_);
+#if defined(USE_DCU)
+    register_module("text_encoder", text_encoder_);
+#endif
     register_module("vae_image_processor", vae_image_processor_);
 
     use_layer3d_rope_ = context.get_model_context("transformer")
@@ -121,39 +193,463 @@ class QwenImageEditPlusPipelineImpl : public torch::nn::Module {
     }
   }
 
-  std::vector<torch::Tensor> _extract_masked_hidden(
-      const torch::Tensor& hidden_states,
-      const torch::Tensor& mask) {
-    auto bool_mask = mask.to(torch::kBool);
-    auto valid_lengths = bool_mask.sum(1);
+#if defined(USE_DCU)
+  torch::Tensor build_qwen2_5_vl_mrope_positions(
+      const torch::Tensor& input_ids,
+      const torch::Tensor& attention_mask,
+      const torch::Tensor& image_grid_thw) {
+    CHECK(input_ids.dim() == 2) << "input_ids must be [B, S]";
+    CHECK(attention_mask.dim() == 2) << "attention_mask must be [B, S]";
 
-    auto valid_lengths_cpu = valid_lengths.to(torch::kCPU).contiguous();
+    auto long_opts =
+        torch::TensorOptions().dtype(torch::kLong).device(input_ids.device());
+    torch::Tensor position_ids =
+        torch::ones({3, input_ids.size(0), input_ids.size(1)}, long_opts);
 
-    std::vector<int64_t> lengths_list;
-    lengths_list.reserve(valid_lengths_cpu.numel());
+    const auto& text_encoder_args = context_.get_model_args("text_encoder");
+    int64_t spatial_merge_size = text_encoder_args.mm_spatial_merge_size();
+    CHECK_GT(spatial_merge_size, 0)
+        << "QwenImageEditPlus text_encoder mm_spatial_merge_size must be > 0";
+    int64_t image_token_id = text_encoder_args.image_token_id();
+    int64_t vision_start_token_id = text_encoder_args.vision_start_token_id();
 
-    int64_t* lengths_ptr = valid_lengths_cpu.data_ptr<int64_t>();
-    for (int64_t i = 0; i < valid_lengths_cpu.numel(); ++i) {
-      lengths_list.push_back(lengths_ptr[i]);
+    int64_t global_image_index = 0;
+    int64_t num_image_grids =
+        image_grid_thw.defined() ? image_grid_thw.size(0) : 0;
+
+    for (int64_t b = 0; b < input_ids.size(0); ++b) {
+      auto mask_b = attention_mask[b].to(torch::kBool);
+      auto ids_b = input_ids[b].index({mask_b}).to(torch::kLong).cpu();
+      std::vector<int64_t> tokens(ids_b.data_ptr<int64_t>(),
+                                  ids_b.data_ptr<int64_t>() + ids_b.numel());
+
+      int64_t image_nums = 0;
+      for (int64_t i = 0; i + 1 < static_cast<int64_t>(tokens.size()); ++i) {
+        if (tokens[i] == vision_start_token_id &&
+            tokens[i + 1] == image_token_id) {
+          image_nums++;
+        }
+      }
+
+      std::vector<torch::Tensor> llm_pos_ids_list;
+      llm_pos_ids_list.reserve(static_cast<size_t>(image_nums) * 2 + 1);
+      int64_t st = 0;
+      int64_t remain_images = image_nums;
+      for (int64_t n = 0; n < image_nums; ++n) {
+        int64_t ed = static_cast<int64_t>(tokens.size()) + 1;
+        if (remain_images > 0) {
+          for (int64_t p = st; p < static_cast<int64_t>(tokens.size()); ++p) {
+            if (tokens[p] == image_token_id) {
+              ed = p;
+              break;
+            }
+          }
+        }
+
+        CHECK(num_image_grids > 0)
+            << "image_grid_thw is required when image tokens exist";
+        CHECK(global_image_index < num_image_grids)
+            << "image_grid_thw count is smaller than required image tokens";
+        int64_t t = image_grid_thw[global_image_index][0].item<int64_t>();
+        int64_t h = image_grid_thw[global_image_index][1].item<int64_t>();
+        int64_t w = image_grid_thw[global_image_index][2].item<int64_t>();
+
+        int64_t llm_grid_t = t;
+        int64_t llm_grid_h = h / spatial_merge_size;
+        int64_t llm_grid_w = w / spatial_merge_size;
+        int64_t text_len = ed - st;
+
+        int64_t st_idx = 0;
+        if (!llm_pos_ids_list.empty()) {
+          st_idx = llm_pos_ids_list.back().max().item<int64_t>() + 1;
+        }
+
+        auto text_pos =
+            torch::arange(text_len, long_opts).view({1, -1}).expand({3, -1}) +
+            st_idx;
+        llm_pos_ids_list.push_back(text_pos);
+
+        auto t_index = torch::arange(llm_grid_t, long_opts)
+                           .view({-1, 1})
+                           .expand({-1, llm_grid_h * llm_grid_w})
+                           .flatten();
+        auto h_index = torch::arange(llm_grid_h, long_opts)
+                           .view({1, -1, 1})
+                           .expand({llm_grid_t, -1, llm_grid_w})
+                           .flatten();
+        auto w_index = torch::arange(llm_grid_w, long_opts)
+                           .view({1, 1, -1})
+                           .expand({llm_grid_t, llm_grid_h, -1})
+                           .flatten();
+        auto vision_pos =
+            torch::stack({t_index, h_index, w_index}, 0) + text_len + st_idx;
+        llm_pos_ids_list.push_back(vision_pos);
+
+        st = ed + llm_grid_t * llm_grid_h * llm_grid_w;
+        global_image_index++;
+        remain_images--;
+      }
+
+      if (st < static_cast<int64_t>(tokens.size())) {
+        int64_t st_idx = 0;
+        if (!llm_pos_ids_list.empty()) {
+          st_idx = llm_pos_ids_list.back().max().item<int64_t>() + 1;
+        }
+        int64_t text_len = static_cast<int64_t>(tokens.size()) - st;
+        auto text_pos =
+            torch::arange(text_len, long_opts).view({1, -1}).expand({3, -1}) +
+            st_idx;
+        llm_pos_ids_list.push_back(text_pos);
+      }
+
+      if (!llm_pos_ids_list.empty()) {
+        auto llm_positions = torch::cat(llm_pos_ids_list, 1).reshape({3, -1});
+        position_ids.index_put_({torch::indexing::Slice(), b, mask_b},
+                                llm_positions.to(position_ids.device()));
+      }
     }
 
-    auto selected = hidden_states.index({bool_mask});
-    auto split_result = torch::split(selected, lengths_list, 0);
-
-    return std::vector<torch::Tensor>(split_result.begin(), split_result.end());
+    return position_ids.reshape({3, -1}).contiguous();
   }
+
+  ModelInputParams build_qwen_vl_input_params(
+      const torch::Tensor& tokens,
+      const torch::Tensor& attention_mask,
+      MMBatchData mm_batch) {
+    ModelInputParams params;
+    CHECK(attention_mask.defined() && attention_mask.dim() == 2)
+        << "QwenImageEditPlus text encoder requires a [B, S] attention mask";
+    int64_t batch_size = attention_mask.size(0);
+    if (tokens.numel() > 0) {
+      auto lengths_cpu =
+          attention_mask.to(torch::kCPU).to(torch::kInt64).sum(/*dim=*/1);
+      const int64_t* lengths_data = lengths_cpu.data_ptr<int64_t>();
+      std::vector<int32_t> seq_lens;
+      seq_lens.reserve(static_cast<size_t>(batch_size));
+      std::vector<int32_t> cu_seqlens_vec;
+      cu_seqlens_vec.reserve(static_cast<size_t>(batch_size) + 1);
+      cu_seqlens_vec.emplace_back(0);
+      int32_t max_seq_len = 0;
+      for (int64_t i = 0; i < batch_size; ++i) {
+        CHECK_GT(lengths_data[i], 0)
+            << "QwenImageEditPlus text encoder sequence length must be > 0";
+        CHECK_LE(lengths_data[i], std::numeric_limits<int32_t>::max())
+            << "QwenImageEditPlus text encoder sequence length exceeds int32";
+        int32_t seq_len = static_cast<int32_t>(lengths_data[i]);
+        seq_lens.emplace_back(seq_len);
+        cu_seqlens_vec.emplace_back(cu_seqlens_vec.back() + seq_len);
+        max_seq_len = std::max(max_seq_len, seq_len);
+      }
+      CHECK_EQ(tokens.numel(), cu_seqlens_vec.back())
+          << "packed token count does not match attention mask";
+      params.meta.num_sequences = static_cast<int32_t>(batch_size);
+      params.meta.actual_num_sequences = static_cast<int32_t>(batch_size);
+      params.meta.q_max_seq_len = max_seq_len;
+      params.meta.kv_max_seq_len = max_seq_len;
+      auto cu_seqlens =
+          torch::tensor(cu_seqlens_vec, torch::kInt).to(tokens.device());
+      params.attention.device.q_seq_lens = cu_seqlens;
+      params.attention.device.kv_seq_lens = cu_seqlens;
+      params.attention.device.q_cu_seq_lens = cu_seqlens;
+      params.attention.host.q_seq_lens = seq_lens;
+      params.attention.host.q_cu_seq_lens = cu_seqlens_vec;
+      params.attention.host.kv_seq_lens = seq_lens;
+      params.meta.batch_forward_type = BatchForwardType::PREFILL;
+    }
+
+    ModelInputParams mm_params;
+    mm_params.multimodal.mm_data = MMBatchData::to(mm_batch, tokens.device());
+    MMDict multimodal_embeds =
+        text_encoder_->get_multimodal_embeddings(mm_params);
+
+    auto image_embedding_value = multimodal_embeds.find("image|embedding");
+    CHECK(image_embedding_value != multimodal_embeds.end())
+        << "Qwen image encoder did not produce image embeddings";
+    torch::Tensor image_embeddings;
+    if (std::holds_alternative<torch::Tensor>(image_embedding_value->second)) {
+      image_embeddings = std::get<torch::Tensor>(image_embedding_value->second);
+    } else {
+      const auto& image_embedding_list =
+          std::get<std::vector<torch::Tensor>>(image_embedding_value->second);
+      image_embeddings = torch::cat(image_embedding_list, 0);
+    }
+
+    torch::Tensor image_mask =
+        tokens.eq(context_.get_model_args("text_encoder").image_token_id());
+    CHECK_EQ(image_mask.sum().item<int64_t>(), image_embeddings.size(0))
+        << "image token count does not match image embedding count";
+
+    MMDict embedding_data;
+    embedding_data["image|embedding"] = image_embeddings;
+    embedding_data["image|mask"] = image_mask;
+    params.multimodal.mm_data = MMBatchData(MMType::IMAGE, embedding_data);
+
+    params.embedding.input_embedding =
+        text_encoder_->get_input_embeddings(tokens, params);
+    return params;
+  }
+#endif
 
   std::pair<torch::Tensor, torch::Tensor> _get_qwen_prompt_embeds(
       const std::vector<std::string>& prompt,
       const std::vector<torch::Tensor>& image,
-      torch::TensorOptions& options) {
-    std::string img_prompt_template =
-        "Picture {}: <|vision_start|><|image_pad|><|vision_end|>";
-    std::string base_img_prompt = "";
+      torch::TensorOptions& options,
+      int64_t max_sequence_length) {
+#if defined(USE_DCU)
+    CHECK(tokenizer_ != nullptr) << "Tokenizer not loaded";
+    CHECK(!text_encoder_.is_empty()) << "Text encoder not loaded";
+    CHECK(!image.empty()) << "QwenImageEditPlus requires input images";
 
-    torch::Tensor prompt_embeds;
-    torch::Tensor prompt_embeds_mask;
+    const auto& text_encoder_args = context_.get_model_args("text_encoder");
+    const auto& processor_args = context_.get_model_args("processor");
+    int64_t merge_size = processor_args.mm_image_merge_size();
+    CHECK_GT(merge_size, 0)
+        << "QwenImageEditPlus processor mm_image_merge_size must be > 0";
+    int64_t merge_length = merge_size * merge_size;
+
+    int64_t batch_size = static_cast<int64_t>(prompt.size());
+    if (batch_size == 0) {
+      for (const auto& img : image) {
+        if (img.dim() == 4) {
+          batch_size = img.size(0);
+          break;
+        }
+      }
+      if (batch_size == 0) {
+        batch_size = 1;
+      }
+    }
+
+    std::vector<std::vector<torch::Tensor>> per_sample_images(
+        static_cast<size_t>(batch_size));
+    for (const auto& img : image) {
+      if (img.dim() == 3) {
+        CHECK_EQ(batch_size, 1)
+            << "unbatched image input can only be used with batch_size=1";
+        per_sample_images[0].push_back(img);
+      } else {
+        CHECK_EQ(img.dim(), 4)
+            << "QwenImageEditPlus image input must be [C,H,W] or [B,C,H,W]";
+        CHECK_EQ(img.size(0), batch_size)
+            << "batched image input size must match prompt batch size";
+        for (int64_t b = 0; b < batch_size; ++b) {
+          per_sample_images[static_cast<size_t>(b)].push_back(img[b]);
+        }
+      }
+    }
+
+    std::vector<MMData> mm_data_list;
+    mm_data_list.reserve(static_cast<size_t>(batch_size));
+    std::vector<torch::Tensor> grid_tensors;
+    std::vector<torch::Tensor> first_sample_grids;
+    std::vector<MMDataItem> first_sample_mm_items;
+    for (int64_t b = 0; b < batch_size; ++b) {
+      std::vector<torch::Tensor> vl_images;
+      vl_images.reserve(per_sample_images[static_cast<size_t>(b)].size());
+      for (auto img : per_sample_images[static_cast<size_t>(b)]) {
+        img = img.to(torch::kFloat32);
+        float max_val = img.max().item<float>();
+        if (max_val <= 1.1f) {
+          img = img.clamp(0.0f, 1.0f) * 255.0f;
+        } else {
+          img = img.clamp(0.0f, 255.0f);
+        }
+        vl_images.push_back(img);
+      }
+
+      std::vector<MMDataItem> mm_items;
+      CHECK(vl_image_processor_.process(vl_images, mm_items))
+          << "VL image processor failed";
+      CHECK(!mm_items.empty()) << "VL image processor produced no image items";
+      std::vector<torch::Tensor> sample_grids;
+      sample_grids.reserve(mm_items.size());
+      for (auto& item : mm_items) {
+        sample_grids.push_back(
+            item.get<torch::Tensor>("image_grid_thw").value().to(torch::kCPU));
+      }
+      if (b == 0) {
+        first_sample_mm_items = mm_items;
+        first_sample_grids = sample_grids;
+      } else {
+        CHECK_EQ(sample_grids.size(), first_sample_grids.size())
+            << "QwenImageEditPlus batch currently requires every sample to "
+               "have the same number of input images";
+        for (size_t i = 0; i < sample_grids.size(); ++i) {
+          CHECK(torch::equal(sample_grids[i], first_sample_grids[i]))
+              << "QwenImageEditPlus batch currently requires identical "
+                 "image_grid_thw across samples. Different input image sizes "
+                 "or aspect ratios should be scheduled in separate batches.";
+        }
+      }
+      for (auto& sample_grid : sample_grids) {
+        grid_tensors.push_back(sample_grid);
+      }
+      MMData mm_data;
+      mm_data.set(MMType::IMAGE, mm_items);
+      mm_data_list.emplace_back(std::move(mm_data));
+    }
+    torch::Tensor image_grid_thw = torch::cat(grid_tensors, 0);
+
+    std::string base_img_prompt;
+    for (size_t i = 0; i < first_sample_mm_items.size(); ++i) {
+      torch::Tensor grid =
+          first_sample_mm_items[i].get<torch::Tensor>("image_grid_thw").value();
+      int64_t num_image_tokens = grid.prod().item<int64_t>() / merge_length;
+      base_img_prompt +=
+          "Picture " + std::to_string(i + 1) + ": <|vision_start|>";
+      for (int64_t j = 0; j < num_image_tokens; ++j) {
+        base_img_prompt += "<|image_pad|>";
+      }
+      base_img_prompt += "<|vision_end|>\n";
+    }
+
+    size_t slot = prompt_template_encode_.find("{}");
+    CHECK(slot != std::string::npos)
+        << "QwenImageEditPlus prompt template must contain {}";
+    std::string prefix_str =
+        prompt_template_encode_.substr(0, slot) + base_img_prompt;
+    std::string suffix_str =
+        prompt_template_encode_.substr(slot + std::string("{}").size());
+
+    std::vector<int32_t> prefix_tokens;
+    CHECK(tokenizer_->encode(prefix_str, &prefix_tokens, false));
+    std::vector<int32_t> suffix_tokens;
+    CHECK(tokenizer_->encode(suffix_str, &suffix_tokens, false));
+    int64_t suffix_len = suffix_tokens.size();
+
+    CHECK(prompt.empty() || static_cast<int64_t>(prompt.size()) == batch_size)
+        << "prompt batch size must match image batch size";
+    std::vector<std::vector<int32_t>> batch_tokens;
+    batch_tokens.reserve(batch_size);
+    int64_t prefix_len = prompt_template_encode_start_idx_;
+    CHECK_GE(prefix_len, 0)
+        << "QwenImageEditPlus prompt_template_encode_start_idx_ must be >= 0";
+
+    for (const auto& each_prompt : prompt) {
+      std::vector<int32_t> tokens;
+      if (!tokenizer_->encode(each_prompt, &tokens, false)) {
+        tokens.clear();
+      }
+
+      if (static_cast<int64_t>(tokens.size()) > max_sequence_length) {
+        LOG(WARNING) << "Input truncated from " << tokens.size() << " to "
+                     << max_sequence_length << " tokens";
+        tokens.resize(max_sequence_length);
+      }
+      batch_tokens.push_back(std::move(tokens));
+    }
+
+    if (batch_tokens.empty()) {
+      batch_tokens.resize(static_cast<size_t>(batch_size));
+    }
+
+    int32_t pad_token_id = text_encoder_args.pad_token_id();
+    if (pad_token_id == 0) {
+      auto pad_id = tokenizer_->token_to_id("<|endoftext|>");
+      pad_token_id = pad_id.value_or(151643);
+    }
+
+    for (auto& tokens : batch_tokens) {
+      int64_t pad_len =
+          max_sequence_length - static_cast<int64_t>(tokens.size());
+      if (pad_len > 0) {
+        tokens.insert(tokens.end(), pad_len, pad_token_id);
+      }
+    }
+
+    int64_t prefix_full_len = prefix_tokens.size();
+    CHECK_LT(prefix_len, prefix_full_len)
+        << "QwenImageEditPlus prompt_template_encode_start_idx_ must be "
+           "inside the encoded prefix. prefix_len="
+        << prefix_len << ", prefix_full_len=" << prefix_full_len;
+    int64_t total_seq_len = prefix_full_len + max_sequence_length + suffix_len;
+    std::vector<int32_t> input_ids_flat;
+    std::vector<int32_t> attention_mask_flat;
+    input_ids_flat.reserve(batch_size * total_seq_len);
+    attention_mask_flat.reserve(batch_size * total_seq_len);
+
+    for (int64_t i = 0; i < batch_size; ++i) {
+      input_ids_flat.insert(
+          input_ids_flat.end(), prefix_tokens.begin(), prefix_tokens.end());
+      attention_mask_flat.insert(
+          attention_mask_flat.end(), static_cast<size_t>(prefix_full_len), 1);
+
+      input_ids_flat.insert(
+          input_ids_flat.end(), batch_tokens[i].begin(), batch_tokens[i].end());
+      int64_t non_pad_count = 0;
+      for (const auto& token : batch_tokens[i]) {
+        if (token != pad_token_id) {
+          non_pad_count++;
+        } else {
+          break;
+        }
+      }
+      for (int64_t j = 0; j < max_sequence_length; ++j) {
+        attention_mask_flat.push_back(j < non_pad_count ? 1 : 0);
+      }
+
+      input_ids_flat.insert(
+          input_ids_flat.end(), suffix_tokens.begin(), suffix_tokens.end());
+      attention_mask_flat.insert(attention_mask_flat.end(), suffix_len, 1);
+    }
+
+    torch::Tensor input_ids =
+        torch::tensor(input_ids_flat, torch::dtype(torch::kLong))
+            .view({batch_size, total_seq_len})
+            .to(device_);
+    torch::Tensor attention_mask =
+        torch::tensor(attention_mask_flat, torch::dtype(torch::kLong))
+            .view({batch_size, total_seq_len})
+            .to(device_);
+
+    torch::Tensor positions_2d = build_qwen2_5_vl_mrope_positions(
+        input_ids, attention_mask, image_grid_thw);
+    torch::Tensor valid_token_mask =
+        attention_mask.view({-1}).to(torch::kBool).contiguous();
+    torch::Tensor valid_token_indices =
+        torch::nonzero(valid_token_mask).squeeze(1).to(device_);
+    torch::Tensor tokens_flat =
+        input_ids.view({-1}).index_select(0, valid_token_indices);
+    torch::Tensor positions_packed =
+        positions_2d.index_select(1, valid_token_indices);
+
+    MMBatchData mm_batch(std::move(mm_data_list));
+
+    std::vector<KVCache> kv_caches(text_encoder_args.n_layers());
+    ModelInputParams input_params = build_qwen_vl_input_params(
+        tokens_flat, attention_mask, std::move(mm_batch));
+#if defined(USE_DCU)
+    input_params.graph.use_dense_flash_attention = true;
+#endif
+    auto model_output = text_encoder_->forward(
+        tokens_flat, positions_packed, kv_caches, input_params);
+    torch::Tensor hidden_states_flat = model_output.hidden_states;
+    int64_t hidden_size = hidden_states_flat.size(-1);
+    torch::Tensor padded_hidden_states_flat =
+        torch::zeros({batch_size * total_seq_len, hidden_size},
+                     hidden_states_flat.options());
+    padded_hidden_states_flat.index_copy_(
+        0, valid_token_indices, hidden_states_flat);
+    torch::Tensor hidden_states_last = padded_hidden_states_flat.view(
+        {batch_size, total_seq_len, hidden_size});
+
+    int64_t end = total_seq_len - suffix_len;
+    CHECK_LT(prefix_len, end)
+        << "QwenImageEditPlus prompt embedding slice is invalid: prefix_len="
+        << prefix_len << ", end=" << end << ", total_seq_len=" << total_seq_len
+        << ", suffix_len=" << suffix_len;
+    torch::Tensor prompt_embeds =
+        hidden_states_last.slice(1, prefix_len, end).to(options);
+    torch::Tensor prompt_embeds_mask =
+        attention_mask.slice(1, prefix_len, end).to(device_);
     return std::make_pair(prompt_embeds, prompt_embeds_mask);
+#else
+    (void)prompt;
+    (void)image;
+    (void)options;
+    (void)max_sequence_length;
+    return std::make_pair(torch::Tensor(), torch::Tensor());
+#endif
   }
 
   void _encode_prompt(const std::vector<torch::Tensor>& image,
@@ -163,10 +659,14 @@ class QwenImageEditPlusPipelineImpl : public torch::nn::Module {
                       torch::TensorOptions& options,
                       int64_t num_images_per_prompt = 1,
                       int64_t max_sequence_length = 1024) {
-    int64_t batch_size = prompt_embeds.defined() ? prompt_embeds.size(0) : 1;
+    int64_t batch_size =
+        prompt_embeds.defined() ? prompt_embeds.size(0) : prompt.size();
+    if (batch_size == 0) {
+      batch_size = 1;
+    }
     if (!prompt_embeds.defined()) {
       std::tie(prompt_embeds, prompt_embeds_mask) =
-          _get_qwen_prompt_embeds(prompt, image, options);
+          _get_qwen_prompt_embeds(prompt, image, options, max_sequence_length);
     }
 
     CHECK(prompt_embeds.defined())
@@ -257,7 +757,8 @@ class QwenImageEditPlusPipelineImpl : public torch::nn::Module {
 
   std::pair<torch::Tensor, torch::Tensor> _prepare_latents(
       const std::vector<torch::Tensor>& images,
-      int64_t batch_size,
+      int64_t request_batch_size,
+      int64_t num_images_per_prompt,
       int64_t num_channels_latents,
       int64_t height,
       int64_t width,
@@ -266,9 +767,10 @@ class QwenImageEditPlusPipelineImpl : public torch::nn::Module {
       torch::Tensor latents = torch::Tensor()) {
     height = 2 * (height / (vae_scale_factor_ * 2));
     width = 2 * (width / (vae_scale_factor_ * 2));
+    const int64_t total_batch_size = request_batch_size * num_images_per_prompt;
 
     std::vector<int64_t> shape = {
-        batch_size, 1, num_channels_latents, height, width};
+        total_batch_size, 1, num_channels_latents, height, width};
 
     torch::Tensor image_latents;
     if (!images.empty()) {
@@ -285,11 +787,21 @@ class QwenImageEditPlusPipelineImpl : public torch::nn::Module {
         }
 
         current_image_latents = torch::cat({current_image_latents}, 0);
+        CHECK_EQ(current_image_latents.size(0), request_batch_size)
+            << "image latent batch size must match request batch size";
+        if (num_images_per_prompt > 1) {
+          auto sizes = current_image_latents.sizes().vec();
+          sizes[0] = total_batch_size;
+          current_image_latents =
+              current_image_latents.unsqueeze(1)
+                  .repeat({1, num_images_per_prompt, 1, 1, 1, 1})
+                  .view(sizes);
+        }
         int64_t image_latent_height = current_image_latents.size(3);
         int64_t image_latent_width = current_image_latents.size(4);
 
         current_image_latents = _pack_latents(current_image_latents,
-                                              batch_size,
+                                              total_batch_size,
                                               num_channels_latents,
                                               image_latent_height,
                                               image_latent_width);
@@ -302,7 +814,7 @@ class QwenImageEditPlusPipelineImpl : public torch::nn::Module {
     if (!latents.defined()) {
       latents = xllm::dit::randn_tensor(shape, seed, options);
       latents = _pack_latents(
-          latents, batch_size, num_channels_latents, height, width);
+          latents, total_batch_size, num_channels_latents, height, width);
     } else {
       latents = latents.to(options);
     }
@@ -341,19 +853,24 @@ class QwenImageEditPlusPipelineImpl : public torch::nn::Module {
     }
     torch::Tensor negative_prompt_embeds_mask;
 
-    if (::xllm::DiTConfig::get_instance().dit_debug_print()) {
-      input.debug_print();
-    }
-
-    if (input.images_list.empty()) {
-      LOG(FATAL) << "QwenImageEditPlus pipeline expected to have "
-                 << "image inputs in images_list";
+    std::vector<torch::Tensor> raw_image_inputs;
+    if (!input.images_list.empty()) {
+      raw_image_inputs = input.images_list;
+    } else if (input.images.defined()) {
+      raw_image_inputs.emplace_back(input.images);
+    } else {
+      LOG(FATAL) << "QwenImageEditPlus pipeline expected to have image inputs "
+                    "in images or images_list. batch_size="
+                 << input.batch_size << ", prompts=" << input.prompts.size()
+                 << ", prompt_embeds_defined=" << prompt_embeds.defined()
+                 << ", images_defined=" << input.images.defined()
+                 << ", images_list_size=" << input.images_list.size();
     }
 
     std::vector<torch::Tensor> image_list;
-    image_list.reserve(input.images_list.size());
+    image_list.reserve(raw_image_inputs.size());
 
-    for (const auto& images : input.images_list) {
+    for (const auto& images : raw_image_inputs) {
       auto img = images.to(options_.device(), dtype_);
       if (img.dim() != 4) {
         LOG(ERROR)
@@ -361,20 +878,34 @@ class QwenImageEditPlusPipelineImpl : public torch::nn::Module {
             << img.dim() << "d tensor";
         continue;
       }
-      if (img.size(0) > 1) {
-        LOG(ERROR) << "currently QwenImageEdit doesn't support batch inference"
-                   << "batch size: " << img.size(0);
-      }
-      image_list.emplace_back(img[0]);
+      image_list.emplace_back(img);
     }
 
     if (image_list.empty()) {
-      LOG(FATAL) << "No valid images found in images_list. ";
+      LOG(FATAL) << "No valid images found in images or images_list. ";
     }
 
-    double height_size = static_cast<double>(image_list[0].size(1));
-    double width_size = static_cast<double>(image_list[0].size(2));
-    int64_t num_images_per_prompt = 1;
+    int64_t batch_size = input.batch_size;
+    if (batch_size == 0 && !prompts.empty()) {
+      batch_size = static_cast<int64_t>(prompts.size());
+    }
+    if (batch_size == 0 && prompt_embeds.defined()) {
+      batch_size = prompt_embeds.size(0);
+    }
+    if (batch_size == 0) {
+      batch_size = image_list[0].size(0);
+    }
+    CHECK_GT(batch_size, 0) << "QwenImageEditPlus batch_size must be > 0";
+    for (const auto& image : image_list) {
+      CHECK_EQ(image.size(0), batch_size)
+          << "all image inputs must have the same batch size";
+    }
+
+    double height_size = static_cast<double>(image_list[0].size(2));
+    double width_size = static_cast<double>(image_list[0].size(3));
+    int64_t num_images_per_prompt = generation_params.num_images_per_prompt;
+    CHECK_GT(num_images_per_prompt, 0)
+        << "QwenImageEditPlus num_images_per_prompt must be > 0";
 
     double aspect_ratio = width_size / height_size;
     auto [calculated_width, calculated_height] =
@@ -389,31 +920,34 @@ class QwenImageEditPlusPipelineImpl : public torch::nn::Module {
 
     current_timestep_ = torch::Tensor();
 
-    int64_t batch_size = prompts.size();
     std::vector<torch::Tensor> condition_images;
     std::vector<torch::Tensor> vae_images;
-    std::vector<std::pair<int64_t, int64_t>> condition_image_sizes;
     std::vector<std::pair<int64_t, int64_t>> vae_image_sizes;
-    if (!image_list.empty() && image_list[0].size(0) != latent_channels_) {
+    if (!image_list.empty() && image_list[0].size(1) != latent_channels_) {
       for (size_t i = 0; i < image_list.size(); i++) {
         aspect_ratio =
-            static_cast<double>(image_list[i].size(2)) / image_list[i].size(1);
+            static_cast<double>(image_list[i].size(3)) / image_list[i].size(2);
         auto [condition_width, condition_height] =
             xllm::dit::calculate_dimensions(CONDITION_IMAGE_SIZE, aspect_ratio);
-        auto [vae_width, vae_height] = xllm::dit::calculate_dimensions(
-            ::xllm::DiTConfig::get_instance().dit_vae_image_size(),
-            aspect_ratio);
-        condition_image_sizes.push_back({condition_width, condition_height});
+        int64_t vae_target_area =
+            get_qwen_image_edit_vae_target_area(height, width);
+        auto [vae_width, vae_height] =
+            xllm::dit::calculate_dimensions(vae_target_area, aspect_ratio);
+        CHECK_GT(vae_width, 0) << "QwenImageEditPlus vae_width must be > 0";
+        CHECK_GT(vae_height, 0) << "QwenImageEditPlus vae_height must be > 0";
         vae_image_sizes.push_back({vae_width, vae_height});
-        auto img = image_list[i].unsqueeze(0);
+        auto img = image_list[i];
         auto condition_img = vae_image_processor_->resize(
             img,
             {condition_height, condition_width},
             /*resample=*/3,  // BICUBIC (approximate LANCZOS)
             /*antialias=*/true);
-        auto vae_img =
-            vae_image_processor_->preprocess(img, vae_height, vae_width)
-                .unsqueeze(2);
+        auto vae_img = vae_image_processor_
+                           ->preprocess(img,
+                                        vae_height,
+                                        vae_width,
+                                        /*resize_mode=*/"default")
+                           .unsqueeze(2);
 
         condition_images.push_back(condition_img);
         vae_images.push_back(vae_img);
@@ -450,7 +984,8 @@ class QwenImageEditPlusPipelineImpl : public torch::nn::Module {
 
     std::tie(final_latents, image_latents) =
         _prepare_latents(vae_images,
-                         batch_size * num_images_per_prompt,
+                         batch_size,
+                         num_images_per_prompt,
                          num_channels_latents,
                          height,
                          width,
@@ -482,14 +1017,9 @@ class QwenImageEditPlusPipelineImpl : public torch::nn::Module {
                                           scheduler_->max_image_seq_len(),
                                           scheduler_->base_shift(),
                                           scheduler_->max_shift());
-    auto [timesteps, num_inference_steps_actual] =
-        xllm::dit::retrieve_timesteps(
-            scheduler_, num_inference_steps, device_, new_sigmas, mu);
-    int64_t num_warmup_steps =
-        std::max(static_cast<int64_t>(timesteps.numel()) -
-                     num_inference_steps_actual * scheduler_->order(),
-                 static_cast<int64_t>(0LL));
-
+    auto timesteps_result = xllm::dit::retrieve_timesteps(
+        scheduler_, num_inference_steps, device_, new_sigmas, mu);
+    auto timesteps = std::get<0>(timesteps_result);
     num_timesteps_ = timesteps.size(0);
     torch::Tensor txt_seq_lens;
     if (prompt_embeds_mask.defined()) {
@@ -633,31 +1163,50 @@ class QwenImageEditPlusPipelineImpl : public torch::nn::Module {
     unpacked_latents = unpacked_latents / latents_std + latents_mean;
     output_image = vae_->decode(unpacked_latents).sample.squeeze(2);
     output_image = vae_image_processor_->postprocess(output_image);
-    auto output = std::vector<torch::Tensor>{{output_image}};
+    auto output_chunks = torch::chunk(output_image, batch_size, /*dim=*/0);
     DiTForwardOutput out;
-    out.tensors = output;
+    out.tensors = std::move(output_chunks);
     return out;
   }
 
   void load_model(std::unique_ptr<DiTModelLoader> loader) {
     LOG(INFO) << "QwenImageEditPlusPipeline loading model from"
               << loader->model_root_path();
-    std::string model_path = loader->model_root_path();
     auto transformer_loader = loader->take_component_loader("transformer");
     auto vae_loader = loader->take_component_loader("vae");
+#if defined(USE_DCU)
     auto clip_loader = loader->take_component_loader("text_encoder");
     auto tokenizer_loader = loader->take_component_loader("tokenizer");
-    auto processor_loader = loader->take_component_loader("processor");
+#endif
     LOG(INFO) << " QwenImageEditplus model components loaded, start to load "
                  "weights to sub models";
 
+    LOG(INFO) << "QwenImageEditPlusPipeline loading vae weights";
     vae_->load_model(std::move(vae_loader));
+    LOG(INFO) << "QwenImageEditPlusPipeline moving vae to device";
     vae_->to(options_.device(), dtype_);
+    LOG(INFO) << "QwenImageEditPlusPipeline vae loaded";
+
+    LOG(INFO) << "QwenImageEditPlusPipeline loading transformer weights";
     transformer_->load_model(std::move(transformer_loader));
+    LOG(INFO) << "QwenImageEditPlusPipeline moving transformer to device";
     transformer_->to(options_.device(), dtype_);
+    LOG(INFO) << "QwenImageEditPlusPipeline transformer loaded";
+
+#if defined(USE_DCU)
+    LOG(INFO) << "QwenImageEditPlusPipeline loading text_encoder weights";
+    text_encoder_->load_model(std::move(clip_loader));
+    LOG(INFO) << "QwenImageEditPlusPipeline moving text_encoder to device";
+    text_encoder_->to(options_.device(), dtype_);
+    LOG(INFO) << "QwenImageEditPlusPipeline text_encoder loaded";
+
+    tokenizer_ = tokenizer_loader->tokenizer();
+    LOG(INFO) << "QwenImageEditPlusPipeline tokenizer loaded";
+#endif
   }
 
  private:
+  DiTModelContext context_;
   // members from former QwenImagePipelineBaseImpl base class
   torch::Device device_ = torch::kCPU;
   torch::ScalarType dtype_;
@@ -666,6 +1215,11 @@ class QwenImageEditPlusPipelineImpl : public torch::nn::Module {
   xllm::VAEImageProcessor vae_image_processor_{nullptr};
   std::unique_ptr<Qwen2VLImageProcessor> qwen_image_processor_{nullptr};
   QwenImageTransformer2DModel transformer_{nullptr};
+#if defined(USE_DCU)
+  QwenImageEditTextEncoder text_encoder_{nullptr};
+  std::unique_ptr<ProcessGroup> vlm_tp_group_;
+  Qwen2VLImageProcessor vl_image_processor_;
+#endif
   std::unique_ptr<Tokenizer> qwen_tokenizer_;
   std::unique_ptr<Tokenizer> tokenizer_;
   xllm::FlowMatchEulerDiscreteScheduler scheduler_{nullptr};
@@ -680,7 +1234,7 @@ class QwenImageEditPlusPipelineImpl : public torch::nn::Module {
   int64_t num_layers_;
   const ParallelArgs parallel_args_;
   torch::Tensor current_timestep_;
-  string prompt_template_encode_;
+  std::string prompt_template_encode_;
   const ModelArgs& vae_model_args_;
   bool use_layer3d_rope_;
   QwenEmbedRope pos_embed_{nullptr};

--- a/xllm/models/dit/pipelines/pipeline_wan_i2v.h
+++ b/xllm/models/dit/pipelines/pipeline_wan_i2v.h
@@ -140,11 +140,10 @@ class WanImageToVideoPipelineImpl : public torch::nn::Module {
 
     LOG(INFO) << "Wan2_2I2VPipeline model components loaded, start to load "
                  "weights to sub models";
-    auto& load_config = LoadConfig::get_instance();
 #if defined(USE_NPU)
+    auto& load_config = LoadConfig::get_instance();
     use_rolling_load_ = load_config.enable_rolling_load() &&
                         ParallelConfig::get_instance().tp_size() == 1;
-#endif
     if (use_rolling_load_) {
       transformer_->load_model(std::move(transformer_loader),
                                /*rolling=*/true);
@@ -153,11 +152,14 @@ class WanImageToVideoPipelineImpl : public torch::nn::Module {
       init_rolling_for(transformer_, rolling_transformer_);
       init_rolling_for(transformer_2_, rolling_transformer_2_);
     } else {
+#endif
       transformer_->load_model(std::move(transformer_loader));
       transformer_->to(options_.device());
       transformer_2_->load_model(std::move(transformer_2_loader));
       transformer_2_->to(options_.device());
+#if defined(USE_NPU)
     }
+#endif
     vae_->load_model(std::move(vae_loader));
     vae_->to(options_.device());
     umt5_->load_model(std::move(umt5_loader));

--- a/xllm/models/dit/processors/vae_image_processor.h
+++ b/xllm/models/dit/processors/vae_image_processor.h
@@ -206,13 +206,18 @@ class VAEImageProcessorImpl : public torch::nn::Module {
                                int64_t width) {
     auto options = image.options();
 
-    image = image.cpu().to(torch::kFloat32);
-
     // BCHW || CHW
-    bool has_batch = (image.dim() == 4);
-    if (has_batch) {
-      image = image.squeeze(0);  // [C, H, W]
+    if (image.dim() == 4) {
+      std::vector<torch::Tensor> resized_images;
+      resized_images.reserve(image.size(0));
+      for (int64_t i = 0; i < image.size(0); ++i) {
+        resized_images.emplace_back(lanczos_resize(image[i], height, width));
+      }
+      return torch::stack(resized_images).to(options);
     }
+    CHECK_EQ(image.dim(), 3) << "lanczos_resize expects CHW or BCHW image";
+
+    image = image.cpu().to(torch::kFloat32);
 
     image = image.permute({1, 2, 0}).contiguous();  // [H, W, C]
 
@@ -230,7 +235,7 @@ class VAEImageProcessorImpl : public torch::nn::Module {
     out = out.permute({2, 0, 1});  // [C, dstH, dstW]
     out = out.to(options);
 
-    return has_batch ? out.unsqueeze(0) : out;  // BCHW 或 CHW
+    return out;
   }
 
  private:

--- a/xllm/models/dit/transformers/transformer_qwen_image.h
+++ b/xllm/models/dit/transformers/transformer_qwen_image.h
@@ -17,15 +17,18 @@ limitations under the License.
 #include <glog/logging.h>
 #include <torch/nn/functional/linear.h>
 #include <torch/torch.h>
+#if defined(USE_NPU)
 #include <torch_npu/csrc/aten/CustomFunctions.h>
-#include <torch_npu/csrc/libs/init_npu.h>
+#endif
 
+#include <algorithm>
 #include <cmath>
 #include <iostream>
 #include <memory>
 #include <optional>
 #include <stdexcept>
 #include <string>
+#include <tuple>
 #include <vector>
 
 #include "core/framework/config/dit_config.h"
@@ -36,12 +39,16 @@ limitations under the License.
 #include "core/framework/state_dict/state_dict.h"
 #include "core/framework/state_dict/utils.h"
 #include "core/layers/common/add_matmul.h"
+#if defined(USE_DCU)
+#include "core/layers/dcu/flash_attention.h"
+#endif
 #include "framework/model_context.h"
 #include "framework/parallel_state/parallel_state.h"
 #include "models/dit/utils/dit_parallel_linear.h"
 #include "models/dit/utils/sequence_parallel_pad_manager.h"
 #include "models/model_registry.h"
 
+#if defined(USE_NPU)
 #ifdef TORCH_HIGHER_THAN_PTA6
 #include <torch_npu/csrc/framework/OpCommand.h>
 #else
@@ -51,13 +58,103 @@ limitations under the License.
 
 #include <torch_npu/csrc/libs/init_npu.h>
 #include <torch_npu/torch_npu.h>
+#endif
 
-#include <cstdlib>
 namespace xllm {
 
 inline bool use_dit_sp_communication_overlap() {
   return DiTConfig::get_instance().dit_sp_communication_overlap() &&
          ParallelConfig::get_instance().sp_size() > 1;
+}
+
+inline torch::Tensor qwen_image_scaled_dot_product_attention(
+    const torch::Tensor& query,
+    const torch::Tensor& key,
+    const torch::Tensor& value) {
+#if defined(USE_DCU)
+  CHECK_EQ(query.dim(), 4) << "Qwen-Image query must be [B,H,S,D]";
+  CHECK_EQ(key.dim(), 4) << "Qwen-Image key must be [B,H,S,D]";
+  CHECK_EQ(value.dim(), 4) << "Qwen-Image value must be [B,H,S,D]";
+  CHECK_EQ(query.size(0), key.size(0)) << "Qwen-Image q/k batch mismatch";
+  CHECK_EQ(query.size(0), value.size(0)) << "Qwen-Image q/v batch mismatch";
+  CHECK_EQ(query.size(1), key.size(1)) << "Qwen-Image q/k head mismatch";
+  CHECK_EQ(key.size(1), value.size(1)) << "Qwen-Image k/v head mismatch";
+  CHECK_EQ(query.size(3), key.size(3)) << "Qwen-Image q/k head dim mismatch";
+  CHECK_EQ(query.size(3), value.size(3)) << "Qwen-Image q/v head dim mismatch";
+  CHECK_EQ(key.size(2), value.size(2)) << "Qwen-Image k/v seq mismatch";
+
+  const int64_t batch_size = query.size(0);
+  const int64_t num_heads = query.size(1);
+  const int64_t q_seq_len = query.size(2);
+  const int64_t kv_seq_len = key.size(2);
+  const int64_t head_dim = query.size(3);
+
+  auto cu_options =
+      torch::TensorOptions().dtype(torch::kInt32).device(query.device());
+  auto cu_seqlens_q =
+      torch::arange(batch_size + 1, cu_options).mul_(q_seq_len).contiguous();
+  auto cu_seqlens_k =
+      torch::arange(batch_size + 1, cu_options).mul_(kv_seq_len).contiguous();
+
+  auto dense_query = query.transpose(1, 2).contiguous().view(
+      {batch_size * q_seq_len, num_heads, head_dim});
+  auto dense_key = key.transpose(1, 2).contiguous().view(
+      {batch_size * kv_seq_len, key.size(1), head_dim});
+  auto dense_value = value.transpose(1, 2).contiguous().view(
+      {batch_size * kv_seq_len, value.size(1), head_dim});
+
+  auto output = layer::dense_varlen_flash_attention(
+      dense_query,
+      dense_key,
+      dense_value,
+      cu_seqlens_q,
+      cu_seqlens_k,
+      std::pow(static_cast<double>(head_dim), -0.5),
+      /*is_causal=*/false);
+  return output.view({batch_size, q_seq_len, num_heads, head_dim})
+      .transpose(1, 2)
+      .contiguous();
+#else
+  return torch::scaled_dot_product_attention(query,
+                                             key,
+                                             value,
+                                             torch::nullopt,
+                                             /*dropout_p=*/0.0,
+                                             /*is_causal=*/false);
+#endif
+}
+
+inline torch::Tensor qwen_image_joint_attention(
+    const torch::Tensor& joint_query,
+    const torch::Tensor& joint_key,
+    const torch::Tensor& joint_value) {
+  constexpr int64_t kAttentionChunkSize = 512;
+  auto query = joint_query.transpose(1, 2);
+  auto key = joint_key.transpose(1, 2);
+  auto value = joint_value.transpose(1, 2);
+  auto attention_output_dtype = query.dtype();
+
+  torch::Tensor output;
+  if (query.size(2) <= kAttentionChunkSize) {
+    output = qwen_image_scaled_dot_product_attention(query, key, value);
+  } else {
+    std::vector<torch::Tensor> attention_chunks;
+    const int64_t num_chunks =
+        (query.size(2) + kAttentionChunkSize - 1) / kAttentionChunkSize;
+    attention_chunks.reserve(num_chunks);
+    for (int64_t start = 0; start < query.size(2);
+         start += kAttentionChunkSize) {
+      int64_t chunk_size = std::min(kAttentionChunkSize, query.size(2) - start);
+      auto query_chunk = query.narrow(2, start, chunk_size);
+      attention_chunks.emplace_back(
+          qwen_image_scaled_dot_product_attention(query_chunk, key, value));
+    }
+    output = torch::cat(attention_chunks, 2);
+  }
+  if (output.dtype() != attention_output_dtype) {
+    output = output.to(attention_output_dtype);
+  }
+  return output.transpose(1, 2);
 }
 
 namespace qwenimage {
@@ -78,8 +175,18 @@ class RMSNormImpl final : public torch::nn::Module {
   }
 
   torch::Tensor forward(const torch::Tensor& hidden_states) {
+#if defined(USE_NPU)
     auto [output, rstd] =
         at_npu::native::custom_ops::npu_rms_norm(hidden_states, weight_, eps_);
+#else
+    torch::Tensor output = hidden_states.to(torch::kFloat32);
+    output =
+        output * torch::rsqrt(output.pow(2).mean(-1, /*keepdim=*/true) + eps_);
+    if (elementwise_affine_) {
+      output = output * weight_.to(output.device(), output.dtype());
+    }
+    output = output.to(hidden_states.dtype());
+#endif
     if (is_bias_ && bias_.defined()) {
       output = output + bias_;
     }
@@ -788,9 +895,23 @@ torch::Tensor apply_rotary_emb_qwen(const torch::Tensor& x,
                           .unsqueeze(-1)
                           .expand({-1, -1, -1, -1, 2})
                           .reshape({1, seqlen, 1, -1});
+#if defined(USE_NPU)
   auto x_out = at_npu::native::custom_ops::npu_rotary_mul(
       x.to(torch::kFloat), cos_expanded, sin_expanded, "interleave");
   return x_out.to(x.dtype());
+#else
+  auto input_dtype = x.dtype();
+  auto x_float = x.to(torch::kFloat32);
+  auto x_flat = x_float.unflatten(-1, std::vector<int64_t>{-1, 2});
+  auto x1 = x_flat.select(-1, 0);
+  auto x2 = x_flat.select(-1, 1);
+  auto cos_half = cos.unsqueeze(0).unsqueeze(2);
+  auto sin_half = sin.unsqueeze(0).unsqueeze(2);
+  auto out1 = x1 * cos_half - x2 * sin_half;
+  auto out2 = x1 * sin_half + x2 * cos_half;
+  auto out = torch::stack({out1, out2}, -1).flatten(-2, -1);
+  return out.to(input_dtype);
+#endif
 }
 
 std::tuple<int64_t, std::optional<torch::Tensor>, std::optional<torch::Tensor>>
@@ -1483,6 +1604,7 @@ class QwenDoubleStreamAttnProcessor2_0Impl : public torch::nn::Module {
     auto joint_key = torch::cat({txt_key, img_key}, 1);
     auto joint_value = torch::cat({txt_value, img_value}, 1);
 
+#if defined(USE_NPU)
     auto results = at_npu::native::custom_ops::npu_fusion_attention(
         joint_query,
         joint_key,
@@ -1498,6 +1620,10 @@ class QwenDoubleStreamAttnProcessor2_0Impl : public torch::nn::Module {
         /*next_tockens=*/65535);
 
     auto joint_hidden_states = std::get<0>(results);
+#else
+    auto joint_hidden_states =
+        qwen_image_joint_attention(joint_query, joint_key, joint_value);
+#endif
     // Reshape back
     joint_hidden_states = joint_hidden_states.flatten(2, 3);
     joint_hidden_states = joint_hidden_states.to(joint_query.dtype());
@@ -1658,6 +1784,7 @@ class QwenDoubleStreamAttnProcessorCMO2_0Impl : public torch::nn::Module {
     auto joint_key = torch::cat({txt_key, img_key}, 1);
     auto joint_value = torch::cat({txt_value, img_value}, 1);
 
+#if defined(USE_NPU)
     auto results = at_npu::native::custom_ops::npu_fusion_attention(
         joint_query,
         joint_key,
@@ -1673,6 +1800,10 @@ class QwenDoubleStreamAttnProcessorCMO2_0Impl : public torch::nn::Module {
         /*next_tockens=*/65535);
 
     auto joint_hidden_states = std::get<0>(results);
+#else
+    auto joint_hidden_states =
+        qwen_image_joint_attention(joint_query, joint_key, joint_value);
+#endif
     joint_hidden_states = joint_hidden_states.flatten(2, 3);
     joint_hidden_states = joint_hidden_states.to(joint_query.dtype());
 

--- a/xllm/models/dit/transformers/transformer_wan.h
+++ b/xllm/models/dit/transformers/transformer_wan.h
@@ -18,6 +18,7 @@ limitations under the License.
 #include <torch/nn/functional/linear.h>
 #include <torch/torch.h>
 
+#include <algorithm>
 #include <cmath>
 #include <functional>
 #include <memory>
@@ -39,8 +40,10 @@ limitations under the License.
 using xllm::dit::DiTParallelLinear;
 using xllm::dit::SpOptions;
 using xllm::dit::TpOptions;
+#if defined(USE_NPU)
 #include "core/layers/npu/loader/rolling_load_manager.h"
 #include "core/layers/npu/loader/rolling_weight_buffer.h"
+#endif
 #include "framework/model_context.h"
 #include "models/dit/transformers/transformer_flux.h"
 #if defined(USE_NPU)
@@ -640,10 +643,39 @@ class WanAttentionImpl : public torch::nn::Module {
         65535);
     torch::Tensor out = std::get<0>(results).transpose(1, 2);
 #else
-    const double scale = 1.0 / std::sqrt(static_cast<double>(dim_head_));
-    auto attn_weights = torch::matmul(q_t, k_t.transpose(-2, -1)) * scale;
-    attn_weights = torch::softmax(attn_weights, -1);
-    torch::Tensor out = torch::matmul(attn_weights, v_t).transpose(1, 2);
+    constexpr int64_t kAttentionChunkSize = 512;
+    constexpr int64_t kHeadDim = 1;
+    constexpr int64_t kSequenceDim = 2;
+    torch::Tensor out;
+    if (q_t.size(kSequenceDim) <= kAttentionChunkSize) {
+      out = torch::scaled_dot_product_attention(q_t,
+                                                k_t,
+                                                v_t,
+                                                torch::nullopt,
+                                                /*dropout_p=*/0.0,
+                                                /*is_causal=*/false)
+                .transpose(kHeadDim, kSequenceDim);
+    } else {
+      std::vector<torch::Tensor> chunks;
+      const int64_t num_chunks =
+          (q_t.size(kSequenceDim) + kAttentionChunkSize - 1) /
+          kAttentionChunkSize;
+      chunks.reserve(num_chunks);
+      for (int64_t start = 0; start < q_t.size(kSequenceDim);
+           start += kAttentionChunkSize) {
+        int64_t chunk_size =
+            std::min(kAttentionChunkSize, q_t.size(kSequenceDim) - start);
+        torch::Tensor q_chunk = q_t.narrow(kSequenceDim, start, chunk_size);
+        chunks.emplace_back(
+            torch::scaled_dot_product_attention(q_chunk,
+                                                k_t,
+                                                v_t,
+                                                torch::nullopt,
+                                                /*dropout_p=*/0.0,
+                                                /*is_causal=*/false));
+      }
+      out = torch::cat(chunks, kSequenceDim).transpose(kHeadDim, kSequenceDim);
+    }
 #endif
     return out.flatten(2, 3);
   }

--- a/xllm/models/dit/utils/sequence_parallel_pad_manager.h
+++ b/xllm/models/dit/utils/sequence_parallel_pad_manager.h
@@ -30,7 +30,7 @@ class SequenceParallelPadManager {
   }
 
   torch::Tensor pad_tensor(const torch::Tensor& ref_tensor,
-                           const string& tensor_name,
+                           const std::string& tensor_name,
                            int64_t dim = -1,
                            bool right_pad = true) {
     auto pad_dim = dim;
@@ -60,7 +60,7 @@ class SequenceParallelPadManager {
   }
 
   void unpad_tensor(torch::Tensor& ref_tensor,
-                    const string& tensor_name,
+                    const std::string& tensor_name,
                     int64_t dim = -1,
                     bool right_pad = true) {
     if (ref_tensor.defined()) {

--- a/xllm/models/models.h
+++ b/xllm/models/models.h
@@ -106,6 +106,9 @@ limitations under the License.
 #include "llm/musa/qwen3.h"  // IWYU pragma: keep
 #elif defined(USE_DCU)
 #include "dit/pipelines/pipeline_flux.h"
+#include "dit/pipelines/pipeline_longcat_image.h"
+#include "dit/pipelines/pipeline_qwenimage_edit_plus.h"
+#include "dit/pipelines/pipeline_wan_i2v.h"
 #include "llm/deepseek_v2.h"  // IWYU pragma: keep
 #include "llm/mimo.h"         // IWYU pragma: keep
 #include "llm/mimo_mtp.h"     // IWYU pragma: keep

--- a/xllm/models/vlm/qwen2_5_vl.h
+++ b/xllm/models/vlm/qwen2_5_vl.h
@@ -702,6 +702,9 @@ REGISTER_MPOSITION_GENERATOR(qwen2_5_vl, QwenVLMPositionGenerator);
     LOAD_ARG_OR(mm_projection_dim, "vision_config.out_hidden_size", 3584);     \
     LOAD_ARG_OR(mm_patch_size, "vision_config.patch_size", 14);                \
     LOAD_ARG_OR(mm_spatial_merge_size, "vision_config.spatial_merge_size", 2); \
+    LOAD_ARG_OR_FUNC(mm_image_merge_size,                                      \
+                     "vision_config.image_merge_size",                         \
+                     [&] { return args->mm_spatial_merge_size(); });           \
     LOAD_ARG_OR(                                                               \
         mm_spatial_patch_size, "vision_config.spatial_patch_size", 14);        \
     LOAD_ARG_OR(mm_window_size, "vision_config.window_size", 112);             \

--- a/xllm/processors/qwen2_vl_image_processor.cpp
+++ b/xllm/processors/qwen2_vl_image_processor.cpp
@@ -80,9 +80,15 @@ Qwen2VLImageProcessor::Qwen2VLImageProcessor(const ModelArgs& args) {
     min_pixels_ = args.mm_image_shortest_edge();
     max_pixels_ = args.mm_image_longest_edge();
   }
-  patch_size_ = args.mm_image_patch_size();
-  temporal_patch_size_ = args.mm_image_temporal_patch_size();
-  merge_size_ = args.mm_image_merge_size();
+  if (args.mm_image_patch_size() > 0) {
+    patch_size_ = args.mm_image_patch_size();
+  }
+  if (args.mm_image_temporal_patch_size() > 0) {
+    temporal_patch_size_ = args.mm_image_temporal_patch_size();
+  }
+  if (args.mm_image_merge_size() > 0) {
+    merge_size_ = args.mm_image_merge_size();
+  }
 
   if (do_rescale_ && do_normalize_) {
     image_mean_.mul_(1.0 / rescale_factor_);


### PR DESCRIPTION
## Description

<!-- What does this PR do? Briefly describe the changes and why they are needed. -->
Add DCU support for Qwen-Image-Edit batch inference, including text encoder execution, DiT batch compatibility checks, shared-memory DiT payload handling, and dense varlen flash attention through the DCU FlashAttention C API.

This also tightens non-DCU/NPU guards around DiT model code paths so Qwen-Image-Edit changes do not accidentally break other platform builds.
## Related Issues

<!-- Link related issues here. Use "Fixes #123" when this PR closes an issue. -->

## Change Type

- [ ] Bug fix
- [x] New feature
- [ ] Performance improvement
- [ ] Refactor
- [ ] Documentation
- [ ] Test
- [ ] Build or CI

## Pull Request Checklist

Thank you for contributing to xLLM. Before requesting review, please make sure the following items are complete.

### PR Title and Commit Messages

- [x] The PR title and each commit message follow the xLLM commit format: `<type>: <subject>`.

> Allowed types: feat, bugfix, docs, test, refactor, chore, style, revert, perf, model, build, release.
> The subject should use clear English, start with a verb, include at least 4 words, and end with `.`.

### Pre-commit Checks

- [x] I have installed `pre-commit` by running `pip install pre-commit` or an equivalent command.
- [x] I have installed the hooks with `pre-commit install`.
- [x] I have run `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

### Self Review

- [x] I have self-reviewed the code according to `.agents/skills/code-review/references/custom-code-style.md`, especially code written or assisted by AI.
- [x] I have rebased this PR onto the latest `main` branch.

### Build and Test Coverage

- [x] Tests have been added or updated as needed.
- [ ] CUDA: `python setup.py build test` has passed on a CUDA machine.
- [ ] NPU: `python setup.py build test` has passed on an NPU machine.
- [ ] MLU: `python setup.py build test` has passed on an MLU machine.

## Reviewer Notes

<!-- Optional: anything reviewers should focus on, known risks, follow-ups, or validation gaps. -->
