### PR TITLE
bugfix: return json body from health report endpoint.

### DIFF
--- a/xllm/server/health_reporter.h
+++ b/xllm/server/health_reporter.h
@@ -17,6 +17,8 @@ limitations under the License.
 
 #include <brpc/health_reporter.h>
 
+#include <nlohmann/json.hpp>
+
 #include "core/common/health_check_manager.h"
 
 namespace xllm {
@@ -36,13 +38,20 @@ class HealthReporter : public brpc::HealthReporter {
 
     bool is_healthy = HealthCheckManager::instance().is_healthy();
 
+    nlohmann::ordered_json report;
     if (!is_healthy) {
       std::string reason = HealthCheckManager::instance().unhealthy_reason();
       LOG(ERROR) << "HealthReporter: cluster is unhealthy, reason: " << reason;
+      report["status"] = "unhealthy";
+      report["reason"] = reason;
       cntl->http_response().set_status_code(503);  // Service Unavailable
     } else {
+      report["status"] = "healthy";
       cntl->http_response().set_status_code(200);  // OK
     }
+
+    cntl->http_response().set_content_type("application/json");
+    cntl->response_attachment().append(report.dump());
   }
 };
 


### PR DESCRIPTION


## Description

The custom brpc HealthReporter set only the HTTP status code and never wrote a response body, so GET /health returned an empty payload. The brpc HealthReporter contract expects the report to be written to response_attachment(). Emit a JSON body ({"status": ...}, plus "reason" when unhealthy) and set the application/json content type so clients can read the cluster health state, not just the status code.

<!-- What does this PR do? Briefly describe the changes and why they are needed. -->

## Related Issues

<!-- Link related issues here. Use "Fixes #123" when this PR closes an issue. -->

## Change Type

- [x] Bug fix
- [ ] New feature
- [ ] Performance improvement
- [ ] Refactor
- [ ] Documentation
- [ ] Test
- [ ] Build or CI

## Pull Request Checklist

Thank you for contributing to xLLM. Before requesting review, please make sure the following items are complete.

### PR Title and Commit Messages

- [x] The PR title and each commit message follow the xLLM commit format: `<type>: <subject>`.

> Allowed types: feat, bugfix, docs, test, refactor, chore, style, revert, perf, model, build, release.
> The subject should use clear English, start with a verb, include at least 4 words, and end with `.`.

### Pre-commit Checks

- [x] I have installed `pre-commit` by running `pip install pre-commit` or an equivalent command.
- [x] I have installed the hooks with `pre-commit install`.
- [x] I have run `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

### Self Review

- [x] I have self-reviewed the code according to `.agents/skills/code-review/references/custom-code-style.md`, especially code written or assisted by AI.
- [x] I have rebased this PR onto the latest `main` branch.

### Build and Test Coverage

- [ ] Tests have been added or updated as needed.
- [ ] CUDA: `python setup.py build test` has passed on a CUDA machine.
- [x] NPU: `python setup.py build test` has passed on an NPU machine.
- [ ] MLU: `python setup.py build test` has passed on an MLU machine.

## Reviewer Notes

<!-- Optional: anything reviewers should focus on, known risks, follow-ups, or validation gaps. -->
