### PR TITLE
feat: support OneRec single-step vocab probs output.

### DIFF
--- a/xllm/c_api/internal/helper.cpp
+++ b/xllm/c_api/internal/helper.cpp
@@ -235,6 +235,51 @@ XLLM_InferOutputTensor make_float_output_tensor(
   return tensor;
 }
 
+// OneRec single-step mode: build a "vocab_probs" FLOAT output tensor from the
+// per-sequence probability distributions carried on SequenceOutput.embedding
+// (routed there by Batch::process_sample_output when max_decode_rounds == 1).
+// Each output row is a [vocab] distribution; the emitted tensor is
+// [num_outputs, vocab]. Returns false (no entry) when nothing is available.
+bool build_vocab_probs_output_tensor(const RequestOutput& req_output,
+                                     XLLM_InferOutputTensor* out_entry) {
+  if (out_entry == nullptr || req_output.outputs.empty()) {
+    return false;
+  }
+  const size_t num_outputs = req_output.outputs.size();
+  int64_t vocab = 0;
+  for (const auto& seq_output : req_output.outputs) {
+    if (seq_output.embedding.defined() && seq_output.embedding.numel() > 0) {
+      vocab = seq_output.embedding.numel();
+      break;
+    }
+  }
+  if (vocab <= 0) {
+    return false;
+  }
+
+  std::vector<float> values;
+  values.reserve(num_outputs * static_cast<size_t>(vocab));
+  for (const auto& seq_output : req_output.outputs) {
+    // Ensure host + fp32 + contiguous; the tensor was already moved to CPU
+    // upstream, this is a cheap no-op safeguard.
+    torch::Tensor row =
+        seq_output.embedding.defined()
+            ? seq_output.embedding.to(torch::kCPU, torch::kFloat32)
+                  .contiguous()
+                  .view({-1})
+            : torch::Tensor();
+    const int64_t row_elems = row.defined() ? row.numel() : 0;
+    const float* data = row_elems > 0 ? row.data_ptr<float>() : nullptr;
+    for (int64_t j = 0; j < vocab; ++j) {
+      values.push_back(j < row_elems ? data[j] : 0.0f);
+    }
+  }
+
+  *out_entry = make_float_output_tensor(
+      "vocab_probs", {static_cast<int64_t>(num_outputs), vocab}, values);
+  return true;
+}
+
 void append_rec_logprobs_to_vector(std::vector<float>* out,
                                    const SequenceOutput& output,
                                    int32_t expected_count) {
@@ -312,6 +357,15 @@ bool populate_raw_output_tensors(const InferenceType inference_type,
     if (FLAGS_enable_extended_item_info) {
       tensor_count += 2;
     }
+    // OneRec single-step mode: optionally emit the full vocab probability
+    // tensor.
+    XLLM_InferOutputTensor vocab_probs_entry{};
+    const bool has_vocab_probs =
+        FLAGS_max_decode_rounds == 1 &&
+        build_vocab_probs_output_tensor(req_output, &vocab_probs_entry);
+    if (has_vocab_probs) {
+      ++tensor_count;
+    }
     auto* entries = new XLLM_InferOutputTensor[tensor_count]();
 
     std::vector<int64_t> item_ids;
@@ -362,6 +416,10 @@ bool populate_raw_output_tensors(const InferenceType inference_type,
       entries[entry_idx++] = make_string_output_tensor("item_type", item_types);
     }
 
+    if (has_vocab_probs) {
+      entries[entry_idx++] = vocab_probs_entry;
+    }
+
     response->output_tensors.entries = entries;
     response->output_tensors.entries_size = tensor_count;
     return true;
@@ -371,7 +429,20 @@ bool populate_raw_output_tensors(const InferenceType inference_type,
   const size_t alloc_elems = num_outputs * token_dim;
   const bool output_sku_logprobs =
       FLAGS_enable_output_sku_logprobs && !req_output.outputs.empty();
-  const size_t tensor_count = output_sku_logprobs ? 2U : 1U;
+
+  // OneRec single-step mode: optionally emit the full vocab probability tensor.
+  XLLM_InferOutputTensor vocab_probs_entry{};
+  const bool has_vocab_probs =
+      FLAGS_max_decode_rounds == 1 &&
+      build_vocab_probs_output_tensor(req_output, &vocab_probs_entry);
+
+  size_t tensor_count = 1U;
+  if (output_sku_logprobs) {
+    ++tensor_count;
+  }
+  if (has_vocab_probs) {
+    ++tensor_count;
+  }
   auto* entries = new XLLM_InferOutputTensor[tensor_count]();
   CHECK(nullptr != entries);
   auto* shape = new int64_t[2]();
@@ -402,6 +473,7 @@ bool populate_raw_output_tensors(const InferenceType inference_type,
   entries[0].data = data;
   entries[0].num_elements = alloc_elems;
 
+  size_t entry_idx = 1;
   if (output_sku_logprobs) {
     const int32_t logprob_width =
         static_cast<int32_t>(req_output.outputs[0].token_ids_logprobs.size());
@@ -413,10 +485,15 @@ bool populate_raw_output_tensors(const InferenceType inference_type,
             &logprob_values, req_output.outputs[i], logprob_width);
       }
     }
-    entries[1] = make_float_output_tensor("sku_logprobs",
-                                          {static_cast<int64_t>(num_outputs),
-                                           static_cast<int64_t>(logprob_width)},
-                                          logprob_values);
+    entries[entry_idx++] =
+        make_float_output_tensor("sku_logprobs",
+                                 {static_cast<int64_t>(num_outputs),
+                                  static_cast<int64_t>(logprob_width)},
+                                 logprob_values);
+  }
+
+  if (has_vocab_probs) {
+    entries[entry_idx++] = vocab_probs_entry;
   }
 
   response->output_tensors.entries = entries;

--- a/xllm/core/framework/batch/batch.cpp
+++ b/xllm/core/framework/batch/batch.cpp
@@ -675,6 +675,31 @@ void Batch::process_sample_output(const SampleOutput& sample_output,
     }
   }
 
+  // OneRec single-step mode (max_decode_rounds == 1): carry the full per-token
+  // vocab probability distribution [rows, vocab] out to the caller. The
+  // sampler already computed softmax(logits) into sample_output.probs; here we
+  // route each row through the existing embedding channel
+  // (output_embedding_ -> SequenceOutput.embedding), which the C API then emits
+  // as the "vocab_probs" output tensor. Gated so multi-round beam search never
+  // pays the large D2H copy.
+  if (FLAGS_max_decode_rounds == 1 && sample_output.probs.defined()) {
+    const int64_t num_seqs = sample_output.probs.size(0);
+    int64_t output_idx = 0;
+    const auto sequences = get_sequences();
+    for (auto* seq : sequences) {
+      CHECK_LT(output_idx, num_seqs);
+      // Force host + fp32 + contiguous so downstream (SequenceOutput.embedding
+      // -> C API) can read data_ptr<float>() directly; probs may live on NPU.
+      auto cur_seq_probs =
+          safe_to(sample_output.probs[output_idx++],
+                  torch::dtype(torch::kFloat32).device(torch::kCPU))
+              .contiguous();
+      // Direct set (not update_embeddings): the single-step sequence is already
+      // finished, so update_embeddings would no-op on the finished_ guard.
+      seq->set_onerec_probs_output(cur_seq_probs.unsqueeze(0));
+    }
+  }
+
   // if sample_output.next_tokens not defined,
   // sample_output.next_tokens.size(0) value is 0,
   // this means all sequences are in prefill stage status.

--- a/xllm/core/framework/request/sequence.cpp
+++ b/xllm/core/framework/request/sequence.cpp
@@ -158,6 +158,20 @@ void Sequence::generate_onerec_output(const Slice<int32_t>& ids,
   }
 }
 
+void Sequence::generate_onerec_probs_output(SequenceOutput& output) const {
+  output.index = index_;
+  // The full vocab probability distribution [rows, vocab] is carried on
+  // output_embedding_ (routed there by Batch::process_sample_output in
+  // single-step mode). Emit it as-is; the C API layer turns it into the
+  // "vocab_probs" output tensor. No token id slicing here.
+  if (output_embedding_.defined()) {
+    output.embedding = output_embedding_;
+  }
+  if (finish_reason_ != FinishReason::NONE) {
+    output.finish_reason = finish_reason_.to_string();
+  }
+}
+
 Sequence::Sequence(size_t index,
                    const std::vector<int32_t>& prompt_token_ids,
                    torch::Tensor input_embedding,

--- a/xllm/core/framework/request/sequence.h
+++ b/xllm/core/framework/request/sequence.h
@@ -189,6 +189,15 @@ class Sequence final {
   void update_mm_embeddings(const std::vector<torch::Tensor>& mm_embeddings);
   // update embeddings to the sequence
   void update_embeddings(const torch::Tensor& embedding);
+  // OneRec single-step mode: directly store the full vocab probability
+  // distribution [1, vocab] as the output embedding, bypassing the finished_
+  // guard and is_embeddings logic in update_embeddings (single-step sequences
+  // are already finished by the time the sampler probs are routed).
+  void set_onerec_probs_output(const torch::Tensor& probs) {
+    if (probs.defined()) {
+      output_embedding_ = probs;
+    }
+  }
   bool has_embedding_id() const { return embedding_block_.is_valid(); }
   int32_t get_embedding_id() const { return embedding_block_.id(); }
   void set_embedding_block(Block embedding_block) {
@@ -228,6 +237,12 @@ class Sequence final {
   SequenceOutput generate_output();
   void generate_sample_outputs(std::vector<SequenceOutput>& outputs,
                                const Tokenizer& tokenizer);
+
+  // OneRec single-step mode output: emit only the sampler's full vocab
+  // probability distribution (stored on output_embedding_ by
+  // Batch::process_sample_output). Does not slice token ids, so it is safe when
+  // single-step generates no decode tokens. Called from SequencesGroup.
+  void generate_onerec_probs_output(SequenceOutput& output) const;
 
   // get the sampling parameters
   const RequestSamplingParam* sampling_param() const {

--- a/xllm/core/framework/request/sequences_group.cpp
+++ b/xllm/core/framework/request/sequences_group.cpp
@@ -126,6 +126,25 @@ void SequencesGroup::generate_outputs(std::vector<SequenceOutput>& outputs,
     return;
   }
 
+  // OneRec single-step mode (max_decode_rounds == 1): return only the sampler's
+  // full vocab probability distribution (carried on each sequence's output
+  // embedding by Batch::process_sample_output). Skip multi-round beam assembly
+  // and, crucially, generate_onerec_output's token slicing, which assumes at
+  // least num_prompt_tokens_ generated tokens and would otherwise crash when
+  // single-step produces none.
+  if (is_onerec_single_step_mode()) {
+    outputs.reserve(outputs.size() + sequences_.size());
+    for (auto& seq : sequences_) {
+      if (seq == nullptr) {
+        continue;
+      }
+      SequenceOutput output;
+      seq->generate_onerec_probs_output(output);
+      outputs.push_back(std::move(output));
+    }
+    return;
+  }
+
   // Check for multi-round beam search results
   if (is_rec_multi_round_mode() && check_beam_search() &&
       sequences_.size() == 1) {

--- a/xllm/core/util/rec_model_utils.h
+++ b/xllm/core/util/rec_model_utils.h
@@ -62,6 +62,14 @@ inline bool is_onerec_xattention_mode() {
          FLAGS_max_decode_rounds > 0;
 }
 
+// OneRec single-step mode: run one step (prefill / round 0) only and return the
+// sampler's full vocab probability distribution instead of a multi-round beam
+// search sequence. Triggered by max_decode_rounds == 1 in the OneRec xattention
+// path.
+inline bool is_onerec_single_step_mode() {
+  return is_onerec_xattention_mode() && FLAGS_max_decode_rounds == 1;
+}
+
 inline bool is_onerec_pipeline_type(RecPipelineType type) {
   return type == RecPipelineType::kOneRecDefault ||
          type == RecPipelineType::kOneRecXAttentionPipeline;


### PR DESCRIPTION
Add a single-step mode for OneRec (max_decode_rounds == 1) that runs one step (prefill / round 0) and returns the sampler's full vocab probability distribution instead of a multi-round beam search sequence.

- rec_model_utils: add is_onerec_single_step_mode() gate.
- batch: in process_sample_output, route SampleOutput.probs [rows, vocab] to each sequence via set_onerec_probs_output (D2H + fp32 + contiguous), gated on max_decode_rounds == 1.
- sequence: add set_onerec_probs_output (direct write, bypassing the finished_ guard in update_embeddings since single-step sequences are already finished) and generate_onerec_probs_output (emit embedding without token slicing).
- sequences_group: add a single-step branch in generate_outputs before the multi-round beam check, so single-step skips generate_onerec_output and its token slice (which crashes when no decode tokens are produced).
- c_api helper: emit a "vocab_probs" FLOAT [num_outputs, vocab] output tensor from SequenceOutput.embedding in populate_raw_output_tensors.

Verified end-to-end via bin/HTTP (3B_git, max_decode_rounds=1): probs computed [1, 25000] and routed to SequenceOutput.embedding; single-step no longer crashes. The c_api vocab_probs emit consumes that embedding (its input is verified populated).

## Description

<!-- What does this PR do? Briefly describe the changes and why they are needed. -->

## Related Issues

<!-- Link related issues here. Use "Fixes #123" when this PR closes an issue. -->

## Change Type

- [ ] Bug fix
- [ ] New feature
- [ ] Performance improvement
- [ ] Refactor
- [ ] Documentation
- [ ] Test
- [ ] Build or CI

## Pull Request Checklist

Thank you for contributing to xLLM. Before requesting review, please make sure the following items are complete.

### PR Title and Commit Messages

- [ ] The PR title and each commit message follow the xLLM commit format: `<type>: <subject>`.

> Allowed types: feat, bugfix, docs, test, refactor, chore, style, revert, perf, model, build, release.
> The subject should use clear English, start with a verb, include at least 4 words, and end with `.`.

### Pre-commit Checks

- [ ] I have installed `pre-commit` by running `pip install pre-commit` or an equivalent command.
- [ ] I have installed the hooks with `pre-commit install`.
- [ ] I have run `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

### Self Review

- [ ] I have self-reviewed the code according to `.agents/skills/code-review/references/custom-code-style.md`, especially code written or assisted by AI.
- [ ] I have rebased this PR onto the latest `main` branch.

### Build and Test Coverage

- [ ] Tests have been added or updated as needed.
- [ ] CUDA: `python setup.py build test` has passed on a CUDA machine.
- [ ] NPU: `python setup.py build test` has passed on an NPU machine.
- [ ] MLU: `python setup.py build test` has passed on an MLU machine.

## Reviewer Notes

<!-- Optional: anything reviewers should focus on, known risks, follow-ups, or validation gaps. -->
