### PR TITLE
bugfix: force fp16 compute path for GDN prefill on npu.

### DIFF
--- a/xllm/core/kernels/npu/xllm_ops/npu_mega_chunk_gdn.cpp
+++ b/xllm/core/kernels/npu/xllm_ops/npu_mega_chunk_gdn.cpp
@@ -88,10 +88,13 @@ std::pair<torch::Tensor, torch::Tensor> npu_mega_chunk_gdn(
     k_normalized = npu_l2norm_last_dim(k);
   }
 
-  const bool use_bf16_compute =
-      q_normalized.scalar_type() == torch::kBFloat16 &&
-      k_normalized.scalar_type() == torch::kBFloat16 &&
-      v.scalar_type() == torch::kBFloat16;
+  // Force the fp16 compute path for GDN prefill. The recurrent state S
+  // accumulates K^T V over the whole prefix across chunks; bf16's 8-bit
+  // mantissa loses precision as the sequence grows, and past ~1700 prefill
+  // tokens the output degenerates into repeated "!". This is a regression from
+  // #1999, which switched this kernel from hardcoded fp16 to bf16. fp16
+  // restores the numerically stable pre-#1999 behavior.
+  const bool use_bf16_compute = false;
   const auto compute_dtype =
       use_bf16_compute ? torch::kBFloat16 : torch::kFloat16;
   auto q_compute = q_normalized.to(compute_dtype);


### PR DESCRIPTION
The recurrent state S accumulates K^T V over the whole prefix across chunks. bf16's 8-bit mantissa loses precision as the sequence grows, and past ~1700 prefill tokens the output degenerates into repeated "!". This regressed in #1999, which switched npu_mega_chunk_gdn from a hardcoded fp16 compute path to bf16. Pin the compute dtype back to fp16 to restore the numerically stable pre-#1999 behavior.

## Description

<!-- What does this PR do? Briefly describe the changes and why they are needed. -->

## Related Issues

<!-- Link related issues here. Use "Fixes #123" when this PR closes an issue. -->

## Change Type

- [ ] Bug fix
- [ ] New feature
- [ ] Performance improvement
- [ ] Refactor
- [ ] Documentation
- [ ] Test
- [ ] Build or CI

## Pull Request Checklist

Thank you for contributing to xLLM. Before requesting review, please make sure the following items are complete.

### PR Title and Commit Messages

- [ ] The PR title and each commit message follow the xLLM commit format: `<type>: <subject>`.

> Allowed types: feat, bugfix, docs, test, refactor, chore, style, revert, perf, model, build, release.
> The subject should use clear English, start with a verb, include at least 4 words, and end with `.`.

### Pre-commit Checks

- [ ] I have installed `pre-commit` by running `pip install pre-commit` or an equivalent command.
- [ ] I have installed the hooks with `pre-commit install`.
- [ ] I have run `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

### Self Review

- [ ] I have self-reviewed the code according to `.agents/skills/code-review/references/custom-code-style.md`, especially code written or assisted by AI.
- [ ] I have rebased this PR onto the latest `main` branch.

### Build and Test Coverage

- [ ] Tests have been added or updated as needed.
- [ ] CUDA: `python setup.py build test` has passed on a CUDA machine.
- [ ] NPU: `python setup.py build test` has passed on an NPU machine.
- [ ] MLU: `python setup.py build test` has passed on an MLU machine.

## Reviewer Notes

<!-- Optional: anything reviewers should focus on, known risks, follow-ups, or validation gaps. -->
