### PR TITLE
bugfix: fix recursive submodule check breaking mlu/ilu/cuda CI.

### DIFF
--- a/.github/workflows/build_x86_64_cuda.yaml
+++ b/.github/workflows/build_x86_64_cuda.yaml
@@ -112,7 +112,7 @@ jobs:
       timeout-minutes: 5
       uses: actions/checkout@v4
       with:
-        submodules: true
+        submodules: recursive
 
     - name: Clean submodules
       run: git submodule foreach --recursive git clean -ffdx

--- a/.github/workflows/build_x86_64_ilu.yaml
+++ b/.github/workflows/build_x86_64_ilu.yaml
@@ -112,7 +112,7 @@ jobs:
       timeout-minutes: 5
       uses: actions/checkout@v4
       with:
-        submodules: true
+        submodules: recursive
 
     - name: Build
       if: ${{ success() }}

--- a/.github/workflows/build_x86_64_mlu.yaml
+++ b/.github/workflows/build_x86_64_mlu.yaml
@@ -112,7 +112,7 @@ jobs:
       timeout-minutes: 5
       uses: actions/checkout@v4
       with:
-        submodules: true
+        submodules: recursive
 
     - name: Build
       if: ${{ success() }}


### PR DESCRIPTION
## Summary
- PR #2030 introduced `git submodule status --recursive` which flags nested submodules (Mooncake/cpprestsdk) that mlu/ilu/cuda CI never initializes, causing build failures
- Revert to first-level submodule check + add targeted recursive check for `third_party/xllm_ops` only (catches pto-isa)
- Unify mlu/ilu/cuda CI workflows to use `submodules: recursive` for consistent checkout

## Test plan
- [ ] mlu CI build passes
- [ ] ilu CI build passes
- [ ] cuda CI build passes
- [ ] npu CI build still passes (already uses recursive)