### PR TITLE
feat: enable NPU aclgraph backend for Python model executor.

### DIFF
--- a/tests/core/kernels/cuda/xllm_ops_test.cpp
+++ b/tests/core/kernels/cuda/xllm_ops_test.cpp
@@ -266,7 +266,7 @@ with patch.object(executor_module, "_create_attention_backend", return_value=Fak
         },
         max_seqs_per_batch=3,
     )
-    assert model_executor.decode_cuda_graph_runner.max_batch == 3
+    assert model_executor.decode_graph_runner.max_batch == 3
 )PY");
 }
 

--- a/tests/core/kernels/npu/npu_xllm_ops_test.cpp
+++ b/tests/core/kernels/npu/npu_xllm_ops_test.cpp
@@ -204,7 +204,7 @@ with patch.object(
         max_seqs_per_batch=3,
     )
     assert model_executor._num_attention_layers == 1
-    assert model_executor.decode_cuda_graph_runner is None
+    assert model_executor.decode_graph_runner is None
     assert model_executor.inductor_runner is None
 )PY");
 }

--- a/tests/python/test_model_executor.py
+++ b/tests/python/test_model_executor.py
@@ -196,7 +196,7 @@ class TestModelExecutorConstruction:
         executor = ModelExecutor(model, config, max_seqs_per_batch=4)
 
         assert executor._num_attention_layers == 3
-        assert executor.decode_cuda_graph_runner is None
+        assert executor.decode_graph_runner is None
         assert executor.inductor_runner is None
 
     @patch(
@@ -227,7 +227,7 @@ class TestModelExecutorConstruction:
             executor = ModelExecutor(
                 model, {"python_graph_backend": off_value}, max_seqs_per_batch=4
             )
-            assert executor.decode_cuda_graph_runner is None
+            assert executor.decode_graph_runner is None
             assert executor.inductor_runner is None
 
 

--- a/tests/python/test_model_executor.py
+++ b/tests/python/test_model_executor.py
@@ -42,6 +42,7 @@ from xllm.python.model_executor.executor import (  # noqa: E402
     ModelExecutor,
     _create_attention_backend,
     _is_npu_device,
+    _resolve_graph_backend,
 )
 
 
@@ -141,6 +142,21 @@ class TestIsNpuDevice:
 
     def test_cpu_type(self):
         assert _is_npu_device(torch.device("cpu")) is False
+
+
+# ---------------------------------------------------------------------------
+# Tests: graph backend resolution
+# ---------------------------------------------------------------------------
+
+
+class TestNpuGraphBackendResolution:
+    def test_enable_graph_selects_aclgraph_on_npu(self):
+        config = {"enable_graph": True, "python_graph_backend": "off"}
+
+        assert (
+            _resolve_graph_backend(config, torch.device("npu"))
+            == "aclgraph"
+        )
 
 
 # ---------------------------------------------------------------------------

--- a/xllm/core/framework/config/execution_config.cpp
+++ b/xllm/core/framework/config/execution_config.cpp
@@ -85,6 +85,7 @@ DEFINE_string(
     python_graph_backend,
     "off",
     "Graph backend for the Python model executor. "
+    "Defaults to aclgraph on NPU when --enable_graph is enabled. "
     "Values: off (eager), cudagraphs (CUDA decode graph with eager prefill), "
     "aclgraph (NPU decode graph with eager prefill), "
     "or any torch.compile backend name.");

--- a/xllm/core/framework/config/execution_config.cpp
+++ b/xllm/core/framework/config/execution_config.cpp
@@ -85,7 +85,8 @@ DEFINE_string(
     python_graph_backend,
     "off",
     "Graph backend for the Python model executor. "
-    "Values: off (eager), cudagraphs (decode full graph with eager prefill), "
+    "Values: off (eager), cudagraphs (CUDA decode graph with eager prefill), "
+    "aclgraph (NPU decode graph with eager prefill), "
     "or any torch.compile backend name.");
 
 namespace xllm {

--- a/xllm/core/kernels/npu/npu_ops_library.cpp
+++ b/xllm/core/kernels/npu/npu_ops_library.cpp
@@ -69,11 +69,10 @@ void apply_rotary_embedding_npu(torch::Tensor& q,
   xllm::kernel::npu::apply_rotary(q, k, cos_sin_cache, positions);
 }
 
-// Stub for graph-mode decode metadata update. Currently only used by
-// DecodeCudaGraphRunner (--python_graph_backend=cudagraphs). Registered here so
-// that the Python ops module can be imported unconditionally on NPU without
-// AttributeError. Will gain a real NPU graph implementation once NPU graph
-// capture is enabled, or be removed if NPU graph takes a different approach.
+// Graph-mode decode metadata update. Copies real data into the head of
+// pre-allocated static buffers and fills padding slots with safe defaults
+// (zero tokens, -1 slot mapping, 1 last-page-len) so that the captured
+// graph operates on valid data for every padded position.
 torch::Tensor update_decode_graph_metadata_npu(
     const torch::Tensor& tokens,
     const torch::Tensor& positions,
@@ -91,19 +90,43 @@ torch::Tensor update_decode_graph_metadata_npu(
     torch::Tensor& dst_paged_kv_indices,
     torch::Tensor& dst_paged_kv_last_page_len,
     int64_t padded_num_tokens) {
-  dst_tokens.slice(0, 0, padded_num_tokens).copy_(tokens);
-  dst_positions.slice(0, 0, padded_num_tokens).copy_(positions);
-  dst_slot_mapping.slice(0, 0, padded_num_tokens).copy_(slot_mapping);
+  const int64_t n = tokens.size(0);
+  const int64_t p = padded_num_tokens;
 
-  const int64_t batch_size = kv_seq_lens.size(0);
-  dst_kv_seq_lens.slice(0, 0, batch_size).copy_(kv_seq_lens);
-  dst_kv_seq_lens_delta.slice(0, 0, batch_size).fill_(1);
-  dst_paged_kv_indptr.slice(0, 0, batch_size + 1).copy_(paged_kv_indptr);
+  dst_tokens.slice(0, 0, n).copy_(tokens);
+  dst_positions.slice(0, 0, n).copy_(positions);
+  dst_slot_mapping.slice(0, 0, n).copy_(slot_mapping);
+  if (p > n) {
+    dst_tokens.slice(0, n, p).zero_();
+    dst_positions.slice(0, n, p).zero_();
+    dst_slot_mapping.slice(0, n, p).fill_(-1);
+  }
+
+  const int64_t src_len = std::min<int64_t>(kv_seq_lens.size(0), n + 1);
+  dst_kv_seq_lens.slice(0, 0, src_len).copy_(kv_seq_lens.slice(0, 0, src_len));
+  if (p >= n) {
+    dst_kv_seq_lens.slice(0, src_len, p + 1)
+        .copy_(kv_seq_lens.slice(0, src_len - 1, src_len));
+  }
+  dst_kv_seq_lens_delta.slice(0, 0, p).copy_(
+      dst_kv_seq_lens.slice(0, 1, p + 1) - dst_kv_seq_lens.slice(0, 0, p));
+
+  const int64_t indptr_len = std::min<int64_t>(paged_kv_indptr.size(0), n + 1);
+  dst_paged_kv_indptr.slice(0, 0, indptr_len)
+      .copy_(paged_kv_indptr.slice(0, 0, indptr_len));
+  if (p >= n) {
+    dst_paged_kv_indptr.slice(0, indptr_len, p + 1)
+        .copy_(paged_kv_indptr.slice(0, indptr_len - 1, indptr_len));
+  }
+
+  dst_paged_kv_last_page_len.slice(0, 0, n).copy_(
+      paged_kv_last_page_len.slice(0, 0, n));
+  if (p > n) {
+    dst_paged_kv_last_page_len.slice(0, n, p).fill_(1);
+  }
 
   const int64_t num_pages = paged_kv_indices.size(0);
   dst_paged_kv_indices.slice(0, 0, num_pages).copy_(paged_kv_indices);
-  dst_paged_kv_last_page_len.slice(0, 0, batch_size)
-      .copy_(paged_kv_last_page_len);
 
   return dst_tokens;
 }

--- a/xllm/models/llm/py_causal_lm.cpp
+++ b/xllm/models/llm/py_causal_lm.cpp
@@ -83,6 +83,7 @@ py::dict PyCausalLM::build_config_dict(
   d["device"] = c10::str(device_);
   d["tp_size"] = tp_size_;
   d["tp_rank"] = tp_rank_;
+  d["enable_graph"] = ExecutionConfig::get_instance().enable_graph();
   d["python_graph_backend"] =
       ExecutionConfig::get_instance().python_graph_backend();
   return d;

--- a/xllm/python/attention/backend.py
+++ b/xllm/python/attention/backend.py
@@ -53,9 +53,6 @@ class AttentionBackend(ABC):
         metadata: AttentionMetadata,
         *,
         graph_mode: bool = False,
-        static_block_table: torch.Tensor | None = None,
-        padded_batch_size: int | None = None,
-        static_slot_mapping: torch.Tensor | None = None,
     ) -> None:
         pass
 

--- a/xllm/python/attention/backend.py
+++ b/xllm/python/attention/backend.py
@@ -53,6 +53,9 @@ class AttentionBackend(ABC):
         metadata: AttentionMetadata,
         *,
         graph_mode: bool = False,
+        static_block_table: torch.Tensor | None = None,
+        padded_batch_size: int | None = None,
+        static_slot_mapping: torch.Tensor | None = None,
     ) -> None:
         pass
 

--- a/xllm/python/attention/npu_paged_attention.py
+++ b/xllm/python/attention/npu_paged_attention.py
@@ -27,6 +27,10 @@ import torch_npu
 
 from xllm.python import ops
 from xllm.python.attention.backend import AttentionBackend, AttentionMetadata, KVCache
+from xllm.python.model_executor.forward_context import (
+    AclGraphTask,
+    get_forward_context,
+)
 
 if TYPE_CHECKING:
     from xllm.python.layers.attention import Attention
@@ -60,10 +64,6 @@ class NpuPagedAttentionBackend(AttentionBackend):
         self._graph_lses: dict[int, torch.Tensor] = {}
         self._current_graph_output: torch.Tensor | None = None
         self._current_graph_lse: torch.Tensor | None = None
-        self._in_capture: bool = False
-        self._task_handles: list[object] = []
-        self._static_slot_mapping: torch.Tensor | None = None
-        self._capture_stream: torch.npu.Stream | None = None
         self._causal_mask = (
             torch.triu(torch.ones(2048, 2048, dtype=torch.float32), 1)
             .to(torch.int8)
@@ -91,12 +91,8 @@ class NpuPagedAttentionBackend(AttentionBackend):
         metadata: AttentionMetadata,
         *,
         graph_mode: bool = False,
-        static_block_table: torch.Tensor | None = None,
-        padded_batch_size: int | None = None,
-        static_slot_mapping: torch.Tensor | None = None,
     ) -> None:
         self._metadata = metadata
-        self._static_slot_mapping = static_slot_mapping
         if metadata.q_cu_seq_lens is not None:
             self._actual_seq_lens: list[int] | None = (
                 metadata.q_cu_seq_lens[1:].cpu().tolist()
@@ -105,15 +101,9 @@ class NpuPagedAttentionBackend(AttentionBackend):
             self._actual_seq_lens = None
 
         if metadata.block_table is not None:
-            if static_block_table is not None:
-                self._block_table_i32 = static_block_table
-            else:
-                self._block_table_i32 = metadata.block_table.to(torch.int32)
+            self._block_table_i32 = metadata.block_table.to(torch.int32)
 
             real_batch = metadata.block_table.shape[0]
-            padded_batch = (
-                padded_batch_size if padded_batch_size is not None else real_batch
-            )
 
             kv_host = metadata.kv_seq_lens_host
             if kv_host is not None:
@@ -126,9 +116,8 @@ class NpuPagedAttentionBackend(AttentionBackend):
                 per_seq_kv = torch.ones(real_batch, dtype=torch.int32)
 
             kv_list = per_seq_kv[:real_batch].tolist()
-            kv_list.extend([1] * (padded_batch - real_batch))
 
-            self._actual_seq_q: list[int] = list(range(1, padded_batch + 1))
+            self._actual_seq_q: list[int] = list(range(1, real_batch + 1))
             self._actual_seq_kv: list[int] = kv_list
         else:
             self._block_table_i32 = None
@@ -194,13 +183,8 @@ class NpuPagedAttentionBackend(AttentionBackend):
         # Write KV to paged cache (kernel expects [T, kv_heads, head_dim]).
         k_3d = k.view(num_tokens, self.num_kv_heads, self.head_dim).contiguous()
         v_3d = v.view(num_tokens, self.num_kv_heads, self.head_dim).contiguous()
-        slot_mapping = (
-            self._static_slot_mapping
-            if self._static_slot_mapping is not None
-            else metadata.slot_mapping
-        )
         ops.reshape_paged_cache(
-            slot_mapping, k_3d, v_3d, k_cache, v_cache
+            metadata.slot_mapping, k_3d, v_3d, k_cache, v_cache
         )
 
         q_3d = q.view(num_tokens, self.num_heads, self.head_dim).contiguous()
@@ -268,8 +252,14 @@ class NpuPagedAttentionBackend(AttentionBackend):
         k_flat = k_cache.view(k_cache.size(0), block_size, -1)
         v_flat = v_cache.view(v_cache.size(0), block_size, -1)
 
-        if self._in_capture and self._current_graph_output is not None:
-            stream = self._capture_stream
+        graph_context = get_forward_context().acl_graph
+        if graph_context is not None:
+            if self._current_graph_output is None:
+                raise RuntimeError("ACL graph output buffer is not prepared")
+            stream = graph_context.stream
+            event = torch.npu.ExternalEvent()
+            event.wait(stream)
+            event.reset(stream)
             torch.npu.graph_task_group_begin(stream)
             try:
                 self._fia_out(q_3d, k_flat, v_flat, block_size)
@@ -277,8 +267,12 @@ class NpuPagedAttentionBackend(AttentionBackend):
                 torch.npu.graph_task_group_end(stream)
                 raise
             handle = torch.npu.graph_task_group_end(stream)
-            self._task_handles.append(
-                (handle, q_3d, k_flat, v_flat, block_size)
+
+            def _update_fia_args() -> None:
+                self._fia_out(q_3d, k_flat, v_flat, block_size)
+
+            graph_context.tasks.append(
+                AclGraphTask(event, handle, _update_fia_args)
             )
             return self._current_graph_output.reshape(
                 num_tokens, self.num_heads * self.head_dim
@@ -300,24 +294,6 @@ class NpuPagedAttentionBackend(AttentionBackend):
             softmax_lse_flag=False,
         )
         return output.reshape(num_tokens, self.num_heads * self.head_dim)
-
-    def begin_capture(self, stream: torch.npu.Stream) -> None:
-        self._in_capture = True
-        self._capture_stream = stream
-        self._task_handles.clear()
-
-    def end_capture(self) -> list[object]:
-        self._in_capture = False
-        return list(self._task_handles)
-
-    def update_replay_args(
-        self, stream: torch.npu.Stream, handles: list[object],
-    ) -> None:
-        for item in handles:
-            handle, q, k, v, block_size = item
-            torch.npu.graph_task_update_begin(stream, handle)
-            self._fia_out(q, k, v, block_size)
-            torch.npu.graph_task_update_end(stream)
 
     # ------------------------------------------------------------------
     # Helpers

--- a/xllm/python/attention/npu_paged_attention.py
+++ b/xllm/python/attention/npu_paged_attention.py
@@ -23,7 +23,9 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 import torch
+import torch_npu
 
+from xllm.python import ops
 from xllm.python.attention.backend import AttentionBackend, AttentionMetadata, KVCache
 
 if TYPE_CHECKING:
@@ -53,6 +55,15 @@ class NpuPagedAttentionBackend(AttentionBackend):
 
         self._kv_caches: list[KVCache] = []
         self._metadata: AttentionMetadata | None = None
+        self._graph_workspace: torch.Tensor | None = None
+        self._graph_outputs: dict[int, torch.Tensor] = {}
+        self._graph_lses: dict[int, torch.Tensor] = {}
+        self._current_graph_output: torch.Tensor | None = None
+        self._current_graph_lse: torch.Tensor | None = None
+        self._in_capture: bool = False
+        self._task_handles: list[object] = []
+        self._static_slot_mapping: torch.Tensor | None = None
+        self._capture_stream: torch.npu.Stream | None = None
         self._causal_mask = (
             torch.triu(torch.ones(2048, 2048, dtype=torch.float32), 1)
             .to(torch.int8)
@@ -80,8 +91,12 @@ class NpuPagedAttentionBackend(AttentionBackend):
         metadata: AttentionMetadata,
         *,
         graph_mode: bool = False,
+        static_block_table: torch.Tensor | None = None,
+        padded_batch_size: int | None = None,
+        static_slot_mapping: torch.Tensor | None = None,
     ) -> None:
         self._metadata = metadata
+        self._static_slot_mapping = static_slot_mapping
         if metadata.q_cu_seq_lens is not None:
             self._actual_seq_lens: list[int] | None = (
                 metadata.q_cu_seq_lens[1:].cpu().tolist()
@@ -89,19 +104,78 @@ class NpuPagedAttentionBackend(AttentionBackend):
         else:
             self._actual_seq_lens = None
 
-        # Pre-compute decode fields once per step (not per layer).
         if metadata.block_table is not None:
-            self._block_table_i32 = metadata.block_table.to(torch.int32)
-            self._actual_seq_kv: list[int] = metadata.kv_seq_lens_host.tolist()
-            if self._actual_seq_lens is not None:
-                self._actual_seq_q: list[int] = self._actual_seq_lens
+            if static_block_table is not None:
+                self._block_table_i32 = static_block_table
             else:
-                batch = metadata.kv_seq_lens_host.size(0)
-                self._actual_seq_q = list(range(1, batch + 1))
+                self._block_table_i32 = metadata.block_table.to(torch.int32)
+
+            real_batch = metadata.block_table.shape[0]
+            padded_batch = (
+                padded_batch_size if padded_batch_size is not None else real_batch
+            )
+
+            kv_host = metadata.kv_seq_lens_host
+            if kv_host is not None:
+                kv_host = kv_host.cpu()
+                if kv_host.numel() == real_batch + 1:
+                    per_seq_kv = kv_host[1:] - kv_host[:-1]
+                else:
+                    per_seq_kv = kv_host
+            else:
+                per_seq_kv = torch.ones(real_batch, dtype=torch.int32)
+
+            kv_list = per_seq_kv[:real_batch].tolist()
+            kv_list.extend([1] * (padded_batch - real_batch))
+
+            self._actual_seq_q: list[int] = list(range(1, padded_batch + 1))
+            self._actual_seq_kv: list[int] = kv_list
         else:
             self._block_table_i32 = None
-            self._actual_seq_kv = []
-            self._actual_seq_q = []
+
+        if graph_mode and self._block_table_i32 is not None:
+            graph_batch_size = self._block_table_i32.shape[0]
+            if self._graph_workspace is None:
+                block_size = self.page_size
+                dummy_q = torch.empty(
+                    graph_batch_size, self.num_heads, self.head_dim,
+                    dtype=self.dtype, device=self.device,
+                )
+                dummy_kv = torch.empty(
+                    self.num_kv_blocks, block_size,
+                    self.num_kv_heads * self.head_dim,
+                    dtype=self.dtype, device=self.device,
+                )
+                self._graph_workspace = (
+                    torch_npu._npu_fused_infer_attention_score_get_max_workspace(
+                        query=dummy_q,
+                        key=dummy_kv,
+                        value=dummy_kv,
+                        block_table=self._block_table_i32,
+                        input_layout="TND",
+                        block_size=block_size,
+                        actual_seq_lengths=self._actual_seq_q,
+                        actual_seq_lengths_kv=self._actual_seq_kv,
+                        num_key_value_heads=self.num_kv_heads,
+                        num_heads=self.num_heads,
+                        sparse_mode=0,
+                        scale=self.scale,
+                        softmax_lse_flag=False,
+                    )
+                )
+            if graph_batch_size not in self._graph_outputs:
+                self._graph_outputs[graph_batch_size] = torch.empty(
+                    graph_batch_size,
+                    self.num_heads,
+                    self.head_dim,
+                    dtype=self.dtype,
+                    device=self.device,
+                )
+                self._graph_lses[graph_batch_size] = torch.empty(
+                    0, dtype=self.dtype, device=self.device
+                )
+            self._current_graph_output = self._graph_outputs[graph_batch_size]
+            self._current_graph_lse = self._graph_lses[graph_batch_size]
 
     def execute(
         self,
@@ -120,8 +194,13 @@ class NpuPagedAttentionBackend(AttentionBackend):
         # Write KV to paged cache (kernel expects [T, kv_heads, head_dim]).
         k_3d = k.view(num_tokens, self.num_kv_heads, self.head_dim).contiguous()
         v_3d = v.view(num_tokens, self.num_kv_heads, self.head_dim).contiguous()
-        torch.ops.xllm_ops.reshape_paged_cache(
-            metadata.slot_mapping, k_3d, v_3d, k_cache, v_cache
+        slot_mapping = (
+            self._static_slot_mapping
+            if self._static_slot_mapping is not None
+            else metadata.slot_mapping
+        )
+        ops.reshape_paged_cache(
+            slot_mapping, k_3d, v_3d, k_cache, v_cache
         )
 
         q_3d = q.view(num_tokens, self.num_heads, self.head_dim).contiguous()
@@ -159,16 +238,12 @@ class NpuPagedAttentionBackend(AttentionBackend):
     # Decode: FIA with block_table (paged KV, no gather)
     # ------------------------------------------------------------------
 
-    def _decode(
-        self, q_3d: torch.Tensor, k_cache: torch.Tensor, v_cache: torch.Tensor,
-        metadata: AttentionMetadata, num_tokens: int,
-    ) -> torch.Tensor:
-        block_size = k_cache.size(1)
-        k_flat = k_cache.view(k_cache.size(0), block_size, -1)
-        v_flat = v_cache.view(v_cache.size(0), block_size, -1)
-
-        output, _ = torch.ops.npu.npu_fused_infer_attention_score(
-            q_3d, k_flat, v_flat,
+    def _fia_out(
+        self, q: torch.Tensor, k: torch.Tensor, v: torch.Tensor,
+        block_size: int,
+    ) -> None:
+        torch.ops.npu.npu_fused_infer_attention_score.out(
+            q, k, v,
             pse_shift=None,
             atten_mask=None,
             actual_seq_lengths=self._actual_seq_q,
@@ -181,8 +256,68 @@ class NpuPagedAttentionBackend(AttentionBackend):
             sparse_mode=0,
             block_size=block_size,
             softmax_lse_flag=False,
+            workspace=self._graph_workspace,
+            out=[self._current_graph_output, self._current_graph_lse],
+        )
+
+    def _decode(
+        self, q_3d: torch.Tensor, k_cache: torch.Tensor, v_cache: torch.Tensor,
+        metadata: AttentionMetadata, num_tokens: int,
+    ) -> torch.Tensor:
+        block_size = k_cache.size(1)
+        k_flat = k_cache.view(k_cache.size(0), block_size, -1)
+        v_flat = v_cache.view(v_cache.size(0), block_size, -1)
+
+        if self._in_capture and self._current_graph_output is not None:
+            stream = self._capture_stream
+            torch.npu.graph_task_group_begin(stream)
+            try:
+                self._fia_out(q_3d, k_flat, v_flat, block_size)
+            except Exception:
+                torch.npu.graph_task_group_end(stream)
+                raise
+            handle = torch.npu.graph_task_group_end(stream)
+            self._task_handles.append(
+                (handle, q_3d, k_flat, v_flat, block_size)
+            )
+            return self._current_graph_output.reshape(
+                num_tokens, self.num_heads * self.head_dim
+            )
+
+        output, _ = torch.ops.npu.npu_fused_infer_attention_score(
+            q_3d, k_flat, v_flat,
+            pse_shift=None,
+            atten_mask=None,
+            actual_seq_lengths=self._actual_seq_q[:num_tokens],
+            actual_seq_lengths_kv=self._actual_seq_kv[:num_tokens],
+            block_table=self._block_table_i32,
+            num_heads=self.num_heads,
+            scale=self.scale,
+            input_layout="TND",
+            num_key_value_heads=self.num_kv_heads,
+            sparse_mode=0,
+            block_size=block_size,
+            softmax_lse_flag=False,
         )
         return output.reshape(num_tokens, self.num_heads * self.head_dim)
+
+    def begin_capture(self, stream: torch.npu.Stream) -> None:
+        self._in_capture = True
+        self._capture_stream = stream
+        self._task_handles.clear()
+
+    def end_capture(self) -> list[object]:
+        self._in_capture = False
+        return list(self._task_handles)
+
+    def update_replay_args(
+        self, stream: torch.npu.Stream, handles: list[object],
+    ) -> None:
+        for item in handles:
+            handle, q, k, v, block_size = item
+            torch.npu.graph_task_update_begin(stream, handle)
+            self._fia_out(q, k, v, block_size)
+            torch.npu.graph_task_update_end(stream)
 
     # ------------------------------------------------------------------
     # Helpers

--- a/xllm/python/layers/linear.py
+++ b/xllm/python/layers/linear.py
@@ -95,6 +95,7 @@ class RowParallelLinear(nn.Module):
     ) -> None:
         super().__init__()
         self.tp_size = tp_size
+        self._weight_is_transposed = False
         self.weight = nn.Parameter(
             torch.empty(
                 out_features,
@@ -110,8 +111,23 @@ class RowParallelLinear(nn.Module):
         else:
             self.register_parameter("bias", None)
 
+    def format_npu_weight_(self) -> None:
+        """Store the weight as ``[K, N]`` FRACTAL_NZ for non-transposed matmul."""
+        if self.weight.device.type not in ("npu", "privateuseone"):
+            return
+        if self._weight_is_transposed:
+            return
+        import torch_npu
+
+        transposed = self.weight.data.transpose(0, 1).contiguous()
+        self.weight.data = torch_npu.npu_format_cast(transposed, 29)
+        self._weight_is_transposed = True
+
     def forward(self, x: torch.Tensor) -> torch.Tensor:
-        out = torch.nn.functional.linear(x, self.weight)
+        if self._weight_is_transposed:
+            out = torch.matmul(x, self.weight)
+        else:
+            out = torch.nn.functional.linear(x, self.weight)
         if self.tp_size > 1:
             ops.all_reduce_(out)
         if self.bias is not None:

--- a/xllm/python/layers/rotary_embedding.py
+++ b/xllm/python/layers/rotary_embedding.py
@@ -59,26 +59,10 @@ class RotaryEmbedding(nn.Module):
             sin_half = sin_half.to(dtype)
 
         device_type = torch.device(device).type if device else "cpu"
-        if device_type in ("npu", "privateuseone"):
-            # NPU path: pre-expand [cos_half, cos_half] so forward() is
-            # index+view only. Skip cos_sin_cache (CUDA-only) to save HBM.
-            self.cos_sin_cache = torch.empty(0)
-            self.register_buffer(
-                "_cos_expanded",
-                torch.cat([cos_half, cos_half], dim=-1).contiguous(),
-                persistent=False,
-            )
-            self.register_buffer(
-                "_sin_expanded",
-                torch.cat([sin_half, sin_half], dim=-1).contiguous(),
-                persistent=False,
-            )
-        else:
-            # CUDA path: [cos(freqs) | sin(freqs)] -> [max_position, head_dim].
-            cos_sin_cache = torch.cat([cos_half, sin_half], dim=-1)
-            self.register_buffer(
-                "cos_sin_cache", cos_sin_cache.contiguous(), persistent=False
-            )
+        cos_sin_cache = torch.cat([cos_half, sin_half], dim=-1)
+        self.register_buffer(
+            "cos_sin_cache", cos_sin_cache.contiguous(), persistent=False
+        )
 
     def forward(
         self, positions: torch.Tensor
@@ -89,6 +73,7 @@ class RotaryEmbedding(nn.Module):
         (zero allocation on the hot path).
         """
         num_tokens = positions.size(0)
-        cos = self._cos_expanded[positions].view(1, num_tokens, 1, self.head_dim)
-        sin = self._sin_expanded[positions].view(1, num_tokens, 1, self.head_dim)
+        cos_half = self.cos_sin_cache[positions]
+        cos = cos_half.view(1, num_tokens, 1, self.head_dim)
+        sin = cos_half.view(1, num_tokens, 1, self.head_dim)
         return cos, sin

--- a/xllm/python/model_executor/executor.py
+++ b/xllm/python/model_executor/executor.py
@@ -94,7 +94,7 @@ class ModelExecutor:
 
         execution_model = model.model
         self.eager_runner = EagerRunner(execution_model, self.attention_backend, device)
-        self.decode_cuda_graph_runner = None
+        self.decode_graph_runner = None
         self.inductor_runner = None
 
         graph_backend = str(config.get("python_graph_backend", "off")).lower()
@@ -104,7 +104,18 @@ class ModelExecutor:
             from xllm.python.model_executor.runners.decode_cuda_graph import (
                 DecodeCudaGraphRunner,
             )
-            self.decode_cuda_graph_runner = DecodeCudaGraphRunner(
+            self.decode_graph_runner = DecodeCudaGraphRunner(
+                execution_model,
+                self.attention_backend,
+                device,
+                max_seqs_per_batch,
+                int(config["max_position_embeddings"]),
+            )
+        elif graph_backend == "aclgraph":
+            from xllm.python.model_executor.runners.decode_acl_graph import (
+                DecodeAclGraphRunner,
+            )
+            self.decode_graph_runner = DecodeAclGraphRunner(
                 execution_model,
                 self.attention_backend,
                 device,
@@ -146,7 +157,7 @@ class ModelExecutor:
         if not self._kv_bound:
             raise RuntimeError("KV caches are not bound")
 
-        graph_runner = self.decode_cuda_graph_runner
+        graph_runner = self.decode_graph_runner
         if graph_runner is not None:
             graph_runner.warmup(input_ids.device, input_ids.dtype)
             if graph_runner.can_execute(input_ids, metadata):

--- a/xllm/python/model_executor/executor.py
+++ b/xllm/python/model_executor/executor.py
@@ -26,6 +26,15 @@ def _is_npu_device(device: torch.device) -> bool:
     return device.type in ("npu", "privateuseone")
 
 
+def _resolve_graph_backend(config: dict, device: torch.device) -> str:
+    graph_backend = str(config.get("python_graph_backend", "off")).lower()
+    graph_disabled = graph_backend in ("", "off", "none", "0")
+    if graph_disabled and config.get("enable_graph", False):
+        if _is_npu_device(device):
+            return "aclgraph"
+    return graph_backend
+
+
 def _create_attention_backend(
     first_attention: Attention,
     device: torch.device,
@@ -97,7 +106,7 @@ class ModelExecutor:
         self.decode_graph_runner = None
         self.inductor_runner = None
 
-        graph_backend = str(config.get("python_graph_backend", "off")).lower()
+        graph_backend = _resolve_graph_backend(config, device)
         if graph_backend in ("", "off", "none", "0"):
             pass
         elif graph_backend == "cudagraphs":

--- a/xllm/python/model_executor/forward_context.py
+++ b/xllm/python/model_executor/forward_context.py
@@ -17,16 +17,32 @@ from __future__ import annotations
 from contextlib import contextmanager
 from contextvars import ContextVar
 from dataclasses import dataclass
+from typing import TYPE_CHECKING, Callable
 
 import torch
 
-from xllm.python.attention.backend import AttentionBackend
+if TYPE_CHECKING:
+    from xllm.python.attention.backend import AttentionBackend
+
+
+@dataclass(frozen=True, slots=True)
+class AclGraphTask:
+    event: object
+    handle: object
+    update: Callable[[], None]
+
+
+@dataclass(slots=True)
+class AclGraphCaptureContext:
+    stream: object
+    tasks: list[AclGraphTask]
 
 
 @dataclass(frozen=True, slots=True)
 class ForwardContext:
     attention_backend: AttentionBackend
     device: torch.device
+    acl_graph: AclGraphCaptureContext | None = None
 
 
 _current_context: ContextVar[ForwardContext | None] = ContextVar(

--- a/xllm/python/model_executor/runners/decode_acl_graph.py
+++ b/xllm/python/model_executor/runners/decode_acl_graph.py
@@ -38,6 +38,8 @@ import torch.nn as nn
 from xllm.python import ops
 from xllm.python.attention.backend import AttentionBackend, AttentionMetadata
 from xllm.python.model_executor.forward_context import (
+    AclGraphCaptureContext,
+    AclGraphTask,
     ForwardContext,
     forward_context,
 )
@@ -77,7 +79,7 @@ class _DecodeGraphEntry:
         "kv_seq_lens_delta",
         "host_seq_lens",
         "host_block_counts",
-        "task_handles",
+        "graph_tasks",
     )
 
 
@@ -99,6 +101,8 @@ class DecodeAclGraphRunner(BaseRunner):
         self._paged_kv_indices_buffer: torch.Tensor | None = None
         self._max_blocks_per_sequence: int = 0
         self._stream: torch.npu.Stream | None = None
+        self._update_stream: torch.npu.Stream | None = None
+        self._replay_done_event: torch.npu.Event | None = None
         self._warmed_up = False
 
     def can_execute(
@@ -169,34 +173,36 @@ class DecodeAclGraphRunner(BaseRunner):
 
         if self._stream is None:
             self._stream = torch.npu.Stream(device=input_ids.device)
+            self._update_stream = torch.npu.Stream(
+                device=input_ids.device, priority=-1
+            )
+            self._replay_done_event = torch.npu.Event()
+
+        assert self._update_stream is not None
+        assert self._replay_done_event is not None
 
         self._fill_entry(entry, input_ids, positions, metadata, batch_size)
 
-        self.attention_backend.prepare(
-            metadata,
-            graph_mode=True,
-            static_block_table=entry.static_metadata.block_table,
-            padded_batch_size=padded_batch_size,
-            static_slot_mapping=entry.static_metadata.slot_mapping,
-        )
+        self.attention_backend.prepare(entry.static_metadata, graph_mode=True)
 
         if first_capture:
-            with forward_context(
-                ForwardContext(self.attention_backend, self.device)
-            ):
-                self._capture(entry)
+            self._capture(entry)
 
         self._stream.wait_stream(torch.npu.current_stream())
         with torch.npu.stream(self._stream):
-            with forward_context(
-                ForwardContext(self.attention_backend, self.device)
-            ):
-                if not first_capture:
-                    self.attention_backend.update_replay_args(
-                        self._stream, entry.task_handles
-                    )
-                entry.graph.replay()
-                output = entry.static_output[:batch_size].clone()
+            entry.graph.replay()
+            output = entry.static_output[:batch_size].clone()
+
+        # A captured FIA task waits on its update event before execution.  This
+        # lets replay run concurrently with the host-side updates for later
+        # layers while preventing the graph from observing stale parameters.
+        with torch.npu.stream(self._update_stream):
+            self._update_stream.wait_event(self._replay_done_event)
+            self._update_graph_tasks(self._update_stream, entry.graph_tasks)
+
+        # The next update must not overwrite task parameters until this replay
+        # has consumed them.
+        self._replay_done_event.record(self._stream)
 
         torch.npu.current_stream().wait_stream(self._stream)
         return output
@@ -232,7 +238,7 @@ class DecodeAclGraphRunner(BaseRunner):
         entry.batch_size = padded_batch_size
         entry.graph = None
         entry.static_output = None
-        entry.task_handles = []
+        entry.graph_tasks = []
         entry.static_input_ids = torch.zeros(
             padded_batch_size, dtype=input_ids.dtype, device=device
         )
@@ -358,6 +364,19 @@ class DecodeAclGraphRunner(BaseRunner):
 
         padded_batch_size = entry.batch_size
         static_metadata = entry.static_metadata
+        torch.sub(
+            cumulative_seq_lens[1:],
+            cumulative_seq_lens[:-1],
+            out=entry.host_seq_lens[:batch_size],
+        )
+        if padded_batch_size > batch_size:
+            entry.host_seq_lens[batch_size:padded_batch_size].fill_(1)
+        torch.cumsum(
+            entry.host_seq_lens,
+            dim=0,
+            out=static_metadata.kv_seq_lens_host[1:],
+        )
+
         page_size = self.attention_backend.page_size
         if page_size == 1:
             static_metadata.paged_kv_indptr_host[: batch_size + 1].copy_(
@@ -365,13 +384,6 @@ class DecodeAclGraphRunner(BaseRunner):
             )
             static_metadata.paged_kv_last_page_len_host.fill_(1)
         else:
-            torch.sub(
-                cumulative_seq_lens[1:],
-                cumulative_seq_lens[:-1],
-                out=entry.host_seq_lens[:batch_size],
-            )
-            if padded_batch_size > batch_size:
-                entry.host_seq_lens[batch_size:padded_batch_size].zero_()
             torch.add(
                 entry.host_seq_lens,
                 page_size - 1,
@@ -413,22 +425,37 @@ class DecodeAclGraphRunner(BaseRunner):
                 batch_size + 1 : padded_batch_size + 1
             ].fill_(int(cumulative_seq_lens[-1]))
 
-        static_metadata.kv_seq_lens_host[: batch_size + 1].copy_(
-            cumulative_seq_lens
-        )
-        if padded_batch_size > batch_size:
-            static_metadata.kv_seq_lens_host[
-                batch_size + 1 :
-            ].fill_(int(cumulative_seq_lens[-1]))
-
     def _capture(self, entry: _DecodeGraphEntry) -> None:
-        for _ in range(_CAPTURE_WARMUP_STEPS):
-            self.model(entry.static_input_ids, entry.static_positions)
+        context = ForwardContext(self.attention_backend, self.device)
+        with forward_context(context):
+            for _ in range(_CAPTURE_WARMUP_STEPS):
+                self.model(entry.static_input_ids, entry.static_positions)
         torch.npu.synchronize()
         entry.graph = torch.npu.NPUGraph()
-        self.attention_backend.begin_capture(self._stream)
-        with torch.npu.graph(entry.graph, stream=self._stream):
-            entry.static_output = self.model(
-                entry.static_input_ids, entry.static_positions
-            )
-        entry.task_handles = self.attention_backend.end_capture()
+        capture_context = AclGraphCaptureContext(self._stream, [])
+        context = ForwardContext(
+            self.attention_backend,
+            self.device,
+            acl_graph=capture_context,
+        )
+        with forward_context(context):
+            with torch.npu.graph(entry.graph, stream=self._stream):
+                entry.static_output = self.model(
+                    entry.static_input_ids, entry.static_positions
+                )
+        entry.graph_tasks = capture_context.tasks
+
+    @staticmethod
+    def _update_graph_tasks(
+        stream: torch.npu.Stream,
+        graph_tasks: list[AclGraphTask],
+    ) -> None:
+        for task in graph_tasks:
+            torch.npu.graph_task_update_begin(stream, task.handle)
+            try:
+                task.update()
+            except Exception:
+                torch.npu.graph_task_update_end(stream)
+                raise
+            torch.npu.graph_task_update_end(stream)
+            task.event.record(stream)

--- a/xllm/python/model_executor/runners/decode_acl_graph.py
+++ b/xllm/python/model_executor/runners/decode_acl_graph.py
@@ -1,0 +1,434 @@
+# Copyright 2026 The xLLM Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://github.com/jd-opensource/xllm/blob/main/LICENSE
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""NPU (Ascend) ACL graph runner for the Python model executor.
+
+Captures and replays decode-step graphs using ``torch.npu.NPUGraph``.
+Mirrors the structure of ``decode_cuda_graph.py`` but adds NPU-specific
+logic:
+
+* ``torch.npu.graph_task_group_begin/end`` around FIA ``.out`` calls during
+  capture.
+* ``torch.npu.graph_task_update_begin/end`` to refresh FIA host params before
+  replay.
+* Static ``block_table`` and ``slot_mapping`` tensors so the graph records
+  fixed addresses whose *contents* are updated via ``_fill_entry`` each step.
+* C++ ACLNN ops (RMSNorm, SiLU, reshape_paged_cache) are used in both eager
+  and capture modes — no PyTorch fallbacks needed.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import torch
+import torch.nn as nn
+
+from xllm.python import ops
+from xllm.python.attention.backend import AttentionBackend, AttentionMetadata
+from xllm.python.model_executor.forward_context import (
+    ForwardContext,
+    forward_context,
+)
+from xllm.python.model_executor.runners.base import BaseRunner
+from xllm.python.model_executor.runners.decode_cuda_graph import (
+    _CAPTURE_WARMUP_STEPS,
+    _decode_bucket,
+)
+
+
+@dataclass(slots=True)
+class _StaticAttentionMetadata:
+    slot_mapping: torch.Tensor
+    paged_kv_indptr: torch.Tensor
+    paged_kv_indices: torch.Tensor
+    paged_kv_last_page_len: torch.Tensor
+    qo_indptr: torch.Tensor | None = None
+    q_cu_seq_lens: torch.Tensor | None = None
+    kv_cu_seq_lens: torch.Tensor | None = None
+    kv_seq_lens_host: torch.Tensor | None = None
+    paged_kv_indptr_host: torch.Tensor | None = None
+    paged_kv_last_page_len_host: torch.Tensor | None = None
+    block_table: torch.Tensor | None = None
+    kv_seq_lens: torch.Tensor | None = None
+    is_prefill: bool = False
+    is_chunked_prefill: bool = False
+
+
+class _DecodeGraphEntry:
+    __slots__ = (
+        "batch_size",
+        "graph",
+        "static_output",
+        "static_input_ids",
+        "static_positions",
+        "static_metadata",
+        "kv_seq_lens_delta",
+        "host_seq_lens",
+        "host_block_counts",
+        "task_handles",
+    )
+
+
+class DecodeAclGraphRunner(BaseRunner):
+    """Decode graph runner for NPU (Ascend) using ACL graph capture/replay."""
+
+    def __init__(
+        self,
+        model: nn.Module,
+        attention_backend: AttentionBackend,
+        device: torch.device,
+        max_batch: int,
+        max_model_len: int,
+    ) -> None:
+        super().__init__(model, attention_backend, device)
+        self.max_batch = max_batch
+        self.max_model_len = max_model_len
+        self._graphs: dict[int, _DecodeGraphEntry] = {}
+        self._paged_kv_indices_buffer: torch.Tensor | None = None
+        self._max_blocks_per_sequence: int = 0
+        self._stream: torch.npu.Stream | None = None
+        self._warmed_up = False
+
+    def can_execute(
+        self, input_ids: torch.Tensor, metadata: AttentionMetadata
+    ) -> bool:
+        return (
+            not metadata.is_prefill
+            and not metadata.is_chunked_prefill
+            and _decode_bucket(input_ids.shape[0]) <= self.max_batch
+        )
+
+    def warmup(self, device: torch.device, _dtype: torch.dtype) -> None:
+        if self._warmed_up:
+            return
+        self._warmed_up = True
+
+        buckets = [size for size in (1, 2, 4, 8) if size <= self.max_batch]
+        buckets.extend(range(16, self.max_batch + 1, 16))
+        page_size = self.attention_backend.page_size
+        for batch_size in buckets:
+            slot_base = torch.arange(
+                batch_size, dtype=torch.int32, device=device
+            ).mul_(page_size)
+            block_ids = torch.arange(
+                batch_size, dtype=torch.int32, device=device
+            )
+            metadata = _StaticAttentionMetadata(
+                slot_mapping=slot_base,
+                paged_kv_indptr=torch.arange(
+                    batch_size + 1, dtype=torch.int32, device=device
+                ),
+                paged_kv_indices=block_ids,
+                paged_kv_last_page_len=torch.ones(
+                    batch_size, dtype=torch.int32, device=device
+                ),
+                kv_seq_lens_host=torch.arange(
+                    batch_size + 1, dtype=torch.int32, device="cpu"
+                ).mul_(2),
+                kv_cu_seq_lens=torch.arange(
+                    batch_size + 1, dtype=torch.int32, device=device
+                ).mul_(2),
+                block_table=block_ids.unsqueeze(1),
+            )
+            self.execute(
+                torch.zeros(batch_size, dtype=torch.int32, device=device),
+                torch.zeros(batch_size, dtype=torch.int32, device=device),
+                metadata,
+            )
+
+    def execute(
+        self,
+        input_ids: torch.Tensor,
+        positions: torch.Tensor,
+        metadata: AttentionMetadata,
+    ) -> torch.Tensor:
+        batch_size = input_ids.shape[0]
+        padded_batch_size = _decode_bucket(batch_size)
+        if padded_batch_size > self.max_batch:
+            raise ValueError("decode batch exceeds ACL graph capacity")
+
+        entry = self._graphs.get(padded_batch_size)
+        first_capture = entry is None
+        if first_capture:
+            entry = self._allocate_entry(
+                padded_batch_size, input_ids, positions, metadata
+            )
+            self._graphs[padded_batch_size] = entry
+
+        if self._stream is None:
+            self._stream = torch.npu.Stream(device=input_ids.device)
+
+        self._fill_entry(entry, input_ids, positions, metadata, batch_size)
+
+        self.attention_backend.prepare(
+            metadata,
+            graph_mode=True,
+            static_block_table=entry.static_metadata.block_table,
+            padded_batch_size=padded_batch_size,
+            static_slot_mapping=entry.static_metadata.slot_mapping,
+        )
+
+        if first_capture:
+            with forward_context(
+                ForwardContext(self.attention_backend, self.device)
+            ):
+                self._capture(entry)
+
+        self._stream.wait_stream(torch.npu.current_stream())
+        with torch.npu.stream(self._stream):
+            with forward_context(
+                ForwardContext(self.attention_backend, self.device)
+            ):
+                if not first_capture:
+                    self.attention_backend.update_replay_args(
+                        self._stream, entry.task_handles
+                    )
+                entry.graph.replay()
+                output = entry.static_output[:batch_size].clone()
+
+        torch.npu.current_stream().wait_stream(self._stream)
+        return output
+
+    def _allocate_entry(
+        self,
+        padded_batch_size: int,
+        input_ids: torch.Tensor,
+        positions: torch.Tensor,
+        metadata: AttentionMetadata,
+    ) -> _DecodeGraphEntry:
+        device = input_ids.device
+        if self._paged_kv_indices_buffer is None:
+            page_size = self.attention_backend.page_size
+            max_blocks_per_sequence = (
+                self.max_model_len + page_size - 1
+            ) // page_size
+            self._paged_kv_indices_buffer = torch.zeros(
+                self.max_batch * max_blocks_per_sequence,
+                dtype=metadata.paged_kv_indices.dtype,
+                device=device,
+            )
+            self._max_blocks_per_sequence = max_blocks_per_sequence
+
+        static_block_table = torch.zeros(
+            padded_batch_size,
+            self._max_blocks_per_sequence,
+            dtype=torch.int32,
+            device=device,
+        )
+
+        entry = _DecodeGraphEntry()
+        entry.batch_size = padded_batch_size
+        entry.graph = None
+        entry.static_output = None
+        entry.task_handles = []
+        entry.static_input_ids = torch.zeros(
+            padded_batch_size, dtype=input_ids.dtype, device=device
+        )
+        entry.static_positions = torch.zeros(
+            padded_batch_size, dtype=torch.int32, device=device
+        )
+        entry.static_metadata = _StaticAttentionMetadata(
+            slot_mapping=torch.zeros(
+                padded_batch_size,
+                dtype=metadata.slot_mapping.dtype,
+                device=device,
+            ),
+            paged_kv_indptr=torch.zeros(
+                padded_batch_size + 1,
+                dtype=metadata.paged_kv_indptr.dtype,
+                device=device,
+            ),
+            paged_kv_indices=self._paged_kv_indices_buffer,
+            paged_kv_last_page_len=torch.zeros(
+                padded_batch_size,
+                dtype=metadata.paged_kv_last_page_len.dtype,
+                device=device,
+            ),
+            kv_cu_seq_lens=torch.zeros(
+                padded_batch_size + 1,
+                dtype=torch.int32,
+                device=device,
+            ),
+            paged_kv_indptr_host=torch.zeros(
+                padded_batch_size + 1, dtype=torch.int32, device="cpu"
+            ),
+            paged_kv_last_page_len_host=torch.ones(
+                padded_batch_size, dtype=torch.int32, device="cpu"
+            ),
+            kv_seq_lens_host=torch.zeros(
+                padded_batch_size + 1, dtype=torch.int32, device="cpu"
+            ),
+            block_table=static_block_table,
+        )
+        entry.kv_seq_lens_delta = torch.empty(
+            padded_batch_size, dtype=torch.int32, device=device
+        )
+        entry.host_seq_lens = torch.empty(
+            padded_batch_size, dtype=torch.int32, device="cpu"
+        )
+        entry.host_block_counts = torch.empty(
+            padded_batch_size, dtype=torch.int32, device="cpu"
+        )
+        return entry
+
+    def _fill_entry(
+        self,
+        entry: _DecodeGraphEntry,
+        input_ids: torch.Tensor,
+        positions: torch.Tensor,
+        metadata: AttentionMetadata,
+        batch_size: int,
+    ) -> None:
+        padded_batch_size = entry.batch_size
+        static_metadata = entry.static_metadata
+        if metadata.kv_cu_seq_lens is None:
+            raise RuntimeError(
+                "decode ACL graph requires device cumulative KV lengths"
+            )
+        graph_positions = positions.to(torch.int32).contiguous()
+        ops.update_decode_graph_metadata(
+            input_ids,
+            graph_positions,
+            metadata.slot_mapping,
+            metadata.kv_cu_seq_lens,
+            metadata.paged_kv_indptr,
+            metadata.paged_kv_indices,
+            metadata.paged_kv_last_page_len,
+            entry.static_input_ids,
+            entry.static_positions,
+            static_metadata.slot_mapping,
+            static_metadata.kv_cu_seq_lens,
+            entry.kv_seq_lens_delta,
+            static_metadata.paged_kv_indptr,
+            static_metadata.paged_kv_indices,
+            static_metadata.paged_kv_last_page_len,
+            padded_batch_size,
+        )
+        self._fill_host_metadata(entry, metadata, batch_size)
+
+        if (
+            metadata.block_table is not None
+            and static_metadata.block_table is not None
+        ):
+            src_bt = metadata.block_table.to(torch.int32)
+            copy_cols = min(
+                src_bt.shape[1],
+                static_metadata.block_table.shape[1],
+            )
+            static_metadata.block_table[:batch_size, :copy_cols].copy_(
+                src_bt[:batch_size, :copy_cols]
+            )
+            if padded_batch_size > batch_size:
+                static_metadata.block_table[batch_size:].zero_()
+
+    def _fill_host_metadata(
+        self,
+        entry: _DecodeGraphEntry,
+        metadata: AttentionMetadata,
+        batch_size: int,
+    ) -> None:
+        cumulative_seq_lens = metadata.kv_seq_lens_host
+        if cumulative_seq_lens is None:
+            raise RuntimeError("decode ACL graph requires host KV lengths")
+        cumulative_seq_lens = cumulative_seq_lens.cpu()
+        if cumulative_seq_lens.numel() == batch_size:
+            cum = torch.zeros(
+                batch_size + 1,
+                dtype=cumulative_seq_lens.dtype,
+                device=cumulative_seq_lens.device,
+            )
+            cum[1:] = torch.cumsum(cumulative_seq_lens, dim=0)
+            cumulative_seq_lens = cum
+        if cumulative_seq_lens.numel() != batch_size + 1:
+            raise RuntimeError(
+                "decode ACL graph requires cumulative host KV lengths"
+            )
+
+        padded_batch_size = entry.batch_size
+        static_metadata = entry.static_metadata
+        page_size = self.attention_backend.page_size
+        if page_size == 1:
+            static_metadata.paged_kv_indptr_host[: batch_size + 1].copy_(
+                cumulative_seq_lens
+            )
+            static_metadata.paged_kv_last_page_len_host.fill_(1)
+        else:
+            torch.sub(
+                cumulative_seq_lens[1:],
+                cumulative_seq_lens[:-1],
+                out=entry.host_seq_lens[:batch_size],
+            )
+            if padded_batch_size > batch_size:
+                entry.host_seq_lens[batch_size:padded_batch_size].zero_()
+            torch.add(
+                entry.host_seq_lens,
+                page_size - 1,
+                out=entry.host_block_counts,
+            )
+            torch.div(
+                entry.host_block_counts,
+                page_size,
+                rounding_mode="floor",
+                out=entry.host_block_counts,
+            )
+            torch.cumsum(
+                entry.host_block_counts,
+                dim=0,
+                out=static_metadata.paged_kv_indptr_host[1:],
+            )
+            torch.sub(
+                entry.host_seq_lens,
+                1,
+                out=static_metadata.paged_kv_last_page_len_host,
+            )
+            torch.remainder(
+                static_metadata.paged_kv_last_page_len_host,
+                page_size,
+                out=static_metadata.paged_kv_last_page_len_host,
+            )
+            torch.add(
+                static_metadata.paged_kv_last_page_len_host,
+                1,
+                out=static_metadata.paged_kv_last_page_len_host,
+            )
+            if padded_batch_size > batch_size:
+                static_metadata.paged_kv_last_page_len_host[
+                    batch_size:padded_batch_size
+                ].fill_(1)
+
+        if page_size == 1 and padded_batch_size > batch_size:
+            static_metadata.paged_kv_indptr_host[
+                batch_size + 1 : padded_batch_size + 1
+            ].fill_(int(cumulative_seq_lens[-1]))
+
+        static_metadata.kv_seq_lens_host[: batch_size + 1].copy_(
+            cumulative_seq_lens
+        )
+        if padded_batch_size > batch_size:
+            static_metadata.kv_seq_lens_host[
+                batch_size + 1 :
+            ].fill_(int(cumulative_seq_lens[-1]))
+
+    def _capture(self, entry: _DecodeGraphEntry) -> None:
+        for _ in range(_CAPTURE_WARMUP_STEPS):
+            self.model(entry.static_input_ids, entry.static_positions)
+        torch.npu.synchronize()
+        entry.graph = torch.npu.NPUGraph()
+        self.attention_backend.begin_capture(self._stream)
+        with torch.npu.graph(entry.graph, stream=self._stream):
+            entry.static_output = self.model(
+                entry.static_input_ids, entry.static_positions
+            )
+        entry.task_handles = self.attention_backend.end_capture()

--- a/xllm/python/models/qwen3.py
+++ b/xllm/python/models/qwen3.py
@@ -38,7 +38,7 @@ from xllm.python.layers import (
     RotaryEmbedding,
     RowParallelLinear,
 )
-from xllm.python.model_executor.forward_context import get_forward_context
+from xllm.python.model_executor.forward_context import ForwardContext, forward_context  # noqa: F401
 from xllm.python.models.base import PyModelBase
 
 
@@ -297,13 +297,10 @@ class Qwen3Model(nn.Module):
         # (its output lives in the graph memory pool), so replay re-casts the
         # updated static_positions correctly.
         positions = positions.to(torch.int64).contiguous()
-        cos, sin = None, None
-        if get_forward_context().device.type in ("npu", "privateuseone"):
-            cos, sin = self.rotary(positions)
         residual: Optional[torch.Tensor] = None
         for layer in self.layers:
             hidden, residual = layer(
-                hidden, residual, positions, self.rotary.cos_sin_cache, cos, sin
+                hidden, residual, positions, self.rotary.cos_sin_cache, None, None
             )
         hidden, _ = self.norm(hidden, residual)
         return hidden

--- a/xllm/python/models/qwen3.py
+++ b/xllm/python/models/qwen3.py
@@ -412,6 +412,11 @@ class Qwen3ForCausalLM(PyModelBase):
             copy_in(p + "mlp.down_proj.weight",
                     shard(p + "mlp.down_proj.weight", dim=1))
 
+            if self.device.type in ("npu", "privateuseone"):
+                layer = self.model.layers[i]
+                layer.self_attn.o_proj.format_npu_weight_()
+                layer.mlp.down_proj.format_npu_weight_()
+
         norm_name = "model.norm.weight"
         if not find(norm_name):
             norm_name = "norm.weight"

--- a/xllm/python/ops/compute.py
+++ b/xllm/python/ops/compute.py
@@ -68,44 +68,17 @@ def fused_qk_norm_rope(
         )
         return qkv[:, :q_size], qkv[:, q_size:q_size + kv_size], qkv[:, q_size + kv_size:]
     if device_type in ("npu", "privateuseone"):
-        return _fused_qk_norm_rope_npu(
-            qkv, num_heads_q, num_heads_k, head_dim, eps,
-            q_weight, k_weight, cos, sin,
+        from xllm.python.ops.triton.split_qkv_rmsnorm_rope import (
+            split_qkv_rmsnorm_rope,
+        )
+        return split_qkv_rmsnorm_rope(
+            qkv, cos_sin_cache, position_ids,
+            q_weight, k_weight,
+            q_size, kv_size, head_dim, eps,
         )
     raise NotImplementedError(
         f"fused_qk_norm_rope is not supported on device type '{device_type}'"
     )
-
-
-def _fused_qk_norm_rope_npu(
-    qkv: torch.Tensor,
-    num_heads_q: int, num_heads_k: int,
-    head_dim: int, eps: float,
-    q_weight: torch.Tensor, k_weight: torch.Tensor,
-    cos: torch.Tensor | None,
-    sin: torch.Tensor | None,
-) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
-    num_tokens = qkv.size(0)
-    q_size = num_heads_q * head_dim
-    k_size = num_heads_k * head_dim
-
-    q = torch.ops.xllm_ops.rms_norm(
-        qkv[:, :q_size].reshape(num_tokens * num_heads_q, head_dim), q_weight, eps,
-    ).view(num_tokens, q_size)
-    k = torch.ops.xllm_ops.rms_norm(
-        qkv[:, q_size:q_size + k_size].reshape(num_tokens * num_heads_k, head_dim),
-        k_weight, eps,
-    ).view(num_tokens, k_size)
-
-    q_out = torch.ops.npu.npu_rotary_mul(
-        q.view(1, num_tokens, num_heads_q, head_dim), cos, sin,
-    ).view(num_tokens, q_size)
-    k_out = torch.ops.npu.npu_rotary_mul(
-        k.view(1, num_tokens, num_heads_k, head_dim), cos, sin,
-    ).view(num_tokens, k_size)
-
-    v = qkv[:, q_size + k_size:]
-    return q_out, k_out, v
 
 
 @torch.library.register_fake("xllm_ops::fused_qk_norm_rope")

--- a/xllm/python/ops/triton/split_qkv_rmsnorm_rope.py
+++ b/xllm/python/ops/triton/split_qkv_rmsnorm_rope.py
@@ -1,0 +1,297 @@
+from __future__ import annotations
+
+import torch
+import triton
+import triton.language as tl
+
+from xllm.python.ops.triton.triton_utils import (
+    extract_slice,
+    get_element,
+    get_vectorcore_num,
+    insert_slice,
+)
+
+
+@triton.jit
+def _split_qkv_rmsnorm_rope_kernel(
+    input_gm_ptr,
+    q_gm_ptr,
+    k_gm_ptr,
+    v_gm_ptr,
+    q_weight_ptr,
+    k_weight_ptr,
+    batch_size,
+    q_hidden_size: tl.constexpr,
+    kv_hidden_size: tl.constexpr,
+    total_hidden_size: tl.constexpr,
+    eps: tl.constexpr,
+    HEAD_DIM: tl.constexpr,
+    ROPE_DIM: tl.constexpr,
+    HALF_ROPE_DIM: tl.constexpr,
+    num_vectorcore: tl.constexpr,
+    batch_size_per_iter_per_vec: tl.constexpr,
+    qk_head_nums_per_iter_per_vec: tl.constexpr,
+    q_head_num: tl.constexpr,
+    kv_head_num: tl.constexpr,
+    qk_head_num_sum: tl.constexpr,
+    v_batch_size_per_iter_per_vec: tl.constexpr,
+    positions_gm_ptr,
+    cos_sin_cache_gm_ptr,
+):
+    row_pid = tl.program_id(0)
+
+    q_weight_values = tl.load(q_weight_ptr + tl.arange(0, HEAD_DIM))
+    k_weight_values = tl.load(k_weight_ptr + tl.arange(0, HEAD_DIM))
+
+    batch_size_per_vec = tl.cdiv(batch_size, num_vectorcore)
+    iter_num_per_vec = tl.cdiv(batch_size_per_vec, batch_size_per_iter_per_vec)
+    v_iter_num_per_vec = tl.cdiv(batch_size_per_vec, v_batch_size_per_iter_per_vec)
+    input_batch_offset = row_pid * batch_size_per_vec
+    mblk_idx = tl.arange(0, batch_size_per_iter_per_vec) + input_batch_offset
+    nblk_idx = tl.arange(0, q_hidden_size + kv_hidden_size)
+    nmask = nblk_idx < total_hidden_size
+
+    input_batch_offset_end = min(input_batch_offset + batch_size_per_vec, batch_size)
+
+    pos_indices = input_batch_offset + tl.arange(0, batch_size_per_iter_per_vec)
+    output_q_nblk_idx = tl.arange(0, q_hidden_size)
+    output_q_nmask = output_q_nblk_idx < q_hidden_size
+    output_kv_nblk_idx = tl.arange(0, kv_hidden_size)
+    output_kv_nmask = output_kv_nblk_idx < kv_hidden_size
+    sin_cos_range = tl.arange(0, ROPE_DIM)
+    cos_sin_cache_offset = cos_sin_cache_gm_ptr + sin_cos_range
+
+    for iter in tl.range(iter_num_per_vec):
+        pos_offset = iter * batch_size_per_iter_per_vec
+        x = tl.load(
+            positions_gm_ptr + pos_indices + pos_offset,
+            mask=(pos_indices + pos_offset) < input_batch_offset_end,
+        )
+        mmask = (mblk_idx + pos_offset) < input_batch_offset_end
+        mask = (mmask[:, None]) & (nmask[None, :])
+        idx = (mblk_idx + pos_offset)[:, None] * total_hidden_size + nblk_idx[None, :]
+        values_tmp1 = tl.load(input_gm_ptr + idx, mask=mask).reshape(
+            qk_head_nums_per_iter_per_vec, HEAD_DIM
+        )
+
+        values_tmp3 = tl.zeros((batch_size_per_iter_per_vec, ROPE_DIM), dtype=tl.bfloat16)
+        for i in tl.range(batch_size_per_iter_per_vec):
+            pos = get_element(x, (i,))
+            values_tmp3 = insert_slice(
+                values_tmp3.reshape(batch_size_per_iter_per_vec, ROPE_DIM),
+                tl.load(pos * ROPE_DIM + cos_sin_cache_offset[:, None]).reshape(
+                    1, ROPE_DIM
+                ),
+                offsets=(i, 0),
+                sizes=(1, ROPE_DIM),
+                strides=(1, 1),
+            )
+        values_tmp3 = values_tmp3.reshape(batch_size_per_iter_per_vec, 1, ROPE_DIM)
+        cos = extract_slice(
+            values_tmp3,
+            offsets=(0, 0, 0),
+            sizes=(batch_size_per_iter_per_vec, 1, HALF_ROPE_DIM),
+            strides=(1, 1, 1),
+        )
+        sin = extract_slice(
+            values_tmp3,
+            offsets=(0, 0, HALF_ROPE_DIM),
+            sizes=(batch_size_per_iter_per_vec, 1, HALF_ROPE_DIM),
+            strides=(1, 1, 1),
+        )
+
+        normalized_values = values_tmp1.to(tl.float32)
+        normalized_values = normalized_values * normalized_values
+        normalized_values = tl.sum(normalized_values, axis=1) / HEAD_DIM
+        normalized_values = 1 / tl.sqrt(normalized_values + eps).reshape(
+            qk_head_nums_per_iter_per_vec, 1
+        )
+        normalized_values = values_tmp1 * normalized_values
+
+        # Q: norm * weight + rope
+        normalized_values_tmp = extract_slice(
+            normalized_values.reshape(
+                batch_size_per_iter_per_vec, qk_head_num_sum, HEAD_DIM
+            ),
+            offsets=(0, 0, 0),
+            sizes=(batch_size_per_iter_per_vec, q_head_num, HEAD_DIM),
+            strides=(1, 1, 1),
+        )
+        normalized_values_tmp = (normalized_values_tmp * q_weight_values).to(tl.bfloat16)
+
+        values_tmp = tl.zeros(
+            (batch_size_per_iter_per_vec, q_head_num, ROPE_DIM), dtype=tl.bfloat16
+        )
+        x1 = extract_slice(
+            normalized_values_tmp,
+            offsets=(0, 0, 0),
+            sizes=(batch_size_per_iter_per_vec, q_head_num, HALF_ROPE_DIM),
+            strides=(1, 1, 1),
+        )
+        x2 = extract_slice(
+            normalized_values_tmp,
+            offsets=(0, 0, HALF_ROPE_DIM),
+            sizes=(batch_size_per_iter_per_vec, q_head_num, HALF_ROPE_DIM),
+            strides=(1, 1, 1),
+        )
+        values_tmp = insert_slice(
+            values_tmp,
+            x1 * cos - x2 * sin,
+            offsets=(0, 0, 0),
+            sizes=(batch_size_per_iter_per_vec, q_head_num, HALF_ROPE_DIM),
+            strides=(1, 1, 1),
+        )
+        values_tmp = insert_slice(
+            values_tmp,
+            x2 * cos + x1 * sin,
+            offsets=(0, 0, HALF_ROPE_DIM),
+            sizes=(batch_size_per_iter_per_vec, q_head_num, HALF_ROPE_DIM),
+            strides=(1, 1, 1),
+        )
+        q_output_idx = output_q_nblk_idx[None, :] + (
+            mblk_idx + pos_offset
+        )[:, None] * q_hidden_size
+        q_mask = (mmask[:, None]) & (output_q_nmask[None, :])
+        tl.store(
+            q_gm_ptr + q_output_idx,
+            values_tmp.reshape(batch_size_per_iter_per_vec, q_hidden_size),
+            mask=q_mask,
+        )
+
+        # K: norm * weight + rope
+        normalized_values_tmp1 = extract_slice(
+            normalized_values.reshape(
+                batch_size_per_iter_per_vec, qk_head_num_sum, HEAD_DIM
+            ),
+            offsets=(0, q_head_num, 0),
+            sizes=(batch_size_per_iter_per_vec, kv_head_num, HEAD_DIM),
+            strides=(1, 1, 1),
+        )
+        normalized_values_tmp1 = (normalized_values_tmp1 * k_weight_values).to(
+            tl.bfloat16
+        )
+
+        values_tmp2 = tl.zeros(
+            (batch_size_per_iter_per_vec, kv_head_num, ROPE_DIM), dtype=tl.bfloat16
+        )
+        x1 = extract_slice(
+            normalized_values_tmp1,
+            offsets=(0, 0, 0),
+            sizes=(batch_size_per_iter_per_vec, kv_head_num, HALF_ROPE_DIM),
+            strides=(1, 1, 1),
+        )
+        x2 = extract_slice(
+            normalized_values_tmp1,
+            offsets=(0, 0, HALF_ROPE_DIM),
+            sizes=(batch_size_per_iter_per_vec, kv_head_num, HALF_ROPE_DIM),
+            strides=(1, 1, 1),
+        )
+        values_tmp2 = insert_slice(
+            values_tmp2,
+            x1 * cos - x2 * sin,
+            offsets=(0, 0, 0),
+            sizes=(batch_size_per_iter_per_vec, kv_head_num, HALF_ROPE_DIM),
+            strides=(1, 1, 1),
+        )
+        values_tmp2 = insert_slice(
+            values_tmp2,
+            x2 * cos + x1 * sin,
+            offsets=(0, 0, HALF_ROPE_DIM),
+            sizes=(batch_size_per_iter_per_vec, kv_head_num, HALF_ROPE_DIM),
+            strides=(1, 1, 1),
+        )
+        kv_output_idx = output_kv_nblk_idx[None, :] + (
+            mblk_idx + pos_offset
+        )[:, None] * kv_hidden_size
+        kv_mask = (mmask[:, None]) & (output_kv_nmask[None, :])
+        tl.store(
+            k_gm_ptr + kv_output_idx,
+            values_tmp2.reshape(batch_size_per_iter_per_vec, kv_hidden_size),
+            mask=kv_mask,
+        )
+
+    # V: just copy
+    mblk_idx = tl.arange(0, v_batch_size_per_iter_per_vec) + input_batch_offset
+    nblk_idx = tl.arange(q_hidden_size + kv_hidden_size, total_hidden_size)
+    nmask = nblk_idx < total_hidden_size
+    out_nblk_idx = tl.arange(0, kv_hidden_size)
+    out_nmask = out_nblk_idx < kv_hidden_size
+
+    for _ in tl.range(v_iter_num_per_vec):
+        mmask = mblk_idx < input_batch_offset_end
+        mask = (mmask[:, None]) & (nmask[None, :])
+        idx = mblk_idx[:, None] * total_hidden_size + nblk_idx[None, :]
+        values = tl.load(input_gm_ptr + idx, mask=mask)
+        out_idx = mblk_idx[:, None] * kv_hidden_size + out_nblk_idx[None, :]
+        out_mask = (mmask[:, None]) & (out_nmask[None, :])
+        tl.store(v_gm_ptr + out_idx, values, mask=out_mask)
+        mblk_idx += v_batch_size_per_iter_per_vec
+
+
+def split_qkv_rmsnorm_rope(
+    qkv: torch.Tensor,
+    cos_sin_cache: torch.Tensor,
+    positions: torch.Tensor,
+    q_weight: torch.Tensor,
+    k_weight: torch.Tensor,
+    q_hidden_size: int,
+    kv_hidden_size: int,
+    head_dim: int,
+    eps: float,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    num_vectorcore = get_vectorcore_num()
+    rope_dim = cos_sin_cache.shape[-1]
+    batch_size = qkv.shape[0]
+    total_hidden_size = q_hidden_size + kv_hidden_size * 2
+
+    q_output = torch.empty(
+        batch_size, q_hidden_size, device=qkv.device, dtype=qkv.dtype
+    )
+    k_output = torch.empty(
+        batch_size, kv_hidden_size, device=qkv.device, dtype=qkv.dtype
+    )
+    v_output = torch.empty(
+        batch_size, kv_hidden_size, device=qkv.device, dtype=qkv.dtype
+    )
+
+    q_head_num = q_hidden_size // head_dim
+    kv_head_num = kv_hidden_size // head_dim
+
+    UB_SIZE = 87040
+    factor = 5 * q_hidden_size + 3 * kv_hidden_size + rope_dim * 2 + q_head_num * rope_dim // 2
+    batch_size_per_iter_per_vec = max(
+        1, int(UB_SIZE / qkv.element_size()) // factor
+    )
+    qk_head_num_sum = q_head_num + kv_head_num
+    qk_head_nums_per_iter_per_vec = batch_size_per_iter_per_vec * qk_head_num_sum
+    v_batch_size_per_iter_per_vec = int(
+        UB_SIZE / torch.bfloat16.itemsize // (kv_hidden_size + 1)
+    )
+
+    grid = (num_vectorcore, 1, 1)
+    _split_qkv_rmsnorm_rope_kernel[grid](
+        qkv,
+        q_output,
+        k_output,
+        v_output,
+        q_weight,
+        k_weight,
+        batch_size,
+        q_hidden_size,
+        kv_hidden_size,
+        total_hidden_size,
+        eps,
+        head_dim,
+        rope_dim,
+        rope_dim // 2,
+        num_vectorcore,
+        batch_size_per_iter_per_vec,
+        qk_head_nums_per_iter_per_vec,
+        q_head_num,
+        kv_head_num,
+        qk_head_num_sum,
+        v_batch_size_per_iter_per_vec,
+        positions,
+        cos_sin_cache,
+    )
+    return q_output, k_output, v_output

--- a/xllm/python/ops/triton/triton_utils.py
+++ b/xllm/python/ops/triton/triton_utils.py
@@ -1,0 +1,22 @@
+from __future__ import annotations
+
+import torch
+import triton
+import triton.language as tl
+import triton.language.extra.cann.extension as _cann_ext
+
+insert_slice = _cann_ext.insert_slice
+extract_slice = _cann_ext.extract_slice
+get_element = _cann_ext.get_element
+
+_NUM_VECTORCORE = -1
+
+
+def get_vectorcore_num() -> int:
+    global _NUM_VECTORCORE
+    if _NUM_VECTORCORE == -1:
+        props = triton.runtime.driver.active.utils.get_device_properties(
+            torch.npu.current_device()
+        )
+        _NUM_VECTORCORE = props.get("num_vectorcore", -1)
+    return _NUM_VECTORCORE


### PR DESCRIPTION
## Description

Add a new "aclgraph" option for --python_graph_backend that captures and replays decode-step graphs on Ascend NPU using native torch.npu.* APIs (NPUGraph, graph_task_group_begin/end, graph_task_update_begin/end).

Also optimize Qwen3 row-parallel weight layout for pytorch path, transform O proj, Down proj from ND to NZ.

## Change Type

- [ ] Bug fix
- [x] New feature
- [ ] Performance improvement
- [ ] Refactor
- [ ] Documentation
- [ ] Test
- [ ] Build or CI

## Performance Comparision (from server log)
Qwen3 1.7B, tp=1, 2k input + 1k output, batch=1
| Metric | C++ graph | Python aclgraph | Delta |
|---|---|---|---|
| TTFT avg (ms) | 40.13| 35.00 | Python 12.8% faster |
| TPOT avg (ms/tok) | 5.60 | 5.11 | Python 8.7% faster |
| Latency avg (s) | 5.785 | 5.295 | Python 8.4% faster |
| Decode toks/s | 178.26 | 194.58 | Python 9.2% faster |

Qwen3 8B, tp=1, 2k input + 1k output, batch=1
| Metric | C++ graph | Python aclgraph | Delta |
|---|---|---|---|
| TTFT avg (ms) | 134.75 | 126 | Python 6.5% faster |
| TPOT avg (ms/tok) | 14.74 | 14.81 | C++ 0.5% faster |
| Latency avg (s) | 15.208 | 15.274 | C++ 0.4% faster |
| Decode toks/s per request | 67.94 | 67.59 | C++ 0.5% faster |

Qwen3 8B, tp=1, 2k input + 1k output, batch=8
| Metric | C++ graph | Python aclgraph | Delta |
|---|---|---|---|
| TTFT avg (ms) | 639.38 | 602.25 | Python 5.8% faster |
| TPOT avg (ms/tok) | 18.73 | 18.38 | Python 1.9% faster |
| Latency avg (s) | 19.803 | 19.413 | Python 2.0% faster |
| Decode toks/s per request | 53.46 | 54.44 | Python 1.8% faster |

## Accuracy
<img width="428" height="214" alt="image" src="https://github.com/user-attachments/assets/351d1a77-0ca8-4255-9589-a570cf499c9a" />


## Unit Tests
<img width="1105" height="223" alt="image" src="https://github.com/user-attachments/assets/d330315a-98f8-4ee6-8c96-7ab2a9a130bb" />
