### PR TITLE
bugfix: redirect draft-extend placeholder KV write to padding block.

### DIFF
--- a/xllm/core/runtime/mtp_worker_impl.cpp
+++ b/xllm/core/runtime/mtp_worker_impl.cpp
@@ -1526,11 +1526,16 @@ void MTPWorkerImpl::prepare_draft_extend_inputs(
     if (use_chunked_prefill) {
       int32_t prev_token_id = state.prev_token_id;
       torch::Tensor prev_embedding = state.prev_embedding;
-      if (prev_token_id < 0) {
+      const bool prev_is_placeholder = prev_token_id < 0;
+      if (prev_is_placeholder) {
         prev_token_id = current_token_id >= 0 ? current_token_id : 0;
         prev_embedding = torch::Tensor();
       }
       add_row(prev_token_id, /*position_offset=*/-1, prev_embedding);
+      if (prev_is_placeholder) {
+        // Redirect to padding block 0 to avoid overwriting correct KV cache.
+        buf.out_new_cache_slots.back() = 0;
+      }
       add_row(state.token_id, /*position_offset=*/0, state.embedding);
       specBuilder::append_seq_len_by_layout(buf.out_q_seq_lens, 2);
       const int32_t kv_len = specBuilder::calc_kv_len(
@@ -1547,11 +1552,16 @@ void MTPWorkerImpl::prepare_draft_extend_inputs(
       int32_t prev_token_id = state.prev_token_id;
       int32_t prev_position_offset = -1;
       torch::Tensor prev_embedding = state.prev_embedding;
-      if (prev_token_id < 0) {
+      const bool prev_is_placeholder = prev_token_id < 0;
+      if (prev_is_placeholder) {
         prev_token_id = state.token_id;
         prev_embedding = torch::Tensor();
       }
       add_row(prev_token_id, prev_position_offset, prev_embedding);
+      if (prev_is_placeholder) {
+        // Redirect to padding block 0 to avoid overwriting correct KV cache.
+        buf.out_new_cache_slots.back() = 0;
+      }
     }
 
     selected_row_idx.emplace_back(


### PR DESCRIPTION


## Description

### Summary
- When `dp_enabled=true` or `enable_atb_spec_kernel=true`, draft extend always adds a prev_token row for DP token-count alignment
- If `prev_token_id < 0` (first decode after prefill or all-draft-rejected), the placeholder row overwrites a valid KV cache entry at position-1, permanently degrading speculative acceptance rate
- Fix: detect placeholder rows and redirect their `new_cache_slots` to block 0 (reserved padding block), preserving correct KV cache content

### Test Results
Verified on DeepSeek-V3.2-w8a8 full model (DP=2, num_speculative_tokens=3, enable_atb_spec_kernel=false):

| Case | WITH fix | WITHOUT fix | Delta |
|------|----------|-------------|-------|
| seed1 1req | 41.97% (175/417) | 39.86% (171/429) | +2.11% |
| seed2 1req | 16.67% (2/12) | 16.67% (2/12) | 0 (short request) |
| seed3 1req | 57.02% (130/228) | 54.70% (128/234) | +2.32% |
| 4req seed1 | 48.47% (333/687) | 48.33% (332/687) | +0.14% (drafted identical) |


## Related Issues

<!-- Link related issues here. Use "Fixes #123" when this PR closes an issue. -->

## Change Type

- [x] Bug fix
- [ ] New feature
- [ ] Performance improvement
- [ ] Refactor
- [ ] Documentation
- [ ] Test
- [ ] Build or CI

## Pull Request Checklist

Thank you for contributing to xLLM. Before requesting review, please make sure the following items are complete.

### PR Title and Commit Messages

- [ ] The PR title and each commit message follow the xLLM commit format: `<type>: <subject>`.

> Allowed types: feat, bugfix, docs, test, refactor, chore, style, revert, perf, model, build, release.
> The subject should use clear English, start with a verb, include at least 4 words, and end with `.`.

### Pre-commit Checks

- [ ] I have installed `pre-commit` by running `pip install pre-commit` or an equivalent command.
- [ ] I have installed the hooks with `pre-commit install`.
- [ ] I have run `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

### Self Review

- [ ] I have self-reviewed the code according to `.agents/skills/code-review/references/custom-code-style.md`, especially code written or assisted by AI.
- [ ] I have rebased this PR onto the latest `main` branch.

### Build and Test Coverage

- [ ] Tests have been added or updated as needed.
- [ ] CUDA: `python setup.py build test` has passed on a CUDA machine.
- [ ] NPU: `python setup.py build test` has passed on an NPU machine.
- [ ] MLU: `python setup.py build test` has passed on an MLU machine.

## Reviewer Notes

<!-- Optional: anything reviewers should focus on, known risks, follow-ups, or validation gaps. -->
