### PR TITLE
bugfix: update model version handling in list_model_versions function.

### DIFF
--- a/xllm/api_service/models_service_impl.cpp
+++ b/xllm/api_service/models_service_impl.cpp
@@ -47,9 +47,12 @@ bool ModelsServiceImpl::list_models(const proto::ModelListRequest* request,
 std::string ModelsServiceImpl::list_model_versions() {
   nlohmann::json model_states_array = nlohmann::json::array();
 
-  for (size_t i = 0; i < model_names_.size(); ++i) {
+  for (size_t i = 0; i < model_versions_.size(); ++i) {
     nlohmann::json model_state;
-    model_state["name"] = model_names_[i];
+    // The repository index reports the model directory name (carried by
+    // model_versions_), so it stays stable regardless of a user-provided
+    // --model_id.
+    model_state["name"] = model_versions_[i];
     model_state["version"] = model_versions_[i];
     model_state["state"] = "READY";
     model_state["reason"] = "normal";


### PR DESCRIPTION
## Description

return model dir name instead of `model_id` for `/v2/repository/index`, but keep returning `model_id` for other interface, such as `/v1/models`.

<!-- What does this PR do? Briefly describe the changes and why they are needed. -->

## Related Issues

<!-- Link related issues here. Use "Fixes #123" when this PR closes an issue. -->

## Change Type

- [x] Bug fix
- [ ] New feature
- [ ] Performance improvement
- [x] Refactor
- [ ] Documentation
- [ ] Test
- [ ] Build or CI

## Pull Request Checklist

Thank you for contributing to xLLM. Before requesting review, please make sure the following items are complete.

### PR Title and Commit Messages

- [x] The PR title and each commit message follow the xLLM commit format: `<type>: <subject>`.

> Allowed types: feat, bugfix, docs, test, refactor, chore, style, revert, perf, model, build, release.
> The subject should use clear English, start with a verb, include at least 4 words, and end with `.`.

### Pre-commit Checks

- [x] I have installed `pre-commit` by running `pip install pre-commit` or an equivalent command.
- [x] I have installed the hooks with `pre-commit install`.
- [x] I have run `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

### Self Review

- [x] I have self-reviewed the code according to `.agents/skills/code-review/references/custom-code-style.md`, especially code written or assisted by AI.
- [x] I have rebased this PR onto the latest `main` branch.

### Build and Test Coverage

- [ ] Tests have been added or updated as needed.
- [ ] CUDA: `python setup.py build test` has passed on a CUDA machine.
- [ ] NPU: `python setup.py build test` has passed on an NPU machine.
- [ ] MLU: `python setup.py build test` has passed on an MLU machine.

## Reviewer Notes

<!-- Optional: anything reviewers should focus on, known risks, follow-ups, or validation gaps. -->
