### PR TITLE
feat: add dsa top-k sharing layer primitives.

### DIFF
--- a/cmake/cc_test.cmake
+++ b/cmake/cc_test.cmake
@@ -11,6 +11,8 @@ include(CMakeParseArguments)
 # COPTS: List of private compile options
 # LINKOPTS: List of link options
 # ARGS: Command line arguments to test case
+# TIMEOUT: Per-CTest timeout in seconds
+# RESOURCE_LOCK: CTest resource lock name
 #
 # Usage:
 # cc_library(
@@ -40,7 +42,7 @@ function(cc_test)
   cmake_parse_arguments(
     CC_TEST # prefix
     "" # options
-    "NAME;ENVIRONMENT" # one value args
+    "NAME;ENVIRONMENT;TIMEOUT;RESOURCE_LOCK" # one value args
     "SRCS;COPTS;LINKOPTS;DEPS;INCLUDES;ARGS;DATA" # multi value args
     ${ARGN}
   )
@@ -128,6 +130,14 @@ function(cc_test)
   if(CC_TEST_ENVIRONMENT)
     set_tests_properties(${_cc_test_${CC_TEST_NAME}_tests}
       PROPERTIES ENVIRONMENT "${CC_TEST_ENVIRONMENT}")
+  endif()
+  if(CC_TEST_TIMEOUT)
+    set_tests_properties(${_cc_test_${CC_TEST_NAME}_tests}
+      PROPERTIES TIMEOUT "${CC_TEST_TIMEOUT}")
+  endif()
+  if(CC_TEST_RESOURCE_LOCK)
+    set_tests_properties(${_cc_test_${CC_TEST_NAME}_tests}
+      PROPERTIES RESOURCE_LOCK "${CC_TEST_RESOURCE_LOCK}")
   endif()
   #add_test(NAME ${CC_TEST_NAME} COMMAND ${CC_TEST_NAME} ${CC_TEST_ARGS})
 endfunction()

--- a/cmake/cc_test.cmake
+++ b/cmake/cc_test.cmake
@@ -11,8 +11,6 @@ include(CMakeParseArguments)
 # COPTS: List of private compile options
 # LINKOPTS: List of link options
 # ARGS: Command line arguments to test case
-# TIMEOUT: Per-CTest timeout in seconds
-# RESOURCE_LOCK: CTest resource lock name
 #
 # Usage:
 # cc_library(
@@ -42,7 +40,7 @@ function(cc_test)
   cmake_parse_arguments(
     CC_TEST # prefix
     "" # options
-    "NAME;ENVIRONMENT;TIMEOUT;RESOURCE_LOCK" # one value args
+    "NAME;ENVIRONMENT" # one value args
     "SRCS;COPTS;LINKOPTS;DEPS;INCLUDES;ARGS;DATA" # multi value args
     ${ARGN}
   )
@@ -130,14 +128,6 @@ function(cc_test)
   if(CC_TEST_ENVIRONMENT)
     set_tests_properties(${_cc_test_${CC_TEST_NAME}_tests}
       PROPERTIES ENVIRONMENT "${CC_TEST_ENVIRONMENT}")
-  endif()
-  if(CC_TEST_TIMEOUT)
-    set_tests_properties(${_cc_test_${CC_TEST_NAME}_tests}
-      PROPERTIES TIMEOUT "${CC_TEST_TIMEOUT}")
-  endif()
-  if(CC_TEST_RESOURCE_LOCK)
-    set_tests_properties(${_cc_test_${CC_TEST_NAME}_tests}
-      PROPERTIES RESOURCE_LOCK "${CC_TEST_RESOURCE_LOCK}")
   endif()
   #add_test(NAME ${CC_TEST_NAME} COMMAND ${CC_TEST_NAME} ${CC_TEST_ARGS})
 endfunction()

--- a/tests/core/layers/CMakeLists.txt
+++ b/tests/core/layers/CMakeLists.txt
@@ -1,3 +1,17 @@
+include(cc_test)
+
+# Backend-independent DSA sharing policy. Keep this target outside platform
+# subdirectories so CUDA, MLU, NPU, and DCU test builds all register it.
+cc_test(
+  NAME
+    dsa_topk_share_plan_test
+  SRCS
+    dsa_topk_share_plan_test.cpp
+  DEPS
+    GTest::gtest_main
+    glog::glog
+)
+
 if(USE_CUDA)
   add_subdirectory(cuda)
 endif()

--- a/tests/core/layers/dsa_topk_share_plan_test.cpp
+++ b/tests/core/layers/dsa_topk_share_plan_test.cpp
@@ -1,0 +1,64 @@
+/* Copyright 2026 The xLLM Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://github.com/jd-opensource/xllm/blob/main/LICENSE
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include "core/layers/common/dsa_topk_share_plan.h"
+
+#include <gtest/gtest.h>
+
+namespace xllm::layer {
+namespace {
+
+ModelArgs make_dsa_mtp_args() {
+  ModelArgs args;
+  args.model_type() = "glm_moe_dsa_mtp";
+  args.index_share_for_mtp_iteration() = true;
+  args.index_head_dim() = 128;
+  args.index_n_heads() = 32;
+  args.index_topk() = 2048;
+  return args;
+}
+
+TEST(DsaTopkSharePlanTest, EnablesCrossStepReuseForMtpModelWithIndexer) {
+  EXPECT_TRUE(is_mtp_dsa_topk_reuse_enabled(make_dsa_mtp_args()));
+}
+
+TEST(DsaTopkSharePlanTest, DisablesCrossStepReuseWhenConfigFlagIsOff) {
+  ModelArgs args = make_dsa_mtp_args();
+  args.index_share_for_mtp_iteration() = false;
+  EXPECT_FALSE(is_mtp_dsa_topk_reuse_enabled(args));
+}
+
+TEST(DsaTopkSharePlanTest, DisablesCrossStepReuseWithoutCompleteIndexer) {
+  ModelArgs args = make_dsa_mtp_args();
+  args.index_head_dim() = 0;
+  EXPECT_FALSE(is_mtp_dsa_topk_reuse_enabled(args));
+
+  args = make_dsa_mtp_args();
+  args.index_n_heads() = 0;
+  EXPECT_FALSE(is_mtp_dsa_topk_reuse_enabled(args));
+
+  args = make_dsa_mtp_args();
+  args.index_topk() = 0;
+  EXPECT_FALSE(is_mtp_dsa_topk_reuse_enabled(args));
+}
+
+TEST(DsaTopkSharePlanTest, DisablesCrossStepReuseForTargetModel) {
+  ModelArgs args = make_dsa_mtp_args();
+  args.model_type() = "glm_moe_dsa";
+  EXPECT_FALSE(is_mtp_dsa_topk_reuse_enabled(args));
+}
+
+}  // namespace
+}  // namespace xllm::layer

--- a/tests/core/layers/mlu/CMakeLists.txt
+++ b/tests/core/layers/mlu/CMakeLists.txt
@@ -202,9 +202,16 @@ cc_test(
     glog::glog
 )
 
+# Each case forks two ranks. Keep CTest from scheduling cases from this target
+# onto the same MLU devices concurrently, and retain an outer timeout in case
+# the process-group runtime does not respond to the in-test cleanup deadline.
 cc_test(
   NAME
     deepseek_v2_attention_multi_device_test
+  TIMEOUT
+    150
+  RESOURCE_LOCK
+    mlu_multi_device
   SRCS
     deepseek_v2_attention_multi_device_test.cpp
     tests_utils.cpp
@@ -214,6 +221,20 @@ cc_test(
     :mlu_layers
     :parallel_state
     :state_dict
+    GTest::gtest_main
+    torch
+    glog::glog
+)
+
+# Cross-layer DSA top-k relay state is pure CPU logic, but the protocol belongs
+# to the MLU decoder/attention boundary.
+cc_test(
+  NAME
+    dsa_topk_relay_test
+  SRCS
+    dsa_topk_relay_test.cpp
+  DEPS
+    :mlu_layers
     GTest::gtest_main
     torch
     glog::glog

--- a/tests/core/layers/mlu/CMakeLists.txt
+++ b/tests/core/layers/mlu/CMakeLists.txt
@@ -202,16 +202,9 @@ cc_test(
     glog::glog
 )
 
-# Each case forks two ranks. Keep CTest from scheduling cases from this target
-# onto the same MLU devices concurrently, and retain an outer timeout in case
-# the process-group runtime does not respond to the in-test cleanup deadline.
 cc_test(
   NAME
     deepseek_v2_attention_multi_device_test
-  TIMEOUT
-    150
-  RESOURCE_LOCK
-    mlu_multi_device
   SRCS
     deepseek_v2_attention_multi_device_test.cpp
     tests_utils.cpp

--- a/tests/core/layers/mlu/deepseek_v2_attention_multi_device_test.cpp
+++ b/tests/core/layers/mlu/deepseek_v2_attention_multi_device_test.cpp
@@ -19,9 +19,14 @@ limitations under the License.
 #include <torch/torch.h>
 #include <unistd.h>
 
+#include <cerrno>
+#include <chrono>
+#include <csignal>
+#include <cstring>
 #include <memory>
 #include <optional>
 #include <string>
+#include <thread>
 #include <vector>
 
 #include "core/framework/config/kv_cache_config.h"
@@ -37,6 +42,7 @@ limitations under the License.
 #include "layers/mlu/tests_utils.h"
 #include "platform/device.h"
 #include "platform/platform.h"
+#include "util/net.h"
 
 namespace xllm {
 namespace layer {
@@ -52,37 +58,278 @@ KVCache create_indexed_kv_cache(torch::Tensor key_cache,
 
 constexpr int32_t EXIT_CODE_SKIP = 77;
 
+constexpr std::chrono::seconds kChildProcessTimeout{120};
+constexpr std::chrono::seconds kChildTerminationGracePeriod{2};
+constexpr std::chrono::milliseconds kChildPollInterval{10};
+
+struct ChildWaitResult {
+  bool any_failed = false;
+  bool any_skipped = false;
+  bool timed_out = false;
+};
+
+pid_t wait_for_pid(pid_t pid, int* status, int options) {
+  pid_t result;
+  do {
+    result = ::waitpid(pid, status, options);
+  } while (result < 0 && errno == EINTR);
+  return result;
+}
+
+void record_child_status(size_t rank, int status, ChildWaitResult& result) {
+  if (WIFEXITED(status)) {
+    const int32_t exit_code = WEXITSTATUS(status);
+    if (exit_code == EXIT_CODE_SKIP) {
+      result.any_skipped = true;
+    } else if (exit_code != 0) {
+      result.any_failed = true;
+      LOG(ERROR) << "Rank " << rank << " failed with code " << exit_code;
+    }
+    return;
+  }
+
+  result.any_failed = true;
+  if (WIFSIGNALED(status)) {
+    LOG(ERROR) << "Rank " << rank << " terminated by signal "
+               << WTERMSIG(status);
+  } else {
+    LOG(ERROR) << "Rank " << rank << " ended unexpectedly";
+  }
+}
+
+bool reap_children_until(
+    const std::vector<pid_t>& child_pids,
+    std::vector<bool>& finished,
+    const std::chrono::steady_clock::time_point& deadline) {
+  while (std::chrono::steady_clock::now() < deadline) {
+    bool all_finished = true;
+    for (size_t rank = 0; rank < child_pids.size(); ++rank) {
+      if (finished[rank]) {
+        continue;
+      }
+
+      int status = 0;
+      const pid_t wait_result =
+          wait_for_pid(child_pids[rank], &status, WNOHANG);
+      if (wait_result == child_pids[rank] ||
+          (wait_result < 0 && errno == ECHILD)) {
+        finished[rank] = true;
+        continue;
+      }
+      if (wait_result < 0) {
+        LOG(ERROR) << "Failed to reap rank " << rank << ": "
+                   << std::strerror(errno);
+      }
+      all_finished = false;
+    }
+    if (all_finished) {
+      return true;
+    }
+    std::this_thread::sleep_for(kChildPollInterval);
+  }
+  return false;
+}
+
+void signal_unfinished_children(const std::vector<pid_t>& child_pids,
+                                const std::vector<bool>& finished,
+                                int signal_number) {
+  for (size_t rank = 0; rank < child_pids.size(); ++rank) {
+    if (finished[rank]) {
+      continue;
+    }
+    if (::kill(child_pids[rank], signal_number) != 0 && errno != ESRCH) {
+      LOG(ERROR) << "Failed to signal rank " << rank << ": "
+                 << std::strerror(errno);
+    }
+  }
+}
+
+void terminate_and_reap_children(const std::vector<pid_t>& child_pids,
+                                 std::vector<bool>& finished) {
+  signal_unfinished_children(child_pids, finished, SIGTERM);
+  const auto term_deadline =
+      std::chrono::steady_clock::now() + kChildTerminationGracePeriod;
+  if (reap_children_until(child_pids, finished, term_deadline)) {
+    return;
+  }
+
+  signal_unfinished_children(child_pids, finished, SIGKILL);
+  const auto kill_deadline =
+      std::chrono::steady_clock::now() + kChildTerminationGracePeriod;
+  reap_children_until(child_pids, finished, kill_deadline);
+  for (size_t rank = 0; rank < child_pids.size(); ++rank) {
+    if (!finished[rank]) {
+      LOG(ERROR) << "Unable to reap timed-out rank " << rank;
+    }
+  }
+}
+
+ChildWaitResult wait_for_children(
+    const std::vector<pid_t>& child_pids,
+    std::chrono::steady_clock::duration timeout = kChildProcessTimeout) {
+  ChildWaitResult result;
+  std::vector<bool> finished(child_pids.size(), false);
+  size_t remaining = child_pids.size();
+  const auto deadline = std::chrono::steady_clock::now() + timeout;
+
+  while (remaining > 0 && std::chrono::steady_clock::now() < deadline) {
+    bool made_progress = false;
+    for (size_t rank = 0; rank < child_pids.size(); ++rank) {
+      if (finished[rank]) {
+        continue;
+      }
+
+      int status = 0;
+      const pid_t wait_result =
+          wait_for_pid(child_pids[rank], &status, WNOHANG);
+      if (wait_result == child_pids[rank]) {
+        finished[rank] = true;
+        --remaining;
+        made_progress = true;
+        record_child_status(rank, status, result);
+      } else if (wait_result < 0) {
+        result.any_failed = true;
+        finished[rank] = true;
+        --remaining;
+        made_progress = true;
+        LOG(ERROR) << "Failed waiting for rank " << rank << ": "
+                   << std::strerror(errno);
+      }
+    }
+    if (remaining > 0 && !made_progress) {
+      std::this_thread::sleep_for(kChildPollInterval);
+    }
+  }
+
+  if (remaining == 0) {
+    return result;
+  }
+
+  result.any_failed = true;
+  result.timed_out = true;
+  const int64_t timeout_ms =
+      std::chrono::duration_cast<std::chrono::milliseconds>(timeout).count();
+  LOG(ERROR) << "Timed out waiting for " << remaining
+             << " multi-device test rank(s) after " << timeout_ms << " ms";
+  terminate_and_reap_children(child_pids, finished);
+  return result;
+}
+
 std::unique_ptr<xllm::ProcessGroup> create_test_process_group(
     int32_t rank,
     int32_t world_size,
     int32_t port,
     const std::string& host,
     const torch::Device& device) {
-  return xllm::create_process_group(rank,
-                                    world_size,
-                                    world_size,
-                                    port,
-                                    false,
-                                    host,
-                                    "attention_multi_device_test_group",
-                                    device);
+  std::unique_ptr<xllm::ProcessGroup> process_group =
+      xllm::create_process_group(rank,
+                                 world_size,
+                                 world_size,
+                                 port,
+                                 false,
+                                 host,
+                                 "attention_multi_device_test_group",
+                                 device);
+  CHECK(process_group) << "Failed to create the test process group";
+
+  // TCPStore construction does not guarantee that every client has joined
+  // before rank 0 can leave a short test. Force one collective rendezvous so
+  // the server stays alive until all ranks have connected.
+  torch::Tensor rendezvous = torch::ones(
+      {1}, torch::TensorOptions().dtype(torch::kFloat32).device(device));
+  process_group->allreduce(rendezvous);
+  CHECK_EQ(rendezvous.item<float>(), static_cast<float>(world_size))
+      << "Multi-device test rendezvous failed";
+  return process_group;
 }
 
 std::unique_ptr<xllm::ProcessGroup> create_test_self_group(
     int32_t rank,
     int32_t world_size,
-    int32_t port,
     const std::string& host,
     const torch::Device& device) {
   return xllm::create_process_group(
       rank,
       world_size,
       /*rank_size=*/1,
-      port + world_size + rank,
+      /*port=*/0,
       false,
       host,
       "attention_multi_device_single_rank_group_" + std::to_string(rank),
       device);
+}
+
+class DistributedAttentionChildContext final {
+ public:
+  DistributedAttentionChildContext(int32_t rank,
+                                   int32_t world_size,
+                                   int32_t device_count,
+                                   int32_t port,
+                                   const std::string& host,
+                                   bool enable_context_parallel)
+      : xllm_device_(rank % device_count),
+        device_(xllm_device_.unwrap()),
+        options_(torch::TensorOptions()
+                     .dtype(torch::kBFloat16)
+                     .device(device_)
+                     .requires_grad(false)) {
+    xllm_device_.set_device();
+    process_group_ =
+        create_test_process_group(rank, world_size, port, host, device_);
+    self_group_ = create_test_self_group(rank, world_size, host, device_);
+    CHECK(process_group_) << "Rank " << rank
+                          << ": failed to create process group";
+    CHECK(self_group_) << "Rank " << rank << ": failed to create self group";
+
+    parallel_args_ =
+        std::make_unique<ParallelArgs>(rank, world_size, process_group_.get());
+    parallel_args_->tp_group_ = process_group_.get();
+    parallel_args_->single_rank_group_ = self_group_.get();
+    parallel_args_->cp_group_ = process_group_.get();
+    if (enable_context_parallel) {
+      parallel_args_->cp_size() = world_size;
+    }
+  }
+
+  xllm::Device& xllm_device() { return xllm_device_; }
+
+  const torch::Device& device() const { return device_; }
+
+  ParallelArgs& parallel_args() { return *parallel_args_; }
+
+  const torch::TensorOptions& options() const { return options_; }
+
+ private:
+  xllm::Device xllm_device_;
+  torch::Device device_;
+  std::unique_ptr<xllm::ProcessGroup> process_group_;
+  std::unique_ptr<xllm::ProcessGroup> self_group_;
+  std::unique_ptr<ParallelArgs> parallel_args_;
+  torch::TensorOptions options_;
+};
+
+template <typename ChildBody>
+int32_t run_distributed_attention_child(int32_t rank,
+                                        int32_t world_size,
+                                        int32_t port,
+                                        const std::string& host,
+                                        bool enable_context_parallel,
+                                        const ChildBody& child_body) {
+  try {
+    const int32_t device_count = xllm::Platform::device_count();
+    if (device_count < world_size) {
+      LOG(WARNING) << "Rank " << rank << ": insufficient devices. Skipping.";
+      return EXIT_CODE_SKIP;
+    }
+
+    KVCacheConfig::get_instance().block_size(16);
+    DistributedAttentionChildContext context(
+        rank, world_size, device_count, port, host, enable_context_parallel);
+    return child_body(context);
+  } catch (const std::exception& e) {
+    LOG(ERROR) << "Rank " << rank << ": Exception: " << e.what();
+    return 1;
+  }
 }
 
 void check_tensors_close(const torch::Tensor& actual,
@@ -335,6 +582,33 @@ AttentionMetadata create_decode_metadata(const torch::TensorOptions& options) {
   return metadata;
 }
 
+// Decode metadata for a bucket of `batch_size` single-token sequences,
+// mirroring how the MLU graph pads num_tokens into a fixed bucket. Each
+// sequence maps to a distinct KV block so the sparse block table has
+// `batch_size` rows.
+AttentionMetadata create_batch_decode_metadata(
+    const torch::TensorOptions& options,
+    int32_t batch_size) {
+  AttentionMetadata metadata;
+  auto int_options = options.dtype(torch::kInt32);
+  metadata.q_cu_seq_lens = torch::arange(batch_size + 1, int_options);
+  metadata.kv_cu_seq_lens = torch::zeros({batch_size + 1}, int_options);
+  metadata.kv_seq_lens = torch::ones({batch_size}, int_options);
+  metadata.block_table = torch::zeros({batch_size, 4}, int_options);
+  for (int32_t i = 0; i < batch_size; ++i) {
+    metadata.block_table[i][0] = i + 1;
+  }
+  metadata.slot_mapping = torch::arange(1, batch_size + 1, int_options);
+  metadata.max_query_len = 1;
+  metadata.max_seq_len = 1;
+  metadata.total_kv_len = batch_size;
+  metadata.compute_dtype = "half";
+  metadata.is_prefill = false;
+  metadata.is_chunked_prefill = false;
+  metadata.is_dummy = false;
+  return metadata;
+}
+
 AttentionMetadata create_prefill_metadata(const torch::TensorOptions& options,
                                           int32_t seq_len) {
   AttentionMetadata metadata;
@@ -570,235 +844,179 @@ int32_t run_attention_test_child(int32_t rank,
                                  const std::string& host,
                                  bool enable_fused_mla_kernel,
                                  int64_t q_lora_rank) {
-  try {
-    const int32_t dev_count = xllm::Platform::device_count();
-    if (dev_count < world_size) {
-      LOG(WARNING) << "Rank " << rank << ": insufficient devices. Skipping.";
-      return EXIT_CODE_SKIP;
-    }
+  return run_distributed_attention_child(
+      rank,
+      world_size,
+      port,
+      host,
+      /*enable_context_parallel=*/false,
+      [enable_fused_mla_kernel,
+       q_lora_rank](DistributedAttentionChildContext& context) {
+        xllm::Device& xllm_device = context.xllm_device();
+        const torch::Device& device = context.device();
+        ParallelArgs& parallel_args = context.parallel_args();
+        const torch::TensorOptions& options = context.options();
+        ModelArgs model_args = create_attention_model_args(q_lora_rank);
+        QuantArgs quant_args = create_default_quant_args();
+        StateDict state_dict = create_attention_state_dict(model_args, options);
 
-    KVCacheConfig::get_instance().block_size(16);
-    const int32_t device_index = rank % dev_count;
-    xllm::Device xllm_device(device_index);
-    xllm_device.set_device();
-    torch::Device device = xllm_device.unwrap();
-    auto process_group =
-        create_test_process_group(rank, world_size, port, host, device);
-    CHECK(process_group) << "Rank " << rank
-                         << ": failed to create process group";
-    auto self_group =
-        create_test_self_group(rank, world_size, port, host, device);
-    CHECK(self_group) << "Rank " << rank << ": failed to create self group";
+        torch::Tensor hidden_states =
+            seeded_tensor("attention_multi_device/hidden_states",
+                          {1, model_args.hidden_size()},
+                          torch::kBFloat16,
+                          device);
+        torch::Tensor positions =
+            torch::tensor({0}, options.dtype(torch::kInt32).device(device));
 
-    ParallelArgs parallel_args(rank, world_size, process_group.get());
-    parallel_args.tp_group_ = process_group.get();
-    parallel_args.single_rank_group_ = self_group.get();
-    parallel_args.cp_group_ = process_group.get();
+        KVCache full_weight_kv_cache =
+            create_decode_kv_cache(model_args, options);
 
-    auto options = torch::TensorOptions()
-                       .dtype(torch::kBFloat16)
-                       .device(device)
-                       .requires_grad(false);
-    ModelArgs model_args = create_attention_model_args(q_lora_rank);
-    QuantArgs quant_args = create_default_quant_args();
-    StateDict state_dict = create_attention_state_dict(model_args, options);
+        torch::Tensor full_weight_output =
+            run_attention_decode_once(model_args,
+                                      quant_args,
+                                      parallel_args,
+                                      options,
+                                      state_dict,
+                                      positions,
+                                      hidden_states,
+                                      full_weight_kv_cache,
+                                      true,
+                                      enable_fused_mla_kernel);
 
-    torch::Tensor hidden_states =
-        seeded_tensor("attention_multi_device/hidden_states",
-                      {1, model_args.hidden_size()},
-                      torch::kBFloat16,
-                      device);
-    torch::Tensor positions =
-        torch::tensor({0}, options.dtype(torch::kInt32).device(device));
-
-    KVCache full_weight_kv_cache = create_decode_kv_cache(model_args, options);
-
-    torch::Tensor full_weight_output =
-        run_attention_decode_once(model_args,
-                                  quant_args,
-                                  parallel_args,
-                                  options,
-                                  state_dict,
-                                  positions,
-                                  hidden_states,
-                                  full_weight_kv_cache,
-                                  true,
-                                  enable_fused_mla_kernel);
-
-    xllm_device.synchronize_default_stream();
-    CHECK_EQ(full_weight_output.size(0), 1)
-        << "DeepseekV2Attention decode replicated token count mismatch";
-    CHECK_EQ(full_weight_output.size(1), model_args.hidden_size())
-        << "DeepseekV2Attention decode replicated hidden size mismatch";
-    check_tensor_same_across_ranks(full_weight_output,
-                                   parallel_args.tp_group_,
-                                   "DeepseekV2Attention decode replicated");
-    return 0;
-  } catch (const std::exception& e) {
-    LOG(ERROR) << "Rank " << rank << ": Exception: " << e.what();
-    return 1;
-  }
+        xllm_device.synchronize_default_stream();
+        CHECK_EQ(full_weight_output.size(0), 1)
+            << "DeepseekV2Attention decode replicated token count mismatch";
+        CHECK_EQ(full_weight_output.size(1), model_args.hidden_size())
+            << "DeepseekV2Attention decode replicated hidden size mismatch";
+        check_tensor_same_across_ranks(full_weight_output,
+                                       parallel_args.tp_group_,
+                                       "DeepseekV2Attention decode replicated");
+        return 0;
+      });
 }
 
 int32_t run_attention_prefill_repl_test_child(int32_t rank,
                                               int32_t world_size,
                                               int32_t port,
                                               const std::string& host) {
-  try {
-    const int32_t dev_count = xllm::Platform::device_count();
-    if (dev_count < world_size) {
-      LOG(WARNING) << "Rank " << rank << ": insufficient devices. Skipping.";
-      return EXIT_CODE_SKIP;
-    }
+  return run_distributed_attention_child(
+      rank,
+      world_size,
+      port,
+      host,
+      /*enable_context_parallel=*/false,
+      [](DistributedAttentionChildContext& context) {
+        xllm::Device& xllm_device = context.xllm_device();
+        const torch::Device& device = context.device();
+        ParallelArgs& parallel_args = context.parallel_args();
+        const torch::TensorOptions& options = context.options();
+        ModelArgs model_args = create_attention_model_args();
+        QuantArgs quant_args = create_default_quant_args();
+        StateDict state_dict = create_attention_state_dict(model_args, options);
 
-    KVCacheConfig::get_instance().block_size(16);
-    const int32_t device_index = rank % dev_count;
-    xllm::Device xllm_device(device_index);
-    xllm_device.set_device();
-    torch::Device device = xllm_device.unwrap();
-    auto process_group =
-        create_test_process_group(rank, world_size, port, host, device);
-    CHECK(process_group) << "Rank " << rank
-                         << ": failed to create process group";
-    auto self_group =
-        create_test_self_group(rank, world_size, port, host, device);
-    CHECK(self_group) << "Rank " << rank << ": failed to create self group";
+        constexpr int32_t seq_len = 4;
+        torch::Tensor tokens =
+            torch::arange(seq_len, options.dtype(torch::kInt32).device(device));
+        torch::Tensor hidden_states =
+            seeded_tensor("attention_multi_device/prefill_hidden_states",
+                          {seq_len, model_args.hidden_size()},
+                          torch::kBFloat16,
+                          device);
+        torch::Tensor positions =
+            torch::arange(seq_len, options.dtype(torch::kInt32).device(device));
 
-    ParallelArgs parallel_args(rank, world_size, process_group.get());
-    parallel_args.tp_group_ = process_group.get();
-    parallel_args.single_rank_group_ = self_group.get();
-    parallel_args.cp_group_ = process_group.get();
+        KVCache full_weight_kv_cache =
+            create_decode_kv_cache(model_args, options);
+        full_weight_kv_cache.get_k_cache().zero_();
 
-    auto options = torch::TensorOptions()
-                       .dtype(torch::kBFloat16)
-                       .device(device)
-                       .requires_grad(false);
-    ModelArgs model_args = create_attention_model_args();
-    QuantArgs quant_args = create_default_quant_args();
-    StateDict state_dict = create_attention_state_dict(model_args, options);
+        auto repl_result =
+            run_attention_prefill_once(model_args,
+                                       quant_args,
+                                       parallel_args,
+                                       options,
+                                       state_dict,
+                                       tokens,
+                                       positions,
+                                       hidden_states,
+                                       full_weight_kv_cache,
+                                       true,
+                                       /*enable_fused_mla_kernel=*/
+                                       false);
 
-    constexpr int32_t seq_len = 4;
-    torch::Tensor tokens =
-        torch::arange(seq_len, options.dtype(torch::kInt32).device(device));
-    torch::Tensor hidden_states =
-        seeded_tensor("attention_multi_device/prefill_hidden_states",
-                      {seq_len, model_args.hidden_size()},
-                      torch::kBFloat16,
-                      device);
-    torch::Tensor positions =
-        torch::arange(seq_len, options.dtype(torch::kInt32).device(device));
-
-    KVCache full_weight_kv_cache = create_decode_kv_cache(model_args, options);
-    full_weight_kv_cache.get_k_cache().zero_();
-
-    auto repl_result = run_attention_prefill_once(model_args,
-                                                  quant_args,
-                                                  parallel_args,
-                                                  options,
-                                                  state_dict,
-                                                  tokens,
-                                                  positions,
-                                                  hidden_states,
-                                                  full_weight_kv_cache,
-                                                  true,
-                                                  /*enable_fused_mla_kernel=*/
-                                                  false);
-
-    xllm_device.synchronize_default_stream();
-    check_repl_output_contract(repl_result,
-                               seq_len,
-                               model_args.hidden_size(),
-                               "DeepseekV2Attention prefill replicated");
-    check_tensor_same_across_ranks(
-        repl_result.global_output,
-        parallel_args.tp_group_,
-        "DeepseekV2Attention prefill replicated output");
-    return 0;
-  } catch (const std::exception& e) {
-    LOG(ERROR) << "Rank " << rank << ": Exception: " << e.what();
-    return 1;
-  }
+        xllm_device.synchronize_default_stream();
+        check_repl_output_contract(repl_result,
+                                   seq_len,
+                                   model_args.hidden_size(),
+                                   "DeepseekV2Attention prefill replicated");
+        check_tensor_same_across_ranks(
+            repl_result.global_output,
+            parallel_args.tp_group_,
+            "DeepseekV2Attention prefill replicated output");
+        return 0;
+      });
 }
 
 int32_t run_attention_prefill_fallback_test_child(int32_t rank,
                                                   int32_t world_size,
                                                   int32_t port,
                                                   const std::string& host) {
-  try {
-    const int32_t dev_count = xllm::Platform::device_count();
-    if (dev_count < world_size) {
-      LOG(WARNING) << "Rank " << rank << ": insufficient devices. Skipping.";
-      return EXIT_CODE_SKIP;
-    }
+  return run_distributed_attention_child(
+      rank,
+      world_size,
+      port,
+      host,
+      /*enable_context_parallel=*/false,
+      [](DistributedAttentionChildContext& context) {
+        xllm::Device& xllm_device = context.xllm_device();
+        const torch::Device& device = context.device();
+        ParallelArgs& parallel_args = context.parallel_args();
+        const torch::TensorOptions& options = context.options();
+        ModelArgs model_args =
+            create_attention_model_args(/*q_lora_rank=*/64,
+                                        /*enable_indexer=*/true);
+        QuantArgs quant_args = create_default_quant_args();
+        StateDict state_dict = create_attention_state_dict(model_args, options);
 
-    KVCacheConfig::get_instance().block_size(16);
-    const int32_t device_index = rank % dev_count;
-    xllm::Device xllm_device(device_index);
-    xllm_device.set_device();
-    torch::Device device = xllm_device.unwrap();
-    auto process_group =
-        create_test_process_group(rank, world_size, port, host, device);
-    CHECK(process_group) << "Rank " << rank
-                         << ": failed to create process group";
-    auto self_group =
-        create_test_self_group(rank, world_size, port, host, device);
-    CHECK(self_group) << "Rank " << rank << ": failed to create self group";
+        constexpr int32_t seq_len = 1;
+        torch::Tensor tokens =
+            torch::arange(seq_len, options.dtype(torch::kInt32).device(device));
+        torch::Tensor hidden_states = seeded_tensor(
+            "attention_multi_device/prefill_hidden_states_fallback",
+            {seq_len, model_args.hidden_size()},
+            torch::kBFloat16,
+            device);
+        torch::Tensor positions =
+            torch::arange(seq_len, options.dtype(torch::kInt32).device(device));
 
-    ParallelArgs parallel_args(rank, world_size, process_group.get());
-    parallel_args.tp_group_ = process_group.get();
-    parallel_args.single_rank_group_ = self_group.get();
-    parallel_args.cp_group_ = process_group.get();
+        KVCache full_weight_kv_cache =
+            create_decode_kv_cache(model_args, options);
+        full_weight_kv_cache.get_k_cache().zero_();
 
-    auto options = torch::TensorOptions()
-                       .dtype(torch::kBFloat16)
-                       .device(device)
-                       .requires_grad(false);
-    ModelArgs model_args = create_attention_model_args(/*q_lora_rank=*/64,
-                                                       /*enable_indexer=*/true);
-    QuantArgs quant_args = create_default_quant_args();
-    StateDict state_dict = create_attention_state_dict(model_args, options);
+        auto repl_result =
+            run_attention_prefill_once(model_args,
+                                       quant_args,
+                                       parallel_args,
+                                       options,
+                                       state_dict,
+                                       tokens,
+                                       positions,
+                                       hidden_states,
+                                       full_weight_kv_cache,
+                                       true,
+                                       /*enable_fused_mla_kernel=*/
+                                       false);
 
-    constexpr int32_t seq_len = 1;
-    torch::Tensor tokens =
-        torch::arange(seq_len, options.dtype(torch::kInt32).device(device));
-    torch::Tensor hidden_states =
-        seeded_tensor("attention_multi_device/prefill_hidden_states_fallback",
-                      {seq_len, model_args.hidden_size()},
-                      torch::kBFloat16,
-                      device);
-    torch::Tensor positions =
-        torch::arange(seq_len, options.dtype(torch::kInt32).device(device));
-
-    KVCache full_weight_kv_cache = create_decode_kv_cache(model_args, options);
-    full_weight_kv_cache.get_k_cache().zero_();
-
-    auto repl_result = run_attention_prefill_once(model_args,
-                                                  quant_args,
-                                                  parallel_args,
-                                                  options,
-                                                  state_dict,
-                                                  tokens,
-                                                  positions,
-                                                  hidden_states,
-                                                  full_weight_kv_cache,
-                                                  true,
-                                                  /*enable_fused_mla_kernel=*/
-                                                  false);
-
-    xllm_device.synchronize_default_stream();
-    check_repl_output_contract(repl_result,
-                               seq_len,
-                               model_args.hidden_size(),
-                               "DeepseekV2Attention prefill fallback");
-    check_tensor_same_across_ranks(
-        repl_result.global_output,
-        parallel_args.tp_group_,
-        "DeepseekV2Attention prefill fallback output");
-    return 0;
-  } catch (const std::exception& e) {
-    LOG(ERROR) << "Rank " << rank << ": Exception: " << e.what();
-    return 1;
-  }
+        xllm_device.synchronize_default_stream();
+        check_repl_output_contract(repl_result,
+                                   seq_len,
+                                   model_args.hidden_size(),
+                                   "DeepseekV2Attention prefill fallback");
+        check_tensor_same_across_ranks(
+            repl_result.global_output,
+            parallel_args.tp_group_,
+            "DeepseekV2Attention prefill fallback output");
+        return 0;
+      });
 }
 
 int32_t run_attention_prefill_sp_test_child(int32_t rank,
@@ -806,627 +1024,793 @@ int32_t run_attention_prefill_sp_test_child(int32_t rank,
                                             int32_t port,
                                             const std::string& host,
                                             bool use_glm5_args = false) {
-  try {
-    const int32_t dev_count = xllm::Platform::device_count();
-    if (dev_count < world_size) {
-      LOG(WARNING) << "Rank " << rank << ": insufficient devices. Skipping.";
-      return EXIT_CODE_SKIP;
-    }
+  return run_distributed_attention_child(
+      rank,
+      world_size,
+      port,
+      host,
+      /*enable_context_parallel=*/false,
+      [use_glm5_args, world_size](DistributedAttentionChildContext& context) {
+        xllm::Device& xllm_device = context.xllm_device();
+        const torch::Device& device = context.device();
+        ParallelArgs& parallel_args = context.parallel_args();
+        const torch::TensorOptions& options = context.options();
+        ModelArgs model_args =
+            use_glm5_args ? create_glm5_attention_model_args()
+                          : create_attention_model_args(/*q_lora_rank=*/64,
+                                                        /*enable_indexer=*/
+                                                        true);
+        QuantArgs quant_args = create_default_quant_args();
+        StateDict state_dict = create_attention_state_dict(model_args, options);
 
-    KVCacheConfig::get_instance().block_size(16);
-    const int32_t device_index = rank % dev_count;
-    xllm::Device xllm_device(device_index);
-    xllm_device.set_device();
-    torch::Device device = xllm_device.unwrap();
-    auto process_group =
-        create_test_process_group(rank, world_size, port, host, device);
-    CHECK(process_group) << "Rank " << rank
-                         << ": failed to create process group";
-    auto self_group =
-        create_test_self_group(rank, world_size, port, host, device);
-    CHECK(self_group) << "Rank " << rank << ": failed to create self group";
+        constexpr int32_t seq_len = 4;
+        torch::Tensor tokens =
+            torch::arange(seq_len, options.dtype(torch::kInt32).device(device));
+        torch::Tensor hidden_states = seeded_tensor(
+            use_glm5_args ? "attention_multi_device/glm5_prefill_hidden_states"
+                          : "attention_multi_device/sp_prefill_hidden_states",
+            {seq_len, model_args.hidden_size()},
+            torch::kBFloat16,
+            device);
+        torch::Tensor positions =
+            torch::arange(seq_len, options.dtype(torch::kInt32).device(device));
 
-    ParallelArgs parallel_args(rank, world_size, process_group.get());
-    parallel_args.tp_group_ = process_group.get();
-    parallel_args.single_rank_group_ = self_group.get();
-    parallel_args.cp_group_ = process_group.get();
+        KVCache full_weight_kv_cache =
+            create_decode_kv_cache(model_args, options);
+        full_weight_kv_cache.get_k_cache().zero_();
 
-    auto options = torch::TensorOptions()
-                       .dtype(torch::kBFloat16)
-                       .device(device)
-                       .requires_grad(false);
-    ModelArgs model_args = use_glm5_args
-                               ? create_glm5_attention_model_args()
-                               : create_attention_model_args(/*q_lora_rank=*/64,
-                                                             /*enable_indexer=*/
-                                                             true);
-    QuantArgs quant_args = create_default_quant_args();
-    StateDict state_dict = create_attention_state_dict(model_args, options);
+        auto sp_result = run_attention_prefill_once(model_args,
+                                                    quant_args,
+                                                    parallel_args,
+                                                    options,
+                                                    state_dict,
+                                                    tokens,
+                                                    positions,
+                                                    hidden_states,
+                                                    full_weight_kv_cache,
+                                                    true,
+                                                    /*enable_fused_mla_kernel=*/
+                                                    false);
 
-    constexpr int32_t seq_len = 4;
-    torch::Tensor tokens =
-        torch::arange(seq_len, options.dtype(torch::kInt32).device(device));
-    torch::Tensor hidden_states = seeded_tensor(
-        use_glm5_args ? "attention_multi_device/glm5_prefill_hidden_states"
-                      : "attention_multi_device/sp_prefill_hidden_states",
-        {seq_len, model_args.hidden_size()},
-        torch::kBFloat16,
-        device);
-    torch::Tensor positions =
-        torch::arange(seq_len, options.dtype(torch::kInt32).device(device));
-
-    KVCache full_weight_kv_cache = create_decode_kv_cache(model_args, options);
-    full_weight_kv_cache.get_k_cache().zero_();
-
-    auto sp_result = run_attention_prefill_once(model_args,
-                                                quant_args,
-                                                parallel_args,
-                                                options,
-                                                state_dict,
-                                                tokens,
-                                                positions,
-                                                hidden_states,
-                                                full_weight_kv_cache,
-                                                true,
-                                                /*enable_fused_mla_kernel=*/
-                                                false);
-
-    xllm_device.synchronize_default_stream();
-    check_sp_output_contract(sp_result,
-                             seq_len,
-                             model_args.hidden_size(),
-                             /*local_token_num=*/seq_len / world_size,
-                             use_glm5_args
-                                 ? "DeepseekV2Attention glm5 prefill sp"
-                                 : "DeepseekV2Attention prefill sp");
-    check_tensor_same_across_ranks(
-        sp_result.global_output,
-        parallel_args.tp_group_,
-        use_glm5_args ? "DeepseekV2Attention glm5 prefill sp output"
-                      : "DeepseekV2Attention prefill sp output");
-    return 0;
-  } catch (const std::exception& e) {
-    LOG(ERROR) << "Rank " << rank << ": Exception: " << e.what();
-    return 1;
-  }
+        xllm_device.synchronize_default_stream();
+        check_sp_output_contract(sp_result,
+                                 seq_len,
+                                 model_args.hidden_size(),
+                                 /*local_token_num=*/seq_len / world_size,
+                                 use_glm5_args
+                                     ? "DeepseekV2Attention glm5 prefill sp"
+                                     : "DeepseekV2Attention prefill sp");
+        check_tensor_same_across_ranks(
+            sp_result.global_output,
+            parallel_args.tp_group_,
+            use_glm5_args ? "DeepseekV2Attention glm5 prefill sp output"
+                          : "DeepseekV2Attention prefill sp output");
+        return 0;
+      });
 }
 
 int32_t run_attention_prefill_sp_baseline_test_child(int32_t rank,
                                                      int32_t world_size,
                                                      int32_t port,
                                                      const std::string& host) {
-  try {
-    const int32_t dev_count = xllm::Platform::device_count();
-    if (dev_count < world_size) {
-      LOG(WARNING) << "Rank " << rank << ": insufficient devices. Skipping.";
-      return EXIT_CODE_SKIP;
-    }
+  return run_distributed_attention_child(
+      rank,
+      world_size,
+      port,
+      host,
+      /*enable_context_parallel=*/false,
+      [world_size](DistributedAttentionChildContext& context) {
+        xllm::Device& xllm_device = context.xllm_device();
+        const torch::Device& device = context.device();
+        ParallelArgs& parallel_args = context.parallel_args();
+        const torch::TensorOptions& options = context.options();
+        ModelArgs model_args =
+            create_attention_model_args(/*q_lora_rank=*/64,
+                                        /*enable_indexer=*/true);
+        QuantArgs quant_args = create_default_quant_args();
+        StateDict state_dict = create_attention_state_dict(model_args, options);
 
-    KVCacheConfig::get_instance().block_size(16);
-    const int32_t device_index = rank % dev_count;
-    xllm::Device xllm_device(device_index);
-    xllm_device.set_device();
-    torch::Device device = xllm_device.unwrap();
-    auto process_group =
-        create_test_process_group(rank, world_size, port, host, device);
-    CHECK(process_group) << "Rank " << rank
-                         << ": failed to create process group";
-    auto self_group =
-        create_test_self_group(rank, world_size, port, host, device);
-    CHECK(self_group) << "Rank " << rank << ": failed to create self group";
+        constexpr int32_t seq_len = 4;
+        torch::Tensor tokens =
+            torch::arange(seq_len, options.dtype(torch::kInt32).device(device));
+        torch::Tensor hidden_states = seeded_tensor(
+            "attention_multi_device/sp_prefill_baseline_hidden_states",
+            {seq_len, model_args.hidden_size()},
+            torch::kBFloat16,
+            device);
+        torch::Tensor positions =
+            torch::arange(seq_len, options.dtype(torch::kInt32).device(device));
 
-    ParallelArgs parallel_args(rank, world_size, process_group.get());
-    parallel_args.tp_group_ = process_group.get();
-    parallel_args.single_rank_group_ = self_group.get();
-    parallel_args.cp_group_ = process_group.get();
+        KVCache baseline_kv_cache = create_decode_kv_cache(model_args, options);
+        baseline_kv_cache.get_k_cache().zero_();
+        KVCache sp_kv_cache = create_decode_kv_cache(model_args, options);
+        sp_kv_cache.get_k_cache().zero_();
 
-    auto options = torch::TensorOptions()
-                       .dtype(torch::kBFloat16)
-                       .device(device)
-                       .requires_grad(false);
-    ModelArgs model_args = create_attention_model_args(/*q_lora_rank=*/64,
-                                                       /*enable_indexer=*/true);
-    QuantArgs quant_args = create_default_quant_args();
-    StateDict state_dict = create_attention_state_dict(model_args, options);
+        auto baseline_result =
+            run_attention_prefill_once(model_args,
+                                       quant_args,
+                                       parallel_args,
+                                       options,
+                                       state_dict,
+                                       tokens,
+                                       positions,
+                                       hidden_states,
+                                       baseline_kv_cache,
+                                       /*enable_full_weight_path=*/true,
+                                       /*enable_fused_mla_kernel=*/false,
+                                       BatchForwardType::PREFILL,
+                                       /*prefix_len=*/0,
+                                       /*build_cp_context=*/false);
+        auto sp_result =
+            run_attention_prefill_once(model_args,
+                                       quant_args,
+                                       parallel_args,
+                                       options,
+                                       state_dict,
+                                       tokens,
+                                       positions,
+                                       hidden_states,
+                                       sp_kv_cache,
+                                       /*enable_full_weight_path=*/true,
+                                       /*enable_fused_mla_kernel=*/
+                                       false);
 
-    constexpr int32_t seq_len = 4;
-    torch::Tensor tokens =
-        torch::arange(seq_len, options.dtype(torch::kInt32).device(device));
-    torch::Tensor hidden_states = seeded_tensor(
-        "attention_multi_device/sp_prefill_baseline_hidden_states",
-        {seq_len, model_args.hidden_size()},
-        torch::kBFloat16,
-        device);
-    torch::Tensor positions =
-        torch::arange(seq_len, options.dtype(torch::kInt32).device(device));
-
-    KVCache baseline_kv_cache = create_decode_kv_cache(model_args, options);
-    baseline_kv_cache.get_k_cache().zero_();
-    KVCache sp_kv_cache = create_decode_kv_cache(model_args, options);
-    sp_kv_cache.get_k_cache().zero_();
-
-    auto baseline_result =
-        run_attention_prefill_once(model_args,
-                                   quant_args,
-                                   parallel_args,
-                                   options,
-                                   state_dict,
-                                   tokens,
-                                   positions,
-                                   hidden_states,
-                                   baseline_kv_cache,
-                                   /*enable_full_weight_path=*/true,
-                                   /*enable_fused_mla_kernel=*/false,
-                                   BatchForwardType::PREFILL,
-                                   /*prefix_len=*/0,
-                                   /*build_cp_context=*/false);
-    auto sp_result =
-        run_attention_prefill_once(model_args,
-                                   quant_args,
-                                   parallel_args,
-                                   options,
-                                   state_dict,
-                                   tokens,
-                                   positions,
-                                   hidden_states,
-                                   sp_kv_cache,
-                                   /*enable_full_weight_path=*/true,
-                                   /*enable_fused_mla_kernel=*/
-                                   false);
-
-    xllm_device.synchronize_default_stream();
-    check_repl_output_contract(baseline_result,
-                               seq_len,
-                               model_args.hidden_size(),
-                               "DeepseekV2Attention prefill baseline");
-    check_sp_output_contract(sp_result,
-                             seq_len,
-                             model_args.hidden_size(),
-                             /*local_token_num=*/seq_len / world_size,
-                             "DeepseekV2Attention prefill sp baseline");
-    check_tensors_close(sp_result.global_output,
-                        baseline_result.global_output,
-                        /*rtol=*/1e-3,
-                        /*atol=*/1e-2,
-                        "DeepseekV2Attention prefill sp output");
-    return 0;
-  } catch (const std::exception& e) {
-    LOG(ERROR) << "Rank " << rank << ": Exception: " << e.what();
-    return 1;
-  }
+        xllm_device.synchronize_default_stream();
+        check_repl_output_contract(baseline_result,
+                                   seq_len,
+                                   model_args.hidden_size(),
+                                   "DeepseekV2Attention prefill baseline");
+        check_sp_output_contract(sp_result,
+                                 seq_len,
+                                 model_args.hidden_size(),
+                                 /*local_token_num=*/seq_len / world_size,
+                                 "DeepseekV2Attention prefill sp baseline");
+        check_tensors_close(sp_result.global_output,
+                            baseline_result.global_output,
+                            /*rtol=*/1e-3,
+                            /*atol=*/1e-2,
+                            "DeepseekV2Attention prefill sp output");
+        return 0;
+      });
 }
 
 int32_t run_attention_chunked_test_child(int32_t rank,
                                          int32_t world_size,
                                          int32_t port,
                                          const std::string& host) {
-  try {
-    const int32_t dev_count = xllm::Platform::device_count();
-    if (dev_count < world_size) {
-      LOG(WARNING) << "Rank " << rank << ": insufficient devices. Skipping.";
-      return EXIT_CODE_SKIP;
-    }
+  return run_distributed_attention_child(
+      rank,
+      world_size,
+      port,
+      host,
+      /*enable_context_parallel=*/false,
+      [world_size](DistributedAttentionChildContext& context) {
+        xllm::Device& xllm_device = context.xllm_device();
+        const torch::Device& device = context.device();
+        ParallelArgs& parallel_args = context.parallel_args();
+        const torch::TensorOptions& options = context.options();
+        ModelArgs model_args =
+            create_attention_model_args(/*q_lora_rank=*/64,
+                                        /*enable_indexer=*/true);
+        QuantArgs quant_args = create_default_quant_args();
+        StateDict state_dict = create_attention_state_dict(model_args, options);
 
-    KVCacheConfig::get_instance().block_size(16);
-    const int32_t device_index = rank % dev_count;
-    xllm::Device xllm_device(device_index);
-    xllm_device.set_device();
-    torch::Device device = xllm_device.unwrap();
-    auto process_group =
-        create_test_process_group(rank, world_size, port, host, device);
-    CHECK(process_group) << "Rank " << rank
-                         << ": failed to create process group";
-    auto self_group =
-        create_test_self_group(rank, world_size, port, host, device);
-    CHECK(self_group) << "Rank " << rank << ": failed to create self group";
+        constexpr int32_t prefix_len = 8;
+        constexpr int32_t chunk1_len = 4;
+        constexpr int32_t chunk2_len = 4;
+        torch::Tensor prefix_tokens = torch::arange(
+            prefix_len, options.dtype(torch::kInt32).device(device));
+        torch::Tensor prefix_hidden_states =
+            seeded_tensor("attention_multi_device/chunked_prefix_hidden_states",
+                          {prefix_len, model_args.hidden_size()},
+                          torch::kBFloat16,
+                          device);
+        torch::Tensor prefix_positions = torch::arange(
+            prefix_len, options.dtype(torch::kInt32).device(device));
 
-    ParallelArgs parallel_args(rank, world_size, process_group.get());
-    parallel_args.tp_group_ = process_group.get();
-    parallel_args.single_rank_group_ = self_group.get();
-    parallel_args.cp_group_ = process_group.get();
+        torch::Tensor chunk1_tokens =
+            torch::arange(prefix_len,
+                          prefix_len + chunk1_len,
+                          options.dtype(torch::kInt32).device(device));
+        torch::Tensor chunk1_hidden_states = seeded_tensor(
+            "attention_multi_device/chunked_suffix1_hidden_states",
+            {chunk1_len, model_args.hidden_size()},
+            torch::kBFloat16,
+            device);
+        torch::Tensor chunk1_positions =
+            torch::arange(prefix_len,
+                          prefix_len + chunk1_len,
+                          options.dtype(torch::kInt32).device(device));
 
-    auto options = torch::TensorOptions()
-                       .dtype(torch::kBFloat16)
-                       .device(device)
-                       .requires_grad(false);
-    ModelArgs model_args = create_attention_model_args(/*q_lora_rank=*/64,
-                                                       /*enable_indexer=*/true);
-    QuantArgs quant_args = create_default_quant_args();
-    StateDict state_dict = create_attention_state_dict(model_args, options);
+        torch::Tensor chunk2_tokens =
+            torch::arange(prefix_len + chunk1_len,
+                          prefix_len + chunk1_len + chunk2_len,
+                          options.dtype(torch::kInt32).device(device));
+        torch::Tensor chunk2_hidden_states = seeded_tensor(
+            "attention_multi_device/chunked_suffix2_hidden_states",
+            {chunk2_len, model_args.hidden_size()},
+            torch::kBFloat16,
+            device);
+        torch::Tensor chunk2_positions =
+            torch::arange(prefix_len + chunk1_len,
+                          prefix_len + chunk1_len + chunk2_len,
+                          options.dtype(torch::kInt32).device(device));
 
-    constexpr int32_t prefix_len = 8;
-    constexpr int32_t chunk1_len = 4;
-    constexpr int32_t chunk2_len = 4;
-    torch::Tensor prefix_tokens =
-        torch::arange(prefix_len, options.dtype(torch::kInt32).device(device));
-    torch::Tensor prefix_hidden_states =
-        seeded_tensor("attention_multi_device/chunked_prefix_hidden_states",
-                      {prefix_len, model_args.hidden_size()},
-                      torch::kBFloat16,
-                      device);
-    torch::Tensor prefix_positions =
-        torch::arange(prefix_len, options.dtype(torch::kInt32).device(device));
+        KVCache full_weight_kv_cache =
+            create_decode_kv_cache(model_args, options);
+        full_weight_kv_cache.get_k_cache().zero_();
 
-    torch::Tensor chunk1_tokens =
-        torch::arange(prefix_len,
-                      prefix_len + chunk1_len,
-                      options.dtype(torch::kInt32).device(device));
-    torch::Tensor chunk1_hidden_states =
-        seeded_tensor("attention_multi_device/chunked_suffix1_hidden_states",
-                      {chunk1_len, model_args.hidden_size()},
-                      torch::kBFloat16,
-                      device);
-    torch::Tensor chunk1_positions =
-        torch::arange(prefix_len,
-                      prefix_len + chunk1_len,
-                      options.dtype(torch::kInt32).device(device));
+        auto sp_prefix_result =
+            run_attention_prefill_once(model_args,
+                                       quant_args,
+                                       parallel_args,
+                                       options,
+                                       state_dict,
+                                       prefix_tokens,
+                                       prefix_positions,
+                                       prefix_hidden_states,
+                                       full_weight_kv_cache,
+                                       true,
+                                       /*enable_fused_mla_kernel=*/
+                                       false);
+        check_sp_output_contract(sp_prefix_result,
+                                 prefix_len,
+                                 model_args.hidden_size(),
+                                 /*local_token_num=*/prefix_len / world_size,
+                                 "DeepseekV2Attention chunked prefix sp");
+        check_tensor_same_across_ranks(
+            sp_prefix_result.global_output,
+            parallel_args.tp_group_,
+            "DeepseekV2Attention chunked prefix output");
 
-    torch::Tensor chunk2_tokens =
-        torch::arange(prefix_len + chunk1_len,
-                      prefix_len + chunk1_len + chunk2_len,
-                      options.dtype(torch::kInt32).device(device));
-    torch::Tensor chunk2_hidden_states =
-        seeded_tensor("attention_multi_device/chunked_suffix2_hidden_states",
-                      {chunk2_len, model_args.hidden_size()},
-                      torch::kBFloat16,
-                      device);
-    torch::Tensor chunk2_positions =
-        torch::arange(prefix_len + chunk1_len,
-                      prefix_len + chunk1_len + chunk2_len,
-                      options.dtype(torch::kInt32).device(device));
+        auto sp_result =
+            run_attention_prefill_once(model_args,
+                                       quant_args,
+                                       parallel_args,
+                                       options,
+                                       state_dict,
+                                       chunk1_tokens,
+                                       chunk1_positions,
+                                       chunk1_hidden_states,
+                                       full_weight_kv_cache,
+                                       true,
+                                       /*enable_fused_mla_kernel=*/
+                                       false,
+                                       BatchForwardType::CHUNKED_PREFILL,
+                                       prefix_len);
 
-    KVCache full_weight_kv_cache = create_decode_kv_cache(model_args, options);
-    full_weight_kv_cache.get_k_cache().zero_();
+        xllm_device.synchronize_default_stream();
+        check_sp_output_contract(sp_result,
+                                 chunk1_len,
+                                 model_args.hidden_size(),
+                                 /*local_token_num=*/chunk1_len / world_size,
+                                 "DeepseekV2Attention chunked prefill sp");
+        check_tensor_same_across_ranks(
+            sp_result.global_output,
+            parallel_args.tp_group_,
+            "DeepseekV2Attention chunked prefill output");
 
-    auto sp_prefix_result =
-        run_attention_prefill_once(model_args,
-                                   quant_args,
-                                   parallel_args,
-                                   options,
-                                   state_dict,
-                                   prefix_tokens,
-                                   prefix_positions,
-                                   prefix_hidden_states,
-                                   full_weight_kv_cache,
-                                   true,
-                                   /*enable_fused_mla_kernel=*/
-                                   false);
-    check_sp_output_contract(sp_prefix_result,
-                             prefix_len,
-                             model_args.hidden_size(),
-                             /*local_token_num=*/prefix_len / world_size,
-                             "DeepseekV2Attention chunked prefix sp");
-    check_tensor_same_across_ranks(sp_prefix_result.global_output,
-                                   parallel_args.tp_group_,
-                                   "DeepseekV2Attention chunked prefix output");
+        auto sp_second_result =
+            run_attention_prefill_once(model_args,
+                                       quant_args,
+                                       parallel_args,
+                                       options,
+                                       state_dict,
+                                       chunk2_tokens,
+                                       chunk2_positions,
+                                       chunk2_hidden_states,
+                                       full_weight_kv_cache,
+                                       true,
+                                       /*enable_fused_mla_kernel=*/false,
+                                       BatchForwardType::CHUNKED_PREFILL,
+                                       prefix_len + chunk1_len);
 
-    auto sp_result =
-        run_attention_prefill_once(model_args,
-                                   quant_args,
-                                   parallel_args,
-                                   options,
-                                   state_dict,
-                                   chunk1_tokens,
-                                   chunk1_positions,
-                                   chunk1_hidden_states,
-                                   full_weight_kv_cache,
-                                   true,
-                                   /*enable_fused_mla_kernel=*/
-                                   false,
-                                   BatchForwardType::CHUNKED_PREFILL,
-                                   prefix_len);
+        xllm_device.synchronize_default_stream();
+        check_sp_output_contract(
+            sp_second_result,
+            chunk2_len,
+            model_args.hidden_size(),
+            /*local_token_num=*/chunk2_len / world_size,
+            "DeepseekV2Attention second chunked prefill sp");
+        check_tensor_same_across_ranks(
+            sp_second_result.global_output,
+            parallel_args.tp_group_,
+            "DeepseekV2Attention second chunked prefill output");
+        return 0;
+      });
+}
 
-    xllm_device.synchronize_default_stream();
-    check_sp_output_contract(sp_result,
-                             chunk1_len,
-                             model_args.hidden_size(),
-                             /*local_token_num=*/chunk1_len / world_size,
-                             "DeepseekV2Attention chunked prefill sp");
-    check_tensor_same_across_ranks(
-        sp_result.global_output,
-        parallel_args.tp_group_,
-        "DeepseekV2Attention chunked prefill output");
+int32_t run_attention_topk_share_test_child(int32_t rank,
+                                            int32_t world_size,
+                                            int32_t port,
+                                            const std::string& host) {
+  return run_distributed_attention_child(
+      rank,
+      world_size,
+      port,
+      host,
+      /*enable_context_parallel=*/true,
+      [](DistributedAttentionChildContext& context) {
+        xllm::Device& xllm_device = context.xllm_device();
+        const torch::Device& device = context.device();
+        ParallelArgs& parallel_args = context.parallel_args();
+        const torch::TensorOptions& options = context.options();
+        ModelArgs model_args =
+            create_attention_model_args(/*q_lora_rank=*/64,
+                                        /*enable_indexer=*/true);
+        QuantArgs quant_args = create_default_quant_args();
+        StateDict state_dict = create_attention_state_dict(model_args, options);
 
-    auto sp_second_result =
-        run_attention_prefill_once(model_args,
-                                   quant_args,
-                                   parallel_args,
-                                   options,
-                                   state_dict,
-                                   chunk2_tokens,
-                                   chunk2_positions,
-                                   chunk2_hidden_states,
-                                   full_weight_kv_cache,
-                                   true,
-                                   /*enable_fused_mla_kernel=*/false,
-                                   BatchForwardType::CHUNKED_PREFILL,
-                                   prefix_len + chunk1_len);
+        // Mirror the production Full/Shared split. The Shared layer owns no
+        // Indexer, so its forward can only succeed by consuming the Full
+        // layer's exported sparse metadata.
+        OptimizationConfig optimization_config;
+        optimization_config.enable_fused_mla_kernel = false;
+        optimization_config.enable_fused_indexer_qk = false;
+        DeepseekV2Attention full_attention(model_args,
+                                           quant_args,
+                                           parallel_args,
+                                           options,
+                                           optimization_config,
+                                           /*enable_indexer=*/true);
+        DeepseekV2Attention shared_attention(model_args,
+                                             quant_args,
+                                             parallel_args,
+                                             options,
+                                             optimization_config,
+                                             /*enable_indexer=*/false);
+        full_attention->load_state_dict(state_dict);
+        shared_attention->load_state_dict(state_dict);
+        CHECK(full_attention->named_children().contains("indexer"))
+            << "Full layer must own an Indexer";
+        CHECK(!shared_attention->named_children().contains("indexer"))
+            << "Shared layer must not own an Indexer";
 
-    xllm_device.synchronize_default_stream();
-    check_sp_output_contract(sp_second_result,
-                             chunk2_len,
-                             model_args.hidden_size(),
-                             /*local_token_num=*/chunk2_len / world_size,
-                             "DeepseekV2Attention second chunked prefill sp");
-    check_tensor_same_across_ranks(
-        sp_second_result.global_output,
-        parallel_args.tp_group_,
-        "DeepseekV2Attention second chunked prefill output");
-    return 0;
-  } catch (const std::exception& e) {
-    LOG(ERROR) << "Rank " << rank << ": Exception: " << e.what();
-    return 1;
-  }
+        torch::Tensor hidden_states =
+            seeded_tensor("attention_multi_device/topk_share_hidden_states",
+                          {1, model_args.hidden_size()},
+                          torch::kBFloat16,
+                          device);
+        torch::Tensor positions =
+            torch::tensor({0}, options.dtype(torch::kInt32).device(device));
+
+        // Use independent, identically initialized caches so the Shared result
+        // is compared with a clean Full-layer recomputation rather than with
+        // state mutated by the baseline forward.
+        KVCache full_kv_cache = create_decode_kv_cache(model_args, options);
+        KVCache shared_kv_cache = create_decode_kv_cache(model_args, options);
+        full_kv_cache.get_k_cache().zero_();
+        shared_kv_cache.get_k_cache().zero_();
+
+        // Full-layer baseline: independently compute the sparse block table and
+        // the attention output.
+        AttentionMetadata full_metadata = create_decode_metadata(options);
+        DsaTopkTransfer full_transfer = DsaTopkTransfer::capture_output();
+        torch::Tensor full_out = full_attention->forward(positions,
+                                                         hidden_states,
+                                                         full_metadata,
+                                                         full_kv_cache,
+                                                         /*sp_ctx=*/nullptr,
+                                                         &full_transfer);
+        xllm_device.synchronize_default_stream();
+
+        const DsaTopkState* full_topk = full_transfer.output();
+        CHECK(full_topk != nullptr)
+            << "Output layer must publish DSA top-k state";
+        const torch::Tensor& full_block_tables = full_topk->block_tables();
+        const torch::Tensor& full_context_lens = full_topk->context_lens();
+        CHECK(full_block_tables.defined())
+            << "Output layer must export a sparse block table";
+        CHECK_EQ(full_block_tables.dim(), 2)
+            << "sparse block table must be 2D {num_tokens, index_topk}";
+        CHECK_EQ(full_block_tables.size(0), 1) << "num_tokens mismatch";
+        CHECK_EQ(full_block_tables.size(1), model_args.index_topk())
+            << "index_topk mismatch";
+        CHECK(full_block_tables.scalar_type() == torch::kInt32)
+            << "sparse block table must be int32";
+        CHECK(torch::isfinite(full_out.to(torch::kFloat32)).all().item<bool>())
+            << "Full layer attention output must be finite";
+
+        // Shared-layer pass: use the production reuse-only relay. Pointer
+        // checks below verify the relay does not copy metadata; numerical
+        // equivalence with the independently recomputed Full result verifies
+        // the no-Indexer Shared path produces the expected attention result.
+        AttentionMetadata shared_metadata = create_decode_metadata(options);
+        DsaTopkTransfer shared_transfer = DsaTopkTransfer::reuse(*full_topk);
+        const DsaTopkState* shared_input = shared_transfer.input();
+        CHECK(shared_input != nullptr) << "Shared layer must receive DSA top-k";
+        CHECK_EQ(shared_input->block_tables().data_ptr(),
+                 full_block_tables.data_ptr())
+            << "Shared relay must reuse the Full layer's sparse block table";
+        CHECK_EQ(shared_input->context_lens().data_ptr(),
+                 full_context_lens.data_ptr())
+            << "Shared relay must reuse the Full layer's context lens";
+        torch::Tensor shared_out = shared_attention->forward(positions,
+                                                             hidden_states,
+                                                             shared_metadata,
+                                                             shared_kv_cache,
+                                                             /*sp_ctx=*/nullptr,
+                                                             &shared_transfer);
+        xllm_device.synchronize_default_stream();
+
+        CHECK(shared_transfer.output() == nullptr)
+            << "A production Shared relay must not self-echo its input";
+        check_tensors_close(shared_out,
+                            full_out,
+                            /*rtol=*/1e-3,
+                            /*atol=*/1e-2,
+                            "Shared attention vs Full indexer baseline");
+        return 0;
+      });
+}
+
+// Dummy runs (DP sync / MTP step_empty / graph warmup) skip the indexer in
+// attention, so an Output layer cannot export a valid sparse block table. This
+// pins that contract: a dummy Output-layer forward must not produce a sparse
+// {num_tokens, index_topk} table. It is the precondition for the decoder
+// bypassing cross-layer sharing on dummy runs, without which a following Shared
+// layer would assert on a missing previous top-k.
+int32_t run_attention_topk_share_dummy_run_test_child(int32_t rank,
+                                                      int32_t world_size,
+                                                      int32_t port,
+                                                      const std::string& host) {
+  return run_distributed_attention_child(
+      rank,
+      world_size,
+      port,
+      host,
+      /*enable_context_parallel=*/true,
+      [](DistributedAttentionChildContext& context) {
+        xllm::Device& xllm_device = context.xllm_device();
+        const torch::Device& device = context.device();
+        ParallelArgs& parallel_args = context.parallel_args();
+        const torch::TensorOptions& options = context.options();
+        ModelArgs model_args =
+            create_attention_model_args(/*q_lora_rank=*/64,
+                                        /*enable_indexer=*/true);
+        QuantArgs quant_args = create_default_quant_args();
+        StateDict state_dict = create_attention_state_dict(model_args, options);
+
+        OptimizationConfig optimization_config;
+        optimization_config.enable_fused_mla_kernel = false;
+        optimization_config.enable_fused_indexer_qk = false;
+        DeepseekV2Attention attention(model_args,
+                                      quant_args,
+                                      parallel_args,
+                                      options,
+                                      optimization_config);
+        attention->load_state_dict(state_dict);
+
+        torch::Tensor hidden_states = seeded_tensor(
+            "attention_multi_device/topk_share_dummy_hidden_states",
+            {1, model_args.hidden_size()},
+            torch::kBFloat16,
+            device);
+        torch::Tensor positions =
+            torch::tensor({0}, options.dtype(torch::kInt32).device(device));
+
+        KVCache kv_cache = create_decode_kv_cache(model_args, options);
+        kv_cache.get_k_cache().zero_();
+
+        // Output-layer pass on a dummy run: the indexer is skipped, so no fresh
+        // sparse block table is computed.
+        AttentionMetadata dummy_metadata = create_decode_metadata(options);
+        dummy_metadata.is_dummy = true;
+        DsaTopkTransfer output_transfer = DsaTopkTransfer::capture_output();
+        attention->forward(positions,
+                           hidden_states,
+                           dummy_metadata,
+                           kv_cache,
+                           /*sp_ctx=*/nullptr,
+                           &output_transfer);
+        xllm_device.synchronize_default_stream();
+
+        // A dummy run must not yield a usable sparse top-k table (width
+        // index_topk), so a Shared layer cannot legally reuse it. The decoder
+        // therefore has to disable cross-layer sharing whenever
+        // attn_metadata.is_dummy is set.
+        const DsaTopkState* dummy_topk = output_transfer.output();
+        const bool produced_sparse_topk =
+            dummy_topk != nullptr && dummy_topk->block_tables().dim() == 2 &&
+            dummy_topk->block_tables().size(1) == model_args.index_topk();
+        CHECK(!produced_sparse_topk) << "Dummy Output-layer run must not "
+                                        "export a sparse top-k block table";
+        return 0;
+      });
+}
+
+// Same Full->Shared numerical and relay contract as above, but on a multi-token
+// decode bucket (batch_size > 1). This also pins the graph invariant that the
+// reused sparse block table's shape strictly equals the captured num_tokens
+// bucket, since every layer in one forward processes the same bucketed count.
+int32_t run_attention_topk_share_bucket_test_child(int32_t rank,
+                                                   int32_t world_size,
+                                                   int32_t port,
+                                                   const std::string& host) {
+  return run_distributed_attention_child(
+      rank,
+      world_size,
+      port,
+      host,
+      /*enable_context_parallel=*/true,
+      [](DistributedAttentionChildContext& context) {
+        xllm::Device& xllm_device = context.xllm_device();
+        const torch::Device& device = context.device();
+        ParallelArgs& parallel_args = context.parallel_args();
+        const torch::TensorOptions& options = context.options();
+        ModelArgs model_args =
+            create_attention_model_args(/*q_lora_rank=*/64,
+                                        /*enable_indexer=*/true);
+        QuantArgs quant_args = create_default_quant_args();
+        StateDict state_dict = create_attention_state_dict(model_args, options);
+
+        OptimizationConfig optimization_config;
+        optimization_config.enable_fused_mla_kernel = false;
+        optimization_config.enable_fused_indexer_qk = false;
+        DeepseekV2Attention full_attention(model_args,
+                                           quant_args,
+                                           parallel_args,
+                                           options,
+                                           optimization_config,
+                                           /*enable_indexer=*/true);
+        DeepseekV2Attention shared_attention(model_args,
+                                             quant_args,
+                                             parallel_args,
+                                             options,
+                                             optimization_config,
+                                             /*enable_indexer=*/false);
+        full_attention->load_state_dict(state_dict);
+        shared_attention->load_state_dict(state_dict);
+        CHECK(full_attention->named_children().contains("indexer"))
+            << "Full layer must own an Indexer";
+        CHECK(!shared_attention->named_children().contains("indexer"))
+            << "Shared layer must not own an Indexer";
+
+        constexpr int32_t kBucketTokens = 4;
+        torch::Tensor hidden_states = seeded_tensor(
+            "attention_multi_device/topk_share_bucket_hidden_states",
+            {kBucketTokens, model_args.hidden_size()},
+            torch::kBFloat16,
+            device);
+        torch::Tensor positions =
+            torch::zeros({kBucketTokens}, options.dtype(torch::kInt32));
+
+        KVCache full_kv_cache = create_decode_kv_cache(model_args, options);
+        KVCache shared_kv_cache = create_decode_kv_cache(model_args, options);
+        full_kv_cache.get_k_cache().zero_();
+        shared_kv_cache.get_k_cache().zero_();
+
+        AttentionMetadata full_metadata =
+            create_batch_decode_metadata(options, kBucketTokens);
+        DsaTopkTransfer full_transfer = DsaTopkTransfer::capture_output();
+        torch::Tensor full_out = full_attention->forward(positions,
+                                                         hidden_states,
+                                                         full_metadata,
+                                                         full_kv_cache,
+                                                         /*sp_ctx=*/nullptr,
+                                                         &full_transfer);
+        xllm_device.synchronize_default_stream();
+
+        const DsaTopkState* full_topk = full_transfer.output();
+        CHECK(full_topk != nullptr)
+            << "Output layer must publish DSA top-k state";
+        const torch::Tensor& full_block_tables = full_topk->block_tables();
+        CHECK(full_block_tables.defined())
+            << "Output layer must export a sparse block table";
+        CHECK_EQ(full_block_tables.size(0), kBucketTokens)
+            << "sparse block table row count must equal the decode bucket";
+        CHECK_EQ(full_block_tables.size(1), model_args.index_topk())
+            << "index_topk mismatch";
+
+        AttentionMetadata shared_metadata =
+            create_batch_decode_metadata(options, kBucketTokens);
+        DsaTopkTransfer shared_transfer = DsaTopkTransfer::reuse(*full_topk);
+        const DsaTopkState* shared_input = shared_transfer.input();
+        CHECK(shared_input != nullptr) << "Shared layer must receive DSA top-k";
+        CHECK_EQ(shared_input->block_tables().sizes(),
+                 full_block_tables.sizes())
+            << "Shared layer reuse shape must strictly equal the captured "
+               "bucket";
+        CHECK_EQ(shared_input->block_tables().data_ptr(),
+                 full_block_tables.data_ptr())
+            << "Shared relay must reuse the Full layer's sparse block table";
+        torch::Tensor shared_out = shared_attention->forward(positions,
+                                                             hidden_states,
+                                                             shared_metadata,
+                                                             shared_kv_cache,
+                                                             /*sp_ctx=*/nullptr,
+                                                             &shared_transfer);
+        xllm_device.synchronize_default_stream();
+
+        CHECK(shared_transfer.output() == nullptr)
+            << "A production Shared relay must not self-echo its input";
+        check_tensors_close(
+            shared_out,
+            full_out,
+            /*rtol=*/1e-3,
+            /*atol=*/1e-2,
+            "Bucketed Shared attention vs Full indexer baseline");
+        return 0;
+      });
 }
 
 }  // namespace
+
+TEST(AttentionMultiDeviceProcessTest, TimedOutChildIsTerminatedAndReaped) {
+  const pid_t child_pid = ::fork();
+  ASSERT_GE(child_pid, 0) << "Failed to fork timeout test child";
+  if (child_pid == 0) {
+    while (true) {
+      ::pause();
+    }
+  }
+
+  const std::vector<pid_t> child_pids{child_pid};
+  const ChildWaitResult result =
+      wait_for_children(child_pids, std::chrono::milliseconds{50});
+  EXPECT_TRUE(result.any_failed);
+  EXPECT_TRUE(result.timed_out);
+
+  int status = 0;
+  errno = 0;
+  EXPECT_EQ(wait_for_pid(child_pid, &status, WNOHANG), -1);
+  EXPECT_EQ(errno, ECHILD) << "Timed-out child was not fully reaped";
+}
 
 class AttentionMultiDeviceTest : public ::testing::Test {
  protected:
   void SetUp() override {
     world_size_ = 2;
-    port_ = 29521;
     host_ = "127.0.0.1";
   }
 
-  void run_test(bool enable_fused_mla_kernel, int64_t q_lora_rank = 0) {
+  template <typename ChildFn>
+  void run_child_test(const ChildFn& child_fn,
+                      const std::string& failure_message) {
+    const int32_t port = net::get_local_free_port();
+    ASSERT_GT(port, 0) << "Failed to allocate a TCP rendezvous port";
     std::vector<pid_t> child_pids;
+    child_pids.reserve(world_size_);
     for (int32_t rank = 0; rank < world_size_; ++rank) {
-      pid_t pid = fork();
+      const pid_t pid = ::fork();
       if (pid == 0) {
-        const int32_t exit_code =
-            run_attention_test_child(rank,
-                                     world_size_,
-                                     port_,
-                                     host_,
-                                     enable_fused_mla_kernel,
-                                     q_lora_rank);
+        const int32_t exit_code = child_fn(rank, world_size_, port, host_);
         _exit(exit_code);
-      } else if (pid > 0) {
-        child_pids.push_back(pid);
-      } else {
-        LOG(FATAL) << "Failed to fork rank " << rank;
       }
+      if (pid > 0) {
+        child_pids.emplace_back(pid);
+        continue;
+      }
+
+      LOG(ERROR) << "Failed to fork rank " << rank << ": "
+                 << std::strerror(errno);
+      std::vector<bool> finished(child_pids.size(), false);
+      terminate_and_reap_children(child_pids, finished);
+      ADD_FAILURE() << "Failed to fork all multi-device test ranks";
+      return;
     }
 
-    bool any_failed = false;
-    bool any_skipped = false;
-    for (size_t i = 0; i < child_pids.size(); ++i) {
-      int32_t status;
-      waitpid(child_pids[i], &status, 0);
-      if (WIFEXITED(status)) {
-        const int32_t exit_code = WEXITSTATUS(status);
-        if (exit_code == EXIT_CODE_SKIP) {
-          any_skipped = true;
-        } else if (exit_code != 0) {
-          any_failed = true;
-          LOG(ERROR) << "Rank " << i << " failed with code " << exit_code;
-        }
-      } else {
-        any_failed = true;
-        LOG(ERROR) << "Rank " << i << " crashed (signal).";
-      }
-    }
-
-    if (any_skipped) {
+    const ChildWaitResult result = wait_for_children(child_pids);
+    if (result.any_skipped && !result.any_failed) {
       GTEST_SKIP() << "Test skipped due to insufficient devices.";
-    } else {
-      ASSERT_FALSE(any_failed)
-          << "Attention multi-device equivalence test failed.";
     }
+    ASSERT_FALSE(result.any_failed)
+        << failure_message
+        << (result.timed_out ? " Child process timeout." : "");
+  }
+
+  void run_test(bool enable_fused_mla_kernel, int64_t q_lora_rank = 0) {
+    run_child_test(
+        [enable_fused_mla_kernel, q_lora_rank](int32_t rank,
+                                               int32_t world_size,
+                                               int32_t port,
+                                               const std::string& host) {
+          return run_attention_test_child(rank,
+                                          world_size,
+                                          port,
+                                          host,
+                                          enable_fused_mla_kernel,
+                                          q_lora_rank);
+        },
+        "Attention multi-device equivalence test failed.");
   }
 
   void run_prefill_repl_test() {
-    std::vector<pid_t> child_pids;
-    for (int32_t rank = 0; rank < world_size_; ++rank) {
-      pid_t pid = fork();
-      if (pid == 0) {
-        const int32_t exit_code = run_attention_prefill_repl_test_child(
-            rank, world_size_, port_, host_);
-        _exit(exit_code);
-      } else if (pid > 0) {
-        child_pids.push_back(pid);
-      } else {
-        LOG(FATAL) << "Failed to fork rank " << rank;
-      }
-    }
-
-    bool any_failed = false;
-    bool any_skipped = false;
-    for (size_t i = 0; i < child_pids.size(); ++i) {
-      int32_t status;
-      waitpid(child_pids[i], &status, 0);
-      if (WIFEXITED(status)) {
-        const int32_t exit_code = WEXITSTATUS(status);
-        if (exit_code == EXIT_CODE_SKIP) {
-          any_skipped = true;
-        } else if (exit_code != 0) {
-          any_failed = true;
-          LOG(ERROR) << "Rank " << i << " failed with code " << exit_code;
-        }
-      } else {
-        any_failed = true;
-        LOG(ERROR) << "Rank " << i << " crashed (signal).";
-      }
-    }
-
-    if (any_skipped) {
-      GTEST_SKIP() << "Test skipped due to insufficient devices.";
-    } else {
-      ASSERT_FALSE(any_failed)
-          << "Attention multi-device replicated prefill test failed.";
-    }
+    run_child_test(
+        [](int32_t rank,
+           int32_t world_size,
+           int32_t port,
+           const std::string& host) {
+          return run_attention_prefill_repl_test_child(
+              rank, world_size, port, host);
+        },
+        "Attention multi-device replicated prefill test failed.");
   }
 
   void run_prefill_fallback_test() {
-    std::vector<pid_t> child_pids;
-    for (int32_t rank = 0; rank < world_size_; ++rank) {
-      pid_t pid = fork();
-      if (pid == 0) {
-        const int32_t exit_code = run_attention_prefill_fallback_test_child(
-            rank, world_size_, port_, host_);
-        _exit(exit_code);
-      } else if (pid > 0) {
-        child_pids.push_back(pid);
-      } else {
-        LOG(FATAL) << "Failed to fork rank " << rank;
-      }
-    }
-
-    bool any_failed = false;
-    bool any_skipped = false;
-    for (size_t i = 0; i < child_pids.size(); ++i) {
-      int32_t status;
-      waitpid(child_pids[i], &status, 0);
-      if (WIFEXITED(status)) {
-        const int32_t exit_code = WEXITSTATUS(status);
-        if (exit_code == EXIT_CODE_SKIP) {
-          any_skipped = true;
-        } else if (exit_code != 0) {
-          any_failed = true;
-          LOG(ERROR) << "Rank " << i << " failed with code " << exit_code;
-        }
-      } else {
-        any_failed = true;
-        LOG(ERROR) << "Rank " << i << " crashed (signal).";
-      }
-    }
-
-    if (any_skipped) {
-      GTEST_SKIP() << "Test skipped due to insufficient devices.";
-    } else {
-      ASSERT_FALSE(any_failed)
-          << "Attention multi-device prefill fallback test failed.";
-    }
+    run_child_test(
+        [](int32_t rank,
+           int32_t world_size,
+           int32_t port,
+           const std::string& host) {
+          return run_attention_prefill_fallback_test_child(
+              rank, world_size, port, host);
+        },
+        "Attention multi-device prefill fallback test failed.");
   }
 
   void run_prefill_sp_test(bool use_glm5_args = false) {
-    std::vector<pid_t> child_pids;
-    for (int32_t rank = 0; rank < world_size_; ++rank) {
-      pid_t pid = fork();
-      if (pid == 0) {
-        const int32_t exit_code = run_attention_prefill_sp_test_child(
-            rank, world_size_, port_, host_, use_glm5_args);
-        _exit(exit_code);
-      } else if (pid > 0) {
-        child_pids.push_back(pid);
-      } else {
-        LOG(FATAL) << "Failed to fork rank " << rank;
-      }
-    }
-
-    bool any_failed = false;
-    bool any_skipped = false;
-    for (size_t i = 0; i < child_pids.size(); ++i) {
-      int32_t status;
-      waitpid(child_pids[i], &status, 0);
-      if (WIFEXITED(status)) {
-        const int32_t exit_code = WEXITSTATUS(status);
-        if (exit_code == EXIT_CODE_SKIP) {
-          any_skipped = true;
-        } else if (exit_code != 0) {
-          any_failed = true;
-          LOG(ERROR) << "Rank " << i << " failed with code " << exit_code;
-        }
-      } else {
-        any_failed = true;
-        LOG(ERROR) << "Rank " << i << " crashed (signal).";
-      }
-    }
-
-    if (any_skipped) {
-      GTEST_SKIP() << "Test skipped due to insufficient devices.";
-    } else {
-      ASSERT_FALSE(any_failed)
-          << "Attention multi-device SP prefill test failed.";
-    }
+    run_child_test(
+        [use_glm5_args](int32_t rank,
+                        int32_t world_size,
+                        int32_t port,
+                        const std::string& host) {
+          return run_attention_prefill_sp_test_child(
+              rank, world_size, port, host, use_glm5_args);
+        },
+        "Attention multi-device SP prefill test failed.");
   }
 
   void run_chunked_test() {
-    std::vector<pid_t> child_pids;
-    for (int32_t rank = 0; rank < world_size_; ++rank) {
-      pid_t pid = fork();
-      if (pid == 0) {
-        const int32_t exit_code =
-            run_attention_chunked_test_child(rank, world_size_, port_, host_);
-        _exit(exit_code);
-      } else if (pid > 0) {
-        child_pids.push_back(pid);
-      } else {
-        LOG(FATAL) << "Failed to fork rank " << rank;
-      }
-    }
-
-    bool any_failed = false;
-    bool any_skipped = false;
-    for (size_t i = 0; i < child_pids.size(); ++i) {
-      int32_t status;
-      waitpid(child_pids[i], &status, 0);
-      if (WIFEXITED(status)) {
-        const int32_t exit_code = WEXITSTATUS(status);
-        if (exit_code == EXIT_CODE_SKIP) {
-          any_skipped = true;
-        } else if (exit_code != 0) {
-          any_failed = true;
-          LOG(ERROR) << "Rank " << i << " failed with code " << exit_code;
-        }
-      } else {
-        any_failed = true;
-        LOG(ERROR) << "Rank " << i << " crashed (signal).";
-      }
-    }
-
-    if (any_skipped) {
-      GTEST_SKIP() << "Test skipped due to insufficient devices.";
-    } else {
-      ASSERT_FALSE(any_failed) << "Attention multi-device chunked test failed.";
-    }
+    run_child_test(
+        [](int32_t rank,
+           int32_t world_size,
+           int32_t port,
+           const std::string& host) {
+          return run_attention_chunked_test_child(rank, world_size, port, host);
+        },
+        "Attention multi-device chunked test failed.");
   }
 
   void run_prefill_sp_baseline_test() {
-    std::vector<pid_t> child_pids;
-    for (int32_t rank = 0; rank < world_size_; ++rank) {
-      pid_t pid = fork();
-      if (pid == 0) {
-        const int32_t exit_code = run_attention_prefill_sp_baseline_test_child(
-            rank, world_size_, port_, host_);
-        _exit(exit_code);
-      } else if (pid > 0) {
-        child_pids.push_back(pid);
-      } else {
-        LOG(FATAL) << "Failed to fork rank " << rank;
-      }
-    }
+    run_child_test(
+        [](int32_t rank,
+           int32_t world_size,
+           int32_t port,
+           const std::string& host) {
+          return run_attention_prefill_sp_baseline_test_child(
+              rank, world_size, port, host);
+        },
+        "Attention multi-device SP prefill baseline test failed.");
+  }
 
-    bool any_failed = false;
-    bool any_skipped = false;
-    for (size_t i = 0; i < child_pids.size(); ++i) {
-      int32_t status;
-      waitpid(child_pids[i], &status, 0);
-      if (WIFEXITED(status)) {
-        const int32_t exit_code = WEXITSTATUS(status);
-        if (exit_code == EXIT_CODE_SKIP) {
-          any_skipped = true;
-        } else if (exit_code != 0) {
-          any_failed = true;
-          LOG(ERROR) << "Rank " << i << " failed with code " << exit_code;
-        }
-      } else {
-        any_failed = true;
-        LOG(ERROR) << "Rank " << i << " crashed (signal).";
-      }
-    }
+  void run_topk_share_test() {
+    run_child_test(
+        [](int32_t rank,
+           int32_t world_size,
+           int32_t port,
+           const std::string& host) {
+          return run_attention_topk_share_test_child(
+              rank, world_size, port, host);
+        },
+        "Attention cross-layer top-k share test failed.");
+  }
 
-    if (any_skipped) {
-      GTEST_SKIP() << "Test skipped due to insufficient devices.";
-    } else {
-      ASSERT_FALSE(any_failed)
-          << "Attention multi-device SP prefill baseline test failed.";
-    }
+  void run_topk_share_dummy_run_test() {
+    run_child_test(
+        [](int32_t rank,
+           int32_t world_size,
+           int32_t port,
+           const std::string& host) {
+          return run_attention_topk_share_dummy_run_test_child(
+              rank, world_size, port, host);
+        },
+        "Attention dummy-run top-k share test failed.");
+  }
+
+  void run_topk_share_bucket_test() {
+    run_child_test(
+        [](int32_t rank,
+           int32_t world_size,
+           int32_t port,
+           const std::string& host) {
+          return run_attention_topk_share_bucket_test_child(
+              rank, world_size, port, host);
+        },
+        "Attention cross-layer top-k share bucket test failed.");
   }
 
   int32_t world_size_;
-  int32_t port_;
   std::string host_;
 };
 
@@ -1464,6 +1848,18 @@ TEST_F(AttentionMultiDeviceTest,
 
 TEST_F(AttentionMultiDeviceTest, PrefillSpNonChunkedMatchesReplicatedBaseline) {
   run_prefill_sp_baseline_test();
+}
+
+TEST_F(AttentionMultiDeviceTest, DummyRunOutputLayerYieldsNoSparseTopk) {
+  run_topk_share_dummy_run_test();
+}
+
+TEST_F(AttentionMultiDeviceTest, SharedLayerReusesFullLayerSparseBlockTable) {
+  run_topk_share_test();
+}
+
+TEST_F(AttentionMultiDeviceTest, SharedLayerReuseShapeMatchesDecodeBucket) {
+  run_topk_share_bucket_test();
 }
 
 }  // namespace test

--- a/tests/core/layers/mlu/deepseek_v2_decoder_layer_test.cpp
+++ b/tests/core/layers/mlu/deepseek_v2_decoder_layer_test.cpp
@@ -37,12 +37,44 @@ limitations under the License.
 #include "layers/cuda/attention.h"
 #endif
 #include "layers/common/attention_metadata_builder.h"
+#include "layers/common/dsa_topk_share_plan.h"
 #include "layers/mlu/tests_utils.h"
 #include "platform/device.h"
 #include "platform/platform.h"
 
 namespace xllm {
 namespace layer {
+
+TEST(DeepseekV2DecoderLayerInterfaceTest, ForwardKeepsModelInputParamsConst) {
+  using ForwardFn = torch::Tensor (DeepseekV2DecoderLayerImpl::*)(
+      torch::Tensor&,
+      std::optional<torch::Tensor>&,
+      torch::Tensor&,
+      const AttentionMetadata&,
+      KVCache&,
+      const ModelInputParams&,
+      const std::optional<torch::Tensor>&,
+      DsaTopkRelay*);
+
+  ForwardFn forward = &DeepseekV2DecoderLayerImpl::forward;
+  EXPECT_TRUE(forward != nullptr);
+}
+
+TEST(DeepseekV2DecoderLayerInterfaceTest, MtpForwardExposesTypedStateOutput) {
+  using ForwardMtpFn = torch::Tensor (DeepseekV2DecoderLayerImpl::*)(
+      torch::Tensor&,
+      std::optional<torch::Tensor>&,
+      torch::Tensor&,
+      const AttentionMetadata&,
+      KVCache&,
+      const ModelInputParams&,
+      const std::optional<torch::Tensor>&,
+      const std::optional<DsaTopkState>&,
+      std::optional<DsaTopkState>&);
+
+  ForwardMtpFn forward_mtp = &DeepseekV2DecoderLayerImpl::forward_mtp;
+  EXPECT_TRUE(forward_mtp != nullptr);
+}
 
 class DeepseekV2DecoderLayerTestPeer {
  public:
@@ -110,6 +142,20 @@ class DeepseekV2DecoderLayerTestPeer {
                                   torch::Tensor x,
                                   ProcessGroup* pg) {
     return decoder.reduce_out(x, pg);
+  }
+
+  static const DsaTopkShareDecision& topk_share_decision(
+      const DeepseekV2DecoderLayerImpl& decoder) {
+    return decoder.topk_share_decision_;
+  }
+
+  static bool mtp_topk_reuse(const DeepseekV2DecoderLayerImpl& decoder) {
+    return decoder.mtp_topk_reuse_;
+  }
+
+  static bool attention_has_child(const DeepseekV2DecoderLayerImpl& decoder,
+                                  const std::string& name) {
+    return decoder.attention_->named_children().contains(name);
   }
 };
 
@@ -599,7 +645,9 @@ class DeepseekV2DecoderLayerTest : public ::testing::Test {
   }
 
   DecoderHolder make_decoder(int32_t layer_id) {
-    return DecoderHolder(DeepseekV2DecoderLayerImpl(context_, layer_id));
+    const DsaTopkSharePlan topk_share_plan(model_args_);
+    return DecoderHolder(
+        DeepseekV2DecoderLayerImpl(context_, layer_id, topk_share_plan));
   }
 
   DecoderHolder make_loaded_decoder(int32_t layer_id) {
@@ -1552,12 +1600,319 @@ INSTANTIATE_TEST_SUITE_P(
         LayerCase{"Moe", 5, {0.7773f, 0.7227f, 1.0938f, 1.1875f, 0.6367f}}),
     case_name);
 
-INSTANTIATE_TEST_SUITE_P(
-    QuantizedCache,
-    DeepseekV2DecoderKvCacheTest,
-    ::testing::Values(QuantCase{"Prefill", "mla_quant_prefill", false},
-                      QuantCase{"Decode", "mla_quant_decode", true}),
-    quant_name);
+namespace {
+
+// Ground-truth indexer_types for GLM5.2-W4A8 (index_topk_freq=4,
+// index_skip_topk_offset=3, 78 layers): 21 Full + 57 Shared. A Full layer owns
+// indexer weights (layers 0/1 plus every 4th layer from 2); the rest are
+// Shared and must reuse the previous Full layer's top-k.
+bool is_full_indexer_layer_glm52(int32_t layer_id) {
+  if (layer_id < 2) {
+    return true;
+  }
+  return (layer_id - 2) % 4 == 0;
+}
+
+std::string build_fs_pattern_glm52(int32_t num_layers) {
+  std::string pattern;
+  pattern.reserve(num_layers);
+  for (int32_t layer_id = 0; layer_id < num_layers; ++layer_id) {
+    pattern.push_back(is_full_indexer_layer_glm52(layer_id) ? 'F' : 'S');
+  }
+  return pattern;
+}
+
+}  // namespace
+
+class DeepseekV2DecoderTopkShareTest : public DeepseekV2DecoderLayerTest {
+ protected:
+  static constexpr int32_t kNumLayers = 78;
+
+  void configure_glm5_indexer() {
+    model_args_.model_type() = "glm_moe_dsa";
+    model_args_.n_layers() = kNumLayers;
+    model_args_.index_n_heads() = 4;
+    model_args_.index_head_dim() = 128;
+    model_args_.index_topk() = 64;
+    // Keep every layer dense so construction only exercises attention/indexer.
+    model_args_.first_k_dense_replace() = kNumLayers;
+  }
+
+  void use_cpu_constructor_context() {
+    options_ = torch::TensorOptions()
+                   .dtype(torch::kBFloat16)
+                   .device(torch::kCPU)
+                   .requires_grad(false);
+    mock_process_group_ =
+        std::make_unique<test::MockProcessGroup>(torch::Device(torch::kCPU));
+    parallel_args_ = ParallelArgs(/*rank=*/0,
+                                  /*world_size=*/1,
+                                  /*dp_size=*/1,
+                                  mock_process_group_.get());
+    parallel_args_.tp_group_ = mock_process_group_.get();
+    parallel_args_.single_rank_group_ = mock_process_group_.get();
+    parallel_args_.cp_group_ = mock_process_group_.get();
+    refresh_ctx();
+  }
+};
+
+TEST_F(DeepseekV2DecoderTopkShareTest,
+       DefaultConstructorWhenShareConfiguredKeepsOwnIndexer) {
+  configure_glm5_indexer();
+  model_args_.index_topk_freq() = 4;
+  model_args_.index_skip_topk_offset() = 3;
+  use_cpu_constructor_context();
+
+  DecoderHolder decoder(DeepseekV2DecoderLayerImpl(context_, /*layer_id=*/3));
+
+  const auto parameters = decoder->named_parameters(/*recurse=*/true);
+  EXPECT_TRUE(parameters.contains("self_attn.indexer.wq_b.weight"));
+  EXPECT_TRUE(parameters.contains("self_attn.indexer.wk.weight"));
+  EXPECT_TRUE(parameters.contains("self_attn.indexer.weights_proj.weight"));
+  EXPECT_TRUE(parameters.contains("self_attn.indexer.k_norm.weight"));
+}
+
+TEST_F(DeepseekV2DecoderTopkShareTest,
+       FreqConfig_WhenGlm52_ThenPlanMatchesIndexerTypes) {
+  configure_glm5_indexer();
+  model_args_.index_topk_freq() = 4;
+  model_args_.index_skip_topk_offset() = 3;
+  model_args_.index_topk_pattern() = "";
+  refresh_ctx();
+
+  int32_t full_count = 0;
+  int32_t shared_count = 0;
+  for (int32_t layer_id = 0; layer_id < kNumLayers; ++layer_id) {
+    auto decoder = make_decoder(layer_id);
+    const DsaTopkShareDecision& decision =
+        DeepseekV2DecoderLayerTestPeer::topk_share_decision(*decoder);
+    const bool expect_full = is_full_indexer_layer_glm52(layer_id);
+    const bool expect_output =
+        expect_full && !is_full_indexer_layer_glm52(layer_id + 1);
+    EXPECT_EQ(decision.reuse_topk, !expect_full) << "layer " << layer_id;
+    EXPECT_EQ(decision.output_topk, expect_output) << "layer " << layer_id;
+    if (expect_full) {
+      ++full_count;
+    } else {
+      ++shared_count;
+    }
+  }
+  EXPECT_EQ(full_count, 21);
+  EXPECT_EQ(shared_count, 57);
+}
+
+TEST_F(DeepseekV2DecoderTopkShareTest,
+       SharedLayerOwnsNoIndexerParametersOrConstants) {
+  configure_glm5_indexer();
+  model_args_.index_topk_freq() = 4;
+  model_args_.index_skip_topk_offset() = 3;
+  refresh_ctx();
+
+  auto full_decoder = make_decoder(/*layer_id=*/2);
+  auto shared_decoder = make_decoder(/*layer_id=*/3);
+
+  EXPECT_TRUE(DeepseekV2DecoderLayerTestPeer::attention_has_child(*full_decoder,
+                                                                  "indexer"));
+  EXPECT_TRUE(DeepseekV2DecoderLayerTestPeer::attention_has_child(
+      *full_decoder, "indexer_rotary_emb"));
+  EXPECT_FALSE(DeepseekV2DecoderLayerTestPeer::attention_has_child(
+      *shared_decoder, "indexer"));
+  EXPECT_FALSE(DeepseekV2DecoderLayerTestPeer::attention_has_child(
+      *shared_decoder, "indexer_rotary_emb"));
+
+  const auto full_parameters = full_decoder->named_parameters(/*recurse=*/true);
+  const auto shared_parameters =
+      shared_decoder->named_parameters(/*recurse=*/true);
+  EXPECT_TRUE(full_parameters.contains("self_attn.indexer.wq_b.weight"));
+  EXPECT_TRUE(full_parameters.contains("self_attn.indexer.wk.weight"));
+  EXPECT_TRUE(
+      full_parameters.contains("self_attn.indexer.weights_proj.weight"));
+  EXPECT_TRUE(full_parameters.contains("self_attn.indexer.k_norm.weight"));
+  EXPECT_FALSE(shared_parameters.contains("self_attn.indexer.wq_b.weight"));
+  EXPECT_FALSE(shared_parameters.contains("self_attn.indexer.wk.weight"));
+  EXPECT_FALSE(
+      shared_parameters.contains("self_attn.indexer.weights_proj.weight"));
+  EXPECT_FALSE(shared_parameters.contains("self_attn.indexer.k_norm.weight"));
+}
+
+TEST_F(DeepseekV2DecoderTopkShareTest,
+       Pattern_WhenEquivalentFsString_ThenPlanMatchesFreqConfig) {
+  configure_glm5_indexer();
+  model_args_.index_topk_freq() = 1;
+  model_args_.index_skip_topk_offset() = 0;
+  model_args_.index_topk_pattern() = build_fs_pattern_glm52(kNumLayers);
+  refresh_ctx();
+
+  for (int32_t layer_id = 0; layer_id < kNumLayers; ++layer_id) {
+    auto decoder = make_decoder(layer_id);
+    const DsaTopkShareDecision& decision =
+        DeepseekV2DecoderLayerTestPeer::topk_share_decision(*decoder);
+    const bool expect_full = is_full_indexer_layer_glm52(layer_id);
+    const bool expect_output =
+        expect_full && !is_full_indexer_layer_glm52(layer_id + 1);
+    EXPECT_EQ(decision.reuse_topk, !expect_full) << "layer " << layer_id;
+    EXPECT_EQ(decision.output_topk, expect_output) << "layer " << layer_id;
+  }
+}
+
+TEST_F(DeepseekV2DecoderTopkShareTest,
+       DefaultIndexer_WhenGlm51_ThenEveryLayerLoadsOwnIndexerWeights) {
+  configure_glm5_indexer();
+  // GLM5.1 has an indexer on every layer but no cross-layer share fields.
+  model_args_.index_topk_freq() = 1;
+  model_args_.index_skip_topk_offset() = 0;
+  model_args_.index_topk_pattern() = "";
+  refresh_ctx();
+
+  const DsaTopkSharePlan topk_share_plan(model_args_);
+  EXPECT_FALSE(topk_share_plan.has_reuse());
+  EXPECT_EQ(topk_share_plan.num_indexer_layers(), kNumLayers);
+
+  for (int32_t layer_id : {0, 3, 6, 7}) {
+    auto decoder = make_loaded_decoder(layer_id);
+    const DsaTopkShareDecision& decision =
+        DeepseekV2DecoderLayerTestPeer::topk_share_decision(*decoder);
+    EXPECT_FALSE(decision.reuse_topk) << "layer " << layer_id;
+    EXPECT_FALSE(decision.output_topk) << "layer " << layer_id;
+    EXPECT_TRUE(DeepseekV2DecoderLayerTestPeer::attention_has_child(*decoder,
+                                                                    "indexer"))
+        << "layer " << layer_id;
+    EXPECT_TRUE(DeepseekV2DecoderLayerTestPeer::attention_has_child(
+        *decoder, "indexer_rotary_emb"))
+        << "layer " << layer_id;
+
+    const auto parameters = decoder->named_parameters(/*recurse=*/true);
+    EXPECT_TRUE(parameters.contains("self_attn.indexer.wq_b.weight"))
+        << "layer " << layer_id;
+    EXPECT_TRUE(parameters.contains("self_attn.indexer.wk.weight"))
+        << "layer " << layer_id;
+    EXPECT_TRUE(parameters.contains("self_attn.indexer.weights_proj.weight"))
+        << "layer " << layer_id;
+    EXPECT_TRUE(parameters.contains("self_attn.indexer.k_norm.weight"))
+        << "layer " << layer_id;
+  }
+}
+
+TEST_F(DeepseekV2DecoderTopkShareTest,
+       MtpLayerAtMainModelBoundaryUsesOnlyCrossStepReuse) {
+  configure_glm5_indexer();
+  model_args_.model_type() = "glm_moe_dsa_mtp";
+  model_args_.index_topk_freq() = 4;
+  model_args_.index_skip_topk_offset() = 3;
+  model_args_.index_share_for_mtp_iteration() = true;
+  refresh_ctx();
+
+  DecoderHolder decoder(
+      DeepseekV2DecoderLayerImpl(context_, /*layer_id=*/kNumLayers));
+  const DsaTopkShareDecision& decision =
+      DeepseekV2DecoderLayerTestPeer::topk_share_decision(*decoder);
+  EXPECT_FALSE(decision.reuse_topk);
+  EXPECT_FALSE(decision.output_topk);
+  EXPECT_TRUE(DeepseekV2DecoderLayerTestPeer::mtp_topk_reuse(*decoder));
+  EXPECT_TRUE(
+      DeepseekV2DecoderLayerTestPeer::attention_has_child(*decoder, "indexer"));
+}
+
+// Prefill CP combined with GLM5.2 cross-layer top-k sharing is not
+// supported yet; the model entry must fatal on this combination. The guard is a
+// pure decision so it can be verified without constructing the full model.
+TEST_F(DeepseekV2DecoderTopkShareTest,
+       CpGuard_WhenCpOffAndSharePlan_ThenNoConflict) {
+  configure_glm5_indexer();
+  model_args_.index_topk_freq() = 4;
+  model_args_.index_skip_topk_offset() = 3;
+  model_args_.index_topk_pattern() = "";
+
+  const DsaTopkSharePlan topk_share_plan(model_args_);
+  EXPECT_TRUE(topk_share_plan.has_reuse());
+  EXPECT_FALSE(cp_conflicts_with_dsa_topk_share(/*enable_prefill_cp=*/false,
+                                                topk_share_plan));
+}
+
+TEST_F(DeepseekV2DecoderTopkShareTest,
+       CpGuard_WhenCpOnAndGlm52FreqPlan_ThenConflict) {
+  configure_glm5_indexer();
+  model_args_.index_topk_freq() = 4;
+  model_args_.index_skip_topk_offset() = 3;
+  model_args_.index_topk_pattern() = "";
+
+  const DsaTopkSharePlan topk_share_plan(model_args_);
+  EXPECT_TRUE(cp_conflicts_with_dsa_topk_share(/*enable_prefill_cp=*/true,
+                                               topk_share_plan));
+}
+
+TEST_F(DeepseekV2DecoderTopkShareTest,
+       CpGuard_WhenCpOnAndPatternPlan_ThenConflict) {
+  configure_glm5_indexer();
+  model_args_.index_topk_freq() = 1;
+  model_args_.index_skip_topk_offset() = 0;
+  model_args_.index_topk_pattern() = build_fs_pattern_glm52(kNumLayers);
+
+  const DsaTopkSharePlan topk_share_plan(model_args_);
+  EXPECT_TRUE(cp_conflicts_with_dsa_topk_share(/*enable_prefill_cp=*/true,
+                                               topk_share_plan));
+}
+
+TEST_F(DeepseekV2DecoderTopkShareTest,
+       CpGuard_WhenPatternHasOnlyFullLayers_ThenNoConflict) {
+  configure_glm5_indexer();
+  model_args_.n_layers() = 4;
+  model_args_.index_topk_freq() = 1;
+  model_args_.index_skip_topk_offset() = 0;
+  model_args_.index_topk_pattern() = "FFFF";
+
+  const DsaTopkSharePlan topk_share_plan(model_args_);
+  EXPECT_FALSE(topk_share_plan.has_reuse());
+  EXPECT_FALSE(cp_conflicts_with_dsa_topk_share(/*enable_prefill_cp=*/true,
+                                                topk_share_plan));
+  EXPECT_FALSE(topk_share_plan.decision_for(/*layer_id=*/3).reuse_topk);
+  EXPECT_FALSE(topk_share_plan.decision_for(/*layer_id=*/3).output_topk);
+}
+
+TEST_F(DeepseekV2DecoderTopkShareTest,
+       CpGuard_WhenShortFreqPlanHasNoSharedLayer_ThenNoConflict) {
+  configure_glm5_indexer();
+  model_args_.n_layers() = 3;
+  model_args_.index_topk_freq() = 4;
+  model_args_.index_skip_topk_offset() = 3;
+  model_args_.index_topk_pattern() = "";
+
+  const DsaTopkSharePlan topk_share_plan(model_args_);
+  EXPECT_FALSE(topk_share_plan.has_reuse());
+  EXPECT_FALSE(cp_conflicts_with_dsa_topk_share(/*enable_prefill_cp=*/true,
+                                                topk_share_plan));
+  EXPECT_FALSE(topk_share_plan.decision_for(/*layer_id=*/2).output_topk);
+}
+
+TEST_F(DeepseekV2DecoderTopkShareTest,
+       CpGuard_WhenCpOnAndGlm51IndexerDoesNotShare_ThenNoConflict) {
+  configure_glm5_indexer();
+  // GLM5.1: every layer owns an indexer, so CP has no cross-layer carrier.
+  model_args_.index_topk_freq() = 1;
+  model_args_.index_skip_topk_offset() = 0;
+  model_args_.index_topk_pattern() = "";
+
+  const DsaTopkSharePlan topk_share_plan(model_args_);
+  EXPECT_FALSE(topk_share_plan.has_reuse());
+  EXPECT_EQ(topk_share_plan.num_indexer_layers(), kNumLayers);
+  EXPECT_FALSE(cp_conflicts_with_dsa_topk_share(/*enable_prefill_cp=*/true,
+                                                topk_share_plan));
+}
+
+TEST_F(DeepseekV2DecoderTopkShareTest,
+       CpGuard_WhenCpOnAndDeepseekV32NoSharePlan_ThenNoConflict) {
+  // DeepSeek-V3.2: has an indexer but every layer self-computes (freq=1, no
+  // pattern), so the existing CP path is unaffected.
+  configure_glm5_indexer();
+  model_args_.index_topk_freq() = 1;
+  model_args_.index_skip_topk_offset() = 0;
+  model_args_.index_topk_pattern() = "";
+
+  const DsaTopkSharePlan topk_share_plan(model_args_);
+  EXPECT_FALSE(topk_share_plan.has_reuse());
+  EXPECT_FALSE(cp_conflicts_with_dsa_topk_share(/*enable_prefill_cp=*/true,
+                                                topk_share_plan));
+}
 
 }  // namespace layer
 }  // namespace xllm

--- a/tests/core/layers/mlu/dsa_topk_relay_test.cpp
+++ b/tests/core/layers/mlu/dsa_topk_relay_test.cpp
@@ -1,0 +1,149 @@
+/* Copyright 2026 The xLLM Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://github.com/jd-opensource/xllm/blob/main/LICENSE
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include "core/layers/mlu/dsa_topk_relay.h"
+
+#include <gtest/gtest.h>
+#include <torch/torch.h>
+
+namespace xllm::layer {
+namespace {
+
+TEST(DsaTopkRelayTest, PublishedStateIsReusedAsOneValue) {
+  DsaTopkRelay relay;
+  const DsaTopkShareDecision publish_decision{
+      .reuse_topk = false,
+      .output_topk = true,
+  };
+  std::optional<DsaTopkTransfer> publish_transfer =
+      relay.prepare_layer(publish_decision);
+  ASSERT_TRUE(publish_transfer.has_value());
+  EXPECT_EQ(publish_transfer->input(), nullptr);
+  EXPECT_TRUE(publish_transfer->captures_output());
+
+  const torch::Tensor block_tables =
+      torch::tensor({{1, 2}, {3, 4}}, torch::dtype(torch::kInt32));
+  const torch::Tensor context_lens =
+      torch::tensor({2, 1}, torch::dtype(torch::kInt32));
+  publish_transfer->publish_output(DsaTopkState(block_tables, context_lens));
+  relay.finish_layer(publish_decision, *publish_transfer);
+
+  const DsaTopkShareDecision reuse_decision{
+      .reuse_topk = true,
+      .output_topk = false,
+  };
+  std::optional<DsaTopkTransfer> reuse_transfer =
+      relay.prepare_layer(reuse_decision);
+  ASSERT_TRUE(reuse_transfer.has_value());
+  ASSERT_NE(reuse_transfer->input(), nullptr);
+  EXPECT_FALSE(reuse_transfer->captures_output());
+  EXPECT_TRUE(
+      torch::equal(reuse_transfer->input()->block_tables(), block_tables));
+  EXPECT_TRUE(
+      torch::equal(reuse_transfer->input()->context_lens(), context_lens));
+}
+
+TEST(DsaTopkRelayTest, ReuseBeforePublishFails) {
+  DsaTopkRelay relay;
+  const DsaTopkShareDecision reuse_decision{
+      .reuse_topk = true,
+      .output_topk = false,
+  };
+
+  EXPECT_DEATH(
+      {
+        const std::optional<DsaTopkTransfer> transfer =
+            relay.prepare_layer(reuse_decision);
+        static_cast<void>(transfer);
+      },
+      "requires a previously published state");
+}
+
+TEST(DsaTopkStateTest, FlattenedStatePreservesSparseMetadataStorage) {
+  const torch::Tensor block_tables =
+      torch::tensor({{{1, 2}}, {{3, 4}}}, torch::dtype(torch::kInt32));
+  const torch::Tensor context_lens =
+      torch::tensor({2, 1}, torch::dtype(torch::kInt32));
+
+  const DsaTopkState state(block_tables, context_lens);
+  const DsaTopkState flattened = state.flattened();
+  EXPECT_TRUE(
+      torch::equal(flattened.block_tables(), block_tables.reshape({2, 2})));
+  EXPECT_TRUE(torch::equal(flattened.context_lens(), context_lens));
+  EXPECT_EQ(flattened.block_tables().data_ptr(), block_tables.data_ptr());
+  EXPECT_EQ(flattened.context_lens().data_ptr(), context_lens.data_ptr());
+}
+
+TEST(DsaTopkTransferTest, EmptyMtpStateCapturesStateForNextStep) {
+  DsaTopkTransfer transfer = DsaTopkTransfer::prepare_mtp_step(
+      std::nullopt, torch::Device(torch::kCPU));
+  EXPECT_EQ(transfer.input(), nullptr);
+  EXPECT_TRUE(transfer.captures_output());
+  EXPECT_FALSE(transfer.mtp_output_state().has_value());
+
+  const torch::Tensor block_tables =
+      torch::tensor({{1, 2}, {3, 4}}, torch::dtype(torch::kInt32));
+  const torch::Tensor context_lens =
+      torch::tensor({2, 1}, torch::dtype(torch::kInt32));
+  transfer.publish_output(DsaTopkState(block_tables, context_lens));
+
+  const std::optional<DsaTopkState> output = transfer.mtp_output_state();
+  ASSERT_TRUE(output.has_value());
+  EXPECT_EQ(output->block_tables().data_ptr(), block_tables.data_ptr());
+  EXPECT_EQ(output->context_lens().data_ptr(), context_lens.data_ptr());
+}
+
+TEST(DsaTopkTransferTest, ExistingMtpStateIsReusedAndRecaptured) {
+  const torch::Tensor block_tables =
+      torch::tensor({{1, 2}, {3, 4}}, torch::kInt32);
+  const torch::Tensor context_lens = torch::tensor({2, 1}, torch::kInt32);
+  const DsaTopkState state(block_tables, context_lens);
+
+  DsaTopkTransfer transfer =
+      DsaTopkTransfer::prepare_mtp_step(state, torch::Device(torch::kCPU));
+  ASSERT_NE(transfer.input(), nullptr);
+  EXPECT_TRUE(transfer.captures_output());
+  EXPECT_EQ(transfer.input()->block_tables().data_ptr(),
+            block_tables.data_ptr());
+  EXPECT_EQ(transfer.input()->context_lens().data_ptr(),
+            context_lens.data_ptr());
+}
+
+TEST(DsaTopkStateTest, RejectsStateWithNonInt32Dtype) {
+  const torch::Tensor block_tables = torch::zeros({2, 2}, torch::kInt64);
+  const torch::Tensor context_lens = torch::zeros({2}, torch::kInt64);
+  EXPECT_DEATH(
+      {
+        const DsaTopkState state(block_tables, context_lens);
+        static_cast<void>(state);
+      },
+      "must use int32");
+}
+
+TEST(DsaTopkStateTest, RejectsSparseMetadataWithMismatchedRows) {
+  const torch::Tensor block_tables =
+      torch::zeros({2, 4}, torch::dtype(torch::kInt32));
+  const torch::Tensor context_lens =
+      torch::zeros({3}, torch::dtype(torch::kInt32));
+  EXPECT_DEATH(
+      {
+        const DsaTopkState state(block_tables, context_lens);
+        static_cast<void>(state);
+      },
+      "row count");
+}
+
+}  // namespace
+}  // namespace xllm::layer

--- a/xllm/core/layers/common/dsa_topk_share_plan.h
+++ b/xllm/core/layers/common/dsa_topk_share_plan.h
@@ -20,7 +20,9 @@ limitations under the License.
 #include <algorithm>
 #include <cctype>
 #include <cstdint>
+#include <limits>
 #include <string>
+#include <vector>
 
 #include "core/framework/model/model_args.h"
 
@@ -36,69 +38,144 @@ inline bool has_dsa_indexer(const ModelArgs& args) {
          args.index_topk() > 0;
 }
 
-inline bool should_skip_topk_from_pattern(const std::string& pattern,
-                                          int32_t layer_id) {
-  CHECK_GE(layer_id, 0) << "DSA top-k sharing layer id must be non-negative.";
-  CHECK_LT(layer_id, static_cast<int32_t>(pattern.size()))
-      << "DSA top-k sharing pattern is shorter than num_hidden_layers.";
-  const char symbol = static_cast<char>(std::toupper(
-      static_cast<unsigned char>(pattern[static_cast<size_t>(layer_id)])));
-  CHECK(symbol == 'F' || symbol == 'S')
-      << "DSA top-k sharing pattern only supports F/S, got " << symbol;
-  return symbol == 'S';
+// Cross-step MTP reuse is a backend-independent DSA policy. Backends own the
+// carrier representation used to transport their top-k state between steps.
+inline bool is_mtp_dsa_topk_reuse_enabled(const ModelArgs& args) {
+  return args.model_type().ends_with("_mtp") &&
+         args.index_share_for_mtp_iteration() && has_dsa_indexer(args);
 }
 
-inline bool should_skip_topk_from_freq(int32_t freq,
-                                       int32_t offset,
-                                       int32_t layer_id) {
-  CHECK_GT(freq, 1) << "DSA top-k sharing freq must be greater than 1.";
-  CHECK_GE(offset, 0) << "DSA top-k sharing offset must be non-negative.";
-  if (offset > 0) {
-    return std::max<int32_t>(layer_id - offset + 1, 0) % freq != 0;
-  }
-  return std::max<int32_t>(layer_id - 1, 0) % freq != 0;
-}
+// Resolves and validates the complete cross-layer plan once. Consumers use the
+// resolved decisions instead of independently interpreting the raw config.
+class DsaTopkSharePlan final {
+ public:
+  explicit DsaTopkSharePlan(const ModelArgs& args) {
+    const int64_t num_layers = args.n_layers();
+    decisions_.resize(static_cast<size_t>(num_layers));
+    has_indexer_ = has_dsa_indexer(args);
 
-inline bool should_next_layer_skip_topk_from_freq(int32_t freq,
-                                                  int32_t offset,
-                                                  int32_t layer_id) {
-  CHECK_GT(freq, 1) << "DSA top-k sharing freq must be greater than 1.";
-  CHECK_GE(offset, 0) << "DSA top-k sharing offset must be non-negative.";
-  if (offset > 0) {
-    return std::max<int32_t>(layer_id - offset + 2, 0) % freq != 0;
+    if (!has_indexer_ ||
+        (args.index_topk_pattern().empty() && args.index_topk_freq() <= 1)) {
+      return;
+    }
+
+    if (!args.index_topk_pattern().empty()) {
+      const std::string& pattern = args.index_topk_pattern();
+      CHECK_EQ(static_cast<int64_t>(pattern.size()), num_layers)
+          << "DSA top-k sharing pattern length must equal num_hidden_layers.";
+      for (int32_t layer_id = 0; layer_id < num_layers; ++layer_id) {
+        decisions_[static_cast<size_t>(layer_id)].reuse_topk =
+            should_reuse_from_pattern(pattern, layer_id);
+      }
+    } else {
+      const int32_t freq = args.index_topk_freq();
+      const int32_t offset = args.index_skip_topk_offset();
+      CHECK_GT(freq, 1) << "DSA top-k sharing freq must be greater than 1.";
+      CHECK_GE(offset, 0) << "DSA top-k sharing offset must be non-negative.";
+      for (int32_t layer_id = 0; layer_id < num_layers; ++layer_id) {
+        decisions_[static_cast<size_t>(layer_id)].reuse_topk =
+            should_reuse_from_freq(freq, offset, layer_id);
+      }
+    }
+
+    for (int32_t layer_id = 0; layer_id < num_layers; ++layer_id) {
+      DsaTopkShareDecision& decision =
+          decisions_[static_cast<size_t>(layer_id)];
+      has_reuse_ = has_reuse_ || decision.reuse_topk;
+      const bool next_layer_reuses =
+          layer_id + 1 < num_layers &&
+          decisions_[static_cast<size_t>(layer_id + 1)].reuse_topk;
+      decision.output_topk = !decision.reuse_topk && next_layer_reuses;
+    }
   }
-  return layer_id % freq != 0;
+
+  const DsaTopkShareDecision& decision_for(int32_t layer_id) const {
+    CHECK_GE(layer_id, 0) << "DSA top-k sharing layer id must be non-negative.";
+    CHECK_LT(static_cast<size_t>(layer_id), decisions_.size())
+        << "DSA top-k sharing layer id exceeds num_hidden_layers.";
+    return decisions_[static_cast<size_t>(layer_id)];
+  }
+
+  bool has_reuse() const { return has_reuse_; }
+
+  bool layer_uses_indexer(int32_t layer_id) const {
+    return has_indexer_ && !decision_for(layer_id).reuse_topk;
+  }
+
+  int64_t num_indexer_layers() const {
+    if (!has_indexer_) {
+      return 0;
+    }
+    return static_cast<int64_t>(
+        std::count_if(decisions_.begin(),
+                      decisions_.end(),
+                      [](const DsaTopkShareDecision& decision) {
+                        return !decision.reuse_topk;
+                      }));
+  }
+
+ private:
+  static bool should_reuse_from_pattern(const std::string& pattern,
+                                        int32_t layer_id) {
+    const char symbol = static_cast<char>(std::toupper(
+        static_cast<unsigned char>(pattern[static_cast<size_t>(layer_id)])));
+    CHECK(symbol == 'F' || symbol == 'S')
+        << "DSA top-k sharing pattern only supports F/S, got " << symbol;
+    return symbol == 'S';
+  }
+
+  static bool should_reuse_from_freq(int32_t freq,
+                                     int32_t offset,
+                                     int32_t layer_id) {
+    if (offset > 0) {
+      return std::max<int32_t>(layer_id - offset + 1, 0) % freq != 0;
+    }
+    return std::max<int32_t>(layer_id - 1, 0) % freq != 0;
+  }
+
+  std::vector<DsaTopkShareDecision> decisions_;
+  bool has_indexer_ = false;
+  bool has_reuse_ = false;
+};
+
+inline std::vector<bool> get_dsa_indexer_layer_mask(const ModelArgs& args,
+                                                    int64_t num_cache_layers) {
+  CHECK_GE(num_cache_layers, 0)
+      << "DSA indexer cache layer count must be non-negative.";
+  CHECK_LE(num_cache_layers, std::numeric_limits<int32_t>::max())
+      << "DSA indexer cache layer count exceeds int32 range.";
+  if (!has_dsa_indexer(args)) {
+    return {};
+  }
+
+  std::vector<bool> layer_mask(static_cast<size_t>(num_cache_layers), true);
+  if (args.model_type().ends_with("_mtp")) {
+    return layer_mask;
+  }
+
+  CHECK_EQ(num_cache_layers, args.n_layers())
+      << "Main-model DSA cache layers must match num_hidden_layers.";
+  const DsaTopkSharePlan topk_share_plan(args);
+  for (int32_t layer_id = 0; layer_id < num_cache_layers; ++layer_id) {
+    layer_mask[static_cast<size_t>(layer_id)] =
+        topk_share_plan.layer_uses_indexer(layer_id);
+  }
+  return layer_mask;
 }
 
 inline DsaTopkShareDecision get_dsa_topk_share_decision(const ModelArgs& args,
                                                         int32_t layer_id) {
-  DsaTopkShareDecision decision;
-  if (!has_dsa_indexer(args)) {
-    return decision;
-  }
-  if (args.index_topk_pattern().empty() && args.index_topk_freq() <= 1) {
-    return decision;
-  }
+  const DsaTopkSharePlan topk_share_plan(args);
+  return topk_share_plan.decision_for(layer_id);
+}
 
-  bool skip_topk = false;
-  bool next_skip_topk = false;
-  if (!args.index_topk_pattern().empty()) {
-    const std::string& pattern = args.index_topk_pattern();
-    skip_topk = should_skip_topk_from_pattern(pattern, layer_id);
-    if (layer_id + 1 < static_cast<int32_t>(pattern.size())) {
-      next_skip_topk = should_skip_topk_from_pattern(pattern, layer_id + 1);
-    }
-  } else {
-    const int32_t freq = args.index_topk_freq();
-    const int32_t offset = args.index_skip_topk_offset();
-    skip_topk = should_skip_topk_from_freq(freq, offset, layer_id);
-    next_skip_topk =
-        should_next_layer_skip_topk_from_freq(freq, offset, layer_id);
-  }
-
-  decision.reuse_topk = skip_topk;
-  decision.output_topk = !skip_topk && next_skip_topk;
-  return decision;
+// Prefill context parallelism combined with a DSA cross-layer top-k share plan
+// is not supported yet: CP shards the sparse block table per local shard, which
+// is incompatible with cross-layer top-k reuse.
+inline bool cp_conflicts_with_dsa_topk_share(
+    bool enable_prefill_cp,
+    const DsaTopkSharePlan& topk_share_plan) {
+  return enable_prefill_cp && topk_share_plan.has_reuse();
 }
 
 }  // namespace xllm::layer

--- a/xllm/core/layers/mlu/CMakeLists.txt
+++ b/xllm/core/layers/mlu/CMakeLists.txt
@@ -5,6 +5,8 @@ cc_library(
     mlu_layers
   HDRS
     attention.h
+    dsa_topk_relay.h
+    dsa_topk_state.h
     deepseek_v2_attention.h
     deepseek_v2_decoder_layer_impl.h
     deepseek_v2_sparse_moe_block.h

--- a/xllm/core/layers/mlu/deepseek_v2_attention.cpp
+++ b/xllm/core/layers/mlu/deepseek_v2_attention.cpp
@@ -29,7 +29,8 @@ DeepseekV2AttentionImpl::DeepseekV2AttentionImpl(
     const QuantArgs& quant_args,
     const ParallelArgs& parallel_args,
     const torch::TensorOptions& options,
-    const OptimizationConfig& optimization_config)
+    const OptimizationConfig& optimization_config,
+    bool enable_indexer)
     : q_lora_rank_(args.q_lora_rank()),
       kv_lora_rank_(args.kv_lora_rank()),
       qk_nope_head_dim_(args.qk_nope_head_dim()),
@@ -39,6 +40,7 @@ DeepseekV2AttentionImpl::DeepseekV2AttentionImpl(
       v_head_dim_(args.v_head_dim()),
       eps_(args.rms_norm_eps()),
       interleaved_(true) {
+  has_indexer_ = enable_lighting_indexer_ && enable_indexer;
   use_full_replicated_attention_weights_ =
       parallel_args.cp_size() > 1 && Platform::uses_model_cp_partition();
   const int64_t tp_size = parallel_args.tp_group_->world_size();
@@ -125,22 +127,20 @@ DeepseekV2AttentionImpl::DeepseekV2AttentionImpl(
                                                   interleaved_,
                                                   options));
 
-  // indexer rotary embedding for lighting indexer
-  indexer_rotary_emb_ = register_module(
-      "indexer_rotary_emb",
-      create_mla_rotary_embedding(args,
-                                  qk_rope_head_dim_,
-                                  max_position_embeddings,
-                                  args.indexer_rope_interleave(),
-                                  options));
-
   if (args.rope_scaling_rope_type() == "deepseek_yarn") {
     float mscale = layer::rotary::yarn_get_mscale(
         args.rope_scaling_factor(), args.rope_scaling_mscale_all_dim());
     scaling *= mscale * mscale;
   }
 
-  if (enable_lighting_indexer_) {
+  if (has_indexer_) {
+    indexer_rotary_emb_ = register_module(
+        "indexer_rotary_emb",
+        create_mla_rotary_embedding(args,
+                                    qk_rope_head_dim_,
+                                    max_position_embeddings,
+                                    args.indexer_rope_interleave(),
+                                    options));
     indexer_ =
         register_module("indexer",
                         Indexer(hidden_size,
@@ -157,9 +157,8 @@ DeepseekV2AttentionImpl::DeepseekV2AttentionImpl(
   }
 
   use_fused_mla_qkv_ = optimization_config.enable_fused_mla_kernel;
-  if (::xllm::KVCacheConfig::get_instance().indexer_cache_dtype() == "int8") {
-    CHECK(enable_lighting_indexer_)
-        << "Indexer cache INT8 requires lighting indexer.";
+  if (has_indexer_ &&
+      ::xllm::KVCacheConfig::get_instance().indexer_cache_dtype() == "int8") {
     CHECK(optimization_config.enable_fused_indexer_qk)
         << "Indexer cache INT8 requires fused indexer Q/K.";
   }
@@ -393,7 +392,7 @@ AttentionMetadata DeepseekV2AttentionImpl::build_mla_attention_metadata(
       attn_indexer_metadata.block_table = new_block_tables.value();
       attn_indexer_metadata.kv_seq_lens = new_context_lens.value();
       attn_indexer_metadata.max_seq_len = index_topk_;
-    } else if (enable_lighting_indexer_) {
+    } else if (has_indexer_) {
       auto index_cache = kv_cache.get_index_cache();
       auto index_cache_scale = kv_cache.get_indexer_cache_scale();
       auto [new_block_tables, new_context_lens] = indexer_(hidden_states,
@@ -407,6 +406,9 @@ AttentionMetadata DeepseekV2AttentionImpl::build_mla_attention_metadata(
       attn_indexer_metadata.block_table = new_block_tables;
       attn_indexer_metadata.kv_seq_lens = new_context_lens;
       attn_indexer_metadata.max_seq_len = index_topk_;
+    } else {
+      CHECK(!enable_lighting_indexer_)
+          << "Shared DSA layer requires externally supplied top-k metadata.";
     }
   }
   return attn_indexer_metadata;
@@ -432,10 +434,13 @@ torch::Tensor DeepseekV2AttentionImpl::forward(
     const torch::Tensor& hidden_states,
     const AttentionMetadata& attn_metadata,
     KVCache& kv_cache,
-    const v32_cp::DeepseekV32CPContext* sp_ctx) {
+    const v32_cp::DeepseekV32CPContext* sp_ctx,
+    DsaTopkTransfer* topk_transfer) {
   bool is_prefill_or_chunked_prefill =
       attn_metadata.is_prefill || attn_metadata.is_chunked_prefill;
   if (sp_ctx != nullptr && can_use_sp()) {
+    // DSA cross-layer top-k sharing under sequence parallel is out of scope
+    // for the eager path; the sequence parallel branch always recomputes.
     return forward_sp(positions,
                       hidden_states,
                       attn_metadata,
@@ -447,7 +452,8 @@ torch::Tensor DeepseekV2AttentionImpl::forward(
                            hidden_states,
                            attn_metadata,
                            kv_cache,
-                           is_prefill_or_chunked_prefill);
+                           is_prefill_or_chunked_prefill,
+                           topk_transfer);
 }
 
 torch::Tensor DeepseekV2AttentionImpl::forward_normal_tp(
@@ -455,7 +461,8 @@ torch::Tensor DeepseekV2AttentionImpl::forward_normal_tp(
     const torch::Tensor& hidden_states,
     const AttentionMetadata& attn_metadata,
     KVCache& kv_cache,
-    bool is_prefill_or_chunked_prefill) {
+    bool is_prefill_or_chunked_prefill,
+    DsaTopkTransfer* topk_transfer) {
   const auto& heads = active_heads();
   torch::Tensor q, q_norm;
   torch::Tensor q_input = torch::empty(
@@ -487,6 +494,15 @@ torch::Tensor DeepseekV2AttentionImpl::forward_normal_tp(
   k_input = k_input.view({k_input.size(0), -1});
   v_input = v_input.view({v_input.size(0), -1});
 
+  // A Shared layer feeds the previous Full layer's sparse block table so the
+  // metadata builder takes its external branch and skips indexer recompute.
+  std::optional<torch::Tensor> shared_block_tables;
+  std::optional<torch::Tensor> shared_context_lens;
+  if (topk_transfer != nullptr && topk_transfer->input() != nullptr) {
+    shared_block_tables = topk_transfer->input()->block_tables();
+    shared_context_lens = topk_transfer->input()->context_lens();
+  }
+
   AttentionMetadata attn_indexer_metadata =
       build_mla_attention_metadata(positions,
                                    hidden_states,
@@ -495,7 +511,18 @@ torch::Tensor DeepseekV2AttentionImpl::forward_normal_tp(
                                    attn_metadata,
                                    kv_cache,
                                    k_cache_scale,
-                                   is_prefill_or_chunked_prefill);
+                                   is_prefill_or_chunked_prefill,
+                                   /*slot_mapping=*/std::nullopt,
+                                   shared_block_tables,
+                                   shared_context_lens);
+
+  // An Output layer exports the freshly computed sparse block table (held in
+  // the resolved metadata) so the caller can cache it for the next Shared
+  // layer.
+  if (topk_transfer != nullptr && topk_transfer->captures_output()) {
+    topk_transfer->publish_output(DsaTopkState(
+        attn_indexer_metadata.block_table, attn_indexer_metadata.kv_seq_lens));
+  }
 
   // mla forward
   auto [attn_output, output_lse] =
@@ -523,7 +550,7 @@ void DeepseekV2AttentionImpl::load_state_dict(const StateDict& state_dict) {
   kv_b_proj_->load_state_dict(state_dict.get_dict_with_prefix("kv_b_proj."));
 
   // load indexer weights
-  if (enable_lighting_indexer_) {
+  if (has_indexer_) {
     indexer_->load_state_dict(state_dict.get_dict_with_prefix("indexer."));
   }
 

--- a/xllm/core/layers/mlu/deepseek_v2_attention.h
+++ b/xllm/core/layers/mlu/deepseek_v2_attention.h
@@ -21,6 +21,7 @@ limitations under the License.
 #include <optional>
 
 #include "attention.h"
+#include "core/layers/mlu/dsa_topk_relay.h"
 #include "framework/kv_cache/kv_cache.h"
 #include "framework/model/model_args.h"
 #include "framework/parallel_state/parallel_args.h"
@@ -50,20 +51,22 @@ class DeepseekV2AttentionImpl : public torch::nn::Module {
                           const QuantArgs& quant_args,
                           const ParallelArgs& parallel_args,
                           const torch::TensorOptions& options,
-                          const OptimizationConfig& optimization_config);
+                          const OptimizationConfig& optimization_config,
+                          bool enable_indexer = true);
 
   torch::Tensor forward(const torch::Tensor& positions,
                         const torch::Tensor& hidden_states,
                         const AttentionMetadata& attn_metadata,
                         KVCache& kv_cache,
-                        const v32_cp::DeepseekV32CPContext* sp_ctx = nullptr);
+                        const v32_cp::DeepseekV32CPContext* sp_ctx = nullptr,
+                        DsaTopkTransfer* topk_transfer = nullptr);
 
   bool use_replicated_attn_weights() const {
     return use_full_replicated_attention_weights_;
   }
 
   bool can_use_sp() const {
-    return enable_lighting_indexer_ && use_replicated_attn_weights();
+    return has_indexer_ && use_replicated_attn_weights();
   }
 
   PostAttnLayout post_attn_layout(bool use_sp_output) const {
@@ -100,7 +103,8 @@ class DeepseekV2AttentionImpl : public torch::nn::Module {
                                   const torch::Tensor& hidden_states,
                                   const AttentionMetadata& attn_metadata,
                                   KVCache& kv_cache,
-                                  bool is_prefill_or_chunked_prefill);
+                                  bool is_prefill_or_chunked_prefill,
+                                  DsaTopkTransfer* topk_transfer);
 
   // ===== sequence parallel related =====
   torch::Tensor forward_sp(const torch::Tensor& positions,
@@ -178,6 +182,7 @@ class DeepseekV2AttentionImpl : public torch::nn::Module {
   bool use_full_replicated_attention_weights_ = false;
   bool use_fused_mla_qkv_ = false;
   bool enable_lighting_indexer_ = false;
+  bool has_indexer_ = false;
   bool has_trans_ = false;
   bool interleaved_ = false;
   double eps_;

--- a/xllm/core/layers/mlu/deepseek_v2_decoder_layer_impl.cpp
+++ b/xllm/core/layers/mlu/deepseek_v2_decoder_layer_impl.cpp
@@ -17,6 +17,8 @@ limitations under the License.
 
 #include <utility>
 
+#include "layers/common/dsa_topk_share_plan.h"
+
 namespace xllm {
 namespace layer {
 
@@ -36,22 +38,46 @@ bool is_mtp_layer(const ModelArgs& model_args) {
   return model_args.model_type().ends_with("_mtp");
 }
 
-bool use_moe_layer(const ModelArgs& model_args, int32_t layer_id) {
-  if (is_mtp_layer(model_args)) {
-    return model_args.mtp_mlp_type() != "dense";
+DsaTopkShareDecision resolve_topk_share_decision(
+    const ModelContext& context,
+    int32_t layer_id,
+    const DsaTopkSharePlan& topk_share_plan) {
+  if (is_mtp_layer(context.get_model_args())) {
+    return DsaTopkShareDecision();
   }
-  return layer_id >= model_args.first_k_dense_replace();
+  return topk_share_plan.decision_for(layer_id);
 }
 }  // namespace
 
 DeepseekV2DecoderLayerImpl::DeepseekV2DecoderLayerImpl(
     const ModelContext& context,
     int32_t layer_id)
-    : parallel_args_(context.get_parallel_args()) {
+    : DeepseekV2DecoderLayerImpl(context, layer_id, DsaTopkShareDecision()) {}
+
+DeepseekV2DecoderLayerImpl::DeepseekV2DecoderLayerImpl(
+    const ModelContext& context,
+    int32_t layer_id,
+    const DsaTopkSharePlan& topk_share_plan)
+    : DeepseekV2DecoderLayerImpl(
+          context,
+          layer_id,
+          resolve_topk_share_decision(context, layer_id, topk_share_plan)) {}
+
+DeepseekV2DecoderLayerImpl::DeepseekV2DecoderLayerImpl(
+    const ModelContext& context,
+    int32_t layer_id,
+    const DsaTopkShareDecision& topk_share_decision)
+    : parallel_args_(context.get_parallel_args()),
+      layer_id_(layer_id),
+      topk_share_decision_(topk_share_decision) {
   const auto& model_args = context.get_model_args();
   const auto& quant_args = context.get_quant_args();
   const auto& options = context.get_tensor_options();
-  is_moe_layer_ = use_moe_layer(model_args, layer_id);
+  const bool mtp_layer = is_mtp_layer(model_args);
+  is_moe_layer_ = mtp_layer ? model_args.mtp_mlp_type() != "dense"
+                            : layer_id >= model_args.first_k_dense_replace();
+
+  mtp_topk_reuse_ = is_mtp_dsa_topk_reuse_enabled(model_args);
 
   // DeepSeek MoE only support ep == world_size when expert parallel is on
   if (parallel_args_.ep_size() > 1) {
@@ -61,12 +87,15 @@ DeepseekV2DecoderLayerImpl::DeepseekV2DecoderLayerImpl(
 
   // Initialize attention layers
   OptimizationConfig optimization_config = context.get_optimization_config();
-  attention_ = register_module("self_attn",
-                               DeepseekV2Attention(model_args,
-                                                   quant_args,
-                                                   parallel_args_,
-                                                   options,
-                                                   optimization_config));
+  attention_ = register_module(
+      "self_attn",
+      DeepseekV2Attention(model_args,
+                          quant_args,
+                          parallel_args_,
+                          options,
+                          optimization_config,
+                          /*enable_indexer=*/
+                          mtp_layer || !topk_share_decision_.reuse_topk));
 
   // Initialize norm layers
   input_norm_ = register_module(
@@ -275,14 +304,94 @@ torch::Tensor DeepseekV2DecoderLayerImpl::forward(
     const AttentionMetadata& attn_metadata,
     KVCache& kv_cache,
     const ModelInputParams& input_params,
-    const std::optional<torch::Tensor>&) {
+    const std::optional<torch::Tensor>& input_ids,
+    DsaTopkRelay* topk_relay) {
+  return forward_impl(x,
+                      residual,
+                      positions,
+                      attn_metadata,
+                      kv_cache,
+                      input_params,
+                      input_ids,
+                      topk_relay,
+                      /*mtp_topk_input=*/nullptr,
+                      /*mtp_topk_output=*/nullptr);
+}
+
+torch::Tensor DeepseekV2DecoderLayerImpl::forward_mtp(
+    torch::Tensor& x,
+    std::optional<torch::Tensor>& residual,
+    torch::Tensor& positions,
+    const AttentionMetadata& attn_metadata,
+    KVCache& kv_cache,
+    const ModelInputParams& input_params,
+    const std::optional<torch::Tensor>& input_ids,
+    const std::optional<DsaTopkState>& topk_input,
+    std::optional<DsaTopkState>& topk_output) {
+  return forward_impl(x,
+                      residual,
+                      positions,
+                      attn_metadata,
+                      kv_cache,
+                      input_params,
+                      input_ids,
+                      /*topk_relay=*/nullptr,
+                      &topk_input,
+                      &topk_output);
+}
+
+torch::Tensor DeepseekV2DecoderLayerImpl::forward_impl(
+    torch::Tensor& x,
+    std::optional<torch::Tensor>& residual,
+    torch::Tensor& positions,
+    const AttentionMetadata& attn_metadata,
+    KVCache& kv_cache,
+    const ModelInputParams& input_params,
+    const std::optional<torch::Tensor>&,
+    DsaTopkRelay* topk_relay,
+    const std::optional<DsaTopkState>* mtp_topk_input,
+    std::optional<DsaTopkState>* mtp_topk_output) {
   // Pre-attention norm
   residual = x;
   x = std::get<0>(input_norm_->forward(x));
 
+  std::optional<DsaTopkTransfer> cross_layer_transfer;
+  if (topk_relay != nullptr && !attn_metadata.is_dummy) {
+    cross_layer_transfer = topk_relay->prepare_layer(topk_share_decision_);
+  }
+
+  // MTP cross-step top-k reuse bridges typed per-layer state into the same
+  // atomic transfer used by attention. It only engages through forward_mtp,
+  // when no cross-layer transfer is active and this is a real forward.
+  std::optional<DsaTopkTransfer> mtp_transfer;
+  DsaTopkTransfer* effective_transfer = cross_layer_transfer.has_value()
+                                            ? &cross_layer_transfer.value()
+                                            : nullptr;
+  const bool use_mtp_topk_bridge =
+      mtp_topk_reuse_ && effective_transfer == nullptr &&
+      mtp_topk_input != nullptr && mtp_topk_output != nullptr &&
+      !attn_metadata.is_dummy;
+  if (use_mtp_topk_bridge) {
+    mtp_transfer =
+        DsaTopkTransfer::prepare_mtp_step(*mtp_topk_input, x.device());
+    effective_transfer = &mtp_transfer.value();
+  }
+
   // Attention
-  x = attention_->forward(
-      positions, x, attn_metadata, kv_cache, context_parallel_context_);
+  x = attention_->forward(positions,
+                          x,
+                          attn_metadata,
+                          kv_cache,
+                          context_parallel_context_,
+                          effective_transfer);
+
+  if (cross_layer_transfer.has_value()) {
+    topk_relay->finish_layer(topk_share_decision_,
+                             cross_layer_transfer.value());
+  }
+  if (use_mtp_topk_bridge) {
+    *mtp_topk_output = mtp_transfer->mtp_output_state();
+  }
   const bool use_sp_output =
       context_parallel_context_ != nullptr && attention_->can_use_sp();
   const auto attn_layout = attention_->post_attn_layout(use_sp_output);

--- a/xllm/core/layers/mlu/deepseek_v2_decoder_layer_impl.h
+++ b/xllm/core/layers/mlu/deepseek_v2_decoder_layer_impl.h
@@ -20,6 +20,7 @@ limitations under the License.
 #include <optional>
 
 #include "attention.h"
+#include "core/layers/mlu/dsa_topk_relay.h"
 #include "deepseek_v2_attention.h"
 #include "framework/kv_cache/kv_cache.h"
 #include "framework/model/model_args.h"
@@ -45,6 +46,10 @@ class DeepseekV2DecoderLayerImpl : public torch::nn::Module {
   explicit DeepseekV2DecoderLayerImpl(const ModelContext& context,
                                       int32_t layer_id);
 
+  DeepseekV2DecoderLayerImpl(const ModelContext& context,
+                             int32_t layer_id,
+                             const DsaTopkSharePlan& topk_share_plan);
+
   ~DeepseekV2DecoderLayerImpl() override = default;
 
   void load_state_dict(const StateDict& state_dict);
@@ -62,9 +67,24 @@ class DeepseekV2DecoderLayerImpl : public torch::nn::Module {
       const AttentionMetadata& attn_metadata,
       KVCache& kv_cache,
       const ModelInputParams& input_params,
-      const std::optional<torch::Tensor>& input_ids = std::nullopt);
+      const std::optional<torch::Tensor>& input_ids = std::nullopt,
+      DsaTopkRelay* topk_relay = nullptr);
+
+  torch::Tensor forward_mtp(torch::Tensor& x,
+                            std::optional<torch::Tensor>& residual,
+                            torch::Tensor& positions,
+                            const AttentionMetadata& attn_metadata,
+                            KVCache& kv_cache,
+                            const ModelInputParams& input_params,
+                            const std::optional<torch::Tensor>& input_ids,
+                            const std::optional<DsaTopkState>& topk_input,
+                            std::optional<DsaTopkState>& topk_output);
 
  private:
+  DeepseekV2DecoderLayerImpl(const ModelContext& context,
+                             int32_t layer_id,
+                             const DsaTopkShareDecision& topk_share_decision);
+
   enum class PostAttnMode {
     kReplicated,
     kPackedLocal,
@@ -105,12 +125,28 @@ class DeepseekV2DecoderLayerImpl : public torch::nn::Module {
   torch::Tensor restore_ffn_output(torch::Tensor x,
                                    const PostAttnCarrier& carrier);
   torch::Tensor reduce_out(torch::Tensor x, ProcessGroup* pg) const;
+  torch::Tensor forward_impl(torch::Tensor& x,
+                             std::optional<torch::Tensor>& residual,
+                             torch::Tensor& positions,
+                             const AttentionMetadata& attn_metadata,
+                             KVCache& kv_cache,
+                             const ModelInputParams& input_params,
+                             const std::optional<torch::Tensor>& input_ids,
+                             DsaTopkRelay* topk_relay,
+                             const std::optional<DsaTopkState>* mtp_topk_input,
+                             std::optional<DsaTopkState>* mtp_topk_output);
 
   friend class DeepseekV2DecoderLayerTestPeer;
 
   // parallel args
   ParallelArgs parallel_args_;
+  int32_t layer_id_;
   bool is_moe_layer_;
+  DsaTopkShareDecision topk_share_decision_;
+  // MTP draft layer reuses the first draft step's top-k across the remaining
+  // steps (cross-step sharing), isolated from the cross-layer DsaTopkRelay
+  // relay used by the main model.
+  bool mtp_topk_reuse_ = false;
 
   DeepseekV2Attention attention_{nullptr};
   DenseMLP mlp_{nullptr};

--- a/xllm/core/layers/mlu/dsa_topk_relay.h
+++ b/xllm/core/layers/mlu/dsa_topk_relay.h
@@ -1,0 +1,119 @@
+/* Copyright 2026 The xLLM Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://github.com/jd-opensource/xllm/blob/main/LICENSE
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#pragma once
+
+#include <glog/logging.h>
+#include <torch/torch.h>
+
+#include <optional>
+#include <utility>
+
+#include "core/layers/common/dsa_topk_share_plan.h"
+#include "core/layers/mlu/dsa_topk_state.h"
+
+namespace xllm::layer {
+
+// Per-attention transfer prepared by a relay or the MTP bridge. Factory
+// methods expose only valid reuse/capture combinations, and output is
+// published as one DsaTopkState rather than through independent pointers.
+class DsaTopkTransfer final {
+ public:
+  static DsaTopkTransfer capture_output() {
+    return DsaTopkTransfer(/*input=*/std::nullopt,
+                           /*captures_output=*/true);
+  }
+
+  static DsaTopkTransfer reuse(const DsaTopkState& input) {
+    return DsaTopkTransfer(input, /*captures_output=*/false);
+  }
+
+  static DsaTopkTransfer reuse_and_capture(const DsaTopkState& input) {
+    return DsaTopkTransfer(input, /*captures_output=*/true);
+  }
+
+  static DsaTopkTransfer prepare_mtp_step(
+      const std::optional<DsaTopkState>& state,
+      const torch::Device& device) {
+    if (!state.has_value()) {
+      return capture_output();
+    }
+    return reuse_and_capture(state->to(device));
+  }
+
+  const DsaTopkState* input() const {
+    return input_.has_value() ? &input_.value() : nullptr;
+  }
+
+  bool captures_output() const { return captures_output_; }
+
+  void publish_output(DsaTopkState output) {
+    CHECK(captures_output_) << "DSA top-k transfer does not capture output.";
+    CHECK(!output_.has_value()) << "DSA top-k output was already published.";
+    output_ = std::move(output);
+  }
+
+  const DsaTopkState* output() const {
+    return output_.has_value() ? &output_.value() : nullptr;
+  }
+
+  std::optional<DsaTopkState> mtp_output_state() const { return output_; }
+
+ private:
+  DsaTopkTransfer(std::optional<DsaTopkState> input, bool captures_output)
+      : input_(std::move(input)), captures_output_(captures_output) {}
+
+  std::optional<DsaTopkState> input_;
+  bool captures_output_ = false;
+  std::optional<DsaTopkState> output_;
+};
+
+// Owns the forward-scoped producer-to-consumer state. The model only resets
+// and passes this relay; layer-role interpretation and transfer validation stay
+// below the model boundary.
+class DsaTopkRelay final {
+ public:
+  void reset() { state_.reset(); }
+
+  std::optional<DsaTopkTransfer> prepare_layer(
+      const DsaTopkShareDecision& decision) const {
+    CHECK(!(decision.reuse_topk && decision.output_topk))
+        << "A DSA layer cannot reuse and publish top-k simultaneously.";
+    if (decision.reuse_topk) {
+      CHECK(state_.has_value())
+          << "DSA top-k reuse requires a previously published state.";
+      return DsaTopkTransfer::reuse(state_.value());
+    }
+    if (decision.output_topk) {
+      return DsaTopkTransfer::capture_output();
+    }
+    return std::nullopt;
+  }
+
+  void finish_layer(const DsaTopkShareDecision& decision,
+                    const DsaTopkTransfer& transfer) {
+    if (!decision.output_topk) {
+      return;
+    }
+    const DsaTopkState* output = transfer.output();
+    CHECK(output != nullptr) << "DSA top-k producer did not publish its state.";
+    state_ = *output;
+  }
+
+ private:
+  std::optional<DsaTopkState> state_;
+};
+
+}  // namespace xllm::layer

--- a/xllm/core/layers/mlu/dsa_topk_state.h
+++ b/xllm/core/layers/mlu/dsa_topk_state.h
@@ -1,0 +1,79 @@
+/* Copyright 2026 The xLLM Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://github.com/jd-opensource/xllm/blob/main/LICENSE
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#pragma once
+
+#include <glog/logging.h>
+#include <torch/torch.h>
+
+#include <utility>
+
+namespace xllm::layer {
+
+// Native MLU sparse-attention state shared between decoder layers or MTP
+// draft steps. Absence is represented by std::optional at the call site so
+// the paired tensors cannot be separated.
+class DsaTopkState final {
+ public:
+  DsaTopkState(torch::Tensor block_tables, torch::Tensor context_lens)
+      : block_tables_(std::move(block_tables)),
+        context_lens_(std::move(context_lens)) {
+    CHECK(block_tables_.defined()) << "DSA top-k block tables must be defined.";
+    CHECK(context_lens_.defined()) << "DSA top-k context lens must be defined.";
+    CHECK(block_tables_.dim() == 2 || block_tables_.dim() == 3)
+        << "DSA top-k block tables must be a 2-D or 3-D tensor.";
+    CHECK_EQ(context_lens_.dim(), 1)
+        << "DSA top-k context lens must be a 1-D tensor.";
+    CHECK(block_tables_.scalar_type() == torch::kInt &&
+          context_lens_.scalar_type() == torch::kInt)
+        << "DSA top-k sparse metadata must use int32.";
+    CHECK(block_tables_.device() == context_lens_.device())
+        << "DSA top-k sparse metadata must use the same device.";
+    CHECK_GT(block_tables_.size(-1), 0)
+        << "DSA top-k block tables must have at least one column.";
+    const int64_t row_count =
+        block_tables_.dim() == 3 ? block_tables_.size(0) * block_tables_.size(1)
+                                 : block_tables_.size(0);
+    CHECK_EQ(row_count, context_lens_.numel())
+        << "DSA top-k block table row count must match context lens.";
+  }
+
+  const torch::Tensor& block_tables() const { return block_tables_; }
+  const torch::Tensor& context_lens() const { return context_lens_; }
+
+  DsaTopkState flattened() const {
+    if (block_tables_.dim() == 2) {
+      return *this;
+    }
+    CHECK(block_tables_.is_contiguous())
+        << "MLU MTP DSA top-k block tables must be contiguous before flatten.";
+    return DsaTopkState(block_tables_.view({-1, block_tables_.size(-1)}),
+                        context_lens_);
+  }
+
+  DsaTopkState to(const torch::Device& device) const {
+    torch::Tensor block_tables = block_tables_.to(
+        block_tables_.options().device(device), /*non_blocking=*/true);
+    torch::Tensor context_lens = context_lens_.to(
+        context_lens_.options().device(device), /*non_blocking=*/true);
+    return DsaTopkState(std::move(block_tables), std::move(context_lens));
+  }
+
+ private:
+  torch::Tensor block_tables_;
+  torch::Tensor context_lens_;
+};
+
+}  // namespace xllm::layer


### PR DESCRIPTION
## Description

add dsa top-k sharing layer primitives.
- centralize cross-layer and cross-step sharing decisions
- add typed MLU top-k relay and decoder/attention transfer hooks
- cover relay, decoder, and multi-device sharing behavior


## Change Type

- [ ] Bug fix
- [x] New feature
- [ ] Performance improvement
- [ ] Refactor
- [ ] Documentation
- [ ] Test
- [ ] Build or CI

## Pull Request Checklist

Thank you for contributing to xLLM. Before requesting review, please make sure the following items are complete.

### PR Title and Commit Messages

- [x] The PR title and each commit message follow the xLLM commit format: `<type>: <subject>`.

> Allowed types: feat, bugfix, docs, test, refactor, chore, style, revert, perf, model, build, release.
> The subject should use clear English, start with a verb, include at least 4 words, and end with `.`.

### Pre-commit Checks

- [x] I have installed `pre-commit` by running `pip install pre-commit` or an equivalent command.
- [x] I have installed the hooks with `pre-commit install`.
- [x] I have run `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

### Self Review

- [x] I have self-reviewed the code according to `.agents/skills/code-review/references/custom-code-style.md`, especially code written or assisted by AI.
- [x] I have rebased this PR onto the latest `main` branch.

### Build and Test Coverage

- [ ] Tests have been added or updated as needed.
- [ ] CUDA: `python setup.py build test` has passed on a CUDA machine.
- [x] NPU: `python setup.py build test` has passed on an NPU machine.
- [x] MLU: `python setup.py build test` has passed on an MLU machine.

## Reviewer Notes

<!-- Optional: anything reviewers should focus on, known risks, follow-ups, or validation gaps. -->
