### PR TITLE
bugfix: check nested submodules recursively before build.

### DIFF
--- a/scripts/build_support/utils.py
+++ b/scripts/build_support/utils.py
@@ -238,12 +238,12 @@ def _run_git_command(repo_root: str, args: list[str]) -> tuple[bool, str]:
     return True, output
 
 def _collect_submodule_init_issues(repo_root: str) -> dict[str, str]:
-    ok, output = _run_git_command(repo_root, ["submodule", "status"])
+    ok, output = _run_git_command(repo_root, ["submodule", "status", "--recursive"])
     if not ok:
         logger.error("❌ Failed to inspect submodule status.")
         _print_manual_check_commands([
             f"cd {repo_root}",
-            "git submodule status",
+            "git submodule status --recursive",
             "git submodule update --init --recursive",
         ])
         exit(1)


### PR DESCRIPTION
## Description

Use `git submodule status --recursive` in the pre-build check to detect uninitialized or mismatched nested submodules (e.g. `xllm_ops/third_party/pto-isa`). Previously only first-level submodules were checked, allowing builds to proceed with stale nested dependencies and fail with cryptic compilation errors.

## Change Type

- [x] Bug fix

## Reviewer Notes

One-line fix. Without this, `git submodule update --init` (non-recursive) passes the check but leaves nested submodules stale, causing `mega_chunk_gdn` kernel compilation failures due to missing API definitions from `pto-isa`.