### PR TITLE
refactor: declare overriding functions override.

### DIFF
--- a/.agents/skills/code-review/references/custom-code-style.md
+++ b/.agents/skills/code-review/references/custom-code-style.md
@@ -153,7 +153,13 @@ ModelArgs(const std::string& path, int32_t num_layers = 12);
 // Good
 ModelOutput forward(torch::Tensor tokens, ...) override;
 
-// Bad
+// Bad – missing override
+ModelOutput forward(torch::Tensor tokens, ...);
+
+// Bad – redundant virtual on override
+virtual ModelOutput forward(torch::Tensor tokens, ...) override;
+
+// Bad – missing override (virtual-only in derived class)
 virtual ModelOutput forward(torch::Tensor tokens, ...);
 ```
 

--- a/xllm/core/distributed_runtime/comm_channel.cpp
+++ b/xllm/core/distributed_runtime/comm_channel.cpp
@@ -485,13 +485,13 @@ class ClientStreamReceiver : public brpc::StreamInputHandler {
     return 0;
   }
 
-  virtual void on_idle_timeout(brpc::StreamId id) override {
+  void on_idle_timeout(brpc::StreamId id) override {
     if (!promise_set_.exchange(true)) {
       close_promise_.set_value();
     }
   }
 
-  virtual void on_closed(brpc::StreamId id) override {
+  void on_closed(brpc::StreamId id) override {
     if (!promise_set_.exchange(true)) {
       close_promise_.set_value();
     }

--- a/xllm/core/distributed_runtime/disagg_pd_service.h
+++ b/xllm/core/distributed_runtime/disagg_pd_service.h
@@ -40,25 +40,25 @@ class DisaggPDService : public proto::DisaggPDService {
                        ::google::protobuf::Closure* done) override;
 
   // for decode recv multiple tokens from prefill
-  virtual void MultiGenerations(::google::protobuf::RpcController* controller,
-                                const proto::DisaggGenerationsRequests* request,
-                                proto::Status* response,
-                                ::google::protobuf::Closure* done) override;
+  void MultiGenerations(::google::protobuf::RpcController* controller,
+                        const proto::DisaggGenerationsRequests* request,
+                        proto::Status* response,
+                        ::google::protobuf::Closure* done) override;
 
-  virtual void SendPullSignal(::google::protobuf::RpcController* controller,
-                              const proto::PullSignal* request,
-                              proto::Status* response,
-                              ::google::protobuf::Closure* done) override;
+  void SendPullSignal(::google::protobuf::RpcController* controller,
+                      const proto::PullSignal* request,
+                      proto::Status* response,
+                      ::google::protobuf::Closure* done) override;
 
-  virtual void LinkInstance(::google::protobuf::RpcController* controller,
-                            const proto::InstanceClusterInfo* request,
-                            proto::Status* response,
-                            ::google::protobuf::Closure* done) override;
+  void LinkInstance(::google::protobuf::RpcController* controller,
+                    const proto::InstanceClusterInfo* request,
+                    proto::Status* response,
+                    ::google::protobuf::Closure* done) override;
 
-  virtual void UnlinkInstance(::google::protobuf::RpcController* controller,
-                              const proto::InstanceClusterInfo* request,
-                              proto::Status* response,
-                              ::google::protobuf::Closure* done) override;
+  void UnlinkInstance(::google::protobuf::RpcController* controller,
+                      const proto::InstanceClusterInfo* request,
+                      proto::Status* response,
+                      ::google::protobuf::Closure* done) override;
 
  protected:
   std::unique_ptr<DisaggPDServiceImpl> disagg_pd_service_impl_;

--- a/xllm/core/distributed_runtime/remote_worker.h
+++ b/xllm/core/distributed_runtime/remote_worker.h
@@ -47,31 +47,31 @@ class RemoteWorker : public WorkerClient {
 
   bool wait_for_server_ready(const std::string& server_address);
 
-  virtual bool init_model(const std::string& model_weights_path,
-                          int32_t random_seed,
-                          MasterStatus master_status) override;
+  bool init_model(const std::string& model_weights_path,
+                  int32_t random_seed,
+                  MasterStatus master_status) override;
 
-  virtual std::tuple<int64_t, int64_t> estimate_kv_cache_capacity() override;
+  std::tuple<int64_t, int64_t> estimate_kv_cache_capacity() override;
 
-  virtual bool allocate_kv_cache(const KVCacheShape& kv_cache_shape) override;
+  bool allocate_kv_cache(const KVCacheShape& kv_cache_shape) override;
 
-  virtual void get_cache_info(uint64_t& cluster_id,
-                              std::string& addr,
-                              uint16_t& port) override;
+  void get_cache_info(uint64_t& cluster_id,
+                      std::string& addr,
+                      uint16_t& port) override;
 
-  virtual bool link_cluster(const std::vector<uint64_t>& cluster_ids,
-                            const std::vector<std::string>& addrs,
-                            const std::vector<uint16_t>& ports) override;
+  bool link_cluster(const std::vector<uint64_t>& cluster_ids,
+                    const std::vector<std::string>& addrs,
+                    const std::vector<uint16_t>& ports) override;
 
-  virtual bool unlink_cluster(const std::vector<uint64_t>& cluster_ids,
-                              const std::vector<std::string>& addrs,
-                              const std::vector<uint16_t>& ports) override;
+  bool unlink_cluster(const std::vector<uint64_t>& cluster_ids,
+                      const std::vector<std::string>& addrs,
+                      const std::vector<uint16_t>& ports) override;
 
   // P2P link for weight transfer
-  virtual bool link_p2p(const std::string& remote_addr) override;
-  virtual bool unlink_p2p(const std::string& remote_addr) override;
+  bool link_p2p(const std::string& remote_addr) override;
+  bool unlink_p2p(const std::string& remote_addr) override;
 
-  virtual bool pull_kv_blocks(
+  bool pull_kv_blocks(
       const uint64_t src_cluster_id,
       const std::string& src_addr,
       const std::vector<uint64_t>& src_blocks,
@@ -88,26 +88,25 @@ class RemoteWorker : public WorkerClient {
       const std::vector<uint64_t>& dst_linear_state_ids = {}) override;
 
   // prepare input request
-  virtual ForwardInput prepare_inputs(Batch& batch) override;
+  ForwardInput prepare_inputs(Batch& batch) override;
 
-  virtual std::optional<ForwardOutput> step(
-      const ForwardInput& inputs) override;
+  std::optional<ForwardOutput> step(const ForwardInput& inputs) override;
 
-  virtual folly::SemiFuture<bool> init_model_async(
+  folly::SemiFuture<bool> init_model_async(
       const std::string& model_weights_path,
       int32_t random_seed,
       MasterStatus master_status) override;
 
-  virtual folly::SemiFuture<std::tuple<int64_t, int64_t>>
+  folly::SemiFuture<std::tuple<int64_t, int64_t>>
   estimate_kv_cache_capacity_async() override;
 
-  virtual folly::SemiFuture<bool> allocate_kv_cache_async(
+  folly::SemiFuture<bool> allocate_kv_cache_async(
       const KVCacheShape& kv_cache_shape) override;
 
-  virtual folly::SemiFuture<bool> allocate_kv_cache_with_transfer_async(
+  folly::SemiFuture<bool> allocate_kv_cache_with_transfer_async(
       const KVCacheShape& kv_cache_shape) override;
 
-  virtual folly::SemiFuture<bool> pull_kv_blocks_async(
+  folly::SemiFuture<bool> pull_kv_blocks_async(
       const uint64_t src_cluster_id,
       const std::string& src_addr,
       const std::vector<uint64_t>& src_blocks,
@@ -115,36 +114,35 @@ class RemoteWorker : public WorkerClient {
       const std::vector<uint64_t>& src_linear_state_ids = {},
       const std::vector<uint64_t>& dst_linear_state_ids = {}) override;
 
-  virtual folly::SemiFuture<uint32_t> transfer_kv_blocks(
+  folly::SemiFuture<uint32_t> transfer_kv_blocks(
       const std::vector<BlockTransferInfo>& block_transfer_info) override;
 
-  virtual void transfer_kv_blocks(
+  void transfer_kv_blocks(
       const uint64_t batch_id,
       const std::vector<BlockTransferInfo>& block_transfer_info) override;
 
-  virtual void prefetch_from_storage(
+  void prefetch_from_storage(
       const std::vector<BlockTransferInfo>& block_transfer_info,
       std::shared_ptr<std::atomic<int32_t>> flag,
       std::shared_ptr<std::atomic<uint32_t>> success_cnt) override;
 
   // Run the model and return the output.
-  virtual folly::SemiFuture<std::optional<ForwardOutput>> step_async(
+  folly::SemiFuture<std::optional<ForwardOutput>> step_async(
       const ForwardInput& inputs) override;
 
-  virtual folly::SemiFuture<std::optional<RawForwardOutput>> step_remote_async(
+  folly::SemiFuture<std::optional<RawForwardOutput>> step_remote_async(
       const ForwardInput& inputs) override;
 
-  virtual folly::SemiFuture<folly::Unit> process_group_test_async() override;
+  folly::SemiFuture<folly::Unit> process_group_test_async() override;
 
-  virtual const torch::Device& device() const override;
+  const torch::Device& device() const override;
 
   folly::SemiFuture<std::optional<RawForwardOutput>>
   get_last_step_result_async();
 
-  virtual int64_t get_active_activation_memory() override;
+  int64_t get_active_activation_memory() override;
 
-  virtual folly::SemiFuture<int64_t> get_active_activation_memory_async()
-      override;
+  folly::SemiFuture<int64_t> get_active_activation_memory_async() override;
 
   // Check if the connection to worker is healthy
   bool check_health();
@@ -152,18 +150,16 @@ class RemoteWorker : public WorkerClient {
   // Get worker global rank
   int32_t global_rank() const { return global_rank_; }
 
-  virtual folly::SemiFuture<bool> sleep_async(
-      MasterStatus master_status) override;
+  folly::SemiFuture<bool> sleep_async(MasterStatus master_status) override;
 
-  virtual folly::SemiFuture<bool> wakeup_async(
-      const WakeupOptions& options) override;
+  folly::SemiFuture<bool> wakeup_async(const WakeupOptions& options) override;
 
-  virtual folly::SemiFuture<bool> update_weights_async(
+  folly::SemiFuture<bool> update_weights_async(
       const std::string& weights_path) override;
 
-  virtual folly::SemiFuture<bool> start_profile_async() override;
+  folly::SemiFuture<bool> start_profile_async() override;
 
-  virtual folly::SemiFuture<bool> stop_profile_async() override;
+  folly::SemiFuture<bool> stop_profile_async() override;
 
  private:
   DISALLOW_COPY_AND_ASSIGN(RemoteWorker);

--- a/xllm/core/framework/block/block_manager_pool.h
+++ b/xllm/core/framework/block/block_manager_pool.h
@@ -70,42 +70,41 @@ class BlockManagerPool : public KVCacheManager {
 
   ~BlockManagerPool() = default;
 
-  virtual bool allocate(Sequence* sequence) override;
-  virtual bool allocate(std::vector<Sequence*>& sequences) override;
-  virtual bool allocate(Sequence* sequence, size_t num_tokens) override;
-  virtual bool allocate(Sequence* sequence,
-                        size_t num_tokens,
-                        size_t needed_copy_in_blocks_num) override;
+  bool allocate(Sequence* sequence) override;
+  bool allocate(std::vector<Sequence*>& sequences) override;
+  bool allocate(Sequence* sequence, size_t num_tokens) override;
+  bool allocate(Sequence* sequence,
+                size_t num_tokens,
+                size_t needed_copy_in_blocks_num) override;
 
   // Try to allocate blocks with num_tokens,
   // return {} if not enough blocks
-  virtual std::vector<Block> allocate(size_t num_tokens,
-                                      int32_t& dp_rank) override;
+  std::vector<Block> allocate(size_t num_tokens, int32_t& dp_rank) override;
 
-  virtual bool try_allocate(Sequence* sequence) override;
+  bool try_allocate(Sequence* sequence) override;
 
-  virtual void deallocate(Request* request) override;
-  virtual void deallocate(std::vector<Sequence*>& sequences) override;
-  virtual void deallocate(Sequence* sequence) override;
+  void deallocate(Request* request) override;
+  void deallocate(std::vector<Sequence*>& sequences) override;
+  void deallocate(Sequence* sequence) override;
 
   void deallocate_without_cache(Sequence* sequence);
 
-  virtual void allocate_shared(Sequence* sequence) override;
-  virtual void cache(Sequence* sequence) override;
-  virtual void cache(Sequence* sequence, size_t num_tokens) override;
+  void allocate_shared(Sequence* sequence) override;
+  void cache(Sequence* sequence) override;
+  void cache(Sequence* sequence, size_t num_tokens) override;
 
-  virtual std::vector<std::vector<BlockTransferInfo>>*
-  get_swap_block_transfer_infos() override;
+  std::vector<std::vector<BlockTransferInfo>>* get_swap_block_transfer_infos()
+      override;
 
   virtual float get_gpu_cache_usage_perc() const;
 
-  virtual uint32_t num_blocks() const override;
-  virtual int32_t block_size() const override;
+  uint32_t num_blocks() const override;
+  int32_t block_size() const override;
   void reset_prefix_cache() override;
-  virtual std::vector<size_t> num_blocks_in_prefix_cache() const override;
-  virtual std::vector<size_t> num_free_blocks() const override;
-  virtual std::vector<size_t> num_used_blocks() const override;
-  virtual double kv_cache_utilization() const override;
+  std::vector<size_t> num_blocks_in_prefix_cache() const override;
+  std::vector<size_t> num_free_blocks() const override;
+  std::vector<size_t> num_used_blocks() const override;
+  double kv_cache_utilization() const override;
 
   // get the options for the block manager
   const Options& options() const { return options_; }

--- a/xllm/core/framework/kv_cache_transfer/llm_data_dist_transfer.h
+++ b/xllm/core/framework/kv_cache_transfer/llm_data_dist_transfer.h
@@ -40,30 +40,30 @@ class LlmDataDistTransfer : public KVCacheTransfer {
   LlmDataDistTransfer(const uint16_t listen_port,
                       const InstanceRole& instance_role,
                       bool enable_lighting_indexer = false);
-  virtual ~LlmDataDistTransfer() = default;
+  ~LlmDataDistTransfer() override = default;
 
-  virtual void initialize(int32_t device_id) override;
+  void initialize(int32_t device_id) override;
 
-  virtual void finalize() override;
+  void finalize() override;
 
-  virtual void register_kv_cache(std::vector<xllm::KVCache>& kv_caches,
-                                 const KVCacheShape& kv_cache_shape,
-                                 const torch::ScalarType dtype) override;
+  void register_kv_cache(std::vector<xllm::KVCache>& kv_caches,
+                         const KVCacheShape& kv_cache_shape,
+                         const torch::ScalarType dtype) override;
 
-  virtual void free_kv_cache() override;
+  void free_kv_cache() override;
 
-  virtual void get_cache_info(uint64_t& cluster_id, std::string& addr) override;
+  void get_cache_info(uint64_t& cluster_id, std::string& addr) override;
 
-  virtual bool link_cluster(const uint64_t cluster_id,
-                            const std::string& remote_addr,
-                            const uint16_t port) override;
+  bool link_cluster(const uint64_t cluster_id,
+                    const std::string& remote_addr,
+                    const uint16_t port) override;
 
-  virtual bool unlink_cluster(const uint64_t& cluster_id,
-                              const std::string& remote_addr,
-                              const uint16_t port,
-                              bool force_flag = true) override;
+  bool unlink_cluster(const uint64_t& cluster_id,
+                      const std::string& remote_addr,
+                      const uint16_t port,
+                      bool force_flag = true) override;
 
-  virtual bool pull_kv_blocks(
+  bool pull_kv_blocks(
       const uint64_t src_cluster_id,
       const std::string& src_addr,
       const std::vector<uint64_t>& src_blocks,
@@ -71,7 +71,7 @@ class LlmDataDistTransfer : public KVCacheTransfer {
       const std::vector<uint64_t>& src_linear_state_ids,
       const std::vector<uint64_t>& dst_linear_state_ids) override;
 
-  virtual bool push_kv_blocks(
+  bool push_kv_blocks(
       std::unordered_map<std::string, KVCacheInfo>& merged_kv_infos,
       std::shared_ptr<NPULayerSynchronizerImpl>& layer_synchronizer,
       bool is_spec_draft,

--- a/xllm/core/framework/kv_cache_transfer/mooncake_transfer_engine.h
+++ b/xllm/core/framework/kv_cache_transfer/mooncake_transfer_engine.h
@@ -150,17 +150,17 @@ class MooncakeTransferEngineService
  public:
   MooncakeTransferEngineService() = default;
 
-  virtual ~MooncakeTransferEngineService() = default;
+  ~MooncakeTransferEngineService() override = default;
 
-  virtual void OpenSession(google::protobuf::RpcController* controller,
-                           const proto::SessionInfo* request,
-                           proto::Status* response,
-                           google::protobuf::Closure* done) override;
+  void OpenSession(google::protobuf::RpcController* controller,
+                   const proto::SessionInfo* request,
+                   proto::Status* response,
+                   google::protobuf::Closure* done) override;
 
-  virtual void CloseSession(google::protobuf::RpcController* controller,
-                            const proto::SessionInfo* request,
-                            proto::Status* response,
-                            google::protobuf::Closure* done) override;
+  void CloseSession(google::protobuf::RpcController* controller,
+                    const proto::SessionInfo* request,
+                    proto::Status* response,
+                    google::protobuf::Closure* done) override;
 };
 
 }  // namespace xllm

--- a/xllm/core/framework/model/causal_lm.h
+++ b/xllm/core/framework/model/causal_lm.h
@@ -304,13 +304,12 @@ class CausalLMImpl : public CausalLM {
     }
   }
 
-  virtual void prepare_expert_weight(
-      int32_t layer_id,
-      const std::vector<int32_t>& expert_ids) override {
+  void prepare_expert_weight(int32_t layer_id,
+                             const std::vector<int32_t>& expert_ids) override {
     return model_->prepare_expert_weight(layer_id, expert_ids);
   }
 
-  virtual void update_expert_weight(int32_t layer_id) {
+  void update_expert_weight(int32_t layer_id) override {
     return model_->update_expert_weight(layer_id);
   }
 

--- a/xllm/core/framework/model/causal_vlm.h
+++ b/xllm/core/framework/model/causal_vlm.h
@@ -92,7 +92,7 @@ class CausalVLMImpl : public CausalVLM {
     return;
   }
 
-  virtual void update_expert_weight(int32_t layer_id) { return; }
+  void update_expert_weight(int32_t layer_id) override { return; }
 
 #if defined(USE_NPU)
   layer::NpuLmHead get_npu_lm_head() override {

--- a/xllm/core/framework/multimodal/mm_embedding_handler.h
+++ b/xllm/core/framework/multimodal/mm_embedding_handler.h
@@ -25,10 +25,10 @@ class MMEmbeddingHandler : public MMHandlerBase {
   MMEmbeddingHandler(MMType::Value mm_type);
   ~MMEmbeddingHandler() = default;
 
-  virtual MMErrCode load(const MMContent& content,
-                         MMInputItem& input,
-                         MMPayload& payload) override;
-  virtual MMErrCode decode(MMInputItem& input) override;
+  MMErrCode load(const MMContent& content,
+                 MMInputItem& input,
+                 MMPayload& payload) override;
+  MMErrCode decode(MMInputItem& input) override;
 
  private:
   MMType::Value mm_type_;

--- a/xllm/core/layers/npu/npu_base_layer.h
+++ b/xllm/core/layers/npu/npu_base_layer.h
@@ -108,7 +108,7 @@ enum class LinearTypeV2 : int {
 class BaseLayer : public torch::nn::Module {
  public:
   explicit BaseLayer(const ModelContext& context);
-  virtual ~BaseLayer() override = default;
+  ~BaseLayer() override = default;
 
   atb::Status execute_node(atb_speed::Model::Node& node,
                            int nodeId = 0,

--- a/xllm/core/layers/npu/npu_column_parallel_linear_impl.h
+++ b/xllm/core/layers/npu/npu_column_parallel_linear_impl.h
@@ -52,9 +52,9 @@ class NpuColumnParallelLinearImpl : public BaseLayer {
 
   ~NpuColumnParallelLinearImpl() override = default;
 
-  virtual void merge_loaded_weights() override;
+  void merge_loaded_weights() override;
 
-  virtual int64_t init_layer() override;
+  int64_t init_layer() override;
 
   virtual torch::Tensor forward(const torch::Tensor& input, int nodeId);
 

--- a/xllm/core/layers/npu/npu_deepseek_v2_decoder_layer_impl.h
+++ b/xllm/core/layers/npu/npu_deepseek_v2_decoder_layer_impl.h
@@ -117,7 +117,7 @@ class NpuDeepseekV2DecoderLayerImpl : public BaseLayer {
 
   void update_expert_weight();
 
-  virtual int64_t init_layer() override;
+  int64_t init_layer() override;
 
   torch::Tensor forward(torch::Tensor& x,
                         torch::Tensor& cos_pos,

--- a/xllm/core/layers/npu/npu_deepseek_v32_decoder_layer_impl.h
+++ b/xllm/core/layers/npu/npu_deepseek_v32_decoder_layer_impl.h
@@ -42,7 +42,7 @@ class NpuDeepseekV32DecoderLayerImpl : public BaseLayer {
 
   ~NpuDeepseekV32DecoderLayerImpl() {};
 
-  virtual void merge_loaded_weights() override;
+  void merge_loaded_weights() override;
 
   torch::Tensor build_expert_routing_map(std::vector<int32_t> expert_lists);
 
@@ -50,7 +50,7 @@ class NpuDeepseekV32DecoderLayerImpl : public BaseLayer {
 
   void update_expert_weight();
 
-  virtual int64_t init_layer() override;
+  int64_t init_layer() override;
 
   torch::Tensor forward(torch::Tensor& x,
                         torch::Tensor& cos_pos,

--- a/xllm/core/layers/npu/npu_eagle3_decoder_layer_impl.h
+++ b/xllm/core/layers/npu/npu_eagle3_decoder_layer_impl.h
@@ -50,9 +50,9 @@ class NpuEagle3DecoderLayerImpl : public BaseLayer {
 
   ~NpuEagle3DecoderLayerImpl() override = default;
 
-  virtual void merge_loaded_weights() override;
+  void merge_loaded_weights() override;
 
-  virtual int64_t init_layer() override;
+  int64_t init_layer() override;
 
   torch::Tensor forward(torch::Tensor& hidden_states,
                         torch::Tensor& hidden_states_extra,

--- a/xllm/core/layers/npu/npu_glm4_decoder_layer_impl.h
+++ b/xllm/core/layers/npu/npu_glm4_decoder_layer_impl.h
@@ -50,7 +50,7 @@ class NpuGlm4DecoderLayerImpl : public BaseLayer {
 
   ~NpuGlm4DecoderLayerImpl() override = default;
 
-  virtual int64_t init_layer() override;
+  int64_t init_layer() override;
 
   torch::Tensor forward(torch::Tensor& x,
                         torch::Tensor& cos_pos,

--- a/xllm/core/layers/npu/npu_llama_decoder_layer_impl.h
+++ b/xllm/core/layers/npu/npu_llama_decoder_layer_impl.h
@@ -49,9 +49,9 @@ class NpuLlamaDecoderLayerImpl : public BaseLayer {
 
   ~NpuLlamaDecoderLayerImpl() override = default;
 
-  virtual void merge_loaded_weights() override;
+  void merge_loaded_weights() override;
 
-  virtual int64_t init_layer() override;
+  int64_t init_layer() override;
 
   torch::Tensor forward(torch::Tensor& x,
                         torch::Tensor& cos_pos,

--- a/xllm/core/layers/npu/npu_qwen2_decoder_layer_impl.h
+++ b/xllm/core/layers/npu/npu_qwen2_decoder_layer_impl.h
@@ -50,9 +50,9 @@ class NpuQwen2DecoderLayerImpl : public BaseLayer {
 
   ~NpuQwen2DecoderLayerImpl() override = default;
 
-  virtual void merge_loaded_weights() override;
+  void merge_loaded_weights() override;
 
-  virtual int64_t init_layer() override;
+  int64_t init_layer() override;
 
   torch::Tensor forward(torch::Tensor& x,
                         torch::Tensor& cos_pos,

--- a/xllm/core/layers/npu/npu_qwen3_decoder_layer_impl.h
+++ b/xllm/core/layers/npu/npu_qwen3_decoder_layer_impl.h
@@ -49,7 +49,7 @@ class NpuQwen3DecoderLayerImpl : public BaseLayer {
 
   ~NpuQwen3DecoderLayerImpl() override = default;
 
-  virtual int64_t init_layer() override;
+  int64_t init_layer() override;
 
   torch::Tensor forward(torch::Tensor& x,
                         torch::Tensor& cos_pos,

--- a/xllm/core/layers/npu/npu_qwen3_moe_decoder_layer_impl.h
+++ b/xllm/core/layers/npu/npu_qwen3_moe_decoder_layer_impl.h
@@ -44,9 +44,9 @@ class NpuQwen3MoeDecoderLayerImpl : public BaseLayer {
 
   ~NpuQwen3MoeDecoderLayerImpl() override = default;
 
-  virtual void merge_loaded_weights();
+  void merge_loaded_weights() override;
 
-  virtual int64_t init_layer() override;
+  int64_t init_layer() override;
 
   torch::Tensor forward(torch::Tensor& x,
                         std::optional<torch::Tensor>& residual,

--- a/xllm/core/layers/npu/npu_siglip_encoder_layer_impl.h
+++ b/xllm/core/layers/npu/npu_siglip_encoder_layer_impl.h
@@ -34,7 +34,7 @@ class NpuSiglipEncoderLayerUpImpl : public BaseLayer {
 
   ~NpuSiglipEncoderLayerUpImpl() override = default;
 
-  virtual void load_state_dict(const StateDict& state_dict) override;
+  void load_state_dict(const StateDict& state_dict) override;
 
   torch::Tensor forward(const torch::Tensor& x);
 
@@ -59,7 +59,7 @@ class NpuSiglipEncoderLayerDownImpl : public BaseLayer {
 
   ~NpuSiglipEncoderLayerDownImpl() override = default;
 
-  virtual void load_state_dict(const StateDict& state_dict) override;
+  void load_state_dict(const StateDict& state_dict) override;
 
   torch::Tensor forward(torch::Tensor& x, torch::Tensor& y);
 
@@ -84,7 +84,7 @@ class NpuSiglipEncoderLayerImpl : public BaseLayer {
 
   ~NpuSiglipEncoderLayerImpl() override = default;
 
-  virtual void load_state_dict(const StateDict& state_dict) override;
+  void load_state_dict(const StateDict& state_dict) override;
 
   void verify_loaded_weights(const std::string& weight_str) const {};
 

--- a/xllm/core/runtime/dit_worker_impl.h
+++ b/xllm/core/runtime/dit_worker_impl.h
@@ -37,7 +37,7 @@ class DiTWorkerImpl : public WorkerImpl {
                 const torch::Device& device,
                 const runtime::Options& options);
 
-  ~DiTWorkerImpl() = default;
+  ~DiTWorkerImpl() override = default;
 
   // initialize model, cache manager. blocking call
   bool init_model(const std::string& model_weights_path,
@@ -54,14 +54,14 @@ class DiTWorkerImpl : public WorkerImpl {
   std::optional<ForwardOutput> step(const ForwardInput& inputs) override;
 
   folly::SemiFuture<std::optional<ForwardOutput>> step_async(
-      const ForwardInput& inputs);
+      const ForwardInput& inputs) override;
 
   folly::SemiFuture<std::optional<DiTForwardOutput>> step_async(
       const DiTForwardInput& inputs);
 
-  void process_group_test();
+  void process_group_test() override;
 
-  folly::SemiFuture<folly::Unit> process_group_test_async();
+  folly::SemiFuture<folly::Unit> process_group_test_async() override;
 
   // prepare input for execution
   DiTForwardInput prepare_inputs(DiTBatch& batch);

--- a/xllm/core/runtime/rec_worker_impl.h
+++ b/xllm/core/runtime/rec_worker_impl.h
@@ -42,7 +42,7 @@ class RecWorkerImpl : public LLMWorkerImpl {
                 const torch::Device& device,
                 const runtime::Options& options);
 
-  virtual ~RecWorkerImpl();
+  ~RecWorkerImpl() override;
 
   bool init_model(const std::string& model_weights_path,
                   int32_t random_seed,
@@ -62,7 +62,7 @@ class RecWorkerImpl : public LLMWorkerImpl {
   std::optional<ForwardOutput> step(const ForwardInput& input) override;
 
   folly::SemiFuture<std::optional<ForwardOutput>> step_async(
-      const ForwardInput& input);
+      const ForwardInput& input) override;
 
  protected:
   std::shared_ptr<MPMCThreadPool> input_builder_thread_pool_;

--- a/xllm/core/scheduler/continuous_scheduler.h
+++ b/xllm/core/scheduler/continuous_scheduler.h
@@ -171,7 +171,7 @@ class ContinuousScheduler : public Scheduler {
   };
 
   ContinuousScheduler(Engine* engine, const Options& options);
-  virtual ~ContinuousScheduler();
+  ~ContinuousScheduler() override;
 
   bool add_request(std::shared_ptr<Request>& request) override;
 
@@ -189,7 +189,7 @@ class ContinuousScheduler : public Scheduler {
     CHECK_GT(old_value, 0) << "pending requests underflow";
   }
 
-  size_t num_pending_requests() {
+  size_t num_pending_requests() override {
     return pending_requests_.load(std::memory_order_relaxed);
   }
 
@@ -223,10 +223,10 @@ class ContinuousScheduler : public Scheduler {
 
   ProfileManager* get_profile_manager() { return profile_manager_.get(); }
 
-  virtual void get_latency_metrics(std::vector<int64_t>& ttft,
-                                   std::vector<int64_t>& tbt) {}
+  void get_latency_metrics(std::vector<int64_t>& ttft,
+                           std::vector<int64_t>& tbt) override {}
 
-  const InstanceInfo& get_instance_info() { return instance_info_; }
+  const InstanceInfo& get_instance_info() override { return instance_info_; }
 
   std::vector<int> last_batch_lengths_;
 

--- a/xllm/core/scheduler/disagg_pd_scheduler.h
+++ b/xllm/core/scheduler/disagg_pd_scheduler.h
@@ -38,9 +38,9 @@ class DisaggPDScheduler : public ContinuousScheduler {
  public:
   DisaggPDScheduler(Engine* engine, const Options& options);
 
-  virtual ~DisaggPDScheduler();
+  ~DisaggPDScheduler() override;
 
-  virtual uint32_t get_waiting_requests_num() const override {
+  uint32_t get_waiting_requests_num() const override {
     return prefill_queue_->size();
   };
 
@@ -82,7 +82,7 @@ class DisaggPDScheduler : public ContinuousScheduler {
   bool enable_schedule_overlap() { return options_.enable_schedule_overlap(); };
 
   void get_latency_metrics(std::vector<int64_t>& ttft,
-                           std::vector<int64_t>& tbt);
+                           std::vector<int64_t>& tbt) override;
 
   bool link_instance(const std::string& instance_name,
                      const std::vector<uint64_t>& cluster_ids,

--- a/xllm/core/scheduler/dit_scheduler.h
+++ b/xllm/core/scheduler/dit_scheduler.h
@@ -66,7 +66,7 @@ class DiTScheduler : public SchedulerBase {
     PROPERTY(bool, disable_log_stats) = false;
   };
 
-  virtual ~DiTScheduler() = default;
+  ~DiTScheduler() override = default;
 
   // add a new request to scheduler.
   virtual bool add_request(std::shared_ptr<DiTRequest>& request) = 0;
@@ -75,7 +75,7 @@ class DiTScheduler : public SchedulerBase {
 class DiTDynamicBatchScheduler : public DiTScheduler {
  public:
   DiTDynamicBatchScheduler(Engine* engine, const Options& options);
-  virtual ~DiTDynamicBatchScheduler();
+  ~DiTDynamicBatchScheduler() override;
 
   bool add_request(std::shared_ptr<DiTRequest>& request) override;
 
@@ -94,7 +94,7 @@ class DiTDynamicBatchScheduler : public DiTScheduler {
     CHECK_GT(old_value, 0) << "pending requests underflow";
   }
 
-  size_t num_pending_requests() {
+  size_t num_pending_requests() override {
     return pending_requests_.load(std::memory_order_relaxed);
   }
 

--- a/xllm/core/scheduler/fixed_steps_scheduler.h
+++ b/xllm/core/scheduler/fixed_steps_scheduler.h
@@ -49,7 +49,7 @@ struct ScheduleResult {
 class FixedStepsScheduler final : public ContinuousScheduler {
  public:
   FixedStepsScheduler(Engine* engine, const Options& options);
-  virtual ~FixedStepsScheduler() = default;
+  ~FixedStepsScheduler() override = default;
 
   bool add_request(std::shared_ptr<Request>& request) override;
 
@@ -118,7 +118,7 @@ class FixedStepsScheduler final : public ContinuousScheduler {
   ScheduleResult schedule_request(const absl::Duration& timeout);
 
   // build a batch of requests from the priority queue
-  virtual std::vector<Batch> prepare_batch();
+  std::vector<Batch> prepare_batch() override;
 
   void handle_prefill_requests(
       size_t& remaining_token_budget,

--- a/xllm/core/scheduler/pd_ooc_scheduler.h
+++ b/xllm/core/scheduler/pd_ooc_scheduler.h
@@ -47,7 +47,7 @@ class PDOOCScheduler : public DisaggPDScheduler {
  public:
   PDOOCScheduler(Engine* engine, const Options& options);
 
-  virtual ~PDOOCScheduler();
+  ~PDOOCScheduler() override;
 
   void step(const absl::Duration& timeout) override;
 

--- a/xllm/core/scheduler/zero_eviction_scheduler.h
+++ b/xllm/core/scheduler/zero_eviction_scheduler.h
@@ -101,7 +101,7 @@ class BlockCapacityGuard {
 class ZeroEvictionScheduler final : public ContinuousScheduler {
  public:
   ZeroEvictionScheduler(Engine* engine, const Options& options);
-  virtual ~ZeroEvictionScheduler();
+  ~ZeroEvictionScheduler() override;
 
  private:
   void handle_prefill_requests(


### PR DESCRIPTION
## Description

<!-- What does this PR do? Briefly describe the changes and why they are needed. -->
Use `override` following "Effective Modern C++" Item 12 guidelines.
> Item 12: Declare overriding functions override.

## Related Issues

<!-- Link related issues here. Use "Fixes #123" when this PR closes an issue. -->

## Change Type

- [ ] Bug fix
- [ ] New feature
- [ ] Performance improvement
- [x] Refactor
- [ ] Documentation
- [ ] Test
- [ ] Build or CI

## Pull Request Checklist

Thank you for contributing to xLLM. Before requesting review, please make sure the following items are complete.

### PR Title and Commit Messages

- [x] The PR title and each commit message follow the xLLM commit format: `<type>: <subject>`.

> Allowed types: feat, bugfix, docs, test, refactor, chore, style, revert, perf, model, build, release.
> The subject should use clear English, start with a verb, include at least 4 words, and end with `.`.

### Pre-commit Checks

- [x] I have installed `pre-commit` by running `pip install pre-commit` or an equivalent command.
- [x] I have installed the hooks with `pre-commit install`.
- [x] I have run `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

### Self Review

- [x] I have self-reviewed the code according to `.agents/skills/code-review/references/custom-code-style.md`, especially code written or assisted by AI.
- [x] I have rebased this PR onto the latest `main` branch.

### Build and Test Coverage

- [x] Tests have been added or updated as needed.
- [x] CUDA: `python setup.py build test` has passed on a CUDA machine.
- [ ] NPU: `python setup.py build test` has passed on an NPU machine.
- [ ] MLU: `python setup.py build test` has passed on an MLU machine.

## Reviewer Notes

<!-- Optional: anything reviewers should focus on, known risks, follow-ups, or validation gaps. -->
