### PR TITLE
perf: avoid mega chunk sequence length device reads on npu.

### DIFF
--- a/xllm/core/kernels/npu/xllm_ops/npu_mega_chunk_gdn.cpp
+++ b/xllm/core/kernels/npu/xllm_ops/npu_mega_chunk_gdn.cpp
@@ -72,6 +72,7 @@ std::pair<torch::Tensor, torch::Tensor> npu_mega_chunk_gdn(
     const std::optional<torch::Tensor>& initial_state,
     bool output_final_state,
     const std::optional<torch::Tensor>& cu_seqlens,
+    c10::ArrayRef<int32_t> q_seq_lens,
     bool use_qk_l2norm_in_kernel) {
   const torch::ScalarType input_dtype = q.scalar_type();
 
@@ -93,12 +94,23 @@ std::pair<torch::Tensor, torch::Tensor> npu_mega_chunk_gdn(
   int64_t num_chunks = 0;
   if (cu_seqlens.has_value() && cu_seqlens->defined()) {
     cu_seqlens_int32 = cu_seqlens->to(torch::kInt32);
-    num_sequences = cu_seqlens_int32.numel() - 1;
-    auto cu_cpu = cu_seqlens_int32.to(torch::kCPU);
-    auto cu_data = cu_cpu.accessor<int32_t, 1>();
-    for (int64_t i = 0; i < num_sequences; ++i) {
-      const int64_t seq_len = cu_data[i + 1] - cu_data[i];
-      num_chunks += (seq_len + kMegaChunkSize - 1) / kMegaChunkSize;
+    if (!q_seq_lens.empty()) {
+      num_sequences = static_cast<int64_t>(q_seq_lens.size());
+      CHECK_EQ(cu_seqlens_int32.numel(), num_sequences + 1)
+          << "cu_seqlens and q_seq_lens must describe the same sequences.";
+      for (const int32_t seq_len : q_seq_lens) {
+        CHECK_GE(seq_len, 0) << "q_seq_lens must be non-negative.";
+        num_chunks += (static_cast<int64_t>(seq_len) + kMegaChunkSize - 1) /
+                      kMegaChunkSize;
+      }
+    } else {
+      num_sequences = cu_seqlens_int32.numel() - 1;
+      auto cu_cpu = cu_seqlens_int32.to(torch::kCPU);
+      auto cu_data = cu_cpu.accessor<int32_t, 1>();
+      for (int64_t i = 0; i < num_sequences; ++i) {
+        const int64_t seq_len = cu_data[i + 1] - cu_data[i];
+        num_chunks += (seq_len + kMegaChunkSize - 1) / kMegaChunkSize;
+      }
     }
   } else {
     const int64_t total_tokens = q.size(1);

--- a/xllm/core/kernels/npu/xllm_ops/xllm_ops_api.h
+++ b/xllm/core/kernels/npu/xllm_ops/xllm_ops_api.h
@@ -373,5 +373,6 @@ std::pair<torch::Tensor, torch::Tensor> npu_mega_chunk_gdn(
     const std::optional<torch::Tensor>& initial_state = std::nullopt,
     bool output_final_state = false,
     const std::optional<torch::Tensor>& cu_seqlens = std::nullopt,
+    c10::ArrayRef<int32_t> q_seq_lens = {},
     bool use_qk_l2norm_in_kernel = false);
 }  // namespace xllm::kernel::npu

--- a/xllm/core/kernels/ops_api.cpp
+++ b/xllm/core/kernels/ops_api.cpp
@@ -1943,6 +1943,7 @@ std::pair<torch::Tensor, torch::Tensor> mega_chunk_gdn(
                                  params.initial_state,
                                  params.output_final_state,
                                  params.cu_seqlens,
+                                 params.q_seq_lens,
                                  params.use_qk_l2norm_in_kernel);
 #else
   NOT_IMPLEMENTED();

--- a/xllm/core/kernels/param.h
+++ b/xllm/core/kernels/param.h
@@ -1678,6 +1678,9 @@ struct MegaChunkGdnParams {
   // Optional cumulative sequence lengths. Shape: [num_sequences + 1]. Dtype:
   // int32.
   std::optional<torch::Tensor> cu_seqlens = std::nullopt;
+  // Optional non-owning host sequence lengths. When provided, these avoid
+  // copying cu_seqlens from the device merely to derive the chunk count.
+  c10::ArrayRef<int32_t> q_seq_lens = {};
   // Whether to apply L2 norm to q and k inside the kernel. Default: false.
   bool use_qk_l2norm_in_kernel = false;
 };

--- a/xllm/core/layers/npu_torch/qwen3_gated_delta_net_base.cpp
+++ b/xllm/core/layers/npu_torch/qwen3_gated_delta_net_base.cpp
@@ -840,6 +840,8 @@ torch::Tensor Qwen3GatedDeltaNetBaseImpl::forward(
     mega_chunk_gdn_params.initial_state = initial_state_tensor;
     mega_chunk_gdn_params.output_final_state = true;
     mega_chunk_gdn_params.cu_seqlens = attn_metadata.q_cu_seq_lens;
+    mega_chunk_gdn_params.q_seq_lens = c10::ArrayRef<int32_t>(
+        attn_metadata.q_seq_lens_vec.data(), static_cast<size_t>(batch_size));
     mega_chunk_gdn_params.use_qk_l2norm_in_kernel = true;
     torch::Tensor packed_core_attn_out;
     std::tie(packed_core_attn_out, last_recurrent_state) =


### PR DESCRIPTION
<html>
<body>
<!--StartFragment--><h2>背景</h2><p>Qwen3.5 在 prefill 阶段，每个 LinearAttention 层都会调用一次<br><code>MegaChunkGdn</code>。原有 NPU 封装为了计算 chunk 数量，会将<br><code>q_cu_seq_lens</code> 转换为 int32，再从设备拷贝到 Host，并在 Host 上读取累积<br>序列长度。</p><p>Qwen3.5-27B 包含 48 个 LinearAttention 层，因此每次 prefill 都会产生 48 次<br>不必要的设备回读和 Host 同步。</p><p>Attention metadata 中已有 Host 侧的 <code>q_seq_lens_vec</code>，其中包含计算 chunk<br>数量所需的序列长度。本次修改直接复用该数据，消除 Qwen3.5 prefill 路径上的<br>冗余设备回读。</p><h2>代码改动</h2><ol start="1"><li>在 <code>MegaChunkGdnParams</code> 和 NPU 封装接口中增加可选的、非持有型 Host<br><code>q_seq_lens</code> 视图。</li><li>在 Qwen3.5 prefill 路径中传入 <code>attn_metadata.q_seq_lens_vec</code>。</li><li>直接使用 Host 序列长度计算 <code>num_sequences</code> 和 <code>num_chunks</code>，并增加序列<br>数量一致性与非负长度检查。</li><li>对于未提供 Host 序列长度的调用方，保留原有设备回读路径作为兼容兜底。</li></ol><p>本次修改不改变 MegaChunkGdn Kernel 计算逻辑、Cache 更新语义、Tensor layout<br>及输出结果。</p><h2>关联 Issue</h2><p>无。</p><h2>改动类型</h2><ul><li><div></div>Bug 修复</li><li><div></div>新功能</li><li><div></div>性能优化</li><li><div></div>重构</li><li><div></div>文档</li><li><div></div>测试</li><li><div></div>构建或 CI</li></ul><h2>验证条件</h2><ul><li>基线：最新 <code>main</code>，commit <code>40b5ff57</code>。</li><li>模型：Qwen3.5-27B。</li><li>并行配置：TP2。</li><li>设备：物理 NPU 2、3。</li><li>请求一：129 tokens 输入，1 token 输出。</li><li>请求二：2049 tokens 输入，1 token 输出。</li></ul><h2>验证结果</h2><div><div>
输入长度 | 预期 chunk 数 | 每个 Rank 使用 Host 信息的次数 | 设备回读次数 | 结果
-- | -- | -- | -- | --
129 | 2 | 48 | 0 | 通过
2049 | 17 | 48 | 0 | 通过

</div></div><p>两个模型请求均成功完成，API 返回的实际输入 token 数分别为 129 和 2049,ttft 收益5%。<br>每个 TP Rank 的 48 次 MegaChunkGdn 调用全部使用 <code>source=host</code>，日志中没有出现<br><code>source=device</code> 或 <code>copying cu_seqlens to CPU</code>。</p><p>129 tokens 用例同时覆盖了输入长度未按 128 对齐的场景。</p><h2>优化路径</h2><p>修改前：</p><pre><code>q_cu_seq_lens（NPU）-&gt; int32 转换 -&gt; 拷贝到 CPU -&gt; Host 读取 -&gt; num_chunks</code></pre><p>修改后：</p><pre><code>q_seq_lens_vec（Host）-&gt; num_chunks</code></pre><p>该修改消除了 Qwen3.5-27B 每次 prefill 中的 48 次设备回读和 Host 同步点。</p><h2>本地验证</h2><ul><li>完整 NPU Extension 构建成功。</li><li>xLLM 可执行程序及 Python Export 模块链接成功。</li><li>Qwen3.5-27B TP2 模型级 prefill 验证通过。</li><li>已覆盖非 128 对齐输入长度。</li></ul><!--EndFragment-->
</body>
</html>