### PR TITLE
bugfix: auto-disable graph double buffer when speculative decoding is active.

### DIFF
--- a/xllm/core/runtime/worker_impl.cpp
+++ b/xllm/core/runtime/worker_impl.cpp
@@ -499,8 +499,9 @@ ForwardInput WorkerImpl::prepare_inputs(Batch& batch) {
 bool WorkerImpl::can_prepare_npu_graph_decode_input(
     const ModelInputParams& input_params) const {
 #if defined(USE_NPU)
-  return FLAGS_enable_graph && FLAGS_enable_graph_double_buffer &&
-         enable_schedule_overlap() && options_.backend() == "llm" &&
+  return !options_.enable_speculative_decode() && FLAGS_enable_graph &&
+         FLAGS_enable_graph_double_buffer && enable_schedule_overlap() &&
+         options_.backend() == "llm" &&
          input_params.meta.batch_forward_type.has_decode();
 #else
   (void)input_params;

--- a/xllm/core/runtime/worker_impl.cpp
+++ b/xllm/core/runtime/worker_impl.cpp
@@ -499,9 +499,10 @@ ForwardInput WorkerImpl::prepare_inputs(Batch& batch) {
 bool WorkerImpl::can_prepare_npu_graph_decode_input(
     const ModelInputParams& input_params) const {
 #if defined(USE_NPU)
-  return !options_.enable_speculative_decode() && FLAGS_enable_graph &&
-         FLAGS_enable_graph_double_buffer && enable_schedule_overlap() &&
-         options_.backend() == "llm" &&
+  return !options_.enable_speculative_decode() &&
+         ::xllm::ExecutionConfig::get_instance().enable_graph() &&
+         ::xllm::ExecutionConfig::get_instance().enable_graph_double_buffer() &&
+         enable_schedule_overlap() && options_.backend() == "llm" &&
          input_params.meta.batch_forward_type.has_decode();
 #else
   (void)input_params;
@@ -513,8 +514,10 @@ bool WorkerImpl::can_prepare_without_compute_stream_wait(
     const ModelInputParams& input_params) const {
 #if defined(USE_NPU)
   (void)input_params;
-  return !options_.enable_speculative_decode() && FLAGS_enable_graph &&
-         FLAGS_enable_graph_double_buffer && options_.backend() == "llm";
+  return !options_.enable_speculative_decode() &&
+         ::xllm::ExecutionConfig::get_instance().enable_graph() &&
+         ::xllm::ExecutionConfig::get_instance().enable_graph_double_buffer() &&
+         options_.backend() == "llm";
 #else
   (void)input_params;
   return false;

--- a/xllm/xllm.cpp
+++ b/xllm/xllm.cpp
@@ -249,6 +249,8 @@ void validate_config(const std::string& model_type) {
   SchedulerConfig& scheduler_config = SchedulerConfig::get_instance();
   ParallelConfig& parallel_config = ParallelConfig::get_instance();
   DisaggPDConfig& disagg_pd_config = DisaggPDConfig::get_instance();
+  SpeculativeConfig& speculative_config = SpeculativeConfig::get_instance();
+  ExecutionConfig& execution_config = ExecutionConfig::get_instance();
 
   if (model_config.backend().empty()) {
     LOG(FATAL) << "Model is not supported currently, model type: "
@@ -301,6 +303,13 @@ void validate_config(const std::string& model_type) {
 #endif
 
 #if defined(USE_NPU)
+  if (speculative_config.num_speculative_tokens() > 0 &&
+      execution_config.enable_graph_double_buffer()) {
+    LOG(WARNING) << "enable_graph_double_buffer is not compatible with "
+                    "speculative decoding. "
+                 << "Disabling enable_graph_double_buffer.";
+    execution_config.enable_graph_double_buffer(false);
+  }
   // enable_xtensor / enable_rolling_load imply enable_manual_loader
   if ((kv_cache_config.enable_xtensor() || load_config.enable_rolling_load()) &&
       !load_config.enable_manual_loader()) {


### PR DESCRIPTION
## Summary
- Fix service hang on startup when MTP (speculative decoding) and graph double buffer are both enabled
- Automatically disable graph double buffer when speculative decoding is active to prevent conflicts
- Replace `FLAGS_` globals with `ExecutionConfig` per style guide section 10