### PR TITLE
feat: add Ascend950 TileLang and causal convolution support.

### DIFF
--- a/xllm/compiler/tilelang/targets/ascend/kernel_family_builder.py
+++ b/xllm/compiler/tilelang/targets/ascend/kernel_family_builder.py
@@ -15,7 +15,7 @@ from . import abi_entry, kernel_registry, toolchain
 from .kernel_registry import RegisteredKernelFamily
 from .kernels import utils as kernel_utils
 from .kernels.utils import render_family_registry_inc, render_family_variants_inc
-from .toolchain import AscendBuildContext, TILELANG_BISHENG_COMMON_FLAGS
+from .toolchain import AscendBuildContext
 
 
 # TileLang variant compilation is much heavier than ordinary C++ compilation:
@@ -71,7 +71,7 @@ class _VariantWorkerArgs:
     plan: _VariantBuildPlan
     entry_symbol: str
     bisheng_executable: str
-    bisheng_arch: str
+    bisheng_compile_flags: tuple[str, ...]
     include_dirs: tuple[str, ...]
     toolchain_options: dict
     fingerprint: dict
@@ -109,8 +109,7 @@ def _run_variant_worker(args: _VariantWorkerArgs) -> _VariantBuildResult:
 
     compile_cmd = [
         args.bisheng_executable,
-        f"--npu-arch={args.bisheng_arch}",
-        *TILELANG_BISHENG_COMMON_FLAGS,
+        *args.bisheng_compile_flags,
         f"-Dg_tilingKey=g_tilingKey__{compile_spec.variant_key}",
         *[f"-I{d}" for d in args.include_dirs],
         str(plan.generated_source),
@@ -327,7 +326,7 @@ def build_kernel_family(
                 plan=plan,
                 entry_symbol=_variant_entry_symbol(plan.compile_spec),
                 bisheng_executable=context.bisheng_executable,
-                bisheng_arch=context.bisheng_arch,
+                bisheng_compile_flags=context.bisheng_compile_flags,
                 include_dirs=tuple(str(d) for d in context.include_dirs),
                 toolchain_options=dict(context.toolchain_options),
                 fingerprint=dict(context.fingerprint),

--- a/xllm/compiler/tilelang/targets/ascend/kernels/causal_conv1d.py
+++ b/xllm/compiler/tilelang/targets/ascend/kernels/causal_conv1d.py
@@ -213,6 +213,14 @@ class CausalConv1dKernel(TilelangKernel):
             "dtype": "float16",
         },
         {
+            "variant_key": "bs1_d6144_w4_silu0_f16",
+            "batch_size": 1,
+            "dim": 6144,
+            "width": 4,
+            "has_silu": 0,
+            "dtype": "float16",
+        },
+        {
             "variant_key": "bs1_d8192_w4_silu0_f16",
             "batch_size": 1,
             "dim": 8192,

--- a/xllm/compiler/tilelang/targets/ascend/toolchain.py
+++ b/xllm/compiler/tilelang/targets/ascend/toolchain.py
@@ -20,10 +20,38 @@ TILELANG_BISHENG_COMMON_FLAGS = [
     "-DBACKEND_HYBM",
 ]
 
+TILELANG_BISHENG_A5_FLAGS = [
+    "-DREGISTER_BASE",
+    "-D__DAV_C310__",
+    "-O2",
+    "-std=gnu++17",
+    "-xcce",
+    "--cce-auto-sync",
+    "--cce-mask-opt",
+    "-mllvm",
+    "-cce-aicore-stack-size=0x8000",
+    "-mllvm",
+    "-cce-aicore-function-stack-size=0x8000",
+    "-mllvm",
+    "-cce-aicore-record-overflow=true",
+    "-mllvm",
+    "-cce-aicore-addr-transform",
+    "-mllvm",
+    "-cce-aicore-jump-expand=true",
+    "-mllvm",
+    "-cce-aicore-dcci-insert-for-scalar=false",
+    "-DL2_CACHE_HINT",
+    "-fPIC",
+    "-Wno-macro-redefined",
+    "-Wno-ignored-attributes",
+    "-Wno-non-c-typedef-for-linkage",
+    "-DBACKEND_HYBM",
+]
+
 ASCEND_DEVICE_TO_BISHENG_ARCH = {
     "a2": DEFAULT_ASCEND_BISHENG_ARCH,
     "a3": DEFAULT_ASCEND_BISHENG_ARCH,
-    "a5": DEFAULT_ASCEND_BISHENG_ARCH,
+    "a5": "dav-c310",
 }
 
 
@@ -32,6 +60,7 @@ class AscendBuildContext:
     device: str | None
     bisheng_arch: str
     bisheng_executable: str
+    bisheng_compile_flags: tuple[str, ...]
     toolchain_options: dict[str, str]
     fingerprint: dict[str, str]
     include_dirs: list[str]
@@ -69,6 +98,17 @@ def build_toolchain_options(device: str | None, bisheng_arch: str) -> dict[str, 
     if device is not None:
         toolchain_options["device"] = device
     return toolchain_options
+
+
+def build_bisheng_compile_flags(
+    device: str | None, bisheng_arch: str
+) -> list[str]:
+    if device == "a5":
+        return [
+            f"--cce-aicore-arch={bisheng_arch}",
+            *TILELANG_BISHENG_A5_FLAGS,
+        ]
+    return [f"--npu-arch={bisheng_arch}", *TILELANG_BISHENG_COMMON_FLAGS]
 
 
 def resolve_npu_home_path() -> str:
@@ -130,6 +170,9 @@ def resolve_build_context(device: str | None, bisheng_executable: str) -> Ascend
         device=normalized_device,
         bisheng_arch=bisheng_arch,
         bisheng_executable=bisheng_executable,
+        bisheng_compile_flags=tuple(
+            build_bisheng_compile_flags(normalized_device, bisheng_arch)
+        ),
         toolchain_options=build_toolchain_options(normalized_device, bisheng_arch),
         fingerprint=fingerprint,
         include_dirs=bisheng_include_dirs(),


### PR DESCRIPTION
## Description

- Resolve Ascend950 TileLang builds to `dav-c310` and use the CANN-compatible A5 BiSheng flags.
- Pass device-specific compile flags through variant workers while preserving the existing A2/A3 `--npu-arch` path.
- Add the FP16 `bs1_d6144_w4_silu0_f16` causal-conv variant used by Qwen3.5 decode.

## Related Issues

N/A

## Change Type

- [ ] Bug fix
- [x] New feature
- [ ] Performance improvement
- [ ] Refactor
- [ ] Documentation
- [ ] Test
- [ ] Build or CI

## Pull Request Checklist

Thank you for contributing to xLLM. Before requesting review, please make sure the following items are complete.

### PR Title and Commit Messages

- [x] The PR title and each commit message follow the xLLM commit format: `<type>: <subject>`.

> Allowed types: feat, bugfix, docs, test, refactor, chore, style, revert, perf, model, build, release.
> The subject should use clear English, start with a verb, include at least 4 words, and end with `.`.

### Pre-commit Checks

- [x] I have installed `pre-commit` by running `pip install pre-commit` or an equivalent command.
- [x] I have installed the hooks with `pre-commit install`.
- [x] I have run `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

### Self Review

- [x] I have self-reviewed the code according to `.agents/skills/code-review/references/custom-code-style.md`, especially code written or assisted by AI.
- [x] I have rebased this PR onto the latest `main` branch.

### Build and Test Coverage

- [x] Tests have been added or updated as needed.
- [ ] CUDA: `python setup.py build test` has passed on a CUDA machine.
- [ ] NPU: `python setup.py build test` has passed on an NPU machine.
- [ ] MLU: `python setup.py build test` has passed on an MLU machine.

## Reviewer Notes

- A focused Ascend950 AOT build passed for all five `causal_conv1d` variants, including `bs1_d6144_w4_silu0_f16`; generated manifests and object files report `a5 / dav-c310`.
- A2/A3 flag assertions confirm that both retained platforms still use the existing `--npu-arch` route.
- Python bytecode compilation and `pre-commit run --all-files` passed.
