### PR TITLE
bugfix: fix qwen3.5 dp empty shard crash across dense and moe.

### DIFF
--- a/xllm/core/layers/npu_torch/fused_moe.cpp
+++ b/xllm/core/layers/npu_torch/fused_moe.cpp
@@ -45,6 +45,25 @@ namespace layer {
 
 namespace {
 
+// Normalize dp_global_token_nums for MoE collectives. Under dp>1 an empty
+// dp_rank is padded with a single fake token by worker_impl (see the empty
+// shard padding path in WorkerImpl::execute_model) but dp_global_token_nums
+// still reports 0 for that rank. Passing this list into
+// parallel_state::gather (an allgather_base) would fail
+// CHECK_EQ(local_rows, token_num_list[rank]) on the padded rank. All ranks
+// apply the same 0->1 normalization so the token list stays consistent across
+// the DP group; the fake row is later dropped by the per-rank slice back.
+std::vector<int32_t> make_moe_dp_token_nums(
+    const std::vector<int32_t>& dp_global_token_nums) {
+  std::vector<int32_t> normalized = dp_global_token_nums;
+  for (int32_t& token_num : normalized) {
+    if (token_num == 0) {
+      token_num = 1;
+    }
+  }
+  return normalized;
+}
+
 // Generic local tensor helpers.
 torch::Tensor get_tensor_with_weight_suffix(const StateDict& state_dict,
                                             const std::string& tensor_name) {
@@ -1124,10 +1143,12 @@ torch::Tensor FusedMoEImpl::forward(const torch::Tensor& hidden_states,
                                     const ModelInputParams& input_params) {
   auto input = hidden_states;
   bool need_slice = false;
+  std::vector<int32_t> moe_dp_token_nums;
   if (should_gather_dp_inputs_for_moe()) {
-    input = parallel_state::gather(input,
-                                   parallel_args_.dp_local_process_group_,
-                                   input_params.parallel.dp_global_token_nums);
+    moe_dp_token_nums =
+        make_moe_dp_token_nums(input_params.parallel.dp_global_token_nums);
+    input = parallel_state::gather(
+        input, parallel_args_.dp_local_process_group_, moe_dp_token_nums);
     need_slice = true;
   }
 
@@ -1148,11 +1169,10 @@ torch::Tensor FusedMoEImpl::forward(const torch::Tensor& hidden_states,
   auto output = forward_expert(input, router_logits, shared_output);
 
   if (need_slice) {
-    const auto& dp_tokens = input_params.parallel.dp_global_token_nums;
     const int64_t dp_rank = parallel_args_.dp_local_process_group_->rank();
-    auto start =
-        std::accumulate(dp_tokens.begin(), dp_tokens.begin() + dp_rank, 0);
-    auto end = start + dp_tokens[dp_rank];
+    auto start = std::accumulate(
+        moe_dp_token_nums.begin(), moe_dp_token_nums.begin() + dp_rank, 0);
+    auto end = start + moe_dp_token_nums[dp_rank];
     output = output.slice(0, start, end);
   }
   return output;

--- a/xllm/core/layers/npu_torch/qwen3_gated_delta_net_base.cpp
+++ b/xllm/core/layers/npu_torch/qwen3_gated_delta_net_base.cpp
@@ -535,6 +535,16 @@ torch::Tensor Qwen3GatedDeltaNetBaseImpl::forward(
     const AttentionMetadata& attn_metadata,
     KVCache& kv_cache,
     const ModelInputParams& input_params) {
+  // Early-return on dummy shards. Under dp>1, an empty shard is padded with a
+  // fake token by worker_impl but its GDN state tensors (kv_cache_tokens_nums,
+  // linear_state_ids etc.) are left undefined. This mirrors the is_dummy
+  // early-return in Attention::forward (npu_torch/attention.cpp). Uses
+  // zeros_like rather than empty_like so downstream post-norm / mlp do not
+  // read uninitialized data. Placed before FlashComm1 sequence gather so
+  // dummy shards do not enter the collective and waste bandwidth.
+  if (attn_metadata.is_dummy) {
+    return torch::zeros_like(hidden_states);
+  }
   const FlashComm1Context* fc1_ctx = get_current_flash_comm1_context();
   torch::Tensor h = hidden_states;
   if (fc1_ctx && is_sequence_sharded(*fc1_ctx)) {

--- a/xllm/core/runtime/worker_impl.cpp
+++ b/xllm/core/runtime/worker_impl.cpp
@@ -186,6 +186,16 @@ void ensure_forward_input_device_tensors(ForwardInput& input,
 
 #if defined(USE_NPU)
 void prepare_input_params_for_linear_attention(ModelInputParams& input_params) {
+  // Early-return on dummy/empty-shard inputs. Under dp>1, an empty shard is
+  // padded with a fake token by worker_impl but its GDN-related tensors
+  // (attention.device.kv_cache_tokens_nums etc.) are left undefined. Reading
+  // them below would raise a c10::Error at gt_Scalar. The condition mirrors
+  // the is_dummy branch of AttentionMetadataBuilder::build in
+  // core/layers/common/attention_metadata_builder.cpp.
+  if (input_params.meta.q_max_seq_len == 0 ||
+      input_params.meta.num_sequences == 0) {
+    return;
+  }
   const std::vector<int32_t>& host_q_seq_lens =
       input_params.attention.host.q_seq_lens;
   const bool has_leading_zero =

--- a/xllm/models/llm/qwen3_5_mtp_base.h
+++ b/xllm/models/llm/qwen3_5_mtp_base.h
@@ -116,7 +116,8 @@ class Qwen3_5MtpModelImplBase : public Qwen3HybridModelImplBase {
         layer::AttentionMetadataBuilder::build(
             input_params,
             model_args_.enable_mla(),
-            build_attention_mask(input_params));
+            build_attention_mask(input_params),
+            /*device=*/device_);
     prepare_mrope(positions, attn_metadata);
 
     torch::Tensor embedding = embed_tokens_(tokens);

--- a/xllm/models/llm/qwen3_next_hybrid_base.h
+++ b/xllm/models/llm/qwen3_next_hybrid_base.h
@@ -109,7 +109,8 @@ class Qwen3HybridModelImplBase : public Qwen3HybridModelModule {
         layer::AttentionMetadataBuilder::build(
             input_params,
             model_args_.enable_mla(),
-            build_attention_mask(input_params));
+            build_attention_mask(input_params),
+            /*device=*/device_);
     const int32_t num_tokens = static_cast<int32_t>(tokens.size(0));
     const auto& batch_forward_type = input_params.meta.batch_forward_type;
     const bool is_prefill_side = batch_forward_type.no_decode();


### PR DESCRIPTION
## 描述

在 Data Parallel(`dp_size > 1`)启用时,请求在 DP 副本间调度会出现某个副本**当前 step 零 sequence** 的情况。为了让 HCCL collective 保持所有 rank 同步,`worker_impl` 会给这种空 shard 补一个 fake token。这套机制对于纯 attention 模型没问题,但 **Qwen3.5 的 hybrid Gated Delta Net(GDN)路径没有考虑 fake shard 的存在** —— 它的 GDN state tensor(`kv_cache_tokens_nums`、`linear_state_ids` 等)是未定义状态就被下游 forward 读了,worker 直接崩掉。MTP draft 模型(`qwen3_5_mtp` / `qwen3_5_moe_mtp`)在另一处调用点也会因为同样原因崩溃。

崩溃现象(拿到空 shard 的 rank 先死,rank 0 后死):

```
rank N(空 shard):
  terminate called after throwing 'c10::Error'
  frame #5: at::_ops::gt_Scalar::call(...)      # 读了未定义的 GDN tensor

  # 或在 MTP 路径上:
  F attention_metadata_builder.cpp:230] Check failed: device.has_value()
    dummy attention requires device when new_cache_slots is undefined

rank 0(连锁死亡):
  F batch_input_builder.cpp:688] Check failed: q_seq_len > 0 (0 vs. 0)
```

<details>
<summary>完整崩溃栈(空 shard rank,GDN 场景)</summary>

```
terminate called after throwing an instance of 'c10::Error'
  what():  Expected a proper Tensor but got None (or an undefined Tensor in C++) for argument #0 'self'
Exception raised from checked_cast_variable at /pytorch/torch/csrc/autograd/VariableTypeManual.cpp:66
frame #0: c10::Error::Error(...) in libc10.so
frame #1: c10::detail::torchCheckFail(...) in libc10.so
frame #5: at::_ops::gt_Scalar::call(at::Tensor const&, c10::Scalar const&) in libtorch_cpu.so
frame #6-13: xllm (GDN forward -> worker execute)
frame #14: libhccl.so
```
</details>

MoE 路径是另一条独立的崩溃链:`FusedMoEImpl::forward` 把 `dp_global_token_nums`(空 shard rank 上仍是 `0`)传给 `parallel_state::gather`,底层 allgather 在 `CHECK_EQ(local_rows, token_num_list[rank])` 断言失败。

DP 均衡场景(所有 rank 都有真实 sequence)不会触发这个 bug,所以单请求 smoke test 全过,只有**并发**下才暴露。

**修复 —— 两个 commit,共 5 处改动,对 `dp=1` 零行为变化**(每处 guard 都由 empty-shard / `is_dummy` 条件触发,`dp_size == 1` 时不会 fire):

- **`worker_impl.cpp`**:`prepare_input_params_for_linear_attention` 在 `q_max_seq_len == 0 || num_sequences == 0` 时早退,避免读到未定义 GDN tensor。对齐 `AttentionMetadataBuilder::build` 里已有的 `is_dummy` 分支。
- **`npu_torch/qwen3_gated_delta_net_base.cpp`**:`Qwen3GatedDeltaNetBaseImpl::forward` 在 `attn_metadata.is_dummy` 时早退返回 `torch::zeros_like(hidden_states)`。**放在 FlashComm1 sequence gather 之前**,dummy shard 完全不进 collective。对齐 `npu_torch/attention.cpp` 现有的 `is_dummy` 早退 pattern。
- **`llm/qwen3_next_hybrid_base.h`**:把 `device_` 传入 `AttentionMetadataBuilder::build`,让 `is_dummy` 分支能在正确的 device 上构造 fake `slot_mapping` / `q_seq_lens` / `kv_seq_lens` tensor。用的是 builder 已有的 `device` 参数(默认 `std::nullopt`),不影响其他调用者。
- **`npu_torch/fused_moe.cpp`**:加一个 file-local helper `make_moe_dp_token_nums`,把 `dp_global_token_nums` 里的 0 归一化为 1。所有 rank 都做同样的 `0→1` 归一化,DP 组内 token list 保持一致,gather 后 fake row 通过已有的 per-rank slice-back 逻辑自然被丢弃。只动 `FusedMoEImpl::forward`(`ep>1` 的路径不在本 PR 范围内)。
- **`llm/qwen3_5_mtp_base.h`**(第 2 个 commit):对称于 hybrid 的修法 —— 在 `Qwen3_5MtpModelImplBase::forward` 里把 `device_` 传入 `AttentionMetadataBuilder::build`,让 MTP draft 路径也能过 empty-shard `is_dummy` 分支。`device_` 已经是这个 base 类的成员,同一函数上面几行(token / positions 放置)就在用。`qwen3_5_mtp` 和 `qwen3_5_moe_mtp` 都继承 `Qwen3_5MtpModelImplBase`,一处改动同时覆盖 dense/MoE 两种 MTP。

**与 #2024 的关系**:#2024(`preserve raw dp token counts for empty shards`)针对同一 empty-shard 根因,但走的是另一条 code path —— 它给 `DpEpPadding`(EP padding / lm-head 输出压缩 / reduce-scatter)加了 `raw_dp_global_token_nums`。本 PR 完全**互补**:修的是 GDN forward、linear-attention 预处理、`FusedMoEImpl::forward` 的 DP gather、以及 MTP draft forward,这些位置 #2024 都没碰。当前 `main` 上 `FusedMoEImpl::forward` 仍然直接用未归一化的 `dp_global_token_nums` 去 gather,所以本 PR 依然必需。

**验证**(Ascend 910C):

- 复现:未修 base → `dp=2` 4 并发 = 4/4 空响应 + `c10::Error`;修后 → **4/4 HTTP 200**,两 rank 都存活。
- 128 并发,`max_tokens=64`,含 warmup:**128/128 HTTP 200,zero crash**,覆盖 4B/9B/27B(dense)和 35B-A3B(MoE,`ep=1`),`dp=2` 和 `dp=4`,`world ∈ {2,4}`。
  - Dense DP 加速:4B `dp=2` 1.39x / `dp=4` 1.76x;9B 1.33x / 1.65x;27B(tp=2) `dp=2` 1.41x。
  - 与 prefix cache 兼容:shared 500-token-prefix workload 下 `dp=4` **3.53x**(88% 效率);9 组实验零 regression。
  - 同 TP PD 分离端到端验证通过(Prefill + Decode 通过 `xllm-service` 串起):instance 成功 link,4/4 HTTP 200,zero crash。
- **MTP + DP**(第 2 个 commit 的验证,Qwen3.5-4B base + Qwen3.5-4B-mtp draft,`--speculative_algorithm=MTP --num_speculative_tokens=2`):
  - 未修 MTP 路径 `dp=2/tp=2/world=4` 4 并发复现出完全相同的崩溃链(rank 2/3 触发 `attention_metadata_builder.cpp:230 CHECK(device.has_value())`,rank 0 连锁到 `batch_input_builder.cpp:667`)。
  - 加了 MTP 修法后,同一 speculative decoding 配置 `dp=2` 返回 **4/4 HTTP 200**,输出正常有语义;diag log 显示 runtime 确实发生了 empty-shard 事件(`dp_rank=0 tokens=0 empty=1` 而 `dp_rank=1` 仍在处理 token),证明修法真的被走到、真的生效。
  - `dp=1` speculative decoding 修前修后 bit-compatible(`is_dummy` 分支不 fire,新增的 `device_` 参数不被读)。

**范围 / 限制**:
- 只覆盖 text-only DP(dense/MoE 走 `--backend=llm`)。Qwen3.5 VL 不走 DP encoder 路径 —— **VL 场景建议 `dp=1`**,后续单独跟进。
- 只 patch `FusedMoEImpl::forward`;expert parallel(`ep>1`)路径本 PR 不动。
- MoE MTP(`qwen3_5_moe_mtp`)通过继承 `Qwen3_5MtpModelImplBase` 自动拿到修法,但没有 MoE-MTP checkpoint 在本机可跑,runtime 验证列为 follow-up。
- 35B-A3B 测的是 `dp=1/tp=4` vs `dp=2/tp=2`(单卡 OOM 无法对齐 tp),wall-clock 是"DP+MoE 修好了"的证据,不是干净的 DP-only 加速。
- 仓库 x86/ARM NPU smoke CI 只覆盖 Qwen2-7B 单卡,不会跑到 Qwen3.5 DP/MoE/MTP;上面这些结论都来自 910C 上手动实测。

## 关联 Issue

无 —— 没有对应 tracking issue。与 #2024 互补(见描述)。

## 变更类型

- [x] Bug fix
- [ ] 新功能
- [ ] 性能优化
- [ ] 重构
- [ ] 文档
- [ ] 测试
- [ ] Build 或 CI

## Pull Request Checklist

### PR 标题与 commit message

- [x] PR 标题和每个 commit message 都遵循 xLLM commit 格式:`<type>: <subject>`。

### Pre-commit 检查

- [ ] 已通过 `pip install pre-commit` 或等效命令安装 pre-commit。
- [ ] 已通过 `pre-commit install` 安装钩子。
- [ ] 已运行 `pre-commit run --all-files` 并修复所有 reported issue。

> 本机 pre-commit 的 `clang-format` 钩子建 virtualenv 失败无法起来。手动用 `clang-format 20.1.6`(`.pre-commit-config.yaml` 里 pinned 的版本)校对过,所有改动文件都没有格式 diff。等环境修好后会再跑一次完整钩子。

### 自审

- [x] 已按 `.agents/skills/code-review/references/custom-code-style.md` 自审代码,尤其是 AI 参与编写的部分。
- [ ] 已 rebase 到最新的 `main` 分支。

> 从 `c2fc480c` 分出。`main` 后来的 commit 改的是 `fused_moe.cpp`(L434 ctor)和 `worker_impl.cpp` 的另一个函数,和本 PR 的改动区域不重叠,能干净 auto-merge。合并前会 rebase 一次。

### Build 与测试覆盖

- [ ] 已按需增加或更新测试。
- [ ] CUDA:在 CUDA 机器上通过 `python setup.py build test`。
- [ ] NPU:在 NPU 机器上通过 `python setup.py build test`。
- [ ] MLU:在 MLU 机器上通过 `python setup.py build test`。

> 单元测试计划作为 follow-up commit(helper 已经按可测试结构组织)。上面描述里的 Ascend 910C 实测已覆盖功能正确性;本机没有跑完整 `build test` 套件的条件,也没有 CUDA/MLU 机器。

## Reviewer 提示

- `dp=1` 生产路径两个 commit 都不受影响:每处 guard 都由 empty-shard / `is_dummy` 条件触发,`dp_size == 1` 时永远不会 fire。
- GDN、MoE、MTP 三处 guard 都刻意对齐 `npu_torch/attention.cpp` 里已有的 `is_dummy` 处理姿势,不引入新的 pattern。
- 第 2 个 commit(MTP 路径)是对 review 意见的直接响应,复现和验证方式与 hybrid 场景完全一致,包括修后 diag log 里能看到运行时真实发生的 empty-shard 事件。
- 与 #2024 互补(不同 code path,见描述),与 #1995(异构 TP PD,改的是 `worker_impl.cpp:~1623` 另一个函数)无冲突。
- 后续 follow-up:(1)`make_moe_dp_token_nums` 和 4 处 early-return / device-passing guard 的单元测试;(2)MoE MTP 的运行时覆盖(等有 checkpoint);(3)VL DP 出 scope,已在文档标注 `dp=1` 推荐。