### PR TITLE
bugfix: preserve UInt8 image precision during resize for DiT.

### DIFF
--- a/xllm/core/runtime/dit_forward_params.h
+++ b/xllm/core/runtime/dit_forward_params.h
@@ -205,23 +205,23 @@ struct DiTForwardInput {
     }
 
     if (images.defined()) {
-      input.images = images.to(device);  // torch::kUInt8
+      input.images = images.to(device, /*dtype=*/torch::kUInt8);
     }
 
     if (mask_images.defined()) {
-      input.mask_images = mask_images.to(device);  // torch::kUInt8
+      input.mask_images = mask_images.to(device, /*dtype=*/torch::kUInt8);
     }
 
     for (auto& img : input.images_list) {
-      img = img.to(device);  // torch::kUInt8
+      img = img.to(device, /*dtype=*/torch::kUInt8);
     }
 
     if (control_image.defined()) {
-      input.control_image = control_image.to(device);  // torch::kUInt8
+      input.control_image = control_image.to(device, /*dtype=*/torch::kUInt8);
     }
 
     if (last_images.defined()) {
-      input.last_images = last_images.to(device);  // torch::kUInt8
+      input.last_images = last_images.to(device, /*dtype=*/torch::kUInt8);
     }
 
     if (prompt_audio.defined()) {

--- a/xllm/core/runtime/dit_forward_params.h
+++ b/xllm/core/runtime/dit_forward_params.h
@@ -205,24 +205,25 @@ struct DiTForwardInput {
     }
 
     if (images.defined()) {
-      input.images = images.to(device, dtype);
+      input.images = images.to(device);  // torch::kUInt8
     }
 
     if (mask_images.defined()) {
-      input.mask_images = mask_images.to(device, dtype);
+      input.mask_images = mask_images.to(device);  // torch::kUInt8
     }
 
     for (auto& img : input.images_list) {
-      img = img.to(device, dtype);
+      img = img.to(device);  // torch::kUInt8
     }
 
     if (control_image.defined()) {
-      input.control_image = control_image.to(device, dtype);
+      input.control_image = control_image.to(device);  // torch::kUInt8
     }
 
     if (last_images.defined()) {
-      input.last_images = last_images.to(device, dtype);
+      input.last_images = last_images.to(device);  // torch::kUInt8
     }
+
     if (prompt_audio.defined()) {
       input.prompt_audio = prompt_audio.to(device, torch::kFloat32);
     }

--- a/xllm/models/dit/pipelines/pipeline_flux_control.h
+++ b/xllm/models/dit/pipelines/pipeline_flux_control.h
@@ -181,8 +181,7 @@ class FluxControlPipelineImpl : public FluxPipelineBaseImpl {
                               int64_t num_images_per_prompt) {
     int image_batch_size = image.size(0);
     int repeat_times;
-    image = image_processor_->preprocess(
-        image, height, width, "default", std::nullopt);
+    image = image_processor_->preprocess(image, height, width);
     if (image_batch_size == 1) {
       repeat_times = batch_size;
     } else {

--- a/xllm/models/dit/pipelines/pipeline_qwenimage_edit_plus.h
+++ b/xllm/models/dit/pipelines/pipeline_qwenimage_edit_plus.h
@@ -939,12 +939,9 @@ class QwenImageEditPlusPipelineImpl : public torch::nn::Module {
         auto condition_img =
             vae_image_processor_->resize(img, condition_height, condition_width)
                 .to(options_);
-        auto vae_img = vae_image_processor_
-                           ->preprocess(img,
-                                        vae_height,
-                                        vae_width,
-                                        /*resize_mode=*/"lanczos")
-                           .unsqueeze(2);
+        auto vae_img =
+            vae_image_processor_->preprocess(img, vae_height, vae_width)
+                .unsqueeze(2);
 
         condition_images.push_back(condition_img);
         vae_images.push_back(vae_img);

--- a/xllm/models/dit/pipelines/pipeline_qwenimage_edit_plus.h
+++ b/xllm/models/dit/pipelines/pipeline_qwenimage_edit_plus.h
@@ -937,8 +937,7 @@ class QwenImageEditPlusPipelineImpl : public torch::nn::Module {
         vae_image_sizes.push_back({vae_width, vae_height});
         auto img = image_list[i];
         auto condition_img =
-            vae_image_processor_
-                ->lanczos_resize(img, condition_height, condition_width)
+            vae_image_processor_->resize(img, condition_height, condition_width)
                 .to(options_);
         auto vae_img = vae_image_processor_
                            ->preprocess(img,

--- a/xllm/models/dit/pipelines/pipeline_qwenimage_edit_plus.h
+++ b/xllm/models/dit/pipelines/pipeline_qwenimage_edit_plus.h
@@ -870,8 +870,7 @@ class QwenImageEditPlusPipelineImpl : public torch::nn::Module {
     std::vector<torch::Tensor> image_list;
     image_list.reserve(raw_image_inputs.size());
 
-    for (const auto& images : raw_image_inputs) {
-      auto img = images.to(options_.device(), dtype_);
+    for (const auto& img : raw_image_inputs) {
       if (img.dim() != 4) {
         LOG(ERROR)
             << "image inputs are expected to be a 4 dim tensor, but got: "
@@ -937,16 +936,15 @@ class QwenImageEditPlusPipelineImpl : public torch::nn::Module {
         CHECK_GT(vae_height, 0) << "QwenImageEditPlus vae_height must be > 0";
         vae_image_sizes.push_back({vae_width, vae_height});
         auto img = image_list[i];
-        auto condition_img = vae_image_processor_->resize(
-            img,
-            {condition_height, condition_width},
-            /*resample=*/3,  // BICUBIC (approximate LANCZOS)
-            /*antialias=*/true);
+        auto condition_img =
+            vae_image_processor_
+                ->lanczos_resize(img, condition_height, condition_width)
+                .to(options_);
         auto vae_img = vae_image_processor_
                            ->preprocess(img,
                                         vae_height,
                                         vae_width,
-                                        /*resize_mode=*/"default")
+                                        /*resize_mode=*/"lanczos")
                            .unsqueeze(2);
 
         condition_images.push_back(condition_img);

--- a/xllm/models/dit/pipelines/pipeline_wan_i2v.h
+++ b/xllm/models/dit/pipelines/pipeline_wan_i2v.h
@@ -466,8 +466,8 @@ class WanImageToVideoPipelineImpl : public torch::nn::Module,
                    << "Using blank white image as fallback.";
       input_image = torch::ones({3, height, width}, torch::kFloat32);
     }
-    torch::Tensor preprocessed_image = video_processor_->preprocess(
-        input_image, height, width, "bicubic_no_aa");
+    torch::Tensor preprocessed_image =
+        video_processor_->preprocess(input_image, height, width);
     preprocessed_image =
         preprocessed_image.to(options_.device(), torch::kFloat32);
 

--- a/xllm/models/dit/processors/flux2_image_processor.h
+++ b/xllm/models/dit/processors/flux2_image_processor.h
@@ -70,13 +70,7 @@ class Flux2ImageProcessorImpl final : public VAEImageProcessorImpl {
                             static_cast<float>(image_width * image_height));
     int64_t width = static_cast<int64_t>(image_width * scale);
     int64_t height = static_cast<int64_t>(image_height * scale);
-    return torch::nn::functional::interpolate(
-               image.unsqueeze(0),  // [1, 3, H, W]
-               torch::nn::functional::InterpolateFuncOptions()
-                   .mode(torch::kBilinear)
-                   .align_corners(false)
-                   .size(std::vector<int64_t>{height, width}))
-        .squeeze(0);
+    return VAEImageProcessorImpl::resize(image, height, width);
   }
 
   torch::Tensor resize_if_exceeds_area(const torch::Tensor& image,

--- a/xllm/models/dit/processors/vae_image_processor.h
+++ b/xllm/models/dit/processors/vae_image_processor.h
@@ -91,12 +91,7 @@ class VAEImageProcessorImpl : public torch::nn::Module {
     auto [target_h, target_w] =
         get_default_height_width(processed, height, width);
     if (do_resize_) {
-      if (resize_mode == "lanczos") {
-        processed = lanczos_resize(processed, target_h, target_w);
-      } else {
-        LOG(FATAL) << "Currently only support 'lanczos'"
-                   << ", but got: " << resize_mode;
-      }
+      processed = resize(processed, target_h, target_w, resize_mode);
     }
     if (processed.max().item<float>() > 1.1f) {
       processed = processed / 255.0f;
@@ -159,41 +154,62 @@ class VAEImageProcessorImpl : public torch::nn::Module {
   }
 
  public:
-  torch::Tensor lanczos_resize(torch::Tensor image,
-                               int64_t height,
-                               int64_t width) {
+  torch::Tensor resize(torch::Tensor image,
+                       int64_t height,
+                       int64_t width,
+                       const std::string& resize_mode = "lanczos") {
     auto options = image.options();
+    image = image.cpu();
 
-    // BCHW || CHW
-    if (image.dim() == 4) {
+    bool squeeze_batch = false;
+    if (image.dim() == 3) {
+      image = image.unsqueeze(0);
+      squeeze_batch = true;
+    }
+    CHECK_EQ(image.dim(), 4) << "resize expects CHW or BCHW image";
+
+    torch::Tensor resized;
+    if (resize_mode == "lanczos") {
       std::vector<torch::Tensor> resized_images;
       resized_images.reserve(image.size(0));
       for (int64_t i = 0; i < image.size(0); ++i) {
-        resized_images.emplace_back(lanczos_resize(image[i], height, width));
+        auto chw_image = image[i];
+        auto hwc_image = chw_image.permute({1, 2, 0}).contiguous();
+
+        int64_t h = hwc_image.size(0);
+        int64_t w = hwc_image.size(1);
+        int64_t c = hwc_image.size(2);
+
+        torch::Tensor out = torch::empty({height, width, c}, torch::kUInt8);
+        lanczos::resize_8bpc(hwc_image.data_ptr<uint8_t>(),
+                             static_cast<int32_t>(w),
+                             static_cast<int32_t>(h),
+                             static_cast<int32_t>(c),
+                             static_cast<int32_t>(width),
+                             static_cast<int32_t>(height),
+                             out.data_ptr<uint8_t>());
+        resized_images.emplace_back(out.permute({2, 0, 1}));
       }
-      return torch::stack(resized_images).to(options);
+      resized = torch::stack(resized_images);
+    } else if (resize_mode == "default" || resize_mode == "bicubic_no_aa") {
+      bool antialias = resize_mode == "default";
+      auto options =
+          torch::nn::functional::InterpolateFuncOptions()
+              .size(std::vector<int64_t>{height, width})
+              .align_corners(/*align_corners=*/false)
+              .antialias(antialias)
+              .mode(torch::kBicubic);  // torch::kNearest, torch::kBilinear
+      resized = torch::nn::functional::interpolate(image, options);
+    } else {
+      LOG(FATAL) << "Currently only support 'lanczos', 'default', and "
+                    "'bicubic_no_aa'"
+                 << ", but got: " << resize_mode;
     }
-    CHECK_EQ(image.dim(), 3) << "lanczos_resize expects CHW or BCHW image";
 
-    image = image.cpu();
-
-    image = image.permute({1, 2, 0}).contiguous();  // [H, W, C]
-
-    int64_t h = image.size(0), w = image.size(1), c = image.size(2);
-
-    torch::Tensor out = torch::empty({height, width, c}, torch::kUInt8);
-    lanczos::resize_8bpc(image.data_ptr<uint8_t>(),
-                         static_cast<int32_t>(w),
-                         static_cast<int32_t>(h),
-                         static_cast<int32_t>(c),
-                         static_cast<int32_t>(width),
-                         static_cast<int32_t>(height),
-                         out.data_ptr<uint8_t>());
-
-    out = out.permute({2, 0, 1});  // [C, dstH, dstW]
-    out = out.to(options);
-
-    return out;
+    if (squeeze_batch) {
+      resized = resized.squeeze(0);
+    }
+    return resized.to(options);
   }
 
  private:

--- a/xllm/models/dit/processors/vae_image_processor.h
+++ b/xllm/models/dit/processors/vae_image_processor.h
@@ -65,13 +65,7 @@ class VAEImageProcessorImpl : public torch::nn::Module {
       const std::string& resize_mode = "lanczos",
       std::optional<std::tuple<int64_t, int64_t, int64_t, int64_t>>
           crop_coords = std::nullopt) {
-    torch::Tensor processed = image.clone();
-    if (processed.dtype() != torch::kFloat32) {
-      processed = processed.to(torch::kFloat32);
-    }
-    if (processed.max().item<float>() > 1.1f) {
-      processed = processed / 255.0f;
-    }
+    torch::Tensor processed = image;
     if (crop_coords.has_value()) {
       auto [x1, y1, x2, y2] = crop_coords.value();
       x1 = std::max(int64_t(0), x1);
@@ -99,23 +93,14 @@ class VAEImageProcessorImpl : public torch::nn::Module {
     if (do_resize_) {
       if (resize_mode == "lanczos") {
         processed = lanczos_resize(processed, target_h, target_w);
-      } else if (resize_mode == "default") {
-        processed = resize(processed,
-                           {target_h, target_w},
-                           /*resample=*/3,  // BICUBIC
-                           /*antialias=*/true);
-      } else if (resize_mode == "bicubic_no_aa") {
-        processed = resize(processed,
-                           {target_h, target_w},
-                           /*resample=*/3,  // BICUBIC
-                           /*antialias=*/false);
       } else {
-        LOG(FATAL) << "Currently only support three resize methods, 'lanczos', "
-                      "'default', and 'bicubic_no_aa'"
+        LOG(FATAL) << "Currently only support 'lanczos'"
                    << ", but got: " << resize_mode;
       }
     }
-
+    if (processed.max().item<float>() > 1.1f) {
+      processed = processed / 255.0f;
+    }
     if (do_normalize_) {
       processed = normalize(processed);
     }
@@ -174,33 +159,6 @@ class VAEImageProcessorImpl : public torch::nn::Module {
   }
 
  public:
-  torch::Tensor resize(const torch::Tensor& image,
-                       const std::vector<int64_t>& size,
-                       size_t resample,
-                       bool antialias) {
-    if (image.dim() != 4) {
-      LOG(FATAL) << "Input image must be a 4D tensor (B x C x H x W).";
-    }
-    auto options = torch::nn::functional::InterpolateFuncOptions()
-                       .size(size)
-                       .align_corners(/*align_corners=*/false)
-                       .antialias(antialias);
-    switch (resample) {
-      case 1:
-        options.mode(torch::kNearest);
-        break;
-      case 2:
-        options.mode(torch::kBilinear);
-        break;
-      case 3:
-        options.mode(torch::kBicubic);
-        break;
-      default:
-        LOG(FATAL) << "Invalid resample value. Must be one of 1, 2, or 3.";
-    }
-    return torch::nn::functional::interpolate(image, options);
-  }
-
   torch::Tensor lanczos_resize(torch::Tensor image,
                                int64_t height,
                                int64_t width) {
@@ -217,20 +175,20 @@ class VAEImageProcessorImpl : public torch::nn::Module {
     }
     CHECK_EQ(image.dim(), 3) << "lanczos_resize expects CHW or BCHW image";
 
-    image = image.cpu().to(torch::kFloat32);
+    image = image.cpu();
 
     image = image.permute({1, 2, 0}).contiguous();  // [H, W, C]
 
     int64_t h = image.size(0), w = image.size(1), c = image.size(2);
 
-    torch::Tensor out = torch::empty({height, width, c}, torch::kFloat32);
-    lanczos::resize_f32(image.data_ptr<float>(),
-                        static_cast<int32_t>(w),
-                        static_cast<int32_t>(h),
-                        static_cast<int32_t>(c),
-                        static_cast<int32_t>(width),
-                        static_cast<int32_t>(height),
-                        out.data_ptr<float>());
+    torch::Tensor out = torch::empty({height, width, c}, torch::kUInt8);
+    lanczos::resize_8bpc(image.data_ptr<uint8_t>(),
+                         static_cast<int32_t>(w),
+                         static_cast<int32_t>(h),
+                         static_cast<int32_t>(c),
+                         static_cast<int32_t>(width),
+                         static_cast<int32_t>(height),
+                         out.data_ptr<uint8_t>());
 
     out = out.permute({2, 0, 1});  // [C, dstH, dstW]
     out = out.to(options);

--- a/xllm/models/dit/processors/vae_image_processor.h
+++ b/xllm/models/dit/processors/vae_image_processor.h
@@ -191,18 +191,15 @@ class VAEImageProcessorImpl : public torch::nn::Module {
         resized_images.emplace_back(out.permute({2, 0, 1}));
       }
       resized = torch::stack(resized_images);
-    } else if (resize_mode == "default" || resize_mode == "bicubic_no_aa") {
-      bool antialias = resize_mode == "default";
-      auto options =
-          torch::nn::functional::InterpolateFuncOptions()
-              .size(std::vector<int64_t>{height, width})
-              .align_corners(/*align_corners=*/false)
-              .antialias(antialias)
-              .mode(torch::kBicubic);  // torch::kNearest, torch::kBilinear
+    } else if (resize_mode == "bicubic") {
+      auto options = torch::nn::functional::InterpolateFuncOptions()
+                         .size(std::vector<int64_t>{height, width})
+                         .align_corners(false)
+                         .antialias(true)
+                         .mode(torch::kBicubic);
       resized = torch::nn::functional::interpolate(image, options);
     } else {
-      LOG(FATAL) << "Currently only support 'lanczos', 'default', and "
-                    "'bicubic_no_aa'"
+      LOG(FATAL) << "Currently only support 'lanczos' and 'bicubic'"
                  << ", but got: " << resize_mode;
     }
 


### PR DESCRIPTION
## Description

This PR updates DiT VAE image preprocessing to keep image resize inputs in `uint8` precision. The resize logic is consolidated into a single `resize` entry point that supports `lanczos`, and `bicubic` resampling modes.

## Related Issues

N/A

## Change Type

- [x] Bug fix
- [ ] New feature
- [ ] Performance improvement
- [ ] Refactor
- [ ] Documentation
- [ ] Test
- [ ] Build or CI

## Pull Request Checklist

Thank you for contributing to xLLM. Before requesting review, please make sure the following items are complete.

### PR Title and Commit Messages

- [ ] The PR title and each commit message follow the xLLM commit format: `<type>: <subject>`.

> Allowed types: feat, bugfix, docs, test, refactor, chore, style, revert, perf, model, build, release.
> The subject should use clear English, start with a verb, include at least 4 words, and end with `.`.

### Pre-commit Checks

- [ ] I have installed `pre-commit` by running `pip install pre-commit` or an equivalent command.
- [ ] I have installed the hooks with `pre-commit install`.
- [x] I have run `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

### Self Review

- [x] I have self-reviewed the code according to `.agents/skills/code-review/references/custom-code-style.md`, especially code written or assisted by AI.
- [ ] I have rebased this PR onto the latest `main` branch.

### Build and Test Coverage

- [ ] Tests have been added or updated as needed.
- [ ] CUDA: `python setup.py build test` has passed on a CUDA machine.
- [x] NPU: `python setup.py build test` has passed on an NPU machine.
- [ ] MLU: `python setup.py build test` has passed on an MLU machine.

