### PR TITLE
feat: support device prefix cache in PD-disaggregated mode for DSV4 and Qwen3.5.

### DIFF
--- a/tests/core/framework/block/composite_block_manager_test.cpp
+++ b/tests/core/framework/block/composite_block_manager_test.cpp
@@ -20,6 +20,7 @@ limitations under the License.
 #include <set>
 
 #include "framework/block/block_utils.h"
+#include "framework/config/scheduler_config.h"
 #include "framework/request/request.h"
 #include "framework/request/sequence.h"
 #include "framework/request/stopping_checker.h"
@@ -728,6 +729,143 @@ TEST(CompositeBlockManagerTest, Dsv4PrefixCacheExactRepeatPopsOneC128) {
             num_tokens - kBlockSizeRatio128);
 
   manager.deallocate_for_sequence(&seq_hit);
+}
+
+// DSV4 D-side (instance_is_decode=true) should skip the SWA leaf's prefix
+// cache entirely: no shared blocks on SWA even when the same prompt was
+// previously seeded. C4 / C128 continue to hit because the role predicate
+// only masks SWA / LINEAR / SINGLE on the DECODE side. This is the mirror of
+// Dsv4PrefixCacheHitOnRepeatedPrefix under the DECODE role.
+TEST(CompositeBlockManagerTest, DecodeRoleSkipsSwaPrefixCache) {
+  const uint32_t base_num_blocks = 4096;
+  const uint32_t window_size = 4 * kBaseBlockSize;
+  const uint32_t max_seqs_per_batch = 4;
+  BlockManager::Options opts = MakeCompositeOptions(
+      base_num_blocks, kBaseBlockSize, window_size, max_seqs_per_batch);
+  opts.max_tokens_per_batch(3 * kBlockSizeRatio128);
+  // First seed the cache under a PREFILL role so all three leaves publish
+  // their blocks -- then swap in a DECODE-role composite that shares the
+  // hash space via the same leaf construction path.
+  ASSERT_TRUE(opts.enable_prefix_cache());
+  {
+    CompositeBlockManager prefill_manager(build_composite_leaves(opts));
+    const size_t num_tokens = 2 * kBlockSizeRatio128;
+    const std::vector<int32_t> prompt(num_tokens, 7);
+    Sequence seq_seed = MakeTestSequence(0, prompt);
+    ASSERT_TRUE(prefill_manager.allocate_sequence(&seq_seed, num_tokens));
+    seq_seed.kv_state().incr_kv_cache_tokens_num(num_tokens);
+    prefill_manager.deallocate_for_sequence(&seq_seed);
+    seq_seed.reset();
+
+    // Under the PREFILL role, SWA/C4/C128 all hit.
+    Sequence seq_p_hit = MakeTestSequence(1, prompt);
+    prefill_manager.allocate_shared_for_sequence(&seq_p_hit);
+    EXPECT_GT(seq_p_hit.kv_state().shared_blocks_num(BlockType::SWA), 0u);
+    EXPECT_GT(seq_p_hit.kv_state().shared_blocks_num(BlockType::C4), 0u);
+    EXPECT_GT(seq_p_hit.kv_state().shared_blocks_num(BlockType::C128), 0u);
+    prefill_manager.deallocate_for_sequence(&seq_p_hit);
+  }
+
+  // Under DECODE role: separate manager (its own SWA leaf ⇒ own cache), so a
+  // fresh prompt lookup must return zero SWA / zero C4 / zero C128. The
+  // point of this test is that CONSTRUCTION does not FATAL and the SWA leaf
+  // is skipped at classify + probe time; the composite still classifies as
+  // SWA_COMPRESSED (C4+C128 remain prefix-cache-on).
+  BlockManager::Options decode_opts = opts;
+  decode_opts.instance_is_decode(true);
+  CompositeBlockManager decode_manager(build_composite_leaves(decode_opts));
+  const size_t num_tokens = 2 * kBlockSizeRatio128;
+  const std::vector<int32_t> prompt(num_tokens, 7);
+  Sequence seq_d = MakeTestSequence(2, prompt);
+  decode_manager.allocate_shared_for_sequence(&seq_d);
+  // SWA prefix cache is off on DECODE ⇒ never hits.
+  EXPECT_EQ(seq_d.kv_state().shared_blocks_num(BlockType::SWA), 0u);
+  // C4/C128 caches are fresh (per-manager) so also zero here, but the intent
+  // is: the participate predicate keeps them enabled so future hits work.
+  EXPECT_EQ(seq_d.kv_state().shared_blocks_num(BlockType::C4), 0u);
+  EXPECT_EQ(seq_d.kv_state().shared_blocks_num(BlockType::C128), 0u);
+  // No safe_hit_tokens change either (nothing mounted).
+  EXPECT_EQ(seq_d.kv_state().kv_cache_tokens_num(), 0u);
+
+  decode_manager.deallocate_for_sequence(&seq_d);
+}
+
+// Qwen3.5 GDN D-side (instance_is_decode=true, LINEAR present): the LINEAR
+// leaf should stop advertising prefix cache, so build_composite_leaves
+// classifies FLAT_KV_LINEAR down to FLAT_KV and no restore-source mount
+// happens. Guards against a null-deref regression inside
+// LinearStateBlockManager::allocate_for_sequence when the checkpoint index
+// is disabled by role.
+TEST(CompositeBlockManagerTest, DecodeRoleSkipsLinearPrefixCache) {
+  // LinearStateBlockManager pulls its chunk stride from the global scheduler
+  // config, so pin a valid stride for this test and restore it after.
+  const int32_t original_chunk_stride =
+      SchedulerConfig::get_instance().max_tokens_per_chunk_for_prefill();
+  SchedulerConfig::get_instance().max_tokens_per_chunk_for_prefill() = 128;
+
+  const uint32_t block_size = 128;
+  const uint32_t num_blocks = 128;
+  BlockManager::Options opts;
+  opts.num_blocks(num_blocks)
+      .block_size(block_size)
+      .enable_linear_state(true)
+      .linear_state_num_slots(64)
+      .enable_prefix_cache(true)
+      .instance_is_decode(true);
+  // No manager_types → flat KV shape. LINEAR is added on top by
+  // build_composite_leaves.
+  CompositeBlockManager manager(build_composite_leaves(opts));
+
+  const std::vector<int32_t> prompt(4 * block_size, 5);
+  Sequence seq = MakeTestSequence(0, prompt);
+  ASSERT_TRUE(manager.allocate_sequence(&seq, prompt.size()));
+  seq.kv_state().incr_kv_cache_tokens_num(prompt.size());
+
+  // Under DECODE role LINEAR prefix cache is off, so no pending_save can turn
+  // into a restore source and allocate_for_sequence stays on the fresh-slot
+  // path.
+  EXPECT_FALSE(seq.has_linear_restore_src_block());
+  manager.deallocate_for_sequence(&seq);
+
+  SchedulerConfig::get_instance().max_tokens_per_chunk_for_prefill() =
+      original_chunk_stride;
+}
+
+// Regression for the PD device-prefix-cache decode path: a Qwen3.5 GDN DECODE
+// instance legitimately runs with --enable_chunked_prefill=false, which leaves
+// max_tokens_per_chunk_for_prefill at its -1 default. build_composite_leaves
+// must NOT abort in that configuration -- the LINEAR prefix cache is off by
+// role, so a positive chunk stride is only required when that cache is on.
+// Before the fix this hit CHECK_GT(chunk_stride, 0) and killed the engine at
+// startup.
+TEST(CompositeBlockManagerTest, DecodeRoleLinearDefaultStrideDoesNotAbort) {
+  const int32_t original_chunk_stride =
+      SchedulerConfig::get_instance().max_tokens_per_chunk_for_prefill();
+  // Emulate --enable_chunked_prefill=false: stride stays at the -1 default.
+  SchedulerConfig::get_instance().max_tokens_per_chunk_for_prefill() = -1;
+
+  const uint32_t block_size = 128;
+  const uint32_t num_blocks = 128;
+  BlockManager::Options opts;
+  opts.num_blocks(num_blocks)
+      .block_size(block_size)
+      .enable_linear_state(true)
+      .linear_state_num_slots(64)
+      .enable_prefix_cache(true)
+      .instance_is_decode(true);
+  // Construction must succeed (no FATAL) with the default stride on the decode
+  // role, and a fresh sequence must still get a working LINEAR slot.
+  CompositeBlockManager manager(build_composite_leaves(opts));
+
+  const std::vector<int32_t> prompt(4 * block_size, 5);
+  Sequence seq = MakeTestSequence(0, prompt);
+  ASSERT_TRUE(manager.allocate_sequence(&seq, prompt.size()));
+  seq.kv_state().incr_kv_cache_tokens_num(prompt.size());
+  EXPECT_FALSE(seq.has_linear_restore_src_block());
+  manager.deallocate_for_sequence(&seq);
+
+  SchedulerConfig::get_instance().max_tokens_per_chunk_for_prefill() =
+      original_chunk_stride;
 }
 
 }  // namespace xllm

--- a/xllm/core/common/types.h
+++ b/xllm/core/common/types.h
@@ -298,6 +298,10 @@ struct KVBlockTransferGroup {
   int32_t group_id = 0;
   std::vector<uint64_t> local_blocks_ids;
   std::vector<uint64_t> remote_blocks_ids;
+  // Number of leading blocks D already has from its own device-side prefix
+  // cache under this group. P uses this to compress its per-group transfer
+  // cursor to the first block D actually needs (no shared -> zero, no-op).
+  uint32_t remote_shared_num = 0;
 };
 
 struct TransferKVInfo {
@@ -310,6 +314,12 @@ struct TransferKVInfo {
   std::vector<uint64_t> remote_linear_state_ids;
   int32_t dp_rank;
   InstanceInfo remote_instance_info;
+  // Number of leading blocks D already holds from its own device-side prefix
+  // cache under BlockType::KV (flat KV path). remote_blocks_ids is shipped
+  // starting from that offset; build_step_transfer_info uses this to
+  // translate a local block index to the correct remote_blocks_ids slot.
+  // Zero when D had no hit, which preserves the pre-existing indexing.
+  uint32_t remote_shared_num = 0;
 
   // XTensor mode: destination offsets from D-node (per-layer)
   // Only populated when KVCacheConfig::enable_xtensor is true.

--- a/xllm/core/distributed_runtime/disagg_pd_service_impl.cpp
+++ b/xllm/core/distributed_runtime/disagg_pd_service_impl.cpp
@@ -175,7 +175,10 @@ void DisaggPDServiceImpl::decode_recv_new_requests(
 
       auto dp_rank = sequence->dp_rank();
       resp->set_dp_rank(dp_rank);
-      resp->set_linear_state_id(sequence->get_single_block_id());
+      // Advertise the recurrent-state slot: LINEAR for Qwen3.5 GDN, SINGLE
+      // for legacy models. Sender-side batch_input_builder resolves the slot
+      // via the same helper so both sides agree.
+      resp->set_linear_state_id(sequence->get_recurrent_state_slot_id());
 
       std::vector<int32_t> block_ids;
       if (sequence->kv_state().has_multi_block_export()) {
@@ -183,12 +186,33 @@ void DisaggPDServiceImpl::decode_recv_new_requests(
         for (const auto& [block_type, blocks_ptr] : export_view) {
           auto* group = resp->mutable_kv_block_groups()->Add();
           group->set_group_id(cache_group_id(block_type));
+          // D-side shared count for this group. P advances its per-group
+          // transfer cursor to this value so it starts pushing at the first
+          // block D actually needs. SWA / LINEAR under DECODE role return
+          // 0 (prefix cache off), which is a no-op advance and reproduces
+          // the pre-existing "push everything" behavior. C4 / C128 may
+          // return >0 and let P skip the leading shared blocks.
+          group->set_remote_shared_num(static_cast<uint32_t>(
+              sequence->kv_state().shared_blocks_num(block_type)));
           group->mutable_block_ids()->Reserve(blocks_ptr->size());
           for (const auto& block : *blocks_ptr) {
-            CHECK(block.is_valid())
-                << "Decode allocated an invalid grouped KV block, group_id="
-                << cache_group_id(block_type);
-            group->mutable_block_ids()->Add(block.id());
+            // Invalid placeholders are legitimate for SWA: the sliding
+            // window release loop leaves moved-from Blocks in place so
+            // positional indexing stays stable, and both P and D produce
+            // the same invalid pattern for the slid-out window. Ship them
+            // as -1 sentinels; P's build_group_step_transfer skips
+            // positions where the local block id is negative, so the
+            // remote id at those positions is never dereferenced. The
+            // CHECK below only refuses invalid blocks under types where
+            // slide-out cannot produce them (C4 / C128), preserving the
+            // guard for genuine allocation bugs.
+            const int32_t block_id = block.is_valid() ? block.id() : -1;
+            if (!block.is_valid()) {
+              CHECK(block_type == BlockType::SWA)
+                  << "Decode allocated an invalid grouped KV block under a "
+                  << "non-SWA leaf, group_id=" << cache_group_id(block_type);
+            }
+            group->mutable_block_ids()->Add(block_id);
           }
         }
       } else {
@@ -196,14 +220,18 @@ void DisaggPDServiceImpl::decode_recv_new_requests(
             sequence->kv_state().shared_blocks_num(BlockType::KV);
         const auto blocks = sequence->kv_state().blocks(BlockType::KV);
 
-        // Collect block IDs (skip prefix-cache-hit blocks)
+        // Tell P where the D-side prefix cache hit ends so its transfer
+        // cursor lines up with the block ids we return below. Zero if there
+        // was no D-side hit -- matches pre-shared_num behavior.
+        resp->set_remote_shared_num(static_cast<uint32_t>(shared_num));
+
+        // Collect block IDs
         block_ids.reserve(blocks.size() - shared_num);
         for (size_t i = shared_num; i < blocks.size(); i++) {
           int32_t block_id = blocks[i].id();
           *(resp->mutable_blocks_ids()->Add()) = block_id;
           block_ids.push_back(block_id);
         }
-        resp->set_num_prefix_blocks(static_cast<int32_t>(shared_num));
       }
       // XTensor mode: calculate and return GlobalXTensor offsets
       if (::xllm::KVCacheConfig::get_instance().enable_xtensor() &&

--- a/xllm/core/distributed_runtime/llm_engine.cpp
+++ b/xllm/core/distributed_runtime/llm_engine.cpp
@@ -517,7 +517,13 @@ bool LLMEngine::allocate_kv_cache(const KVCacheCapacity& kv_cache_cap) {
   const int32_t block_size = static_cast<int32_t>(kv_cache_cap.block_size());
   const bool enable_gdn_attention = has_linear_attention_layers(args_);
 
-  if (options_.enable_prefix_cache() && enable_gdn_attention) {
+  // DECODE-side skips LINEAR prefix cache by role (see
+  // composite_block_manager.cpp::leaf_participates_in_prefix_cache), so the
+  // chunked-prefill + chunk-stride guards below are only meaningful for
+  // PREFILL / MIX. On DECODE the linear-state cache is disabled anyway and
+  // pd_launch.sh legitimately sets --enable_chunked_prefill=false.
+  const bool is_decode = options_.instance_role() == InstanceRole::DECODE;
+  if (options_.enable_prefix_cache() && enable_gdn_attention && !is_decode) {
     const auto& scheduler_config = ::xllm::SchedulerConfig::get_instance();
     CHECK(scheduler_config.enable_chunked_prefill())
         << "Linear-attention prefix cache requires block-aligned chunked "
@@ -555,7 +561,11 @@ bool LLMEngine::allocate_kv_cache(const KVCacheCapacity& kv_cache_cap) {
       .slot_size(kv_cache_cap.slot_size())
       .model_id(options_.model_id())
       .max_seqs_per_batch(options_.max_seqs_per_batch())
-      .num_speculative_tokens(options_.num_speculative_tokens());
+      .num_speculative_tokens(options_.num_speculative_tokens())
+      // DECODE-side prefix cache participation is per-leaf and gated by the
+      // predicate in composite_block_manager.cpp. P and MIX are treated
+      // identically (both admit prefix cache on every leaf).
+      .instance_is_decode(options_.instance_role() == InstanceRole::DECODE);
   if (enable_gdn_attention) {
     // The unified linear-state slot pool spans all physical slots [0, N);
     // id 0 is reserved as padding and ids [1, N) serve live and checkpoint

--- a/xllm/core/distributed_runtime/vlm_engine.cpp
+++ b/xllm/core/distributed_runtime/vlm_engine.cpp
@@ -339,7 +339,11 @@ bool VLMEngine::allocate_kv_cache(const KVCacheCapacity& kv_cache_cap) {
       .enable_prefix_cache(options_.enable_prefix_cache())
       .enable_disagg_pd(options_.enable_disagg_pd())
       .hasher_type(BlockHasherType::MM)
-      .max_seqs_per_batch(options_.max_seqs_per_batch());
+      .max_seqs_per_batch(options_.max_seqs_per_batch())
+      // DECODE-side prefix cache participation is per-leaf and gated by the
+      // predicate in composite_block_manager.cpp; mirror llm_engine so a
+      // linear-attention VLM decode instance disables the LINEAR prefix cache.
+      .instance_is_decode(options_.instance_role() == InstanceRole::DECODE);
   if (enable_linear_attention) {
     // The unified linear-state slot pool spans all physical slots [0, N);
     // id 0 is reserved as padding and ids [1, N) serve live and checkpoint

--- a/xllm/core/framework/batch/batch_input_builder.cpp
+++ b/xllm/core/framework/batch/batch_input_builder.cpp
@@ -251,6 +251,7 @@ TransferKVInfo BatchInputBuilder::build_step_transfer_info(
   info.remote_instance_info = full_info.remote_instance_info;
   info.local_linear_state_ids = full_info.local_linear_state_ids;
   info.remote_linear_state_ids = full_info.remote_linear_state_ids;
+  info.remote_shared_num = full_info.remote_shared_num;
 
   if (block_size == 0 || local_block_ids.empty()) {
     return info;
@@ -264,19 +265,35 @@ TransferKVInfo BatchInputBuilder::build_step_transfer_info(
   const size_t map_end = std::min(win_end, local_size);
   const size_t remote_stride =
       static_cast<size_t>(util::kv_split_size_effective());
-  const size_t remote_end = map_end * remote_stride;
-  CHECK_GE(util::align_up(remote_size, remote_stride), remote_end)
-      << "remote block coverage shortage, request_id=" << full_info.request_id
-      << ", remote_size=" << remote_size << ", remote_end=" << remote_end
-      << ", remote_stride=" << remote_stride;
+  // D shipped remote_blocks_ids starting at its shared_num, so P's local
+  // index `local_idx` maps to remote slot `local_idx - remote_shared_num`.
+  // The P scheduler has already advanced next_transfer_block_idx to at least
+  // remote_shared_num, so win_begin >= remote_shared_num is invariant here.
+  const size_t remote_shared_num =
+      static_cast<size_t>(full_info.remote_shared_num);
+  CHECK_GE(win_begin, remote_shared_num)
+      << "P transfer cursor slid below D-side shared prefix, request_id="
+      << full_info.request_id << ", win_begin=" << win_begin
+      << ", remote_shared_num=" << remote_shared_num;
 
   const size_t stable_end = static_cast<size_t>(seq_len / block_size);
   *advanced_transfer_block_idx =
       std::max(next_transfer_block_idx, std::min(stable_end, map_end));
 
-  if (win_begin >= map_end) {
+  // Early-return before computing remote_end: when the current chunk stops
+  // inside the D-side shared prefix, map_end can be less than remote_shared_num
+  // and the (map_end - remote_shared_num) subtraction below would underflow
+  // size_t. There is nothing to transfer in that case anyway.
+  if (win_begin >= map_end || map_end <= remote_shared_num) {
     return info;
   }
+
+  const size_t remote_end = (map_end - remote_shared_num) * remote_stride;
+  CHECK_GE(util::align_up(remote_size, remote_stride), remote_end)
+      << "remote block coverage shortage, request_id=" << full_info.request_id
+      << ", remote_size=" << remote_size << ", remote_end=" << remote_end
+      << ", remote_stride=" << remote_stride
+      << ", remote_shared_num=" << remote_shared_num;
 
   std::vector<size_t> remote_idxs;
   const size_t block_cnt = map_end - win_begin;
@@ -286,7 +303,8 @@ TransferKVInfo BatchInputBuilder::build_step_transfer_info(
   for (size_t local_idx = win_begin; local_idx < map_end; ++local_idx) {
     info.local_blocks_ids.emplace_back(local_block_ids[local_idx]);
     for (size_t offset = 0; offset < remote_stride; ++offset) {
-      const size_t remote_idx = local_idx * remote_stride + offset;
+      const size_t remote_idx =
+          (local_idx - remote_shared_num) * remote_stride + offset;
       if (remote_idx >= full_info.remote_blocks_ids.size()) {
         if (remote_stride > 1) {
           break;
@@ -347,10 +365,21 @@ KVBlockTransferGroup BatchInputBuilder::build_group_step_transfer(
     if (local_block_id < 0) {
       continue;
     }
+    // Skip positions where the remote side sent a -1 sentinel: those
+    // correspond to slid-out SWA slots on D, whose ids are meaningless.
+    // P still holds a valid local block there but the transfer would land
+    // in undefined memory. Both sides slide the window identically, so
+    // this branch normally coincides with the local-invalid branch above.
+    // Remote comes in as int32 via proto and is stored zero-extended in the
+    // uint64 struct field, so a negative sentinel round-trips to the low
+    // 32 bits being all-ones.
+    const uint64_t remote_block_id = full_group.remote_blocks_ids[local_idx];
+    if (static_cast<int32_t>(remote_block_id) < 0) {
+      continue;
+    }
     step_group.local_blocks_ids.emplace_back(
         static_cast<uint64_t>(local_block_id));
-    step_group.remote_blocks_ids.emplace_back(
-        full_group.remote_blocks_ids[local_idx]);
+    step_group.remote_blocks_ids.emplace_back(remote_block_id);
   }
   return step_group;
 }
@@ -967,8 +996,18 @@ void BatchInputBuilder::setup_kv_cache_info(
       step_info.request_id = transfer_kv_info->request_id;
       step_info.dp_rank = transfer_kv_info->dp_rank;
       step_info.remote_instance_info = transfer_kv_info->remote_instance_info;
-      step_info.local_linear_state_ids =
-          transfer_kv_info->local_linear_state_ids;
+      // Populate the sender-side linear-state slot id on demand from the
+      // sequence. Transfer builders never carry this forward from the
+      // scheduler (the field on TransferKVInfo is initialized empty), so
+      // deriving it here at build time keeps the P->D transport aligned
+      // with the D response, which advertises the same slot via
+      // Sequence::get_recurrent_state_slot_id() in disagg_pd_service_impl.
+      const int32_t local_recurrent_slot =
+          sequence->get_recurrent_state_slot_id();
+      if (local_recurrent_slot >= 0) {
+        step_info.local_linear_state_ids.emplace_back(
+            static_cast<uint64_t>(local_recurrent_slot));
+      }
       step_info.remote_linear_state_ids =
           transfer_kv_info->remote_linear_state_ids;
       for (const auto& full_group : transfer_kv_info->block_transfer_groups) {
@@ -1071,9 +1110,28 @@ void BatchInputBuilder::setup_kv_cache_info(
         seq_len,
         static_cast<uint32_t>(block_size),
         &advanced_transfer_block_idx);
+    // Populate the sender-side linear-state slot id on demand from the
+    // sequence (see the grouped path above for the rationale). Uses the
+    // same helper as the D-side response so both sides agree on slot id.
+    if (step_info.local_linear_state_ids.empty()) {
+      const int32_t local_recurrent_slot =
+          sequence->get_recurrent_state_slot_id();
+      if (local_recurrent_slot >= 0) {
+        step_info.local_linear_state_ids.emplace_back(
+            static_cast<uint64_t>(local_recurrent_slot));
+      }
+    }
     sequence->kv_state().advance_transfer_block_idx(
         advanced_transfer_block_idx);
-    if (!step_info.local_blocks_ids.empty()) {
+    // Keep the step if it carries KV blocks OR a recurrent-state slot. When a
+    // fully prefix-hit final chunk transfers zero KV blocks, the step still
+    // carries the final linear/recurrent state that D must receive (its LINEAR
+    // prefix cache is off by role), so gating solely on local_blocks_ids would
+    // silently drop it. The transfer consumer already handles a
+    // linear-state-only step (kv_cache_transfer.cpp filter keeps infos with a
+    // non-empty local_linear_state_ids).
+    if (!step_info.local_blocks_ids.empty() ||
+        !step_info.local_linear_state_ids.empty()) {
       state.transfer_kv_infos.emplace_back(std::move(step_info));
     }
   }

--- a/xllm/core/framework/block/block_manager.h
+++ b/xllm/core/framework/block/block_manager.h
@@ -89,6 +89,12 @@ class BlockManager {
     // runtime::Options). Used by CompositeBlockManager to adjust SWA block
     // release accounting.
     PROPERTY(uint32_t, num_speculative_tokens) = 0;
+    // Role flag: true on the DECODE side of disaggregated PD. In that role
+    // the composite skips prefix cache on leaves whose data forward never
+    // reads before P overwrites it (SWA, LINEAR). Same predicate governs
+    // future host offload participation -- see
+    // leaf_participates_in_prefix_cache in composite_block_manager.cpp.
+    PROPERTY(bool, instance_is_decode) = false;
   };
 
   explicit BlockManager(Options options) : options_(options) {}

--- a/xllm/core/framework/block/block_manager_pool.cpp
+++ b/xllm/core/framework/block/block_manager_pool.cpp
@@ -58,7 +58,8 @@ BlockManagerPool::BlockManagerPool(const Options& options, int32_t dp_size)
       .model_id(options_.model_id())
       .enable_linear_state(options_.enable_linear_state())
       .linear_state_num_slots(options_.linear_state_num_slots())
-      .num_speculative_tokens(options_.num_speculative_tokens());
+      .num_speculative_tokens(options_.num_speculative_tokens())
+      .instance_is_decode(options_.instance_is_decode());
 
   uint32_t num_single_blocks = std::max<uint32_t>(
       options_.num_single_blocks(), default_max_single_block_sequences + 2);

--- a/xllm/core/framework/block/block_manager_pool.h
+++ b/xllm/core/framework/block/block_manager_pool.h
@@ -59,6 +59,11 @@ class BlockManagerPool : public KVCacheManager {
     PROPERTY(BlockHasherType, hasher_type) = BlockHasherType::TEXT;
     PROPERTY(uint32_t, num_single_blocks) = 0;
     PROPERTY(uint32_t, num_speculative_tokens) = 0;
+    // Role flag: true on the DECODE side of disaggregated PD. Forwarded to
+    // BlockManager::Options for every composite leaf; the leaf's prefix
+    // cache participation goes through the shared predicate (see
+    // composite_block_manager.cpp::leaf_participates_in_prefix_cache).
+    PROPERTY(bool, instance_is_decode) = false;
   };
 
   explicit BlockManagerPool(const Options& options, int32_t dp_size = 1);

--- a/xllm/core/framework/block/composite_block_manager.cpp
+++ b/xllm/core/framework/block/composite_block_manager.cpp
@@ -41,6 +41,40 @@ uint32_t ceil_div(uint32_t numerator, uint32_t denominator) {
   return (numerator + denominator - 1) / denominator;
 }
 
+// Whether a leaf of the given BlockType participates in prefix cache under
+// the current role. On the PREFILL side (instance_is_decode == false) every
+// cache-bearing leaf participates. On the DECODE side we skip SWA and
+// LINEAR because the D forward never reads their shared prefix before P
+// overwrites it -- SWA hits carry gap-invalid placeholders that would break
+// the grouped-response CHECK, and LINEAR restore is a net waste (D does no
+// prefill). SINGLE has never had a prefix cache and stays out on both sides.
+//
+// The same predicate governs the set of leaves that will participate in
+// future host offload (see xllm_docs/pd_d_side_skip_swa_linear_prefix_cache.md
+// §11) -- keep the two decisions aligned by reusing this function when host
+// offload grows past BlockType::KV.
+bool leaf_participates_in_prefix_cache(BlockType type,
+                                       bool instance_is_decode) {
+  if (!instance_is_decode) {
+    return true;
+  }
+  switch (type) {
+    case BlockType::KV:
+    case BlockType::C4:
+    case BlockType::C128:
+      return true;
+    case BlockType::SWA:
+    case BlockType::LINEAR:
+    case BlockType::SINGLE:
+      return false;
+  }
+  // Fail loudly on unhandled BlockType. Falling back to false would silently
+  // disable prefix cache for the new leaf across both P and D, and every
+  // request would end up re-prefilling its prompt with no visible error.
+  LOG(FATAL) << "leaf_participates_in_prefix_cache: unhandled BlockType="
+             << static_cast<int32_t>(type);
+}
+
 // Wrap the leaf in a concurrency adapter when sequence-level calls may run
 // off the scheduler thread (disagg PD / kvcache store / host-offload).
 std::unique_ptr<BlockManager> maybe_concurrent(
@@ -84,27 +118,54 @@ std::map<BlockType, CompositeBlockManager::LeafEntry> build_composite_leaves(
     int32_t dp_rank) {
   std::map<BlockType, CompositeBlockManager::LeafEntry> leaves;
 
+  const bool prefix_cache_on = options.enable_prefix_cache();
+  const bool is_decode = options.instance_is_decode();
+  const bool linear_participates =
+      leaf_participates_in_prefix_cache(BlockType::LINEAR, is_decode);
+  const bool swa_participates =
+      leaf_participates_in_prefix_cache(BlockType::SWA, is_decode);
+  const bool c4_participates =
+      leaf_participates_in_prefix_cache(BlockType::C4, is_decode);
+  const bool c128_participates =
+      leaf_participates_in_prefix_cache(BlockType::C128, is_decode);
+  const bool kv_participates =
+      leaf_participates_in_prefix_cache(BlockType::KV, is_decode);
+
   // LINEAR resource leaf (Qwen3.5-Next GDN). Additive on top of the KV
   // family: a GDN model holds both KV and LINEAR. Not an admission leaf
   // (block_size==1 would misreport pool capacity). Scheduler-thread only, so
-  // no ConcurrentBlockManagerImpl wrap. supports_prefix_cache=true so
-  // probe_prefix_leaves picks it up; the FLAT_KV_LINEAR trimmer pulls out
-  // the deepest checkpoint as a restore source.
+  // no ConcurrentBlockManagerImpl wrap. supports_prefix_cache follows the
+  // role predicate; on DECODE it is off so probe_prefix_leaves skips the
+  // leaf and the composite classifies FLAT_KV_LINEAR down to FLAT_KV.
   if (options.enable_linear_state()) {
     CHECK_GT(options.linear_state_num_slots(), 0)
         << "linear_state_num_slots must be set when linear state is enabled";
-    const int32_t chunk_stride =
+    const bool linear_prefix_cache = prefix_cache_on && linear_participates;
+    int32_t chunk_stride =
         SchedulerConfig::get_instance().max_tokens_per_chunk_for_prefill();
-    CHECK_GT(chunk_stride, 0)
-        << "max_tokens_per_chunk_for_prefill must be positive for linear state";
+    // The chunk stride is the checkpoint boundary for the LINEAR prefix cache.
+    // It only matters when that cache is on (PREFILL role); the LINEAR leaf
+    // holds no token cache otherwise (see set_kv_cache_info's LINEAR skip) and
+    // each sequence takes exactly one slot regardless of block_size. When the
+    // cache is off (DECODE role) chunked prefill is legitimately disabled and
+    // the stride is left at its -1 default, so require a positive stride only
+    // when the LINEAR prefix cache is actually enabled, and fall back to a
+    // valid positive block_size otherwise so the pool sizing stays well-formed.
+    if (linear_prefix_cache) {
+      CHECK_GT(chunk_stride, 0) << "max_tokens_per_chunk_for_prefill must be "
+                                   "positive for linear state prefix cache";
+    } else if (chunk_stride <= 0) {
+      chunk_stride = 1;
+    }
     leaves.emplace(
         BlockType::LINEAR,
         CompositeBlockManager::LeafEntry{
             std::make_unique<LinearStateBlockManager>(
                 static_cast<uint32_t>(options.linear_state_num_slots()),
-                chunk_stride),
+                chunk_stride,
+                linear_prefix_cache),
             /*participates_in_admission=*/false,
-            /*supports_prefix_cache=*/options.enable_prefix_cache()});
+            /*supports_prefix_cache=*/linear_prefix_cache});
   }
 
   if (options.manager_types().empty()) {
@@ -112,13 +173,15 @@ std::map<BlockType, CompositeBlockManager::LeafEntry> build_composite_leaves(
     // the flat (non-xtensor) KV leaf.
     BlockManager::Options kv_opts = options;
     kv_opts.block_type(BlockType::KV);
+    const bool kv_prefix_cache =
+        prefix_cache_on && !options.enable_xtensor() && kv_participates;
+    kv_opts.enable_prefix_cache(kv_prefix_cache);
     leaves.emplace(
         BlockType::KV,
         CompositeBlockManager::LeafEntry{
             maybe_concurrent(make_kv_leaf(kv_opts, dp_rank), options),
             /*participates_in_admission=*/true,
-            /*supports_prefix_cache=*/
-            options.enable_prefix_cache() && !options.enable_xtensor()});
+            /*supports_prefix_cache=*/kv_prefix_cache});
     return leaves;
   }
 
@@ -143,19 +206,22 @@ std::map<BlockType, CompositeBlockManager::LeafEntry> build_composite_leaves(
           << " for composite BlockManagerImpl sub-manager";
       const BlockType key =
           compress_ratio == 4 ? BlockType::C4 : BlockType::C128;
+      const bool compressed_participates =
+          key == BlockType::C4 ? c4_participates : c128_participates;
+      const bool compressed_prefix_cache =
+          prefix_cache_on && compressed_participates;
       opts.block_type(key)
-          .enable_prefix_cache(options.enable_prefix_cache())
+          .enable_prefix_cache(compressed_prefix_cache)
           .hasher_type(options.hasher_type());
       // C4/C128: full-history attention (no window), so hits must form a
       // solid left-to-right prefix. The default BlockManagerImpl probe is
       // exactly right. Cross-leaf min happens in the composite.
-      leaves.emplace(
-          key,
-          CompositeBlockManager::LeafEntry{
-              maybe_concurrent(std::make_unique<BlockManagerImpl>(opts),
-                               options),
-              /*participates_in_admission=*/true,
-              /*supports_prefix_cache=*/options.enable_prefix_cache()});
+      leaves.emplace(key,
+                     CompositeBlockManager::LeafEntry{
+                         maybe_concurrent(
+                             std::make_unique<BlockManagerImpl>(opts), options),
+                         /*participates_in_admission=*/true,
+                         /*supports_prefix_cache=*/compressed_prefix_cache});
     } else if (type == kManagerTypeSlidingWindowBlockManager) {
       const uint32_t swa_blocks_per_seq = options.swa_blocks_per_seq();
       CHECK_GT(swa_blocks_per_seq, 0u) << "swa_blocks_per_seq must be positive";
@@ -169,11 +235,12 @@ std::map<BlockType, CompositeBlockManager::LeafEntry> build_composite_leaves(
       // Slack fits the peak "old blocks not yet released + new tail".
       const uint32_t swa_total_blocks =
           swa_blocks_per_seq * max_seqs + burst_blocks + max_seqs + 2;
+      const bool swa_prefix_cache = prefix_cache_on && swa_participates;
       opts.num_blocks(swa_total_blocks)
           .swa_blocks_per_seq(swa_blocks_per_seq)
           .sliding_window_size(sliding_window_size)
           .block_type(BlockType::SWA)
-          .enable_prefix_cache(options.enable_prefix_cache())
+          .enable_prefix_cache(swa_prefix_cache)
           .hasher_type(options.hasher_type());
       // SWA is not an admission leaf (pool sized by ring, not token budget)
       // but serves gap-tolerant prefix cache.
@@ -183,7 +250,7 @@ std::map<BlockType, CompositeBlockManager::LeafEntry> build_composite_leaves(
               maybe_concurrent(
                   std::make_unique<SlidingWindowBlockManager>(opts), options),
               /*participates_in_admission=*/false,
-              /*supports_prefix_cache=*/options.enable_prefix_cache()});
+              /*supports_prefix_cache=*/swa_prefix_cache});
     } else {
       LOG(FATAL) << "Unknown manager_type " << type;
     }
@@ -212,13 +279,25 @@ CompositeBlockManager::classify_leaf_combination(
   const bool has_c128 = has_prefix(BlockType::C128);
   const bool has_linear = has_prefix(BlockType::LINEAR);
 
-  if (has_swa || has_c4 || has_c128) {
-    CHECK(has_swa && has_c4 && has_c128)
-        << "SWA_COMPRESSED requires all of {SWA, C4, C128}; got SWA=" << has_swa
-        << " C4=" << has_c4 << " C128=" << has_c128;
+  // SWA_COMPRESSED requires C4 + C128 to make sense (a compressed shape with
+  // only one granularity is not a shape we ship). SWA is optional here on
+  // purpose: the DECODE role turns off SWA prefix cache via the role
+  // predicate, so has_swa is false while C4/C128 stay on -- trim /
+  // classify still route through this branch, but probes will be missing
+  // the SWA entry and trim_swa_compressed guards accordingly.
+  if (has_c4 || has_c128) {
+    CHECK(has_c4 && has_c128)
+        << "SWA_COMPRESSED requires both C4 and C128 with prefix cache on; "
+        << "got C4=" << has_c4 << " C128=" << has_c128;
     CHECK(!has_kv) << "SWA_COMPRESSED must not carry a KV leaf";
     CHECK(!has_linear) << "SWA_COMPRESSED must not carry a LINEAR leaf";
     return LeafCombination::SWA_COMPRESSED;
+  }
+  if (has_swa) {
+    // A prefix-cache-on SWA leaf paired with no compressed leaves is not a
+    // shape we build; the classifier surfaces the misconfiguration loudly
+    // instead of silently mounting garbage.
+    LOG(FATAL) << "SWA prefix cache is on but neither C4 nor C128 is present";
   }
   if (has_kv) {
     return has_linear ? LeafCombination::FLAT_KV_LINEAR

--- a/xllm/core/framework/block/hierarchy_block_manager_pool.cpp
+++ b/xllm/core/framework/block/hierarchy_block_manager_pool.cpp
@@ -48,7 +48,11 @@ HierarchyBlockManagerPool::HierarchyBlockManagerPool(
         options_.enable_host_offload()) {
       leaf = std::make_unique<ConcurrentBlockManagerImpl>(std::move(leaf));
     }
-    host_block_managers_.emplace_back(std::move(leaf));
+    // Per-BlockType map, KV-only today; SWA / C4 / C128 slots stay empty
+    // until host offload grows past the flat-KV shape.
+    std::unordered_map<BlockType, std::unique_ptr<BlockManager>> per_type;
+    per_type.emplace(BlockType::KV, std::move(leaf));
+    host_block_managers_.emplace_back(std::move(per_type));
   }
 
   load_block_transfer_infos_.resize(host_block_managers_.size());
@@ -73,7 +77,7 @@ void HierarchyBlockManagerPool::deallocate(Sequence* sequence) {
   // completes and the offload callback caches + frees them.
   auto host_blocks = sequence->host_kv_state().blocks(BlockType::KV);
   if (!host_blocks.empty()) {
-    host_block_managers_[dp_rank]->deallocate(host_blocks);
+    host_block_managers_[dp_rank].at(BlockType::KV)->deallocate(host_blocks);
   }
 
   // Release device blocks via the composite (includes prefix cache flush).
@@ -90,6 +94,13 @@ void HierarchyBlockManagerPool::collect_offload_pairs(Sequence* sequence,
   if (!options_.enable_prefix_cache()) {
     return;
   }
+
+  // Host offload is KV-only today. When extended to SWA / C4 / C128, iterate
+  // this body over BlockType values whose predicate returns true for the
+  // current role (see composite_block_manager.cpp
+  // ::leaf_participates_in_prefix_cache). host_block_managers_ is already a
+  // per-BlockType map; the missing pieces are the SWA / C4 / C128 host leaf
+  // constructions in the ctor and the tail-continuity handling for SWA.
 
   std::vector<Block>* device_blocks =
       sequence->kv_state().mutable_blocks(BlockType::KV);
@@ -119,8 +130,9 @@ void HierarchyBlockManagerPool::collect_offload_pairs(Sequence* sequence,
                                       ? cached_device_block_num - host_block_num
                                       : 0;
   if (needed_block_num != 0) {
-    std::vector<Block> new_host_blocks =
-        host_block_managers_[dp_rank]->allocate(needed_block_num);
+    std::vector<Block> new_host_blocks = host_block_managers_[dp_rank]
+                                             .at(BlockType::KV)
+                                             ->allocate(needed_block_num);
     if (new_host_blocks.size() != needed_block_num) {
       // Host pool exhausted; skip offload this round rather than partially
       // copy.
@@ -322,7 +334,9 @@ void HierarchyBlockManagerPool::allocate_host_shared(Sequence* sequence) {
   if (options_.enable_prefix_cache()) {
     int32_t dp_rank = BlockManagerPool::get_dp_rank(sequence);
     std::vector<Block> shared_blocks =
-        host_block_managers_[dp_rank]->allocate_shared(sequence->tokens());
+        host_block_managers_[dp_rank]
+            .at(BlockType::KV)
+            ->allocate_shared(sequence->tokens());
     sequence->add_shared_host_blocks(BlockType::KV, std::move(shared_blocks));
   }
 }
@@ -338,8 +352,9 @@ void HierarchyBlockManagerPool::prefetch_from_storage(
 
     int32_t dp_rank = BlockManagerPool::get_dp_rank(prefill_sequence.get());
     std::vector<Block> shared_blocks =
-        host_block_managers_[dp_rank]->allocate_shared(
-            prefill_sequence->tokens());
+        host_block_managers_[dp_rank]
+            .at(BlockType::KV)
+            ->allocate_shared(prefill_sequence->tokens());
     prefill_sequence->add_shared_host_blocks(BlockType::KV,
                                              std::move(shared_blocks));
 
@@ -353,8 +368,9 @@ void HierarchyBlockManagerPool::prefetch_from_storage(
       continue;
     }
 
-    auto host_blocks =
-        host_block_managers_[dp_rank]->allocate(num_additional_blocks);
+    auto host_blocks = host_block_managers_[dp_rank]
+                           .at(BlockType::KV)
+                           ->allocate(num_additional_blocks);
     if (host_blocks.size() != num_additional_blocks) {
       continue;
     }
@@ -405,8 +421,10 @@ bool HierarchyBlockManagerPool::update_prefetch_result(
       auto cached_blocks =
           prefill_sequence->host_kv_state().shared_blocks_num(BlockType::KV);
 
-      host_block_managers_[dp_rank]->cache(
-          host_blocks.slice(cached_blocks - success_cnt, cached_blocks));
+      host_block_managers_[dp_rank]
+          .at(BlockType::KV)
+          ->cache(
+              host_blocks.slice(cached_blocks - success_cnt, cached_blocks));
     }
   }
 
@@ -453,7 +471,8 @@ void HierarchyBlockManagerPool::transfer_blocks() {
           .thenValue([device_blocks = std::move(src_blocks),
                       host_blocks = std::move(dst_blocks),
                       device_block_mgr_ptr = block_managers_[i].get(),
-                      host_block_mgr_ptr = host_block_managers_[i].get()](
+                      host_block_mgr_ptr =
+                          host_block_managers_[i].at(BlockType::KV).get()](
                          std::vector<folly::Try<uint32_t>>&& results) mutable {
             bool copy_ok = true;
             for (auto&& result : results) {

--- a/xllm/core/framework/block/hierarchy_block_manager_pool.h
+++ b/xllm/core/framework/block/hierarchy_block_manager_pool.h
@@ -15,6 +15,8 @@ limitations under the License.
 
 #pragma once
 
+#include <unordered_map>
+
 #include "block_manager_pool.h"
 #include "distributed_runtime/engine.h"
 #include "util/blockingconcurrentqueue.h"
@@ -74,7 +76,15 @@ class HierarchyBlockManagerPool : public BlockManagerPool {
 
  private:
   Engine* engine_;
-  std::vector<std::unique_ptr<BlockManager>> host_block_managers_;
+  // Per-dp host block manager map keyed by BlockType. Today only
+  // BlockType::KV is populated; SWA / C4 / C128 slots are reserved so future
+  // host offload of the DSV4 composite shape can plug in without touching
+  // the container. Participation follows the same role-gated predicate as
+  // device prefix cache -- see composite_block_manager.cpp
+  // ::leaf_participates_in_prefix_cache and
+  // xllm_docs/pd_d_side_skip_swa_linear_prefix_cache.md §11.
+  std::vector<std::unordered_map<BlockType, std::unique_ptr<BlockManager>>>
+      host_block_managers_;
 
   // BlockTransferInfo per step
   std::vector<std::vector<BlockTransferInfo>> load_block_transfer_infos_;

--- a/xllm/core/framework/block/linear_state_block_manager.cpp
+++ b/xllm/core/framework/block/linear_state_block_manager.cpp
@@ -28,11 +28,12 @@ namespace xllm {
 namespace {
 
 BlockManager::Options make_linear_state_options(uint32_t num_slots,
-                                                int32_t chunk_stride) {
+                                                int32_t chunk_stride,
+                                                bool enable_prefix_cache) {
   BlockManager::Options options;
   options.num_blocks(num_slots);
   options.block_size(chunk_stride);
-  options.enable_prefix_cache(true);
+  options.enable_prefix_cache(enable_prefix_cache);
   options.enable_disagg_pd(false);
   options.block_type(BlockType::LINEAR);
   return options;
@@ -41,8 +42,11 @@ BlockManager::Options make_linear_state_options(uint32_t num_slots,
 }  // namespace
 
 LinearStateBlockManager::LinearStateBlockManager(uint32_t num_slots,
-                                                 int32_t chunk_stride)
-    : BlockManagerImpl(make_linear_state_options(num_slots, chunk_stride)) {
+                                                 int32_t chunk_stride,
+                                                 bool enable_prefix_cache)
+    : BlockManagerImpl(make_linear_state_options(num_slots,
+                                                 chunk_stride,
+                                                 enable_prefix_cache)) {
   CHECK_GT(num_slots, 1u)
       << "linear-state leaf needs at least one usable slot (plus padding)";
   CHECK_GT(chunk_stride, 0)
@@ -69,9 +73,13 @@ LinearStateBlockManager::allocate_for_sequence(Sequence* seq,
   // never surface as an allocation failure, or the composite would roll back
   // the whole sequence.
   const std::optional<XXH3Key> pending_hash = seq->take_pending_linear_save();
-  const bool should_apply_save = pending_hash.has_value() &&
-                                 seq->has_linear_state_slot() &&
-                                 !prefix_cache_->contains(*pending_hash);
+  // When prefix cache is off (DECODE role for LINEAR) the checkpoint index
+  // is not constructed; skip save-rotation entirely. batch_input_builder
+  // still may set a pending hash from an earlier PREFILL role transition,
+  // so guard here instead of assuming pending_hash stays nullopt.
+  const bool should_apply_save =
+      prefix_cache_ != nullptr && pending_hash.has_value() &&
+      seq->has_linear_state_slot() && !prefix_cache_->contains(*pending_hash);
   Block new_live_slot = should_apply_save ? allocate() : Block();
   if (new_live_slot.is_valid()) {
     // Pin the warm slot into the checkpoint index (refcount+1) and mount a
@@ -150,7 +158,7 @@ std::vector<Block> LinearStateBlockManager::allocate_shared(
   // restore would look for a checkpoint that need not be there; on a miss the
   // sequence cold-starts on a non-empty KV prefix and its recurrent state is
   // corrupt.
-  if (token_ids.size() == 0) {
+  if (token_ids.size() == 0 || prefix_cache_ == nullptr) {
     return {};
   }
   return prefix_cache_->match(token_ids.slice(0, token_ids.size() - 1),

--- a/xllm/core/framework/block/linear_state_block_manager.h
+++ b/xllm/core/framework/block/linear_state_block_manager.h
@@ -45,8 +45,13 @@ class LinearStateBlockManager final : public BlockManagerImpl {
   // chunk), used as block_size for both the slot pool and the prefix-cache hash
   // domain. Defaults to -1 (probe disabled) for block-level unit tests that
   // drive the slot pool directly and never exercise the token-based match().
+  // |enable_prefix_cache| toggles the checkpoint index; when false the leaf
+  // still serves live-slot allocation but skips save-rotation and returns an
+  // empty allocate_shared. Composite drives this via the role-gated predicate
+  // in composite_block_manager.cpp.
   explicit LinearStateBlockManager(uint32_t num_slots,
-                                   int32_t chunk_stride = -1);
+                                   int32_t chunk_stride = -1,
+                                   bool enable_prefix_cache = true);
   ~LinearStateBlockManager() override = default;
 
   // ---- BlockManagerImpl overrides ----

--- a/xllm/core/framework/request/sequence.h
+++ b/xllm/core/framework/request/sequence.h
@@ -216,6 +216,18 @@ class Sequence final {
     return kv_state_.get_linear_block_id();
   }
 
+  // Recurrent state slot for models with sequence-scoped CONV/SSM caches.
+  // Prefer the dedicated LINEAR slot (Qwen3.5 GDN, drawn from
+  // LinearStateBlockManager); fall back to the SINGLE resource block id for
+  // legacy models where recurrent state still lives in the SINGLE slot. All
+  // P/D endpoints that advertise or consume the recurrent-state slot id must
+  // use this helper so the sender and receiver agree on which slot is holding
+  // the state.
+  int32_t get_recurrent_state_slot_id() const {
+    const int32_t linear_slot = get_linear_state_slot_id();
+    return linear_slot >= 0 ? linear_slot : get_single_block_id();
+  }
+
   void set_pending_linear_save(const XXH3Key& hash) {
     kv_state_.set_pending_linear_save(hash);
   }
@@ -352,6 +364,11 @@ class Sequence final {
 
   KVCacheState& kv_state() { return kv_state_; }
 
+  // Host-side block state, per BlockType (mirrors kv_state_). Today only
+  // BlockType::KV is populated by HierarchyBlockManagerPool; when host
+  // offload is extended past the flat-KV shape (SWA / C4 / C128), the
+  // additional per-type slots land under the same KVCacheState here without
+  // touching this signature.
   KVCacheState& host_kv_state() { return host_kv_state_; }
 
   // for generated tokens

--- a/xllm/core/scheduler/disagg_pd_scheduler.cpp
+++ b/xllm/core/scheduler/disagg_pd_scheduler.cpp
@@ -552,6 +552,7 @@ void DisaggPDScheduler::dispatch_requests() {
             for (const auto& resp_group : resp.kv_block_groups()) {
               KVBlockTransferGroup group;
               group.group_id = resp_group.group_id();
+              group.remote_shared_num = resp_group.remote_shared_num();
               group.remote_blocks_ids.reserve(resp_group.block_ids_size());
               for (const int32_t block_id : resp_group.block_ids()) {
                 group.remote_blocks_ids.emplace_back(
@@ -560,13 +561,11 @@ void DisaggPDScheduler::dispatch_requests() {
               info.block_transfer_groups.emplace_back(std::move(group));
             }
           } else {
-            const size_t prefix_blocks =
-                static_cast<size_t>(resp.num_prefix_blocks());
-            info.remote_blocks_ids.resize(prefix_blocks, 0);
             for (const int32_t block_id : resp.blocks_ids()) {
               info.remote_blocks_ids.emplace_back(
                   static_cast<uint64_t>(block_id));
             }
+            info.remote_shared_num = resp.remote_shared_num();
           }
           if (resp.linear_state_id() >= 0) {
             info.remote_linear_state_ids.emplace_back(resp.linear_state_id());
@@ -599,12 +598,39 @@ void DisaggPDScheduler::dispatch_requests() {
                     << ", num_layers=" << info.dst_xtensor_layer_offsets.size();
           }
 
-          const int32_t num_prefix_blocks = resp.num_prefix_blocks();
-          if (num_prefix_blocks > 0) {
-            sequence->kv_state().set_next_transfer_block_idx(
-                static_cast<size_t>(num_prefix_blocks));
-          }
           sequence->kv_state().set_transfer_kv_info(std::move(info));
+
+          // Compress per-group transfer cursors to the D-side shared count.
+          // advance_group_transfer_block_idx is monotonic max, so this is a
+          // no-op if the group's remote_shared_num is 0 (SWA / LINEAR under
+          // DECODE, or D that got no prefix cache hit); when it is >0, P
+          // starts pushing at the first block D actually needs, skipping the
+          // shared prefix without touching P's own local shared_num.
+          const auto& groups =
+              sequence->kv_state().transfer_kv_info()->block_transfer_groups;
+          for (const auto& g : groups) {
+            if (g.remote_shared_num == 0) {
+              continue;
+            }
+            const std::optional<BlockType> block_type =
+                block_type_from_cache_group_id(g.group_id);
+            if (!block_type.has_value()) {
+              LOG(ERROR) << "Unknown KV cache transfer group_id: "
+                         << g.group_id;
+              continue;
+            }
+            sequence->kv_state().advance_group_transfer_block_idx(
+                block_type.value(), static_cast<size_t>(g.remote_shared_num));
+          }
+          // Flat KV counterpart: the flat response ships block_ids starting
+          // from D's shared_num. Advance the flat transfer cursor to the same
+          // origin so build_step_transfer_info indexes remote_blocks_ids from
+          // 0 instead of from local_idx 0 (which would demand D returned
+          // every prompt block).
+          if (!has_grouped_cache && resp.remote_shared_num() > 0) {
+            sequence->kv_state().advance_transfer_block_idx(
+                static_cast<size_t>(resp.remote_shared_num()));
+          }
         }
 
         // Push to request_queue_; it will be executed by the engine.
@@ -718,8 +744,12 @@ void DisaggPDScheduler::prefill_send_first_generation() {
           block_ids.push_back(block.id());
         }
         ADD_VECTOR_TO_PROTO(gen->mutable_block_ids(), block_ids);
+        // Advertise the recurrent-state slot the D side should pull from.
+        // Prefer the dedicated LINEAR slot (Qwen3.5 GDN); fall back to
+        // SINGLE for legacy models where the CONV/SSM caches still live in
+        // the SINGLE slot. Must match the D-side response helper.
         gen->set_linear_state_id(
-            request->sequences()[0]->get_single_block_id());
+            request->sequences()[0]->get_recurrent_state_slot_id());
         gen->set_dp_size(instance_info_.dp_size);
         gen->set_dp_rank(request->sequences()[0]->dp_rank());
       }
@@ -929,9 +959,15 @@ bool DisaggPDScheduler::decode_recv_first_generation(
     }
     std::vector<uint64_t> src_linear_state_ids;
     std::vector<uint64_t> dst_linear_state_ids;
-    if (src_linear_state_id >= 0 && sequence->get_single_block_id() >= 0) {
+    // Resolve the destination recurrent-state slot with the same helper the
+    // sender used to advertise src_linear_state_id (LINEAR for Qwen3.5 GDN,
+    // SINGLE otherwise), so PULL writes the pulled state into the slot the
+    // decode forward actually reads (see
+    // Sequence::get_recurrent_state_slot_id).
+    const int32_t dst_linear_state_id = sequence->get_recurrent_state_slot_id();
+    if (src_linear_state_id >= 0 && dst_linear_state_id >= 0) {
       src_linear_state_ids.emplace_back(src_linear_state_id);
-      dst_linear_state_ids.emplace_back(sequence->get_single_block_id());
+      dst_linear_state_ids.emplace_back(dst_linear_state_id);
     }
 
     int32_t dst_dp_rank = sequence->dp_rank();

--- a/xllm/core/scheduler/pd_ooc_scheduler.cpp
+++ b/xllm/core/scheduler/pd_ooc_scheduler.cpp
@@ -27,6 +27,7 @@ limitations under the License.
 #include "common/interruption_bus.h"
 #include "common/macros.h"
 #include "core/distributed_runtime/pd_ooc_service.h"
+#include "core/framework/block/block.h"
 #include "core/framework/config/disagg_pd_config.h"
 #include "core/framework/config/scheduler_config.h"
 #include "disagg_pd.pb.h"
@@ -1481,17 +1482,67 @@ void PDOOCScheduler::dispatch_requests() {
         for (auto& sequence : requests[i]->sequences()) {
           TransferKVInfo info;
           info.request_id = requests[i]->request_id();
-          for (auto& bid : resps.resps()[i].blocks_ids()) {
-            info.remote_blocks_ids.emplace_back(bid);
+          const auto& resp = resps.resps()[i];
+          const bool has_grouped_cache = resp.kv_block_groups_size() > 0;
+          if (has_grouped_cache) {
+            for (const auto& resp_group : resp.kv_block_groups()) {
+              KVBlockTransferGroup group;
+              group.group_id = resp_group.group_id();
+              group.remote_shared_num = resp_group.remote_shared_num();
+              group.remote_blocks_ids.reserve(resp_group.block_ids_size());
+              for (const int32_t block_id : resp_group.block_ids()) {
+                group.remote_blocks_ids.emplace_back(
+                    static_cast<uint64_t>(block_id));
+              }
+              info.block_transfer_groups.emplace_back(std::move(group));
+            }
+          } else {
+            for (const int32_t block_id : resp.blocks_ids()) {
+              info.remote_blocks_ids.emplace_back(
+                  static_cast<uint64_t>(block_id));
+            }
+            info.remote_shared_num = resp.remote_shared_num();
           }
-          if (resps.resps()[i].linear_state_id() >= 0) {
-            info.remote_linear_state_ids.emplace_back(
-                resps.resps()[i].linear_state_id());
+          if (resp.linear_state_id() >= 0) {
+            info.remote_linear_state_ids.emplace_back(resp.linear_state_id());
           }
-          info.dp_rank = resps.resps()[i].dp_rank();
+          if (!has_grouped_cache) {
+            const size_t prompt_blocks =
+                (requests[i]->state().prompt_tokens.size() +
+                 kv_cache_manager_->block_size() - 1) /
+                kv_cache_manager_->block_size();
+            info.local_blocks_ids.resize(prompt_blocks);
+          }
+          info.dp_rank = resp.dp_rank();
           // TODO: remote_instances_info_ is not multi-thread safe.
           info.remote_instance_info = remote_instances_info_[selected_instance];
           sequence->kv_state().set_transfer_kv_info(std::move(info));
+
+          // Compress per-group transfer cursors to the D-side shared count.
+          // Monotonic max; no-op when a group's remote_shared_num is 0.
+          const auto& groups =
+              sequence->kv_state().transfer_kv_info()->block_transfer_groups;
+          for (const auto& g : groups) {
+            if (g.remote_shared_num == 0) {
+              continue;
+            }
+            const std::optional<BlockType> block_type =
+                block_type_from_cache_group_id(g.group_id);
+            if (!block_type.has_value()) {
+              LOG(ERROR) << "Unknown KV cache transfer group_id: "
+                         << g.group_id;
+              continue;
+            }
+            sequence->kv_state().advance_group_transfer_block_idx(
+                block_type.value(), static_cast<size_t>(g.remote_shared_num));
+          }
+          // Flat KV counterpart: response ships block_ids starting from D's
+          // shared_num; advance the flat cursor so build_step_transfer_info
+          // indexes remote_blocks_ids from 0 rather than local_idx 0.
+          if (!has_grouped_cache && resp.remote_shared_num() > 0) {
+            sequence->kv_state().advance_transfer_block_idx(
+                static_cast<size_t>(resp.remote_shared_num()));
+          }
         }
 
         // push to request_queue_, and will be executed by engine.
@@ -1597,8 +1648,11 @@ void PDOOCScheduler::prefill_send_first_generation() {
           block_ids.push_back(block.id());
         }
         ADD_VECTOR_TO_PROTO(gen->mutable_block_ids(), block_ids);
+        // Advertise the recurrent-state slot to pull from: LINEAR for
+        // Qwen3.5 GDN, SINGLE fallback. Must match the D-side response
+        // helper (Sequence::get_recurrent_state_slot_id).
         gen->set_linear_state_id(
-            request->sequences()[0]->get_single_block_id());
+            request->sequences()[0]->get_recurrent_state_slot_id());
         gen->set_dp_size(instance_info_.dp_size);
         gen->set_dp_rank(request->sequences()[0]->dp_rank());
       }
@@ -1741,11 +1795,16 @@ bool PDOOCScheduler::decode_recv_multi_generations(
     }
     std::vector<uint64_t> src_linear_state_ids;
     std::vector<uint64_t> dst_linear_state_ids;
-    if (src_linear_state_id >= 0 &&
-        request->sequences()[0]->get_single_block_id() >= 0) {
+    // Resolve the destination recurrent-state slot with the same helper the
+    // sender used to advertise src_linear_state_id (LINEAR for Qwen3.5 GDN,
+    // SINGLE otherwise), so PULL writes the pulled state into the slot the
+    // decode forward actually reads (see
+    // Sequence::get_recurrent_state_slot_id).
+    const int32_t dst_linear_state_id =
+        request->sequences()[0]->get_recurrent_state_slot_id();
+    if (src_linear_state_id >= 0 && dst_linear_state_id >= 0) {
       src_linear_state_ids.emplace_back(src_linear_state_id);
-      dst_linear_state_ids.emplace_back(
-          request->sequences()[0]->get_single_block_id());
+      dst_linear_state_ids.emplace_back(dst_linear_state_id);
     }
 
     int32_t dst_dp_rank = request->sequences()[0]->dp_rank();
@@ -1907,16 +1966,61 @@ void PDOOCScheduler::dispatch_offline_requests() {
       for (auto& sequence : request->sequences()) {
         TransferKVInfo info;
         info.request_id = request->request_id();
-        for (auto& bid : resps.resps()[0].blocks_ids()) {
-          info.remote_blocks_ids.emplace_back(bid);
+        const auto& resp = resps.resps()[0];
+        const bool has_grouped_cache = resp.kv_block_groups_size() > 0;
+        if (has_grouped_cache) {
+          for (const auto& resp_group : resp.kv_block_groups()) {
+            KVBlockTransferGroup group;
+            group.group_id = resp_group.group_id();
+            group.remote_shared_num = resp_group.remote_shared_num();
+            group.remote_blocks_ids.reserve(resp_group.block_ids_size());
+            for (const int32_t block_id : resp_group.block_ids()) {
+              group.remote_blocks_ids.emplace_back(
+                  static_cast<uint64_t>(block_id));
+            }
+            info.block_transfer_groups.emplace_back(std::move(group));
+          }
+        } else {
+          for (const int32_t block_id : resp.blocks_ids()) {
+            info.remote_blocks_ids.emplace_back(
+                static_cast<uint64_t>(block_id));
+          }
+          info.remote_shared_num = resp.remote_shared_num();
         }
-        if (resps.resps()[0].linear_state_id() >= 0) {
-          info.remote_linear_state_ids.emplace_back(
-              resps.resps()[0].linear_state_id());
+        if (resp.linear_state_id() >= 0) {
+          info.remote_linear_state_ids.emplace_back(resp.linear_state_id());
         }
-        info.dp_rank = resps.resps()[0].dp_rank();
+        if (!has_grouped_cache) {
+          const size_t prompt_blocks = (request->state().prompt_tokens.size() +
+                                        kv_cache_manager_->block_size() - 1) /
+                                       kv_cache_manager_->block_size();
+          info.local_blocks_ids.resize(prompt_blocks);
+        }
+        info.dp_rank = resp.dp_rank();
         info.remote_instance_info = remote_instances_info_[target_instance];
         sequence->kv_state().set_transfer_kv_info(std::move(info));
+
+        // Compress per-group / flat transfer cursors to the D-side shared
+        // counts; see the online dispatch path above for the rationale.
+        const auto& groups =
+            sequence->kv_state().transfer_kv_info()->block_transfer_groups;
+        for (const auto& g : groups) {
+          if (g.remote_shared_num == 0) {
+            continue;
+          }
+          const std::optional<BlockType> block_type =
+              block_type_from_cache_group_id(g.group_id);
+          if (!block_type.has_value()) {
+            LOG(ERROR) << "Unknown KV cache transfer group_id: " << g.group_id;
+            continue;
+          }
+          sequence->kv_state().advance_group_transfer_block_idx(
+              block_type.value(), static_cast<size_t>(g.remote_shared_num));
+        }
+        if (!has_grouped_cache && resp.remote_shared_num() > 0) {
+          sequence->kv_state().advance_transfer_block_idx(
+              static_cast<size_t>(resp.remote_shared_num()));
+        }
       }
 
       // Move to transfer queue for KV cache transfer
@@ -2046,7 +2150,7 @@ void PDOOCScheduler::prefill_send_multi_generations() {
         for (const auto& block : blocks) {
           multi_req->mutable_block_ids()->Add(block.id());
         }
-        multi_req->set_linear_state_id(sequence->get_single_block_id());
+        multi_req->set_linear_state_id(sequence->get_recurrent_state_slot_id());
         multi_req->set_dp_size(instance_info_.dp_size);
         multi_req->set_dp_rank(sequence->dp_rank());
       }

--- a/xllm/proto/disagg_pd.proto
+++ b/xllm/proto/disagg_pd.proto
@@ -114,9 +114,13 @@ message DisaggResponse {
   // is opaque to the PD protocol.
   repeated KVBlockGroup kv_block_groups = 20;
 
-  // Number of leading blocks served from decode-side prefix cache.
-  // Prefill uses this to skip cached blocks during KV transfer.
-  int32 num_prefix_blocks = 21;
+  // Flat KV counterpart of KVBlockGroup.remote_shared_num: the number of
+  // leading blocks the D side already holds from its own prefix cache under
+  // BlockType::KV. P advances its per-sequence transfer cursor to this value
+  // so it starts pushing at the first block D actually needs. Zero when the
+  // request did not hit the D-side cache; also zero on responses from
+  // engines that do not populate it (backward-compatible default).
+  uint32 remote_shared_num = 21;
 }
 
 // XTensor mode: offsets for one layer
@@ -131,6 +135,11 @@ message KVBlockGroup {
   int32 group_id = 1;
   reserved 2;
   repeated int32 block_ids = 3;
+  // Number of leading blocks the D side already holds from its own prefix
+  // cache. P advances its per-group transfer cursor to this value so it
+  // starts pushing at the first block that D actually needs. Zero when D
+  // has no shared prefix (e.g. DECODE-side SWA prefix cache is off by role).
+  uint32 remote_shared_num = 4;
 }
 
 // Deprecated: Use DisaggGenerationsRequest instead


### PR DESCRIPTION
## Description

<!-- What does this PR do? Briefly describe the changes and why they are needed. -->

## Related Issues

<!-- Link related issues here. Use "Fixes #123" when this PR closes an issue. -->

## Change Type

- [ ] Bug fix
- [x] New feature
- [ ] Performance improvement
- [ ] Refactor
- [ ] Documentation
- [ ] Test
- [ ] Build or CI

## Pull Request Checklist

Thank you for contributing to xLLM. Before requesting review, please make sure the following items are complete.

### PR Title and Commit Messages

- [x] The PR title and each commit message follow the xLLM commit format: `<type>: <subject>`.

> Allowed types: feat, bugfix, docs, test, refactor, chore, style, revert, perf, model, build, release.
> The subject should use clear English, start with a verb, include at least 4 words, and end with `.`.

### Pre-commit Checks

- [x] I have installed `pre-commit` by running `pip install pre-commit` or an equivalent command.
- [x] I have installed the hooks with `pre-commit install`.
- [x] I have run `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

### Self Review

- [x] I have self-reviewed the code according to `.agents/skills/code-review/references/custom-code-style.md`, especially code written or assisted by AI.
- [x] I have rebased this PR onto the latest `main` branch.

### Build and Test Coverage

- [ ] Tests have been added or updated as needed.
- [ ] CUDA: `python setup.py build test` has passed on a CUDA machine.
- [x] NPU: `python setup.py build test` has passed on an NPU machine.
- [ ] MLU: `python setup.py build test` has passed on an MLU machine.

## Reviewer Notes

<!-- Optional: anything reviewers should focus on, known risks, follow-ups, or validation gaps. -->
