### PR TITLE
bugfix: fix Qwen3.5-2B causal conv decode.

### DIFF
--- a/tests/core/kernels/npu/tilelang/causal_conv1d_decode_wrapper_test.cpp
+++ b/tests/core/kernels/npu/tilelang/causal_conv1d_decode_wrapper_test.cpp
@@ -30,7 +30,6 @@ namespace xllm::kernel::npu::tilelang {
 namespace {
 
 constexpr int32_t kWidth = 4;
-constexpr int32_t kDim = 2048;
 constexpr int32_t kStateLen = kWidth - 1;
 
 class TileLangCausalConv1dDecodeWrapperTest : public ::testing::Test {
@@ -112,6 +111,7 @@ torch::Tensor conv_state_t_to_pytorch(const torch::Tensor& conv_state_t) {
 
 struct CausalConv1dDecodeTestCase {
   std::string name;
+  int64_t dim;
   int64_t batch_size;
   bool has_silu;
   int64_t num_cache_lines;
@@ -121,6 +121,7 @@ struct CausalConv1dDecodeTestCase {
 void run_causal_conv1d_decode_case(
     const CausalConv1dDecodeTestCase& test_case) {
   ASSERT_GT(test_case.batch_size, 0);
+  ASSERT_GT(test_case.dim, 0);
   ASSERT_GT(test_case.num_cache_lines, 0);
 
   const auto npu_device = torch::Device("npu:0");
@@ -131,11 +132,11 @@ void run_causal_conv1d_decode_case(
 
   torch::manual_seed(test_case.seed);
 
-  auto x_raw = torch::randn({test_case.batch_size, kDim}, bf16_opts);
-  auto conv_state_raw =
-      torch::randn({test_case.num_cache_lines, kDim, kStateLen}, bf16_opts);
-  auto weight_raw = torch::randn({kDim, kWidth}, bf16_opts);
-  auto bias_raw = torch::randn({kDim}, bf16_opts);
+  auto x_raw = torch::randn({test_case.batch_size, test_case.dim}, bf16_opts);
+  auto conv_state_raw = torch::randn(
+      {test_case.num_cache_lines, test_case.dim, kStateLen}, bf16_opts);
+  auto weight_raw = torch::randn({test_case.dim, kWidth}, bf16_opts);
+  auto bias_raw = torch::randn({test_case.dim}, bf16_opts);
 
   auto init_indices = torch::arange(0, test_case.batch_size, i32_opts);
   auto current_indices = torch::arange(0, test_case.batch_size, i32_opts);
@@ -193,10 +194,17 @@ void run_causal_conv1d_decode_case(
 TEST_F(TileLangCausalConv1dDecodeWrapperTest, DecodeBatch1Silu) {
   const std::vector<CausalConv1dDecodeTestCase> cases = {
       {.name = "decode_bs1_sl1",
+       .dim = 2048,
        .batch_size = 1,
        .has_silu = true,
        .num_cache_lines = 4,
        .seed = 42},
+      {.name = "qwen35_2b_tp2_decode_bs1_sl1",
+       .dim = 3072,
+       .batch_size = 1,
+       .has_silu = true,
+       .num_cache_lines = 4,
+       .seed = 43},
   };
   for (const auto& tc : cases) {
     SCOPED_TRACE(::testing::Message() << "case=" << tc.name);

--- a/xllm/compiler/tilelang/targets/ascend/kernels/causal_conv1d_decode.py
+++ b/xllm/compiler/tilelang/targets/ascend/kernels/causal_conv1d_decode.py
@@ -189,7 +189,7 @@ class CausalConv1dDecodeKernel(TilelangKernel):
         for d in sorted(
             {
                 dim // tp
-                for dim in [2048, 4096, 5120, 8192, 10240]
+                for dim in [2048, 4096, 5120, 6144, 8192, 10240]
                 for tp in [1, 2, 4, 8]
                 if dim % tp == 0
             }

--- a/xllm/core/kernels/npu/tilelang/causal_conv1d_wrapper.cpp
+++ b/xllm/core/kernels/npu/tilelang/causal_conv1d_wrapper.cpp
@@ -92,8 +92,8 @@ void check_supported(const torch::Tensor& x,
   CHECK(initial_state_mode.defined())
       << "TileLang causal_conv1d: initial_state_mode must be defined";
 
-  CHECK(x.scalar_type() == c10::ScalarType::BFloat16)
-      << "TileLang causal_conv1d: only bfloat16 is supported, got "
+  CHECK(x.scalar_type() == c10::ScalarType::Half)
+      << "TileLang causal_conv1d: only float16 is supported, got "
       << x.scalar_type();
 
   CHECK(x.device().type() == c10::DeviceType::PrivateUse1 &&


### PR DESCRIPTION
## 问题背景

本 PR 修复昇腾 NPU 上 Qwen3.5-2B 在关闭投机解码时，普通 decode 阶段的 causal convolution 无法执行的问题。

相关实现最初由 [PR #1762：feat: tilelang support conv1d decode.](https://github.com/xLLM-AI/xllm/pull/1762) 引入。该 PR 完成了 causal-conv decode 的 TileLang 接入，当时未考虑模型维度覆盖和 fallback dtype：

- Qwen3.5-2B 的 causal-conv 总维度为 6144，在 TP2 下本地维度为 3072；原有特化列表没有覆盖 6144 及其 TP 派生维度。
- 特化未命中后会进入 generic fallback。调用方会将输入转换为 FP16，而 generic wrapper 却校验为 BF16，导致 dtype 检查失败。
- 图模式下，未支持的 shape 进入 fallback 后还可能导致 graph capture 失败。

MegaChunkGdn 不能覆盖该问题：它处理的是 prefill 阶段的 gated-delta recurrence，普通 decode 仍会调用 causal-conv update 路径。

## 修改内容

- 在 causal-conv decode 的模型维度列表中增加 6144，生成 TP1、TP2、TP4、TP8 对应特化，并覆盖开启和关闭 SiLU 的情况。
- 将 generic causal-conv wrapper 的 dtype 校验修正为 FP16，与生成的 generic kernel 及 fallback 调用方保持一致。
- 增加 Qwen3.5-2B TP2、维度 3072 的回归用例。

## 验证结果

- `python setup.py build` 编译通过。
- `causal_conv1d_decode_wrapper_test` 通过：
  - 原有维度 2048：`max_diff=0`
  - Qwen3.5-2B TP2 维度 3072：`max_diff=0`
- Qwen3.5-2B 端到端冒烟验证通过：
  - Target TP2
  - 投机步数为 0
  - 关闭 prefix cache
  - 开启 graph、schedule overlap 和 chunked prefill
  - `max_seqs_per_batch=16`
  - 16/8/4/2/1 五个 graph bucket 均捕获成功
  - 真实请求成功生成 8 tokens
  - 两个 rank 日志中均未出现 dtype、缺少编译变体或 graph capture 错误