### PR TITLE
docs: change Qwen3.5 communication_backend from lccl to hccl.

### DIFF
--- a/docs/src/content/docs/en/cookbook/autoregressive_models/qwen/qwen3_5.md
+++ b/docs/src/content/docs/en/cookbook/autoregressive_models/qwen/qwen3_5.md
@@ -137,7 +137,7 @@ do
     --max_tokens_per_batch=32768 \
     --max_seqs_per_batch=8 \
     --block_size=128 \
-    --communication_backend="lccl" \
+    --communication_backend="hccl" \
     --enable_prefix_cache=false \
     --enable_chunked_prefill=true \
     --enable_schedule_overlap=true \

--- a/docs/src/content/docs/zh/cookbook/autoregressive_models/qwen/qwen3_5.md
+++ b/docs/src/content/docs/zh/cookbook/autoregressive_models/qwen/qwen3_5.md
@@ -137,7 +137,7 @@ do
     --max_tokens_per_batch=32768 \
     --max_seqs_per_batch=8 \
     --block_size=128 \
-    --communication_backend="lccl" \
+    --communication_backend="hccl" \
     --enable_prefix_cache=false \
     --enable_chunked_prefill=true \
     --enable_schedule_overlap=true \


### PR DESCRIPTION
## Summary
- Change `--communication_backend="lccl"` to `--communication_backend="hccl"` in both Chinese and English Qwen3.5 cookbook pages.