### PR TITLE
feat: add enable_onerec_async_perf C API option.

### DIFF
--- a/xllm/c_api/default.h
+++ b/xllm/c_api/default.h
@@ -142,6 +142,7 @@ const XLLM_InitOptions XLLM_INIT_REC_OPTIONS_DEFAULT = {
     .total_conversion_threshold = 256,
     .rec_worker_max_concurrency = 1,
     .enable_multistream_perf_mode = false,
+    .enable_onerec_async_perf = false,
     .enable_onerec_multistream_core_split = false,
     .onerec_multistream_core_ratio = 0.5,
     .constrained_decoding_filter_path = "",

--- a/xllm/c_api/internal/rec.cpp
+++ b/xllm/c_api/internal/rec.cpp
@@ -214,11 +214,13 @@ XLLM_CAPI_EXPORT bool xllm_rec_initialize(
         xllm_init_options.total_conversion_threshold;
     FLAGS_enable_multistream_perf_mode =
         xllm_init_options.enable_multistream_perf_mode;
+    FLAGS_enable_onerec_async_perf = xllm_init_options.enable_onerec_async_perf;
     FLAGS_enable_onerec_multistream_core_split =
         xllm_init_options.enable_onerec_multistream_core_split;
     FLAGS_onerec_multistream_core_ratio =
         xllm_init_options.onerec_multistream_core_ratio;
     apply_multistream_perf_mode_env_overrides();
+    apply_onerec_async_perf_env_overrides();
 
     if (xllm_init_options.request_queue_size > 0) {
       FLAGS_request_queue_size = xllm_init_options.request_queue_size;

--- a/xllm/c_api/types.h
+++ b/xllm/c_api/types.h
@@ -211,6 +211,11 @@ typedef struct XLLM_CAPI_EXPORT XLLM_InitOptions {
   /** Whether to enable OneRec xattention multistream performance mode */
   bool enable_multistream_perf_mode;
 
+  /** Whether to enable OneRec xattention async perf env overrides in one shot:
+   *  XLLM_ONEREC_XATTN_ASYNC_BEAM_SEARCH, XLLM_ONEREC_XATTN_ASYNC_CACHE_SELECT,
+   *  TASK_QUEUE_ENABLE, PER_STREAM_QUEUE. Default false. */
+  bool enable_onerec_async_perf;
+
   /** Whether to split NPU cores between two OneRec worker streams */
   bool enable_onerec_multistream_core_split;
 

--- a/xllm/core/common/global_flags.cpp
+++ b/xllm/core/common/global_flags.cpp
@@ -732,6 +732,12 @@ DEFINE_bool(enable_multistream_perf_mode,
             "Enable experimental OneRec xattention multistream performance "
             "mode. When enabled, it disables OneRec xattention prepare/model "
             "forward serialization and enables thread-local ACLNN cache.");
+DEFINE_bool(enable_onerec_async_perf,
+            false,
+            "Enable OneRec xattention async perf env overrides in one shot: "
+            "XLLM_ONEREC_XATTN_ASYNC_BEAM_SEARCH, "
+            "XLLM_ONEREC_XATTN_ASYNC_CACHE_SELECT, TASK_QUEUE_ENABLE, "
+            "PER_STREAM_QUEUE.");
 DEFINE_bool(enable_onerec_multistream_core_split,
             false,
             "Limit each of two OneRec NPU worker streams to a configurable "
@@ -758,6 +764,17 @@ void apply_multistream_perf_mode_env_overrides() {
   set_env_override("XLLM_ONEREC_XATTN_SERIALIZE_PREPARE", "false");
   set_env_override("XLLM_ONEREC_XATTN_SERIALIZE_MODEL_FORWARD", "false");
   set_env_override("XLLM_ATB_ACLNN_THREAD_LOCAL_CACHE", "1");
+}
+
+void apply_onerec_async_perf_env_overrides() {
+  if (!FLAGS_enable_onerec_async_perf) {
+    return;
+  }
+
+  set_env_override("XLLM_ONEREC_XATTN_ASYNC_BEAM_SEARCH", "1");
+  set_env_override("XLLM_ONEREC_XATTN_ASYNC_CACHE_SELECT", "1");
+  set_env_override("TASK_QUEUE_ENABLE", "1");
+  set_env_override("PER_STREAM_QUEUE", "1");
 }
 
 #if defined(USE_NPU)

--- a/xllm/core/common/global_flags.h
+++ b/xllm/core/common/global_flags.h
@@ -339,10 +339,13 @@ DECLARE_bool(use_audio_in_video);
 // --- concurrent rec worker config ---
 DECLARE_uint32(rec_worker_max_concurrency);
 DECLARE_bool(enable_multistream_perf_mode);
+DECLARE_bool(enable_onerec_async_perf);
 DECLARE_bool(enable_onerec_multistream_core_split);
 DECLARE_double(onerec_multistream_core_ratio);
 
 void apply_multistream_perf_mode_env_overrides();
+
+void apply_onerec_async_perf_env_overrides();
 
 #if defined(USE_NPU)
 DECLARE_string(npu_kernel_backend);

--- a/xllm/xllm.cpp
+++ b/xllm/xllm.cpp
@@ -367,6 +367,7 @@ int main(int argc, char** argv) {
   FLAGS_minloglevel = 0;
   google::ParseCommandLineFlags(&argc, &argv, true);
   apply_multistream_perf_mode_env_overrides();
+  apply_onerec_async_perf_env_overrides();
 
   google::InitGoogleLogging("xllm");
 


### PR DESCRIPTION
Add a single boolean option to XLLM_InitOptions that enables all four OneRec xattention async performance env overrides in one shot:
  XLLM_ONEREC_XATTN_ASYNC_BEAM_SEARCH=1
  XLLM_ONEREC_XATTN_ASYNC_CACHE_SELECT=1
  TASK_QUEUE_ENABLE=1
  PER_STREAM_QUEUE=1

Follows the existing apply_multistream_perf_mode_env_overrides() pattern. Works via both the C API (XLLM_InitOptions.enable_onerec_async_perf) and CLI (--enable_onerec_async_perf). Default false (backward-compatible).

## Description

<!-- What does this PR do? Briefly describe the changes and why they are needed. -->

## Related Issues

<!-- Link related issues here. Use "Fixes #123" when this PR closes an issue. -->

## Change Type

- [ ] Bug fix
- [ ] New feature
- [ ] Performance improvement
- [ ] Refactor
- [ ] Documentation
- [ ] Test
- [ ] Build or CI

## Pull Request Checklist

Thank you for contributing to xLLM. Before requesting review, please make sure the following items are complete.

### PR Title and Commit Messages

- [ ] The PR title and each commit message follow the xLLM commit format: `<type>: <subject>`.

> Allowed types: feat, bugfix, docs, test, refactor, chore, style, revert, perf, model, build, release.
> The subject should use clear English, start with a verb, include at least 4 words, and end with `.`.

### Pre-commit Checks

- [ ] I have installed `pre-commit` by running `pip install pre-commit` or an equivalent command.
- [ ] I have installed the hooks with `pre-commit install`.
- [ ] I have run `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

### Self Review

- [ ] I have self-reviewed the code according to `.agents/skills/code-review/references/custom-code-style.md`, especially code written or assisted by AI.
- [ ] I have rebased this PR onto the latest `main` branch.

### Build and Test Coverage

- [ ] Tests have been added or updated as needed.
- [ ] CUDA: `python setup.py build test` has passed on a CUDA machine.
- [ ] NPU: `python setup.py build test` has passed on an NPU machine.
- [ ] MLU: `python setup.py build test` has passed on an MLU machine.

## Reviewer Notes

<!-- Optional: anything reviewers should focus on, known risks, follow-ups, or validation gaps. -->
