### PR TITLE
refactor: update argument parsing for multi-machine launches.

### DIFF
--- a/xllm/launch_server.py
+++ b/xllm/launch_server.py
@@ -156,15 +156,21 @@ def _build_parser() -> argparse.ArgumentParser:
         "--nnodes",
         type=int,
         default=1,
-        help="Total number of xllm ranks.",
+        help="Total number of nodes (one node per device) across all machines.",
     )
     parser.add_argument(
-        "--node_rank",
-        "--node-rank",
-        dest="node_rank",
+        "--machine_rank",
+        "--machine-rank",
+        dest="machine_rank",
         type=int,
         default=None,
-        help="Launch only this rank. If omitted, local ranks 0..nnodes-1 are launched.",
+        help=(
+            "Index of this machine (0-based) in a multi-machine launch. This "
+            "machine launches one node per local device (the local device "
+            "count), and the launcher assigns each the global card rank "
+            "machine_rank * device_count + local_index. If omitted, all nnodes "
+            "nodes are launched locally on a single machine."
+        ),
     )
     parser.add_argument(
         "--log-dir",
@@ -253,42 +259,108 @@ def _validate_args(parser: argparse.ArgumentParser, args: argparse.Namespace) ->
         parser.error("--nnodes must be greater than 0")
     if args.start_port < 1 or args.start_port > 65535:
         parser.error("--port/--start-port must be in range [1, 65535]")
-    if args.node_rank is not None and (
-        args.node_rank < 0 or args.node_rank >= args.nnodes
-    ):
-        parser.error("--node-rank must be in range [0, nnodes)")
+    if args.machine_rank is not None and args.machine_rank < 0:
+        parser.error("--machine-rank must be greater than or equal to 0")
 
-    launches_all_local_ranks = args.node_rank is None
-    if launches_all_local_ranks and args.nnodes > 1:
+    if args.machine_rank is None and args.nnodes > 1:
         if args.start_port + args.nnodes - 1 > 65535:
             parser.error("--port + --nnodes - 1 must be less than or equal to 65535")
 
 
-def _resolve_ranks(args: argparse.Namespace) -> list[int]:
-    if args.node_rank is not None:
-        return [args.node_rank]
-    return list(range(args.nnodes))
+def _reject_managed_flags(
+    parser: argparse.ArgumentParser,
+    extra_args: Sequence[str],
+) -> None:
+    """Reject a manual --node_rank, which the launcher assigns per process.
+
+    The launcher generates each node's global card rank and forwards it to the
+    binary as --node_rank, so a user-supplied one would only collide.
+    """
+    for arg in extra_args:
+        flag = arg.split("=", 1)[0]
+        if flag in ("--node_rank", "--node-rank"):
+            parser.error(
+                "--node_rank is assigned automatically by the launcher; use "
+                "--machine-rank for multi-machine launches, or run the xllm "
+                "binary directly (without `serve`) to set --node_rank manually."
+            )
 
 
-def _resolve_port(
+def _detect_device_count(parser: argparse.ArgumentParser) -> int:
+    """Number of local nodes (cards) on this machine, from the device count.
+
+    Each machine hosts one node per visible device (matching multi_machine.md),
+    and the visible set is controlled by the accelerator's *_VISIBLE_DEVICES
+    env mask, which Platform.get_device_count() honors.
+    """
+    # Imported lazily so the common launch path keeps a light import surface
+    # and only touches the auto_config package (and its device probing) when a
+    # multi-machine launch actually needs the local device count.
+    from xllm.auto_config.utils import Platform
+
+    device_count = Platform.get_device_count()
+    if device_count is None or device_count < 1:
+        parser.error(
+            "could not detect the local device count for a multi-machine "
+            "launch (--machine-rank is set); set the accelerator's "
+            "*_VISIBLE_DEVICES env mask (e.g. ASCEND_RT_VISIBLE_DEVICES / "
+            "CUDA_VISIBLE_DEVICES) so the device count is discoverable."
+        )
+    return device_count
+
+
+def _validate_machine_topology(
+    parser: argparse.ArgumentParser,
     args: argparse.Namespace,
-    rank: int,
-    launches_all_local_ranks: bool,
-) -> int:
-    if launches_all_local_ranks:
-        return args.start_port + rank
-    return args.start_port
+    device_count: int,
+) -> None:
+    base_rank = args.machine_rank * device_count
+    last_rank = base_rank + device_count - 1
+    if last_rank >= args.nnodes:
+        parser.error(
+            f"--machine-rank {args.machine_rank} with {device_count} local "
+            f"nodes maps to global card ranks [{base_rank}, {last_rank}], which "
+            f"is outside [0, {args.nnodes}); check --nnodes and the visible "
+            f"device count."
+        )
+    if args.start_port + device_count - 1 > 65535:
+        parser.error(
+            "--port plus the number of local nodes minus 1 must be less than "
+            "or equal to 65535"
+        )
+
+
+def _resolve_launch_targets(
+    parser: argparse.ArgumentParser,
+    args: argparse.Namespace,
+) -> list[tuple[int, int]]:
+    """Map each launched process to its (global card rank, service port).
+
+    The launcher generates the global card rank and passes it to the binary as
+    --node_rank. Two modes:
+    - --machine-rank M: launch this machine's slice of nodes, global ranks
+      [M * device_count, (M + 1) * device_count), ports start_port + local_index.
+    - no --machine-rank: single-machine launch of all nnodes nodes, global
+      ranks 0..nnodes-1, ports start_port + rank.
+    """
+    if args.machine_rank is not None:
+        device_count = _detect_device_count(parser)
+        _validate_machine_topology(parser, args, device_count)
+        base_rank = args.machine_rank * device_count
+        return [
+            (base_rank + local_index, args.start_port + local_index)
+            for local_index in range(device_count)
+        ]
+    return [(rank, args.start_port + rank) for rank in range(args.nnodes)]
 
 
 def _build_command(
     binary_path: str,
     args: argparse.Namespace,
     rank: int,
+    port: int,
     extra_args: Sequence[str],
-    launches_all_local_ranks: bool,
 ) -> list[str]:
-    port = _resolve_port(args, rank, launches_all_local_ranks)
-
     command = [binary_path]
     if args.config_json_file is not None:
         command.append(f"--config_json_file={args.config_json_file}")
@@ -462,20 +534,20 @@ def launch_server(argv: Sequence[str] | None = None) -> int:
     config_json = _load_config_json(parser, args)
     _apply_config_json_overrides(parser, args, config_json)
     _validate_args(parser, args)
+    _reject_managed_flags(parser, extra_args)
 
     binary_path = _resolve_binary_path(args.binary_path)
 
     _ensure_python_model_path()
 
-    launches_all_local_ranks = args.node_rank is None
-    ranks = _resolve_ranks(args)
+    targets = _resolve_launch_targets(parser, args)
     commands = [
-        _build_command(binary_path, args, rank, extra_args, launches_all_local_ranks)
-        for rank in ranks
+        _build_command(binary_path, args, rank, port, extra_args)
+        for rank, port in targets
     ]
 
-    for rank, command in zip(ranks, commands):
-        logger.info("rank %s: %s", rank, _format_command(command))
+    for (rank, port), command in zip(targets, commands):
+        logger.info("rank %s (port %s): %s", rank, port, _format_command(command))
 
     if args.dry_run:
         return 0
@@ -484,7 +556,7 @@ def launch_server(argv: Sequence[str] | None = None) -> int:
     processes: list[ServerProcess] = []
     readiness_stop_event: threading.Event | None = None
     try:
-        for rank, command in zip(ranks, commands):
+        for (rank, _port), command in zip(targets, commands):
             processes.append(_start_process(command, rank, args.log_dir))
             if args.log_dir is not None:
                 logger.info(
@@ -492,9 +564,10 @@ def launch_server(argv: Sequence[str] | None = None) -> int:
                     rank,
                     os.path.join(args.log_dir, f"node_{rank}.log"),
                 )
-        # Only rank 0 serves the HTTP API, so probe its port for readiness.
-        if 0 in ranks:
-            rank_0_port = _resolve_port(args, 0, launches_all_local_ranks)
+        # Only rank 0 (the master node) serves the HTTP API, so probe its port
+        # for readiness when this machine hosts it.
+        rank_0_port = next((port for rank, port in targets if rank == 0), None)
+        if rank_0_port is not None:
             _, readiness_stop_event = _start_readiness_probe(rank_0_port)
         return _wait_for_processes(processes)
     except BaseException:


### PR DESCRIPTION

## Description
This Refactor is for `xllm serve`(python-interface launch method).
- Renamed `--node_rank` to `--machine_rank` for clarity.
- Enhanced help descriptions for `--machine_rank` and `--nnodes`.
- Added validation for `--machine_rank` and device count detection.
- Introduced `_reject_managed_flags` to prevent manual setting of `--node_rank`.
- Updated launch target resolution to accommodate multi-machine configurations.

<!-- What does this PR do? Briefly describe the changes and why they are needed. -->

## Related Issues

<!-- Link related issues here. Use "Fixes #123" when this PR closes an issue. -->

## Change Type

- [ ] Bug fix
- [ ] New feature
- [ ] Performance improvement
- [x] Refactor
- [ ] Documentation
- [ ] Test
- [ ] Build or CI

## Pull Request Checklist

Thank you for contributing to xLLM. Before requesting review, please make sure the following items are complete.

### PR Title and Commit Messages

- [x] The PR title and each commit message follow the xLLM commit format: `<type>: <subject>`.

> Allowed types: feat, bugfix, docs, test, refactor, chore, style, revert, perf, model, build, release.
> The subject should use clear English, start with a verb, include at least 4 words, and end with `.`.

### Pre-commit Checks

- [x] I have installed `pre-commit` by running `pip install pre-commit` or an equivalent command.
- [x] I have installed the hooks with `pre-commit install`.
- [x] I have run `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

### Self Review

- [x] I have self-reviewed the code according to `.agents/skills/code-review/references/custom-code-style.md`, especially code written or assisted by AI.
- [x] I have rebased this PR onto the latest `main` branch.

### Build and Test Coverage

- [ ] Tests have been added or updated as needed.
- [ ] CUDA: `python setup.py build test` has passed on a CUDA machine.
- [x] NPU: `python setup.py build test` has passed on an NPU machine.
- [ ] MLU: `python setup.py build test` has passed on an MLU machine.

## Reviewer Notes

<!-- Optional: anything reviewers should focus on, known risks, follow-ups, or validation gaps. -->
