### PR TITLE
perf: integrate GammaAddRmsNorm for Qwen3.5 NPU.

### DIFF
--- a/xllm/core/kernels/npu/xllm_ops/CMakeLists.txt
+++ b/xllm/core/kernels/npu/xllm_ops/CMakeLists.txt
@@ -36,6 +36,7 @@ cc_library(
     beam_search_rec_final.cpp
     npu_mega_chunk_gdn.cpp
     layer_norm_fwd.cpp
+    gamma_add_rms_norm.cpp
   INCLUDES
     ${PROJECT_SOURCE_DIR}/third_party/xllm_ops/build/autogen
   DEPS

--- a/xllm/core/kernels/npu/xllm_ops/gamma_add_rms_norm.cpp
+++ b/xllm/core/kernels/npu/xllm_ops/gamma_add_rms_norm.cpp
@@ -1,0 +1,58 @@
+/* Copyright 2026 The xLLM Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://github.com/jd-opensource/xllm/blob/main/LICENSE
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include "core/kernels/npu/aclnn/pytorch_npu_helper.hpp"
+#include "core/kernels/npu/xllm_ops/xllm_ops_api.h"
+
+namespace xllm::kernel::npu {
+
+std::tuple<torch::Tensor, torch::Tensor, torch::Tensor> gamma_add_rms_norm(
+    const torch::Tensor& x1,
+    const torch::Tensor& x2,
+    const torch::Tensor& gamma,
+    double epsilon,
+    bool add_gamma_offset) {
+  CHECK_GT(x1.numel(), 0) << "x1 must not be empty.";
+  CHECK_GT(x2.numel(), 0) << "x2 must not be empty.";
+  CHECK_GT(gamma.numel(), 0) << "gamma must not be empty.";
+  CHECK_EQ(x1.sizes(), x2.sizes()) << "x1 and x2 must have the same shape.";
+  CHECK_GE(x1.dim(), gamma.dim())
+      << "x1 must have at least as many dimensions as gamma.";
+
+  const torch::IntArrayRef x1_shape = x1.sizes();
+  const int64_t keep_dims = x1.dim() - gamma.dim();
+  std::vector<int64_t> rstd_shape;
+  rstd_shape.reserve(static_cast<size_t>(x1.dim()));
+  for (int64_t index = 0; index < x1.dim(); ++index) {
+    rstd_shape.emplace_back(index < keep_dims ? x1_shape[index] : 1);
+  }
+
+  torch::Tensor y_out = torch::empty_like(x1);
+  torch::Tensor rstd_out =
+      torch::empty(rstd_shape, x1.options().dtype(torch::kFloat32));
+  torch::Tensor x_out = torch::empty_like(x1);
+  EXEC_NPU_CMD(aclnnGammaAddRmsNorm,
+               x1,
+               x2,
+               gamma,
+               epsilon,
+               add_gamma_offset,
+               y_out,
+               rstd_out,
+               x_out);
+  return {y_out, rstd_out, x_out};
+}
+
+}  // namespace xllm::kernel::npu

--- a/xllm/core/kernels/npu/xllm_ops/xllm_ops_api.h
+++ b/xllm/core/kernels/npu/xllm_ops/xllm_ops_api.h
@@ -180,6 +180,13 @@ std::tuple<at::Tensor, at::Tensor> quant_lightning_indexer(
     bool return_value);
 at::Tensor hc_pre_inv_rms(const at::Tensor& x, double epsilon);
 
+std::tuple<torch::Tensor, torch::Tensor, torch::Tensor> gamma_add_rms_norm(
+    const torch::Tensor& x1,
+    const torch::Tensor& x2,
+    const torch::Tensor& gamma,
+    double epsilon,
+    bool add_gamma_offset);
+
 std::tuple<at::Tensor, at::Tensor, at::Tensor> hc_pre_sinkhorn(
     const at::Tensor& mixes,
     const at::Tensor& rsqrt,

--- a/xllm/core/kernels/ops_api.cpp
+++ b/xllm/core/kernels/ops_api.cpp
@@ -354,9 +354,18 @@ void fused_layernorm(FusedLayerNormParams& params) {
                         params.dynamic_quant);
 #elif defined(USE_NPU)
   if (params.residual.has_value()) {
-    std::tie(params.output, std::ignore, params.residual_out) =
-        npu::add_rms_norm(
-            params.input, params.residual.value(), params.weight, params.eps);
+    if (params.add_gamma_offset) {
+      std::tie(params.output, std::ignore, params.residual_out) =
+          npu::gamma_add_rms_norm(params.input,
+                                  params.residual.value(),
+                                  params.weight,
+                                  params.eps,
+                                  params.add_gamma_offset);
+    } else {
+      std::tie(params.output, std::ignore, params.residual_out) =
+          npu::add_rms_norm(
+              params.input, params.residual.value(), params.weight, params.eps);
+    }
   } else {
     params.output =
         npu::rms_norm(params.input, params.weight, params.eps, params.mode);

--- a/xllm/core/kernels/param.h
+++ b/xllm/core/kernels/param.h
@@ -265,6 +265,8 @@ struct FusedLayerNormParams {
   std::string mode;
   // Epsilon value for numerical stability in normalization computation.
   double eps;
+  // Apply the Gemma/Qwen3.5 gamma offset inside NPU residual RMSNorm.
+  bool add_gamma_offset = false;
   // Whether to store output before normalization to residual_out.
   // Not supported when both bias and residual are not provided.
   bool store_output_before_norm = false;

--- a/xllm/core/layers/common/qwen3_next_rms_norm.cpp
+++ b/xllm/core/layers/common/qwen3_next_rms_norm.cpp
@@ -42,7 +42,7 @@ Qwen3NextRMSNormImpl::forward(torch::Tensor& input,
     return std::make_tuple(norm_params.norm_out, std::nullopt);
   }
 
-  // With residual: use fused_layernorm (which calls npu::add_rms_norm on NPU)
+  // With residual: use the fused NPU AddRmsNorm path.
   xllm::kernel::FusedLayerNormParams fused_params;
   fused_params.input = input;
   fused_params.residual = residual;
@@ -52,7 +52,12 @@ Qwen3NextRMSNormImpl::forward(torch::Tensor& input,
   fused_params.output = torch::empty_like(input);
   fused_params.residual_out = torch::empty_like(residual.value());
 #endif
+#if defined(USE_NPU)
+  fused_params.weight = weight_;
+  fused_params.add_gamma_offset = true;
+#else
   fused_params.weight = 1.0 + weight_;
+#endif
   fused_params.eps = eps_;
   fused_params.mode = "rmsnorm";
   xllm::kernel::fused_layernorm(fused_params);


### PR DESCRIPTION
## 中文说明

### 为什么修改

Qwen3.5 Gated DeltaNet 的 residual RMSNorm 路径原先需要先计算
`gamma + 1`，再调用 `AddRmsNorm`。本 PR 接入 xllm_ops 的
`GammaAddRmsNorm`，将 gamma offset 融合到 RMSNorm kernel，减少一次算子
下发。非 NPU 路径保持不变。

### 怎么修改

- 新增 xLLM NPU `GammaAddRmsNorm` wrapper、API 声明和 CMake 注册。
- Qwen3.5 residual RMSNorm 的 NPU 路径使用 `GammaAddRmsNorm`，并通过
  `addGammaOffset=true` 在 kernel 内计算 `gamma + 1`。
- 将 `third_party/xllm_ops` 更新到
  `98a8b346a8b545ca1d21f50d465b5ff6c4a4c63a`，包含
  `aclnnGammaAddRmsNorm`。

### 验证

- xLLM/xllm_ops 静态接入检查：18/18 PASS。
- 使用 CANN 9.0.0 从当前 xllm_ops 指针重新构建完整自定义算子包，并使用该包
  构建 xLLM。
- 单算子 BF16 `4x2048` 精度 smoke：1 passed。
- Qwen3.5-2B 图模式 E2E：两条链路各 10 轮，每轮 4 个正式请求，合计
  80/80 请求成功。

E2E 配置：Ascend 910B3 单卡 TP1、NPU 6、CPU 绑核 `48-71`、BF16、
`enable_graph=true`、`enable_schedule_overlap=true`、输入/输出
`2048/2048`、并发 4、每轮 1 个 warmup 请求和 4 个正式请求。

候选链路为 `GammaAddRmsNorm(addGammaOffset=true)`，基线为
`Add(gamma, 1) + AddRmsNorm`。

| 统计口径 | 指标 | 原链路 | GammaAddRmsNorm | 变化 |
|---|---|---:|---:|---:|
| 全部 10 轮 | TTFT | 340.187 ms | 314.339 ms | -7.598% |
| 全部 10 轮 | TPOT | 6.566 ms | 6.341 ms | -3.427% |
| 全部 10 轮 | 平均请求时延 | 13.7828 s | 13.2924 s | -3.558% |
| 全部 10 轮 | 请求吞吐 | 0.2900 req/s | 0.3000 req/s | +3.451% |
| 全部 10 轮 | 输出吞吐 | 593.941 tok/s | 614.447 tok/s | +3.453% |


逐轮 TPOT 实际值：

| Round | 原链路 (ms) | GammaAddRmsNorm (ms) | 差值 (ms) |
|---:|---:|---:|---:|
| 1 | 6.34 | 6.28 | -0.06 |
| 2 | 7.61 | 6.38 | -1.23 |
| 3 | 6.43 | 6.40 | -0.03 |
| 4 | 6.75 | 6.41 | -0.34 |
| 5 | 6.46 | 6.40 | -0.06 |
| 6 | 6.34 | 6.22 | -0.12 |
| 7 | 6.43 | 6.30 | -0.13 |
| 8 | 6.43 | 6.32 | -0.11 |
| 9 | 6.44 | 6.35 | -0.09 |
| 10 | 6.43 | 6.35 | -0.08 |

本 PR 的 7 个改动文件与验证分支逐文件一致，xllm_ops 指针均为 `98a8b346`。

### 状态

当前保持 Draft，等待 rebase 到最新主线并完成最终 CI/review。

## English Description

### Why

The Qwen3.5 Gated DeltaNet residual RMSNorm path previously computed
`gamma + 1` before calling `AddRmsNorm`. This PR integrates xllm_ops
`GammaAddRmsNorm`, fusing the gamma offset into the RMSNorm kernel and removing
one operator launch. Non-NPU paths remain unchanged.

### Changes

- Add the xLLM NPU `GammaAddRmsNorm` wrapper, API declaration, and CMake
  registration.
- Use `GammaAddRmsNorm` for the Qwen3.5 NPU residual RMSNorm path, with
  `addGammaOffset=true` computing `gamma + 1` inside the kernel.
- Update `third_party/xllm_ops` to
  `98a8b346a8b545ca1d21f50d465b5ff6c4a4c63a`.

### Validation

- xLLM/xllm_ops static integration checks: 18/18 PASS.
- Rebuilt the complete custom-op package from the current xllm_ops pointer with
  CANN 9.0.0, then built xLLM against that package.
- BF16 `4x2048` single-op accuracy smoke: 1 passed.
- Qwen3.5-2B graph-mode E2E: 10 rounds per path, 4 measured requests per
  round, with 80/80 total measured requests successful.

E2E configuration: one Ascend 910B3, TP1, NPU 6, CPU affinity `48-71`, BF16,
`enable_graph=true`, `enable_schedule_overlap=true`, input/output
`2048/2048`, concurrency 4, and 1 warmup plus 4 measured requests per round.

The candidate is `GammaAddRmsNorm(addGammaOffset=true)` and the baseline is
`Add(gamma, 1) + AddRmsNorm`.

| Scope | Metric | Baseline | GammaAddRmsNorm | Change |
|---|---|---:|---:|---:|
| All 10 rounds | TTFT | 340.187 ms | 314.339 ms | -7.598% |
| All 10 rounds | TPOT | 6.566 ms | 6.341 ms | -3.427% |
| All 10 rounds | Average latency | 13.7828 s | 13.2924 s | -3.558% |
| All 10 rounds | Request throughput | 0.2900 req/s | 0.3000 req/s | +3.451% |
| All 10 rounds | Output throughput | 593.941 tok/s | 614.447 tok/s | +3.453% |

Per-round TPOT values:

| Round | Baseline (ms) | GammaAddRmsNorm (ms) | Delta (ms) |
|---:|---:|---:|---:|
| 1 | 6.34 | 6.28 | -0.06 |
| 2 | 7.61 | 6.38 | -1.23 |
| 3 | 6.43 | 6.40 | -0.03 |
| 4 | 6.75 | 6.41 | -0.34 |
| 5 | 6.46 | 6.40 | -0.06 |
| 6 | 6.34 | 6.22 | -0.12 |
| 7 | 6.43 | 6.30 | -0.13 |
| 8 | 6.43 | 6.32 | -0.11 |
| 9 | 6.44 | 6.35 | -0.09 |
| 10 | 6.43 | 6.35 | -0.08 |

This PR-modified files match the validation branch exactly, and both use xllm_ops
`98a8b346`.

### Status

This PR remains a Draft pending rebase onto current main and final CI/review.
