### PR TITLE
bugfix: mark prefill complete after empty token decoding. (#1951)

### DIFF
--- a/tests/core/scheduler/continuous_scheduler_test.cpp
+++ b/tests/core/scheduler/continuous_scheduler_test.cpp
@@ -991,6 +991,36 @@ TEST(ContinuousSchedulerTest, BatchRejectedStreamsCancelAtSchedulingBoundary) {
   EXPECT_TRUE(requests[1]->cancelled());
   EXPECT_TRUE(scheduler->get_running_requests().empty());
 }
+
+TEST(ContinuousSchedulerTest,
+     BatchStreamMarksPrefillFinishedWhenFirstTokenDecodesEmpty) {
+  ContinuousScheduler::Options opt =
+      create_scheduler_options(1024, 16, 0, 1024, 1);
+  auto engine = std::make_unique<FakeEngine>(32, 4);
+  auto scheduler = std::make_unique<TestContinuousScheduler>(engine.get(), opt);
+
+  auto request = generate_request_with_prompt_tokens({1, 2, 3, 4}, 4, 30000);
+  request->state().stream = true;
+  make_request_decode_ready(request);
+
+  bool callback_called = false;
+  bool outputs_empty = false;
+  bool finished_on_prefill_instance = false;
+  request->state().outputs_func =
+      [&](const std::vector<RequestOutput>& outputs) {
+        callback_called = true;
+        outputs_empty = outputs.size() == 1 && outputs[0].outputs.empty();
+        finished_on_prefill_instance =
+            outputs.size() == 1 && outputs[0].finished_on_prefill_instance;
+        return std::vector<bool>{true};
+      };
+
+  scheduler->reject_streams({request});
+
+  EXPECT_TRUE(callback_called);
+  EXPECT_TRUE(outputs_empty);
+  EXPECT_TRUE(finished_on_prefill_instance);
+}
 // ============== Async RL training: Pause/Resume tests ==============
 
 // TEST: pause()/resume() state transitions are correct and idempotent.

--- a/xllm/core/scheduler/async_response_processor.cpp
+++ b/xllm/core/scheduler/async_response_processor.cpp
@@ -302,12 +302,12 @@ void AsyncResponseProcessor::batch_process_stream_requests(
         auto seq_output = seq->generate_streaming_output(size, *tokenizer_);
         if (seq_output.has_value()) {
           req_output->outputs.push_back(std::move(seq_output.value()));
-          if (seq->num_generated_tokens() == 1) {
-            // currently only support one sequence when enable_service_routing
-            // IMPROVE LATER: support enable_schedule_overlap in Default mode
-            // for stream request
-            req_output->finished_on_prefill_instance = true;
-          }
+        }
+        if (seq->num_generated_tokens() == 1) {
+          // currently only support one sequence when enable_service_routing
+          // IMPROVE LATER: support enable_schedule_overlap in Default mode
+          // for stream request
+          req_output->finished_on_prefill_instance = true;
         }
       }
       counter->decrement_count();


### PR DESCRIPTION
## Description

PD分离场景压力测试，`num_concurrent_requests` 与真实活动请求不一致，导致请求完成后计数残留，并可能错误触发 `max_concurrent_requests` 限流

由 #16dbbca feat: implement rpc interface in APIService for xllm service internal usage. 引入

**故障原因**
PD 流式 Prefill 请求生成首 token 后，代码只有在该 token 解码出非空文本时，才设置
  finished_on_prefill_instance。如果首 token 是特殊 token、控制 token或不完整的 byte-fallback token，解码
  结果为空，Prefill 完成标志就不会上报，导致并发请求计数没有减少并持续残留，最终误触发并发限流。

**修复方案：**

 将 Prefill 完成标志与文本解码结果解耦：

  - 有非空文本时，正常追加流式输出。
  - 只要首 token 已生成，无论解码文本是否为空，都设置 finished_on_prefill_instance = true。
  - 上层收到完成标志后，沿用现有逻辑释放并发计数。

## Related Issues

<!-- Link related issues here. Use "Fixes #123" when this PR closes an issue. -->

## Change Type

- [x] Bug fix
- [ ] New feature
- [ ] Performance improvement
- [ ] Refactor
- [ ] Documentation
- [ ] Test
- [ ] Build or CI

## Pull Request Checklist

Thank you for contributing to xLLM. Before requesting review, please make sure the following items are complete.

### PR Title and Commit Messages

- [ ] The PR title and each commit message follow the xLLM commit format: `<type>: <subject>`.

> Allowed types: feat, bugfix, docs, test, refactor, chore, style, revert, perf, model, build, release.
> The subject should use clear English, start with a verb, include at least 4 words, and end with `.`.

### Pre-commit Checks

- [x] I have installed `pre-commit` by running `pip install pre-commit` or an equivalent command.
- [x] I have installed the hooks with `pre-commit install`.
- [x] I have run `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

### Self Review

- [x] I have self-reviewed the code according to `.agents/skills/code-review/references/custom-code-style.md`, especially code written or assisted by AI.
- [x] I have rebased this PR onto the latest `main` branch.

### Build and Test Coverage

- [ ] Tests have been added or updated as needed.
- [ ] CUDA: `python setup.py build test` has passed on a CUDA machine.
- [x] NPU: `python setup.py build test` has passed on an NPU machine.
- [x] MLU: `python setup.py build test` has passed on an MLU machine.

## Reviewer Notes

<!-- Optional: anything reviewers should focus on, known risks, follow-ups, or validation gaps. -->
