### PR TITLE
bugfix: skip prefix-cached blocks during PD KV transfer.

### DIFF
--- a/xllm/core/distributed_runtime/disagg_pd_service_impl.cpp
+++ b/xllm/core/distributed_runtime/disagg_pd_service_impl.cpp
@@ -196,13 +196,14 @@ void DisaggPDServiceImpl::decode_recv_new_requests(
             sequence->kv_state().shared_blocks_num(BlockType::KV);
         const auto blocks = sequence->kv_state().blocks(BlockType::KV);
 
-        // Collect block IDs
+        // Collect block IDs (skip prefix-cache-hit blocks)
         block_ids.reserve(blocks.size() - shared_num);
         for (size_t i = shared_num; i < blocks.size(); i++) {
           int32_t block_id = blocks[i].id();
           *(resp->mutable_blocks_ids()->Add()) = block_id;
           block_ids.push_back(block_id);
         }
+        resp->set_num_prefix_blocks(static_cast<int32_t>(shared_num));
       }
       // XTensor mode: calculate and return GlobalXTensor offsets
       if (::xllm::KVCacheConfig::get_instance().enable_xtensor() &&

--- a/xllm/core/scheduler/disagg_pd_scheduler.cpp
+++ b/xllm/core/scheduler/disagg_pd_scheduler.cpp
@@ -560,6 +560,9 @@ void DisaggPDScheduler::dispatch_requests() {
               info.block_transfer_groups.emplace_back(std::move(group));
             }
           } else {
+            const size_t prefix_blocks =
+                static_cast<size_t>(resp.num_prefix_blocks());
+            info.remote_blocks_ids.resize(prefix_blocks, 0);
             for (const int32_t block_id : resp.blocks_ids()) {
               info.remote_blocks_ids.emplace_back(
                   static_cast<uint64_t>(block_id));
@@ -596,6 +599,11 @@ void DisaggPDScheduler::dispatch_requests() {
                     << ", num_layers=" << info.dst_xtensor_layer_offsets.size();
           }
 
+          const int32_t num_prefix_blocks = resp.num_prefix_blocks();
+          if (num_prefix_blocks > 0) {
+            sequence->kv_state().set_next_transfer_block_idx(
+                static_cast<size_t>(num_prefix_blocks));
+          }
           sequence->kv_state().set_transfer_kv_info(std::move(info));
         }
 

--- a/xllm/proto/disagg_pd.proto
+++ b/xllm/proto/disagg_pd.proto
@@ -113,6 +113,10 @@ message DisaggResponse {
   // Group-aware block allocation. group_id is defined by the cache layout and
   // is opaque to the PD protocol.
   repeated KVBlockGroup kv_block_groups = 20;
+
+  // Number of leading blocks served from decode-side prefix cache.
+  // Prefill uses this to skip cached blocks during KV transfer.
+  int32 num_prefix_blocks = 21;
 }
 
 // XTensor mode: offsets for one layer


### PR DESCRIPTION
## Summary

- Fix crash in PD disaggregation when `enable_prefix_cache=true`: decode-side prefix cache hit causes `batch_input_builder.cpp` CHECK failure (`remote block coverage shortage`)
- Add `num_prefix_blocks` field to `DisaggResponse` proto so prefill knows how many blocks decode served from cache
- Prefill pads `remote_blocks_ids` and advances the transfer cursor to skip cached blocks

## Root Cause

When decode allocates blocks for an incoming PD request, it performs prefix cache matching (`allocate_shared`). The response only returns non-shared block IDs (lines skipped via `shared_blocks_num`). However, prefill's `batch_input_builder` maps `local_block_ids[i]` → `remote_blocks_ids[i]` positionally — with fewer remote IDs than local blocks, the CHECK at `batch_input_builder.cpp:269` fails:

```
Check failed: remote_size >= remote_end (1 vs. 6)
remote block coverage shortage
```

This bug predates the scheduler refactor (#1992) — verified by building commit `ca6a5fd7e` (pre-refactor) and reproducing the same crash.

## Changes

1. **Proto** (`disagg_pd.proto`): Add `int32 num_prefix_blocks = 21` to `DisaggResponse`
2. **Decode side** (`disagg_pd_service_impl.cpp`): Set `num_prefix_blocks` to `shared_blocks_num` after collecting non-shared block IDs
3. **Prefill side** (`disagg_pd_scheduler.cpp`): Pad `remote_blocks_ids` with `num_prefix_blocks` leading zeros and set `next_transfer_block_idx` to skip them during transfer

## Test Plan

- [x] PD + prefix_cache=true + chunked_prefill=true: shared-prefix 50 reqs (concurrency 15) — PASS
- [x] PD + prefix_cache=true: sharegpt 100 reqs (concurrency 20) — PASS
- [x] PD + prefix_cache=true: random 1500-token input, 50 reqs (concurrency 15) — PASS
- [x] PD + prefix_cache=false: all tests pass (no behavior change, `num_prefix_blocks` defaults to 0)
- [x] Verified `num_prefix_cache_tokens` shows cache hits (640, 512 tokens) in prefill logs

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)