### PR TITLE
bugfix: propagate prefix cache usage across pd.

### DIFF
--- a/tests/core/scheduler/disagg_pd_chunked_prefill_scheduler_test.cpp
+++ b/tests/core/scheduler/disagg_pd_chunked_prefill_scheduler_test.cpp
@@ -529,6 +529,7 @@ TEST(DisaggPDChunkedPrefillSchedulerTest,
   EXPECT_EQ(sequence->kv_state().kv_cache_tokens_num(), 8u);
   EXPECT_EQ(sequence->kv_state().shared_blocks_num(BlockType::KV), 4u);
   EXPECT_EQ(sequence->kv_state().num_blocks(BlockType::KV), 5u);
+  EXPECT_EQ(request->num_prefix_cache_tokens(), 8u);
 
   block_manager->deallocate(request.get());
   release_prefix_cache(block_manager);

--- a/tests/core/scheduler/disagg_pd_scheduler_test.cpp
+++ b/tests/core/scheduler/disagg_pd_scheduler_test.cpp
@@ -206,7 +206,8 @@ void release_prefix_cache(BlockManagerPool* block_manager) {
 }
 
 bool recv_first_generation(DisaggPDScheduler* scheduler,
-                           const torch::Tensor& mtp_embedding) {
+                           const torch::Tensor& mtp_embedding,
+                           int32_t num_cached_tokens = 0) {
   return scheduler->decode_recv_first_generation(
       "req",
       /*token_id=*/42,
@@ -222,7 +223,8 @@ bool recv_first_generation(DisaggPDScheduler* scheduler,
       /*src_linear_state_id=*/-1,
       /*src_dp_size=*/1,
       /*src_dp_rank=*/0,
-      mtp_embedding);
+      mtp_embedding,
+      num_cached_tokens);
 }
 
 }  // namespace
@@ -333,6 +335,42 @@ TEST(DisaggPDSchedulerTest, FirstDecodeTokenLatencyIsNonNegative) {
   // pre-fix it was created_time + ttft (~now+100ms), yielding a negative ITL.
   int64_t first_itl = queued->sequences()[0]->tbt(absl::Now());
   EXPECT_GE(first_itl, 0);
+}
+
+TEST(DisaggPDSchedulerTest, PreservesPrefillCachedTokensOnDecodeRequest) {
+  FakeEngine engine(/*num_blocks=*/8, /*block_size=*/2);
+  TestDisaggPDScheduler scheduler(&engine, make_options());
+  std::shared_ptr<Request> request = make_request({1, 2, 3, 4});
+  Sequence* sequence = request->sequences()[0].get();
+  ASSERT_TRUE(engine.block_manager_pool()->allocate(sequence));
+  sequence->kv_state().set_kv_cache_tokens_num(sequence->num_prompt_tokens());
+  ASSERT_TRUE(scheduler.decode_schedule(request, "prefill"));
+
+  ASSERT_TRUE(recv_first_generation(
+      &scheduler, torch::Tensor(), /*num_cached_tokens=*/2));
+
+  std::shared_ptr<Request> queued;
+  ASSERT_TRUE(scheduler.pop_decode_request_for_test(&queued));
+  EXPECT_EQ(queued->num_prefix_cache_tokens(), 2u);
+}
+
+TEST(DisaggPDSchedulerTest, InvalidPrefillCachedTokensFallBackToZero) {
+  for (int32_t num_cached_tokens : {-1, 5}) {
+    FakeEngine engine(/*num_blocks=*/8, /*block_size=*/2);
+    TestDisaggPDScheduler scheduler(&engine, make_options());
+    std::shared_ptr<Request> request = make_request({1, 2, 3, 4});
+    Sequence* sequence = request->sequences()[0].get();
+    ASSERT_TRUE(engine.block_manager_pool()->allocate(sequence));
+    sequence->kv_state().set_kv_cache_tokens_num(sequence->num_prompt_tokens());
+    ASSERT_TRUE(scheduler.decode_schedule(request, "prefill"));
+
+    ASSERT_TRUE(
+        recv_first_generation(&scheduler, torch::Tensor(), num_cached_tokens));
+
+    std::shared_ptr<Request> queued;
+    ASSERT_TRUE(scheduler.pop_decode_request_for_test(&queued));
+    EXPECT_EQ(queued->num_prefix_cache_tokens(), 0u);
+  }
 }
 
 TEST(DisaggPDSchedulerTest, AmortizedTokenLatencyRoundsHalfUp) {

--- a/xllm/core/distributed_runtime/disagg_pd_service_impl.cpp
+++ b/xllm/core/distributed_runtime/disagg_pd_service_impl.cpp
@@ -279,7 +279,8 @@ void DisaggPDServiceImpl::decode_recv_first_generation(
         linear_state_id,
         gen.dp_size(),
         gen.dp_rank(),
-        mtp_bootstrap_embedding);
+        mtp_bootstrap_embedding,
+        gen.num_cached_tokens());
     if (!success) {
       response->set_ok(false);
       return;

--- a/xllm/core/framework/request/request.cpp
+++ b/xllm/core/framework/request/request.cpp
@@ -187,7 +187,12 @@ void Request::record_num_prefix_cache_tokens() {
   for (const auto& seq : sequences()) {
     current_max = std::max(current_max, seq->num_prefix_cache_tokens());
   }
-  num_prefix_cache_tokens_ = std::max(num_prefix_cache_tokens_, current_max);
+  record_num_prefix_cache_tokens(current_max);
+}
+
+void Request::record_num_prefix_cache_tokens(size_t num_prefix_cache_tokens) {
+  num_prefix_cache_tokens_ =
+      std::max(num_prefix_cache_tokens_, num_prefix_cache_tokens);
 }
 
 void Request::update_connection_status() {

--- a/xllm/core/framework/request/request.h
+++ b/xllm/core/framework/request/request.h
@@ -159,6 +159,8 @@ class Request : public RequestBase {
 
   void record_num_prefix_cache_tokens();
 
+  void record_num_prefix_cache_tokens(size_t num_prefix_cache_tokens);
+
   size_t num_prefix_cache_tokens() const { return num_prefix_cache_tokens_; }
 
  private:

--- a/xllm/core/scheduler/disagg_pd_chunked_prefill_scheduler.cpp
+++ b/xllm/core/scheduler/disagg_pd_chunked_prefill_scheduler.cpp
@@ -243,6 +243,7 @@ void DisaggPDChunkedPrefillScheduler::schedule_waiting_prefill(
 
     queue.pop_top();
     running_requests_.emplace_back(request);
+    request->record_num_prefix_cache_tokens();
     running_sequences_.emplace_back(sequence);
     running_sequences_budgets_.emplace_back(actual_tokens);
     remaining_token_budget -= actual_tokens;

--- a/xllm/core/scheduler/disagg_pd_scheduler.cpp
+++ b/xllm/core/scheduler/disagg_pd_scheduler.cpp
@@ -660,6 +660,17 @@ void DisaggPDScheduler::prefill_send_first_generation() {
       gen->set_req_id(request->request_id());
       gen->set_x_request_id(request->x_request_id());
       gen->set_x_request_time(request->x_request_time());
+      const size_t num_cached_tokens = request->num_prefix_cache_tokens();
+      if (num_cached_tokens >
+          static_cast<size_t>(std::numeric_limits<int32_t>::max())) {
+        LOG(WARNING) << "Invalid num_cached_tokens on prefill, request_id: "
+                     << request->request_id()
+                     << ", num_cached_tokens: " << num_cached_tokens
+                     << ". Falling back to 0.";
+        gen->set_num_cached_tokens(0);
+      } else {
+        gen->set_num_cached_tokens(static_cast<int32_t>(num_cached_tokens));
+      }
       if (request->sequences()[0]->first_token().has_value()) {
         auto token = gen->mutable_tokens()->Add();
         token->set_token_id(
@@ -802,7 +813,8 @@ bool DisaggPDScheduler::decode_recv_first_generation(
     int32_t src_linear_state_id,
     int32_t src_dp_size,
     int32_t src_dp_rank,
-    torch::Tensor mtp_bootstrap_embedding) {
+    torch::Tensor mtp_bootstrap_embedding,
+    int32_t num_cached_tokens) {
   // push to request_queue_, and will be executed by engine.
   std::shared_ptr<Request> request = nullptr;
   {
@@ -832,6 +844,16 @@ bool DisaggPDScheduler::decode_recv_first_generation(
     return false;
   }
   Sequence* sequence = request->sequences()[0].get();
+  if (num_cached_tokens < 0 ||
+      static_cast<size_t>(num_cached_tokens) > sequence->num_prompt_tokens()) {
+    LOG(WARNING) << "Invalid num_cached_tokens from prefill, request_id: "
+                 << req_id << ", num_cached_tokens: " << num_cached_tokens
+                 << ", num_prompt_tokens: " << sequence->num_prompt_tokens()
+                 << ". Falling back to 0.";
+    num_cached_tokens = 0;
+  }
+  request->record_num_prefix_cache_tokens(
+      static_cast<size_t>(num_cached_tokens));
   const bool need_mtp_bootstrap = options_.num_speculative_tokens() > 0;
   if (need_mtp_bootstrap) {
     const int32_t slot_id = sequence->get_single_block_id();

--- a/xllm/core/scheduler/disagg_pd_scheduler.h
+++ b/xllm/core/scheduler/disagg_pd_scheduler.h
@@ -74,7 +74,8 @@ class DisaggPDScheduler : public ContinuousScheduler {
       int32_t src_linear_state_id,
       int32_t src_dp_size,
       int32_t src_dp_rank,
-      torch::Tensor mtp_bootstrap_embedding = torch::Tensor());
+      torch::Tensor mtp_bootstrap_embedding = torch::Tensor(),
+      int32_t num_cached_tokens = 0);
 
   // decode allocate blocks with prefix cache.
   bool try_allocate(Sequence* sequence);

--- a/xllm/proto/disagg_pd.proto
+++ b/xllm/proto/disagg_pd.proto
@@ -255,6 +255,8 @@ message DisaggGenerationsRequest {
   int32 linear_state_id = 13;
   // MTP bootstrap state for the first decode draft extend.
   Tensor mtp_bootstrap_embedding = 14;
+  // Number of prompt tokens served from the prefill prefix cache.
+  int32 num_cached_tokens = 15;
 }
 
 message DisaggGenerationsRequests {


### PR DESCRIPTION
## Description

### background
In disaggregated PD serving, Prefix Cache blocks were successfully matched, but the request log and final usage always reported zero cached prompt tokens. The second request for the same prompt had a significantly lower TTFT, and the cache block and matched-token metrics increased correctly, while num_prefix_cache_tokens remained zero. As a result, the real cache-hit count could not reach the final OpenAI usage response.

### Root Cause
• DisaggPDChunkedPrefillScheduler matched shared cache blocks but did not record the matched token count in the Request.
• DisaggGenerationsRequest did not carry the cached-token count when Prefill sent the first generation to Decode.
• Decode reconstructs an independent Request and therefore could not recover the Prefix Cache usage observed on Prefill.
• A chunked-prefill request may be scheduled multiple times, so the request-level statistic must retain the maximum cached-token count across scheduling iterations.

### Fix
• Record request-level cached prompt tokens after Prefix Cache matching in the PD chunked-prefill scheduler.
• Add an explicit Request recording API that retains the maximum value across chunked scheduling iterations.
• Add num_cached_tokens to DisaggGenerationsRequest.
• Propagate the value from Prefill to Decode, validate its range, and record it on the final Decode-side Request.
• Add regression coverage for the PD scheduler and chunked-prefill path.

## Related Issues

<!-- Link related issues here. Use "Fixes #123" when this PR closes an issue. -->

## Change Type

- [ ] Bug fix
- [x] New feature
- [ ] Performance improvement
- [ ] Refactor
- [ ] Documentation
- [ ] Test
- [ ] Build or CI

## Pull Request Checklist

Thank you for contributing to xLLM. Before requesting review, please make sure the following items are complete.

### PR Title and Commit Messages

- [x] The PR title and each commit message follow the xLLM commit format: `<type>: <subject>`.

> Allowed types: feat, bugfix, docs, test, refactor, chore, style, revert, perf, model, build, release.
> The subject should use clear English, start with a verb, include at least 4 words, and end with `.`.

### Pre-commit Checks

- [x] I have installed `pre-commit` by running `pip install pre-commit` or an equivalent command.
- [x] I have installed the hooks with `pre-commit install`.
- [x] I have run `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

### Self Review

- [x] I have self-reviewed the code according to `.agents/skills/code-review/references/custom-code-style.md`, especially code written or assisted by AI.
- [x] I have rebased this PR onto the latest `main` branch.

### Build and Test Coverage

- [ ] Tests have been added or updated as needed.
- [ ] CUDA: `python setup.py build test` has passed on a CUDA machine.
- [x] NPU: `python setup.py build test` has passed on an NPU machine.
- [x] MLU: `python setup.py build test` has passed on an MLU machine.

## Reviewer Notes

<!-- Optional: anything reviewers should focus on, known risks, follow-ups, or validation gaps. -->
