### PR TITLE
bugfix: fix cross-TP-rank state divergence during stochastic sampling with asynchronous MTP scheduling.

### DIFF
--- a/xllm/core/framework/model_context.cpp
+++ b/xllm/core/framework/model_context.cpp
@@ -107,7 +107,11 @@ void ModelContext::derive_optimization_config() {
   optimization_config_.enable_spec_token_broadcast = false;
 
   // determine whether to enable fused kernel based on backend
-  if (Platform::is_dcu()) {
+  if (Platform::is_npu()) {
+    // Unify speculative sampling results across TP ranks to guard against
+    // per-rank RNG divergence under enable_schedule_overlap.
+    optimization_config_.enable_spec_token_broadcast = true;
+  } else if (Platform::is_dcu()) {
     // DCU currently uses the unfused speculative sampling path.
     optimization_config_.enable_fused_spec_kernel = false;
   } else if (Platform::is_mlu()) {


### PR DESCRIPTION
## Description
开启mtp+随机采样出现的报错现象：
<img width="1193" height="122" alt="image" src="https://github.com/user-attachments/assets/0ba08332-6485-47a8-bbd8-981f9cde1042" />

在随机采样场景下，各 TP rank 使用独立的 NPU RNG generator。即使初始 seed 相同，异步调度后，不同 rank 的随机算子提交、graph replay 或 RNG offset 消费顺序仍可能产生差异，导致 draft token 或 validate 后的 accepted token 不一致。随后各 rank 会基于不同 token 更新 draft KV cache、position 和下一轮输入，造成 MTP 状态分叉和接受率下降。Greedy sampling 不消耗 RNG，因此通常不受影响。
代码中已有 enable_spec_token_broadcast 机制，用于在 schedule overlap 下统一各 TP rank 的 speculative sampling 结果，但此前仅对 MLU 启用，NPU 路径没有生效。

本修复在 NPU 上启用该能力，并保留现有的 enable_spec_token_broadcast && enable_schedule_overlap 判断。每步 draft sampling 和 target validation 后均广播实际 token，使所有 TP rank 使用一致的 token 更新后续 MTP 状态，同时保留 PR #1931 引入的异步执行，避免重新加入 compute_stream.synchronize() 及其带来的 NPU 空泡。

PR #1931 删除了 run_llm_no_sync_impl() 中每次 forward 后的 compute_stream.synchronize()，将 MTP 执行从逐轮同步改为异步提交。该改动消除了不必要的同步等待，但也暴露了此前被同步执行掩盖的跨-rank采样一致性问题。

## Change Type

- [x] Bug fix
- [ ] New feature
- [ ] Performance improvement
- [ ] Refactor
- [ ] Documentation
- [ ] Test
- [ ] Build or CI

## Reviewer Notes

<!-- Optional: anything reviewers should focus on, known risks, follow-ups, or validation gaps. -->
