### PR TITLE
bugfix: map global ranks to local devices.

### DIFF
--- a/docs/src/content/docs/en/cli_reference.md
+++ b/docs/src/content/docs/en/cli_reference.md
@@ -6,7 +6,7 @@ sidebar:
 
 xLLM uses gflags to manage service startup parameters. `--model <PATH>` is the only required flag. When `--config_json_file` is used, values in the JSON file override command-line flag values. The tables below are grouped by the Config classes in `/xllm/core/framework/config`, with one Config per section. The `ConfigJsonUtils` section contains the common JSON config-file flags.
 
-> **Device selection**: xLLM no longer provides `--devices` / `--device_id` / `--draft_devices`. The devices to run on are determined by the visible-device mask environment variables (`ASCEND_RT_VISIBLE_DEVICES` for NPU, `CUDA_VISIBLE_DEVICES` for NVIDIA, `MLU_VISIBLE_DEVICES` for Cambricon, `HIP_VISIBLE_DEVICES` for DCU, `MUSA_VISIBLE_DEVICES` for Moore Threads). Each process uses all of its visible devices: a single-card process exposes one card, while single-process multi-card exposes several. The draft model always uses the same devices as the target model.
+> **Device selection**: xLLM no longer provides `--devices` / `--device_id` / `--draft_devices`. The available devices are determined by the visible-device mask environment variables (`ASCEND_RT_VISIBLE_DEVICES` for NPU, `CUDA_VISIBLE_DEVICES` for NVIDIA, `MLU_VISIBLE_DEVICES` for Cambricon, `HIP_VISIBLE_DEVICES` for DCU, `MUSA_VISIBLE_DEVICES` for Moore Threads). Each service process selects one runtime logical device from its visible devices according to its global `node_rank`; visible-device subsetting and reordering are resolved by the hardware runtime. The draft model always shares the selected device with the target model.
 
 ## ConfigJsonUtils
 

--- a/docs/src/content/docs/zh/cli_reference.md
+++ b/docs/src/content/docs/zh/cli_reference.md
@@ -6,7 +6,7 @@ sidebar:
 
 xLLM 使用 gflags 管理服务启动参数。`--model <PATH>` 是唯一必填参数。使用 `--config_json_file` 时，JSON 文件中的值会覆盖命令行 flag 值。下表按 `/xllm/core/framework/config` 下的 Config 类分组，一个 Config 对应一节；`ConfigJsonUtils` 一节包含配置文件相关的通用参数。
 
-> **设备选择**：xLLM 不再提供 `--devices` / `--device_id` / `--draft_devices` 参数。运行设备由可见设备掩码环境变量决定（NPU 用 `ASCEND_RT_VISIBLE_DEVICES`，NVIDIA 用 `CUDA_VISIBLE_DEVICES`，寒武纪用 `MLU_VISIBLE_DEVICES`，DCU 用 `HIP_VISIBLE_DEVICES`，摩尔线程用 `MUSA_VISIBLE_DEVICES`）。每个进程会使用其可见的全部设备：单卡进程只暴露一张卡，单进程多卡则暴露多张卡。draft 模型始终与 target 模型使用相同设备。
+> **设备选择**：xLLM 不再提供 `--devices` / `--device_id` / `--draft_devices` 参数。可用设备由可见设备掩码环境变量决定（NPU 用 `ASCEND_RT_VISIBLE_DEVICES`，NVIDIA 用 `CUDA_VISIBLE_DEVICES`，寒武纪用 `MLU_VISIBLE_DEVICES`，DCU 用 `HIP_VISIBLE_DEVICES`，摩尔线程用 `MUSA_VISIBLE_DEVICES`）。每个服务进程根据全局 `node_rank` 从其可见设备中选择一个运行时逻辑设备；可见设备的子集化与重排由硬件运行时解析。draft 模型始终与 target 模型共享所选设备。
 
 ## ConfigJsonUtils
 

--- a/tests/core/util/device_name_utils_test.cpp
+++ b/tests/core/util/device_name_utils_test.cpp
@@ -17,6 +17,7 @@ limitations under the License.
 
 #include <gtest/gtest.h>
 
+#include <cstdint>
 #include <string>
 #include <vector>
 
@@ -25,6 +26,72 @@ limitations under the License.
 
 namespace xllm {
 namespace {
+
+struct RankMapping {
+  int32_t node_rank;
+  int32_t expected_device_idx;
+};
+
+class MultiNodeDeviceRankTest : public testing::TestWithParam<RankMapping> {};
+
+TEST_P(MultiNodeDeviceRankTest, MapsGlobalRankToLocalLogicalDevice) {
+  const RankMapping param = GetParam();
+
+  EXPECT_EQ(DeviceNameUtils::get_device_idx(param.node_rank,
+                                            /*nnodes=*/16,
+                                            /*visible_device_count=*/8),
+            param.expected_device_idx);
+}
+
+INSTANTIATE_TEST_SUITE_P(
+    TwoNodesWithEightDevicesEach,
+    MultiNodeDeviceRankTest,
+    testing::Values(RankMapping{/*node_rank=*/0, /*expected_device_idx=*/0},
+                    RankMapping{/*node_rank=*/7, /*expected_device_idx=*/7},
+                    RankMapping{/*node_rank=*/8, /*expected_device_idx=*/0},
+                    RankMapping{/*node_rank=*/15, /*expected_device_idx=*/7}));
+
+TEST(DeviceNameUtilsTest, RejectsNegativeGlobalRank) {
+  EXPECT_DEATH(DeviceNameUtils::get_device_idx(/*node_rank=*/-1,
+                                               /*nnodes=*/16,
+                                               /*visible_device_count=*/8),
+               "node_rank");
+}
+
+TEST(DeviceNameUtilsTest, RejectsRankOutsideWorld) {
+  EXPECT_DEATH(DeviceNameUtils::get_device_idx(/*node_rank=*/16,
+                                               /*nnodes=*/16,
+                                               /*visible_device_count=*/8),
+               "node_rank");
+}
+
+TEST(DeviceNameUtilsTest, RejectsNoVisibleDevice) {
+  EXPECT_DEATH(DeviceNameUtils::get_device_idx(/*node_rank=*/0,
+                                               /*nnodes=*/1,
+                                               /*visible_device_count=*/0),
+               "accelerator device");
+  EXPECT_DEATH(DeviceNameUtils::get_device_idx(/*node_rank=*/0,
+                                               /*nnodes=*/1,
+                                               /*visible_device_count=*/-1),
+               "accelerator device");
+}
+
+TEST(DeviceNameUtilsTest, MapsAnyValidRankToOnlyVisibleDevice) {
+  EXPECT_EQ(DeviceNameUtils::get_device_idx(/*node_rank=*/7,
+                                            /*nnodes=*/8,
+                                            /*visible_device_count=*/1),
+            0);
+}
+
+TEST(DeviceNameUtilsTest, PreservesGlobalRankInput) {
+  int32_t node_rank = 8;
+
+  EXPECT_EQ(DeviceNameUtils::get_device_idx(node_rank,
+                                            /*nnodes=*/16,
+                                            /*visible_device_count=*/8),
+            0);
+  EXPECT_EQ(node_rank, 8);
+}
 
 TEST(DeviceNameUtilsTest, ParseGeneratedDeviceString) {
   const std::vector<torch::Device> devices =

--- a/xllm/core/distributed_runtime/CMakeLists.txt
+++ b/xllm/core/distributed_runtime/CMakeLists.txt
@@ -1,5 +1,3 @@
-include(cc_library)
-
 if(USE_NPU OR USE_CUDA OR USE_MLU OR USE_DCU)
   include_directories(
     ${CMAKE_SOURCE_DIR}/third_party/spdlog/include

--- a/xllm/core/distributed_runtime/master.cpp
+++ b/xllm/core/distributed_runtime/master.cpp
@@ -199,17 +199,14 @@ Master::Master(const Options& options, EngineType type)
       master_status_(options.master_status()) {
   const auto model_path =
       std::filesystem::path(options_.model_path()).lexically_normal();
-  // Multi-process serving runs one worker per process. Enumerate the visible
-  // cards (honoring *_VISIBLE_DEVICES) and select the single card this process
-  // owns by its node_rank, so `devices` holds exactly the card this process
-  // uses -- mirroring the historical single-element devices semantics.
+  // Multi-process serving runs one worker per process. Select one runtime
+  // logical device from the process-visible devices while keeping node_rank as
+  // the global distributed identity.
+  const int32_t visible_device_count = Platform::device_count();
+  const int32_t device_idx = DeviceNameUtils::get_device_idx(
+      options_.node_rank(), options_.nnodes(), visible_device_count);
   const auto visible_devices = DeviceNameUtils::parse_devices("auto");
-  CHECK_LT(options_.node_rank(), static_cast<int32_t>(visible_devices.size()))
-      << "node_rank " << options_.node_rank()
-      << " exceeds the number of visible devices " << visible_devices.size()
-      << ". Ensure *_VISIBLE_DEVICES exposes all cards used across processes.";
-  const std::vector<torch::Device> devices = {
-      visible_devices[options_.node_rank()]};
+  const std::vector<torch::Device> devices = {visible_devices[device_idx]};
   // World size is the node count (one worker per process).
   const int32_t global_world_size = options_.nnodes();
   std::string cp_model_type;

--- a/xllm/core/platform/device_name_utils.cpp
+++ b/xllm/core/platform/device_name_utils.cpp
@@ -29,6 +29,17 @@ limitations under the License.
 
 namespace xllm {
 
+int32_t DeviceNameUtils::get_device_idx(int32_t node_rank,
+                                        int32_t nnodes,
+                                        int32_t visible_device_count) {
+  CHECK_GT(visible_device_count, 0)
+      << "At least one accelerator device must be visible.";
+  CHECK_GE(node_rank, 0) << "node_rank must be non-negative.";
+  CHECK_LT(node_rank, nnodes) << "node_rank " << node_rank
+                              << " must be less than nnodes " << nnodes << ".";
+  return node_rank % visible_device_count;
+}
+
 std::vector<torch::Device> DeviceNameUtils::parse_devices(
     const std::string& device_str) {
   std::vector<torch::Device> devices;

--- a/xllm/core/platform/device_name_utils.h
+++ b/xllm/core/platform/device_name_utils.h
@@ -27,6 +27,10 @@ namespace xllm {
 
 class DeviceNameUtils {
  public:
+  static int32_t get_device_idx(int32_t node_rank,
+                                int32_t nnodes,
+                                int32_t visible_device_count);
+
   static std::vector<torch::Device> parse_devices(
       const std::string& device_str);
 


### PR DESCRIPTION

## Description

- validate global rank and visible device count before device selection
- add multi-node rank mapping regression tests and document logical device behavior

## Related Issues

<!-- Link related issues here. Use "Fixes #123" when this PR closes an issue. -->

## Change Type

- [x] Bug fix
- [ ] New feature
- [ ] Performance improvement
- [ ] Refactor
- [ ] Documentation
- [ ] Test
- [ ] Build or CI

## Pull Request Checklist

Thank you for contributing to xLLM. Before requesting review, please make sure the following items are complete.

### PR Title and Commit Messages

- [x] The PR title and each commit message follow the xLLM commit format: `<type>: <subject>`.

> Allowed types: feat, bugfix, docs, test, refactor, chore, style, revert, perf, model, build, release.
> The subject should use clear English, start with a verb, include at least 4 words, and end with `.`.

### Pre-commit Checks

- [x] I have installed `pre-commit` by running `pip install pre-commit` or an equivalent command.
- [x] I have installed the hooks with `pre-commit install`.
- [x] I have run `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

### Self Review

- [x] I have self-reviewed the code according to `.agents/skills/code-review/references/custom-code-style.md`, especially code written or assisted by AI.
- [x] I have rebased this PR onto the latest `main` branch.

### Build and Test Coverage

- [ ] Tests have been added or updated as needed.
- [ ] CUDA: `python setup.py build test` has passed on a CUDA machine.
- [x] NPU: `python setup.py build test` has passed on an NPU machine.
- [x] MLU: `python setup.py build test` has passed on an MLU machine.

## Reviewer Notes

<!-- Optional: anything reviewers should focus on, known risks, follow-ups, or validation gaps. -->
