### PR TITLE
refactor: replace wan2.2 tp with linear.cpp.

### DIFF
--- a/xllm/core/framework/parallel_state/dit_collective_communicator.cpp
+++ b/xllm/core/framework/parallel_state/dit_collective_communicator.cpp
@@ -95,7 +95,7 @@ ProcessGroup* DiTCollectiveCommunicator::create_process_group_by_type(
     std::unique_ptr<ProcessGroup>& member_group,
     const torch::Device& device) {
   int32_t group_size = parallel_args_->get_group_size_by_type(group_type);
-  if (group_size > 1 && dit_mapping_) {
+  if (dit_mapping_) {
     auto parallel_info = dit_mapping_->get_parallel_info(group_type);
     auto group_id = parallel_info.current_group_id();
     auto num_group = parallel_info.num_group();

--- a/xllm/core/framework/quant_args.h
+++ b/xllm/core/framework/quant_args.h
@@ -112,16 +112,6 @@ struct QuantArgs {
 
   // ── Convenience helpers for weight-loading prefix resolution ──────────
 
-  bool is_quantized() const { return !quant_descs_.empty(); }
-
-  // Returns `quant_key` when the model is quantized (quant_descs is
-  // non-empty), otherwise returns `fallback`.  Use this to pick between
-  // checkpoint key names / prefixes at load time without repeated if/else.
-  std::string resolve_prefix(const std::string& quant_key,
-                             const std::string& fallback) const {
-    return quant_descs_.empty() ? fallback : quant_key;
-  }
-
   // ── Module-level helpers ────────────────────────────────────────────────
 
   bool should_ignore_module(const std::string& module_name) const {

--- a/xllm/core/layers/common/linear.h
+++ b/xllm/core/layers/common/linear.h
@@ -285,6 +285,14 @@ class RowParallelLinearImpl : public torch::nn::Module {
   }
   ProcessGroup* process_group() const { return process_group_; }
 
+  bool is_weight_loaded() const {
+    if (quant_args_.quant_method() == kQuantMethodSmoothquant) {
+      return qweight_is_loaded_ && per_channel_scale_is_loaded_ &&
+             smooth_is_loaded_;
+    }
+    return weight_is_loaded_;
+  }
+
  private:
   torch::Tensor forward_impl(torch::Tensor input,
                              RowParallelReduceMode reduce_mode);

--- a/xllm/models/dit/transformers/transformer_wan.h
+++ b/xllm/models/dit/transformers/transformer_wan.h
@@ -36,13 +36,12 @@ limitations under the License.
 #include "core/framework/state_dict/utils.h"
 #include "core/layers/common/ada_layer_norm.h"
 #include "core/layers/common/add_matmul.h"
+#include "core/layers/common/linear.h"
 #include "core/layers/common/rms_norm.h"
 #include "models/dit/utils/dit_parallel_linear.h"
 #include "models/dit/utils/sparse_attention.h"
+#include "models/dit/utils/util.h"
 
-using xllm::dit::DiTParallelLinear;
-using xllm::dit::SpOptions;
-using xllm::dit::TpOptions;
 #if defined(USE_NPU)
 #include "core/layers/npu/loader/rolling_load_manager.h"
 #include "core/layers/npu/loader/rolling_weight_buffer.h"
@@ -140,6 +139,23 @@ inline torch::Tensor sp_slice_heads(const torch::Tensor& input,
       .view({input.size(0), -1, n_heads * sp_group->world_size(), dim_head})
       .slice(2, sp_group->rank() * n_heads, (sp_group->rank() + 1) * n_heads)
       .flatten(2, 3);
+}
+
+inline torch::Tensor sp_all_to_all_reverse(const torch::Tensor& input,
+                                           int64_t heads,
+                                           int64_t dim_head,
+                                           int64_t tp_size,
+                                           ProcessGroup* sp_group) {
+  auto fn = parallel_state::all_to_all_4D(
+      input.view({input.size(0),
+                  -1,
+                  heads / (tp_size * sp_group->world_size()),
+                  dim_head}),
+      /*scatter_dim=*/1,
+      /*gather_dim=*/2,
+      /*async=*/false,
+      sp_group);
+  return fn().view({input.size(0), -1, heads * dim_head / tp_size});
 }
 
 class FP32LayerNormImpl : public torch::nn::Module {
@@ -242,16 +258,12 @@ class WanTimestepEmbeddingImpl : public torch::nn::Module {
   }
 
   void load_state_dict(const StateDict& state_dict) {
-    linear_1_->load_state_dict(state_dict.get_dict_with_prefix(
-        quant_args_.resolve_prefix("0.", "linear_1.")));
-    linear_2_->load_state_dict(state_dict.get_dict_with_prefix(
-        quant_args_.resolve_prefix("2.", "linear_2.")));
+    linear_1_->load_state_dict(state_dict.get_dict_with_prefix("linear_1."));
+    linear_2_->load_state_dict(state_dict.get_dict_with_prefix("linear_2."));
   }
   void verify_loaded_weights(const std::string& prefix) const {
-    linear_1_->verify_loaded_weights(
-        prefix + quant_args_.resolve_prefix("0.", "linear_1."));
-    linear_2_->verify_loaded_weights(
-        prefix + quant_args_.resolve_prefix("2.", "linear_2."));
+    linear_1_->verify_loaded_weights(prefix + "linear_1.");
+    linear_2_->verify_loaded_weights(prefix + "linear_2.");
   }
 
  private:
@@ -336,19 +348,15 @@ class WanGELUImpl : public torch::nn::Module {
         options_(context.get_tensor_options()),
         parallel_args_(parallel_args) {
     quant_args_ = context.get_quant_args();
-    std::optional<TpOptions> tp = std::nullopt;
-    if (::xllm::ParallelConfig::get_instance().tp_size() > 1) {
-      tp = TpOptions::col(parallel_args_.dit_tp_group_,
-                          /*gather_output=*/false);
-    }
-    auto proj = DiTParallelLinear(dim_in,
-                                  dim_out,
-                                  with_bias,
-                                  options_,
-                                  /*sp=*/std::nullopt,
-                                  tp,
-                                  quant_args_);
-    proj_ = register_module("proj", proj);
+    proj_ = register_module(
+        "proj",
+        layer::ColumnParallelLinear(dim_in,
+                                    dim_out,
+                                    with_bias,
+                                    /*gather_output=*/false,
+                                    quant_args_,
+                                    parallel_args_.dit_tp_group_,
+                                    options_));
   }
 
   torch::Tensor forward(const torch::Tensor& hidden_states_in) {
@@ -362,19 +370,11 @@ class WanGELUImpl : public torch::nn::Module {
   }
 
   void load_state_dict(const StateDict& state_dict) {
-    if (quant_args_.is_quantized()) {
-      // Quantized checkpoint stores weights directly under the module's
-      // own prefix — no additional sub-prefix wrapping.
-      proj_->as<DiTParallelLinear>()->load_state_dict(state_dict);
-    } else {
-      proj_->as<DiTParallelLinear>()->load_state_dict(
-          state_dict.get_dict_with_prefix("proj."));
-    }
+    proj_->load_state_dict(state_dict.get_dict_with_prefix("proj."));
   }
 
   void verify_loaded_weights(const std::string& prefix) const {
-    proj_->as<DiTParallelLinear>()->verify_loaded_weights(
-        prefix + quant_args_.resolve_prefix("", "proj."));
+    CHECK(proj_->is_weight_loaded()) << prefix << "proj weight not loaded";
   }
 
  private:
@@ -382,7 +382,7 @@ class WanGELUImpl : public torch::nn::Module {
   bool approximate_;
   torch::TensorOptions options_;
   ParallelArgs parallel_args_;
-  DiTParallelLinear proj_{nullptr};
+  layer::ColumnParallelLinear proj_{nullptr};
 };
 TORCH_MODULE(WanGELU);
 
@@ -432,16 +432,16 @@ class WanFeedForwardImpl : public torch::nn::Module {
 
     dropout_ = register_module("dropout", torch::nn::Dropout(dropout));
 
-    auto tp_out = TpOptions::row(parallel_args_.dit_tp_group_,
-                                 /*gather_output=*/true);
-    auto proj_out = DiTParallelLinear(actual_inner_dim,
-                                      actual_dim_out,
-                                      with_bias,
-                                      options_,
-                                      /*sp=*/std::nullopt,
-                                      tp_out,
-                                      quant_args_);
-    proj_out_ = register_module("proj_out", proj_out);
+    proj_out_ = register_module(
+        "proj_out",
+        layer::RowParallelLinear(actual_inner_dim,
+                                 actual_dim_out,
+                                 with_bias,
+                                 /*input_is_parallelized=*/true,
+                                 /*enable_result_reduction=*/true,
+                                 quant_args_,
+                                 parallel_args_.dit_tp_group_,
+                                 options_));
 
     if (final_dropout) {
       final_dropout_ =
@@ -460,17 +460,13 @@ class WanFeedForwardImpl : public torch::nn::Module {
   }
 
   void load_state_dict(const StateDict& state_dict) {
-    act_fn_->load_state_dict(state_dict.get_dict_with_prefix(
-        quant_args_.resolve_prefix("0.", "net.0.")));
-    proj_out_->load_state_dict(state_dict.get_dict_with_prefix(
-        quant_args_.resolve_prefix("2.", "net.2.")));
+    act_fn_->load_state_dict(state_dict.get_dict_with_prefix("net.0."));
+    proj_out_->load_state_dict(state_dict.get_dict_with_prefix("net.2."));
   }
 
   void verify_loaded_weights(const std::string& prefix) const {
-    act_fn_->verify_loaded_weights(prefix +
-                                   quant_args_.resolve_prefix("0.", "net.0."));
-    proj_out_->verify_loaded_weights(
-        prefix + quant_args_.resolve_prefix("2.", "net.2."));
+    act_fn_->verify_loaded_weights(prefix + "net.0.");
+    CHECK(proj_out_->is_weight_loaded()) << prefix << "net.2 weight not loaded";
   }
 
  private:
@@ -479,7 +475,7 @@ class WanFeedForwardImpl : public torch::nn::Module {
   ParallelArgs parallel_args_;
   WanGELU act_fn_{nullptr};
   torch::nn::Dropout dropout_{nullptr};
-  DiTParallelLinear proj_out_{nullptr};
+  layer::RowParallelLinear proj_out_{nullptr};
   torch::nn::Dropout final_dropout_{nullptr};
 };
 TORCH_MODULE(WanFeedForward);
@@ -532,17 +528,13 @@ class WanPixArtAlphaTextProjectionImpl : public torch::nn::Module {
   }
 
   void load_state_dict(const StateDict& state_dict) {
-    linear_1_->load_state_dict(state_dict.get_dict_with_prefix(
-        quant_args_.resolve_prefix("0.", "linear_1.")));
-    linear_2_->load_state_dict(state_dict.get_dict_with_prefix(
-        quant_args_.resolve_prefix("2.", "linear_2.")));
+    linear_1_->load_state_dict(state_dict.get_dict_with_prefix("linear_1."));
+    linear_2_->load_state_dict(state_dict.get_dict_with_prefix("linear_2."));
   }
 
   void verify_loaded_weights(const std::string& prefix) const {
-    linear_1_->verify_loaded_weights(
-        prefix + quant_args_.resolve_prefix("0.", "linear_1."));
-    linear_2_->verify_loaded_weights(
-        prefix + quant_args_.resolve_prefix("2.", "linear_2."));
+    linear_1_->verify_loaded_weights(prefix + "linear_1.");
+    linear_2_->verify_loaded_weights(prefix + "linear_2.");
   }
 
  private:
@@ -583,87 +575,71 @@ class WanAttentionImpl : public torch::nn::Module {
     } else {
       kv_inner_dim_ = heads_ * dim_head_;
     }
-    // Pre-build options that get reused
-    auto tp_qk = TpOptions::col(parallel_args_.dit_tp_group_,
-                                /*gather_output=*/false);
-    auto tp_v = TpOptions::col(parallel_args_.dit_tp_group_,
-                               /*gather_output=*/false);
-    auto tp_out = TpOptions::row(parallel_args_.dit_tp_group_,
-                                 /*gather_output=*/true);
+    // Q/K: TP column only (SP handled in forward() due to norm ordering)
+    to_q_ = register_module(
+        "to_q",
+        layer::ColumnParallelLinear(dim_,
+                                    heads_ * dim_head_,
+                                    true,
+                                    /*gather_output=*/false,
+                                    quant_args_,
+                                    parallel_args_.dit_tp_group_,
+                                    options_));
+    to_k_ = register_module(
+        "to_k",
+        layer::ColumnParallelLinear(dim_,
+                                    kv_inner_dim_,
+                                    true,
+                                    /*gather_output=*/false,
+                                    quant_args_,
+                                    parallel_args_.dit_tp_group_,
+                                    options_));
 
-    auto sp_before = SpOptions(heads_,
-                               dim_head_,
-                               dim_,
-                               /*before_attention=*/true,
-                               parallel_args_.dit_sp_group_);
-    auto sp_after = SpOptions(heads_,
-                              dim_head_,
-                              dim_,
-                              /*before_attention=*/false,
-                              parallel_args_.dit_sp_group_);
-
-    // Q/K: TP only (SP handled in forward() due to norm ordering)
-    to_q_ = register_module("to_q",
-                            DiTParallelLinear(dim_,
-                                              heads_ * dim_head_,
-                                              true,
-                                              options_,
-                                              /*sp=*/std::nullopt,
-                                              tp_qk,
-                                              quant_args_));
-    to_k_ = register_module("to_k",
-                            DiTParallelLinear(dim_,
-                                              kv_inner_dim_,
-                                              true,
-                                              options_,
-                                              /*sp=*/std::nullopt,
-                                              tp_qk,
-                                              quant_args_));
-
-    // V: TP+SP for self-attention, TP only for cross-attention
-    bool is_self_attn = cross_attention_dim_head <= 0;
+    // V: TP column only (SP all2all handled in forward())
     to_v_ = register_module(
         "to_v",
-        DiTParallelLinear(dim_,
-                          kv_inner_dim_,
-                          true,
-                          options_,
-                          is_self_attn ? sp_before : std::optional<SpOptions>{},
-                          tp_v,
-                          quant_args_));
+        layer::ColumnParallelLinear(dim_,
+                                    kv_inner_dim_,
+                                    true,
+                                    /*gather_output=*/false,
+                                    quant_args_,
+                                    parallel_args_.dit_tp_group_,
+                                    options_));
 
-    // to_out: TP+SP row parallel
-    to_out_ = register_module("to_out",
-                              DiTParallelLinear(heads_ * dim_head_,
-                                                dim_,
-                                                true,
-                                                options_,
-                                                sp_after,
-                                                tp_out,
-                                                quant_args_));
+    // to_out: TP row only (SP all2all handled in forward())
+    to_out_ = register_module(
+        "to_out",
+        layer::RowParallelLinear(heads_ * dim_head_,
+                                 dim_,
+                                 true,
+                                 /*input_is_parallelized=*/true,
+                                 /*enable_result_reduction=*/true,
+                                 quant_args_,
+                                 parallel_args_.dit_tp_group_,
+                                 options_));
     norm_q_ = register_module(
         "norm_q", layer::RMSNorm(dim_head_ * heads_, eps_, options_));
     norm_k_ = register_module(
         "norm_k", layer::RMSNorm(dim_head_ * heads_, eps_, options_));
     if (added_kv_proj_dim_ > 0) {
-      auto add_k_tp = TpOptions::col(parallel_args_.dit_tp_group_,
-                                     /*gather_output=*/false);
-      auto add_v_tp = TpOptions::col(parallel_args_.dit_tp_group_,
-                                     /*gather_output=*/false);
-      auto add_k_proj = DiTParallelLinear(added_kv_proj_dim_,
-                                          heads_ * dim_head_,
-                                          true,
-                                          options_,
-                                          /*sp=*/std::nullopt,
-                                          add_k_tp);
-      add_k_proj_ = register_module("add_k_proj", add_k_proj);
-      auto add_v_proj = DiTParallelLinear(added_kv_proj_dim_,
-                                          heads_ * dim_head_,
-                                          true,
-                                          options_,
-                                          /*sp=*/std::nullopt,
-                                          add_v_tp);
-      add_v_proj_ = register_module("add_v_proj", add_v_proj);
+      add_k_proj_ = register_module(
+          "add_k_proj",
+          layer::ColumnParallelLinear(added_kv_proj_dim_,
+                                      heads_ * dim_head_,
+                                      true,
+                                      /*gather_output=*/false,
+                                      QuantArgs(),
+                                      parallel_args_.dit_tp_group_,
+                                      options_));
+      add_v_proj_ = register_module(
+          "add_v_proj",
+          layer::ColumnParallelLinear(added_kv_proj_dim_,
+                                      heads_ * dim_head_,
+                                      true,
+                                      /*gather_output=*/false,
+                                      QuantArgs(),
+                                      parallel_args_.dit_tp_group_,
+                                      options_));
       norm_added_k_ = register_module(
           "norm_added_k", layer::RMSNorm(dim_head_ * heads_, eps_, options_));
     }
@@ -817,7 +793,7 @@ class WanAttentionImpl : public torch::nn::Module {
       key = std::get<0>(norm_k_->forward(key));
     }
 
-    // ── Step 3: SP all2all for Q/K (V already done in layer) ──
+    // ── Step 3: SP all2all for Q/K/V (self-attn) or slice K/V (cross-attn) ──
     int64_t batch_size = query.size(0);
     int64_t n_heads = heads_;
     if (::xllm::ParallelConfig::get_instance().tp_size() > 1) {
@@ -835,6 +811,11 @@ class WanAttentionImpl : public torch::nn::Module {
                             dim_head_,
                             ::xllm::ParallelConfig::get_instance().tp_size(),
                             parallel_args_.dit_sp_group_);
+        value = sp_all_to_all(value,
+                              heads_,
+                              dim_head_,
+                              ::xllm::ParallelConfig::get_instance().tp_size(),
+                              parallel_args_.dit_sp_group_);
       } else {
         key = sp_slice_heads(key,
                              heads_,
@@ -897,20 +878,24 @@ class WanAttentionImpl : public torch::nn::Module {
     if (hidden_states_img.defined()) {
       hidden_states = hidden_states + hidden_states_img;
     }
+    if (::xllm::ParallelConfig::get_instance().sp_size() > 1) {
+      hidden_states = sp_all_to_all_reverse(
+          hidden_states,
+          heads_,
+          dim_head_,
+          ::xllm::ParallelConfig::get_instance().tp_size(),
+          parallel_args_.dit_sp_group_);
+    }
     hidden_states = to_out_->forward(hidden_states);
 
     return hidden_states;
   }
 
   void load_state_dict(const StateDict& state_dict) {
-    to_q_->load_state_dict(state_dict.get_dict_with_prefix(
-        quant_args_.resolve_prefix("q.", "to_q.")));
-    to_k_->load_state_dict(state_dict.get_dict_with_prefix(
-        quant_args_.resolve_prefix("k.", "to_k.")));
-    to_v_->load_state_dict(state_dict.get_dict_with_prefix(
-        quant_args_.resolve_prefix("v.", "to_v.")));
-    to_out_->load_state_dict(state_dict.get_dict_with_prefix(
-        quant_args_.resolve_prefix("o.", "to_out.0.")));
+    to_q_->load_state_dict(state_dict.get_dict_with_prefix("to_q."));
+    to_k_->load_state_dict(state_dict.get_dict_with_prefix("to_k."));
+    to_v_->load_state_dict(state_dict.get_dict_with_prefix("to_v."));
+    to_out_->load_state_dict(state_dict.get_dict_with_prefix("to_out.0."));
 
     norm_q_->load_state_dict(state_dict.get_dict_with_prefix("norm_q."));
     norm_k_->load_state_dict(state_dict.get_dict_with_prefix("norm_k."));
@@ -926,17 +911,16 @@ class WanAttentionImpl : public torch::nn::Module {
   }
 
   void verify_loaded_weights(const std::string& prefix) const {
-    to_q_->verify_loaded_weights(prefix +
-                                 quant_args_.resolve_prefix("q.", "to_q."));
-    to_k_->verify_loaded_weights(prefix +
-                                 quant_args_.resolve_prefix("k.", "to_k."));
-    to_v_->verify_loaded_weights(prefix +
-                                 quant_args_.resolve_prefix("v.", "to_v."));
-    to_out_->verify_loaded_weights(
-        prefix + quant_args_.resolve_prefix("o.", "to_out.0."));
+    CHECK(to_q_->is_weight_loaded()) << prefix << "to_q weight not loaded";
+    CHECK(to_k_->is_weight_loaded()) << prefix << "to_k weight not loaded";
+    CHECK(to_v_->is_weight_loaded()) << prefix << "to_v weight not loaded";
+    CHECK(to_out_->is_weight_loaded())
+        << prefix << "to_out.0 weight not loaded";
     if (add_k_proj_) {
-      add_k_proj_->verify_loaded_weights(prefix + "add_k_proj.");
-      add_v_proj_->verify_loaded_weights(prefix + "add_v_proj.");
+      CHECK(add_k_proj_->is_weight_loaded())
+          << prefix << "add_k_proj weight not loaded";
+      CHECK(add_v_proj_->is_weight_loaded())
+          << prefix << "add_v_proj weight not loaded";
     }
   }
 
@@ -951,12 +935,12 @@ class WanAttentionImpl : public torch::nn::Module {
   float dropout_;
   bool is_cross_attention_;
 
-  DiTParallelLinear to_q_{nullptr};
-  DiTParallelLinear to_k_{nullptr};
-  DiTParallelLinear to_v_{nullptr};
-  DiTParallelLinear to_out_{nullptr};
-  DiTParallelLinear add_k_proj_{nullptr};
-  DiTParallelLinear add_v_proj_{nullptr};
+  layer::ColumnParallelLinear to_q_{nullptr};
+  layer::ColumnParallelLinear to_k_{nullptr};
+  layer::ColumnParallelLinear to_v_{nullptr};
+  layer::RowParallelLinear to_out_{nullptr};
+  layer::ColumnParallelLinear add_k_proj_{nullptr};
+  layer::ColumnParallelLinear add_v_proj_{nullptr};
   ParallelArgs parallel_args_;
 
   layer::RMSNorm norm_q_{nullptr};
@@ -1119,12 +1103,11 @@ class WanTimeTextImageEmbeddingImpl : public torch::nn::Module {
   }
 
   void load_state_dict(const StateDict& state_dict) {
-    time_embedder_->load_state_dict(state_dict.get_dict_with_prefix(
-        quant_args_.resolve_prefix("time_embedding.", "time_embedder.")));
-    time_proj_->load_state_dict(state_dict.get_dict_with_prefix(
-        quant_args_.resolve_prefix("time_projection.1.", "time_proj.")));
-    text_embedder_->load_state_dict(state_dict.get_dict_with_prefix(
-        quant_args_.resolve_prefix("text_embedding.", "text_embedder.")));
+    time_embedder_->load_state_dict(
+        state_dict.get_dict_with_prefix("time_embedder."));
+    time_proj_->load_state_dict(state_dict.get_dict_with_prefix("time_proj."));
+    text_embedder_->load_state_dict(
+        state_dict.get_dict_with_prefix("text_embedder."));
     if (image_embedder_) {
       image_embedder_->load_state_dict(
           state_dict.get_dict_with_prefix("image_embedder."));
@@ -1132,15 +1115,9 @@ class WanTimeTextImageEmbeddingImpl : public torch::nn::Module {
   }
 
   void verify_loaded_weights(const std::string& prefix) const {
-    time_embedder_->verify_loaded_weights(
-        prefix +
-        quant_args_.resolve_prefix("time_embedding.", "time_embedder."));
-    time_proj_->verify_loaded_weights(
-        prefix +
-        quant_args_.resolve_prefix("time_projection.1.", "time_proj."));
-    text_embedder_->verify_loaded_weights(
-        prefix +
-        quant_args_.resolve_prefix("text_embedding.", "text_embedder."));
+    time_embedder_->verify_loaded_weights(prefix + "time_embedder.");
+    time_proj_->verify_loaded_weights(prefix + "time_proj.");
+    text_embedder_->verify_loaded_weights(prefix + "text_embedder.");
     if (image_embedder_) {
       image_embedder_->verify_loaded_weights(prefix + "image_embedder.");
     }
@@ -1431,36 +1408,26 @@ class WanTransformerBlockImpl : public torch::nn::Module {
   }
 
   void load_state_dict(const StateDict& state_dict) {
-    attn1_->load_state_dict(state_dict.get_dict_with_prefix(
-        quant_args_.resolve_prefix("self_attn.", "attn1.")));
-    attn2_->load_state_dict(state_dict.get_dict_with_prefix(
-        quant_args_.resolve_prefix("cross_attn.", "attn2.")));
+    attn1_->load_state_dict(state_dict.get_dict_with_prefix("attn1."));
+    attn2_->load_state_dict(state_dict.get_dict_with_prefix("attn2."));
     if (cross_attn_norm_ && norm2_) {
-      norm2_->load_state_dict(state_dict.get_dict_with_prefix(
-          quant_args_.resolve_prefix("norm3.", "norm2.")));
+      norm2_->load_state_dict(state_dict.get_dict_with_prefix("norm2."));
     }
-    ff_->load_state_dict(state_dict.get_dict_with_prefix(
-        quant_args_.resolve_prefix("ffn.", "ffn.")));
-    weight::load_weight(
-        state_dict,
-        quant_args_.resolve_prefix("modulation", "scale_shift_table"),
-        scale_shift_table_,
-        scale_shift_table_loaded_);
+    ff_->load_state_dict(state_dict.get_dict_with_prefix("ffn."));
+    weight::load_weight(state_dict,
+                        "scale_shift_table",
+                        scale_shift_table_,
+                        scale_shift_table_loaded_);
   }
 
   void verify_loaded_weights(const std::string& prefix) const {
-    attn1_->verify_loaded_weights(
-        prefix + quant_args_.resolve_prefix("self_attn.", "attn1."));
+    attn1_->verify_loaded_weights(prefix + "attn1.");
     if (cross_attn_norm_) {
-      norm2_->verify_loaded_weights(
-          prefix + quant_args_.resolve_prefix("norm3.", "norm2."));
+      norm2_->verify_loaded_weights(prefix + "norm2.");
     }
-    attn2_->verify_loaded_weights(
-        prefix + quant_args_.resolve_prefix("cross_attn.", "attn2."));
-    ff_->verify_loaded_weights(prefix +
-                               quant_args_.resolve_prefix("ffn.", "ffn."));
-    auto scale_key =
-        quant_args_.resolve_prefix("modulation", "scale_shift_table");
+    attn2_->verify_loaded_weights(prefix + "attn2.");
+    ff_->verify_loaded_weights(prefix + "ffn.");
+    auto scale_key = "scale_shift_table";
     CHECK(scale_shift_table_loaded_)
         << scale_key << " is not loaded for " << prefix + scale_key;
   }
@@ -1732,25 +1699,17 @@ class WanTransformer3DModelImpl : public torch::nn::Module {
                         patch_embedding_->bias,
                         pad_embedding_bias_loaded_);
 
-    if (quant_args_.is_quantized()) {
-      // Quantized checkpoint stores condition_embedder weights directly
-      // under the top-level prefix — no "condition_embedder." wrapper.
-      condition_embedder_->load_state_dict(state_dict);
-      proj_out_->load_state_dict(state_dict.get_dict_with_prefix("head.head."));
-    } else {
-      condition_embedder_->load_state_dict(
-          state_dict.get_dict_with_prefix("condition_embedder."));
-      proj_out_->load_state_dict(state_dict.get_dict_with_prefix("proj_out."));
-    }
+    condition_embedder_->load_state_dict(
+        state_dict.get_dict_with_prefix("condition_embedder."));
+    proj_out_->load_state_dict(state_dict.get_dict_with_prefix("proj_out."));
     for (int64_t i = 0; i < transformer_layers_.size(); ++i) {
       transformer_layers_[i]->load_state_dict(
           state_dict.get_dict_with_prefix("blocks." + std::to_string(i) + "."));
     }
-    weight::load_weight(
-        state_dict,
-        quant_args_.resolve_prefix("head.modulation", "scale_shift_table"),
-        scale_shift_table_,
-        scale_shift_table_loaded_);
+    weight::load_weight(state_dict,
+                        "scale_shift_table",
+                        scale_shift_table_,
+                        scale_shift_table_loaded_);
   }
 
   void verify_loaded_weights(const std::string& prefix) const {
@@ -1759,20 +1718,13 @@ class WanTransformer3DModelImpl : public torch::nn::Module {
     CHECK(pad_embedding_bias_loaded_) << "patch_embedding is not loaded for"
                                       << prefix << "pad_embedding.bias";
 
-    if (quant_args_.is_quantized()) {
-      condition_embedder_->verify_loaded_weights(prefix);
-      proj_out_->verify_loaded_weights(prefix + "head.head.");
-    } else {
-      condition_embedder_->verify_loaded_weights(prefix +
-                                                 "condition_embedder.");
-      proj_out_->verify_loaded_weights(prefix + "proj_out.");
-    }
+    condition_embedder_->verify_loaded_weights(prefix + "condition_embedder.");
+    proj_out_->verify_loaded_weights(prefix + "proj_out.");
     for (size_t i = 0; i < transformer_layers_.size(); ++i) {
       transformer_layers_[i]->verify_loaded_weights(prefix + "blocks." +
                                                     std::to_string(i) + ".");
     }
-    auto scale_key =
-        quant_args_.resolve_prefix("head.modulation", "scale_shift_table");
+    auto scale_key = "scale_shift_table";
     CHECK(scale_shift_table_loaded_)
         << scale_key << " is not loaded for " << prefix + scale_key;
   }
@@ -1785,7 +1737,10 @@ class WanTransformer3DModelImpl : public torch::nn::Module {
                   bool rolling = false) {
     auto freqs_cos_fp32 = rope_->get_freqs_cos().clone();
     auto freqs_sin_fp32 = rope_->get_freqs_sin().clone();
-    this->to(rolling ? torch::kCPU : options_.device(), torch::kBFloat16);
+
+    dit::to_bf16_preserve_quant(*this,
+                                rolling ? torch::kCPU : options_.device());
+
     for (const auto& state_dict : loader->get_state_dicts()) {
       load_state_dict(*state_dict);
     }

--- a/xllm/models/dit/transformers/transformer_wan.h
+++ b/xllm/models/dit/transformers/transformer_wan.h
@@ -1737,7 +1737,7 @@ class WanTransformer3DModelImpl : public torch::nn::Module {
                   bool rolling = false) {
     auto freqs_cos_fp32 = rope_->get_freqs_cos().clone();
     auto freqs_sin_fp32 = rope_->get_freqs_sin().clone();
-
+    // TODO: check the dtype solution. just use the options' dtype to control, instead of the to dtype.
     dit::to_bf16_preserve_quant(*this,
                                 rolling ? torch::kCPU : options_.device());
 

--- a/xllm/models/dit/utils/util.h
+++ b/xllm/models/dit/utils/util.h
@@ -86,4 +86,24 @@ torch::Tensor randn_tensor(const std::vector<int64_t>& shape,
   return latents;
 }
 
+// Convert module parameters & buffers to BF16 on the target device,
+// but leave Int8 (quantized) tensors unchanged — to(bf16) would corrupt them.
+inline void to_bf16_preserve_quant(torch::nn::Module& module,
+                                   torch::Device device) {
+  for (auto& p : module.named_parameters()) {
+    if (p.value().scalar_type() == torch::kInt8) {
+      p.value().set_data(p.value().to(device, torch::kInt8));
+    } else {
+      p.value().set_data(p.value().to(device, torch::kBFloat16));
+    }
+  }
+  for (auto& b : module.named_buffers()) {
+    if (b.value().scalar_type() == torch::kInt8) {
+      b.value().set_data(b.value().to(device, torch::kInt8));
+    } else {
+      b.value().set_data(b.value().to(device, torch::kBFloat16));
+    }
+  }
+}
+
 }  // namespace xllm::dit


### PR DESCRIPTION
percision compared between refactor and no refactor: 
1) tp4cfg2sp1 + no quant + no rolling weight,  0.9992
2) tp1cfg2sp4 + no quant + rolling weight, 0.9967
3) tp1cfg2sp4 + quant + rolling weight, 0.9953

percision reasons: 
1.  The bias of RowParallelLinear is accumulated in different stages, which causes precision deviation due to add order
2.  torch:addmm in linear.cpp vs xllm::kernel::matmul in dit_parallel_linear.cpp  causes percision gap.