### PR TITLE
bugfix: align Qwen2.5-VL text encoder M-RoPE handling

### DIFF
--- a/xllm/models/vlm/npu/qwen2_5_vl.h
+++ b/xllm/models/vlm/npu/qwen2_5_vl.h
@@ -809,8 +809,7 @@ REGISTER_MODEL_ARGS(qwen2_5_vl, [&] {
     return args->mm_hidden_size() / args->mm_num_attention_heads();
   });
 
-  LOAD_ARG_OR(
-      rope_scaling_rope_type, "vision_config.rope_scaling.type", "mrope");
+  LOAD_ARG_OR(rope_scaling_rope_type, "rope_scaling.type", "mrope");
   LOAD_ARG(rope_scaling_mrope_section, "rope_scaling.mrope_section");
   LOAD_ARG_OR(vocab_size, "vocab_size", 152064);
 });


### PR DESCRIPTION
## Description

Fix Qwen2.5-VL text encoder position embedding handling by aligning the M-RoPE path with the diffusers reference behavior.

This PR corrects the VLM text encoder RoPE/M-RoPE handling so that Qwen2.5-VL prompt embeddings are closer to diffusers outputs. The fix reduces divergence in text transformer hidden states and improves final prompt embedding alignment for Qwen2.5-VL image-edit workloads.

## Related Issues

N/A

## Change Type

- [x] Bug fix
- [ ] New feature
- [ ] Performance improvement
- [ ] Refactor
- [ ] Documentation
- [ ] Test
- [ ] Build or CI

## Pull Request Checklist

Thank you for contributing to xLLM. Before requesting review, please make sure the following items are complete.

### PR Title and Commit Messages

- [x] The PR title and each commit message follow the xLLM commit format: `<type>: <subject>`.

> Allowed types: feat, bugfix, docs, test, refactor, chore, style, revert, perf, model, build, release.
> The subject should use clear English, start with a verb, include at least 4 words, and end with `.`.

### Pre-commit Checks

- [ ] I have installed `pre-commit` by running `pip install pre-commit` or an equivalent command.
- [ ] I have installed the hooks with `pre-commit install`.
- [ ] I have run `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

### Self Review

- [x] I have self-reviewed the code according to `.agents/skills/code-review/references/custom-code-style.md`, especially code written or assisted by AI.
- [ ] I have rebased this PR onto the latest `main` branch.

### Build and Test Coverage

- [ ] Tests have been added or updated as needed.
- [ ] CUDA: `python setup.py build test` has passed on a CUDA machine.
- [x] NPU: `python setup.py build test` has passed on an NPU machine.
- [ ] MLU: `python setup.py build test` has passed on an MLU machine.

## Reviewer Notes

Validated against diffusers intermediate dumps for Qwen2.5-VL prompt embedding alignment. The text encoder hidden states and final prompt embeddings are closer after the M-RoPE handling fix.

Known remaining gap: vision encoder image embeddings still show small numerical differences from diffusers, likely due to vision encoder implementation or precision differences. This PR focuses on the text encoder position embedding path.
