### PR TITLE
feat: support openai style integer array prompt for completions.

### DIFF
--- a/tests/api_service/CMakeLists.txt
+++ b/tests/api_service/CMakeLists.txt
@@ -43,6 +43,17 @@ cc_test(
 
 cc_test(
   NAME
+    completion_json_parser_test
+  SRCS
+    completion_json_parser_test.cpp
+  DEPS
+    api_service
+    GTest::gtest_main
+    nlohmann_json::nlohmann_json
+)
+
+cc_test(
+  NAME
     anthropic_json_test
   SRCS
     anthropic_json_test.cpp

--- a/tests/api_service/completion_json_parser_test.cpp
+++ b/tests/api_service/completion_json_parser_test.cpp
@@ -1,0 +1,128 @@
+/* Copyright 2026 The xLLM Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://github.com/jd-opensource/xllm/blob/main/LICENSE
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include "api_service/completion_json_parser.h"
+
+#include <gtest/gtest.h>
+
+#include <nlohmann/json.hpp>
+
+namespace xllm {
+
+namespace {
+
+void expect_error(const std::string& input,
+                  const std::string& expected_message) {
+  auto [status, result] = preprocess_completion_prompt(input);
+  ASSERT_FALSE(status.ok()) << "Expected error but got success";
+  EXPECT_EQ(status.code(), StatusCode::INVALID_ARGUMENT);
+  EXPECT_EQ(status.message(), expected_message);
+}
+
+}  // namespace
+
+// String prompt passes through with bytes untouched.
+TEST(PreprocessCompletionPromptTest, StringPromptPassThroughUnchanged) {
+  std::string input = R"({"prompt": "hello", "max_tokens": 8})";
+  auto [status, result] = preprocess_completion_prompt(input);
+  ASSERT_TRUE(status.ok()) << status.message();
+  EXPECT_EQ(result, input);
+}
+
+// Missing prompt passes through unchanged.
+TEST(PreprocessCompletionPromptTest, MissingPromptPassThroughUnchanged) {
+  std::string input = R"({"max_tokens": 8})";
+  auto [status, result] = preprocess_completion_prompt(input);
+  ASSERT_TRUE(status.ok()) << status.message();
+  EXPECT_EQ(result, input);
+}
+
+// Scalar integer prompt is left to json2pb, passed through unchanged.
+TEST(PreprocessCompletionPromptTest, ScalarPromptPassThroughUnchanged) {
+  std::string input = R"({"prompt": 785})";
+  auto [status, result] = preprocess_completion_prompt(input);
+  ASSERT_TRUE(status.ok()) << status.message();
+  EXPECT_EQ(result, input);
+}
+
+// Integer array prompt is moved into token_ids and prompt is cleared.
+TEST(PreprocessCompletionPromptTest, IntegerArrayMovedToTokenIds) {
+  std::string input = R"({"prompt": [785, 785], "max_tokens": 8})";
+  auto [status, result] = preprocess_completion_prompt(input);
+  ASSERT_TRUE(status.ok()) << status.message();
+  auto json = nlohmann::json::parse(result);
+  EXPECT_EQ(json["prompt"], "");
+  EXPECT_EQ(json["token_ids"], (std::vector<int32_t>{785, 785}));
+  EXPECT_EQ(json["max_tokens"], 8);
+}
+
+// Boundary int32 values are accepted.
+TEST(PreprocessCompletionPromptTest, Int32BoundaryValuesAccepted) {
+  std::string input = R"({"prompt": [2147483647, 0]})";
+  auto [status, result] = preprocess_completion_prompt(input);
+  ASSERT_TRUE(status.ok()) << status.message();
+  auto json = nlohmann::json::parse(result);
+  EXPECT_EQ(json["token_ids"], (std::vector<int32_t>{2147483647, 0}));
+}
+
+TEST(PreprocessCompletionPromptTest, EmptyArrayRejected) {
+  expect_error(R"({"prompt": []})", "prompt array is empty");
+}
+
+TEST(PreprocessCompletionPromptTest, ArrayOfStringsRejected) {
+  expect_error(R"({"prompt": ["a", "b"]})",
+               "batch prompts (array of strings) are not supported");
+}
+
+TEST(PreprocessCompletionPromptTest, NestedArraysRejected) {
+  expect_error(R"({"prompt": [[1, 2], [3, 4]]})",
+               "batch prompts (nested arrays) are not supported");
+}
+
+TEST(PreprocessCompletionPromptTest, FloatElementRejected) {
+  expect_error(R"({"prompt": [785.5]})",
+               "prompt array must contain only integer token ids");
+}
+
+TEST(PreprocessCompletionPromptTest, ObjectElementRejected) {
+  expect_error(R"({"prompt": [{"a": 1}]})",
+               "prompt array must contain only integer token ids");
+}
+
+TEST(PreprocessCompletionPromptTest, MixedElementRejected) {
+  expect_error(R"({"prompt": [1, "a"]})",
+               "prompt array must contain only integer token ids");
+}
+
+TEST(PreprocessCompletionPromptTest, TokenIdExceedsInt32PositiveRejected) {
+  expect_error(R"({"prompt": [2147483648]})", "token id exceeds int32 range");
+}
+
+TEST(PreprocessCompletionPromptTest, TokenIdExceedsInt32NegativeRejected) {
+  expect_error(R"({"prompt": [-2147483649]})", "token id exceeds int32 range");
+}
+
+TEST(PreprocessCompletionPromptTest, PromptArrayAndTokenIdsRejected) {
+  expect_error(R"({"prompt": [785], "token_ids": [1]})",
+               "specify prompt as a token array or token_ids, not both");
+}
+
+TEST(PreprocessCompletionPromptTest, InvalidJsonRejected) {
+  auto [status, result] = preprocess_completion_prompt("{not valid json");
+  ASSERT_FALSE(status.ok());
+  EXPECT_EQ(status.code(), StatusCode::INVALID_ARGUMENT);
+}
+
+}  // namespace xllm

--- a/tests/core/util/CMakeLists.txt
+++ b/tests/core/util/CMakeLists.txt
@@ -9,6 +9,7 @@ cc_test(
     http_downloader_test.cpp
     suffix_decoding_cache_test.cpp
     threadpool_test.cpp
+    vocab_validation_test.cpp
   DEPS
     util
     :platform

--- a/tests/core/util/vocab_validation_test.cpp
+++ b/tests/core/util/vocab_validation_test.cpp
@@ -1,0 +1,63 @@
+/* Copyright 2026 The xLLM Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://github.com/jd-opensource/xllm/blob/main/LICENSE
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include <gtest/gtest.h>
+
+#include <vector>
+
+#include "core/util/utils.h"
+
+namespace xllm::util {
+
+TEST(VocabValidationTest, AllTokensInRangeReturnsNullopt) {
+  const std::vector<int> token_ids = {0, 1, 785, 999};
+  EXPECT_FALSE(
+      find_out_of_vocab_token(token_ids, /*vocab_size=*/1000).has_value());
+}
+
+TEST(VocabValidationTest, EmptyTokensReturnsNullopt) {
+  const std::vector<int> token_ids = {};
+  EXPECT_FALSE(
+      find_out_of_vocab_token(token_ids, /*vocab_size=*/1000).has_value());
+}
+
+TEST(VocabValidationTest, NegativeTokenIsFlagged) {
+  const std::vector<int> token_ids = {5, -1, 7};
+  const auto invalid = find_out_of_vocab_token(token_ids, /*vocab_size=*/1000);
+  ASSERT_TRUE(invalid.has_value());
+  EXPECT_EQ(invalid.value(), -1);
+}
+
+TEST(VocabValidationTest, TokenEqualToVocabSizeIsFlagged) {
+  const std::vector<int> token_ids = {1000};
+  const auto invalid = find_out_of_vocab_token(token_ids, /*vocab_size=*/1000);
+  ASSERT_TRUE(invalid.has_value());
+  EXPECT_EQ(invalid.value(), 1000);
+}
+
+TEST(VocabValidationTest, UpperAndLowerBoundaryAreInRange) {
+  const std::vector<int> token_ids = {0, 999};
+  EXPECT_FALSE(
+      find_out_of_vocab_token(token_ids, /*vocab_size=*/1000).has_value());
+}
+
+TEST(VocabValidationTest, ReturnsFirstOutOfRangeToken) {
+  const std::vector<int> token_ids = {2000, 3000};
+  const auto invalid = find_out_of_vocab_token(token_ids, /*vocab_size=*/1000);
+  ASSERT_TRUE(invalid.has_value());
+  EXPECT_EQ(invalid.value(), 2000);
+}
+
+}  // namespace xllm::util

--- a/xllm/api_service/CMakeLists.txt
+++ b/xllm/api_service/CMakeLists.txt
@@ -8,6 +8,7 @@ cc_library(
     api_service_impl.h
     call.h
     chat_json_parser.h
+    completion_json_parser.h
     completion_service_impl.h
     rec_completion_service_impl.h
     chat_service_impl.h
@@ -32,6 +33,7 @@ cc_library(
   SRCS
     api_service.cpp
     chat_json_parser.cpp
+    completion_json_parser.cpp
     service_impl_factory.cpp
     call.cpp
     completion_service_impl.cpp

--- a/xllm/api_service/api_service.cpp
+++ b/xllm/api_service/api_service.cpp
@@ -23,6 +23,7 @@ limitations under the License.
 #include <filesystem>
 
 #include "api_service/chat_json_parser.h"
+#include "api_service/completion_json_parser.h"
 #include "api_service/service_impl_factory.h"
 #include "api_service/serving_mode.h"
 #include "call.h"
@@ -195,11 +196,20 @@ void APIService::CompletionsHttp(::google::protobuf::RpcController* controller,
       google::protobuf::Arena::CreateMessage<proto::CompletionResponse>(arena);
 
   auto ctrl = reinterpret_cast<brpc::Controller*>(controller);
+
+  auto [preprocess_status, processed_json] =
+      preprocess_completion_prompt(ctrl->request_attachment().to_string());
+  if (!preprocess_status.ok()) {
+    ctrl->SetFailed(preprocess_status.message());
+    LOG(ERROR) << "completion prompt preprocessing failed: "
+               << preprocess_status.message();
+    return;
+  }
+
   std::string error;
   json2pb::Json2PbOptions options;
-  butil::IOBuf& buf = ctrl->request_attachment();
-  butil::IOBufAsZeroCopyInputStream iobuf_stream(buf);
-  auto st = json2pb::JsonToProtoMessage(&iobuf_stream, req_pb, options, &error);
+  auto st =
+      json2pb::JsonToProtoMessage(processed_json, req_pb, options, &error);
   if (!st) {
     ctrl->SetFailed(error);
     LOG(ERROR) << "parse json to proto failed: " << error;

--- a/xllm/api_service/completion_json_parser.cpp
+++ b/xllm/api_service/completion_json_parser.cpp
@@ -1,0 +1,104 @@
+/* Copyright 2026 The xLLM Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://github.com/jd-opensource/xllm/blob/main/LICENSE
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include "api_service/completion_json_parser.h"
+
+#include <glog/logging.h>
+
+#include <cstdint>
+#include <limits>
+#include <nlohmann/json.hpp>
+
+namespace xllm {
+
+std::pair<Status, std::string> preprocess_completion_prompt(
+    std::string json_str) {
+  try {
+    auto json = nlohmann::json::parse(json_str);
+    if (!json.contains("prompt") || !json["prompt"].is_array()) {
+      // string / scalar / missing prompt: leave bytes untouched.
+      return {Status(), std::move(json_str)};
+    }
+
+    if (json.contains("token_ids")) {
+      return {Status(StatusCode::INVALID_ARGUMENT,
+                     "specify prompt as a token array or token_ids, not both"),
+              ""};
+    }
+
+    const auto& prompt = json["prompt"];
+    if (prompt.empty()) {
+      return {Status(StatusCode::INVALID_ARGUMENT, "prompt array is empty"),
+              ""};
+    }
+
+    const auto& first = prompt.front();
+    if (first.is_string()) {
+      return {Status(StatusCode::INVALID_ARGUMENT,
+                     "batch prompts (array of strings) are not supported"),
+              ""};
+    }
+    if (first.is_array()) {
+      return {Status(StatusCode::INVALID_ARGUMENT,
+                     "batch prompts (nested arrays) are not supported"),
+              ""};
+    }
+
+    std::vector<int32_t> token_ids;
+    token_ids.reserve(prompt.size());
+    for (const auto& elem : prompt) {
+      if (!elem.is_number_integer()) {
+        return {Status(StatusCode::INVALID_ARGUMENT,
+                       "prompt array must contain only integer token ids"),
+                ""};
+      }
+      if (elem.is_number_unsigned()) {
+        uint64_t value = elem.get<uint64_t>();
+        if (value >
+            static_cast<uint64_t>(std::numeric_limits<int32_t>::max())) {
+          return {Status(StatusCode::INVALID_ARGUMENT,
+                         "token id exceeds int32 range"),
+                  ""};
+        }
+        token_ids.emplace_back(static_cast<int32_t>(value));
+      } else {
+        int64_t value = elem.get<int64_t>();
+        if (value < std::numeric_limits<int32_t>::min() ||
+            value > std::numeric_limits<int32_t>::max()) {
+          return {Status(StatusCode::INVALID_ARGUMENT,
+                         "token id exceeds int32 range"),
+                  ""};
+        }
+        token_ids.emplace_back(static_cast<int32_t>(value));
+      }
+    }
+
+    json["token_ids"] = token_ids;
+    json["prompt"] = "";
+    return {Status(), json.dump()};
+  } catch (const nlohmann::json::exception& e) {
+    return {Status(StatusCode::INVALID_ARGUMENT,
+                   "Invalid JSON format: " + std::string(e.what())),
+            ""};
+  } catch (const std::exception& e) {
+    LOG(ERROR) << "Exception during completion JSON preprocessing: "
+               << e.what();
+    return {Status(StatusCode::UNKNOWN,
+                   "Internal server error during JSON processing."),
+            ""};
+  }
+}
+
+}  // namespace xllm

--- a/xllm/api_service/completion_json_parser.h
+++ b/xllm/api_service/completion_json_parser.h
@@ -1,0 +1,32 @@
+/* Copyright 2026 The xLLM Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://github.com/jd-opensource/xllm/blob/main/LICENSE
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#pragma once
+
+#include <string>
+#include <utility>
+
+#include "core/common/types.h"
+
+namespace xllm {
+
+// Normalizes OpenAI-style completion JSON before protobuf parsing. An integer
+// array prompt is moved into "token_ids" and "prompt" is cleared; a string
+// prompt (or a missing/scalar prompt) is passed through unchanged. Batch and
+// malformed array forms are rejected with INVALID_ARGUMENT.
+std::pair<Status, std::string> preprocess_completion_prompt(
+    std::string json_str);
+
+}  // namespace xllm

--- a/xllm/api_service/completion_service_impl.cpp
+++ b/xllm/api_service/completion_service_impl.cpp
@@ -230,13 +230,11 @@ void CompletionServiceImpl::process_async_rpc_impl(
   RequestParams request_params(rpc_request, "", "");
 
   std::optional<std::vector<int>> prompt_tokens = std::nullopt;
+  if (rpc_request.token_ids_size() > 0) {
+    prompt_tokens = std::vector<int>(rpc_request.token_ids().begin(),
+                                     rpc_request.token_ids().end());
+  }
   if (rpc_request.has_routing()) {
-    prompt_tokens = std::vector<int>{};
-    prompt_tokens->reserve(rpc_request.token_ids_size());
-    for (int i = 0; i < rpc_request.token_ids_size(); i++) {
-      prompt_tokens->emplace_back(rpc_request.token_ids(i));
-    }
-
     request_params.decode_address = rpc_request.routing().decode_name();
   }
 
@@ -281,13 +279,11 @@ void CompletionServiceImpl::process_async_impl(
   }
 
   std::optional<std::vector<int>> prompt_tokens = std::nullopt;
+  if (rpc_request.token_ids_size() > 0) {
+    prompt_tokens = std::vector<int>(rpc_request.token_ids().begin(),
+                                     rpc_request.token_ids().end());
+  }
   if (rpc_request.has_routing()) {
-    prompt_tokens = std::vector<int>{};
-    prompt_tokens->reserve(rpc_request.token_ids_size());
-    for (int i = 0; i < rpc_request.token_ids_size(); i++) {
-      prompt_tokens->emplace_back(rpc_request.token_ids(i));
-    }
-
     request_params.decode_address = rpc_request.routing().decode_name();
   }
 

--- a/xllm/core/distributed_runtime/llm_master.cpp
+++ b/xllm/core/distributed_runtime/llm_master.cpp
@@ -40,6 +40,7 @@ limitations under the License.
 #include "util/net.h"
 #include "util/scope_guard.h"
 #include "util/timer.h"
+#include "util/utils.h"
 
 namespace xllm {
 namespace {
@@ -288,7 +289,10 @@ std::shared_ptr<Request> LLMMaster::generate_request(
     const RequestParams& sp,
     std::optional<Call*> call,
     OutputCallback callback) {
-  if (prompt.empty()) {
+  // A request is valid as long as it carries either text or pre-tokenized
+  // prompt tokens; pure-token input (no text) is a first-class input.
+  const bool has_prompt_tokens = prompt_tokens.has_value();
+  if (prompt.empty() && !has_prompt_tokens) {
     CALLBACK_WITH_ERROR(StatusCode::INVALID_ARGUMENT,
                         "Prompt is empty",
                         sp.service_request_id,
@@ -300,7 +304,7 @@ std::shared_ptr<Request> LLMMaster::generate_request(
   Timer timer;
   std::vector<int> local_prompt_tokens;
 
-  if (prompt_tokens.has_value()) {
+  if (has_prompt_tokens) {
     local_prompt_tokens = std::move(prompt_tokens.value());
   } else {
     if (!tokenizer_->encode(
@@ -315,6 +319,23 @@ std::shared_ptr<Request> LLMMaster::generate_request(
   }
 
   COUNTER_ADD(tokenization_latency_seconds, timer.elapsed_seconds());
+
+  // Validate directly-supplied prompt tokens against the vocabulary range to
+  // avoid out-of-bounds embedding lookups. Encoded tokens are trusted, so only
+  // scan when tokens were provided and the vocab range is known.
+  const int64_t vocab_size = model_args_.vocab_size();
+  if (has_prompt_tokens && vocab_size > 0) {
+    const auto invalid_token =
+        util::find_out_of_vocab_token(local_prompt_tokens, vocab_size);
+    if (invalid_token.has_value()) {
+      CALLBACK_WITH_ERROR(StatusCode::INVALID_ARGUMENT,
+                          "Prompt token id out of vocabulary range: " +
+                              std::to_string(invalid_token.value()),
+                          sp.service_request_id,
+                          sp.source_xservice_addr);
+      return nullptr;
+    }
+  }
 
   const int32_t max_context_len = model_args_.max_position_embeddings();
   int32_t prompt_token_limit = max_context_len;

--- a/xllm/core/util/utils.h
+++ b/xllm/core/util/utils.h
@@ -93,6 +93,20 @@ static inline int64_t align_up(int64_t value, int64_t alignment) {
   return ((value + alignment - 1) / alignment) * alignment;
 }
 
+// Returns the first token id in `token_ids` that falls outside the valid
+// vocabulary range [0, vocab_size); std::nullopt if all ids are in range.
+// Callers must skip the scan when vocab_size <= 0 (range unknown).
+inline std::optional<int> find_out_of_vocab_token(
+    const std::vector<int>& token_ids,
+    int64_t vocab_size) {
+  for (int token_id : token_ids) {
+    if (token_id < 0 || token_id >= vocab_size) {
+      return token_id;
+    }
+  }
+  return std::nullopt;
+}
+
 bool match_suffix(const Slice<int32_t>& data, const Slice<int32_t>& suffix);
 
 std::vector<uint32_t> cal_vec_split_index(uint32_t vec_size, uint32_t part_num);

--- a/xllm/core/util/utils.h
+++ b/xllm/core/util/utils.h
@@ -96,10 +96,10 @@ static inline int64_t align_up(int64_t value, int64_t alignment) {
 // Returns the first token id in `token_ids` that falls outside the valid
 // vocabulary range [0, vocab_size); std::nullopt if all ids are in range.
 // Callers must skip the scan when vocab_size <= 0 (range unknown).
-inline std::optional<int> find_out_of_vocab_token(
-    const std::vector<int>& token_ids,
+inline std::optional<int32_t> find_out_of_vocab_token(
+    const std::vector<int32_t>& token_ids,
     int64_t vocab_size) {
-  for (int token_id : token_ids) {
+  for (int32_t token_id : token_ids) {
     if (token_id < 0 || token_id >= vocab_size) {
       return token_id;
     }


### PR DESCRIPTION
## Description

* Decouple the two gates in completion_service_impl: build prompt_tokens whenever token_ids_size() \> 0, and use routing only to set decode_address, removing the empty-vector-with-value hazard when routing is present but token_ids is empty.
* Relax the empty-prompt check in LLMMaster::generate_request to reject only when both prompt and prompt_tokens are empty, making token-only input a first-class valid input.
* Add a vocab bounds check that scans \[0, vocab_size) only for direct token input when vocab_size \> 0, returning INVALID_ARGUMENT with the offending id; the encode path is not validated and pays no cost.
* Extract util::find_out_of_vocab_token as a pure function and add boundary unit tests.


## Change Type

- [ ] Bug fix
- [x] New feature
- [ ] Performance improvement
- [ ] Refactor
- [ ] Documentation
- [ ] Test
- [ ] Build or CI

## Pull Request Checklist

Thank you for contributing to xLLM. Before requesting review, please make sure the following items are complete.

### PR Title and Commit Messages

- [x] The PR title and each commit message follow the xLLM commit format: `<type>: <subject>`.

> Allowed types: feat, bugfix, docs, test, refactor, chore, style, revert, perf, model, build, release.
> The subject should use clear English, start with a verb, include at least 4 words, and end with `.`.

### Pre-commit Checks

- [ ] I have installed `pre-commit` by running `pip install pre-commit` or an equivalent command.
- [ ] I have installed the hooks with `pre-commit install`.
- [ ] I have run `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

### Self Review

- [x] I have self-reviewed the code according to `.agents/skills/code-review/references/custom-code-style.md`, especially code written or assisted by AI.
- [x] I have rebased this PR onto the latest `main` branch.

### Build and Test Coverage

- [ ] Tests have been added or updated as needed.
- [ ] CUDA: `python setup.py build test` has passed on a CUDA machine.
- [x] NPU: `python setup.py build test` has passed on an NPU machine.
- [x] MLU: `python setup.py build test` has passed on an MLU machine.

## Reviewer Notes

<!-- Optional: anything reviewers should focus on, known risks, follow-ups, or validation gaps. -->
