### PR TITLE
bugfix: fix beam search pathway for mlu.

### DIFF
--- a/tests/core/framework/request/sequence_kv_state_test.cpp
+++ b/tests/core/framework/request/sequence_kv_state_test.cpp
@@ -36,6 +36,23 @@ TEST(KVCacheStateTest, TransferCursorTracksAndResets) {
   EXPECT_EQ(state.next_transfer_block_idx(), 0u);
 }
 
+TEST(KVCacheStateTest, ResetClearsBeamSourceState) {
+  KVCacheState state;
+  Block block(/*id=*/1, /*allocator=*/nullptr);
+  const std::vector<Block> src_blocks{block};
+  const uint32_t external_ref_count = block.ref_count();
+
+  state.set_src_blocks(src_blocks, /*need_swap=*/true);
+  EXPECT_FALSE(state.src_blocks().empty());
+  EXPECT_TRUE(state.need_swap());
+  EXPECT_EQ(block.ref_count(), external_ref_count + 1);
+
+  state.reset();
+  EXPECT_TRUE(state.src_blocks().empty());
+  EXPECT_FALSE(state.need_swap());
+  EXPECT_EQ(block.ref_count(), external_ref_count);
+}
+
 // Finding 2 regression: has_any_blocks() must report true for ANY
 // cache-bearing type (KV / SWA / C4 / C128) and IGNORE SINGLE. The pool's
 // "started_empty" rollback decision relies on this so that a DSV4 sequence

--- a/xllm/core/framework/request/sequence_kv_state.cpp
+++ b/xllm/core/framework/request/sequence_kv_state.cpp
@@ -337,6 +337,8 @@ void KVCacheState::reset() {
   num_owned_shared_blocks_.clear();
   pushed_local_block_count_ = 0;
   composite_blocks_.clear();
+  src_blocks_.clear();
+  need_swap_ = false;
   transfer_kv_info_.reset();
   next_transfer_block_idx_ = 0;
   pending_linear_save_hash_.reset();

--- a/xllm/core/runtime/worker_impl.cpp
+++ b/xllm/core/runtime/worker_impl.cpp
@@ -1043,7 +1043,11 @@ void WorkerImpl::apply_kv_block_swaps(const ModelInputParams& input_params) {
       ::xllm::BeamSearchConfig::get_instance().enable_block_copy_kernel()) {
     return;
   }
-#elif defined(USE_CUDA) || defined(USE_DCU)
+#elif defined(USE_CUDA) || defined(USE_DCU) || defined(USE_MLU)
+  // MLU has no fused block-copy kernel (enable_block_copy_kernel defaults to
+  // false), so it always falls through to the torch swap path below. Without
+  // this, beam-search copy-on-write blocks are allocated but never populated
+  // with the source KV, leaving each diverging beam reading stale pool memory.
   if (input_params.block_copy.swap_blocks.size() == 0) {
     return;
   }
@@ -1051,7 +1055,8 @@ void WorkerImpl::apply_kv_block_swaps(const ModelInputParams& input_params) {
   return;
 #endif
 
-#if defined(USE_NPU) || defined(USE_CUDA) || defined(USE_DCU)
+#if defined(USE_NPU) || defined(USE_CUDA) || defined(USE_DCU) || \
+    defined(USE_MLU)
   std::vector<int64_t> src_indices, dst_indices;
   src_indices.reserve(input_params.block_copy.swap_blocks.size());
   dst_indices.reserve(input_params.block_copy.swap_blocks.size());


### PR DESCRIPTION
## Description

This branch fixes two beam-search KV cache issues:

  1. It clears stale beam source blocks and swap state when resetting a sequence’s KV cache, preventing
     obsolete references from leaking into subsequent reuse.

  2. It enables KV block copy-on-write for beam search on MLU. Diverging beams now correctly copy the
     source beam’s KV data into newly allocated blocks instead of reading stale or uninitialized cache
     memory.

  Together, these fixes improve beam-search correctness, determinism, and KV cache lifecycle management on
  MLU.


## Change Type

- [x] Bug fix
- [ ] New feature
- [ ] Performance improvement
- [ ] Refactor
- [ ] Documentation
- [ ] Test
- [ ] Build or CI

## Pull Request Checklist

Thank you for contributing to xLLM. Before requesting review, please make sure the following items are complete.

### PR Title and Commit Messages

- [x] The PR title and each commit message follow the xLLM commit format: `<type>: <subject>`.

> Allowed types: feat, bugfix, docs, test, refactor, chore, style, revert, perf, model, build, release.
> The subject should use clear English, start with a verb, include at least 4 words, and end with `.`.

### Pre-commit Checks

- [x] I have installed `pre-commit` by running `pip install pre-commit` or an equivalent command.
- [x] I have installed the hooks with `pre-commit install`.
- [x] I have run `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

### Self Review

- [x] I have self-reviewed the code according to `.agents/skills/code-review/references/custom-code-style.md`, especially code written or assisted by AI.
- [x] I have rebased this PR onto the latest `main` branch.

### Build and Test Coverage

- [ ] Tests have been added or updated as needed.
- [ ] CUDA: `python setup.py build test` has passed on a CUDA machine.
- [x] NPU: `python setup.py build test` has passed on an NPU machine.
- [x] MLU: `python setup.py build test` has passed on an MLU machine.

## Reviewer Notes

<!-- Optional: anything reviewers should focus on, known risks, follow-ups, or validation gaps. -->
