### PR TITLE
feat: guide stale cache cleanup on xllm_ops precompile failure.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -70,7 +70,18 @@ if(USE_NPU)
       RESULT_VARIABLE XLLM_OPS_RESULT
     )
     if(NOT XLLM_OPS_RESULT EQUAL 0)
-      message(FATAL_ERROR "Failed to precompile xllm ops, error code: ${XLLM_OPS_RESULT}")
+      message(FATAL_ERROR
+        "Failed to precompile xllm ops, error code: ${XLLM_OPS_RESULT}.\n"
+        "This precompile ran because the xllm_ops git HEAD changed "
+        "(e.g. after switching commits/branches or updating the submodule).\n"
+        "A common cause of failure here is a stale incremental build cache: "
+        "removed or renamed operators leave dangling CMake targets and opc "
+        "reports 'xxx.json not generated'.\n"
+        "Fix by removing the stale xllm_ops build directory and re-running the "
+        "build. CMake re-triggers the xllm_ops precompile automatically (the "
+        "HEAD cache is only updated after a successful precompile), and the "
+        "main C++ incremental build is unaffected:\n"
+        "  rm -rf ${XLLM_OPS_BUILD_DIR}")
     endif()
 
     ## Adapt to the modification in DeekSeekV4 where the installation path of xllm_ops has been changed to custom_xllm_math


### PR DESCRIPTION
Expand the FATAL_ERROR message so a failed xllm_ops precompile explains that it was triggered by an xllm_ops git HEAD change, that a stale incremental build cache is a common cause (dangling CMake targets and opc reporting 'xxx.json not generated'), and how to recover by removing XLLM_OPS_BUILD_DIR. Notes that CMake re-triggers the precompile on the next build since the HEAD cache is only updated on success, and that the main C++ incremental build is unaffected.

## Description

<!-- What does this PR do? Briefly describe the changes and why they are needed. -->

## Related Issues

<!-- Link related issues here. Use "Fixes #123" when this PR closes an issue. -->

## Change Type

- [ ] Bug fix
- [ ] New feature
- [ ] Performance improvement
- [ ] Refactor
- [ ] Documentation
- [ ] Test
- [ ] Build or CI

## Pull Request Checklist

Thank you for contributing to xLLM. Before requesting review, please make sure the following items are complete.

### PR Title and Commit Messages

- [ ] The PR title and each commit message follow the xLLM commit format: `<type>: <subject>`.

> Allowed types: feat, bugfix, docs, test, refactor, chore, style, revert, perf, model, build, release.
> The subject should use clear English, start with a verb, include at least 4 words, and end with `.`.

### Pre-commit Checks

- [ ] I have installed `pre-commit` by running `pip install pre-commit` or an equivalent command.
- [ ] I have installed the hooks with `pre-commit install`.
- [ ] I have run `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

### Self Review

- [ ] I have self-reviewed the code according to `.agents/skills/code-review/references/custom-code-style.md`, especially code written or assisted by AI.
- [ ] I have rebased this PR onto the latest `main` branch.

### Build and Test Coverage

- [ ] Tests have been added or updated as needed.
- [ ] CUDA: `python setup.py build test` has passed on a CUDA machine.
- [ ] NPU: `python setup.py build test` has passed on an NPU machine.
- [ ] MLU: `python setup.py build test` has passed on an MLU machine.

## Reviewer Notes

<!-- Optional: anything reviewers should focus on, known risks, follow-ups, or validation gaps. -->
