### PR TITLE
perf: add native split gated RMSNorm for Qwen3.5 and Qwen3.6 on NPU

### DIFF
--- a/xllm/core/layers/common/rms_norm_gated.cpp
+++ b/xllm/core/layers/common/rms_norm_gated.cpp
@@ -15,13 +15,37 @@ limitations under the License.
 
 #include "rms_norm_gated.h"
 
+#if defined(USE_NPU)
+#include <ATen/ops/silu.h>
+
+#include <cstdlib>
+#include <cstring>
+#endif
+
 #include <glog/logging.h>
 
 #include "framework/state_dict/utils.h"
+#if defined(USE_NPU)
+#include "xllm/core/kernels/npu/npu_ops_api.h"
+#endif
 #include "xllm/core/kernels/ops_api.h"
 
 namespace xllm {
 namespace layer {
+
+#if defined(USE_NPU)
+namespace {
+
+bool enable_native_split_gated_rms_norm() {
+  static const bool enabled = []() {
+    const char* value = std::getenv("XLLM_NATIVE_SPLIT_GATED_RMS_NORM");
+    return value != nullptr && std::strcmp(value, "1") == 0;
+  }();
+  return enabled;
+}
+
+}  // namespace
+#endif
 
 RmsNormGatedImpl::RmsNormGatedImpl(int64_t dim,
                                    double eps,
@@ -33,6 +57,17 @@ RmsNormGatedImpl::RmsNormGatedImpl(int64_t dim,
 
 torch::Tensor RmsNormGatedImpl::forward(torch::Tensor& input,
                                         std::optional<torch::Tensor> gate) {
+#if defined(USE_NPU)
+  if (enable_native_split_gated_rms_norm() && gate.has_value() &&
+      input.dim() == 2 && input.size(0) >= 1024 && input.size(1) == norm_dim_) {
+    auto normalized =
+        xllm::kernel::npu::rms_norm(input, weight_, eps_, "rmsnorm");
+    auto gate_value = gate.value();
+    at::silu_(gate_value);
+    normalized.mul_(gate_value);
+    return normalized;
+  }
+#endif
   xllm::kernel::GatedLayerNormParams params;
   params.x = input;
   params.weight = weight_;


### PR DESCRIPTION
## 中文说明

### 为什么修改

Qwen3.5/Qwen3.6 Gated DeltaNet 的大 token prefill 场景当前使用融合 Gated RMSNorm 算子。将该路径拆分为 Ascend 原生 RmsNorm、SiLU 和逐元素乘后，端到端测试中 6 个场景的 TTFT 和 E2E 均有改善，其中 35B TP=2/TP=4 的 E2E 分别提升 7.35%/5.49%。

### 怎么修改

- 仅在 NPU 构建中增加原生拆分路径。
- 通过 `XLLM_NATIVE_SPLIT_GATED_RMS_NORM=1` 显式启用，默认仍走原融合实现。
- 当 gate 存在、输入为二维、token 行数不小于 1024 且 hidden size 与 RMSNorm 维度一致时，依次执行：
  1. NPU 原生 `rms_norm`；
  2. gate 原地 SiLU；
  3. normalized output 原地乘 gate。
- 其他设备、未设置环境变量或不满足形状条件时均回退原 `gated_layer_norm` 路径。
- NPU 专用头文件和 helper 均置于 `USE_NPU` 条件编译保护内，不影响其他后端。

### 性能测试配置

- 测试代码基线：`95a3e499674900f6d08cce881d14e31479f14ca1`
- workload：warmup 3，正式请求 20，统计 19 条稳态请求；平均输入约 4317 tokens，输出 25 tokens。
- MTP：3 speculative tokens；启用 graph、chunked prefill、schedule overlap 和 LCCL。
- A/B 使用相同模型、draft model、二进制构建选项、workload 和物理卡。

负数表示优化版延迟降低。

| 场景 | TTFT 基线/优化 (ms) | TTFT Δ | TPOT 基线/优化 (ms) | TPOT Δ | E2E 基线/优化 (ms) | E2E Δ | MTP 接受率基线/优化 | Δ (pp) |
|---|---:|---:|---:|---:|---:|---:|---:|---:|
| Qwen3.5 2B TP=1 | 109.684 / 102.474 | -6.57% | 4.4316 / 4.3895 | -0.95% | 216.011 / 208.111 | -3.66% | 72.95% / 75.86% | +2.92 |
| Qwen3.5 2B TP=2 | 80.684 / 77.053 | -4.50% | 4.2158 / 4.1789 | -0.87% | 181.795 / 177.279 | -2.48% | 76.24% / 73.46% | -2.77 |
| Qwen3.6 27B TP=2 | 656.368 / 620.105 | -5.52% | 15.0632 / 15.1211 | +0.38% | 1017.942 / 983.063 | -3.43% | 65.40% / 64.60% | -0.80 |
| Qwen3.6 27B TP=4 | 396.421 / 382.316 | -3.56% | 9.8737 / 10.0158 | +1.44% | 633.568 / 622.616 | -1.73% | 67.31% / 64.90% | -2.41 |
| Qwen3.6 35B TP=2 | 212.947 / 195.842 | -8.03% | 6.9526 / 6.5053 | -6.43% | 379.921 / 352.005 | -7.35% | 90.63% / 92.53% | +1.90 |
| Qwen3.6 35B TP=4 | 159.316 / 149.895 | -5.91% | 5.8632 / 5.5632 | -5.12% | 300.053 / 283.584 | -5.49% | 92.35% / 92.53% | +0.18 |

### 验证

- `clang-format 20.1.6`：通过。
- `git diff --check`：通过。
- 6 个场景 A/B 性能测试：通过，每组均有 19 条稳态样本。

<img width="1227" height="628" alt="image" src="https://github.com/user-attachments/assets/71dc8db8-7bf8-4457-acac-0c86b4faf7ac" />

## English Description

### Why

The Qwen3.5/Qwen3.6 Gated DeltaNet path currently uses a fused Gated RMSNorm operator for large-token prefill workloads. After splitting this path into native Ascend RmsNorm, SiLU, and elementwise multiplication, all six end-to-end scenarios improve TTFT and E2E latency. The 35B TP=2 and TP=4 workloads improve E2E latency by 7.35% and 5.49%, respectively.

### What changed

- Add the native split path only for NPU builds.
- Enable it explicitly with `XLLM_NATIVE_SPLIT_GATED_RMS_NORM=1`; the fused implementation remains the default.
- When a gate is present, the input is 2-D, the row count is at least 1024, and the hidden size matches the RMSNorm dimension, run:
  1. native NPU `rms_norm`;
  2. in-place SiLU on the gate;
  3. in-place multiplication of the normalized output and gate.
- Fall back to the existing `gated_layer_norm` path for other devices, when the environment variable is unset, or when the shape conditions are not met.
- Guard all NPU-only includes and helpers with `USE_NPU` so other backends are unaffected.

### Performance setup

- Evaluated source baseline: `95a3e499674900f6d08cce881d14e31479f14ca1`
- Workload: 3 warmup requests and 20 formal requests; metrics use 19 steady-state requests. Average input length is about 4,317 tokens and output length is 25 tokens.
- MTP uses 3 speculative tokens. Graph mode, chunked prefill, schedule overlap, and LCCL are enabled.
- Each A/B pair uses the same model, draft model, binary build options, workload, and physical devices.

Negative deltas mean lower latency.

| Scenario | TTFT baseline/optimized (ms) | TTFT Δ | TPOT baseline/optimized (ms) | TPOT Δ | E2E baseline/optimized (ms) | E2E Δ | MTP acceptance baseline/optimized | Δ (pp) |
|---|---:|---:|---:|---:|---:|---:|---:|---:|
| Qwen3.5 2B TP=1 | 109.684 / 102.474 | -6.57% | 4.4316 / 4.3895 | -0.95% | 216.011 / 208.111 | -3.66% | 72.95% / 75.86% | +2.92 |
| Qwen3.5 2B TP=2 | 80.684 / 77.053 | -4.50% | 4.2158 / 4.1789 | -0.87% | 181.795 / 177.279 | -2.48% | 76.24% / 73.46% | -2.77 |
| Qwen3.6 27B TP=2 | 656.368 / 620.105 | -5.52% | 15.0632 / 15.1211 | +0.38% | 1017.942 / 983.063 | -3.43% | 65.40% / 64.60% | -0.80 |
| Qwen3.6 27B TP=4 | 396.421 / 382.316 | -3.56% | 9.8737 / 10.0158 | +1.44% | 633.568 / 622.616 | -1.73% | 67.31% / 64.90% | -2.41 |
| Qwen3.6 35B TP=2 | 212.947 / 195.842 | -8.03% | 6.9526 / 6.5053 | -6.43% | 379.921 / 352.005 | -7.35% | 90.63% / 92.53% | +1.90 |
| Qwen3.6 35B TP=4 | 159.316 / 149.895 | -5.91% | 5.8632 / 5.5632 | -5.12% | 300.053 / 283.584 | -5.49% | 92.35% / 92.53% | +0.18 |

### Validation

- `clang-format 20.1.6`: passed.
- `git diff --check`: passed.
- Six A/B performance scenarios: passed with 19 steady-state samples per run.
<img width="1227" height="628" alt="image" src="https://github.com/user-attachments/assets/71dc8db8-7bf8-4457-acac-0c86b4faf7ac" />

