### PR TITLE
bugfix: fix mlu graph linear state padding.

### DIFF
--- a/tests/core/runtime/mlu_graph_executor_test.cpp
+++ b/tests/core/runtime/mlu_graph_executor_test.cpp
@@ -23,6 +23,7 @@ limitations under the License.
 #include <vector>
 
 #include "base_executor_impl.h"
+#include "core/common/constants.h"
 #include "core/framework/batch/batch.h"
 #include "core/framework/config/execution_config.h"
 #include "core/framework/kv_cache/kv_cache.h"
@@ -436,6 +437,43 @@ TEST_F(MluGraphExecutorTest, PersistentTensorBytesIncludeLazyAux) {
 
   EXPECT_GT(base_bytes, output_bytes);
   EXPECT_EQ(param.get_persistent_tensor_bytes(), base_bytes + output_bytes);
+}
+
+TEST_F(MluGraphExecutorTest, LinearStatePaddingTailUsesPaddingId) {
+  ::xllm::mlu::GraphPersistentParam param(
+      model_args_, tensor_options_.device(), options_);
+
+  ForwardInput first_input = prepare_inputs(/*batch_size=*/4, /*seed=*/83);
+  first_input.input_params.embedding.linear_state_ids = {10, 20, 30, 40};
+  first_input.input_params.embedding.linear_state_indices =
+      torch::tensor(first_input.input_params.embedding.linear_state_ids,
+                    tensor_options_.dtype(torch::kInt32));
+
+  param.init_params(first_input.input_params,
+                    /*padding_num_tokens=*/4,
+                    /*padding_needed=*/0);
+  param.update_input_buffer(first_input.token_ids,
+                            first_input.positions,
+                            first_input.input_params,
+                            /*padding_needed=*/0);
+
+  ForwardInput second_input = prepare_inputs(/*batch_size=*/3, /*seed=*/89);
+  second_input.input_params.embedding.linear_state_ids = {11, 21, 31};
+  second_input.input_params.embedding.linear_state_indices =
+      torch::tensor(second_input.input_params.embedding.linear_state_ids,
+                    tensor_options_.dtype(torch::kInt32));
+
+  param.update_input_buffer(second_input.token_ids,
+                            second_input.positions,
+                            second_input.input_params,
+                            /*padding_needed=*/1);
+
+  torch_mlu::synchronize();
+  torch::Tensor linear_state_indices =
+      param.params_.embedding.linear_state_indices.cpu();
+  EXPECT_TRUE(torch::equal(linear_state_indices,
+                           torch::tensor({11, 21, 31, kPaddingLinearStateId},
+                                         torch::dtype(torch::kInt32))));
 }
 
 TEST_F(MluGraphExecutorTest, PrefillThenDecodeCapturesAndReplays) {

--- a/xllm/core/runtime/mlu_graph_executor_impl.cpp
+++ b/xllm/core/runtime/mlu_graph_executor_impl.cpp
@@ -29,6 +29,7 @@ limitations under the License.
 
 #include "common/global_flags.h"
 #include "common/metrics.h"
+#include "core/common/constants.h"
 #include "core/framework/config/execution_config.h"
 #include "framework/model/causal_vlm.h"
 #include "util/utils.h"
@@ -305,10 +306,10 @@ GraphPersistentParam::GraphPersistentParam(const ModelArgs& args,
   // bound covers both paths when speculative decode is enabled.
   q_seq_lens_ = torch::zeros({max_seq_lens}, int_tensor_options);
   kv_seq_lens_ = torch::zeros({max_seq_lens}, int_tensor_options);
-  // The max_seq_lens index will be used as the padding value under MLU graph,
-  // and this value will not be used in valid computations.
+  // Padding decode rows can still execute stateful graph kernels. Point them
+  // at the reserved padding slot so they cannot update a live request state.
   linear_state_indices_ =
-      torch::full({max_seq_lens}, max_seq_lens, int_tensor_options);
+      torch::full({max_seq_lens}, kPaddingLinearStateId, int_tensor_options);
 }
 
 void GraphPersistentParam::init_params(const ModelInputParams& params,
@@ -437,6 +438,11 @@ void GraphPersistentParam::update_input_buffer(const torch::Tensor& tokens,
           .copy_(torch::tensor(params.embedding.linear_state_ids,
                                linear_state_indices_.options()),
                  /*non_blocking=*/true);
+    }
+    if (padded_tokens > actual_batch_size) {
+      linear_state_indices_
+          .slice(/*dim=*/0, /*start=*/actual_batch_size, /*end=*/padded_tokens)
+          .fill_(kPaddingLinearStateId);
     }
     params_.embedding.linear_state_ids = params.embedding.linear_state_ids;
     params_.embedding.linear_state_indices =


### PR DESCRIPTION
## Description

The padding row in the MLU graph decode reuses an old linear state ID. Qwen3.5/Qwen3.5-MoE has linear attention layers like Gated Delta Nets, which read and write per-sequence conv/ssm caches via `linear_state_indices` during decoding. To reuse the graph, the MLU graph pads the decode batch to the bucket size; for example, if the actual batch is 3, it will be executed as if the bucket is 4. Although only the first 3 rows of output are ultimately returned, the kernel for the 4th padding row is also executed.

Previously, `GraphPersistentParam::update_input_buffer()` only updated `linear_state_indices_` within the range [0, actual_batch_size), without clearing `[actual_batch_size, padded_tokens]`. Therefore, if batch=4 is run first in the same bucket, the actual ID (e.g., 40) is written to the tail position; then batch=3 is run, and the fourth row still contains 40. The GDN decode kernel will use this residual ID to update the conv/ssm cache for slot 40, polluting the state of a real request, manifesting as a few garbled or nonsensical responses.

Remedial solution:

Explicitly point all graph padding rows to the preserved padding state slot, instead of retaining the old value.

## Change Type

- [x] Bug fix
- [ ] New feature
- [ ] Performance improvement
- [ ] Refactor
- [ ] Documentation
- [ ] Test
- [ ] Build or CI

## Pull Request Checklist

Thank you for contributing to xLLM. Before requesting review, please make sure the following items are complete.

### PR Title and Commit Messages

- [x] The PR title and each commit message follow the xLLM commit format: `<type>: <subject>`.

> Allowed types: feat, bugfix, docs, test, refactor, chore, style, revert, perf, model, build, release.
> The subject should use clear English, start with a verb, include at least 4 words, and end with `.`.

### Pre-commit Checks

- [x] I have installed `pre-commit` by running `pip install pre-commit` or an equivalent command.
- [x] I have installed the hooks with `pre-commit install`.
- [x] I have run `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

### Self Review

- [x] I have self-reviewed the code according to `.agents/skills/code-review/references/custom-code-style.md`, especially code written or assisted by AI.
- [x] I have rebased this PR onto the latest `main` branch.

### Build and Test Coverage

- [ ] Tests have been added or updated as needed.
- [ ] CUDA: `python setup.py build test` has passed on a CUDA machine.
- [x] NPU: `python setup.py build test` has passed on an NPU machine.
- [x] MLU: `python setup.py build test` has passed on an MLU machine.

## Reviewer Notes

<!-- Optional: anything reviewers should focus on, known risks, follow-ups, or validation gaps. -->
