### PR TITLE
feat: support deepseek-v3 fp8 w8a8 on dcu device.

### DIFF
--- a/scripts/build_support/env.py
+++ b/scripts/build_support/env.py
@@ -228,6 +228,10 @@ def set_cuda_envs() -> None:
 def set_dcu_envs() -> None:
     set_common_envs()
     os.environ["DCU_PATH"] = get_dcu_root_path() or ""
+    if not os.getenv("FLASH_ATTENTION_LIB"):
+        flash_attn_lib = _find_dcu_so("flash_attn", "lib/libflash_attention.so")
+        if flash_attn_lib:
+            os.environ["FLASH_ATTENTION_LIB"] = flash_attn_lib
     if not os.getenv("FLASH_MLA_LIB"):
         flash_mla_lib = _find_dcu_so("flash_mla", "cuda*.so")
         if flash_mla_lib:
@@ -236,6 +240,12 @@ def set_dcu_envs() -> None:
         aiter_cpp_api_lib = _find_dcu_so("aiter", "jit/module_cpp_api.so")
         if aiter_cpp_api_lib:
             os.environ["AITER_CPP_API_LIB"] = aiter_cpp_api_lib
+    if not os.getenv("AITER_MOE_C_KERNEL_LIB"):
+        aiter_moe_c_kernel_lib = _find_dcu_so(
+            "aiter", "jit/module_moe_c_kernel.so"
+        )
+        if aiter_moe_c_kernel_lib:
+            os.environ["AITER_MOE_C_KERNEL_LIB"] = aiter_moe_c_kernel_lib
 
 def set_maca_envs():
     os.environ["PYTHON_INCLUDE_PATH"] = get_python_include_path()

--- a/setup.py
+++ b/setup.py
@@ -375,6 +375,12 @@ class ExtBuild(build_ext):
                 aiter_cpp_api_lib = os.getenv("AITER_CPP_API_LIB")
                 if aiter_cpp_api_lib:
                     cmake_args += [f"-DAITER_CPP_API_LIB={aiter_cpp_api_lib}"]
+
+                aiter_moe_c_kernel_lib = os.getenv("AITER_MOE_C_KERNEL_LIB")
+                if aiter_moe_c_kernel_lib:
+                    cmake_args += [
+                        f"-DAITER_MOE_C_KERNEL_LIB={aiter_moe_c_kernel_lib}"
+                    ]
             else:
                 raise RuntimeError(
                     "DCU build requires a HIP/ROCm PyTorch environment. "

--- a/xllm/core/framework/hf_model_loader.cpp
+++ b/xllm/core/framework/hf_model_loader.cpp
@@ -93,28 +93,45 @@ bool is_compressed_tensors_int8_scheme(const nlohmann::json& config,
          num_bits_it->get<int64_t>() == 8 && dynamic == expected_dynamic;
 }
 
-bool try_load_compressed_tensors_quant_cfg(const JsonReader& reader,
-                                           QuantArgs& quant_args) {
+const nlohmann::json* get_compressed_tensors_config(
+    const nlohmann::json& data,
+    const JsonReader& reader,
+    const std::string& config_key) {
   const auto quant_method =
-      reader.value<std::string>("quantization_config.quant_method");
+      reader.value<std::string>(config_key + ".quant_method");
   if (!quant_method.has_value() ||
       !boost::iequals(*quant_method, "compressed-tensors")) {
-    return false;
+    return nullptr;
   }
 
-  const auto& data = reader.data();
-  auto quant_config_it = data.find("quantization_config");
+  auto quant_config_it = data.find(config_key);
   if (quant_config_it == data.end() || !quant_config_it->is_object()) {
-    LOG(ERROR) << "quantization_config must be an object for "
-                  "compressed-tensors quantization.";
+    LOG(ERROR) << config_key << " must be an object for "
+               << "compressed-tensors quantization.";
+    return nullptr;
+  }
+  return &(*quant_config_it);
+}
+
+bool try_load_compressed_tensors_quant_cfg(const JsonReader& reader,
+                                           QuantArgs& quant_args) {
+  const nlohmann::json data = reader.data();
+  std::string config_key = "quantization_config";
+  const nlohmann::json* quant_config =
+      get_compressed_tensors_config(data, reader, config_key);
+  if (quant_config == nullptr && Platform::is_dcu()) {
+    config_key = "compression_config";
+    quant_config = get_compressed_tensors_config(data, reader, config_key);
+  }
+  if (quant_config == nullptr) {
     return false;
   }
 
-  auto config_groups_it = quant_config_it->find("config_groups");
-  if (config_groups_it == quant_config_it->end() ||
+  auto config_groups_it = quant_config->find("config_groups");
+  if (config_groups_it == quant_config->end() ||
       !config_groups_it->is_object()) {
-    LOG(ERROR) << "quantization_config.config_groups must be an object for "
-                  "compressed-tensors quantization.";
+    LOG(ERROR) << config_key << ".config_groups must be an object for "
+               << "compressed-tensors quantization.";
     return false;
   }
 
@@ -142,8 +159,8 @@ bool try_load_compressed_tensors_quant_cfg(const JsonReader& reader,
         quant_args.moe_weight_bits() = 8;
         quant_args.activation_dynamic() = true;
         quant_args.is_compressed_tensors_w8a8_dynamic() = true;
-        if (const auto ignore = reader.value<std::vector<std::string>>(
-                "quantization_config.ignore");
+        if (const auto ignore =
+                reader.value<std::vector<std::string>>(config_key + ".ignore");
             ignore.has_value()) {
           quant_args.ignored_modules() = *ignore;
         }
@@ -160,17 +177,16 @@ bool try_load_compressed_tensors_quant_cfg(const JsonReader& reader,
     if (dynamic_it != input_activations_it->end() && !dynamic_it->is_null()) {
       quant_args.activation_dynamic() = dynamic_it->get<bool>();
     }
-    if (const auto ignore = reader.value<std::vector<std::string>>(
-            "quantization_config.ignore");
+    if (const auto ignore =
+            reader.value<std::vector<std::string>>(config_key + ".ignore");
         ignore.has_value()) {
       quant_args.ignored_modules() = *ignore;
     }
     return true;
   }
 
-  LOG(ERROR) << "Failed to find an FP8 config_group in "
-                "quantization_config.config_groups for compressed-tensors "
-                "quantization.";
+  LOG(ERROR) << "Failed to find an FP8 config_group in " << config_key
+             << ".config_groups for compressed-tensors quantization.";
   return false;
 }
 
@@ -382,7 +398,8 @@ void check_safetensors_cleanup(::Status status,
 }  // namespace
 
 bool load_quant_cfg(const JsonReader& reader, QuantArgs& quant_args) {
-  if (!reader.contains("quantization_config")) {
+  if (!reader.contains("quantization_config") &&
+      !reader.contains("compression_config")) {
     return true;
   }
 

--- a/xllm/core/kernels/dcu/CMakeLists.txt
+++ b/xllm/core/kernels/dcu/CMakeLists.txt
@@ -44,6 +44,7 @@ set(DCU_LOCAL_HIP_SOURCES
   ${CMAKE_SOURCE_DIR}/xllm/core/kernels/dcu/scaled_quantize.hip
   ${CMAKE_SOURCE_DIR}/xllm/core/kernels/dcu/scaled_matmul.cpp
   ${CMAKE_SOURCE_DIR}/xllm/core/kernels/dcu/build_block_table_from_paged_kv.hip
+  ${CMAKE_SOURCE_DIR}/xllm/core/kernels/dcu/gather_mla_latent_cache.hip
   ${CMAKE_SOURCE_DIR}/xllm/core/kernels/dcu/random_sample.hip
   ${CMAKE_SOURCE_DIR}/xllm/core/kernels/dcu/rejection_sample.hip
 
@@ -52,6 +53,9 @@ set(DCU_LOCAL_HIP_SOURCES
   ${CMAKE_SOURCE_DIR}/xllm/core/kernels/dcu/global_capture_instance.cpp
   ${CMAKE_SOURCE_DIR}/xllm/core/kernels/dcu/group_gemm.cpp
   ${CMAKE_SOURCE_DIR}/xllm/core/kernels/dcu/flash_mla_adapter.cpp
+  ${CMAKE_SOURCE_DIR}/xllm/core/kernels/dcu/aiter_moe_adapter.cpp
+  ${CMAKE_SOURCE_DIR}/xllm/core/kernels/dcu/aiter_quant_adapter.cpp
+  ${CMAKE_SOURCE_DIR}/xllm/core/kernels/dcu/hipblaslt_fp8_adapter.cpp
   ${CMAKE_SOURCE_DIR}/xllm/core/kernels/dcu/topk_gate.cpp
 )
 
@@ -79,12 +83,22 @@ set_target_properties(flash_mla PROPERTIES IMPORTED_LOCATION "${FLASH_MLA_LIB}")
 
 if(NOT DEFINED AITER_CPP_API_LIB OR NOT EXISTS "${AITER_CPP_API_LIB}")
   message(FATAL_ERROR
-    "AITER_CPP_API_LIB is required for DCU grouped topk. Install aiter and set "
-    "AITER_CPP_API_LIB before invoking setup.py.")
+    "AITER_CPP_API_LIB is required for DCU grouped topk and FP8 activation "
+    "quantization. Install aiter and set AITER_CPP_API_LIB before invoking "
+    "setup.py.")
 endif()
 add_library(aiter_cpp_api SHARED IMPORTED)
 set_target_properties(aiter_cpp_api PROPERTIES
   IMPORTED_LOCATION "${AITER_CPP_API_LIB}")
+
+if(NOT DEFINED AITER_MOE_C_KERNEL_LIB OR NOT EXISTS "${AITER_MOE_C_KERNEL_LIB}")
+  message(FATAL_ERROR
+    "AITER_MOE_C_KERNEL_LIB is required for DCU AITER MoE FP8 kernels. "
+    "Install aiter and set AITER_MOE_C_KERNEL_LIB before invoking setup.py.")
+endif()
+add_library(aiter_moe_c_kernel SHARED IMPORTED)
+set_target_properties(aiter_moe_c_kernel PROPERTIES
+  IMPORTED_LOCATION "${AITER_MOE_C_KERNEL_LIB}")
 
 cc_library(
   NAME
@@ -100,6 +114,7 @@ cc_library(
     glog::glog
     :platform
     aiter_cpp_api
+    aiter_moe_c_kernel
     flash_mla
 )
 
@@ -107,8 +122,12 @@ add_dependencies(dcu_kernels ${DCU_HIPIFY_TARGET})
 
 get_filename_component(FLASH_MLA_LIB_DIR "${FLASH_MLA_LIB}" DIRECTORY)
 get_filename_component(AITER_CPP_API_LIB_DIR "${AITER_CPP_API_LIB}" DIRECTORY)
+get_filename_component(AITER_MOE_C_KERNEL_LIB_DIR
+                       "${AITER_MOE_C_KERNEL_LIB}" DIRECTORY)
 set_property(TARGET dcu_kernels APPEND PROPERTY BUILD_RPATH "${FLASH_MLA_LIB_DIR}")
 set_property(TARGET dcu_kernels APPEND PROPERTY BUILD_RPATH "${AITER_CPP_API_LIB_DIR}")
+set_property(TARGET dcu_kernels APPEND PROPERTY BUILD_RPATH
+             "${AITER_MOE_C_KERNEL_LIB_DIR}")
 
 target_include_directories(dcu_kernels
   PUBLIC

--- a/xllm/core/kernels/dcu/aiter_moe_adapter.cpp
+++ b/xllm/core/kernels/dcu/aiter_moe_adapter.cpp
@@ -1,0 +1,256 @@
+/* Copyright 2026 The xLLM Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://github.com/jd-opensource/xllm/blob/main/LICENSE
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include "kernels/dcu/aiter_moe_adapter.h"
+
+#include <glog/logging.h>
+
+#include <algorithm>
+
+namespace aiter {
+namespace native {
+
+void moe_sorting_fwd(
+    torch::Tensor& topk_ids,
+    torch::Tensor& topk_weights,
+    torch::Tensor& sorted_token_ids,
+    torch::Tensor& sorted_weights,
+    torch::Tensor& sorted_expert_ids,
+    torch::Tensor& tokens_positions_per_expert,
+    torch::Tensor& num_valid_ids,
+    std::optional<torch::Tensor> moe_buf = std::nullopt,
+    int num_experts = 0,
+    int unit_size = 0,
+    std::optional<torch::Tensor> local_expert_mask = std::nullopt);
+
+torch::Tensor moe_c_moe_gemm_marlin_w8a8_fp8(
+    torch::Tensor input,
+    torch::Tensor b_qweight,
+    torch::Tensor output,
+    torch::Tensor a_scale,
+    torch::Tensor b_scale,
+    std::optional<torch::Tensor> topk_weights,
+    torch::Tensor sorted_token_ids,
+    torch::Tensor expert_ids,
+    torch::Tensor num_tokens_post_pad,
+    int64_t top_k,
+    int64_t mode,
+    int64_t delta,
+    int64_t size_m);
+
+}  // namespace native
+}  // namespace aiter
+
+namespace xllm {
+namespace kernel {
+namespace dcu {
+namespace aiter {
+namespace {
+
+constexpr int64_t kMarlinKTile = 64;
+constexpr int64_t kMarlinNTile = 16;
+constexpr int64_t kMoeGemm1SmallTokenMode = 60121;
+constexpr int64_t kMoeGemm1LargeTokenMode = 60098;
+constexpr int64_t kMoeGemm2TinyTokenMode = 60042;
+constexpr int64_t kMoeGemm2SmallTokenMode = 60038;
+constexpr int64_t kMoeGemm2MediumTokenMode = 60043;
+constexpr int64_t kMoeGemm2LargeTokenMode = 60046;
+constexpr int64_t kMoeSelectedMMax = 512;
+
+void check_fp8_moe_weight(const torch::Tensor& weight) {
+  CHECK(weight.defined()) << "AITER MoE weight must be defined.";
+  CHECK(weight.is_contiguous()) << "AITER MoE weight must be contiguous.";
+  CHECK_EQ(weight.dim(), 3)
+      << "AITER MoE weight must be [E,N,K], got " << weight.sizes();
+  CHECK(weight.scalar_type() == torch::kFloat8_e4m3fn ||
+        weight.scalar_type() == torch::kFloat8_e5m2)
+      << "AITER MoE weight must be FP8.";
+  CHECK_EQ(weight.size(2) % kMarlinKTile, 0)
+      << "AITER MoE weight K must be divisible by " << kMarlinKTile;
+}
+
+void check_scale(const torch::Tensor& scale, const torch::Tensor& weight) {
+  CHECK(scale.defined()) << "AITER MoE weight scale must be defined.";
+  CHECK(scale.is_cuda()) << "AITER MoE weight scale must be on DCU.";
+  CHECK(scale.is_contiguous()) << "AITER MoE weight scale must be contiguous.";
+  CHECK_EQ(scale.scalar_type(), torch::kFloat32)
+      << "AITER MoE weight scale must be float32.";
+  CHECK_EQ(scale.dim(), 3) << "AITER MoE weight scale must be [E,N,1], got "
+                           << scale.sizes();
+  CHECK_EQ(scale.size(0), weight.size(0))
+      << "AITER MoE weight scale expert dim mismatch.";
+  CHECK_EQ(scale.size(1), weight.size(1))
+      << "AITER MoE weight scale output channel dim mismatch.";
+  CHECK_EQ(scale.size(2), 1) << "AITER MoE weight scale last dim must be 1.";
+}
+
+}  // namespace
+
+int64_t select_moe_gemm1_mode(int64_t num_tokens) {
+  CHECK_GT(num_tokens, 0) << "num_tokens must be positive.";
+  if (num_tokens <= 256) {
+    return kMoeGemm1SmallTokenMode;
+  }
+  return kMoeGemm1LargeTokenMode;
+}
+
+int64_t select_moe_gemm2_mode(int64_t num_tokens) {
+  CHECK_GT(num_tokens, 0) << "num_tokens must be positive.";
+  if (num_tokens == 2 || num_tokens == 3) {
+    return kMoeGemm2TinyTokenMode;
+  }
+  if (num_tokens <= 16) {
+    return kMoeGemm2SmallTokenMode;
+  }
+  if (num_tokens <= 64) {
+    return kMoeGemm2MediumTokenMode;
+  }
+  if (num_tokens <= 256) {
+    return kMoeGemm2LargeTokenMode;
+  }
+  return kMoeGemm2MediumTokenMode;
+}
+
+int64_t select_moe_m_key(int64_t num_tokens) {
+  CHECK_GT(num_tokens, 0) << "num_tokens must be positive.";
+  return std::min<int64_t>(num_tokens, kMoeSelectedMMax);
+}
+
+torch::Tensor moe_layout_shuffle_gemm1(const torch::Tensor& weight) {
+  // The exported AITER C kernel currently expects the same marlin packing for
+  // the first and second MoE GEMMs.
+  return moe_layout_shuffle_gemm2(weight);
+}
+
+torch::Tensor moe_layout_shuffle_gemm2(const torch::Tensor& weight) {
+  check_fp8_moe_weight(weight);
+  CHECK_EQ(weight.size(1) % kMarlinNTile, 0)
+      << "AITER MoE weight N must be divisible by " << kMarlinNTile;
+  torch::Tensor transposed = weight.permute({0, 2, 1}).contiguous();
+  const int64_t experts = transposed.size(0);
+  const int64_t size_k = transposed.size(1);
+  const int64_t size_n = transposed.size(2);
+
+  torch::Tensor shuffled = transposed.reshape({experts,
+                                               size_k / kMarlinKTile,
+                                               kMarlinKTile,
+                                               size_n / kMarlinNTile,
+                                               kMarlinNTile});
+  shuffled = shuffled.permute({0, 1, 3, 4, 2}).contiguous();
+  shuffled = shuffled.reshape(
+      {experts, size_k / kMarlinKTile, size_n / kMarlinNTile, 1, 16, 4, 16});
+  shuffled = shuffled.permute({0, 1, 2, 3, 5, 4, 6}).contiguous();
+  return shuffled.view(weight.sizes());
+}
+
+MoeSortedTokens moe_align_block_size(const torch::Tensor& topk_ids,
+                                     const torch::Tensor& topk_weights,
+                                     int64_t num_experts,
+                                     int64_t block_size) {
+  CHECK(topk_ids.defined()) << "topk_ids must be defined.";
+  CHECK(topk_weights.defined()) << "topk_weights must be defined.";
+  CHECK(topk_ids.is_cuda() && topk_weights.is_cuda())
+      << "topk tensors must be on DCU.";
+  CHECK_EQ(topk_ids.sizes(), topk_weights.sizes())
+      << "topk ids/weights shape mismatch.";
+  CHECK_EQ(topk_ids.dim(), 2) << "topk_ids must be [M,topk].";
+  CHECK_GT(num_experts, 0) << "num_experts must be positive.";
+  CHECK_GT(block_size, 0) << "block_size must be positive.";
+
+  torch::Tensor ids = topk_ids.scalar_type() == torch::kInt32
+                          ? topk_ids.contiguous()
+                          : topk_ids.to(torch::kInt32).contiguous();
+  torch::Tensor weights = topk_weights.to(torch::kFloat32).contiguous();
+
+  const int64_t topk = ids.size(1);
+  const int64_t max_num_tokens_padded =
+      ids.numel() + num_experts * block_size - topk;
+  const int64_t max_num_m_blocks =
+      (max_num_tokens_padded + block_size - 1) / block_size;
+
+  torch::TensorOptions int_options =
+      ids.options().dtype(torch::kInt32).device(ids.device());
+  torch::TensorOptions fp_options =
+      ids.options().dtype(torch::kFloat32).device(ids.device());
+  MoeSortedTokens sorted_tokens{
+      torch::empty({max_num_tokens_padded}, int_options),
+      torch::empty({max_num_tokens_padded}, fp_options),
+      torch::empty({max_num_m_blocks}, int_options),
+      torch::empty({num_experts * 2}, int_options),
+      torch::empty({1}, int_options)};
+
+  ::aiter::native::moe_sorting_fwd(ids,
+                                   weights,
+                                   sorted_tokens.sorted_token_ids,
+                                   sorted_tokens.sorted_weights,
+                                   sorted_tokens.expert_ids,
+                                   sorted_tokens.tokens_positions_per_expert,
+                                   sorted_tokens.num_tokens_post_pad,
+                                   std::nullopt,
+                                   static_cast<int>(num_experts),
+                                   static_cast<int>(block_size),
+                                   std::nullopt);
+  return sorted_tokens;
+}
+
+torch::Tensor moe_gemm_fp8_channelwise(
+    const torch::Tensor& input,
+    const torch::Tensor& weight,
+    const torch::Tensor& output,
+    const torch::Tensor& input_scale,
+    const torch::Tensor& weight_scale,
+    const std::optional<torch::Tensor>& topk_weights,
+    const MoeSortedTokens& sorted_tokens,
+    int64_t topk,
+    int64_t mode,
+    int64_t delta,
+    int64_t selected_m) {
+  CHECK(input.defined()) << "AITER MoE input must be defined.";
+  CHECK(input.is_cuda()) << "AITER MoE input must be on DCU.";
+  CHECK(input.is_contiguous()) << "AITER MoE input must be contiguous.";
+  CHECK(input.scalar_type() == torch::kFloat8_e4m3fn ||
+        input.scalar_type() == torch::kFloat8_e5m2)
+      << "AITER MoE input must be FP8.";
+  CHECK(output.defined()) << "AITER MoE output must be defined.";
+  CHECK(output.is_cuda()) << "AITER MoE output must be on DCU.";
+  CHECK(output.is_contiguous()) << "AITER MoE output must be contiguous.";
+  CHECK(input_scale.defined()) << "AITER MoE input scale must be defined.";
+  CHECK(input_scale.is_cuda()) << "AITER MoE input scale must be on DCU.";
+  CHECK(input_scale.is_contiguous())
+      << "AITER MoE input scale must be contiguous.";
+  check_fp8_moe_weight(weight);
+  CHECK(weight.is_cuda()) << "AITER MoE weight must be on DCU.";
+  check_scale(weight_scale, weight);
+
+  return ::aiter::native::moe_c_moe_gemm_marlin_w8a8_fp8(
+      input,
+      weight,
+      output,
+      input_scale,
+      weight_scale,
+      topk_weights,
+      sorted_tokens.sorted_token_ids,
+      sorted_tokens.expert_ids,
+      sorted_tokens.num_tokens_post_pad,
+      topk,
+      mode,
+      delta,
+      selected_m);
+}
+
+}  // namespace aiter
+}  // namespace dcu
+}  // namespace kernel
+}  // namespace xllm

--- a/xllm/core/kernels/dcu/aiter_moe_adapter.h
+++ b/xllm/core/kernels/dcu/aiter_moe_adapter.h
@@ -1,0 +1,66 @@
+/* Copyright 2026 The xLLM Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://github.com/jd-opensource/xllm/blob/main/LICENSE
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+// Thin adapter around AITER's xLLM-facing MoE FP8 symbols.
+
+#pragma once
+
+#include <torch/torch.h>
+
+#include <cstdint>
+#include <optional>
+
+namespace xllm {
+namespace kernel {
+namespace dcu {
+namespace aiter {
+
+struct MoeSortedTokens {
+  torch::Tensor sorted_token_ids;
+  torch::Tensor sorted_weights;
+  torch::Tensor expert_ids;
+  torch::Tensor tokens_positions_per_expert;
+  torch::Tensor num_tokens_post_pad;
+};
+
+torch::Tensor moe_layout_shuffle_gemm1(const torch::Tensor& weight);
+torch::Tensor moe_layout_shuffle_gemm2(const torch::Tensor& weight);
+
+int64_t select_moe_gemm1_mode(int64_t num_tokens);
+int64_t select_moe_gemm2_mode(int64_t num_tokens);
+int64_t select_moe_m_key(int64_t num_tokens);
+
+MoeSortedTokens moe_align_block_size(const torch::Tensor& topk_ids,
+                                     const torch::Tensor& topk_weights,
+                                     int64_t num_experts,
+                                     int64_t block_size);
+
+torch::Tensor moe_gemm_fp8_channelwise(
+    const torch::Tensor& input,
+    const torch::Tensor& weight,
+    const torch::Tensor& output,
+    const torch::Tensor& input_scale,
+    const torch::Tensor& weight_scale,
+    const std::optional<torch::Tensor>& topk_weights,
+    const MoeSortedTokens& sorted_tokens,
+    int64_t topk,
+    int64_t mode,
+    int64_t delta,
+    int64_t selected_m);
+
+}  // namespace aiter
+}  // namespace dcu
+}  // namespace kernel
+}  // namespace xllm

--- a/xllm/core/kernels/dcu/aiter_quant_adapter.cpp
+++ b/xllm/core/kernels/dcu/aiter_quant_adapter.cpp
@@ -1,0 +1,98 @@
+/* Copyright 2026 The xLLM Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://github.com/jd-opensource/xllm/blob/main/LICENSE
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include "kernels/dcu/aiter_quant_adapter.h"
+
+#include <glog/logging.h>
+
+namespace aiter {
+namespace native {
+
+void dynamic_per_token_scaled_quant(
+    torch::Tensor& out,
+    const torch::Tensor& input,
+    torch::Tensor& scales,
+    const std::optional<at::Tensor>& scale_ub = std::nullopt,
+    bool shuffle_scale = false,
+    const std::optional<at::Tensor>& num_rows = std::nullopt,
+    int num_rows_factor = 1);
+
+}  // namespace native
+}  // namespace aiter
+
+namespace xllm {
+namespace kernel {
+namespace dcu {
+namespace aiter {
+namespace {
+
+void check_per_token_quant_inputs(const torch::Tensor& input,
+                                  const std::optional<torch::Tensor>& output) {
+  CHECK(input.defined()) << "dcu::aiter: input must be defined";
+  CHECK(input.is_cuda()) << "dcu::aiter: input must be on DCU";
+  CHECK(input.is_contiguous()) << "dcu::aiter: input must be contiguous";
+  CHECK_EQ(input.dim(), 2) << "dcu::aiter: input must be [M,K], got "
+                           << input.sizes();
+  CHECK(input.scalar_type() == torch::kFloat32 ||
+        input.scalar_type() == torch::kFloat16 ||
+        input.scalar_type() == torch::kBFloat16)
+      << "dcu::aiter: input must be fp32, fp16, or bf16";
+
+  if (output.has_value() && output.value().defined()) {
+    const torch::Tensor& output_tensor = output.value();
+    CHECK(output_tensor.is_cuda()) << "dcu::aiter: output must be on DCU";
+    CHECK(output_tensor.device() == input.device())
+        << "dcu::aiter: output must be on the same DCU device";
+    CHECK(output_tensor.is_contiguous())
+        << "dcu::aiter: output must be contiguous";
+    CHECK(output_tensor.scalar_type() == torch::kFloat8_e4m3fn ||
+          output_tensor.scalar_type() == torch::kFloat8_e5m2)
+        << "dcu::aiter: output must be FP8";
+    CHECK_EQ(output_tensor.sizes(), input.sizes())
+        << "dcu::aiter: output shape must match input";
+  }
+}
+
+}  // namespace
+
+std::tuple<torch::Tensor, torch::Tensor> per_token_quant_fp8(
+    const torch::Tensor& input,
+    const std::optional<torch::Tensor>& output) {
+  check_per_token_quant_inputs(input, output);
+
+  torch::Tensor result_output;
+  if (output.has_value() && output.value().defined()) {
+    result_output = output.value();
+  } else {
+    result_output =
+        torch::empty_like(input, input.options().dtype(torch::kFloat8_e4m3fn));
+  }
+  torch::Tensor result_scale =
+      torch::empty({input.size(0), 1}, input.options().dtype(torch::kFloat32));
+
+  ::aiter::native::dynamic_per_token_scaled_quant(result_output,
+                                                  input,
+                                                  result_scale,
+                                                  std::nullopt,
+                                                  /*shuffle_scale=*/false,
+                                                  std::nullopt,
+                                                  /*num_rows_factor=*/1);
+  return std::make_tuple(result_output, result_scale);
+}
+
+}  // namespace aiter
+}  // namespace dcu
+}  // namespace kernel
+}  // namespace xllm

--- a/xllm/core/kernels/dcu/aiter_quant_adapter.h
+++ b/xllm/core/kernels/dcu/aiter_quant_adapter.h
@@ -1,0 +1,42 @@
+/* Copyright 2026 The xLLM Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://github.com/jd-opensource/xllm/blob/main/LICENSE
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+// Thin adapter around AITER's xLLM-facing quantization symbols.
+
+#pragma once
+
+#include <torch/torch.h>
+
+#include <optional>
+#include <tuple>
+
+namespace xllm {
+namespace kernel {
+namespace dcu {
+namespace aiter {
+
+// Dynamic per-token FP8 activation quantization.
+//
+// input:  [M, K] fp32/fp16/bf16 contiguous
+// output: optional [M, K] fp8 contiguous
+// scale:  returns [M, 1] fp32 dequant scale
+std::tuple<torch::Tensor, torch::Tensor> per_token_quant_fp8(
+    const torch::Tensor& input,
+    const std::optional<torch::Tensor>& output);
+
+}  // namespace aiter
+}  // namespace dcu
+}  // namespace kernel
+}  // namespace xllm

--- a/xllm/core/kernels/dcu/dcu_ops_api.h
+++ b/xllm/core/kernels/dcu/dcu_ops_api.h
@@ -68,6 +68,15 @@ torch::Tensor group_gemm(const torch::Tensor& input,
 torch::Tensor build_block_table_from_paged_kv_cuda(
     const torch::Tensor& paged_kv_indptr,
     const torch::Tensor& paged_kv_indices);
+
+// Gather DCU DeepSeek MLA latent cache from paged layout to a contiguous
+// [total_kv_len, latent_dim] tensor for full-context prefill.
+torch::Tensor gather_mla_latent_cache(const torch::Tensor& k_cache,
+                                      const torch::Tensor& block_table,
+                                      const torch::Tensor& kv_cu_seq_lens,
+                                      int64_t total_kv_len,
+                                      int64_t max_seq_len);
+
 torch::Tensor random_sample(const torch::Tensor& probs);
 torch::Tensor rejection_sample(const torch::Tensor& draft_token_ids,
                                const torch::Tensor& num_draft_tokens,

--- a/xllm/core/kernels/dcu/gather_mla_latent_cache.hip
+++ b/xllm/core/kernels/dcu/gather_mla_latent_cache.hip
@@ -1,0 +1,189 @@
+/* Copyright 2026 The xLLM Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://github.com/jd-opensource/xllm/blob/main/LICENSE
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include <ATen/hip/impl/HIPGuardImplMasqueradingAsCUDA.h>
+#include <ATen/hip/impl/HIPStreamMasqueradingAsCUDA.h>
+#include <c10/hip/HIPException.h>
+#include <glog/logging.h>
+#include <hip/hip_runtime.h>
+#include <torch/extension.h>
+
+#include <algorithm>
+#include <cstdint>
+
+namespace xllm {
+namespace kernel {
+namespace dcu {
+namespace {
+
+template <typename StorageT>
+__global__ void gather_mla_latent_cache_kernel(
+    const StorageT* __restrict__ k_cache,
+    const int32_t* __restrict__ block_table,
+    const int32_t* __restrict__ kv_cu_seq_lens,
+    int64_t block_table_stride,
+    int64_t chunks_per_sequence,
+    int64_t block_size,
+    int64_t latent_dim,
+    StorageT* __restrict__ output) {
+  const int64_t global_chunk = static_cast<int64_t>(blockIdx.x);
+  const int64_t seq_idx = global_chunk / chunks_per_sequence;
+  const int64_t chunk_idx = global_chunk - seq_idx * chunks_per_sequence;
+  const int64_t seq_start = static_cast<int64_t>(kv_cu_seq_lens[seq_idx]);
+  const int64_t seq_end = static_cast<int64_t>(kv_cu_seq_lens[seq_idx + 1]);
+  const int64_t seq_len = seq_end - seq_start;
+  if (seq_len <= 0) {
+    return;
+  }
+
+  const int64_t linear_idx =
+      chunk_idx * static_cast<int64_t>(blockDim.x) +
+      static_cast<int64_t>(threadIdx.x);
+  const int64_t seq_numel = seq_len * latent_dim;
+  if (linear_idx >= seq_numel) {
+    return;
+  }
+
+  const int64_t token_idx = linear_idx / latent_dim;
+  const int64_t dim_idx = linear_idx - token_idx * latent_dim;
+  const int64_t logical_block_idx = token_idx / block_size;
+  const int64_t token_offset = token_idx - logical_block_idx * block_size;
+  const int32_t physical_block =
+      block_table[seq_idx * block_table_stride + logical_block_idx];
+  if (physical_block < 0) {
+    return;
+  }
+
+  const int64_t src_row =
+      static_cast<int64_t>(physical_block) * block_size + token_offset;
+  const int64_t dst_row = seq_start + token_idx;
+  output[dst_row * latent_dim + dim_idx] =
+      k_cache[src_row * latent_dim + dim_idx];
+}
+
+template <typename StorageT>
+void launch_gather_mla_latent_cache_kernel(
+    const torch::Tensor& k_cache,
+    const torch::Tensor& block_table,
+    const torch::Tensor& kv_cu_seq_lens,
+    torch::Tensor& output,
+    int64_t max_seq_len) {
+  const int64_t batch_size = block_table.size(0);
+  const int64_t block_size = k_cache.size(1);
+  const int64_t latent_dim = k_cache.size(-1);
+  const int64_t block_table_stride = block_table.size(1);
+  constexpr int32_t kThreads = 256;
+  const int64_t max_seq_numel = std::max<int64_t>(max_seq_len * latent_dim, 1);
+  const int64_t chunks_per_sequence =
+      (max_seq_numel + kThreads - 1) / kThreads;
+  CHECK_GT(chunks_per_sequence, 0)
+      << "gather_mla_latent_cache chunks_per_sequence must be positive.";
+  CHECK_LE(batch_size * chunks_per_sequence, INT32_MAX)
+      << "gather_mla_latent_cache launch grid is too large.";
+
+  const at::hip::OptionalHIPGuardMasqueradingAsCUDA device_guard(
+      k_cache.device());
+  const hipStream_t stream =
+      c10::hip::getCurrentHIPStreamMasqueradingAsCUDA(k_cache.get_device());
+  hipLaunchKernelGGL(
+      (gather_mla_latent_cache_kernel<StorageT>),
+      dim3(static_cast<uint32_t>(batch_size * chunks_per_sequence)),
+      dim3(kThreads),
+      0,
+      stream,
+      reinterpret_cast<const StorageT*>(k_cache.data_ptr()),
+      block_table.data_ptr<int32_t>(),
+      kv_cu_seq_lens.data_ptr<int32_t>(),
+      block_table_stride,
+      chunks_per_sequence,
+      block_size,
+      latent_dim,
+      reinterpret_cast<StorageT*>(output.data_ptr()));
+  C10_HIP_KERNEL_LAUNCH_CHECK();
+}
+
+}  // namespace
+
+torch::Tensor gather_mla_latent_cache(const torch::Tensor& k_cache,
+                                      const torch::Tensor& block_table,
+                                      const torch::Tensor& kv_cu_seq_lens,
+                                      int64_t total_kv_len,
+                                      int64_t max_seq_len) {
+  CHECK(k_cache.defined()) << "gather_mla_latent_cache requires k_cache.";
+  CHECK(block_table.defined())
+      << "gather_mla_latent_cache requires block_table.";
+  CHECK(kv_cu_seq_lens.defined())
+      << "gather_mla_latent_cache requires kv_cu_seq_lens.";
+  CHECK(k_cache.is_cuda()) << "k_cache must be on a HIP/DCU device.";
+  CHECK(block_table.is_cuda()) << "block_table must be on a HIP/DCU device.";
+  CHECK(kv_cu_seq_lens.is_cuda())
+      << "kv_cu_seq_lens must be on a HIP/DCU device.";
+  CHECK_EQ(k_cache.dim(), 4)
+      << "k_cache must be [blocks, block_size, 1, dim], got "
+      << k_cache.sizes();
+  CHECK_EQ(k_cache.size(2), 1) << "MLA latent cache must have one KV head.";
+  CHECK_EQ(block_table.dim(), 2)
+      << "block_table must be [batch, max_blocks], got "
+      << block_table.sizes();
+  CHECK_EQ(kv_cu_seq_lens.dim(), 1)
+      << "kv_cu_seq_lens must be [batch + 1], got "
+      << kv_cu_seq_lens.sizes();
+  CHECK_EQ(kv_cu_seq_lens.size(0), block_table.size(0) + 1)
+      << "kv_cu_seq_lens size must match block_table batch.";
+  CHECK_GT(total_kv_len, 0)
+      << "gather_mla_latent_cache total_kv_len must be positive.";
+  CHECK_GT(max_seq_len, 0)
+      << "gather_mla_latent_cache max_seq_len must be positive.";
+  CHECK(k_cache.is_contiguous()) << "k_cache must be contiguous.";
+
+  torch::Tensor block_table_i32 =
+      block_table.scalar_type() == torch::kInt32 ? block_table
+                                                 : block_table.to(torch::kInt32);
+  block_table_i32 = block_table_i32.contiguous();
+  torch::Tensor kv_cu_seq_lens_i32 =
+      kv_cu_seq_lens.scalar_type() == torch::kInt32
+          ? kv_cu_seq_lens
+          : kv_cu_seq_lens.to(torch::kInt32);
+  kv_cu_seq_lens_i32 = kv_cu_seq_lens_i32.contiguous();
+
+  torch::Tensor output =
+      torch::empty({total_kv_len, k_cache.size(-1)}, k_cache.options());
+  switch (k_cache.element_size()) {
+    case 1:
+      launch_gather_mla_latent_cache_kernel<uint8_t>(
+          k_cache, block_table_i32, kv_cu_seq_lens_i32, output, max_seq_len);
+      break;
+    case 2:
+      launch_gather_mla_latent_cache_kernel<uint16_t>(
+          k_cache, block_table_i32, kv_cu_seq_lens_i32, output, max_seq_len);
+      break;
+    case 4:
+      launch_gather_mla_latent_cache_kernel<uint32_t>(
+          k_cache, block_table_i32, kv_cu_seq_lens_i32, output, max_seq_len);
+      break;
+    case 8:
+      launch_gather_mla_latent_cache_kernel<uint64_t>(
+          k_cache, block_table_i32, kv_cu_seq_lens_i32, output, max_seq_len);
+      break;
+    default:
+      LOG(FATAL) << "Unsupported k_cache element size: "
+                 << k_cache.element_size();
+  }
+  return output;
+}
+
+}  // namespace dcu
+}  // namespace kernel
+}  // namespace xllm

--- a/xllm/core/kernels/dcu/hipblaslt_fp8_adapter.cpp
+++ b/xllm/core/kernels/dcu/hipblaslt_fp8_adapter.cpp
@@ -1,0 +1,274 @@
+/* Copyright 2026 The xLLM Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://github.com/jd-opensource/xllm/blob/main/LICENSE
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include "kernels/dcu/hipblaslt_fp8_adapter.h"
+
+#include <ATen/hip/impl/HIPGuardImplMasqueradingAsCUDA.h>
+#include <glog/logging.h>
+#include <hip/hip_runtime_api.h>
+#include <hipblaslt/hipblaslt.h>
+
+#include <limits>
+#include <mutex>
+#include <optional>
+#include <vector>
+
+namespace xllm {
+namespace kernel {
+namespace dcu {
+namespace hipblaslt_fp8 {
+namespace {
+
+class HipblasLtHandleCache final {
+ public:
+  static HipblasLtHandleCache& instance() {
+    // HIP/PyTorch runtime teardown may run before C++ static destructors.
+    // Keep hipBLASLt handles alive until process exit and let the OS reclaim
+    // them to avoid shutdown-time hipblasLtDestroy crashes.
+    static HipblasLtHandleCache* cache = new HipblasLtHandleCache();
+    return *cache;
+  }
+
+  hipblasLtHandle_t get_current_device_handle() {
+    int device_id = 0;
+    CHECK_EQ(hipGetDevice(&device_id), hipSuccess)
+        << "dcu::hipblaslt_fp8: failed to query current device";
+    CHECK_GE(device_id, 0) << "dcu::hipblaslt_fp8: invalid device id";
+
+    std::lock_guard<std::mutex> lock(mutex_);
+    CHECK_LT(static_cast<size_t>(device_id), handles_.size())
+        << "dcu::hipblaslt_fp8: device id exceeds device count";
+    hipblasLtHandle_t& handle = handles_[static_cast<size_t>(device_id)];
+    if (handle == nullptr) {
+      CHECK_EQ(hipblasLtCreate(&handle), HIPBLAS_STATUS_SUCCESS)
+          << "dcu::hipblaslt_fp8: hipblasLtCreate failed";
+    }
+    return handle;
+  }
+
+ private:
+  HipblasLtHandleCache() {
+    int device_count = 0;
+    CHECK_EQ(hipGetDeviceCount(&device_count), hipSuccess)
+        << "dcu::hipblaslt_fp8: failed to query device count";
+    CHECK_GT(device_count, 0) << "dcu::hipblaslt_fp8: no DCU device found";
+    handles_.resize(static_cast<size_t>(device_count), nullptr);
+  }
+
+  std::mutex mutex_;
+  std::vector<hipblasLtHandle_t> handles_;
+};
+
+bool is_fp8_dtype(torch::ScalarType dtype) {
+  return dtype == torch::kFloat8_e4m3fn || dtype == torch::kFloat8_e5m2;
+}
+
+hipDataType data_type_from_scalar(torch::ScalarType dtype) {
+  if (dtype == torch::kFloat8_e4m3fn) {
+    return HIP_R_8F_E4M3;
+  }
+  if (dtype == torch::kFloat8_e5m2) {
+    return HIP_R_8F_E5M2;
+  }
+  if (dtype == torch::kFloat16) {
+    return HIP_R_16F;
+  }
+  if (dtype == torch::kBFloat16) {
+    return HIP_R_16BF;
+  }
+  if (dtype == torch::kFloat32) {
+    return HIP_R_32F;
+  }
+  LOG(FATAL) << "dcu::hipblaslt_fp8: unsupported dtype " << dtype;
+  return HIP_R_32F;
+}
+
+int to_blas_int(int64_t value, const char* name) {
+  CHECK_GT(value, 0) << "dcu::hipblaslt_fp8: " << name << " must be positive";
+  CHECK_LE(value, static_cast<int64_t>(std::numeric_limits<int>::max()))
+      << "dcu::hipblaslt_fp8: " << name << " exceeds hipBLASLt int limit";
+  return static_cast<int>(value);
+}
+
+torch::Tensor normalize_scale(const torch::Tensor& scale,
+                              int64_t expected_size,
+                              const char* name) {
+  CHECK(scale.defined()) << "dcu::hipblaslt_fp8: " << name
+                         << " must be defined";
+  CHECK(scale.is_cuda()) << "dcu::hipblaslt_fp8: " << name << " must be on DCU";
+  CHECK(scale.scalar_type() == torch::kFloat32)
+      << "dcu::hipblaslt_fp8: " << name << " must be float32";
+
+  if (scale.numel() == 1) {
+    return scale.reshape({1}).expand({expected_size}).contiguous();
+  }
+
+  torch::Tensor normalized = scale;
+  if (scale.dim() == 2) {
+    CHECK_EQ(scale.size(1), 1)
+        << "dcu::hipblaslt_fp8: " << name << " must be [N] or [N,1], got "
+        << scale.sizes();
+    normalized = scale.squeeze(1);
+  }
+  CHECK_EQ(normalized.dim(), 1)
+      << "dcu::hipblaslt_fp8: " << name
+      << " must be scalar, [1], [N], or [N,1], got " << scale.sizes();
+  CHECK_EQ(normalized.size(0), expected_size)
+      << "dcu::hipblaslt_fp8: " << name << " size mismatch, expected "
+      << expected_size << ", got " << normalized.size(0);
+  return normalized.contiguous();
+}
+
+void check_fp8_gemm_inputs(const torch::Tensor& activation,
+                           const torch::Tensor& weight,
+                           const std::optional<torch::Tensor>& output) {
+  CHECK(activation.defined())
+      << "dcu::hipblaslt_fp8: activation must be defined";
+  CHECK(weight.defined()) << "dcu::hipblaslt_fp8: weight must be defined";
+  CHECK(activation.is_cuda())
+      << "dcu::hipblaslt_fp8: activation must be on DCU";
+  CHECK(weight.device() == activation.device())
+      << "dcu::hipblaslt_fp8: weight must be on the same DCU device";
+  CHECK(activation.is_contiguous())
+      << "dcu::hipblaslt_fp8: activation must be contiguous";
+  CHECK(weight.is_contiguous())
+      << "dcu::hipblaslt_fp8: weight must be contiguous";
+  CHECK_EQ(activation.dim(), 2)
+      << "dcu::hipblaslt_fp8: activation must be [M,K], got "
+      << activation.sizes();
+  CHECK_EQ(weight.dim(), 2)
+      << "dcu::hipblaslt_fp8: weight must be [N,K], got " << weight.sizes();
+  CHECK_EQ(weight.size(1), activation.size(1))
+      << "dcu::hipblaslt_fp8: weight K " << weight.size(1)
+      << " != activation K " << activation.size(1);
+  CHECK(is_fp8_dtype(activation.scalar_type()))
+      << "dcu::hipblaslt_fp8: activation must be FP8";
+  CHECK(weight.scalar_type() == activation.scalar_type())
+      << "dcu::hipblaslt_fp8: activation/weight FP8 dtype must match";
+
+  if (output.has_value() && output.value().defined()) {
+    const torch::Tensor& output_tensor = output.value();
+    CHECK(output_tensor.is_cuda())
+        << "dcu::hipblaslt_fp8: output must be on DCU";
+    CHECK(output_tensor.device() == activation.device())
+        << "dcu::hipblaslt_fp8: output must be on the same DCU device";
+    CHECK(output_tensor.is_contiguous())
+        << "dcu::hipblaslt_fp8: output must be contiguous";
+    CHECK_EQ(output_tensor.dim(), 2)
+        << "dcu::hipblaslt_fp8: output must be [M,N], got "
+        << output_tensor.sizes();
+    CHECK_EQ(output_tensor.size(0), activation.size(0))
+        << "dcu::hipblaslt_fp8: output M mismatch";
+    CHECK_EQ(output_tensor.size(1), weight.size(0))
+        << "dcu::hipblaslt_fp8: output N mismatch";
+  }
+}
+
+}  // namespace
+
+torch::Tensor fp8_gemm_nt(const torch::Tensor& activation,
+                          const torch::Tensor& weight,
+                          const torch::Tensor& activation_scale,
+                          const torch::Tensor& weight_scale,
+                          torch::ScalarType output_dtype,
+                          const std::optional<torch::Tensor>& bias,
+                          const std::optional<torch::Tensor>& output) {
+  check_fp8_gemm_inputs(activation, weight, output);
+  CHECK(output_dtype == torch::kFloat16 || output_dtype == torch::kBFloat16)
+      << "dcu::hipblaslt_fp8: output dtype must be fp16 or bf16";
+
+  torch::Tensor result_output;
+  if (output.has_value() && output.value().defined()) {
+    result_output = output.value();
+  } else {
+    result_output = torch::empty({activation.size(0), weight.size(0)},
+                                 activation.options().dtype(output_dtype));
+  }
+
+  torch::Tensor activation_scale_1d =
+      normalize_scale(activation_scale, activation.size(0), "activation_scale");
+  torch::Tensor weight_scale_1d =
+      normalize_scale(weight_scale, weight.size(0), "weight_scale");
+
+  const at::hip::OptionalHIPGuardMasqueradingAsCUDA device_guard(
+      activation.device());
+  hipblasLtHandle_t handle =
+      HipblasLtHandleCache::instance().get_current_device_handle();
+
+  const int64_t m = activation.size(0);
+  const int64_t n = weight.size(0);
+  const int64_t k = activation.size(1);
+  const int blas_m = to_blas_int(n, "N");
+  const int blas_n = to_blas_int(m, "M");
+  const int blas_k = to_blas_int(k, "K");
+
+  const size_t lda = static_cast<size_t>(k);
+  const size_t ldb = static_cast<size_t>(k);
+  const size_t ldc = static_cast<size_t>(n);
+  const size_t ldd = static_cast<size_t>(n);
+  const float alpha = 1.0F;
+  const float beta = 0.0F;
+  const hipDataType fp8_type = data_type_from_scalar(activation.scalar_type());
+  const hipDataType output_type = data_type_from_scalar(output_dtype);
+  const hipblasLtMatmulMatrixScale_t scale_mode =
+      HIPBLASLT_MATMUL_MATRIX_SCALE_OUTER_VEC_32F;
+  const hipStream_t stream = at::hip::getCurrentHIPStreamMasqueradingAsCUDA();
+
+  hipblasStatus_t status = hipblasLtGemmExQ(handle,
+                                            HIPBLAS_OP_T,
+                                            HIPBLAS_OP_N,
+                                            blas_m,
+                                            blas_n,
+                                            blas_k,
+                                            &alpha,
+                                            weight.data_ptr(),
+                                            fp8_type,
+                                            lda,
+                                            activation.data_ptr(),
+                                            fp8_type,
+                                            ldb,
+                                            &beta,
+                                            result_output.data_ptr(),
+                                            output_type,
+                                            ldc,
+                                            result_output.data_ptr(),
+                                            output_type,
+                                            ldd,
+                                            HIPBLAS_COMPUTE_32F,
+                                            weight_scale_1d.data_ptr(),
+                                            scale_mode,
+                                            activation_scale_1d.data_ptr(),
+                                            scale_mode,
+                                            nullptr,
+                                            output_type,
+                                            stream);
+  CHECK_EQ(status, HIPBLAS_STATUS_SUCCESS)
+      << "dcu::hipblaslt_fp8: hipblasLtGemmExQ failed, M=" << m << ", N=" << n
+      << ", K=" << k << ", status=" << status;
+
+  if (bias.has_value() && bias.value().defined()) {
+    CHECK(bias.value().device() == activation.device())
+        << "dcu::hipblaslt_fp8: bias must be on the same DCU device";
+    CHECK_EQ(bias.value().numel(), weight.size(0))
+        << "dcu::hipblaslt_fp8: bias size must match output N";
+    result_output.add_(bias.value());
+  }
+  return result_output;
+}
+
+}  // namespace hipblaslt_fp8
+}  // namespace dcu
+}  // namespace kernel
+}  // namespace xllm

--- a/xllm/core/kernels/dcu/hipblaslt_fp8_adapter.h
+++ b/xllm/core/kernels/dcu/hipblaslt_fp8_adapter.h
@@ -1,0 +1,47 @@
+/* Copyright 2026 The xLLM Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://github.com/jd-opensource/xllm/blob/main/LICENSE
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#pragma once
+
+#include <torch/torch.h>
+
+#include <optional>
+
+namespace xllm {
+namespace kernel {
+namespace dcu {
+namespace hipblaslt_fp8 {
+
+// Dense FP8 NT GEMM through hipBLASLt outer-vector channelwise scaling:
+//   output = (activation * activation_scale) @
+//            (weight * weight_scale).transpose(0, 1)
+//
+// activation:       [M, K] FP8 contiguous
+// weight:           [N, K] FP8 contiguous
+// activation_scale: scalar, [1], [M], or [M,1] float32
+// weight_scale:     scalar, [1], [N], or [N,1] float32
+// output:           optional [M, N] fp16/bf16 contiguous
+torch::Tensor fp8_gemm_nt(const torch::Tensor& activation,
+                          const torch::Tensor& weight,
+                          const torch::Tensor& activation_scale,
+                          const torch::Tensor& weight_scale,
+                          torch::ScalarType output_dtype,
+                          const std::optional<torch::Tensor>& bias,
+                          const std::optional<torch::Tensor>& output);
+
+}  // namespace hipblaslt_fp8
+}  // namespace dcu
+}  // namespace kernel
+}  // namespace xllm

--- a/xllm/core/kernels/ops_api.cpp
+++ b/xllm/core/kernels/ops_api.cpp
@@ -32,7 +32,9 @@ limitations under the License.
 #include "musa/musa_ops_api.h"
 #elif defined(USE_DCU)
 #include "cuda/cuda_ops_api.h"
+#include "dcu/aiter_quant_adapter.h"
 #include "dcu/dcu_ops_api.h"
+#include "dcu/hipblaslt_fp8_adapter.h"
 #endif
 
 #include <numeric>
@@ -1187,6 +1189,11 @@ std::tuple<torch::Tensor, torch::Tensor> fp8_scaled_quantize(
     Fp8ScaledQuantizeParams& params) {
 #if defined(USE_CUDA)
   return cuda::fp8_scaled_quantize(params.input, params.output, params.scale);
+#elif defined(USE_DCU)
+  CHECK(!params.scale.has_value() || !params.scale.value().defined())
+      << "DCU fp8_scaled_quantize currently supports only dynamic per-token "
+         "quantization.";
+  return dcu::aiter::per_token_quant_fp8(params.input, params.output);
 #else
   NOT_IMPLEMENTED();
 #endif
@@ -1315,8 +1322,22 @@ torch::Tensor fp8_scaled_matmul(Fp8ScaledMatmulParams& params) {
     return out_2d.view(out_shape);
   }
   return out_2d;
+#elif defined(USE_DCU)
+  torch::Tensor out_2d = dcu::hipblaslt_fp8::fp8_gemm_nt(params.a,
+                                                         params.b,
+                                                         params.a_scale,
+                                                         params.b_scale,
+                                                         params.output_dtype,
+                                                         params.bias,
+                                                         params.output);
+  if (params.input_shape.has_value()) {
+    std::vector<int64_t> out_shape = params.input_shape.value();
+    out_shape.back() = params.b.size(0);
+    return out_2d.view(out_shape);
+  }
+  return out_2d;
 #else
-  LOG(FATAL) << "fp8_scaled_matmul is only supported on CUDA";
+  LOG(FATAL) << "fp8_scaled_matmul is only supported on CUDA/DCU";
   return torch::Tensor();
 #endif
 }

--- a/xllm/core/layers/common/linear.cpp
+++ b/xllm/core/layers/common/linear.cpp
@@ -61,6 +61,10 @@ inline bool is_unfused_checkpoint(const std::vector<float>& scales) {
          scales.back() > std::numeric_limits<float>::lowest();
 }
 
+bool is_fp8_dtype(torch::ScalarType dtype) {
+  return dtype == torch::kFloat8_e4m3fn || dtype == torch::kFloat8_e5m2;
+}
+
 // Realigns FP8 partitions to a unified global scale to enable fusion.
 // Logic:
 // 1. Recover original values (FP8 -> FP16) using partition-specific scales.
@@ -243,6 +247,27 @@ bool is_w8a8_quant(
     const std::optional<std::string>& resolved_weight_quant_method) {
   return resolved_weight_quant_method.has_value() &&
          resolved_weight_quant_method.value() == "w8a8";
+}
+
+bool is_fp8_channelwise_w8a8(const QuantArgs& quant_args) {
+#if defined(USE_DCU)
+  // Compressed-tensors FP8 W8A8 currently pairs dynamic activations with
+  // per-output-channel weight scales on DCU.
+  return quant_args.quant_method() == kQuantMethodFp8 &&
+         quant_args.activation_dynamic();
+#else
+  (void)quant_args;
+  return false;
+#endif
+}
+
+void check_fp8_activation_dynamic_supported(const QuantArgs& quant_args) {
+  if (!quant_args.activation_dynamic()) {
+    return;
+  }
+  CHECK(is_fp8_channelwise_w8a8(quant_args))
+      << "DCU FP8 currently supports only compressed-tensors dynamic "
+         "channelwise W8A8.";
 }
 
 torch::Dtype get_w8a8_deq_scale_dtype(const torch::TensorOptions& options) {
@@ -576,11 +601,12 @@ ColumnParallelLinearImpl::ColumnParallelLinearImpl(
         torch::empty({out_features_per_partition, in_features},
                      options.dtype(torch::kFloat8_e4m3fn)),
         /*requires_grad=*/false);
-    // Weight scale is per-tensor (scalar)
-    weight_scale_ =
-        register_parameter("weight_scale",
-                           torch::empty({1}, options.dtype(torch::kFloat32)),
-                           /*requires_grad=*/false);
+    const int64_t weight_scale_size =
+        is_fp8_channelwise_w8a8(quant_args_) ? out_features_per_partition : 1;
+    weight_scale_ = register_parameter(
+        "weight_scale",
+        torch::empty({weight_scale_size}, options.dtype(torch::kFloat32)),
+        /*requires_grad=*/false);
     // For static activation quantization, input_scale is pre-computed
     if (!quant_args_.activation_dynamic()) {
       input_scale_ =
@@ -663,9 +689,7 @@ torch::Tensor ColumnParallelLinearImpl::forward(torch::Tensor input) {
 
     output = xllm::kernel::scaled_matmul(matmul_params);
   } else if (quant_args_.quant_method() == kQuantMethodFp8) {
-    CHECK(!quant_args_.activation_dynamic())
-        << "FP8 quantization does not support activation_dynamic yet";
-
+    check_fp8_activation_dynamic_supported(quant_args_);
     auto scale = input_scale_.defined()
                      ? std::optional<torch::Tensor>(input_scale_)
                      : std::nullopt;
@@ -775,7 +799,11 @@ void ColumnParallelLinearImpl::load_state_dict(const StateDict& state_dict) {
   } else if (quant_args_.quant_method() == kQuantMethodFp8) {
     // FP8 quantization: load FP8 weight and scales
     LOAD_SHARDED_WEIGHT(weight, 0);
-    LOAD_WEIGHT(weight_scale);
+    if (is_fp8_channelwise_w8a8(quant_args_)) {
+      LOAD_SHARDED_WEIGHT(weight_scale, 0);
+    } else {
+      LOAD_WEIGHT(weight_scale);
+    }
     // For static activation quantization, load input_scale
     if (!quant_args_.activation_dynamic() && input_scale_.defined()) {
       LOAD_WEIGHT(input_scale);
@@ -853,52 +881,58 @@ void ColumnParallelLinearImpl::load_state_dict(
     LOAD_FUSED_WEIGHT(qweight, 0);
     LOAD_FUSED_WEIGHT(per_channel_scale, 0);
   } else if (quant_args_.quant_method() == kQuantMethodFp8) {
-    // FP8 fused layer loading: each partition may have its own per-tensor scale
-    // (unfused checkpoint). We must requantize all partitions with max_scale.
+    if (is_fp8_channelwise_w8a8(quant_args_)) {
+      LOAD_FUSED_WEIGHT(weight, 0);
+      LOAD_FUSED_WEIGHT(weight_scale, 0);
+    } else {
+      // FP8 fused layer loading: each partition may have its own per-tensor
+      // scale (unfused checkpoint). We must requantize all partitions with
+      // max_scale.
 
-    // Step 1: Collect partition info BEFORE LOAD_FUSED_WEIGHT (clears list)
-    Fp8PartitionInfo partition_info;
-    if (!weight_scale_is_loaded_) {
-      for (const auto& prefix : prefixes) {
-        auto scale_tensor = state_dict.get_tensor(prefix + "weight_scale");
-        if (scale_tensor.defined()) {
-          partition_info.scales.push_back(scale_tensor.flatten().item<float>());
-        }
-        auto weight_tensor = state_dict.get_sharded_tensor(
-            prefix + "weight", 0, rank, world_size);
-        if (weight_tensor.defined()) {
-          partition_info.logical_widths.push_back(weight_tensor.size(0));
+      // Step 1: Collect partition info BEFORE LOAD_FUSED_WEIGHT (clears list)
+      Fp8PartitionInfo partition_info;
+      if (!weight_scale_is_loaded_) {
+        for (const auto& prefix : prefixes) {
+          auto scale_tensor = state_dict.get_tensor(prefix + "weight_scale");
+          if (scale_tensor.defined()) {
+            partition_info.scales.push_back(
+                scale_tensor.flatten().item<float>());
+          }
+          auto weight_tensor = state_dict.get_sharded_tensor(
+              prefix + "weight", 0, rank, world_size);
+          if (weight_tensor.defined()) {
+            partition_info.logical_widths.push_back(weight_tensor.size(0));
+          }
         }
       }
-    }
 
-    // Step 2: Load fused weight
-    LOAD_FUSED_WEIGHT(weight, 0);
+      // Step 2: Load fused weight
+      LOAD_FUSED_WEIGHT(weight, 0);
 
-    // Step 3: Requantize if needed (unfused checkpoint case)
-    if (!weight_scale_is_loaded_ && !partition_info.empty()) {
-      float max_scale = compute_max_scale(partition_info.scales);
+      // Step 3: Requantize if needed (unfused checkpoint case)
+      if (!weight_scale_is_loaded_ && !partition_info.empty()) {
+        float max_scale = compute_max_scale(partition_info.scales);
 
-      if (is_unfused_checkpoint(partition_info.scales) && weight_.defined() &&
-          partition_info.logical_widths.size() ==
-              partition_info.scales.size()) {
-        requantize_fp8_weight(weight_,
-                              partition_info.scales,
-                              partition_info.logical_widths,
-                              max_scale);
+        if (is_unfused_checkpoint(partition_info.scales) && weight_.defined() &&
+            partition_info.logical_widths.size() ==
+                partition_info.scales.size()) {
+          requantize_fp8_weight(weight_,
+                                partition_info.scales,
+                                partition_info.logical_widths,
+                                max_scale);
+        }
+
+        weight_scale_.fill_(max_scale);
+        weight_scale_is_loaded_ = true;
       }
 
-      weight_scale_.fill_(max_scale);
-      weight_scale_is_loaded_ = true;
-    }
-
-    // Step 4: Load input_scale for static activation quantization
-    if (!quant_args_.activation_dynamic() && input_scale_.defined() &&
-        !input_scale_is_loaded_) {
-      auto max_input_scale = load_max_input_scale(state_dict, prefixes);
-      if (max_input_scale.defined()) {
-        input_scale_.copy_(max_input_scale.view({1}));
-        input_scale_is_loaded_ = true;
+      // Step 4: Load input_scale for static activation quantization
+      if (input_scale_.defined() && !input_scale_is_loaded_) {
+        auto max_input_scale = load_max_input_scale(state_dict, prefixes);
+        if (max_input_scale.defined()) {
+          input_scale_.copy_(max_input_scale.view({1}));
+          input_scale_is_loaded_ = true;
+        }
       }
     }
   } else if (is_w8a8_quant(resolved_weight_quant_method_)) {
@@ -1042,12 +1076,12 @@ QKVParallelLinearImpl::QKVParallelLinearImpl(
         torch::empty({out_features_per_partition, hidden_size},
                      options.dtype(torch::kFloat8_e4m3fn)),
         /*requires_grad=*/false);
-    // Weight scale: create {3} for Q/K/V, will use max() after loading
-    // load separate scales then merge with max
-    weight_scale_ =
-        register_parameter("weight_scale",
-                           torch::empty({3}, options.dtype(torch::kFloat32)),
-                           /*requires_grad=*/false);
+    const int64_t weight_scale_size =
+        is_fp8_channelwise_w8a8(quant_args_) ? out_features_per_partition : 3;
+    weight_scale_ = register_parameter(
+        "weight_scale",
+        torch::empty({weight_scale_size}, options.dtype(torch::kFloat32)),
+        /*requires_grad=*/false);
     // For static activation quantization, input_scale is pre-computed
     // Also create {3} for Q/K/V, will use max() after loading
     if (!quant_args_.activation_dynamic()) {
@@ -1088,13 +1122,7 @@ torch::Tensor QKVParallelLinearImpl::forward(torch::Tensor input) {
 
   torch::Tensor output;
   if (quant_args_.quant_method() == kQuantMethodFp8) {
-    // FP8 W8A8 quantization
-    CHECK(!quant_args_.activation_dynamic())
-        << "FP8 quantization does not support activation_dynamic yet";
-
-    // Use max of Q/K/V scales as unified scale for fused projection
-    // Note: weight_scale_ and input_scale_ are already scalar tensors
-    // (replaced with max values in load_state_dict)
+    check_fp8_activation_dynamic_supported(quant_args_);
     auto a_scale = input_scale_.defined()
                        ? std::optional<torch::Tensor>(input_scale_)
                        : std::nullopt;
@@ -1181,6 +1209,11 @@ void QKVParallelLinearImpl::load_state_dict(
   }
   // FP8: load weight_scale and input_scale, requantize if needed
   if (quant_args_.quant_method() == kQuantMethodFp8) {
+    if (is_fp8_channelwise_w8a8(quant_args_)) {
+      LOAD_QKV_WEIGHT(weight_scale, 0, num_kv_head_replicas_);
+      return;
+    }
+
     // Build partition info for Q/K/V
     Fp8PartitionInfo partition_info;
     int64_t num_heads_per_partition = num_heads_ / world_size_;
@@ -1366,11 +1399,12 @@ RowParallelLinearImpl::RowParallelLinearImpl(
         torch::empty({out_features, in_features_per_partition},
                      options.dtype(torch::kFloat8_e4m3fn)),
         /*requires_grad=*/false);
-    // Weight scale is per-tensor (scalar)
-    weight_scale_ =
-        register_parameter("weight_scale",
-                           torch::empty({1}, options.dtype(torch::kFloat32)),
-                           /*requires_grad=*/false);
+    const int64_t weight_scale_size =
+        is_fp8_channelwise_w8a8(quant_args_) ? out_features : 1;
+    weight_scale_ = register_parameter(
+        "weight_scale",
+        torch::empty({weight_scale_size}, options.dtype(torch::kFloat32)),
+        /*requires_grad=*/false);
     // For static activation quantization, input_scale is pre-computed
     if (!quant_args_.activation_dynamic()) {
       input_scale_ =
@@ -1456,10 +1490,7 @@ torch::Tensor RowParallelLinearImpl::forward(torch::Tensor input) {
 
     output = xllm::kernel::scaled_matmul(matmul_params);
   } else if (quant_args_.quant_method() == kQuantMethodFp8) {
-    // FP8 W8A8 quantization
-    CHECK(!quant_args_.activation_dynamic())
-        << "FP8 quantization does not support activation_dynamic yet";
-
+    check_fp8_activation_dynamic_supported(quant_args_);
     if (!input_is_parallelized_) {
       input = xllm::parallel_state::scatter(input, process_group_);
     }
@@ -1603,8 +1634,17 @@ ReplicatedLinearImpl::ReplicatedLinearImpl(
       options_(options),
       output_dtype_(c10::typeMetaToScalarType(options.dtype())) {
   (void)linear_extra_args;
-  if (!quant_args_.quant_descs().empty() ||
-      quant_args_.is_compressed_tensors_w8a8_dynamic()) {
+  if (quant_args_.quant_method() == kQuantMethodFp8) {
+    // Replicated projections are mixed in DeepSeek checkpoints: attention
+    // low-rank projections can be FP8, while router gates remain BF16. Keep the
+    // storage in runtime dtype initially and switch to FP8 lazily after seeing
+    // the checkpoint tensor dtype in load_state_dict().
+    weight_ =
+        register_parameter("weight",
+                           torch::empty({out_features, in_features}, options),
+                           /*requires_grad=*/false);
+  } else if (!quant_args_.quant_descs().empty() ||
+             quant_args_.is_compressed_tensors_w8a8_dynamic()) {
     // quant_descs is not empty: default initialize weight as kInt8.
     // During load_state_dict, the weight will be lazily re-registered to the
     // appropriate dtype based on the resolved quant method.
@@ -1629,6 +1669,16 @@ ReplicatedLinearImpl::ReplicatedLinearImpl(
 torch::Tensor ReplicatedLinearImpl::forward(torch::Tensor input) {
   auto bias =
       bias_.defined() ? std::optional<torch::Tensor>(bias_) : std::nullopt;
+  if (is_fp8_dtype(weight_.scalar_type())) {
+    check_fp8_activation_dynamic_supported(quant_args_);
+    CHECK(weight_scale_.defined())
+        << "weight_scale is required for FP8 replicated linear.";
+    auto scale = input_scale_.defined()
+                     ? std::optional<torch::Tensor>(input_scale_)
+                     : std::nullopt;
+    return fp8_linear_forward(
+        input, weight_, weight_scale_, scale, bias, output_dtype_);
+  }
   if (is_w8a8_quant(resolved_weight_quant_method_)) {
     CHECK(input_scale_is_loaded_ && input_scale_.defined())
         << "input_scale is required for w8a8 quant matmul.";
@@ -1720,8 +1770,48 @@ void ReplicatedLinearImpl::load_state_dict(const StateDict& state_dict) {
                           weight_scale_is_loaded_,
                           weight_offset_,
                           weight_offset_is_loaded_});
+
+  if (quant_args_.quant_method() == kQuantMethodFp8) {
+    torch::Tensor checkpoint_weight = state_dict.get_tensor("weight");
+    if (checkpoint_weight.defined() &&
+        is_fp8_dtype(checkpoint_weight.scalar_type())) {
+      const int64_t out_features = weight_.size(0);
+      const int64_t in_features = weight_.size(1);
+      const int64_t weight_scale_size =
+          is_fp8_channelwise_w8a8(quant_args_) ? out_features : 1;
+      std::vector<weight::LazyParameterSpec> specs;
+      specs.reserve(quant_args_.activation_dynamic() ? 2 : 3);
+      specs.push_back(weight::LazyParameterSpec{
+          &weight_,
+          &weight_is_loaded_,
+          "weight",
+          {out_features, in_features},
+          options_.dtype(checkpoint_weight.scalar_type())});
+      specs.push_back(
+          weight::LazyParameterSpec{&weight_scale_,
+                                    &weight_scale_is_loaded_,
+                                    "weight_scale",
+                                    {weight_scale_size},
+                                    options_.dtype(torch::kFloat32)});
+      if (!quant_args_.activation_dynamic()) {
+        specs.push_back(
+            weight::LazyParameterSpec{&input_scale_,
+                                      &input_scale_is_loaded_,
+                                      "input_scale",
+                                      {1},
+                                      options_.dtype(torch::kFloat32)});
+      }
+      weight::ensure_parameter_storage(this, specs);
+    }
+  }
+
   LOAD_WEIGHT(weight);
-  if (is_w8a8_quant(resolved_weight_quant_method_)) {
+  if (is_fp8_dtype(weight_.scalar_type())) {
+    LOAD_WEIGHT(weight_scale);
+    if (!quant_args_.activation_dynamic() && input_scale_.defined()) {
+      LOAD_WEIGHT(input_scale);
+    }
+  } else if (is_w8a8_quant(resolved_weight_quant_method_)) {
     LOAD_WEIGHT(input_scale);
     LOAD_WEIGHT(input_offset);
     LOAD_WEIGHT(deq_scale);

--- a/xllm/core/layers/dcu/CMakeLists.txt
+++ b/xllm/core/layers/dcu/CMakeLists.txt
@@ -1,30 +1,18 @@
 include(cc_library)
 
 if(NOT TARGET flash_attention)
-  if(NOT FLASH_ATTENTION_LIB)
-    set(FLASH_ATTENTION_LIB "/opt/dtk/lib")
-  endif()
-
-  set(FLASH_ATTENTION_LIB
-      "${FLASH_ATTENTION_LIB}"
-      CACHE PATH "Directory containing libflash_attention.so")
-
-  find_library(
-    _flash_attn_lib_path flash_attention
-    PATHS "${FLASH_ATTENTION_LIB}"
-    NO_DEFAULT_PATH)
-
-  if(_flash_attn_lib_path)
-    add_library(flash_attention SHARED IMPORTED)
-    set_target_properties(
-      flash_attention PROPERTIES
-      IMPORTED_LOCATION "${_flash_attn_lib_path}"
-      INTERFACE_COMPILE_DEFINITIONS "BUILD_FA_KVCACHE")
-    message(STATUS "Found libflash_attention: ${_flash_attn_lib_path}")
-  else()
+  if(NOT DEFINED FLASH_ATTENTION_LIB OR NOT EXISTS "${FLASH_ATTENTION_LIB}")
     message(FATAL_ERROR
-      "libflash_attention.so not found in ${FLASH_ATTENTION_LIB}.")
+      "FLASH_ATTENTION_LIB is required for DCU FlashAttention. Install "
+      "flash_attn in the current Python environment or set FLASH_ATTENTION_LIB "
+      "to libflash_attention.so before invoking setup.py.")
   endif()
+  add_library(flash_attention SHARED IMPORTED)
+  set_target_properties(
+    flash_attention PROPERTIES
+    IMPORTED_LOCATION "${FLASH_ATTENTION_LIB}"
+    INTERFACE_COMPILE_DEFINITIONS "BUILD_FA_KVCACHE")
+  message(STATUS "Found libflash_attention: ${FLASH_ATTENTION_LIB}")
 endif()
 
 cc_library(

--- a/xllm/core/layers/dcu/deepseek_v2_attention.cpp
+++ b/xllm/core/layers/dcu/deepseek_v2_attention.cpp
@@ -19,13 +19,16 @@ limitations under the License.
 #include <torch/torch.h>
 
 #include <cmath>
+#include <cstdint>
 #include <optional>
 #include <tuple>
 #include <vector>
 
+#include "kernels/dcu/dcu_ops_api.h"
 #include "kernels/dcu/flash_mla_adapter.h"
 #include "layers/common/rotary_embedding.h"
 #include "layers/common/rotary_embedding_util.h"
+#include "layers/dcu/flash_attention.h"
 
 namespace xllm {
 namespace layer {
@@ -45,6 +48,58 @@ torch::Tensor to_deepseek_rope_layout(const torch::Tensor& tensor) {
       .contiguous();
 }
 
+bool is_fp8_dtype(torch::ScalarType dtype) {
+  return dtype == torch::kFloat8_e4m3fn || dtype == torch::kFloat8_e5m2;
+}
+
+bool has_prefill_context(const AttentionMetadata& attn_metadata) {
+  if (attn_metadata.is_chunked_prefill) {
+    return true;
+  }
+  CHECK(attn_metadata.q_cu_seq_lens.defined())
+      << "DeepSeek MHA prefill requires q_cu_seq_lens.";
+  CHECK(attn_metadata.kv_cu_seq_lens.defined())
+      << "DeepSeek MHA prefill requires kv_cu_seq_lens.";
+  return !torch::equal(attn_metadata.q_cu_seq_lens,
+                       attn_metadata.kv_cu_seq_lens);
+}
+
+void check_first_phase_prefill_metadata(
+    const AttentionMetadata& attn_metadata) {
+  CHECK(attn_metadata.is_prefill || attn_metadata.is_chunked_prefill)
+      << "DeepSeek MHA prefill must run in prefill/chunked prefill phase.";
+  CHECK(!attn_metadata.is_chunked_prefill)
+      << "DCU DeepSeek MHA prefill phase 1 does not support chunked "
+         "prefill/context yet.";
+  CHECK(attn_metadata.q_cu_seq_lens.defined())
+      << "DeepSeek MHA prefill requires q_cu_seq_lens.";
+  CHECK(attn_metadata.kv_cu_seq_lens.defined())
+      << "DeepSeek MHA prefill requires kv_cu_seq_lens.";
+  CHECK(torch::equal(attn_metadata.q_cu_seq_lens, attn_metadata.kv_cu_seq_lens))
+      << "DCU DeepSeek MHA prefill phase 1 only supports no prefix/cache "
+         "context; q_cu_seq_lens must equal kv_cu_seq_lens.";
+}
+
+void check_context_prefill_metadata(const AttentionMetadata& attn_metadata) {
+  CHECK(attn_metadata.is_prefill || attn_metadata.is_chunked_prefill)
+      << "DeepSeek context prefill must run in prefill/chunked prefill phase.";
+  CHECK(attn_metadata.q_cu_seq_lens.defined())
+      << "DeepSeek context prefill requires q_cu_seq_lens.";
+  CHECK(attn_metadata.kv_cu_seq_lens.defined())
+      << "DeepSeek context prefill requires kv_cu_seq_lens.";
+  CHECK(attn_metadata.kv_seq_lens.defined() ||
+        attn_metadata.kv_cu_seq_lens.defined())
+      << "DeepSeek context prefill requires KV sequence lengths.";
+  CHECK_GT(attn_metadata.total_kv_len, 0)
+      << "DeepSeek context prefill requires total KV length.";
+  CHECK(attn_metadata.block_table.defined())
+      << "DeepSeek context prefill requires block_table.";
+  CHECK(attn_metadata.slot_mapping.defined())
+      << "DeepSeek context prefill requires slot_mapping.";
+  CHECK_GE(attn_metadata.max_seq_len, attn_metadata.max_query_len)
+      << "context prefill expects max_seq_len >= max_query_len.";
+}
+
 }  // namespace
 
 DeepseekV2AttentionImpl::DeepseekV2AttentionImpl(
@@ -58,7 +113,8 @@ DeepseekV2AttentionImpl::DeepseekV2AttentionImpl(
       qk_rope_head_dim_(args.qk_rope_head_dim()),
       v_head_dim_(args.v_head_dim()),
       eps_(args.rms_norm_eps()),
-      interleaved_(false) {
+      interleaved_(false),
+      runtime_dtype_(c10::typeMetaToScalarType(options.dtype())) {
   const int64_t tp_size = parallel_args.tp_group_->world_size();
   const int64_t num_heads = args.n_heads();
   const int64_t hidden_size = args.hidden_size();
@@ -75,7 +131,7 @@ DeepseekV2AttentionImpl::DeepseekV2AttentionImpl(
     q_a_proj_ = register_module(
         "q_a_proj",
         ReplicatedLinear(
-            hidden_size, q_lora_rank_, /*bias=*/false, QuantArgs(), options));
+            hidden_size, q_lora_rank_, /*bias=*/false, quant_args, options));
     q_a_layernorm_ =
         register_module("q_a_layernorm", RMSNorm(q_lora_rank_, eps_, options));
     q_b_proj_ =
@@ -106,7 +162,7 @@ DeepseekV2AttentionImpl::DeepseekV2AttentionImpl(
                       ReplicatedLinear(hidden_size,
                                        kv_lora_rank_ + qk_rope_head_dim_,
                                        /*bias=*/false,
-                                       QuantArgs(),
+                                       quant_args,
                                        options));
   kv_a_layernorm_ =
       register_module("kv_a_layernorm", RMSNorm(kv_lora_rank_, eps_, options));
@@ -116,15 +172,10 @@ DeepseekV2AttentionImpl::DeepseekV2AttentionImpl(
                            num_heads * (qk_nope_head_dim_ + v_head_dim_),
                            /*bias=*/false,
                            /*gather_output=*/false,
-                           QuantArgs(),
+                           quant_args,
                            weight_group,
                            options,
                            attention_linear_extra_args));
-
-  torch::Tensor weights = kv_b_proj_->weight().unflatten(
-      0, {tp_heads_, qk_nope_head_dim_ + v_head_dim_});
-  w_kc_ = weights.slice(1, 0, qk_nope_head_dim_);
-  w_vc_ = weights.slice(1, qk_nope_head_dim_, qk_nope_head_dim_ + v_head_dim_);
 
   rotary_emb_ =
       register_module("rotary_emb",
@@ -179,10 +230,12 @@ void DeepseekV2AttentionImpl::store_latent_cache(
 
 torch::Tensor DeepseekV2AttentionImpl::project_output(
     const torch::Tensor& attn_latent) {
+  CHECK(w_vc_.defined()) << "DeepSeek MLA absorbed value weight is not loaded.";
   torch::Tensor attn_bmm =
       torch::bmm(attn_latent.transpose(0, 1), w_vc_);  // [tp_heads, tokens, v]
   attn_bmm = attn_bmm.transpose(0, 1);                 // [tokens, tp_heads, v]
-  torch::Tensor proj_input = attn_bmm.flatten(1, 2);   // [tokens, tp_heads*v]
+  torch::Tensor proj_input =
+      attn_bmm.flatten(1, 2).contiguous();  // [tokens, tp_heads*v]
   return o_proj_->forward(proj_input);
 }
 
@@ -209,56 +262,113 @@ torch::Tensor DeepseekV2AttentionImpl::decode_flash_mla(
   return project_output(attn_latent);
 }
 
-torch::Tensor DeepseekV2AttentionImpl::prefill_sdpa(
-    const torch::Tensor& q_nope_absorbed,
+torch::Tensor DeepseekV2AttentionImpl::prefill_mha(
+    const torch::Tensor& q_nope,
     const torch::Tensor& q_pe,
-    const torch::Tensor& latent_cache,
+    const torch::Tensor& c_kv_normed,
+    const torch::Tensor& k_pe,
     const AttentionMetadata& attn_metadata) {
-  const int64_t head_dim = kv_lora_rank_ + qk_rope_head_dim_;
-  torch::Tensor q_input = torch::cat({q_nope_absorbed, q_pe}, /*dim=*/-1);
-  const int64_t num_tokens = q_input.size(0);
+  check_first_phase_prefill_metadata(attn_metadata);
 
-  torch::Tensor q_cu = attn_metadata.q_cu_seq_lens.cpu().to(torch::kInt64);
-  torch::Tensor kv_cu = attn_metadata.kv_cu_seq_lens.cpu().to(torch::kInt64);
-  const int64_t batch_size = q_cu.size(0) - 1;
+  torch::Tensor kv =
+      kv_b_proj_->forward(c_kv_normed)
+          .view({-1, tp_heads_, qk_nope_head_dim_ + v_head_dim_});
+  std::vector<torch::Tensor> kv_vec =
+      kv.split({qk_nope_head_dim_, v_head_dim_}, /*dim=*/-1);
+  torch::Tensor k_nope = kv_vec[0].contiguous();
+  torch::Tensor value = kv_vec[1].contiguous();
 
-  torch::Tensor out_latent =
-      torch::empty({num_tokens, tp_heads_, kv_lora_rank_}, q_input.options());
+  torch::Tensor query = torch::cat({q_nope, q_pe}, /*dim=*/-1).contiguous();
+  torch::Tensor key =
+      torch::cat({k_nope, k_pe.unsqueeze(1).expand({-1, tp_heads_, -1})},
+                 /*dim=*/-1)
+          .contiguous();
 
-  for (int64_t i = 0; i < batch_size; ++i) {
-    const int64_t q_start = q_cu[i].item<int64_t>();
-    const int64_t q_end = q_cu[i + 1].item<int64_t>();
-    const int64_t kv_start = kv_cu[i].item<int64_t>();
-    const int64_t kv_end = kv_cu[i + 1].item<int64_t>();
-    const int64_t sq = q_end - q_start;
-    const int64_t sk = kv_end - kv_start;
-    if (sk == 0) {
-      continue;
-    }
+  torch::Tensor cu_seqlens =
+      attn_metadata.q_cu_seq_lens.to(torch::kInt32).contiguous();
+  std::vector<torch::Tensor> result = flash_attention_varlen_forward(
+      query,
+      key,
+      value,
+      /*num_heads=*/tp_heads_,
+      /*num_kv_heads=*/tp_heads_,
+      cu_seqlens,
+      cu_seqlens,
+      /*max_seqlen_q=*/attn_metadata.max_query_len,
+      /*max_seqlen_k=*/attn_metadata.max_query_len,
+      /*softmax_scale=*/softmax_scale_,
+      /*is_causal=*/attn_metadata.is_causal,
+      /*window_size_left=*/-1,
+      /*window_size_right=*/attn_metadata.is_causal ? 0 : -1,
+      /*is_bf16_output=*/query.scalar_type() == torch::kBFloat16);
 
-    torch::Tensor q_seq = q_input.slice(0, q_start, q_end);          // [sq,H,D]
-    torch::Tensor kv_seq = latent_cache.slice(0, kv_start, kv_end);  // [sk,D]
+  CHECK(!result.empty()) << "DeepSeek MHA prefill returned no output.";
+  torch::Tensor proj_input = result[0].flatten(1, 2).contiguous();
+  return o_proj_->forward(proj_input);
+}
 
-    torch::Tensor q4 = q_seq.permute({1, 0, 2}).unsqueeze(0).contiguous();
-    torch::Tensor kv4 = kv_seq.view({1, 1, sk, head_dim});
+torch::Tensor DeepseekV2AttentionImpl::prefill_mha_with_full_context(
+    const torch::Tensor& q_nope,
+    const torch::Tensor& q_pe,
+    const AttentionMetadata& attn_metadata,
+    const torch::Tensor& k_cache) {
+  check_context_prefill_metadata(attn_metadata);
 
-    torch::Tensor attn = torch::scaled_dot_product_attention(
-        q4,
-        kv4,
-        kv4,
-        std::nullopt,
-        /*dropout_p=*/0.0,
-        /*is_causal=*/attn_metadata.is_causal,
-        /*scale=*/static_cast<double>(softmax_scale_),
-        /*enable_gqa=*/true);                // [1, H, sq, D]
-    attn = attn.slice(-1, 0, kv_lora_rank_)  // keep o_latent cols
-               .squeeze(0)
-               .permute({1, 0, 2})
-               .contiguous();  // [sq, H, kv_lora]
-    out_latent.slice(0, q_start, q_end).copy_(attn);
-  }
+  const int64_t batch_size = attn_metadata.block_table.size(0);
+  CHECK_GT(batch_size, 0) << "DeepSeek context prefill batch size must be > 0.";
+  const int64_t required_blocks =
+      (attn_metadata.max_seq_len + k_cache.size(1) - 1) / k_cache.size(1);
+  CHECK_LE(required_blocks, attn_metadata.block_table.size(1))
+      << "DeepSeek context prefill block_table does not contain enough blocks.";
+  torch::Tensor latent_cache =
+      kernel::dcu::gather_mla_latent_cache(k_cache,
+                                           attn_metadata.block_table,
+                                           attn_metadata.kv_cu_seq_lens,
+                                           attn_metadata.total_kv_len,
+                                           attn_metadata.max_seq_len);
+  torch::Tensor c_kv_normed =
+      latent_cache.slice(/*dim=*/-1, /*start=*/0, kv_lora_rank_).contiguous();
+  torch::Tensor k_pe =
+      latent_cache.slice(/*dim=*/-1, /*start=*/kv_lora_rank_).contiguous();
 
-  return project_output(out_latent);
+  torch::Tensor kv =
+      kv_b_proj_->forward(c_kv_normed)
+          .view({-1, tp_heads_, qk_nope_head_dim_ + v_head_dim_});
+  std::vector<torch::Tensor> kv_vec =
+      kv.split({qk_nope_head_dim_, v_head_dim_}, /*dim=*/-1);
+  torch::Tensor k_nope = kv_vec[0].contiguous();
+  torch::Tensor value = kv_vec[1].contiguous();
+
+  torch::Tensor query = torch::cat({q_nope, q_pe}, /*dim=*/-1).contiguous();
+  torch::Tensor key =
+      torch::cat({k_nope, k_pe.unsqueeze(1).expand({-1, tp_heads_, -1})},
+                 /*dim=*/-1)
+          .contiguous();
+
+  torch::Tensor q_cu_seqlens =
+      attn_metadata.q_cu_seq_lens.to(torch::kInt32).contiguous();
+  torch::Tensor kv_cu_seqlens =
+      attn_metadata.kv_cu_seq_lens.to(torch::kInt32).contiguous();
+  std::vector<torch::Tensor> result = flash_attention_varlen_forward(
+      query,
+      key,
+      value,
+      /*num_heads=*/tp_heads_,
+      /*num_kv_heads=*/tp_heads_,
+      q_cu_seqlens,
+      kv_cu_seqlens,
+      /*max_seqlen_q=*/attn_metadata.max_query_len,
+      /*max_seqlen_k=*/attn_metadata.max_seq_len,
+      /*softmax_scale=*/softmax_scale_,
+      /*is_causal=*/attn_metadata.is_causal,
+      /*window_size_left=*/-1,
+      /*window_size_right=*/attn_metadata.is_causal ? 0 : -1,
+      /*is_bf16_output=*/query.scalar_type() == torch::kBFloat16);
+
+  CHECK(!result.empty())
+      << "DeepSeek full-context MHA prefill returned no output.";
+  torch::Tensor proj_input = result[0].flatten(1, 2).contiguous();
+  return o_proj_->forward(proj_input);
 }
 
 torch::Tensor DeepseekV2AttentionImpl::forward(
@@ -266,9 +376,8 @@ torch::Tensor DeepseekV2AttentionImpl::forward(
     const torch::Tensor& hidden_states,
     const AttentionMetadata& attn_metadata,
     KVCache& kv_cache) {
-  const bool is_prefill = attn_metadata.is_prefill;
-  CHECK(!attn_metadata.is_chunked_prefill)
-      << "DCU DeepSeek-V2 chunked prefill is not supported yet.";
+  const bool use_prefill_attention =
+      attn_metadata.is_prefill || attn_metadata.is_chunked_prefill;
   CHECK_EQ(positions.numel(), hidden_states.size(0))
       << "DCU DeepSeek-V2 position/token mismatch, positions: "
       << positions.sizes() << ", hidden_states: " << hidden_states.sizes()
@@ -287,7 +396,7 @@ torch::Tensor DeepseekV2AttentionImpl::forward(
                        positions,
                        attn_metadata.q_cu_seq_lens,
                        attn_metadata.max_query_len,
-                       /*is_prompt=*/is_prefill);
+                       /*is_prompt=*/use_prefill_attention);
   k_pe = k_pe_3d.squeeze(1).contiguous();
   torch::Tensor latent_normed = torch::cat({c_kv_normed, k_pe}, /*dim=*/-1);
 
@@ -306,13 +415,20 @@ torch::Tensor DeepseekV2AttentionImpl::forward(
                        positions,
                        attn_metadata.q_cu_seq_lens,
                        attn_metadata.max_query_len,
-                       /*is_prompt=*/is_prefill);
+                       /*is_prompt=*/use_prefill_attention);
+
+  if (use_prefill_attention) {
+    if (has_prefill_context(attn_metadata)) {
+      return prefill_mha_with_full_context(
+          q_nope, q_pe, attn_metadata, k_cache);
+    }
+    return prefill_mha(q_nope, q_pe, c_kv_normed, k_pe, attn_metadata);
+  }
+
+  CHECK(w_kc_.defined()) << "DeepSeek MLA absorbed key weight is not loaded.";
   torch::Tensor q_nope_absorbed =
       torch::bmm(q_nope.transpose(0, 1), w_kc_).transpose(0, 1);
 
-  if (is_prefill) {
-    return prefill_sdpa(q_nope_absorbed, q_pe, latent_normed, attn_metadata);
-  }
   return decode_flash_mla(q_nope_absorbed, q_pe, attn_metadata, kv_cache);
 }
 
@@ -332,11 +448,41 @@ void DeepseekV2AttentionImpl::load_state_dict(const StateDict& state_dict) {
   kv_b_proj_->load_state_dict(state_dict.get_dict_with_prefix("kv_b_proj."));
   o_proj_->load_state_dict(state_dict.get_dict_with_prefix("o_proj."));
 
-  if (kv_b_proj_->is_weight_loaded() && !has_trans_) {
-    w_vc_ = w_vc_.transpose(1, 2)
-                .contiguous();  // [H, v_head, kv_lora] -> [H, kv_lora, v_head]
-    has_trans_ = true;
+  if (kv_b_proj_->is_weight_loaded()) {
+    refresh_kv_b_proj_weights();
   }
+}
+
+void DeepseekV2AttentionImpl::refresh_kv_b_proj_weights() {
+  torch::Tensor kv_b_weight = kv_b_proj_->weight();
+  CHECK(kv_b_weight.defined())
+      << "DeepSeek MLA kv_b_proj weight must be loaded.";
+  if (is_fp8_dtype(kv_b_weight.scalar_type())) {
+    torch::Tensor weight_scale = kv_b_proj_->weight_scale();
+    CHECK(weight_scale.defined())
+        << "DeepSeek MLA FP8 kv_b_proj requires weight_scale.";
+    torch::Tensor scale = weight_scale;
+    if (scale.dim() == 2) {
+      CHECK_EQ(scale.size(1), 1)
+          << "DeepSeek MLA kv_b_proj weight_scale must be [N] or [N,1].";
+      scale = scale.squeeze(1);
+    }
+    CHECK_EQ(scale.dim(), 1)
+        << "DeepSeek MLA kv_b_proj weight_scale must be [N] or [N,1].";
+    CHECK_EQ(scale.size(0), kv_b_weight.size(0))
+        << "DeepSeek MLA kv_b_proj weight_scale output dim mismatch.";
+    kv_b_weight = (kv_b_weight.to(runtime_dtype_) *
+                   scale.to(kv_b_weight.device(), runtime_dtype_).view({-1, 1}))
+                      .contiguous();
+  }
+
+  torch::Tensor weights =
+      kv_b_weight.unflatten(0, {tp_heads_, qk_nope_head_dim_ + v_head_dim_});
+  w_kc_ = weights.slice(1, 0, qk_nope_head_dim_).contiguous();
+  w_vc_ = weights.slice(1, qk_nope_head_dim_, qk_nope_head_dim_ + v_head_dim_)
+              .transpose(1, 2)
+              .contiguous();
+  has_trans_ = true;
 }
 
 }  // namespace layer

--- a/xllm/core/layers/dcu/deepseek_v2_attention.h
+++ b/xllm/core/layers/dcu/deepseek_v2_attention.h
@@ -13,7 +13,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
 
-// DCU DeepSeek-V2 MLA attention. Prefill uses SDPA and decode uses FlashMLA.
+// DCU DeepSeek-V2 MLA attention. Prefill expands MLA to MHA with
+// FlashAttention varlen; decode uses FlashMLA.
 
 #pragma once
 
@@ -63,12 +64,20 @@ class DeepseekV2AttentionImpl final : public torch::nn::Module {
                                  const AttentionMetadata& attn_metadata,
                                  KVCache& kv_cache);
 
-  torch::Tensor prefill_sdpa(const torch::Tensor& q_nope_absorbed,
-                             const torch::Tensor& q_pe,
-                             const torch::Tensor& latent_cache,
-                             const AttentionMetadata& attn_metadata);
+  torch::Tensor prefill_mha(const torch::Tensor& q_nope,
+                            const torch::Tensor& q_pe,
+                            const torch::Tensor& c_kv_normed,
+                            const torch::Tensor& k_pe,
+                            const AttentionMetadata& attn_metadata);
+
+  torch::Tensor prefill_mha_with_full_context(
+      const torch::Tensor& q_nope,
+      const torch::Tensor& q_pe,
+      const AttentionMetadata& attn_metadata,
+      const torch::Tensor& k_cache);
 
   torch::Tensor project_output(const torch::Tensor& attn_latent);
+  void refresh_kv_b_proj_weights();
 
   int64_t q_lora_rank_;
   int64_t kv_lora_rank_;
@@ -80,6 +89,7 @@ class DeepseekV2AttentionImpl final : public torch::nn::Module {
   double eps_;
   float softmax_scale_;
   bool interleaved_;
+  torch::ScalarType runtime_dtype_;
 
   ReplicatedLinear q_a_proj_{nullptr};
   RMSNorm q_a_layernorm_{nullptr};

--- a/xllm/core/layers/dcu/flash_attention.cpp
+++ b/xllm/core/layers/dcu/flash_attention.cpp
@@ -44,9 +44,9 @@ limitations under the License.
 //   block_table:    (batch_size, max_num_blocks_per_seq) int32, -1 padded
 //   output:         same shape as q
 //
-// prefix_prefill_varlen_fwd is used for the prefill phase.
+// hg_prefix_prefill_varlen_fwd is used for the prefill phase.
 // Q may contain many tokens per sequence. Uses the general fwd kernel.
-std::vector<torch::Tensor> prefix_prefill_varlen_fwd(
+std::vector<torch::Tensor> hg_prefix_prefill_varlen_fwd(
     const torch::Tensor& q,
     const torch::Tensor& k,
     const torch::Tensor& v,
@@ -70,12 +70,13 @@ std::vector<torch::Tensor> prefix_prefill_varlen_fwd(
     std::optional<torch::Tensor> scales_q_ = std::nullopt,
     std::optional<torch::Tensor> scales_k_ = std::nullopt,
     std::optional<torch::Tensor> scales_v_ = std::nullopt,
+    std::optional<torch::Tensor> s_aux_ = std::nullopt,
     const bool is_bf16_output = false);
 
-// prefix_decode_varlen_fwd is used for the decode phase and chunked prefill.
+// hg_prefix_decode_varlen_fwd is used for decode and short chunked prefill.
 // Q is typically short (often 1 token per sequence). Uses the KV-cache kernel
 // with GQA to MQA ngroups optimization and split parallelism for small batches.
-std::vector<torch::Tensor> prefix_decode_varlen_fwd(
+std::vector<torch::Tensor> hg_prefix_decode_varlen_fwd(
     torch::Tensor& q,
     const torch::Tensor& k,
     const torch::Tensor& v,
@@ -95,23 +96,28 @@ std::vector<torch::Tensor> prefix_decode_varlen_fwd(
     int32_t window_size_right,
     const float softcap,
     const bool return_softmax,
-    const int32_t layout);
+    const int32_t layout,
+    std::optional<torch::Tensor> scales_q_ = std::nullopt,
+    std::optional<torch::Tensor> scales_k_ = std::nullopt,
+    std::optional<torch::Tensor> scales_v_ = std::nullopt,
+    std::optional<torch::Tensor> s_aux_ = std::nullopt,
+    const bool is_bf16_output = false);
 
-// Dense varlen forward kernel from flash_api.cpp. This is the non-KV-cache
-// path used by full-sequence DiT attention.
+// Plain FlashAttention varlen forward from libflash_attention.so. This is used
+// by MLA implementations that expand prefill into ordinary MHA.
 std::vector<torch::Tensor> varlen_fwd(
     const torch::Tensor& q,
     const torch::Tensor& k,
     const torch::Tensor& v,
-    const int32_t num_heads,
-    const int32_t num_heads_k,
+    int32_t num_heads,
+    int32_t num_heads_k,
     std::optional<torch::Tensor>& out_,
     const torch::Tensor& cu_seqlens_q,
     const torch::Tensor& cu_seqlens_k,
     std::optional<torch::Tensor>& seqused_k,
     std::optional<torch::Tensor>& alibi_slopes_,
-    const int32_t max_seqlen_q,
-    const int32_t max_seqlen_k,
+    int32_t max_seqlen_q,
+    int32_t max_seqlen_k,
     const float p_dropout,
     const float softmax_scale,
     const bool zero_tensors,
@@ -121,14 +127,68 @@ std::vector<torch::Tensor> varlen_fwd(
     const float softcap,
     const bool return_softmax,
     std::optional<at::Generator> gen_,
-    const int32_t layout,
+    int32_t layout,
     std::optional<torch::Tensor> q_descale_ = std::nullopt,
     std::optional<torch::Tensor> k_descale_ = std::nullopt,
     std::optional<torch::Tensor> v_descale_ = std::nullopt,
-    const bool is_bf16_output = true);
+    const bool is_bf16_output = false);
 
 namespace xllm {
 namespace layer {
+
+std::vector<torch::Tensor> flash_attention_varlen_forward(
+    const torch::Tensor& query,
+    const torch::Tensor& key,
+    const torch::Tensor& value,
+    int64_t num_heads,
+    int64_t num_kv_heads,
+    const torch::Tensor& cu_seqlens_q,
+    const torch::Tensor& cu_seqlens_k,
+    int64_t max_seqlen_q,
+    int64_t max_seqlen_k,
+    float softmax_scale,
+    bool is_causal,
+    int64_t window_size_left,
+    int64_t window_size_right,
+    bool is_bf16_output,
+    std::optional<torch::Tensor> output,
+    std::optional<torch::Tensor> seqused_k,
+    std::optional<torch::Tensor> alibi_slopes,
+    std::optional<torch::Tensor> q_descale,
+    std::optional<torch::Tensor> k_descale,
+    std::optional<torch::Tensor> v_descale) {
+  CHECK_GT(num_heads, 0) << "num_heads must be positive.";
+  CHECK_GT(num_kv_heads, 0) << "num_kv_heads must be positive.";
+  CHECK_GT(max_seqlen_q, 0) << "max_seqlen_q must be positive.";
+  CHECK_GT(max_seqlen_k, 0) << "max_seqlen_k must be positive.";
+  std::optional<at::Generator> generator = std::nullopt;
+  return varlen_fwd(query,
+                    key,
+                    value,
+                    static_cast<int32_t>(num_heads),
+                    static_cast<int32_t>(num_kv_heads),
+                    output,
+                    cu_seqlens_q,
+                    cu_seqlens_k,
+                    seqused_k,
+                    alibi_slopes,
+                    static_cast<int32_t>(max_seqlen_q),
+                    static_cast<int32_t>(max_seqlen_k),
+                    /*p_dropout=*/0.0f,
+                    softmax_scale,
+                    /*zero_tensors=*/false,
+                    is_causal,
+                    static_cast<int32_t>(window_size_left),
+                    static_cast<int32_t>(window_size_right),
+                    /*softcap=*/0.0f,
+                    /*return_softmax=*/false,
+                    generator,
+                    /*layout=*/1,
+                    q_descale,
+                    k_descale,
+                    v_descale,
+                    is_bf16_output);
+}
 
 namespace {
 
@@ -340,7 +400,7 @@ void FlashAttentionImpl::prefill_forward(const AttentionMetadata& attn_metadata,
 
   // Prefill: KV has been stored into paged cache by reshape_paged_cache.
   // Q is already in packed format [total_tokens, nh, hd], no padding needed.
-  // prefix_prefill_varlen_fwd reads Q, K/V cache, cu_seqlens_q, seqused_k,
+  // hg_prefix_prefill_varlen_fwd reads Q, K/V cache, cu_seqlens_q, seqused_k,
   // and block_table directly.
   torch::Tensor kv_seq_lens = get_or_compute_seqlens(
       attn_metadata.kv_seq_lens, attn_metadata.kv_cu_seq_lens);
@@ -358,7 +418,7 @@ void FlashAttentionImpl::prefill_forward(const AttentionMetadata& attn_metadata,
   std::optional<torch::Tensor> cu_seqlens_k_opt = std::nullopt;
   std::optional<torch::Tensor> alibi_opt = std::nullopt;
 
-  std::vector<torch::Tensor> result = prefix_prefill_varlen_fwd(
+  std::vector<torch::Tensor> result = hg_prefix_prefill_varlen_fwd(
       query,
       k_cache,
       v_cache,
@@ -414,7 +474,7 @@ void FlashAttentionImpl::paged_forward(const AttentionMetadata& attn_metadata,
     max_q_len = 1;
   }
 
-  // For prefix_decode_varlen_fwd, the window semantics are:
+  // For hg_prefix_decode_varlen_fwd, the window semantics are:
   //   - window_left = -1 means infinite lookback (converted to seqlen_k
   //   internally)
   //   - window_left >= 0 enables a sliding window of that size
@@ -428,27 +488,57 @@ void FlashAttentionImpl::paged_forward(const AttentionMetadata& attn_metadata,
   std::optional<torch::Tensor> cu_seqlens_k_opt = std::nullopt;
   std::optional<torch::Tensor> alibi_opt = std::nullopt;
 
-  std::vector<torch::Tensor> result = prefix_decode_varlen_fwd(
-      query,
-      k_cache,
-      v_cache,
-      out_opt,
-      cu_seqlens_q,
-      cu_seqlens_k_opt,
-      kv_seq_lens,
-      alibi_opt,
-      block_table,
-      /*max_seqlen_q=*/static_cast<int32_t>(max_q_len),
-      /*max_seqlen_k=*/static_cast<int32_t>(max_kv_len),
-      /*p_dropout=*/0.0f,
-      /*softmax_scale=*/scale_,
-      /*zero_tensors=*/false,
-      /*is_causal=*/attn_metadata.is_causal,
-      /*window_size_left=*/static_cast<int32_t>(window_left),
-      /*window_size_right=*/static_cast<int32_t>(window_right),
-      /*softcap=*/0.0f,
-      /*return_softmax=*/false,
-      /*layout=*/1);
+  constexpr int64_t kHgPrefixDecodeMaxQueryLen = 16;
+  const bool use_prefill_kernel =
+      is_chunked_prefill && max_q_len > kHgPrefixDecodeMaxQueryLen;
+  std::vector<torch::Tensor> result;
+  if (use_prefill_kernel) {
+    // Match HG flash-attention's own prefix varlen dispatch: long query chunks
+    // use the prefill kernel, while decode/short chunks stay on decode kernel.
+    result = hg_prefix_prefill_varlen_fwd(
+        query,
+        k_cache,
+        v_cache,
+        out_opt,
+        cu_seqlens_q,
+        cu_seqlens_k_opt,
+        kv_seq_lens,
+        alibi_opt,
+        block_table,
+        /*max_seqlen_q=*/static_cast<int32_t>(max_q_len),
+        /*max_seqlen_k=*/static_cast<int32_t>(max_kv_len),
+        /*p_dropout=*/0.0f,
+        /*softmax_scale=*/scale_,
+        /*zero_tensors=*/false,
+        /*is_causal=*/attn_metadata.is_causal,
+        /*window_size_left=*/static_cast<int32_t>(window_left),
+        /*window_size_right=*/static_cast<int32_t>(window_right),
+        /*softcap=*/0.0f,
+        /*return_softmax=*/false,
+        /*layout=*/1);
+  } else {
+    result = hg_prefix_decode_varlen_fwd(
+        query,
+        k_cache,
+        v_cache,
+        out_opt,
+        cu_seqlens_q,
+        cu_seqlens_k_opt,
+        kv_seq_lens,
+        alibi_opt,
+        block_table,
+        /*max_seqlen_q=*/static_cast<int32_t>(max_q_len),
+        /*max_seqlen_k=*/static_cast<int32_t>(max_kv_len),
+        /*p_dropout=*/0.0f,
+        /*softmax_scale=*/scale_,
+        /*zero_tensors=*/false,
+        /*is_causal=*/attn_metadata.is_causal,
+        /*window_size_left=*/static_cast<int32_t>(window_left),
+        /*window_size_right=*/static_cast<int32_t>(window_right),
+        /*softcap=*/0.0f,
+        /*return_softmax=*/false,
+        /*layout=*/1);
+  }
 
   // Output is already packed, matching query shape.
   output.copy_(result[0]);

--- a/xllm/core/layers/dcu/flash_attention.h
+++ b/xllm/core/layers/dcu/flash_attention.h
@@ -17,7 +17,9 @@ limitations under the License.
 
 #include <torch/torch.h>
 
+#include <optional>
 #include <tuple>
+#include <vector>
 
 #include "framework/kv_cache/kv_cache.h"
 #include "layers/common/attention_metadata.h"
@@ -33,6 +35,28 @@ torch::Tensor dense_varlen_flash_attention(torch::Tensor query,
                                            const torch::Tensor& cu_seqlens_k,
                                            double softmax_scale,
                                            bool is_causal);
+
+std::vector<torch::Tensor> flash_attention_varlen_forward(
+    const torch::Tensor& query,
+    const torch::Tensor& key,
+    const torch::Tensor& value,
+    int64_t num_heads,
+    int64_t num_kv_heads,
+    const torch::Tensor& cu_seqlens_q,
+    const torch::Tensor& cu_seqlens_k,
+    int64_t max_seqlen_q,
+    int64_t max_seqlen_k,
+    float softmax_scale,
+    bool is_causal,
+    int64_t window_size_left,
+    int64_t window_size_right,
+    bool is_bf16_output,
+    std::optional<torch::Tensor> output = std::nullopt,
+    std::optional<torch::Tensor> seqused_k = std::nullopt,
+    std::optional<torch::Tensor> alibi_slopes = std::nullopt,
+    std::optional<torch::Tensor> q_descale = std::nullopt,
+    std::optional<torch::Tensor> k_descale = std::nullopt,
+    std::optional<torch::Tensor> v_descale = std::nullopt);
 
 // FlashAttentionImpl uses the mha_fwd_kvcache_bshd HIP kernel from
 // libflash_attention to compute paged attention directly from KV cache,

--- a/xllm/core/layers/dcu/fused_moe.cpp
+++ b/xllm/core/layers/dcu/fused_moe.cpp
@@ -20,11 +20,86 @@ limitations under the License.
 #include <numeric>
 
 #include "framework/parallel_state/parallel_state.h"
+#include "kernels/dcu/aiter_moe_adapter.h"
+#include "kernels/dcu/aiter_quant_adapter.h"
 #include "kernels/ops_api.h"
 #include "layers/common/dp_utils.h"
 
 namespace xllm {
 namespace layer {
+namespace {
+
+constexpr int64_t kAiterMoeBlockSize = 16;
+
+struct LocalFp8ExpertRouting {
+  torch::Tensor token_ids;
+  torch::Tensor expert_ids;
+  torch::Tensor weights;
+  int64_t num_assignments = 0;
+};
+
+bool is_fp8_channelwise_moe(const QuantArgs& quant_args) {
+  return quant_args.quant_method() == kQuantMethodFp8 &&
+         quant_args.activation_dynamic();
+}
+
+torch::Tensor shuffle_moe_gemm1_weight(const torch::Tensor& weight) {
+  return xllm::kernel::dcu::aiter::moe_layout_shuffle_gemm1(weight);
+}
+
+torch::Tensor shuffle_moe_gemm2_weight(const torch::Tensor& weight) {
+  return xllm::kernel::dcu::aiter::moe_layout_shuffle_gemm2(weight);
+}
+
+torch::Tensor materialize_fp8_moe_weight(torch::Tensor shuffled_weight,
+                                         const torch::Tensor& parameter) {
+  CHECK(shuffled_weight.defined()) << "shuffled FP8 MoE weight is undefined.";
+  CHECK(parameter.defined()) << "target FP8 MoE parameter is undefined.";
+  CHECK_EQ(parameter.sizes(), shuffled_weight.sizes())
+      << "shuffled FP8 MoE weight size mismatch.";
+  if (shuffled_weight.device() == parameter.device() &&
+      shuffled_weight.scalar_type() == parameter.scalar_type() &&
+      shuffled_weight.is_contiguous()) {
+    return shuffled_weight;
+  }
+  return shuffled_weight.to(parameter.options()).contiguous();
+}
+
+LocalFp8ExpertRouting select_local_fp8_experts(
+    const torch::Tensor& expert_id,
+    const torch::Tensor& reduce_weight,
+    int64_t topk,
+    int64_t start_expert_id,
+    int64_t num_experts_per_rank) {
+  CHECK_EQ(expert_id.sizes(), reduce_weight.sizes())
+      << "FP8 MoE expert id/reduce weight shape mismatch.";
+  const int64_t end_expert_id = start_expert_id + num_experts_per_rank;
+  torch::Tensor local_mask = torch::logical_and(expert_id.ge(start_expert_id),
+                                                expert_id.lt(end_expert_id));
+  torch::Tensor flat_indices =
+      torch::nonzero(local_mask.reshape({-1})).reshape({-1}).to(torch::kInt64);
+  LocalFp8ExpertRouting routing;
+  routing.num_assignments = flat_indices.numel();
+  if (routing.num_assignments == 0) {
+    return routing;
+  }
+
+  torch::Tensor flat_expert_id = expert_id.reshape({-1});
+  torch::Tensor flat_reduce_weight = reduce_weight.reshape({-1});
+  routing.token_ids = flat_indices.div(topk, "floor").to(torch::kInt64);
+  routing.expert_ids =
+      (flat_expert_id.index_select(0, flat_indices).to(torch::kInt64) -
+       start_expert_id)
+          .to(torch::kInt32)
+          .view({routing.num_assignments, 1})
+          .contiguous();
+  routing.weights = flat_reduce_weight.index_select(0, flat_indices)
+                        .view({routing.num_assignments, 1})
+                        .contiguous();
+  return routing;
+}
+
+}  // namespace
 
 FusedMoEImpl::FusedMoEImpl(const ModelArgs& model_args,
                            const FusedMoEArgs& moe_args,
@@ -52,11 +127,18 @@ FusedMoEImpl::FusedMoEImpl(const ModelArgs& model_args,
   const std::string& topk_method = model_args.topk_method();
   int64_t ep_size = parallel_args.ep_size();
   int64_t ep_rank = 0;
+  CHECK_GT(ep_size, 0) << "ep_size must be positive.";
   tp_pg_ = parallel_args.tp_group_;
   if (ep_size > 1) {
+    CHECK(parallel_args.moe_ep_group_ != nullptr)
+        << "DCU FusedMoE requires a MoE EP process group when ep_size > 1.";
+    CHECK(parallel_args.moe_tp_group_ != nullptr)
+        << "DCU FusedMoE requires a MoE TP process group when ep_size > 1.";
     ep_rank = parallel_args.moe_ep_group_->rank();
     tp_pg_ = parallel_args.moe_tp_group_;
   }
+  CHECK_EQ(num_experts % ep_size, 0)
+      << "n_routed_experts must be divisible by ep_size.";
 
   num_experts_per_rank_ = num_experts / ep_size;
   start_expert_id_ = ep_rank * num_experts_per_rank_;
@@ -97,21 +179,40 @@ FusedMoEImpl::FusedMoEImpl(const ModelArgs& model_args,
   }
 
   const int64_t world_size = tp_pg_->world_size();
-  int64_t local_intermediate_size = intermediate_size / world_size;
+  CHECK_EQ(intermediate_size % world_size, 0)
+      << "moe_intermediate_size must be divisible by TP world size.";
+  const int64_t local_intermediate_size = intermediate_size / world_size;
+  torch::TensorOptions expert_weight_options = options_;
+  if (is_fp8_channelwise_moe(quant_args_)) {
+    expert_weight_options = options_.dtype(torch::kFloat8_e4m3fn);
+  }
 
   w13_ = register_parameter(
       "w13",
       torch::empty(
           {num_experts_per_rank_, local_intermediate_size * 2, hidden_size_},
-          options_),
+          expert_weight_options),
       false);
 
   w2_ = register_parameter(
       "w2",
       torch::empty(
           {num_experts_per_rank_, hidden_size_, local_intermediate_size},
-          options_),
+          expert_weight_options),
       false);
+
+  if (is_fp8_channelwise_moe(quant_args_)) {
+    w13_scale_ = register_parameter(
+        "w13_scale",
+        torch::empty({num_experts_per_rank_, local_intermediate_size * 2, 1},
+                     options_.dtype(torch::kFloat32)),
+        false);
+    w2_scale_ = register_parameter(
+        "w2_scale",
+        torch::empty({num_experts_per_rank_, hidden_size_, 1},
+                     options_.dtype(torch::kFloat32)),
+        false);
+  }
 }
 
 // ---------------------------------------------------------------------------
@@ -140,31 +241,35 @@ torch::Tensor FusedMoEImpl::expert_gemm(const torch::Tensor& input,
 //   step 2 — moe_gen_idx     → cuda::moe_fused_compute_index (fused)
 //   step 3 — moe_expand_input → torch index_select
 // ---------------------------------------------------------------------------
-torch::Tensor FusedMoEImpl::select_experts(
-    const torch::Tensor& hidden_states_2d,
-    const torch::Tensor& router_logits_2d,
-    SelectedExpertInfo& selected_expert_info) {
+std::pair<torch::Tensor, torch::Tensor> FusedMoEImpl::route_experts(
+    const torch::Tensor& router_logits_2d) {
   std::optional<torch::Tensor> e_score_correction_bias = std::nullopt;
   if (e_score_correction_bias_.defined()) {
     e_score_correction_bias = e_score_correction_bias_;
   }
 
-  // ---- Step 1: moe_active_topk ----
   torch::Tensor reduce_weight;
   torch::Tensor expert_id;
-  {
-    xllm::kernel::MoeFusedTopkParams params;
-    params.input = router_logits_2d;
-    params.topk = topk_;
-    params.num_expert_group = num_expert_group_;
-    params.topk_group = topk_group_;
-    params.normalize = renormalize_;
-    params.normed_by = "topk_logit";
-    params.scoring_func = scoring_func_;
-    params.route_scale = route_scale_;
-    params.e_score_correction_bias = e_score_correction_bias;
-    std::tie(reduce_weight, expert_id) = xllm::kernel::moe_active_topk(params);
-  }
+  xllm::kernel::MoeFusedTopkParams params;
+  params.input = router_logits_2d;
+  params.topk = topk_;
+  params.num_expert_group = num_expert_group_;
+  params.topk_group = topk_group_;
+  params.normalize = renormalize_;
+  params.normed_by = "topk_logit";
+  params.scoring_func = scoring_func_;
+  params.route_scale = route_scale_;
+  params.e_score_correction_bias = e_score_correction_bias;
+  std::tie(reduce_weight, expert_id) = xllm::kernel::moe_active_topk(params);
+  return {reduce_weight, expert_id};
+}
+
+torch::Tensor FusedMoEImpl::select_experts(
+    const torch::Tensor& hidden_states_2d,
+    const torch::Tensor& router_logits_2d,
+    SelectedExpertInfo& selected_expert_info) {
+  // ---- Step 1: moe_active_topk ----
+  auto [reduce_weight, expert_id] = route_experts(router_logits_2d);
 
   // ---- Step 2: moe_gen_idx (fused kernel) ----
   torch::Tensor src_dst, dst_src, expert_sizes;
@@ -211,6 +316,169 @@ torch::Tensor FusedMoEImpl::select_experts(
   return expand_all;
 }
 
+torch::Tensor FusedMoEImpl::forward_fp8_channelwise_experts(
+    const torch::Tensor& hidden_states,
+    const torch::Tensor& hidden_states_2d,
+    const torch::Tensor& router_logits_2d) {
+  CHECK(w13_.defined() && w2_.defined())
+      << "FP8 MoE weights must be loaded before forward.";
+  CHECK(w13_scale_.defined() && w2_scale_.defined())
+      << "FP8 MoE weight scales must be loaded before forward.";
+
+  const int64_t num_tokens = hidden_states_2d.size(0);
+  const torch::ScalarType output_dtype = hidden_states.dtype().toScalarType();
+  auto [reduce_weight, expert_id] = route_experts(router_logits_2d);
+  if (parallel_args_.ep_size() > 1) {
+    LocalFp8ExpertRouting routing =
+        select_local_fp8_experts(expert_id,
+                                 reduce_weight,
+                                 topk_,
+                                 start_expert_id_,
+                                 num_experts_per_rank_);
+    torch::Tensor final_hidden_states_2d =
+        torch::zeros({num_tokens, hidden_size_},
+                     hidden_states_2d.options().dtype(output_dtype));
+    if (routing.num_assignments == 0) {
+      return final_hidden_states_2d.reshape(hidden_states.sizes());
+    }
+
+    xllm::kernel::dcu::aiter::MoeSortedTokens sorted_tokens =
+        xllm::kernel::dcu::aiter::moe_align_block_size(routing.expert_ids,
+                                                       routing.weights,
+                                                       num_experts_per_rank_,
+                                                       kAiterMoeBlockSize);
+    torch::Tensor local_hidden_states =
+        hidden_states_2d.index_select(0, routing.token_ids).contiguous();
+    torch::Tensor quantized_input;
+    torch::Tensor input_scale;
+    std::tie(quantized_input, input_scale) =
+        xllm::kernel::dcu::aiter::per_token_quant_fp8(local_hidden_states,
+                                                      std::nullopt);
+
+    torch::Tensor gemm1_out =
+        torch::empty({routing.num_assignments, 1, w13_.size(1)},
+                     hidden_states_2d.options().dtype(output_dtype));
+    xllm::kernel::dcu::aiter::moe_gemm_fp8_channelwise(
+        quantized_input,
+        w13_,
+        gemm1_out,
+        input_scale,
+        w13_scale_,
+        std::nullopt,
+        sorted_tokens,
+        /*topk=*/1,
+        xllm::kernel::dcu::aiter::select_moe_gemm1_mode(
+            routing.num_assignments),
+        /*delta=*/1,
+        xllm::kernel::dcu::aiter::select_moe_m_key(routing.num_assignments));
+
+    torch::Tensor act_out =
+        torch::empty({routing.num_assignments, w13_.size(1) / 2},
+                     hidden_states_2d.options().dtype(output_dtype));
+    {
+      xllm::kernel::ActivationParams activation_params;
+      activation_params.input =
+          gemm1_out.view({routing.num_assignments, w13_.size(1)});
+      activation_params.output = act_out;
+      activation_params.act_mode = hidden_act_;
+      activation_params.is_gated = is_gated_;
+      xllm::kernel::active(activation_params);
+    }
+
+    torch::Tensor quantized_act;
+    torch::Tensor act_scale;
+    std::tie(quantized_act, act_scale) =
+        xllm::kernel::dcu::aiter::per_token_quant_fp8(act_out.contiguous(),
+                                                      std::nullopt);
+
+    torch::Tensor gemm2_out =
+        torch::empty({routing.num_assignments, 1, hidden_size_},
+                     hidden_states_2d.options().dtype(output_dtype));
+    xllm::kernel::dcu::aiter::moe_gemm_fp8_channelwise(
+        quantized_act,
+        w2_,
+        gemm2_out,
+        act_scale,
+        w2_scale_,
+        routing.weights,
+        sorted_tokens,
+        /*topk=*/1,
+        xllm::kernel::dcu::aiter::select_moe_gemm2_mode(
+            routing.num_assignments),
+        /*delta=*/1,
+        xllm::kernel::dcu::aiter::select_moe_m_key(routing.num_assignments));
+
+    torch::Tensor local_output =
+        gemm2_out.view({routing.num_assignments, hidden_size_});
+    final_hidden_states_2d.index_add_(0, routing.token_ids, local_output);
+    return final_hidden_states_2d.reshape(hidden_states.sizes());
+  }
+
+  xllm::kernel::dcu::aiter::MoeSortedTokens sorted_tokens =
+      xllm::kernel::dcu::aiter::moe_align_block_size(
+          expert_id, reduce_weight, num_total_experts_, kAiterMoeBlockSize);
+
+  torch::Tensor quantized_input;
+  torch::Tensor input_scale;
+  std::tie(quantized_input, input_scale) =
+      xllm::kernel::dcu::aiter::per_token_quant_fp8(
+          hidden_states_2d.contiguous(), std::nullopt);
+
+  torch::Tensor gemm1_out =
+      torch::empty({num_tokens, topk_, w13_.size(1)},
+                   hidden_states_2d.options().dtype(output_dtype));
+  xllm::kernel::dcu::aiter::moe_gemm_fp8_channelwise(
+      quantized_input,
+      w13_,
+      gemm1_out,
+      input_scale,
+      w13_scale_,
+      std::nullopt,
+      sorted_tokens,
+      topk_,
+      xllm::kernel::dcu::aiter::select_moe_gemm1_mode(num_tokens),
+      topk_,
+      xllm::kernel::dcu::aiter::select_moe_m_key(num_tokens));
+
+  torch::Tensor act_out =
+      torch::empty({num_tokens * topk_, w13_.size(1) / 2},
+                   hidden_states_2d.options().dtype(output_dtype));
+  {
+    xllm::kernel::ActivationParams activation_params;
+    activation_params.input =
+        gemm1_out.view({num_tokens * topk_, w13_.size(1)});
+    activation_params.output = act_out;
+    activation_params.act_mode = hidden_act_;
+    activation_params.is_gated = is_gated_;
+    xllm::kernel::active(activation_params);
+  }
+
+  torch::Tensor quantized_act;
+  torch::Tensor act_scale;
+  std::tie(quantized_act, act_scale) =
+      xllm::kernel::dcu::aiter::per_token_quant_fp8(act_out.contiguous(),
+                                                    std::nullopt);
+
+  torch::Tensor gemm2_out =
+      torch::empty({num_tokens, topk_, hidden_size_},
+                   hidden_states_2d.options().dtype(output_dtype));
+  xllm::kernel::dcu::aiter::moe_gemm_fp8_channelwise(
+      quantized_act,
+      w2_,
+      gemm2_out,
+      act_scale,
+      w2_scale_,
+      reduce_weight.contiguous(),
+      sorted_tokens,
+      /*topk=*/1,
+      xllm::kernel::dcu::aiter::select_moe_gemm2_mode(num_tokens),
+      topk_,
+      xllm::kernel::dcu::aiter::select_moe_m_key(num_tokens));
+
+  torch::Tensor final_hidden_states = gemm2_out.sum(/*dim=*/1);
+  return final_hidden_states.reshape(hidden_states.sizes());
+}
+
 // ---------------------------------------------------------------------------
 // forward_experts
 // ---------------------------------------------------------------------------
@@ -228,6 +496,43 @@ torch::Tensor FusedMoEImpl::forward_experts(
   auto hidden_states_dtype = hidden_states.dtype().toScalarType();
   auto hidden_states_2d = hidden_states.reshape({-1, hidden_states.size(-1)});
   auto router_logits_2d = router_logits.reshape({-1, router_logits.size(-1)});
+
+  if (is_fp8_channelwise_moe(quant_args_)) {
+    auto final_hidden_states = forward_fp8_channelwise_experts(
+        hidden_states, hidden_states_2d, router_logits_2d);
+
+    auto current_stream = device_.current_stream();
+    routed_stream_->wait_stream(*current_stream);
+    {
+      torch::StreamGuard stream_guard = routed_stream_->set_stream_guard();
+      if (parallel_args_.ep_size() > 1) {
+        final_hidden_states = parallel_state::reduce(
+            final_hidden_states, parallel_args_.moe_ep_group_);
+      }
+      if (tp_pg_->world_size() > 1) {
+        final_hidden_states =
+            parallel_state::reduce(final_hidden_states, tp_pg_);
+      }
+    }
+
+    torch::Tensor shared_expert_output;
+    if (n_shared_experts_ > 0) {
+      shared_stream_->wait_stream(*current_stream);
+      {
+        torch::StreamGuard stream_guard = shared_stream_->set_stream_guard();
+        shared_expert_output = shared_experts_(hidden_states);
+        shared_expert_output =
+            shared_expert_output.reshape({-1, shared_expert_output.size(-1)});
+      }
+    }
+
+    current_stream->wait_stream(*routed_stream_);
+    if (n_shared_experts_ > 0) {
+      current_stream->wait_stream(*shared_stream_);
+      final_hidden_states += shared_expert_output.reshape(hidden_states_shape);
+    }
+    return final_hidden_states;
+  }
 
   // ---- Steps 1-3: select experts ----
   SelectedExpertInfo selected_expert_info;
@@ -378,6 +683,19 @@ void FusedMoEImpl::load_experts(const StateDict& state_dict) {
   const int64_t num_experts_per_rank = num_experts_per_rank_;
   const int64_t num_total_experts = num_total_experts_;
   std::vector<std::string> prefixes = {"gate_proj.", "up_proj."};
+  if (is_fp8_channelwise_moe(quant_args_)) {
+    auto shuffle_w13 = [this](const torch::Tensor& weight) {
+      return materialize_fp8_moe_weight(shuffle_moe_gemm1_weight(weight), w13_);
+    };
+    auto shuffle_w2 = [this](const torch::Tensor& weight) {
+      return materialize_fp8_moe_weight(shuffle_moe_gemm2_weight(weight), w2_);
+    };
+    LOAD_MOE_FUSED_WEIGHT_TRANSFORM("weight", w1, w3, w13, shuffle_w13);
+    LOAD_MOE_WEIGHT_TRANSFORM("down_proj.", "weight", w2, shuffle_w2, 1);
+    LOAD_MOE_FUSED_WEIGHT("weight_scale", w1_scale, w3_scale, w13_scale);
+    LOAD_MOE_WEIGHT("down_proj.", "weight_scale", w2_scale, -1);
+    return;
+  }
   LOAD_MOE_FUSED_WEIGHT("weight", w1, w3, w13);
   LOAD_MOE_WEIGHT("down_proj.", "weight", w2, 1);
 }

--- a/xllm/core/layers/dcu/fused_moe.h
+++ b/xllm/core/layers/dcu/fused_moe.h
@@ -17,6 +17,8 @@ limitations under the License.
 
 #include <torch/torch.h>
 
+#include <utility>
+
 #include "framework/model/model_args.h"
 #include "framework/model/model_input_params.h"
 #include "framework/parallel_state/parallel_args.h"
@@ -67,6 +69,14 @@ class FusedMoEImpl final : public torch::nn::Module {
                                const torch::Tensor& router_logits_2d,
                                SelectedExpertInfo& selected_expert_info);
 
+  std::pair<torch::Tensor, torch::Tensor> route_experts(
+      const torch::Tensor& router_logits_2d);
+
+  torch::Tensor forward_fp8_channelwise_experts(
+      const torch::Tensor& hidden_states,
+      const torch::Tensor& hidden_states_2d,
+      const torch::Tensor& router_logits_2d);
+
   // per-expert matmul: groups input by token_count, multiplies by weight[e]
   torch::Tensor expert_gemm(const torch::Tensor& input,
                             const torch::Tensor& weight,
@@ -106,6 +116,10 @@ class FusedMoEImpl final : public torch::nn::Module {
   DEFINE_FUSED_WEIGHT(w1);
   DEFINE_FUSED_WEIGHT(w3);
   DEFINE_FUSED_WEIGHT(w2);
+  DEFINE_FUSED_WEIGHT(w1_scale);
+  DEFINE_FUSED_WEIGHT(w3_scale);
+  DEFINE_WEIGHT(w13_scale);
+  DEFINE_FUSED_WEIGHT(w2_scale);
   DEFINE_WEIGHT(e_score_correction_bias);
 
   void load_e_score_correction_bias(const StateDict& state_dict);

--- a/xllm/models/dit/utils/sparse_attention.h
+++ b/xllm/models/dit/utils/sparse_attention.h
@@ -21,7 +21,9 @@ limitations under the License.
 #include <tuple>
 #include <vector>
 
+#if defined(USE_NPU)
 #include "core/kernels/npu/npu_ops_api.h"
+#endif
 
 namespace xllm::dit {
 
@@ -105,6 +107,7 @@ inline torch::Tensor avgpool(const torch::Tensor& input,
 //  Internal helpers live in the rain_fusion namespace to scope
 //  preprocessing from the sparse_attention variant.
 // =========================================================================
+#if defined(USE_NPU)
 namespace rain_fusion {
 
 // Layout helpers: merge B*N for NPU 8-dim compliance.
@@ -777,5 +780,6 @@ inline std::tuple<torch::Tensor, torch::Tensor> attention(
 }
 
 }  // namespace sparse_attention
+#endif  // defined(USE_NPU)
 
 }  // namespace xllm::dit

--- a/xllm/models/llm/deepseek_v3.h
+++ b/xllm/models/llm/deepseek_v3.h
@@ -26,14 +26,17 @@ class DeepseekV3ForCausalLMImpl
  public:
   DeepseekV3ForCausalLMImpl(const ModelContext& context)
       : LlmForCausalLMImplBase<DeepseekV2Model>(context) {
+#if !defined(USE_DCU)
     // Check if prefix cache or chunked prefill is enabled for unsupported
-    // models
+    // models. DCU DeepSeek context prefill is handled by the DCU
+    // attention implementation.
     CHECK(!::xllm::KVCacheConfig::get_instance().enable_prefix_cache())
         << "deepseek_v3 have not supported "
            "enable_prefix_cache yet. Please disable it.";
     CHECK(!::xllm::SchedulerConfig::get_instance().enable_chunked_prefill())
         << "deepseek_v3 have not supported "
            "enable_chunked_prefill yet. Please disable it.";
+#endif
   }
 };
 TORCH_MODULE(DeepseekV3ForCausalLM);

--- a/xllm/models/models.h
+++ b/xllm/models/models.h
@@ -110,6 +110,7 @@ limitations under the License.
 #include "dit/pipelines/pipeline_qwenimage_edit_plus.h"
 #include "dit/pipelines/pipeline_wan_i2v.h"
 #include "llm/deepseek_v2.h"  // IWYU pragma: keep
+#include "llm/deepseek_v3.h"  // IWYU pragma: keep
 #include "llm/mimo.h"         // IWYU pragma: keep
 #include "llm/mimo_mtp.h"     // IWYU pragma: keep
 #include "llm/qwen2.h"


### PR DESCRIPTION
## Description
Add deepseek-V3/R1/V3.1 FP8 W8A8 support for DCU.

-  add compressed-tensors dynamic channelwise FP8 loading for DCU.
- add AITER FP8 MoE and hipBLASLt FP8 linear support for DCU.
- update flash-attention build support and DeepSeek MLA prefill support for DCU.
- guard NPU sparse attention code for non-NPU builds.

Related models: https://modelscope.cn/organization/hygon?tab=model
<!-- What does this PR do? Briefly describe the changes and why they are needed. -->

## Related Issues

<!-- Link related issues here. Use "Fixes #123" when this PR closes an issue. -->

## Change Type

- [ ] Bug fix
- [x] New feature
- [ ] Performance improvement
- [ ] Refactor
- [ ] Documentation
- [ ] Test
- [ ] Build or CI

## Pull Request Checklist

Thank you for contributing to xLLM. Before requesting review, please make sure the following items are complete.

### PR Title and Commit Messages

- [x] The PR title and each commit message follow the xLLM commit format: `<type>: <subject>`.

> Allowed types: feat, bugfix, docs, test, refactor, chore, style, revert, perf, model, build, release.
> The subject should use clear English, start with a verb, include at least 4 words, and end with `.`.

### Pre-commit Checks

- [x] I have installed `pre-commit` by running `pip install pre-commit` or an equivalent command.
- [x] I have installed the hooks with `pre-commit install`.
- [x] I have run `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

### Self Review

- [x] I have self-reviewed the code according to `.agents/skills/code-review/references/custom-code-style.md`, especially code written or assisted by AI.
- [x] I have rebased this PR onto the latest `main` branch.

### Build and Test Coverage

- [ ] Tests have been added or updated as needed.
- [x] CUDA: `python setup.py build test` has passed on a CUDA machine.
- [ ] NPU: `python setup.py build test` has passed on an NPU machine.
- [ ] MLU: `python setup.py build test` has passed on an MLU machine.

## Reviewer Notes

<!-- Optional: anything reviewers should focus on, known risks, follow-ups, or validation gaps. -->
