### PR TITLE
bugfix: prevent incompatible npu graph replays.

### DIFF
--- a/tests/core/runtime/acl_graph_executor_test.cpp
+++ b/tests/core/runtime/acl_graph_executor_test.cpp
@@ -416,6 +416,83 @@ class AclGraphExecutorTest : public ::testing::Test {
 
     return batch;
   }
+
+  void ExpectDpReplayMismatchFallsBack(
+      bool decode_no_padding,
+      const std::vector<int32_t>& captured_dp_token_nums,
+      const std::vector<int32_t>& replay_dp_token_nums,
+      bool capture_empty_rank = false) {
+    ExecutionConfig& execution_config = ExecutionConfig::get_instance();
+    const bool original_decode_no_padding =
+        execution_config.enable_graph_mode_decode_no_padding();
+    const bool original_double_buffer =
+        execution_config.enable_graph_double_buffer();
+    execution_config.enable_graph_mode_decode_no_padding(decode_no_padding);
+    execution_config.enable_graph_double_buffer(true);
+
+    std::unique_ptr<Batch> batch = CreateTestBatch();
+    EXPECT_FALSE(batch->empty());
+    ForwardInput forward_input =
+        batch->prepare_forward_input(options_.num_decoding_tokens(),
+                                     /*min_decoding_batch_size=*/0,
+                                     model_args_);
+    forward_input = forward_input.to(*device_, torch::kFloat32);
+
+    ModelInputParams capture_params = forward_input.input_params;
+    capture_params.parallel.dp_global_token_nums = captured_dp_token_nums;
+    capture_params.parallel.dp_is_decode.assign(captured_dp_token_nums.size(),
+                                                1);
+    if (capture_empty_rank) {
+      capture_params.meta.num_sequences = 0;
+      capture_params.attention.host.q_seq_lens.clear();
+      capture_params.attention.host.kv_seq_lens.clear();
+    }
+
+    std::unique_ptr<::xllm::npu::AclGraphExecutorImpl> graph_executor =
+        std::make_unique<::xllm::npu::AclGraphExecutorImpl>(
+            model_.get(), model_args_, *device_, options_);
+    const double eager_fallbacks_before =
+        COUNTER_num_model_execution_total_eager.get_value();
+    for (int32_t slot_idx = 0;
+         slot_idx < graph_executor->graph_slot_count_for_test();
+         ++slot_idx) {
+      graph_executor->run({forward_input.token_ids},
+                          {forward_input.positions},
+                          kv_caches_,
+                          {capture_params});
+    }
+    EXPECT_EQ(COUNTER_num_model_execution_total_eager.get_value(),
+              eager_fallbacks_before);
+
+    ModelInputParams replay_params = forward_input.input_params;
+    replay_params.parallel.dp_global_token_nums = replay_dp_token_nums;
+    replay_params.parallel.dp_is_decode.assign(replay_dp_token_nums.size(), 1);
+    graph_executor->prepare_graph_input(forward_input.token_ids,
+                                        forward_input.positions,
+                                        kv_caches_,
+                                        replay_params);
+    const ModelOutput eager_output = model_->forward({forward_input.token_ids},
+                                                     {forward_input.positions},
+                                                     kv_caches_,
+                                                     {replay_params});
+    const ModelOutput fallback_output =
+        graph_executor->run({forward_input.token_ids},
+                            {forward_input.positions},
+                            kv_caches_,
+                            {replay_params});
+
+    EXPECT_EQ(COUNTER_num_model_execution_total_eager.get_value(),
+              eager_fallbacks_before + 1);
+    EXPECT_TRUE(torch::allclose(eager_output.hidden_states,
+                                fallback_output.hidden_states,
+                                /*rtol=*/1e-5,
+                                /*atol=*/1e-6));
+
+    execution_config.enable_graph_mode_decode_no_padding(
+        original_decode_no_padding);
+    execution_config.enable_graph_double_buffer(original_double_buffer);
+  }
+
   bool initialized_ = false;
   ModelArgs model_args_;
   std::unique_ptr<torch::Device> device_;
@@ -524,6 +601,30 @@ TEST_F(AclGraphExecutorTest, GraphReplayConsistency) {
       << "First output:\n"
       << output1.hidden_states << "\nSecond output:\n"
       << output2.hidden_states;
+}
+
+TEST_F(AclGraphExecutorTest,
+       DpReplayFallsBackWhenRoundedBucketDistributionChanges) {
+  ExpectDpReplayMismatchFallsBack(
+      /*decode_no_padding=*/false,
+      /*captured_dp_token_nums=*/{9, 1},
+      /*replay_dp_token_nums=*/{16, 15});
+}
+
+TEST_F(AclGraphExecutorTest,
+       DpReplayFallsBackWhenNoPaddingDistributionChanges) {
+  ExpectDpReplayMismatchFallsBack(
+      /*decode_no_padding=*/true,
+      /*captured_dp_token_nums=*/{8, 1},
+      /*replay_dp_token_nums=*/{8, 7});
+}
+
+TEST_F(AclGraphExecutorTest, DpReplayFallsBackWhenEmptyRankBecomesNonEmpty) {
+  ExpectDpReplayMismatchFallsBack(
+      /*decode_no_padding=*/true,
+      /*captured_dp_token_nums=*/{8, 0},
+      /*replay_dp_token_nums=*/{8, 1},
+      /*capture_empty_rank=*/true);
 }
 
 TEST_F(AclGraphExecutorTest, PreservesAuxHiddenStatesAcrossGraphReplay) {

--- a/xllm/core/runtime/acl_graph_executor_impl.cpp
+++ b/xllm/core/runtime/acl_graph_executor_impl.cpp
@@ -93,6 +93,7 @@ bool AclGraph::capture(CausalLM* model,
       static_cast<uint32_t>(tokens.size(/*dim=*/0));
   CHECK_GE(num_tokens_, actual_num_tokens)
       << "num_tokens_ >= actual_num_tokens";
+  captured_dp_global_token_nums_ = params.parallel.dp_global_token_nums;
   auto graph_params = persistent_param_.update(tokens,
                                                k_cache,
                                                v_cache,
@@ -360,6 +361,28 @@ ModelOutput AclGraph::replay(CausalLM* model,
   return ModelOutput(get_hidden_states(actual_num_tokens));
 }
 
+bool AclGraph::is_replay_compatible(const ModelInputParams& params) const {
+  const std::vector<int32_t>& replay_dp_global_token_nums =
+      params.parallel.dp_global_token_nums;
+  const bool has_distributed_input =
+      captured_dp_global_token_nums_.size() > 1 ||
+      replay_dp_global_token_nums.size() > 1;
+  if (!has_distributed_input) {
+    return true;
+  }
+  if (captured_dp_global_token_nums_ == replay_dp_global_token_nums) {
+    return true;
+  }
+
+  LOG_FIRST_N(WARNING, 10)
+      << "Falling back to eager mode because the DP token distribution differs "
+         "from the ACL graph capture. Replaying would reuse DP/EP padding "
+         "tensor descriptors captured for another distribution. captured="
+      << captured_dp_global_token_nums_
+      << ", replay=" << replay_dp_global_token_nums;
+  return false;
+}
+
 void AclGraph::prepare_replay_inputs(const torch::Tensor& tokens,
                                      const torch::Tensor& positions,
                                      std::vector<KVCache>& kv_cache,
@@ -551,6 +574,11 @@ ModelOutput AclGraphExecutorImpl::run(const torch::Tensor& tokens,
   auto& active_persistent_param = *active_slot.persistent_param;
 
   if (replay_graph != nullptr) {
+    if (!replay_graph->is_replay_compatible(params_single)) {
+      replay_graph->discard_prepared_replay_inputs();
+      COUNTER_INC(num_model_execution_total_eager);
+      return model_->forward(tokens, positions, kv_caches, params);
+    }
     // Replay the existing graph
     VLOG(kGraphExecutorLogVerboseLevel)
         << "AclGraphExecutorImpl::run() in replay mode";
@@ -678,6 +706,10 @@ void AclGraphExecutorImpl::prepare_graph_input(const torch::Tensor& tokens,
     }
     auto it = slot.graphs.find(graph_key);
     if (it == slot.graphs.end()) {
+      return;
+    }
+    if (!it->second->is_replay_compatible(params)) {
+      it->second->discard_prepared_replay_inputs();
       return;
     }
     graph = it->second.get();

--- a/xllm/core/runtime/acl_graph_executor_impl.h
+++ b/xllm/core/runtime/acl_graph_executor_impl.h
@@ -80,6 +80,15 @@ class AclGraph {
                      std::vector<KVCache>& kv_cache,
                      const ModelInputParams& params);
 
+  // DP/EP padding tensors are captured with shapes derived from the complete
+  // per-rank token distribution. Reusing the graph for a different
+  // distribution would keep the old tensor descriptors.
+  [[nodiscard]] bool is_replay_compatible(const ModelInputParams& params) const;
+
+  void discard_prepared_replay_inputs() {
+    replay_inputs_prepared_.store(false, std::memory_order_release);
+  }
+
   void prepare_replay_inputs(const torch::Tensor& tokens,
                              const torch::Tensor& positions,
                              std::vector<KVCache>& kv_cache,
@@ -120,6 +129,7 @@ class AclGraph {
   std::shared_ptr<AclGraphTaskUpdateContext> graph_task_context_;
   std::optional<c10_npu::NPUStream> update_stream_;
   std::atomic<bool> replay_inputs_prepared_{false};
+  std::vector<int32_t> captured_dp_global_token_nums_;
 };
 
 // Executor implementation using ACL graph optimization


### PR DESCRIPTION
## Description

ACL graph keys are based on the rounded or exact maximum DP token bucket. Two decode steps can therefore select the same graph while carrying different per-rank token distributions.

The persistent DP/EP padding buffers are refreshed before replay, but the graph keeps the tensor descriptors and empty-rank branches recorded during capture. Replaying with another distribution can expose stale tails, truncate new padding metadata, or reuse the wrong q_cu_seq_lens binding.

This change:

- records the complete `dp_global_token_nums` vector for each captured ACL graph;
- skips double-buffer input preparation when the next request is incompatible;
- falls back to eager execution before replay when the distribution changed; and
- adds coverage for rounded buckets, `decode_no_padding`, and empty-to-nonempty rank transitions.

The distribution vector is global and identical on all DP ranks, so the fallback decision remains collective-safe.

## Dependency

Depends on #2024.

#2024 preserves raw DP token counts for empty shards so fake execution rows are excluded from LM-head/output compaction. This PR fixes graph persistence consistency but intentionally does not duplicate that accounting change. Without #2024, graph and eager execution follow the same metadata after fallback, but both can still count an empty shard's fake row.

Please merge #2024 first, or rebase this PR after #2024 lands.

## Related Issues

- Depends on #2024

## Change Type

- [x] Bug fix
- [ ] New feature
- [ ] Performance improvement
- [ ] Refactor
- [ ] Documentation
- [x] Test
- [ ] Build or CI

## Pull Request Checklist

### PR Title and Commit Messages

- [x] The PR title and each commit message follow the xLLM commit format: `<type>: <subject>`.

### Pre-commit Checks

- [ ] I have installed `pre-commit` by running `pip install pre-commit` or an equivalent command.
- [ ] I have installed the hooks with `pre-commit install`.
- [ ] I have run `pre-commit run --all-files` and fixed any reported issues.

Changed-file validation passed:

```text
pre-commit run --files tests/core/runtime/acl_graph_executor_test.cpp \
  xllm/core/runtime/acl_graph_executor_impl.cpp \
  xllm/core/runtime/acl_graph_executor_impl.h
clang-format.............................................................Passed
```

### Self Review

- [x] I have self-reviewed the code according to `.agents/skills/code-review/references/custom-code-style.md`, especially code written or assisted by AI.
- [x] I have rebased this PR onto the latest `main` branch.

### Build and Test Coverage

- [x] Tests have been added or updated as needed.
- [ ] CUDA: `python setup.py build test` has passed on a CUDA machine.
- [x] NPU: a full `python setup.py build --device npu` completed successfully on an Ascend development machine.
- [ ] MLU: `python setup.py build test` has passed on an MLU machine.

NPU test results:

- targeted graph replay tests: 3/3 passed;
- complete `acl_graph_executor_test`: 24/24 passed.

## Reviewer Notes

This intentionally falls back to eager execution instead of caching one graph per DP distribution. The latter can create an unbounded graph cache for normal scheduling variance.

Please review together with #2024 for the complete empty-shard data flow.
