### PR TITLE
refactor: declare functions noexcept if they won't emit exceptions.

### DIFF
--- a/.agents/skills/code-review/references/custom-code-style.md
+++ b/.agents/skills/code-review/references/custom-code-style.md
@@ -157,6 +157,28 @@ ModelOutput forward(torch::Tensor tokens, ...) override;
 virtual ModelOutput forward(torch::Tensor tokens, ...);
 ```
 
+- **Declare functions `noexcept` if they won't emit exceptions.** This is part of the function's interface contract, like `const`. Pay special attention to move constructors, move assignment operators, and `swap`: `std::vector` reallocation moves elements only when move is `noexcept`. Do not use C++98 exception specifications (`throw()`). Do not mark `noexcept` on functions that may throw or call APIs that can throw.
+
+```cpp
+// Good – move is noexcept; vector reallocation can move instead of copy
+MyResource(MyResource&& other) noexcept;
+MyResource& operator=(MyResource&& other) noexcept;
+
+void swap(MyResource& lhs, MyResource& rhs) noexcept;
+```
+
+```cpp
+// Bad – move not noexcept; std::vector may fall back to copy
+MyResource(MyResource&& other);
+MyResource& operator=(MyResource&& other);
+
+// Bad – deprecated C++98 exception specification
+void reset() throw();
+
+// Bad – noexcept on a function that may throw
+void parse_file(const std::string& path) noexcept;
+```
+
 - **Structs must not have member functions**. If you need methods, use a `class`. Structs are for plain data aggregation only.
 
 ---

--- a/xllm/core/framework/model/model_input_params.h
+++ b/xllm/core/framework/model/model_input_params.h
@@ -661,7 +661,7 @@ struct BlockTransferInfo {
     memcpy(hash_key, other.hash_key, XXH3_128BITS_HASH_VALUE_LEN);
   }
 
-  BlockTransferInfo(BlockTransferInfo&& other)
+  BlockTransferInfo(BlockTransferInfo&& other) noexcept
       : src_block_id(other.src_block_id),
         dst_block_id(other.dst_block_id),
         transfer_type(other.transfer_type) {
@@ -679,7 +679,7 @@ struct BlockTransferInfo {
     return *this;
   }
 
-  BlockTransferInfo& operator=(BlockTransferInfo&& other) {
+  BlockTransferInfo& operator=(BlockTransferInfo&& other) noexcept {
     src_block_id = other.src_block_id;
     dst_block_id = other.dst_block_id;
     transfer_type = other.transfer_type;

--- a/xllm/core/layers/npu/buffer/atb_workspace.h
+++ b/xllm/core/layers/npu/buffer/atb_workspace.h
@@ -36,9 +36,9 @@ class AtbWorkspace {
 
   AtbWorkspace& operator=(const AtbWorkspace&) = delete;
 
-  AtbWorkspace(AtbWorkspace&&) = default;
+  AtbWorkspace(AtbWorkspace&&) noexcept = default;
 
-  AtbWorkspace& operator=(AtbWorkspace&&) = default;
+  AtbWorkspace& operator=(AtbWorkspace&&) noexcept = default;
 
   void* get_workspace_buffer(uint64_t bufferSize);
 

--- a/xllm/core/platform/stream.h
+++ b/xllm/core/platform/stream.h
@@ -63,7 +63,7 @@ class Stream {
 
   Stream(const Stream&) = delete;
   Stream& operator=(const Stream&) = delete;
-  Stream(Stream&&) = default;
+  Stream(Stream&&) noexcept = default;
   Stream& operator=(Stream&&) = default;
 
   explicit Stream(PlatformStream stream, const int32_t timeout = -1);


### PR DESCRIPTION
## Description

<!-- What does this PR do? Briefly describe the changes and why they are needed. -->
Use `noexcept` following "Effective Modern C++" Item 14 guidelines. 
> Item 14: Declare functions noexcept if they won’t emit exceptions.

## Related Issues

<!-- Link related issues here. Use "Fixes #123" when this PR closes an issue. -->

## Change Type

- [ ] Bug fix
- [ ] New feature
- [ ] Performance improvement
- [x] Refactor
- [ ] Documentation
- [ ] Test
- [ ] Build or CI

## Pull Request Checklist

Thank you for contributing to xLLM. Before requesting review, please make sure the following items are complete.

### PR Title and Commit Messages

- [x] The PR title and each commit message follow the xLLM commit format: `<type>: <subject>`.

> Allowed types: feat, bugfix, docs, test, refactor, chore, style, revert, perf, model, build, release.
> The subject should use clear English, start with a verb, include at least 4 words, and end with `.`.

### Pre-commit Checks

- [x] I have installed `pre-commit` by running `pip install pre-commit` or an equivalent command.
- [x] I have installed the hooks with `pre-commit install`.
- [x] I have run `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

### Self Review

- [x] I have self-reviewed the code according to `.agents/skills/code-review/references/custom-code-style.md`, especially code written or assisted by AI.
- [x] I have rebased this PR onto the latest `main` branch.

### Build and Test Coverage

- [x] Tests have been added or updated as needed.
- [x] CUDA: `python setup.py build test` has passed on a CUDA machine.
- [ ] NPU: `python setup.py build test` has passed on an NPU machine.
- [ ] MLU: `python setup.py build test` has passed on an MLU machine.

## Reviewer Notes

<!-- Optional: anything reviewers should focus on, known risks, follow-ups, or validation gaps. -->
