### PR TITLE
bugfix: fix padded decode cuda graph metadata.

### DIFF
--- a/tests/core/runtime/cuda_graph_executor_test.cpp
+++ b/tests/core/runtime/cuda_graph_executor_test.cpp
@@ -767,6 +767,82 @@ TEST(CudaGraphExecutorTest, BatchDecodePaddedBucket100CaptureAndReplay) {
       << "100 -> 112 graph replay should match eager";
 }
 
+TEST(CudaGraphExecutorTest, BatchDecodeNoPaddingBucket100CaptureAndReplay) {
+  if (!torch::cuda::is_available()) {
+    GTEST_SKIP() << "CUDA is not available at runtime.";
+  }
+
+  ScopedConfigSnapshot config_snapshot;
+  ExecutionConfig::get_instance()
+      .enable_graph(true)
+      .enable_graph_vmm_pool(false)
+      .enable_graph_mode_decode_no_padding(true);
+  SchedulerConfig::get_instance().max_tokens_per_batch(128);
+
+  const torch::Device device = InitXllmCudaDeviceForTest(/*device_index=*/0);
+  xllm::layer::flashinfer::FlashinferWorkspace::get_instance().initialize(
+      device);
+
+  ModelArgs args = make_test_model_args();
+  args.max_position_embeddings(16);
+  runtime::Options options =
+      make_test_runtime_options(/*max_seqs_per_batch=*/100);
+
+  runtime::cuda::CudaGraphPersistentParam persistent(args, device, options);
+  EXPECT_EQ(persistent.q_seq_lens(/*actual_batch_size=*/0).size(0), 101);
+  EXPECT_EQ(persistent.kv_seq_lens(/*actual_batch_size=*/0).size(0), 101);
+  EXPECT_EQ(
+      persistent.persistent_paged_kv_indptr(/*actual_batch_size=*/0).size(0),
+      101);
+  EXPECT_EQ(
+      persistent.persistent_paged_kv_last_page_len(/*actual_batch_size=*/0)
+          .size(0),
+      100);
+  EXPECT_EQ(
+      persistent.persistent_decode_qo_indptr(/*actual_batch_size=*/0).size(0),
+      101);
+  EXPECT_EQ(persistent.persistent_block_tables(/*actual_batch_size=*/0).size(0),
+            100);
+
+  auto model = std::make_unique<FakeAttnCausalLM>(args, device);
+  auto graph_exec = std::make_unique<runtime::cuda::CudaGraphExecutorImpl>(
+      model.get(), args, device, options);
+
+  constexpr int32_t kActualBatchSize = 100;
+  torch::TensorOptions iopt =
+      torch::TensorOptions().dtype(torch::kInt32).device(device);
+  torch::Tensor tokens = torch::arange(1, kActualBatchSize + 1, iopt);
+  torch::Tensor positions = torch::zeros({kActualBatchSize}, iopt);
+  ModelInputParams params = MakeBatchDecodeParams(device, kActualBatchSize);
+
+  std::vector<KVCache> kv = MakeKvCaches(device,
+                                         /*num_pages=*/kActualBatchSize,
+                                         /*page_size=*/1,
+                                         /*num_kv_heads=*/1,
+                                         /*head_dim=*/128);
+  std::vector<KVCache> eager_kv = MakeSingleKvCaches(
+      kv[0].get_k_cache().clone(), kv[0].get_v_cache().clone());
+  torch::Tensor eager_out =
+      model->forward(tokens, positions, eager_kv, params).hidden_states.clone();
+  torch::cuda::synchronize();
+
+  torch::Tensor first_out =
+      graph_exec->run(tokens, positions, kv, params).hidden_states.clone();
+  torch::cuda::synchronize();
+  EXPECT_EQ(first_out.size(0), kActualBatchSize);
+  EXPECT_TRUE(
+      torch::allclose(first_out, eager_out, /*rtol=*/1e-3, /*atol=*/1e-3))
+      << "100-token no-padding graph capture and first replay should match "
+         "eager";
+
+  torch::Tensor second_out =
+      graph_exec->run(tokens, positions, kv, params).hidden_states.clone();
+  torch::cuda::synchronize();
+  EXPECT_TRUE(
+      torch::allclose(second_out, eager_out, /*rtol=*/1e-3, /*atol=*/1e-3))
+      << "100-token no-padding graph replay should match eager";
+}
+
 TEST(CudaGraphExecutorTest,
      BatchDecodeCaptureAndReplayWithLinearOnlyLayerZero) {
   if (!torch::cuda::is_available()) {
@@ -831,6 +907,7 @@ TEST(CudaGraphExecutorTest, PrefillPiecewiseCaptureAndReplay) {
   ScopedConfigSnapshot config_snapshot;
   ExecutionConfig::get_instance()
       .enable_graph(true)
+      .enable_graph_mode_decode_no_padding(true)
       .enable_prefill_piecewise_graph(true)
       .enable_graph_vmm_pool(false)
       .max_tokens_for_graph_mode(128);

--- a/tests/core/runtime/cuda_graph_executor_test.cpp
+++ b/tests/core/runtime/cuda_graph_executor_test.cpp
@@ -266,6 +266,33 @@ ModelInputParams MakeDecodeParams(const torch::Device& device) {
   return p;
 }
 
+ModelInputParams MakeBatchDecodeParams(const torch::Device& device,
+                                       int32_t num_sequences) {
+  CHECK_GT(num_sequences, 0);
+
+  ModelInputParams p;
+  p.meta.batch_forward_type = BatchForwardType::DECODE;
+  p.meta.num_sequences = num_sequences;
+  p.meta.kv_max_seq_len = 1;
+  p.meta.q_max_seq_len = 1;
+  p.enable_graph = false;
+
+  torch::TensorOptions iopt =
+      torch::TensorOptions().dtype(torch::kInt32).device(device);
+  torch::Tensor cumulative_lens = torch::arange(0, num_sequences + 1, iopt);
+  p.attention.device.q_seq_lens = cumulative_lens;
+  p.attention.device.kv_seq_lens = cumulative_lens.clone();
+  p.attention.device.q_cu_seq_lens = p.attention.device.q_seq_lens;
+  p.attention.device.new_cache_slots = torch::arange(0, num_sequences, iopt);
+  p.attention.device.block_tables =
+      torch::arange(0, num_sequences, iopt).unsqueeze(/*dim=*/1);
+  p.attention.device.paged_kv_indptr = cumulative_lens.clone();
+  p.attention.device.paged_kv_indices = torch::arange(0, num_sequences, iopt);
+  p.attention.device.paged_kv_last_page_len =
+      torch::ones({num_sequences}, iopt);
+  return p;
+}
+
 ModelInputParams MakePrefillParams(const torch::Device& device,
                                    int32_t num_tokens) {
   CHECK_GT(num_tokens, 0);
@@ -384,7 +411,7 @@ TEST(CudaGraphExecutorTest, DecodeMetadataFastPathUpdatesPersistentBuffers) {
       device);
   ModelArgs args = make_test_model_args();
   runtime::Options options =
-      make_test_runtime_options(/*max_seqs_per_batch=*/2);
+      make_test_runtime_options(/*max_seqs_per_batch=*/4);
   runtime::cuda::CudaGraphPersistentParam persistent(args, device, options);
 
   torch::TensorOptions iopt =
@@ -414,32 +441,33 @@ TEST(CudaGraphExecutorTest, DecodeMetadataFastPathUpdatesPersistentBuffers) {
       torch::equal(persistent.persistent_tokens(/*actual_tokens=*/4).cpu(),
                    torch::tensor({10, 11, 0, 0}, torch::dtype(torch::kInt32))));
   EXPECT_TRUE(
-      torch::equal(persistent.persistent_positions(/*actual_tokens=*/2).cpu(),
-                   torch::tensor({20, 21}, torch::dtype(torch::kInt32))));
+      torch::equal(persistent.persistent_positions(/*actual_tokens=*/4).cpu(),
+                   torch::tensor({20, 21, 0, 0}, torch::dtype(torch::kInt32))));
   EXPECT_TRUE(torch::equal(
       persistent.persistent_new_cache_slots(/*actual_tokens=*/4).cpu(),
-      torch::tensor({5, 7, 0, 0}, torch::dtype(torch::kInt32))));
-  EXPECT_TRUE(
-      torch::equal(persistent.kv_seq_lens(/*actual_batch_size=*/3).cpu(),
-                   torch::tensor({0, 4, 9}, torch::dtype(torch::kInt32))));
+      torch::tensor({5, 7, -1, -1}, torch::dtype(torch::kInt32))));
   EXPECT_TRUE(torch::equal(
-      persistent.persistent_kv_seq_lens_delta(/*actual_batch_size=*/2).cpu(),
-      torch::tensor({4, 5}, torch::dtype(torch::kInt32))));
+      persistent.kv_seq_lens(/*actual_batch_size=*/5).cpu(),
+      torch::tensor({0, 4, 9, 9, 9}, torch::dtype(torch::kInt32))));
+  EXPECT_TRUE(torch::equal(
+      persistent.persistent_kv_seq_lens_delta(/*actual_batch_size=*/4).cpu(),
+      torch::tensor({4, 5, 0, 0}, torch::dtype(torch::kInt32))));
 
+  EXPECT_TRUE(torch::equal(
+      updated->attn_metadata->q_cu_seq_lens.cpu(),
+      torch::tensor({0, 1, 2, 3, 4}, torch::dtype(torch::kInt32))));
+  EXPECT_TRUE(torch::equal(
+      updated->attn_metadata->kv_cu_seq_lens.cpu(),
+      torch::tensor({0, 4, 9, 9, 9}, torch::dtype(torch::kInt32))));
   EXPECT_TRUE(
-      torch::equal(updated->attn_metadata->q_cu_seq_lens.cpu(),
-                   torch::tensor({0, 1, 2}, torch::dtype(torch::kInt32))));
-  EXPECT_TRUE(
-      torch::equal(updated->attn_metadata->kv_cu_seq_lens.cpu(),
-                   torch::tensor({0, 4, 9}, torch::dtype(torch::kInt32))));
-  EXPECT_TRUE(torch::equal(updated->attn_metadata->kv_seq_lens.cpu(),
-                           torch::tensor({4, 5}, torch::dtype(torch::kInt32))));
+      torch::equal(updated->attn_metadata->kv_seq_lens.cpu(),
+                   torch::tensor({4, 5, 0, 0}, torch::dtype(torch::kInt32))));
   EXPECT_TRUE(
       torch::equal(updated->attn_metadata->slot_mapping.cpu(),
-                   torch::tensor({5, 7, 0, 0}, torch::dtype(torch::kInt32))));
-  EXPECT_TRUE(
-      torch::equal(updated->attn_metadata->paged_kv_indptr.cpu(),
-                   torch::tensor({0, 1, 3}, torch::dtype(torch::kInt32))));
+                   torch::tensor({5, 7, -1, -1}, torch::dtype(torch::kInt32))));
+  EXPECT_TRUE(torch::equal(
+      updated->attn_metadata->paged_kv_indptr.cpu(),
+      torch::tensor({0, 1, 3, 3, 3}, torch::dtype(torch::kInt32))));
   EXPECT_TRUE(
       torch::equal(updated->attn_metadata->paged_kv_indices
                        .slice(/*dim=*/0,
@@ -447,12 +475,13 @@ TEST(CudaGraphExecutorTest, DecodeMetadataFastPathUpdatesPersistentBuffers) {
                               /*end=*/3)
                        .cpu(),
                    torch::tensor({2, 4, 6}, torch::dtype(torch::kInt32))));
-  EXPECT_TRUE(torch::equal(updated->attn_metadata->paged_kv_last_page_len.cpu(),
-                           torch::tensor({1, 2}, torch::dtype(torch::kInt32))));
-  ASSERT_TRUE(updated->attn_metadata->qo_indptr.has_value());
   EXPECT_TRUE(
-      torch::equal(updated->attn_metadata->qo_indptr.value().cpu(),
-                   torch::tensor({0, 1, 2}, torch::dtype(torch::kInt32))));
+      torch::equal(updated->attn_metadata->paged_kv_last_page_len.cpu(),
+                   torch::tensor({1, 2, 1, 1}, torch::dtype(torch::kInt32))));
+  ASSERT_TRUE(updated->attn_metadata->qo_indptr.has_value());
+  EXPECT_TRUE(torch::equal(
+      updated->attn_metadata->qo_indptr.value().cpu(),
+      torch::tensor({0, 1, 2, 3, 4}, torch::dtype(torch::kInt32))));
   EXPECT_TRUE(torch::equal(updated->attn_metadata->block_table.cpu(),
                            params.attention.device.block_tables.cpu()));
 }
@@ -467,7 +496,7 @@ TEST(CudaGraphExecutorTest, DecodeMetadataFastPathUpdatesLinearStateIndices) {
       device);
   ModelArgs args = make_test_model_args();
   runtime::Options options =
-      make_test_runtime_options(/*max_seqs_per_batch=*/2);
+      make_test_runtime_options(/*max_seqs_per_batch=*/4);
   runtime::cuda::CudaGraphPersistentParam persistent(args, device, options);
 
   torch::TensorOptions iopt =
@@ -510,7 +539,7 @@ TEST(CudaGraphExecutorTest, DecodeMetadataFastPathFallbackMatchesLegacyPath) {
       device);
   ModelArgs args = make_test_model_args();
   runtime::Options options =
-      make_test_runtime_options(/*max_seqs_per_batch=*/2);
+      make_test_runtime_options(/*max_seqs_per_batch=*/4);
   runtime::cuda::CudaGraphPersistentParam fast_path_persistent(
       args, device, options);
   runtime::cuda::CudaGraphPersistentParam fallback_persistent(
@@ -518,12 +547,12 @@ TEST(CudaGraphExecutorTest, DecodeMetadataFastPathFallbackMatchesLegacyPath) {
 
   torch::TensorOptions iopt =
       torch::TensorOptions().dtype(torch::kInt32).device(device);
-  torch::Tensor tokens = torch::tensor({10, 11}, iopt);
-  torch::Tensor positions = torch::tensor({20, 21}, iopt);
-  ModelInputParams fast_params = make_multi_sequence_decode_params(device);
-  ModelInputParams fallback_params = make_multi_sequence_decode_params(device);
+  torch::Tensor tokens = torch::tensor({10, 11, 12}, iopt);
+  torch::Tensor positions = torch::tensor({20, 21, 22}, iopt);
+  ModelInputParams fast_params = MakeBatchDecodeParams(device, 3);
+  ModelInputParams fallback_params = MakeBatchDecodeParams(device, 3);
   torch::Tensor new_cache_slots_base =
-      torch::tensor({5, 99, 7, 88}, iopt).view({2, 2});
+      torch::tensor({0, 99, 1, 88, 2, 77}, iopt).view({3, 2});
   fallback_params.attention.device.new_cache_slots =
       new_cache_slots_base.select(1, 0);
   ASSERT_FALSE(
@@ -561,21 +590,29 @@ TEST(CudaGraphExecutorTest, DecodeMetadataFastPathFallbackMatchesLegacyPath) {
       fast_path_persistent.persistent_tokens(/*actual_tokens=*/4).cpu(),
       fallback_persistent.persistent_tokens(/*actual_tokens=*/4).cpu()));
   EXPECT_TRUE(torch::equal(
-      fast_path_persistent.persistent_positions(/*actual_tokens=*/2).cpu(),
-      fallback_persistent.persistent_positions(/*actual_tokens=*/2).cpu()));
+      fast_path_persistent.persistent_positions(/*actual_tokens=*/4).cpu(),
+      fallback_persistent.persistent_positions(/*actual_tokens=*/4).cpu()));
   EXPECT_TRUE(torch::equal(
       fast_path_persistent.persistent_new_cache_slots(/*actual_tokens=*/4)
           .cpu(),
       fallback_persistent.persistent_new_cache_slots(/*actual_tokens=*/4)
           .cpu()));
   EXPECT_TRUE(torch::equal(
-      fast_path_persistent.kv_seq_lens(/*actual_batch_size=*/3).cpu(),
-      fallback_persistent.kv_seq_lens(/*actual_batch_size=*/3).cpu()));
+      fast_path_persistent.kv_seq_lens(/*actual_batch_size=*/5).cpu(),
+      fallback_persistent.kv_seq_lens(/*actual_batch_size=*/5).cpu()));
+  EXPECT_TRUE(torch::equal(
+      fast_path_persistent.persistent_kv_seq_lens_delta(/*actual_batch_size=*/4)
+          .cpu(),
+      fallback_persistent.persistent_kv_seq_lens_delta(/*actual_batch_size=*/4)
+          .cpu()));
   EXPECT_TRUE(torch::equal(fast_updated->attn_metadata->kv_seq_lens.cpu(),
                            fallback_updated->attn_metadata->kv_seq_lens.cpu()));
   EXPECT_TRUE(
       torch::equal(fast_updated->attn_metadata->q_cu_seq_lens.cpu(),
                    fallback_updated->attn_metadata->q_cu_seq_lens.cpu()));
+  EXPECT_TRUE(
+      torch::equal(fast_updated->attn_metadata->kv_cu_seq_lens.cpu(),
+                   fallback_updated->attn_metadata->kv_cu_seq_lens.cpu()));
   EXPECT_TRUE(
       torch::equal(fast_updated->attn_metadata->slot_mapping.cpu(),
                    fallback_updated->attn_metadata->slot_mapping.cpu()));
@@ -588,6 +625,11 @@ TEST(CudaGraphExecutorTest, DecodeMetadataFastPathFallbackMatchesLegacyPath) {
   EXPECT_TRUE(torch::equal(
       fast_updated->attn_metadata->paged_kv_last_page_len.cpu(),
       fallback_updated->attn_metadata->paged_kv_last_page_len.cpu()));
+  ASSERT_TRUE(fast_updated->attn_metadata->qo_indptr.has_value());
+  ASSERT_TRUE(fallback_updated->attn_metadata->qo_indptr.has_value());
+  EXPECT_TRUE(
+      torch::equal(fast_updated->attn_metadata->qo_indptr.value().cpu(),
+                   fallback_updated->attn_metadata->qo_indptr.value().cpu()));
 }
 
 TEST(CudaGraphExecutorTest, BatchDecodeCaptureAndReplay) {
@@ -648,6 +690,81 @@ TEST(CudaGraphExecutorTest, BatchDecodeCaptureAndReplay) {
   torch::cuda::synchronize();
   EXPECT_TRUE(torch::allclose(out2, eager_out, /*rtol=*/1e-3, /*atol=*/1e-3))
       << "graph replay output should match eager output";
+}
+
+TEST(CudaGraphExecutorTest, BatchDecodePaddedBucket100CaptureAndReplay) {
+  if (!torch::cuda::is_available()) {
+    GTEST_SKIP() << "CUDA is not available at runtime.";
+  }
+
+  ScopedConfigSnapshot config_snapshot;
+  ExecutionConfig::get_instance()
+      .enable_graph(true)
+      .enable_graph_vmm_pool(false)
+      .enable_graph_mode_decode_no_padding(false);
+  SchedulerConfig::get_instance().max_tokens_per_batch(128);
+
+  const torch::Device device = InitXllmCudaDeviceForTest(/*device_index=*/0);
+  xllm::layer::flashinfer::FlashinferWorkspace::get_instance().initialize(
+      device);
+
+  ModelArgs args = make_test_model_args();
+  args.max_position_embeddings(16);
+  runtime::Options options =
+      make_test_runtime_options(/*max_seqs_per_batch=*/100);
+
+  runtime::cuda::CudaGraphPersistentParam persistent(args, device, options);
+  EXPECT_EQ(persistent.q_seq_lens(/*actual_batch_size=*/0).size(0), 113);
+  EXPECT_EQ(persistent.kv_seq_lens(/*actual_batch_size=*/0).size(0), 113);
+  EXPECT_EQ(
+      persistent.persistent_paged_kv_indptr(/*actual_batch_size=*/0).size(0),
+      113);
+  EXPECT_EQ(
+      persistent.persistent_paged_kv_last_page_len(/*actual_batch_size=*/0)
+          .size(0),
+      112);
+  EXPECT_EQ(
+      persistent.persistent_decode_qo_indptr(/*actual_batch_size=*/0).size(0),
+      113);
+  EXPECT_EQ(persistent.persistent_block_tables(/*actual_batch_size=*/0).size(0),
+            112);
+
+  auto model = std::make_unique<FakeAttnCausalLM>(args, device);
+  auto graph_exec = std::make_unique<runtime::cuda::CudaGraphExecutorImpl>(
+      model.get(), args, device, options);
+
+  constexpr int32_t kActualBatchSize = 100;
+  torch::TensorOptions iopt =
+      torch::TensorOptions().dtype(torch::kInt32).device(device);
+  torch::Tensor tokens = torch::arange(1, kActualBatchSize + 1, iopt);
+  torch::Tensor positions = torch::zeros({kActualBatchSize}, iopt);
+  ModelInputParams params = MakeBatchDecodeParams(device, kActualBatchSize);
+
+  std::vector<KVCache> kv = MakeKvCaches(device,
+                                         /*num_pages=*/kActualBatchSize,
+                                         /*page_size=*/1,
+                                         /*num_kv_heads=*/1,
+                                         /*head_dim=*/128);
+  std::vector<KVCache> eager_kv = MakeSingleKvCaches(
+      kv[0].get_k_cache().clone(), kv[0].get_v_cache().clone());
+  torch::Tensor eager_out =
+      model->forward(tokens, positions, eager_kv, params).hidden_states.clone();
+  torch::cuda::synchronize();
+
+  torch::Tensor first_out =
+      graph_exec->run(tokens, positions, kv, params).hidden_states.clone();
+  torch::cuda::synchronize();
+  EXPECT_EQ(first_out.size(0), kActualBatchSize);
+  EXPECT_TRUE(
+      torch::allclose(first_out, eager_out, /*rtol=*/1e-3, /*atol=*/1e-3))
+      << "100 -> 112 graph capture and first replay should match eager";
+
+  torch::Tensor second_out =
+      graph_exec->run(tokens, positions, kv, params).hidden_states.clone();
+  torch::cuda::synchronize();
+  EXPECT_TRUE(
+      torch::allclose(second_out, eager_out, /*rtol=*/1e-3, /*atol=*/1e-3))
+      << "100 -> 112 graph replay should match eager";
 }
 
 TEST(CudaGraphExecutorTest,

--- a/xllm/core/kernels/cuda/llm_decode_metadata_update.cu
+++ b/xllm/core/kernels/cuda/llm_decode_metadata_update.cu
@@ -40,17 +40,29 @@ __global__ void llm_decode_metadata_update_kernel(
     }
     if (idx >= params.actual_num_tokens && idx < params.padded_num_tokens) {
       params.dst_tokens[idx] = 0;
-      params.dst_new_cache_slots[idx] = 0;
+      params.dst_positions[idx] = 0;
+      params.dst_new_cache_slots[idx] = -1;
     }
     if (idx < params.actual_batch_size + 1) {
       params.dst_kv_seq_lens[idx] = params.src_kv_seq_lens[idx];
       params.dst_paged_kv_indptr[idx] = params.src_paged_kv_indptr[idx];
+    }
+    if (idx >= params.actual_batch_size + 1 &&
+        idx < params.padded_num_tokens + 1) {
+      params.dst_kv_seq_lens[idx] =
+          params.src_kv_seq_lens[params.actual_batch_size];
+      params.dst_paged_kv_indptr[idx] =
+          params.src_paged_kv_indptr[params.actual_batch_size];
     }
     if (idx < params.actual_batch_size) {
       params.dst_kv_seq_lens_delta[idx] =
           params.src_kv_seq_lens[idx + 1] - params.src_kv_seq_lens[idx];
       params.dst_paged_kv_last_page_len[idx] =
           params.src_paged_kv_last_page_len[idx];
+    }
+    if (idx >= params.actual_batch_size && idx < params.padded_num_tokens) {
+      params.dst_kv_seq_lens_delta[idx] = 0;
+      params.dst_paged_kv_last_page_len[idx] = 1;
     }
     if (idx < params.actual_indices_size) {
       params.dst_paged_kv_indices[idx] = params.src_paged_kv_indices[idx];
@@ -63,8 +75,8 @@ __global__ void llm_decode_metadata_update_kernel(
 void update_llm_decode_metadata(const LlmDecodeMetadataUpdateParams& params,
                                 LlmDecodeMetadataUpdateStream stream) {
   int64_t max_work_size = params.actual_num_tokens;
-  if (params.padded_num_tokens > max_work_size) {
-    max_work_size = params.padded_num_tokens;
+  if (params.padded_num_tokens + 1 > max_work_size) {
+    max_work_size = params.padded_num_tokens + 1;
   }
   if (params.actual_batch_size + 1 > max_work_size) {
     max_work_size = params.actual_batch_size + 1;

--- a/xllm/core/runtime/cuda_graph_executor_impl.cpp
+++ b/xllm/core/runtime/cuda_graph_executor_impl.cpp
@@ -103,6 +103,22 @@ bool is_cuda_contiguous_int32_tensor(const torch::Tensor& tensor) {
          tensor.scalar_type() == torch::kInt32 && tensor.is_contiguous();
 }
 
+int64_t get_graph_bucket_num_tokens(int64_t num_tokens) {
+  if (num_tokens <= 1) {
+    return 1;
+  }
+  if (num_tokens <= 2) {
+    return 2;
+  }
+  if (num_tokens <= 4) {
+    return 4;
+  }
+  if (num_tokens <= 8) {
+    return 8;
+  }
+  return ((num_tokens + 15) / 16) * 16;
+}
+
 }  // namespace
 
 // CudaGraphPersistentParam implementation
@@ -113,7 +129,8 @@ CudaGraphPersistentParam::CudaGraphPersistentParam(
     : args_(args), device_(device), options_(options) {
   // Use max_tokens_per_batch for first dimension size
   const int64_t max_tokens_per_batch = options.max_tokens_per_batch();
-  // num_sequences
+  // Round the sequence capacity to the same bucket used by graph execution so
+  // the largest configured decode batch can be padded safely.
   int64_t max_seqs_per_batch;
   if (is_rec_multi_round_mode()) {
     // max_seqs_per_batch is the max sequence count per Batch in a scheduler
@@ -124,6 +141,7 @@ CudaGraphPersistentParam::CudaGraphPersistentParam(
   } else {
     max_seqs_per_batch = options.max_seqs_per_batch();
   }
+  max_seqs_per_batch = get_graph_bucket_num_tokens(max_seqs_per_batch);
   auto tensor_options = torch::TensorOptions().device(device);
 
   const int64_t max_seq_len = args_.max_position_embeddings();
@@ -393,6 +411,13 @@ std::optional<ModelInputParams> CudaGraphPersistentParam::update(
     persistent_positions_
         .slice(/*dim=*/0, /*start=*/0, /*end=*/actual_num_tokens)
         .copy_(positions, /*non_blocking=*/true);
+    if (padded_num_tokens > actual_num_tokens) {
+      persistent_positions_
+          .slice(/*dim=*/0,
+                 /*start=*/actual_num_tokens,
+                 /*end=*/padded_num_tokens)
+          .fill_(0);
+    }
   }
 
   if (!is_rec_multi_round_mode() && !use_llm_decode_fast_path) {
@@ -411,6 +436,14 @@ std::optional<ModelInputParams> CudaGraphPersistentParam::update(
         << actual_batch_size + 1 << "]";
     kv_seq_lens_.slice(/*dim=*/0, /*start=*/0, /*end=*/actual_batch_size + 1)
         .copy_(params.attention.device.kv_seq_lens, /*non_blocking=*/true);
+    if (params.meta.batch_forward_type.is_decode() &&
+        padded_num_tokens > actual_num_tokens) {
+      kv_seq_lens_
+          .slice(/*dim=*/0,
+                 /*start=*/actual_batch_size + 1,
+                 /*end=*/padded_num_tokens + 1)
+          .fill_(params.attention.device.kv_seq_lens[-1].item<int32_t>());
+    }
 
     VLOG(kGraphExecutorLogVerboseLevel)
         << "copy_ new_cache_slots: src shape="
@@ -424,7 +457,7 @@ std::optional<ModelInputParams> CudaGraphPersistentParam::update(
           .slice(/*dim=*/0,
                  /*start=*/actual_num_tokens,
                  /*end=*/padded_num_tokens)
-          .fill_(0);
+          .fill_(-1);
     }
 
     // Keep metadata tensors pointing to persistent buffers used by graph
@@ -681,21 +714,21 @@ std::optional<ModelInputParams> CudaGraphPersistentParam::update(
   if (use_llm_decode_fast_path) {
     const uint32_t slot_mapping_tokens =
         padded_num_tokens > 0 ? padded_num_tokens : actual_num_tokens;
-    attn_metadata->q_cu_seq_lens =
-        persistent_decode_qo_indptr(static_cast<uint32_t>(actual_batch_size));
-    attn_metadata->kv_cu_seq_lens =
-        kv_seq_lens(static_cast<uint32_t>(actual_batch_size + 1));
-    attn_metadata->kv_seq_lens =
-        persistent_kv_seq_lens_delta(static_cast<uint32_t>(actual_batch_size));
+    // Decode has one query token per sequence, so its graph-facing metadata
+    // must describe the padded token bucket rather than only the real batch.
+    const uint32_t metadata_batch =
+        padded_num_tokens > 0 ? padded_num_tokens
+                              : static_cast<uint32_t>(actual_batch_size);
+    attn_metadata->q_cu_seq_lens = persistent_decode_qo_indptr(metadata_batch);
+    attn_metadata->kv_cu_seq_lens = kv_seq_lens(metadata_batch + 1);
+    attn_metadata->kv_seq_lens = persistent_kv_seq_lens_delta(metadata_batch);
     attn_metadata->slot_mapping =
         persistent_new_cache_slots(slot_mapping_tokens);
-    attn_metadata->paged_kv_indptr =
-        persistent_paged_kv_indptr(static_cast<uint32_t>(actual_batch_size));
+    attn_metadata->paged_kv_indptr = persistent_paged_kv_indptr(metadata_batch);
     attn_metadata->paged_kv_indices = persistent_paged_kv_indices_;
-    attn_metadata->paged_kv_last_page_len = persistent_paged_kv_last_page_len(
-        static_cast<uint32_t>(actual_batch_size));
-    attn_metadata->qo_indptr =
-        persistent_decode_qo_indptr(static_cast<uint32_t>(actual_batch_size));
+    attn_metadata->paged_kv_last_page_len =
+        persistent_paged_kv_last_page_len(metadata_batch);
+    attn_metadata->qo_indptr = persistent_decode_qo_indptr(metadata_batch);
   } else {
     CHECK(params.attention.device.paged_kv_indptr.defined())
         << "paged_kv_indptr should not be null";
@@ -714,6 +747,16 @@ std::optional<ModelInputParams> CudaGraphPersistentParam::update(
                /*start=*/0,
                /*end=*/actual_batch_size + 1)
         .copy_(params.attention.device.paged_kv_indptr, /*non_blocking=*/true);
+    const bool pad_decode_metadata =
+        params.meta.batch_forward_type.is_decode() &&
+        padded_num_tokens > actual_num_tokens;
+    if (pad_decode_metadata) {
+      persistent_paged_kv_indptr_
+          .slice(/*dim=*/0,
+                 /*start=*/actual_batch_size + 1,
+                 /*end=*/padded_num_tokens + 1)
+          .fill_(params.attention.device.paged_kv_indptr[-1].item<int32_t>());
+    }
     CHECK(params.attention.device.paged_kv_indices.defined())
         << "paged_kv_indices should not be null";
     const int64_t actual_indices_size =
@@ -739,14 +782,35 @@ std::optional<ModelInputParams> CudaGraphPersistentParam::update(
                /*end=*/actual_batch_size)
         .copy_(params.attention.device.paged_kv_last_page_len,
                /*non_blocking=*/true);
-    attn_metadata->kv_seq_lens =
-        torch::diff(kv_seq_lens(/*actual_batch_size=*/actual_batch_size + 1));
-    attn_metadata->paged_kv_indptr =
-        persistent_paged_kv_indptr(actual_batch_size);
+    if (pad_decode_metadata) {
+      persistent_paged_kv_last_page_len_
+          .slice(/*dim=*/0,
+                 /*start=*/actual_batch_size,
+                 /*end=*/padded_num_tokens)
+          .fill_(1);
+    }
+    const int64_t metadata_batch =
+        params.meta.batch_forward_type.is_decode() && padded_num_tokens > 0
+            ? padded_num_tokens
+            : actual_batch_size;
+    if (params.meta.batch_forward_type.is_decode()) {
+      attn_metadata->q_cu_seq_lens =
+          persistent_decode_qo_indptr(metadata_batch);
+      attn_metadata->kv_cu_seq_lens = kv_seq_lens(metadata_batch + 1);
+      torch::Tensor kv_seq_lens_delta =
+          persistent_kv_seq_lens_delta(metadata_batch);
+      kv_seq_lens_delta.copy_(torch::diff(attn_metadata->kv_cu_seq_lens),
+                              /*non_blocking=*/true);
+      attn_metadata->kv_seq_lens = kv_seq_lens_delta;
+    } else {
+      attn_metadata->kv_seq_lens =
+          torch::diff(kv_seq_lens(/*actual_batch_size=*/metadata_batch + 1));
+    }
+    attn_metadata->paged_kv_indptr = persistent_paged_kv_indptr(metadata_batch);
     attn_metadata->paged_kv_indices = persistent_paged_kv_indices_;
     attn_metadata->paged_kv_last_page_len =
-        persistent_paged_kv_last_page_len(actual_batch_size);
-    attn_metadata->qo_indptr = persistent_decode_qo_indptr(actual_batch_size);
+        persistent_paged_kv_last_page_len(metadata_batch);
+    attn_metadata->qo_indptr = persistent_decode_qo_indptr(metadata_batch);
   }
   // Update plan_info if attn_metadata exists and enable_cuda_graph is true
   // This ensures plan_info is updated before CUDA graph capture/replay
@@ -1575,18 +1639,7 @@ uint32_t CudaGraphExecutorImpl::get_bucket_num_tokens(uint32_t num_tokens,
       !is_prefill) {
     return num_tokens;
   }
-  if (num_tokens <= 1) {
-    return 1;
-  } else if (num_tokens <= 2) {
-    return 2;
-  } else if (num_tokens <= 4) {
-    return 4;
-  } else if (num_tokens <= 8) {
-    return 8;
-  } else {
-    // For num_tokens > 8, use multiples of 16
-    return ((num_tokens + 15) / 16) * 16;
-  }
+  return static_cast<uint32_t>(get_graph_bucket_num_tokens(num_tokens));
 }
 
 }  // namespace xllm::runtime::cuda

--- a/xllm/core/runtime/cuda_graph_executor_impl.cpp
+++ b/xllm/core/runtime/cuda_graph_executor_impl.cpp
@@ -103,7 +103,13 @@ bool is_cuda_contiguous_int32_tensor(const torch::Tensor& tensor) {
          tensor.scalar_type() == torch::kInt32 && tensor.is_contiguous();
 }
 
-int64_t get_graph_bucket_num_tokens(int64_t num_tokens) {
+int64_t get_graph_bucket_num_tokens(int64_t num_tokens, bool is_prefill) {
+  // no_padding only works for decode, prefill requires padding for graph reuse
+  if (::xllm::ExecutionConfig::get_instance()
+          .enable_graph_mode_decode_no_padding() &&
+      !is_prefill) {
+    return num_tokens;
+  }
   if (num_tokens <= 1) {
     return 1;
   }
@@ -141,7 +147,8 @@ CudaGraphPersistentParam::CudaGraphPersistentParam(
   } else {
     max_seqs_per_batch = options.max_seqs_per_batch();
   }
-  max_seqs_per_batch = get_graph_bucket_num_tokens(max_seqs_per_batch);
+  max_seqs_per_batch =
+      get_graph_bucket_num_tokens(max_seqs_per_batch, /*is_prefill=*/false);
   auto tensor_options = torch::TensorOptions().device(device);
 
   const int64_t max_seq_len = args_.max_position_embeddings();
@@ -1633,13 +1640,8 @@ ModelOutput CudaGraphExecutorImpl::run(const torch::Tensor& tokens,
 // bucket will be [1, 2, 4, 8, 16, 32, 48, 64, ..., max_seqs_per_batch]
 uint32_t CudaGraphExecutorImpl::get_bucket_num_tokens(uint32_t num_tokens,
                                                       bool is_prefill) const {
-  // no_padding only works for decode, prefill requires padding for graph reuse
-  if (::xllm::ExecutionConfig::get_instance()
-          .enable_graph_mode_decode_no_padding() &&
-      !is_prefill) {
-    return num_tokens;
-  }
-  return static_cast<uint32_t>(get_graph_bucket_num_tokens(num_tokens));
+  return static_cast<uint32_t>(
+      get_graph_bucket_num_tokens(num_tokens, is_prefill));
 }
 
 }  // namespace xllm::runtime::cuda


### PR DESCRIPTION
## Description

Native C++ decode CUDA graphs normally pad the token/query batch to reusable graph buckets. With `max_seqs_per_batch=100`, padding mode executes a 112-row graph. Before this fix, FlashInfer decode metadata still described only the 100 real sequences, so capture could complete but replay could access metadata out of bounds and surface a CUDA illegal-memory-access error (or a later NCCL failure under TP2).

This was previously hidden when `enable_graph_mode_decode_no_padding=true`: decode used the exact runtime batch size and never entered the `100 -> 112` padding path. This PR now supports both modes explicitly and aligns the CUDA bucket policy with `AclGraphExecutorImpl`:

- when decode no-padding mode is enabled, graph size and persistent sequence capacity remain at the actual batch size (`100 -> 100`);
- otherwise, persistent per-sequence capacity follows the graph bucket rule (`100 -> 112`);
- prefill continues to use padded graph buckets even when decode no-padding mode is enabled, preserving piecewise graph reuse;
- padded decode metadata is generated consistently in both the CUDA fast path and fallback path;
- padded sequences are represented as empty KV sequences by repeating cumulative KV offsets, setting KV-length deltas to `0`, and setting `paged_kv_last_page_len` to `1`;
- padded cache slots use `-1`, so `reshape_paged_cache` skips them instead of writing to real slot `0`;
- graph-facing KV-length metadata stays in persistent buffers, keeping capture/replay addresses stable;
- tests cover fast/fallback metadata equivalence, padded decode `100 -> 112`, no-padding decode `100 -> 100`, and prefill piecewise graphs with the decode no-padding flag enabled.

The FlashInfer plan/decode invocation itself is unchanged. Padding and persistent graph inputs remain owned by `CudaGraphExecutorImpl`.

## Related Issues

None.

## Change Type

- [x] Bug fix
- [ ] New feature
- [ ] Performance improvement
- [ ] Refactor
- [ ] Documentation
- [ ] Test
- [ ] Build or CI

## Pull Request Checklist

Thank you for contributing to xLLM. Before requesting review, please make sure the following items are complete.

### PR Title and Commit Messages

- [x] The PR title and each commit message follow the xLLM commit format: `<type>: <subject>`.

> Allowed types: feat, bugfix, docs, test, refactor, chore, style, revert, perf, model, build, release.
> The subject should use clear English, start with a verb, include at least 4 words, and end with `.`.

### Pre-commit Checks

- [ ] I have installed `pre-commit` by running `pip install pre-commit` or an equivalent command.
- [ ] I have installed the hooks with `pre-commit install`.
- [ ] I have run `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

### Self Review

- [x] I have self-reviewed the code according to `.agents/skills/code-review/references/custom-code-style.md`, especially code written or assisted by AI.
- [x] I have rebased this PR onto the latest `main` branch.

### Build and Test Coverage

- [x] Tests have been added or updated as needed.
- [x] CUDA: `python setup.py build test` has passed on a CUDA machine.
- [ ] NPU: `python setup.py build test` has passed on an NPU machine.
- [ ] MLU: `python setup.py build test` has passed on an MLU machine.

CUDA validation was run inside `zmc-xllm-cuda-x86`:

- `python setup.py test --test-name cuda_graph_executor_test`: 11/11 tests passed;
- `python setup.py test`: 684/684 executed tests passed (2 randomized fused-sampler tests skipped; disabled tests were not run).

Real C++ graph service sweeps also passed at TP1 and TP2 for batches `1 2 3 5 7 8 13 16 31 47 100`, with input length 1024 and output length 256. Both service configurations enabled:

- `enable_graph=true`;
- `enable_graph_vmm_pool=true`;
- `enable_prefill_piecewise_graph=true`;
- `max_tokens_for_graph_mode=1024`.

The full sweep passed in both decode modes:

- padding mode: `enable_graph_mode_decode_no_padding=false`, including `100 -> 112`;
- no-padding mode: `enable_graph_mode_decode_no_padding=true`, including exact batch 100.

No CUDA illegal-memory-access or in-request NCCL failure occurred. The TP2 no-padding log contains a TCPStore heartbeat warning only after the completed sweep, when the test harness intentionally stopped rank 0 before rank 1.

## Reviewer Notes

Please focus review on:

- consistency between runtime graph bucket selection and persistent sequence capacity;
- decode-only scope of `enable_graph_mode_decode_no_padding`;
- metadata shape consistency and persistent-address stability in padding mode;
- prefill retaining bucket padding when decode no-padding mode is enabled.

The service runs used idle GPUs at test start, but latency measurements are not used as performance conclusions.
