### PR TITLE
bugfix: fixes multi-node worker address selection.

### DIFF
--- a/tests/core/util/CMakeLists.txt
+++ b/tests/core/util/CMakeLists.txt
@@ -7,6 +7,7 @@ cc_test(
     blocking_counter_test.cpp
     device_name_utils_test.cpp
     http_downloader_test.cpp
+    net_test.cpp
     suffix_decoding_cache_test.cpp
     threadpool_test.cpp
     vocab_validation_test.cpp

--- a/tests/core/util/net_test.cpp
+++ b/tests/core/util/net_test.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2025-2026 The xLLM Authors.
+/* Copyright 2026 The xLLM Authors. All Rights Reserved.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -13,24 +13,30 @@ See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
 
-#pragma once
-#include <cstdint>
-#include <string>
-#include <vector>
+#include "core/util/net.h"
+
+#include <gtest/gtest.h>
 
 namespace xllm {
 namespace net {
+namespace {
 
-std::string get_local_ip_addr();
-std::string get_route_ip(const std::string& remote_addr);
-int get_local_free_port();
-uint64_t convert_ip_port_to_uint64(const std::string& ip, uint16_t port);
-std::pair<std::string, uint16_t> convert_uint64_to_ip_port(uint64_t input);
-void parse_host_port_from_addr(const std::string& addr,
-                               std::string& host,
-                               int& port);
+TEST(NetTest, SelectsLoopbackForLoopbackRemote) {
+  EXPECT_EQ(get_route_ip("127.0.0.1:19888"), "127.0.0.1");
+}
 
-std::string extract_ip(const std::string& input);
-std::string extract_port(const std::string& input);
+TEST(NetTest, ResolvesRemoteHostname) {
+  EXPECT_EQ(get_route_ip("localhost:19888"), "127.0.0.1");
+}
+
+TEST(NetTest, ReturnsEmptyWhenRemoteHasNoUsableRoute) {
+  EXPECT_TRUE(get_route_ip("255.255.255.255:19888").empty());
+}
+
+TEST(NetTest, ReturnsEmptyWhenRemoteCannotBeResolved) {
+  EXPECT_TRUE(get_route_ip("worker.invalid:19888").empty());
+}
+
+}  // namespace
 }  // namespace net
 }  // namespace xllm

--- a/xllm/core/distributed_runtime/worker_server.cpp
+++ b/xllm/core/distributed_runtime/worker_server.cpp
@@ -133,7 +133,12 @@ void WorkerServer::create_server(const runtime::Options& options,
   //    std::make_unique<WorkerServiceImpl>(worker_impl);
   auto worker_service = std::make_shared<WorkerService>(options, device);
 
-  auto addr = net::get_local_ip_addr();
+  std::string addr = net::get_local_ip_addr_for_remote(master_node_addr);
+  if (addr.empty()) {
+    LOG(ERROR) << "Failed to select a local address for master "
+               << master_node_addr;
+    return;
+  }
   auto worker_server =
       ServerRegistry::get_instance().register_server(server_name_);
   if (!worker_server->start(worker_service, addr + ":0")) {

--- a/xllm/core/distributed_runtime/worker_server.cpp
+++ b/xllm/core/distributed_runtime/worker_server.cpp
@@ -133,7 +133,7 @@ void WorkerServer::create_server(const runtime::Options& options,
   //    std::make_unique<WorkerServiceImpl>(worker_impl);
   auto worker_service = std::make_shared<WorkerService>(options, device);
 
-  std::string addr = net::get_local_ip_addr_for_remote(master_node_addr);
+  std::string addr = net::get_route_ip(master_node_addr);
   if (addr.empty()) {
     LOG(ERROR) << "Failed to select a local address for master "
                << master_node_addr;

--- a/xllm/core/util/net.cpp
+++ b/xllm/core/util/net.cpp
@@ -28,7 +28,6 @@ limitations under the License.
 #include <mutex>
 #include <sstream>
 #include <unordered_set>
-#include <utility>
 
 namespace xllm {
 namespace net {
@@ -37,10 +36,6 @@ namespace {
 
 std::mutex g_port_mutex;
 std::unordered_set<int> g_allocated_port_map;
-
-bool is_loopback(const sockaddr_in& addr) {
-  return (ntohl(addr.sin_addr.s_addr) & 0xff000000U) == 0x7f000000U;
-}
 
 std::string to_ip_addr(const sockaddr_in& addr) {
   char ip[INET_ADDRSTRLEN]{'\0'};
@@ -56,6 +51,7 @@ std::string to_ip_addr(const sockaddr_in& addr) {
 
 // TODO: return private ip
 std::string get_local_ip_addr() {
+  char ip[INET_ADDRSTRLEN]{'\0'};
   char hostname[256];
   int ret = gethostname(hostname, sizeof(hostname));
   if (ret != 0) {
@@ -74,27 +70,18 @@ std::string get_local_ip_addr() {
   }
   std::unique_ptr<struct addrinfo, decltype(&freeaddrinfo)> guard(info,
                                                                   freeaddrinfo);
-  std::string loopback_addr;
-  for (const struct addrinfo* current = info; current != nullptr;
-       current = current->ai_next) {
-    const sockaddr_in* addr =
-        reinterpret_cast<const sockaddr_in*>(current->ai_addr);
-    std::string ip = to_ip_addr(*addr);
-    if (ip.empty()) {
-      continue;
-    }
-    if (!is_loopback(*addr)) {
-      return ip;
-    }
-    if (loopback_addr.empty()) {
-      loopback_addr = std::move(ip);
-    }
+  const sockaddr_in* addr = reinterpret_cast<const sockaddr_in*>(info->ai_addr);
+  const char* result =
+      inet_ntop(addr->sin_family, &addr->sin_addr, ip, sizeof(ip));
+  if (result == nullptr) {
+    LOG(ERROR) << "inet_ntop failed";
+    return "";
   }
 
-  return loopback_addr;
+  return std::string(ip);
 }
 
-std::string get_local_ip_addr_for_remote(const std::string& remote_addr) {
+std::string get_route_ip(const std::string& remote_addr) {
   std::string remote_host;
   int remote_port = 0;
   parse_host_port_from_addr(remote_addr, remote_host, remote_port);
@@ -114,13 +101,8 @@ std::string get_local_ip_addr_for_remote(const std::string& remote_addr) {
   std::unique_ptr<struct addrinfo, decltype(&freeaddrinfo)> guard(info,
                                                                   freeaddrinfo);
 
-  bool has_non_loopback_remote = false;
   for (const struct addrinfo* current = info; current != nullptr;
        current = current->ai_next) {
-    const sockaddr_in* remote =
-        reinterpret_cast<const sockaddr_in*>(current->ai_addr);
-    has_non_loopback_remote = has_non_loopback_remote || !is_loopback(*remote);
-
     const int fd = socket(AF_INET, SOCK_DGRAM, 0);
     if (fd < 0) {
       continue;
@@ -141,27 +123,13 @@ std::string get_local_ip_addr_for_remote(const std::string& remote_addr) {
     }
 
     std::string local_ip = to_ip_addr(local);
-    if (!local_ip.empty() && (!is_loopback(local) || is_loopback(*remote))) {
+    if (!local_ip.empty()) {
       return local_ip;
     }
   }
 
-  std::string local_ip = get_local_ip_addr();
-  if (has_non_loopback_remote && !local_ip.empty()) {
-    in_addr addr;
-    if (inet_pton(AF_INET, local_ip.c_str(), &addr) == 1) {
-      sockaddr_in local;
-      memset(&local, 0, sizeof(local));
-      local.sin_family = AF_INET;
-      local.sin_addr = addr;
-      if (is_loopback(local)) {
-        LOG(ERROR) << "No routable local address found for remote address "
-                   << remote_addr;
-        return "";
-      }
-    }
-  }
-  return local_ip;
+  LOG(ERROR) << "No local route found for remote address " << remote_addr;
+  return "";
 }
 
 int get_local_free_port() {

--- a/xllm/core/util/net.cpp
+++ b/xllm/core/util/net.cpp
@@ -28,6 +28,7 @@ limitations under the License.
 #include <mutex>
 #include <sstream>
 #include <unordered_set>
+#include <utility>
 
 namespace xllm {
 namespace net {
@@ -37,11 +38,24 @@ namespace {
 std::mutex g_port_mutex;
 std::unordered_set<int> g_allocated_port_map;
 
+bool is_loopback(const sockaddr_in& addr) {
+  return (ntohl(addr.sin_addr.s_addr) & 0xff000000U) == 0x7f000000U;
+}
+
+std::string to_ip_addr(const sockaddr_in& addr) {
+  char ip[INET_ADDRSTRLEN]{'\0'};
+  const char* result =
+      inet_ntop(addr.sin_family, &addr.sin_addr, ip, sizeof(ip));
+  if (result == nullptr) {
+    return "";
+  }
+  return std::string(ip);
+}
+
 }  // namespace
 
 // TODO: return private ip
 std::string get_local_ip_addr() {
-  char ip[INET_ADDRSTRLEN]{'\0'};
   char hostname[256];
   int ret = gethostname(hostname, sizeof(hostname));
   if (ret != 0) {
@@ -60,15 +74,94 @@ std::string get_local_ip_addr() {
   }
   std::unique_ptr<struct addrinfo, decltype(&freeaddrinfo)> guard(info,
                                                                   freeaddrinfo);
-  const sockaddr_in* addr = reinterpret_cast<const sockaddr_in*>(info->ai_addr);
-  const char* result =
-      inet_ntop(addr->sin_family, &addr->sin_addr, ip, sizeof(ip));
-  if (result == nullptr) {
-    LOG(ERROR) << "inet_ntop failed";
-    return "";
+  std::string loopback_addr;
+  for (const struct addrinfo* current = info; current != nullptr;
+       current = current->ai_next) {
+    const sockaddr_in* addr =
+        reinterpret_cast<const sockaddr_in*>(current->ai_addr);
+    std::string ip = to_ip_addr(*addr);
+    if (ip.empty()) {
+      continue;
+    }
+    if (!is_loopback(*addr)) {
+      return ip;
+    }
+    if (loopback_addr.empty()) {
+      loopback_addr = std::move(ip);
+    }
   }
 
-  return std::string(ip);
+  return loopback_addr;
+}
+
+std::string get_local_ip_addr_for_remote(const std::string& remote_addr) {
+  std::string remote_host;
+  int remote_port = 0;
+  parse_host_port_from_addr(remote_addr, remote_host, remote_port);
+
+  struct addrinfo* info = nullptr;
+  struct addrinfo hints;
+  memset(&hints, 0, sizeof(hints));
+  hints.ai_family = AF_INET;
+  hints.ai_socktype = SOCK_DGRAM;
+  std::string port = std::to_string(remote_port);
+  int ret = getaddrinfo(remote_host.c_str(), port.c_str(), &hints, &info);
+  if (ret != 0) {
+    LOG(ERROR) << "Failed to resolve remote address " << remote_addr << ": "
+               << gai_strerror(ret);
+    return "";
+  }
+  std::unique_ptr<struct addrinfo, decltype(&freeaddrinfo)> guard(info,
+                                                                  freeaddrinfo);
+
+  bool has_non_loopback_remote = false;
+  for (const struct addrinfo* current = info; current != nullptr;
+       current = current->ai_next) {
+    const sockaddr_in* remote =
+        reinterpret_cast<const sockaddr_in*>(current->ai_addr);
+    has_non_loopback_remote = has_non_loopback_remote || !is_loopback(*remote);
+
+    const int fd = socket(AF_INET, SOCK_DGRAM, 0);
+    if (fd < 0) {
+      continue;
+    }
+    ret = connect(fd, current->ai_addr, current->ai_addrlen);
+    if (ret != 0) {
+      ::close(fd);
+      continue;
+    }
+
+    sockaddr_in local{};
+    socklen_t local_len = sizeof(local);
+    ret =
+        getsockname(fd, reinterpret_cast<struct sockaddr*>(&local), &local_len);
+    ::close(fd);
+    if (ret != 0) {
+      continue;
+    }
+
+    std::string local_ip = to_ip_addr(local);
+    if (!local_ip.empty() && (!is_loopback(local) || is_loopback(*remote))) {
+      return local_ip;
+    }
+  }
+
+  std::string local_ip = get_local_ip_addr();
+  if (has_non_loopback_remote && !local_ip.empty()) {
+    in_addr addr;
+    if (inet_pton(AF_INET, local_ip.c_str(), &addr) == 1) {
+      sockaddr_in local;
+      memset(&local, 0, sizeof(local));
+      local.sin_family = AF_INET;
+      local.sin_addr = addr;
+      if (is_loopback(local)) {
+        LOG(ERROR) << "No routable local address found for remote address "
+                   << remote_addr;
+        return "";
+      }
+    }
+  }
+  return local_ip;
 }
 
 int get_local_free_port() {

--- a/xllm/core/util/net.h
+++ b/xllm/core/util/net.h
@@ -22,6 +22,7 @@ namespace xllm {
 namespace net {
 
 std::string get_local_ip_addr();
+std::string get_local_ip_addr_for_remote(const std::string& remote_addr);
 int get_local_free_port();
 uint64_t convert_ip_port_to_uint64(const std::string& ip, uint16_t port);
 std::pair<std::string, uint16_t> convert_uint64_to_ip_port(uint64_t input);


### PR DESCRIPTION
## Description

  Workers now determine their bind/advertised IP from the network route to the master node, instead of
  using a generic local IP. This ensures the master receives a reachable worker address on multi-NIC or
  multi-network hosts.

  It also:
  - Fails worker startup clearly if no route to the master can be found.
  - Adds route-IP lookup support in the network utility.
  - Adds unit tests for loopback, hostname resolution, invalid routes, and unresolvable hosts.

## Change Type

- [x] Bug fix
- [ ] New feature
- [ ] Performance improvement
- [ ] Refactor
- [ ] Documentation
- [ ] Test
- [ ] Build or CI

## Pull Request Checklist

Thank you for contributing to xLLM. Before requesting review, please make sure the following items are complete.

### PR Title and Commit Messages

- [x] The PR title and each commit message follow the xLLM commit format: `<type>: <subject>`.

> Allowed types: feat, bugfix, docs, test, refactor, chore, style, revert, perf, model, build, release.
> The subject should use clear English, start with a verb, include at least 4 words, and end with `.`.

### Pre-commit Checks

- [x] I have installed `pre-commit` by running `pip install pre-commit` or an equivalent command.
- [x] I have installed the hooks with `pre-commit install`.
- [x] I have run `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

### Self Review

- [x] I have self-reviewed the code according to `.agents/skills/code-review/references/custom-code-style.md`, especially code written or assisted by AI.
- [x] I have rebased this PR onto the latest `main` branch.

### Build and Test Coverage

- [ ] Tests have been added or updated as needed.
- [ ] CUDA: `python setup.py build test` has passed on a CUDA machine.
- [x] NPU: `python setup.py build test` has passed on an NPU machine.
- [x] MLU: `python setup.py build test` has passed on an MLU machine.

## Reviewer Notes

<!-- Optional: anything reviewers should focus on, known risks, follow-ups, or validation gaps. -->
