### PR TITLE
bugfix: defer stream cancellation to scheduler boundary.

### DIFF
--- a/tests/core/scheduler/continuous_scheduler_test.cpp
+++ b/tests/core/scheduler/continuous_scheduler_test.cpp
@@ -28,7 +28,7 @@ class FakeTokenizer : public Tokenizer {
   }
   std::string decode(const Slice<int32_t>& ids,
                      bool skip_special_tokens) const {
-    NOT_IMPLEMENTED();
+    return "";
   }
   std::optional<int32_t> token_to_id(const std::string_view& token) const {
     NOT_IMPLEMENTED();
@@ -52,7 +52,7 @@ class FakeEngine : public Engine {
     fake_tokenizer_ = std::make_unique<FakeTokenizer>();
     fake_block_manager_ = std::make_unique<BlockManagerPool>(opt, 1);
   }
-  ForwardOutput step(std::vector<Batch>& batch) { NOT_IMPLEMENTED(); }
+  ForwardOutput step(std::vector<Batch>& batch) { return {}; }
   void update_last_step_result(std::vector<Batch>& batch) { NOT_IMPLEMENTED(); }
   const Tokenizer* tokenizer() const { return fake_tokenizer_.get(); }
   BlockManagerPool* block_manager_pool() const {
@@ -60,14 +60,29 @@ class FakeEngine : public Engine {
   }
   const ModelArgs& model_args() const { NOT_IMPLEMENTED(); }
   const TokenizerArgs& tokenizer_args() const { NOT_IMPLEMENTED(); }
-  std::vector<int64_t> get_active_activation_memory() const {
-    NOT_IMPLEMENTED();
-  }
+  std::vector<int64_t> get_active_activation_memory() const { return {0}; }
   bool init() override { return true; }
 
  private:
   std::unique_ptr<Tokenizer> fake_tokenizer_;
   std::unique_ptr<BlockManagerPool> fake_block_manager_;
+};
+
+class TestContinuousScheduler final : public ContinuousScheduler {
+ public:
+  TestContinuousScheduler(Engine* engine, const Options& options)
+      : ContinuousScheduler(engine, options) {}
+
+  void reject_stream(const std::shared_ptr<Request>& request) {
+    response_processor_->process_stream_request(request);
+    response_processor_->wait_completion();
+  }
+
+  void reject_streams(const std::vector<std::shared_ptr<Request>>& requests) {
+    std::vector<std::shared_ptr<Request>> request_copy = requests;
+    response_processor_->batch_process_stream_requests(request_copy);
+    response_processor_->wait_completion();
+  }
 };
 
 template <typename T>
@@ -879,6 +894,105 @@ TEST(ContinuousSchedulerTest, PDDecodeBestOfOneSkipsExpansionAndShares) {
   // teardown (BlockManagerImpl checks all blocks are on the free list).
   block_manager_pool->deallocate_without_cache(seq0);
   (void)engine.release();
+}
+
+TEST(ContinuousSchedulerTest, RejectedStreamCancelsAtSchedulingBoundary) {
+  ContinuousScheduler::Options opt =
+      create_scheduler_options(1024, 16, 0, 1024, 1);
+  opt.enable_schedule_overlap() = false;
+  auto engine = std::make_unique<FakeEngine>(32, 4);
+  auto scheduler = std::make_unique<TestContinuousScheduler>(engine.get(), opt);
+  BlockManagerPool* block_manager_pool = engine->block_manager_pool();
+  const size_t initial_free_blocks =
+      util::max(block_manager_pool->num_free_blocks());
+
+  auto request = generate_request_with_prompt_tokens({1, 2, 3, 4}, 4, 30000);
+  request->state().stream = true;
+  request->state().output_func = [](const RequestOutput&) { return false; };
+  make_request_decode_ready(request);
+  scheduler->add_request(request);
+
+  std::vector<Batch> batch = scheduler->prepare_batch_test();
+  ASSERT_EQ(batch.size(), 1u);
+  ASSERT_EQ(batch[0].size(), 1u);
+  EXPECT_LT(util::max(block_manager_pool->num_free_blocks()),
+            initial_free_blocks);
+
+  scheduler->reject_stream(request);
+
+  EXPECT_FALSE(request->cancelled());
+
+  scheduler->step(absl::ZeroDuration());
+
+  EXPECT_TRUE(request->cancelled());
+  EXPECT_TRUE(scheduler->get_running_requests().empty());
+  EXPECT_EQ(util::max(block_manager_pool->num_free_blocks()),
+            initial_free_blocks);
+
+  scheduler->reject_stream(request);
+  scheduler->step(absl::ZeroDuration());
+
+  EXPECT_TRUE(request->cancelled());
+  EXPECT_TRUE(scheduler->get_running_requests().empty());
+  EXPECT_EQ(util::max(block_manager_pool->num_free_blocks()),
+            initial_free_blocks);
+}
+
+TEST(ContinuousSchedulerTest, BatchRejectedStreamsCancelAtSchedulingBoundary) {
+  ContinuousScheduler::Options opt =
+      create_scheduler_options(1024, 16, 0, 1024, 1);
+  opt.enable_schedule_overlap() = false;
+  auto engine = std::make_unique<FakeEngine>(32, 4);
+  auto scheduler = std::make_unique<TestContinuousScheduler>(engine.get(), opt);
+  BlockManagerPool* block_manager_pool = engine->block_manager_pool();
+
+  std::vector<std::shared_ptr<Request>> requests =
+      generate_request({4, 4},
+                       {4, 4},
+                       std::nullopt,
+                       std::nullopt,
+                       std::nullopt,
+                       std::nullopt,
+                       30000);
+  for (std::shared_ptr<Request>& request : requests) {
+    request->state().stream = true;
+    request->state().output_func = [](const RequestOutput&) { return true; };
+    make_request_decode_ready(request);
+    scheduler->add_request(request);
+  }
+  requests[0]->state().outputs_func = [](const std::vector<RequestOutput>&) {
+    return std::vector<bool>{false, true};
+  };
+
+  std::vector<Batch> batch = scheduler->prepare_batch_test();
+  ASSERT_EQ(batch.size(), 1u);
+  ASSERT_EQ(batch[0].size(), 2u);
+  const size_t free_blocks_before_cancel =
+      util::max(block_manager_pool->num_free_blocks());
+
+  scheduler->reject_streams(requests);
+  scheduler->reject_streams(requests);
+
+  EXPECT_FALSE(requests[0]->cancelled());
+  EXPECT_FALSE(requests[1]->cancelled());
+
+  scheduler->step(absl::ZeroDuration());
+
+  EXPECT_TRUE(requests[0]->cancelled());
+  EXPECT_FALSE(requests[1]->cancelled());
+  ASSERT_EQ(scheduler->get_running_requests().size(), 1u);
+  EXPECT_EQ(scheduler->get_running_requests()[0], requests[1]);
+  EXPECT_GT(util::max(block_manager_pool->num_free_blocks()),
+            free_blocks_before_cancel);
+
+  requests[1]->state().outputs_func = [](const std::vector<RequestOutput>&) {
+    return std::vector<bool>{false};
+  };
+  scheduler->reject_streams({requests[1]});
+  EXPECT_FALSE(requests[1]->cancelled());
+  scheduler->step(absl::ZeroDuration());
+  EXPECT_TRUE(requests[1]->cancelled());
+  EXPECT_TRUE(scheduler->get_running_requests().empty());
 }
 // ============== Async RL training: Pause/Resume tests ==============
 

--- a/xllm/core/scheduler/async_response_processor.cpp
+++ b/xllm/core/scheduler/async_response_processor.cpp
@@ -36,7 +36,8 @@ AsyncResponseProcessor::AsyncResponseProcessor(
     const Tokenizer* tokenizer,
     const std::optional<InstanceRole>& role,
     bool enable_service_routing,
-    bool disable_log_stats)
+    bool disable_log_stats,
+    std::function<void(std::shared_ptr<Request>)> cancel_request)
     : response_threadpool_(
           /*num_threads=*/::xllm::ServiceConfig::get_instance()
               .num_response_handling_threads(),
@@ -52,7 +53,10 @@ AsyncResponseProcessor::AsyncResponseProcessor(
       tokenizer_(tokenizer->clone()),
       role_(role.value_or(InstanceRole::DEFAULT)),
       enable_batch_response_(enable_service_routing),
-      disable_log_stats_(disable_log_stats) {}
+      disable_log_stats_(disable_log_stats),
+      cancel_request_(std::move(cancel_request)) {}
+
+AsyncResponseProcessor::~AsyncResponseProcessor() { wait_completion(); }
 
 void AsyncResponseProcessor::process_failed_request(
     std::shared_ptr<Request> request,
@@ -214,7 +218,8 @@ void AsyncResponseProcessor::process_stream_request(
   if (!is_all_seqs_closed) {
     // output the delta text til the end of the sequence to the client
 
-    auto runnable = [request,
+    auto runnable = [cancel_request = cancel_request_,
+                     request,
                      this,
                      indexes = std::move(indexes),
                      num_tokens = std::move(num_tokens)]() {
@@ -232,8 +237,7 @@ void AsyncResponseProcessor::process_stream_request(
         }
       }
       if (!request->state().output_func(req_output)) {
-        // cancel the request if on_stream returns false
-        request->set_cancel();
+        cancel_request(request);
       }
     };
     if (request->state().response_thread_id < 0) {
@@ -318,7 +322,8 @@ void AsyncResponseProcessor::batch_process_stream_requests(
   }
 
   rpc_threadpool_.schedule(
-      [counter = std::unique_ptr<BlockingCounter>(counter),
+      [cancel_request = cancel_request_,
+       counter = std::unique_ptr<BlockingCounter>(counter),
        requests = std::move(requests),
        request_outputs = std::move(request_outputs)]() mutable {
         auto& resp_callback = requests[0]->state().outputs_func;
@@ -326,8 +331,7 @@ void AsyncResponseProcessor::batch_process_stream_requests(
         std::vector<bool> status_set = resp_callback(request_outputs);
         for (size_t i = 0; i < requests.size(); ++i) {
           if (!status_set[i]) {
-            // cancel the request if on_stream returns false
-            requests[i]->set_cancel();
+            cancel_request(requests[i]);
           }
         }
       });

--- a/xllm/core/scheduler/async_response_processor.h
+++ b/xllm/core/scheduler/async_response_processor.h
@@ -15,6 +15,7 @@ limitations under the License.
 
 #pragma once
 #include <cstdint>
+#include <functional>
 
 #include "common/macros.h"
 #include "common/types.h"
@@ -28,11 +29,13 @@ class Sequence;
 class Tokenizer;
 class AsyncResponseProcessor final {
  public:
-  AsyncResponseProcessor(const Tokenizer* tokenizer,
-                         const std::optional<InstanceRole>& role,
-                         bool enable_service_routing,
-                         bool disable_log_stats);
-  virtual ~AsyncResponseProcessor() = default;
+  AsyncResponseProcessor(
+      const Tokenizer* tokenizer,
+      const std::optional<InstanceRole>& role,
+      bool enable_service_routing,
+      bool disable_log_stats,
+      std::function<void(std::shared_ptr<Request>)> cancel_request);
+  ~AsyncResponseProcessor();
 
   void process_completed_request(std::shared_ptr<Request> request);
 
@@ -77,6 +80,8 @@ class AsyncResponseProcessor final {
   bool enable_batch_response_ = false;
 
   bool disable_log_stats_ = false;
+
+  std::function<void(std::shared_ptr<Request>)> cancel_request_;
 };
 
 }  // namespace xllm

--- a/xllm/core/scheduler/continuous_scheduler.cpp
+++ b/xllm/core/scheduler/continuous_scheduler.cpp
@@ -99,6 +99,18 @@ inline size_t maybe_align_cp_prefill_tokens(const Sequence* sequence,
 
 }  // namespace
 
+void CancelRequestQueue::submit(std::shared_ptr<Request> request) {
+  std::lock_guard<std::mutex> lock(mutex_);
+  requests_.emplace_back(std::move(request));
+}
+
+std::vector<std::shared_ptr<Request>> CancelRequestQueue::take_all() {
+  std::vector<std::shared_ptr<Request>> requests;
+  std::lock_guard<std::mutex> lock(mutex_);
+  requests.swap(requests_);
+  return requests;
+}
+
 ContinuousScheduler::ContinuousScheduler(Engine* engine, const Options& options)
     : options_(options),
       engine_(engine),
@@ -130,11 +142,16 @@ ContinuousScheduler::ContinuousScheduler(Engine* engine, const Options& options)
   profile_manager_ =
       std::make_unique<ProfileManager>(engine, profile_manager_options);
 
+  cancel_request_queue_ = std::make_shared<CancelRequestQueue>();
   response_processor_ = std::make_unique<AsyncResponseProcessor>(
       engine_->tokenizer(),
       options_.instance_role(),
       options_.enable_service_routing(),
-      options_.disable_log_stats());
+      options_.disable_log_stats(),
+      [cancel_request_queue =
+           cancel_request_queue_](std::shared_ptr<Request> request) {
+        cancel_request_queue->submit(std::move(request));
+      });
   create_waiting_queue(options);
   create_running_queue(options);
   if (options_.enable_service_routing()) {
@@ -1210,6 +1227,7 @@ std::vector<Batch> ContinuousScheduler::schedule_request(
   const auto deadline = absl::Now() + timeout;
   std::vector<Batch> batch;
   while (true) {
+    apply_cancel_requests();
     batch = prepare_batch();
     bool all_empty =
         std::all_of(batch.begin(), batch.end(), [](const Batch& one_batch) {
@@ -1235,6 +1253,14 @@ std::vector<Batch> ContinuousScheduler::schedule_request(
   }
   // return an empty batch
   return batch;
+}
+
+void ContinuousScheduler::apply_cancel_requests() {
+  std::vector<std::shared_ptr<Request>> requests =
+      cancel_request_queue_->take_all();
+  for (const std::shared_ptr<Request>& request : requests) {
+    request->set_cancel();
+  }
 }
 
 // step the scheduler forward by one step

--- a/xllm/core/scheduler/continuous_scheduler.h
+++ b/xllm/core/scheduler/continuous_scheduler.h
@@ -44,6 +44,16 @@ namespace xllm {
 class Engine;
 class RequestPriorityQueue;
 
+class CancelRequestQueue final {
+ public:
+  void submit(std::shared_ptr<Request> request);
+  std::vector<std::shared_ptr<Request>> take_all();
+
+ private:
+  std::mutex mutex_;
+  std::vector<std::shared_ptr<Request>> requests_;
+};
+
 class ContinuousScheduler : public Scheduler {
  public:
   struct Options {
@@ -272,6 +282,8 @@ class ContinuousScheduler : public Scheduler {
   // low.
   std::deque<std::shared_ptr<Request>> preemptable_requests_;
 
+  std::shared_ptr<CancelRequestQueue> cancel_request_queue_;
+
   std::unique_ptr<AsyncResponseProcessor> response_processor_;
 
   std::unique_ptr<ProfileManager> profile_manager_;
@@ -385,6 +397,8 @@ class ContinuousScheduler : public Scheduler {
   std::condition_variable pause_cv_;
 
  private:
+  void apply_cancel_requests();
+
   std::vector<Batch> schedule_request(const absl::Duration& timeout);
 
   virtual void update_token_latency_metrics(std::vector<Sequence*>& sequences);


### PR DESCRIPTION

## Description

Issue: In PD-disaggregated serving, a failed Decode streaming response could cancel a request
  asynchronously between the scheduler’s terminal-state scan and running-queue rebuild, violating
  scheduler invariants and triggering a fatal error that terminated the Decode process.

  Fix: Defer streaming cancellations through a thread-safe queue and apply them at the next scheduler
  boundary, ensuring safe state transitions and KV Cache release. The fix supports single, batched,
  duplicate, and late cancellations, with corresponding unit-test coverage.

## Change Type

- [x] Bug fix
- [ ] New feature
- [ ] Performance improvement
- [ ] Refactor
- [ ] Documentation
- [ ] Test
- [ ] Build or CI

## Pull Request Checklist

Thank you for contributing to xLLM. Before requesting review, please make sure the following items are complete.

### PR Title and Commit Messages

- [x] The PR title and each commit message follow the xLLM commit format: `<type>: <subject>`.

> Allowed types: feat, bugfix, docs, test, refactor, chore, style, revert, perf, model, build, release.
> The subject should use clear English, start with a verb, include at least 4 words, and end with `.`.

### Pre-commit Checks

- [x] I have installed `pre-commit` by running `pip install pre-commit` or an equivalent command.
- [x] I have installed the hooks with `pre-commit install`.
- [x] I have run `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

### Self Review

- [x] I have self-reviewed the code according to `.agents/skills/code-review/references/custom-code-style.md`, especially code written or assisted by AI.
- [x] I have rebased this PR onto the latest `main` branch.

### Build and Test Coverage

- [ ] Tests have been added or updated as needed.
- [ ] CUDA: `python setup.py build test` has passed on a CUDA machine.
- [x] NPU: `python setup.py build test` has passed on an NPU machine.
- [x] MLU: `python setup.py build test` has passed on an MLU machine.

## Reviewer Notes

<!-- Optional: anything reviewers should focus on, known risks, follow-ups, or validation gaps. -->
