### PR TITLE
bugfix: pass estimated linear state slots.

### DIFF
--- a/xllm/core/distributed_runtime/llm_engine.cpp
+++ b/xllm/core/distributed_runtime/llm_engine.cpp
@@ -513,6 +513,8 @@ bool LLMEngine::allocate_kv_cache(const KVCacheCapacity& kv_cache_cap) {
       .enable_kvcache_store(options_.enable_kvcache_store())
       .enable_xtensor(::xllm::KVCacheConfig::get_instance().enable_xtensor())
       .num_layers(args_.n_layers())
+      .linear_state_num_slots(
+          static_cast<int32_t>(kv_cache_cap.num_linear_state_blocks()))
       .slot_size(kv_cache_cap.slot_size())
       .model_id(options_.model_id())
       .max_seqs_per_batch(options_.max_seqs_per_batch())

--- a/xllm/core/distributed_runtime/vlm_engine.cpp
+++ b/xllm/core/distributed_runtime/vlm_engine.cpp
@@ -309,6 +309,8 @@ bool VLMEngine::allocate_kv_cache(const KVCacheCapacity& kv_cache_cap) {
       .host_num_blocks(0)  // no host cache for vlm engine currently.
       .block_size(block_size)
       .enable_linear_state(has_linear_attention_layers(args_))
+      .linear_state_num_slots(
+          static_cast<int32_t>(kv_cache_cap.num_linear_state_blocks()))
       .enable_prefix_cache(options_.enable_prefix_cache())
       .enable_disagg_pd(options_.enable_disagg_pd())
       .hasher_type(BlockHasherType::MM)


### PR DESCRIPTION
## 问题

PR #1846 为混合线性注意力模型启用了 LINEAR block manager。KV Cache 容量估算已经生成 `num_linear_state_blocks`，并使用该数量分配 Conv/SSM state cache；但 LLM/VLM engine 创建 `BlockManagerPool` 时没有继续传递该值。

因此，Qwen3Next、Qwen3.5 等模型会以 `enable_linear_state=true` 和默认的 `linear_state_num_slots=0` 创建 block manager，并在服务 ready 前触发：

```text
linear_state_num_slots must be set when linear state is enabled
```

## 修改

- LLM engine 将 `kv_cache_cap.num_linear_state_blocks()` 传给 `BlockManagerPool::Options::linear_state_num_slots`。
- VLM engine 同步使用相同的容量估算结果，保证两条运行路径行为一致。

该修改只补齐容量估算到 block manager 的参数传递，不改变 slot 数计算方式，也不引入后续 linear-state prefix-cache 的 restore 或 checkpoint-stride 功能。

## 影响

- 恢复混合线性注意力 LLM/VLM 的 block manager 初始化。
- 普通全注意力模型仍保持 `enable_linear_state=false`，不使用 LINEAR leaf。
- 不涉及 MTP 调度、stream 同步或推理热路径。

## 关联

- 引入 LINEAR block manager：#1846
- 后续容量估算与 restore 工作：#1940


