### PR TITLE
bugfix: initialize NPU python runtime for standalone C++ tests.

### DIFF
--- a/cmake/cc_test.cmake
+++ b/cmake/cc_test.cmake
@@ -116,7 +116,7 @@ function(cc_test)
     target_sources(${CC_TEST_NAME} PRIVATE
       "${PROJECT_SOURCE_DIR}/tests/npu_test_environment.cpp"
     )
-    set(COMMON_LIBS Python::Python torch_npu torch_python)
+    set(COMMON_LIBS ascendcl Python::Python torch_npu torch_python)
     target_link_libraries(${CC_TEST_NAME} PRIVATE ${COMMON_LIBS})
   endif()
 

--- a/tests/core/platform/shared_vmm_allocator_test.cpp
+++ b/tests/core/platform/shared_vmm_allocator_test.cpp
@@ -24,6 +24,8 @@ limitations under the License.
 #if defined(USE_NPU)
 #include <acl/acl.h>
 #include <torch_npu/torch_npu.h>
+
+#include "tests/npu_test_environment.h"
 #endif
 
 namespace {
@@ -31,6 +33,9 @@ namespace {
 class SharedVMMAllocatorTestEnvironment : public ::testing::Environment {
  public:
   void SetUp() override {
+#if defined(USE_NPU)
+    xllm::testing::init_npu_test_runtime();
+#endif
     google::InitGoogleLogging("platform_vmm_test");
     google::SetStderrLogging(google::INFO);
 
@@ -50,6 +55,9 @@ class SharedVMMAllocatorTestEnvironment : public ::testing::Environment {
     aclFinalize();
 #endif
     google::ShutdownGoogleLogging();
+#if defined(USE_NPU)
+    xllm::testing::finalize_npu_test_runtime();
+#endif
   }
 };
 

--- a/tests/core/runtime/acl_graph_executor_test.cpp
+++ b/tests/core/runtime/acl_graph_executor_test.cpp
@@ -50,11 +50,14 @@ limitations under the License.
 #include "core/runtime/options.h"
 #include "core/runtime/speculative_worker_impl.h"
 #include "models/model_registry.h"
+#include "tests/npu_test_environment.h"
 
 // Global test environment for ACL graph executor tests
 class AclGraphExecutorTestEnvironment : public ::testing::Environment {
  public:
   void SetUp() override {
+    xllm::testing::init_npu_test_runtime();
+
     // Initialize glog
     google::InitGoogleLogging("acl_graph_executor_test");
     google::SetStderrLogging(google::INFO);
@@ -75,6 +78,8 @@ class AclGraphExecutorTestEnvironment : public ::testing::Environment {
     aclrtResetDevice(0);
     aclFinalize();
     LOG(INFO) << "AclGraphExecutorTestEnvironment TearDown completed.";
+
+    xllm::testing::finalize_npu_test_runtime();
   }
 };
 

--- a/tests/core/runtime/acl_graph_task_update_test.cpp
+++ b/tests/core/runtime/acl_graph_task_update_test.cpp
@@ -40,6 +40,7 @@ limitations under the License.
 #include "core/runtime/acl_graph_executor_impl.h"
 #include "core/runtime/base_executor_impl.h"
 #include "core/runtime/options.h"
+#include "tests/npu_test_environment.h"
 
 #if defined(__GNUC__)
 #pragma GCC diagnostic push
@@ -56,6 +57,8 @@ limitations under the License.
 class AclGraphTaskUpdateTestEnvironment : public ::testing::Environment {
  public:
   void SetUp() override {
+    xllm::testing::init_npu_test_runtime();
+
     google::InitGoogleLogging("acl_graph_task_update_test");
     google::SetStderrLogging(google::INFO);
     int ret = aclrtSetDevice(0);
@@ -70,6 +73,8 @@ class AclGraphTaskUpdateTestEnvironment : public ::testing::Environment {
     torch_npu::finalize_npu();
     aclrtResetDevice(0);
     aclFinalize();
+
+    xllm::testing::finalize_npu_test_runtime();
   }
 };
 

--- a/tests/npu_test_environment.cpp
+++ b/tests/npu_test_environment.cpp
@@ -13,23 +13,96 @@ See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
 
+#include "tests/npu_test_environment.h"
+
 #include <Python.h>
+#include <acl/acl.h>
 #include <gtest/gtest.h>
 
+#include <cstdio>
 #include <cstdlib>
+
+namespace xllm::testing {
 
 namespace {
 
+// Main-thread state saved by init_npu_test_runtime(). Test tear-down code
+// reacquires the GIL here so pybind11 objects held by torch_npu / torch can
+// dec_ref safely during process exit (otherwise pybind11 aborts with
+// PyGILState_Check failure).
+PyThreadState* g_saved_thread_state = nullptr;
+
+}  // namespace
+
+void init_npu_test_runtime() {
+  if (Py_IsInitialized()) {
+    return;
+  }
+
+  // 1. Tolerate ACL_ERROR_INTERNAL_ERROR — dump server may fail to start but
+  //    the runtime is still usable, matching the production launch path.
+  const auto acl_ret = aclInit(nullptr);
+  if (acl_ret != ACL_SUCCESS && acl_ret != ACL_ERROR_INTERNAL_ERROR) {
+    std::fprintf(stderr, "aclInit failed with error %d\n", acl_ret);
+    std::abort();
+  }
+
+  // 2. Boot the Python interpreter before importing torch_npu.
+  setenv("TORCH_DEVICE_BACKEND_AUTOLOAD", "0", 1);
+  Py_InitializeEx(0);
+
+  // 3. Import torch_npu and run its Python-side runtime init. Suppressing
+  //    torch._C._get_accelerator during import matches production and avoids
+  //    a spurious CUDA-vs-NPU accelerator check on import.
+  const int import_ret = PyRun_SimpleString(
+      "import os\n"
+      "os.environ['TORCH_DEVICE_BACKEND_AUTOLOAD'] = '0'\n"
+      "import torch\n"
+      "_orig_get_accelerator = torch._C._get_accelerator\n"
+      "try:\n"
+      "    torch._C._get_accelerator = lambda: torch.device('cpu')\n"
+      "    import torch_npu\n"
+      "finally:\n"
+      "    torch._C._get_accelerator = _orig_get_accelerator\n"
+      "import torch_npu.npu as _npu_mod\n"
+      "try:\n"
+      "    torch_npu._C._npu_init()\n"
+      "except RuntimeError as e:\n"
+      "    if 'already initialized' not in str(e).lower():\n"
+      "        raise\n"
+      "_npu_mod._initialized = True\n"
+      "_npu_mod._original_pid = os.getpid()\n");
+  if (import_ret != 0) {
+    std::fprintf(stderr, "torch_npu Python-side init failed\n");
+    std::abort();
+  }
+
+  // 4. Release the GIL so torch_npu's C++ entry points can PyGILState_Ensure
+  //    without deadlocking against the main thread.
+  g_saved_thread_state = PyEval_SaveThread();
+}
+
+void finalize_npu_test_runtime() {
+  if (g_saved_thread_state != nullptr) {
+    PyEval_RestoreThread(g_saved_thread_state);
+    g_saved_thread_state = nullptr;
+  }
+}
+
+}  // namespace xllm::testing
+
+namespace {
+
+// Mirror xllm.cpp::main()::init_npu_python_runtime() for every NPU test binary
+// via a global gtest Environment. Tests that register their own custom
+// Environment (e.g. AclGraphExecutorTestEnvironment) must call
+// xllm::testing::init_npu_test_runtime() from their own SetUp before touching
+// NPU APIs — gtest Environment ordering depends on TU link order and cannot be
+// relied on, and this file's Environment cannot deterministically run first.
 class NpuPythonEnvironment : public ::testing::Environment {
  public:
-  void SetUp() override {
-    if (Py_IsInitialized()) {
-      return;
-    }
-
-    setenv("TORCH_DEVICE_BACKEND_AUTOLOAD", "0", 1);
-    Py_InitializeEx(0);
-  }
+  void SetUp() override { xllm::testing::init_npu_test_runtime(); }
+  void TearDown() override { xllm::testing::finalize_npu_test_runtime(); }
 };
 
 ::testing::Environment* const kNpuPythonEnvironment =

--- a/tests/npu_test_environment.h
+++ b/tests/npu_test_environment.h
@@ -1,0 +1,31 @@
+/* Copyright 2026 The xLLM Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://github.com/jd-opensource/xllm/blob/main/LICENSE
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#pragma once
+
+namespace xllm::testing {
+
+// Mirror xllm.cpp::main()::init_npu_python_runtime(): aclInit tolerating
+// ACL_ERROR_INTERNAL_ERROR, Py_InitializeEx, import torch_npu + _npu_init(),
+// then PyEval_SaveThread() to release the GIL. Idempotent — safe to call from
+// multiple Environments in the same process.
+void init_npu_test_runtime();
+
+// Reacquire the GIL saved by init_npu_test_runtime so pybind11 objects held by
+// torch_npu / torch can dec_ref safely during process exit. Call from the
+// Environment's TearDown; idempotent.
+void finalize_npu_test_runtime();
+
+}  // namespace xllm::testing


### PR DESCRIPTION
Standalone gtest binaries never call xllm's main() launcher, so aclInit, Python interpreter boot, and torch_npu._C._npu_init() were missing, and NPU tests died at aclInit=500000 or during first torch device access.

Extract a shared xllm::testing::init_npu_test_runtime()/finalize helper that mirrors xllm.cpp init sequence (tolerate ACL dump-server failure, Py_InitializeEx, import torch_npu with autoload disabled, run _npu_init, release the GIL via PyEval_SaveThread). Register a global gtest Environment for the common case, and invoke it explicitly from tests that ship their own custom Environment (SharedVMMAllocator, AclGraphExecutor, AclGraphTaskUpdate) plus the ten Triton test mains tracked in the torch_npu_ops submodule bump. Add ascendcl to the cc_test common libs so aclInit resolves at link time.

## Description

<!-- What does this PR do? Briefly describe the changes and why they are needed. -->

## Related Issues

<!-- Link related issues here. Use "Fixes #123" when this PR closes an issue. -->

## Change Type

- [ ] Bug fix
- [ ] New feature
- [ ] Performance improvement
- [ ] Refactor
- [ ] Documentation
- [ ] Test
- [ ] Build or CI

## Pull Request Checklist

Thank you for contributing to xLLM. Before requesting review, please make sure the following items are complete.

### PR Title and Commit Messages

- [ ] The PR title and each commit message follow the xLLM commit format: `<type>: <subject>`.

> Allowed types: feat, bugfix, docs, test, refactor, chore, style, revert, perf, model, build, release.
> The subject should use clear English, start with a verb, include at least 4 words, and end with `.`.

### Pre-commit Checks

- [ ] I have installed `pre-commit` by running `pip install pre-commit` or an equivalent command.
- [ ] I have installed the hooks with `pre-commit install`.
- [ ] I have run `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

### Self Review

- [ ] I have self-reviewed the code according to `.agents/skills/code-review/references/custom-code-style.md`, especially code written or assisted by AI.
- [ ] I have rebased this PR onto the latest `main` branch.

### Build and Test Coverage

- [ ] Tests have been added or updated as needed.
- [ ] CUDA: `python setup.py build test` has passed on a CUDA machine.
- [x] NPU: `python setup.py build test` has passed on an NPU machine.
- [ ] MLU: `python setup.py build test` has passed on an MLU machine.

## Reviewer Notes

<!-- Optional: anything reviewers should focus on, known risks, follow-ups, or validation gaps. -->
