### PR TITLE
bugfix: ignore linear state slots for attention-only models.

### DIFF
--- a/tests/core/framework/kv_cache/kv_cache_estimation_test.cpp
+++ b/tests/core/framework/kv_cache/kv_cache_estimation_test.cpp
@@ -60,6 +60,18 @@ TEST(KVCacheEstimationTest, EstimatesStandardAttentionBlocks) {
   EXPECT_EQ(capacity.n_blocks(), 128);
 }
 
+TEST(KVCacheEstimationTest, IgnoresLinearStateSlotsWithoutLinearAttention) {
+  ModelArgs model_args = make_standard_args();
+  KVCacheEstimateOptions options = make_estimate_options();
+  options.max_linear_state_cache_slots = 32;
+
+  KVCacheCapacity capacity = estimate_kv_cache_capacity(model_args, options);
+
+  EXPECT_EQ(capacity.num_linear_attention_layers(), 0);
+  EXPECT_EQ(capacity.num_linear_state_blocks(), 2);
+  EXPECT_EQ(capacity.linear_cache_size_in_bytes(), 0);
+}
+
 TEST(KVCacheEstimationTest, UserIndexerCacheDtypeDirectlyControlsQuantization) {
   ModelArgs model_args = make_standard_args();
   model_args.model_type("unsupported_model")

--- a/xllm/core/framework/kv_cache/kv_cache_estimation.cpp
+++ b/xllm/core/framework/kv_cache/kv_cache_estimation.cpp
@@ -244,6 +244,9 @@ int64_t calculate_linear_state_blocks(int64_t cache_size_in_bytes,
                                       bool enable_prefix_cache) {
   CHECK_GE(max_linear_state_cache_slots, 0)
       << "max_linear_state_cache_slots must be greater than or equal to 0.";
+  if (num_linear_attention_layers <= 0 || linear_slot_size <= 0) {
+    return kPaddingLinearStateBlocks;
+  }
   const int64_t max_blocks =
       max_linear_state_blocks(cache_size_in_bytes,
                               num_linear_attention_layers,


### PR DESCRIPTION
## 修改内容与原因

### 1. 直接运行最新 main 的问题

运行 Qwen3.5-2B TP2、MTP5 服务时可稳定复现：

```text
Target：Qwen3.5-2B，TP2
Draft：Qwen3.5-2B-mtp
num_speculative_tokens：5
max_concurrent_requests：32
```

服务会在模型加载完成后的 KV Cache 容量估算阶段直接退出，无法进入 ready，也无法发起推理请求：

```text
Check failed: requested_blocks <= max_blocks (34 vs. 2)
max_linear_state_cache_slots requires 34 linear-state blocks,
but only 2 fit in the configured KV cache budget.
```

对应调用链为：

```text
estimate_kv_cache_capacity
→ LLMEngine::estimate_kv_cache_capacity
→ SpeculativeEngine::allocate_kv_cache
→ LLMMaster 初始化失败
```

Qwen3.5 MTP Draft 只有一层普通 Attention，不包含 linear-attention/GDN 层，因此它不需要分配 linear-state cache。当前错误不是显存确实不足，而是把服务并发数错误地作为该 attention-only 模型的 linear-state 容量约束。

### 2. 关联 PR 为什么会引入该问题

该问题由 #1940 和 #1957 的组合改动触发。

#### #1940：引入 linear-state 容量估算，但缺少 attention-only 分支

#1940 新增 `calculate_linear_state_blocks()`。对于没有 linear-attention layer 的模型：

```text
num_linear_attention_layers = 0
linear_slot_size = 0
max_blocks = 2（仅保留 padding blocks）
```

`max_linear_state_blocks()` 已经正确判断该模型最多只需要两个 padding blocks，但 `calculate_linear_state_blocks()` 随后仍继续检查 `max_linear_state_cache_slots`：

```cpp
requested_blocks = max_linear_state_cache_slots + 2;
CHECK_LE(requested_blocks, max_blocks);
```

也就是说，模型没有任何 linear state，却仍按照 linear-state slot 数进行容量检查。这是问题的根本原因。

#### #1957：把服务并发数传入新字段，使潜在问题变成启动失败

#1957 清理旧字段后，将服务并发数写入：

```cpp
estimate_options.max_linear_state_cache_slots =
    ServiceConfig::get_instance().max_concurrent_requests();
```

当前配置的 `max_concurrent_requests=32`，因此容量估算得到：

```text
requested_blocks = 32 + 2 padding = 34
max_blocks = 2
```

最终触发 `34 <= 2` 检查失败。

需要注意，服务启动日志中的 runtime option 可能仍显示 `max_linear_state_cache_slots=0`；实际进入 `LLMEngine` 容量估算的是 `ServiceConfig.max_concurrent_requests`，本例中为 32。

### 3. 影响范围

该问题不只影响草稿模型。触发条件是：

```text
(num_linear_attention_layers == 0 或 linear_slot_size == 0)
并且 max_linear_state_cache_slots > 0
```

因此影响范围由模型结构和 slot 配置决定，而不是由 TP 数或 MTP 深度决定：

| 场景 | 是否可能受影响 | 原因 |
|---|---|---|
| Qwen3.5 MTP Draft | 是 | Draft 为 attention-only，收到非零 slots |
| 其他 TP 的 attention-only Draft | 是 | 与 TP 数无关 |
| 非投机场景的 attention-only Target | 是 | Target 也经过相同的 `LLMEngine` 容量估算路径 |
| 其他 speculative depth | 是 | 与 MTP 步数无关 |
| Hybrid / linear-attention 模型 | 不属于本缺陷 | 存在真实 linear state，应继续执行容量约束 |

当前 `LLMEngine` 会把 `ServiceConfig.max_concurrent_requests` 传给 `max_linear_state_cache_slots`。因此在默认并发数非零时，普通 attention-only Target 或 Draft 都可能在服务启动阶段失败；不要求开启 `enable_mtp_draft_body_tp1` 才会触发。

在本次 Qwen3.5 场景中，Target 包含 GDN/linear-attention 层，所以没有触发这个特定缺陷；attention-only MTP Draft 最先触发了错误。若 Target 本身也是 attention-only，同样可能受影响。

### 4. 如何修复

本 PR 在应用 slot 数量约束之前，先判断模型是否真的包含 linear state：

```cpp
if (num_linear_attention_layers <= 0 || linear_slot_size <= 0) {
  return kPaddingLinearStateBlocks;
}
```

修复后的行为：

| 模型类型 | 修复前 | 修复后 |
|---|---|---|
| Attention-only | 继续检查 slots，可能出现 `34 vs. 2` 并退出 | 忽略无意义的 slots，只保留 2 个 padding blocks |
| Hybrid / linear-attention | 正常执行容量上限检查 | 保持原逻辑不变 |

对于 attention-only 模型，最终容量为：

```text
num_linear_attention_layers = 0
num_linear_state_blocks = 2
linear_cache_size_in_bytes = 0
```

两个 padding blocks 用于保持现有 block/slot 管理约定；因为 linear-attention layer 数为 0，实际 linear-state cache 占用仍为 0。

该修复只跳过对“不存在的 linear state”的无效检查。对于真正包含 linear-attention layer 的模型，`requested_blocks <= max_blocks` 约束仍然保留，不会掩盖显存配置错误。

### 5. 回归测试

新增 attention-only 容量估算用例，显式设置：

```text
max_linear_state_cache_slots = 32
num_linear_attention_layers = 0
```

并验证：

```text
num_linear_state_blocks = 2
linear_cache_size_in_bytes = 0
```

## 修改范围

本 PR 只包含通用 KV Cache 容量修复及回归测试：

- `xllm/core/framework/kv_cache/kv_cache_estimation.cpp`：3 行修复；
- `tests/core/framework/kv_cache/kv_cache_estimation_test.cpp`：12 行回归测试。

不包含 MTP pipeline、Target handoff、TileLang kernel 或性能优化代码。该修复覆盖所有经过同一容量估算路径的 attention-only Target 和 Draft，不依赖 TP 数、是否启用投机解码或 MTP 深度。

## 验证

基于最新 main `5019610d`：

```text
python setup.py test --test-name kv_cache_estimation_test --device npu

[==========] Running 8 tests from 1 test suite.
[  PASSED  ] 8 tests.
```

格式检查：

```text
pre-commit run --files \
  xllm/core/framework/kv_cache/kv_cache_estimation.cpp \
  tests/core/framework/kv_cache/kv_cache_estimation_test.cpp

clang-format.............................................................Passed
```

### 实际服务验证

基于 PR commit `2e976c72f`（base：main `5019610d`）重新构建完整服务二进制，并实际启动：

```text
Target：Qwen3.5-2B，TP2
Draft：Qwen3.5-2B-mtp，TP2
num_speculative_tokens：5
max_concurrent_requests：32
NPU：14、15
```

服务启动阶段的容量日志符合预期：

```text
Target：linear_slot_size=3194880, linear_blocks=34
Draft：linear_slot_size=0, linear_blocks=2, reserved_linear_bytes=0.00 B
```

结果：

- 两个 rank 均完成 Target/Draft 权重加载和 KV Cache 分配，服务进入 ready；
- `/v1/models` ready gate：PASS；
- 真实 chat completion 请求：PASS，返回 11 个 completion tokens；
- 停服清理：PASS，无残留 PID、端口或 NPU 进程。

完整不可覆盖的服务 attempt：

```text
/home/g00510989/xllm/runs/20260717_pr1973_linear_state_attention_only/
  service/tp2-mtp5-c32-head2e976c72/
```

## 关联 PR

- #1940：引入 linear-state restore 与容量估算，缺少 attention-only 的提前返回。
- #1957：将服务并发数接入 `max_linear_state_cache_slots`，使潜在问题稳定触发。
