### PR TITLE
bugfix: add dim=6144 to causal_conv1d kernel specializations for Qwen3.5

### DIFF
--- a/xllm/compiler/tilelang/targets/ascend/kernels/causal_conv1d.py
+++ b/xllm/compiler/tilelang/targets/ascend/kernels/causal_conv1d.py
@@ -189,37 +189,21 @@ class CausalConv1dKernel(TilelangKernel):
     ]
     SPECIALIZATIONS = [
         {
-            "variant_key": "bs1_d2048_w4_silu0_f16",
+            "variant_key": f"bs1_d{d}_w4_silu0_f16",
             "batch_size": 1,
-            "dim": 2048,
+            "dim": d,
             "width": 4,
             "has_silu": 0,
             "dtype": "float16",
-        },
-        {
-            "variant_key": "bs1_d4096_w4_silu0_f16",
-            "batch_size": 1,
-            "dim": 4096,
-            "width": 4,
-            "has_silu": 0,
-            "dtype": "float16",
-        },
-        {
-            "variant_key": "bs1_d5120_w4_silu0_f16",
-            "batch_size": 1,
-            "dim": 5120,
-            "width": 4,
-            "has_silu": 0,
-            "dtype": "float16",
-        },
-        {
-            "variant_key": "bs1_d8192_w4_silu0_f16",
-            "batch_size": 1,
-            "dim": 8192,
-            "width": 4,
-            "has_silu": 0,
-            "dtype": "float16",
-        },
+        }
+        for d in sorted(
+            {
+                dim // tp
+                for dim in [2048, 4096, 5120, 6144, 8192]
+                for tp in [1, 2, 4, 8]
+                if dim % tp == 0
+            }
+        )
     ]
 
     @staticmethod

--- a/xllm/compiler/tilelang/targets/ascend/kernels/causal_conv1d_decode.py
+++ b/xllm/compiler/tilelang/targets/ascend/kernels/causal_conv1d_decode.py
@@ -189,7 +189,7 @@ class CausalConv1dDecodeKernel(TilelangKernel):
         for d in sorted(
             {
                 dim // tp
-                for dim in [2048, 4096, 5120, 8192, 10240]
+                for dim in [2048, 4096, 5120, 6144, 8192, 10240]
                 for tp in [1, 2, 4, 8]
                 if dim % tp == 0
             }

--- a/xllm/core/kernels/npu/tilelang/causal_conv1d_wrapper.cpp
+++ b/xllm/core/kernels/npu/tilelang/causal_conv1d_wrapper.cpp
@@ -92,8 +92,8 @@ void check_supported(const torch::Tensor& x,
   CHECK(initial_state_mode.defined())
       << "TileLang causal_conv1d: initial_state_mode must be defined";
 
-  CHECK(x.scalar_type() == c10::ScalarType::BFloat16)
-      << "TileLang causal_conv1d: only bfloat16 is supported, got "
+  CHECK(x.scalar_type() == c10::ScalarType::Half)
+      << "TileLang causal_conv1d: only float16 is supported, got "
       << x.scalar_type();
 
   CHECK(x.device().type() == c10::DeviceType::PrivateUse1 &&

--- a/xllm/core/kernels/npu/tilelang/causal_conv1d_wrapper.cpp
+++ b/xllm/core/kernels/npu/tilelang/causal_conv1d_wrapper.cpp
@@ -92,7 +92,7 @@ void check_supported(const torch::Tensor& x,
   CHECK(initial_state_mode.defined())
       << "TileLang causal_conv1d: initial_state_mode must be defined";
 
-  CHECK(x.scalar_type() == c10::ScalarType::Half)
+  CHECK(x.scalar_type() == torch::kHalf)
       << "TileLang causal_conv1d: only float16 is supported, got "
       << x.scalar_type();
 


### PR DESCRIPTION
## Summary
- Add dim=6144 specialization to causal_conv1d kernel for Qwen3.5 model support
- Refactor hard-coded specializations into list comprehension covering all TP partition combinations
- Fix dtype check in C++ wrapper: BFloat16 → float16 to match Python kernel definition