### PR TITLE
bugfix: order SHM H2D with graph replay on NPU.

### DIFF
--- a/xllm/compiler/tilelang/targets/ascend/kernels/embedding.py
+++ b/xllm/compiler/tilelang/targets/ascend/kernels/embedding.py
@@ -1,0 +1,77 @@
+#!/usr/bin/env python3
+
+import tilelang
+import tilelang.language as T
+
+from .utils import DEFAULT_ASCEND_PASS_CONFIGS, detect_vec_core_num
+from ....common.spec import DispatchField, TilelangKernel, register_kernel
+
+MAX_TOKENS = 192
+VOCAB_SIZE = 248320
+HIDDEN_DIMS = (2560, 5120)
+DTYPE = "bfloat16"
+VEC_NUM = 2
+
+
+def build_embedding_kernel(vocab_size: int, hidden_dim: int, vec_core_num: int):
+    if vec_core_num <= 0 or vec_core_num % VEC_NUM != 0:
+        raise ValueError("vec_core_num must be positive and divisible by 2")
+
+    @T.prim_func
+    def embedding_kernel(
+        weight: T.Tensor((vocab_size, hidden_dim), DTYPE),
+        token_ids: T.Tensor((MAX_TOKENS,), "int32"),
+        output: T.Tensor((MAX_TOKENS, hidden_dim), DTYPE),
+        num_tokens: T.int32,
+    ):
+        with T.Kernel(vec_core_num // VEC_NUM, is_npu=True) as (cid, vid):
+            task_id = cid * VEC_NUM + vid
+            row_ub = T.alloc_ub((hidden_dim,), DTYPE)
+            rows_per_task = (num_tokens + vec_core_num - 1) // vec_core_num
+            for row_local in T.serial(rows_per_task):
+                row = task_id + row_local * vec_core_num
+                if row < num_tokens:
+                    token_id = token_ids[row]
+                    if token_id >= 0:
+                        if token_id < vocab_size:
+                            T.copy(weight[token_id, 0], row_ub)
+                        else:
+                            T.tile.fill(row_ub, 0)
+                    else:
+                        T.tile.fill(row_ub, 0)
+                    T.copy(row_ub, output[row, 0])
+
+    return embedding_kernel
+
+
+@register_kernel
+class EmbeddingKernel(TilelangKernel):
+    DISPATCH_SCHEMA = [
+        DispatchField("vocab_size", "int32"),
+        DispatchField("hidden_dim", "int32"),
+        DispatchField("dtype", "dtype"),
+    ]
+    SPECIALIZATIONS = [
+        {
+            "variant_key": f"v248320_h{hidden_dim}_bf16",
+            "vocab_size": VOCAB_SIZE,
+            "hidden_dim": hidden_dim,
+            "dtype": DTYPE,
+        }
+        for hidden_dim in HIDDEN_DIMS
+    ]
+
+    @staticmethod
+    def generate_source(vocab_size: int, hidden_dim: int, dtype: str) -> str:
+        if dtype != DTYPE:
+            raise ValueError(f"embedding only supports {DTYPE}, got {dtype}")
+        tilelang.disable_cache()
+        kernel = build_embedding_kernel(
+            vocab_size=vocab_size,
+            hidden_dim=hidden_dim,
+            vec_core_num=detect_vec_core_num(),
+        )
+        with tilelang.tvm.transform.PassContext(
+            opt_level=3, config=DEFAULT_ASCEND_PASS_CONFIGS
+        ):
+            return tilelang.engine.lower(kernel).kernel_source

--- a/xllm/core/distributed_runtime/worker_service.cpp
+++ b/xllm/core/distributed_runtime/worker_service.cpp
@@ -315,7 +315,13 @@ void WorkerService::create_polling_shm_thread(
         Timer timer;
         while (true) {
           ForwardInput fwd_input;
-          input_shm_manager->input_read(fwd_input, device_);
+          // NPU graph task updates cannot safely overlap an H2D enqueue from
+          // the SHM polling thread. Keep scheduler overlap, but defer device
+          // materialization to WorkerImpl's ordered prepare stream.
+          const bool defer_graph_overlap_h2d =
+              options_.enable_schedule_overlap() && options_.enable_graph();
+          input_shm_manager->input_read(
+              fwd_input, device_, !defer_graph_overlap_h2d);
           timer.reset();
           // model output variables
           torch::Tensor next_tokens;

--- a/xllm/core/kernels/npu/tilelang/CMakeLists.txt
+++ b/xllm/core/kernels/npu/tilelang/CMakeLists.txt
@@ -128,6 +128,11 @@ tilelang_register_runtime_kernel(
 )
 
 tilelang_register_runtime_kernel(
+  NAME embedding
+  WRAPPER_SRCS embedding_wrapper.cpp
+)
+
+tilelang_register_runtime_kernel(
   NAME fused_gdn_gating
   WRAPPER_SRCS fused_gdn_gating_wrapper.cpp
 )

--- a/xllm/core/kernels/npu/tilelang/embedding_wrapper.cpp
+++ b/xllm/core/kernels/npu/tilelang/embedding_wrapper.cpp
@@ -1,0 +1,75 @@
+/* Copyright 2025-2026 The xLLM Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://github.com/jd-opensource/xllm/blob/main/LICENSE
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include <c10/core/DeviceType.h>
+#include <glog/logging.h>
+#include <torch_npu/csrc/core/npu/NPUStream.h>
+
+#include <cstdint>
+
+#include "acl/acl.h"
+#include "dispatch_registry.h"
+#include "tilelang_ops_api.h"
+
+#ifndef XLLM_TL_EMBEDDING_REGISTRY_INC
+#error "XLLM_TL_EMBEDDING_REGISTRY_INC is not defined"
+#endif
+
+namespace xllm::kernel::npu::tilelang {
+namespace {
+
+#include XLLM_TL_EMBEDDING_REGISTRY_INC
+
+EmbeddingSpecialization build_runtime_specialization(
+    const torch::Tensor& weight) {
+  return make_embedding_specialization(
+      EmbeddingVocabSize{static_cast<int32_t>(weight.size(0))},
+      EmbeddingHiddenDim{static_cast<int32_t>(weight.size(1))},
+      EmbeddingDType{to_tilelang_dtype(weight.scalar_type())});
+}
+
+}  // namespace
+
+torch::Tensor embedding(const torch::Tensor& weight,
+                        const torch::Tensor& token_ids) {
+  CHECK(weight.defined() && token_ids.defined());
+  CHECK(weight.device().type() == c10::DeviceType::PrivateUse1 &&
+        token_ids.device().type() == c10::DeviceType::PrivateUse1);
+  CHECK_EQ(weight.dim(), 2);
+  CHECK_EQ(token_ids.dim(), 1);
+  CHECK_EQ(weight.scalar_type(), c10::ScalarType::BFloat16);
+  CHECK_EQ(token_ids.scalar_type(), c10::ScalarType::Int);
+  CHECK(weight.is_contiguous());
+  CHECK(token_ids.is_contiguous());
+  CHECK_GT(token_ids.size(0), 0);
+  CHECK_LE(token_ids.size(0), 192);
+
+  const auto* entry =
+      find_embedding_kernel_entry(build_runtime_specialization(weight));
+  CHECK(entry != nullptr) << "TileLang embedding: no compiled variant";
+
+  torch::Tensor output =
+      torch::empty({token_ids.size(0), weight.size(1)}, weight.options());
+  aclrtStream stream = c10_npu::getCurrentNPUStream(weight.device().index())
+                           .stream(/*need_empty=*/true);
+  entry->fn(reinterpret_cast<uint8_t*>(const_cast<void*>(weight.data_ptr())),
+            reinterpret_cast<uint8_t*>(const_cast<void*>(token_ids.data_ptr())),
+            reinterpret_cast<uint8_t*>(output.data_ptr()),
+            static_cast<int32_t>(token_ids.size(0)),
+            stream);
+  return output;
+}
+
+}  // namespace xllm::kernel::npu::tilelang

--- a/xllm/core/kernels/npu/tilelang/tilelang_ops_api.h
+++ b/xllm/core/kernels/npu/tilelang/tilelang_ops_api.h
@@ -24,6 +24,9 @@ limitations under the License.
 
 namespace xllm::kernel::npu::tilelang {
 
+torch::Tensor embedding(const torch::Tensor& weight,
+                        const torch::Tensor& token_ids);
+
 // Public TileLang kernel APIs exported to the xLLM NPU runtime.
 //
 // Apply TileLang RoPE kernel in-place on a single input tensor.

--- a/xllm/core/layers/common/word_embedding_impl.cpp
+++ b/xllm/core/layers/common/word_embedding_impl.cpp
@@ -15,6 +15,10 @@ limitations under the License.
 
 #include "word_embedding_impl.h"
 
+#if defined(USE_NPU)
+#include "core/kernels/npu/tilelang/tilelang_ops_api.h"
+#endif
+
 namespace xllm {
 namespace layer {
 
@@ -47,8 +51,16 @@ WordEmbeddingImpl::WordEmbeddingImpl(int64_t num_embeddings,
 // The input to the module is a list of indices, and the output is the
 // corresponding word embeddings.
 torch::Tensor WordEmbeddingImpl::forward(torch::Tensor input) {
-  namespace F = torch::nn::functional;
-  auto output = F::embedding(input, weight_);
+#if defined(USE_NPU)
+  const bool use_tilelang =
+      input.numel() <= 192 && weight_.size(0) == 248320 &&
+      (weight_.size(1) == 2560 || weight_.size(1) == 5120);
+  auto output = use_tilelang
+                    ? xllm::kernel::npu::tilelang::embedding(weight_, input)
+                    : torch::nn::functional::embedding(input, weight_);
+#else
+  auto output = torch::nn::functional::embedding(input, weight_);
+#endif
   if (world_size_ > 1) {
     output = xllm::parallel_state::gather(output, parallel_args_.tp_group_);
   }

--- a/xllm/core/runtime/forward_shared_memory_manager.cpp
+++ b/xllm/core/runtime/forward_shared_memory_manager.cpp
@@ -28,6 +28,7 @@ limitations under the License.
 #include "core/framework/config/eplb_config.h"
 #include "core/framework/config/execution_config.h"
 #include "core/framework/config/model_config.h"
+#include "core/framework/config/scheduler_config.h"
 #include "platform/stream.h"
 #if defined(USE_CUDA)
 #include <cuda_runtime_api.h>
@@ -2369,7 +2370,15 @@ inline void deserialize_forward_input_payload(
   read_linear_state_cache_ops(context, input_params.linear_state_cache_ops);
   normalize_linear_state_ids(input_params.embedding.linear_state_ids,
                              input_params.meta.num_sequences);
-  if (!input_params.embedding.linear_state_ids.empty()) {
+  bool defer_linear_state_indices_h2d = false;
+#if defined(USE_NPU)
+  defer_linear_state_indices_h2d =
+      stream != nullptr &&
+      ::xllm::ExecutionConfig::get_instance().enable_graph() &&
+      ::xllm::SchedulerConfig::get_instance().enable_schedule_overlap();
+#endif
+  if (!defer_linear_state_indices_h2d &&
+      !input_params.embedding.linear_state_ids.empty()) {
     input_params.embedding.linear_state_indices =
         torch::tensor(input_params.embedding.linear_state_ids, torch::kInt)
             .to(device, /*non_blocking=*/true);

--- a/xllm/core/runtime/forward_shared_memory_manager.cpp
+++ b/xllm/core/runtime/forward_shared_memory_manager.cpp
@@ -28,7 +28,6 @@ limitations under the License.
 #include "core/framework/config/eplb_config.h"
 #include "core/framework/config/execution_config.h"
 #include "core/framework/config/model_config.h"
-#include "core/framework/config/scheduler_config.h"
 #include "platform/stream.h"
 #if defined(USE_CUDA)
 #include <cuda_runtime_api.h>
@@ -2227,13 +2226,18 @@ inline void initialize_device_buffer_session(ReadContext& context,
 #endif
 
   auto& session = *context.device_session;
-  torch::Tensor host_input_buffer =
-      torch::from_blob(const_cast<char*>(payload_base),
-                       {static_cast<int64_t>(payload_size)},
-                       torch::TensorOptions()
-                           .dtype(torch::kUInt8)
-                           .device(torch::kCPU)
-                           .pinned_memory(/*pinned_memory=*/true));
+  // POSIX shared-memory pages are not pinned merely because TensorOptions says
+  // so. Own a genuinely pinned staging copy and keep it alive with ForwardInput
+  // until the asynchronous H2D has completed.
+  forward_input.input_host_buffer =
+      torch::empty({static_cast<int64_t>(payload_size)},
+                   torch::TensorOptions()
+                       .dtype(torch::kUInt8)
+                       .device(torch::kCPU)
+                       .pinned_memory(/*pinned_memory=*/true));
+  std::memcpy(
+      forward_input.input_host_buffer.data_ptr(), payload_base, payload_size);
+  const torch::Tensor& host_input_buffer = forward_input.input_host_buffer;
 
   auto device_options =
       torch::TensorOptions().dtype(torch::kUInt8).device(device);
@@ -2370,14 +2374,7 @@ inline void deserialize_forward_input_payload(
   read_linear_state_cache_ops(context, input_params.linear_state_cache_ops);
   normalize_linear_state_ids(input_params.embedding.linear_state_ids,
                              input_params.meta.num_sequences);
-  bool defer_linear_state_indices_h2d = false;
-#if defined(USE_NPU)
-  defer_linear_state_indices_h2d =
-      stream != nullptr &&
-      ::xllm::ExecutionConfig::get_instance().enable_graph() &&
-      ::xllm::SchedulerConfig::get_instance().enable_schedule_overlap();
-#endif
-  if (!defer_linear_state_indices_h2d &&
+  if (materialize_device_buffer &&
       !input_params.embedding.linear_state_ids.empty()) {
     input_params.embedding.linear_state_indices =
         torch::tensor(input_params.embedding.linear_state_ids, torch::kInt)
@@ -3152,8 +3149,10 @@ bool ForwardSharedMemoryManager::input_write(const ForwardInput& input) {
   return true;
 }
 
-void ForwardSharedMemoryManager::input_read(ForwardInput& input,
-                                            const torch::Device& device) {
+void ForwardSharedMemoryManager::input_read(
+    ForwardInput& input,
+    const torch::Device& device,
+    bool materialize_device_buffer_on_read) {
   while (true) {
     if (control_ptr_->version != last_version_) {
       last_version_ = control_ptr_->version;
@@ -3168,13 +3167,25 @@ void ForwardSharedMemoryManager::input_read(ForwardInput& input,
   uint64_t total_size;
   read_data(data_ptr, total_size);
   bool materialize_device_buffer = false;
+  bool own_pinned_host_payload = false;
 #if defined(USE_NPU)
-  materialize_device_buffer = true;
+  materialize_device_buffer = materialize_device_buffer_on_read;
+  own_pinned_host_payload = !materialize_device_buffer;
 #elif defined(USE_CUDA)
   materialize_device_buffer = device.type() == torch::kCUDA;
 #elif defined(USE_MLU)
   materialize_device_buffer = device.type() == torch::kPrivateUse1;
 #endif
+  if (own_pinned_host_payload) {
+    input.input_host_buffer =
+        torch::empty({static_cast<int64_t>(total_size)},
+                     torch::TensorOptions()
+                         .dtype(torch::kUInt8)
+                         .device(torch::kCPU)
+                         .pinned_memory(/*pinned_memory=*/true));
+    std::memcpy(input.input_host_buffer.data_ptr(), data_ptr, total_size);
+    data_ptr = static_cast<const char*>(input.input_host_buffer.data_ptr());
+  }
   deserialize_forward_input_payload(data_ptr,
                                     total_size,
                                     input,

--- a/xllm/core/runtime/forward_shared_memory_manager.h
+++ b/xllm/core/runtime/forward_shared_memory_manager.h
@@ -104,7 +104,9 @@ class ForwardSharedMemoryManager : public SharedMemoryManager {
   };
 
   bool input_write(const ForwardInput& input);
-  void input_read(ForwardInput& input, const torch::Device& device);
+  void input_read(ForwardInput& input,
+                  const torch::Device& device,
+                  bool materialize_device_buffer_on_read = true);
   bool raw_output_write(
       const torch::Tensor& next_tokens,
       const torch::Tensor& logprobs,


### PR DESCRIPTION
## 背景

[PR1964](https://github.com/xLLM-AI/xllm/pull/1964) 为减少 Qwen3.5 `CausalConv1d` 前的 Host-to-Device（H2D）空泡，把 SHM 输入的 device materialization 提前到了 `ForwardSharedMemoryManager::input_read()`。在 NPU Graph、schedule overlap、SHM 同时开启时，`input_read()` 运行在后台 polling thread，因此整包 payload 以及 `linear_state_indices` 的异步 H2D 都从 polling stream 下发。

这条快速路径在普通解码下可以隐藏搬运开销，但 MTP5 会增加 draft、validate 和 Graph replay 轮次，放大 polling stream 与计算线程并发下发的窗口。TP2 两个 rank 的推进顺序一旦不同，一个 rank 可能停在 Graph task update/H2D，另一个 rank 已进入 HCCL 等待，最终表现为不对称等待、卡住或 TPOT 波动。

## 根因

问题不是 SHM 容量太小，而是 SHM 内存属性和异步执行顺序不成立：

1. POSIX SHM 是普通共享内存，`torch::from_blob(..., pinned_memory=true)` 只修改 Tensor 描述，不能把底层页面变成真正的 pinned memory。
2. polling thread 在该内存上发起 non-blocking H2D 后，producer 可以很快复用或覆盖 SHM；原 Tensor 也没有独立 ownership 保证异步搬运完成前 payload 一直有效。
3. polling stream 的 H2D 与计算线程的 Graph task update/replay 没有统一的 stream/event 顺序。MTP5 + TP2 下，这个竞态更容易放大为 rank 间不对称等待。
4. 仅延迟 `linear_state_indices.to(NPU)` 仍保留了整包 payload 的 polling-stream H2D，虽然能避免卡死，但没有消除共享内存生命周期和跨 stream 排序问题，性能只能到约 2.994 ms TPOT。

## 修改

本 PR 保留 SHM transport、schedule overlap 和 Graph replay，只调整 NPU Graph + overlap 组合下的输入 materialization 位置：

- `WorkerService` 在 `enable_graph && enable_schedule_overlap` 时调用 `input_read(..., false)`，明确禁止 polling thread 发起 NPU H2D。
- `ForwardSharedMemoryManager` 把本轮 SHM payload 复制到真正的、由 `ForwardInput` 持有的 pinned CPU snapshot。这样 producer 可以继续写下一轮 SHM，而当前轮 snapshot 的生命周期覆盖后续异步 H2D。
- `linear_state_indices` 与整包 payload 一起延迟，不再从 polling stream 单独下发。
- 后续继续走现有 `WorkerImpl` prepare path，由 ordered prepare stream 执行 `ForwardInput::to(NPU)`，再按已有 capture mutex / ready event 顺序进入 Graph task update 和 replay。

改动范围为 3 个文件，PR 相对 main 为 41 行新增、13 行删除；没有修改 `WorkerImpl` 的执行逻辑，只复用其已有有序 H2D 路径。

跨平台影响被限制在 NPU：

- NPU 非 Graph 或未开启 schedule overlap 时继续使用原有提前 H2D 快速路径；
- CUDA、MLU 的 device materialization 分支保持不变；
- CPU 默认路径不会新增 pinned-memory 分配；
- SHM wire format、producer 写入逻辑和 Graph replay 逻辑均未改变。

## 时序图

![PR2035 ordered SHM H2D 泳道图](https://raw.githubusercontent.com/pjgao/xllm/pr-assets/pr2035-ordered-shm-h2d-swimlane.png)

图中关键术语：

- **POSIX SHM**：scheduler 与 worker 之间传递序列化输入的普通共享内存，不等同于 pinned memory。
- **polling thread / polling stream**：后台轮询 SHM version、反序列化输入的线程及其曾经使用的 NPU stream；修复后只做 CPU staging，不再 enqueue NPU 工作。
- **owned pinned CPU snapshot**：从 SHM 拷贝出的本轮私有锁页副本，由 `ForwardInput` 持有，避免 producer 复用 SHM 时破坏尚未完成的 H2D。
- **prepare stream**：worker 现有的有序输入准备 stream；payload 和 indices 的 H2D 在这里统一下发。
- **Graph task update / replay**：更新已捕获 NPU Graph 的动态输入和任务参数，然后重放 Graph。
- **ready event**：prepare stream 与 compute stream 之间的完成信号，保证 Graph update/replay 只消费已就绪输入。
- **rank / HCCL**：TP2 的两个进程通过 HCCL 集合通信同步；一侧执行顺序异常时，另一侧通常表现为 HCCL 等待。
- **MTP5**：推测解码深度为 5，更多 draft/validate/replay 轮次会扩大竞态窗口。

## 验证

构建与测试：

- NPU `xllm` 目标重新编译、链接成功；
- `BatchTest.SharedMemoryRoundTripPreservesLinearStateIds`：PASS；
- `BatchTest.SharedMemoryRoundTripPreservesEmptyRankTensors`：PASS；
- `git diff --check`：PASS。

端到端配置：

- Qwen3.5-2B，Target TP2，Draft Body TP1，MTP5；
- HCCL AIV、Graph、schedule overlap、graph decode no-padding、SHM 开启；
- graph double buffer、prefix cache 关闭；
- rank 绑核 480–519 / 520–559；
- `log_request` 数据集，warmup 8，正式 3 × 20，每请求输出 25 tokens；
- 当前 PR 提交 `6e2d9a2b` 对应二进制，正式请求前 ready、真实生成 smoke 均 PASS。

最终 60 条结果：

| 指标 | 结果 |
| --- | ---: |
| 成功请求 | 60 / 60 |
| Client E2E | 145.645 ms |
| Client TTFT | 74.868 ms |
| Client TPOT | **2.949 ms** |
| Server TPOT | 2.975 ms |
| MTP acceptance rate | 59.322% |

全程无 timeout、无 rank hang；停止后的 PID、端口和 NPU cleanup 为 PASS。作为对照，之前仅延迟 `linear_state_indices` 的窄修复 Client TPOT 为 2.994 ms；本方案恢复到历史 2.9 ms 区间，同时从根因上修复 SHM ownership 与跨 stream 排序问题。

本机端到端 binary 同时包含机器所需的权重加载 patch 和 greedy sampling broadcast bypass patch；这两部分不在本 PR 中。
