### PR TITLE
feat: add Qwen3.5 Python model cuda impl.

### DIFF
--- a/docker/Dockerfile.cuda
+++ b/docker/Dockerfile.cuda
@@ -24,6 +24,7 @@ ARG http_proxy=
 ARG https_proxy=
 # Optional: use pypi mirror (e.g. https://pypi.tuna.tsinghua.edu.cn/simple)
 ARG UV_DEFAULT_INDEX=
+ARG PIP_INDEX_URL=
 # Optional: accelerate github https clone (e.g. https://gh-proxy.com/)
 ARG GIT_HTTPS_MIRROR_PREFIX=
 # Optional: use rustup proxy (example: https://rsproxy.cn)
@@ -101,8 +102,10 @@ ENV NVSHMEM_HOME=/usr/local
 
 # Install cmake
 RUN set -eux; \
-    url="https://github.com/Kitware/CMake/releases/download/v${CMAKE_VERSION}/cmake-${CMAKE_VERSION}-linux-x86_64.tar.gz"; \
-    curl -fL --retry 3 --retry-delay 2 -o /tmp/cmake.tar.gz "${url}"; \
+    github_url="https://github.com/Kitware/CMake/releases/download/v${CMAKE_VERSION}/cmake-${CMAKE_VERSION}-linux-x86_64.tar.gz"; \
+    url="${GIT_HTTPS_MIRROR_PREFIX}${github_url}"; \
+    curl -fL --retry 3 --retry-all-errors --retry-delay 2 \
+      -o /tmp/cmake.tar.gz "${url}"; \
     mkdir -p /opt/cmake; \
     tar -xzf /tmp/cmake.tar.gz -C /opt/cmake --strip-components=1; \
     rm -f /tmp/cmake.tar.gz; \

--- a/tests/core/framework/batch/batch_packed_input_test.cpp
+++ b/tests/core/framework/batch/batch_packed_input_test.cpp
@@ -36,6 +36,7 @@ namespace {
 void expect_linear_state_cache_op_eq(const LinearStateCacheOp& actual,
                                      const LinearStateCacheOp& expected) {
   EXPECT_EQ(actual.linear_state_id, expected.linear_state_id);
+  EXPECT_EQ(actual.reset_requested, expected.reset_requested);
   EXPECT_EQ(actual.restore_requested, expected.restore_requested);
   EXPECT_EQ(actual.restore_src_slot_id, expected.restore_src_slot_id);
 }
@@ -110,6 +111,7 @@ TEST(BatchPackedInputTest, PackedProtoLazyUnpackPreservesLinearStateCacheOps) {
 
   LinearStateCacheOp no_restore_op;
   no_restore_op.linear_state_id = 8;
+  no_restore_op.reset_requested = true;
 
   input.input_params.linear_state_cache_ops = {restore_op, no_restore_op};
 

--- a/tests/core/framework/config/config_json_test.cpp
+++ b/tests/core/framework/config/config_json_test.cpp
@@ -195,6 +195,31 @@ std::filesystem::path config_test_file_path() {
   return std::filesystem::path("tests/core/framework/config/config_test.json");
 }
 
+TEST(ModelConfigValidationTest, RejectsQwen35PythonSpeculativeDecode) {
+  const std::optional<std::string> error =
+      ModelConfig::validate_python_speculative_decode(
+          "python", "qwen3_5_moe_text", 4);
+
+  ASSERT_TRUE(error.has_value());
+  EXPECT_NE(error->find("does not support speculative decoding"),
+            std::string::npos);
+  EXPECT_TRUE(
+      ModelConfig::validate_python_speculative_decode("py", "qwen3_5_text", 1)
+          .has_value());
+}
+
+TEST(ModelConfigValidationTest, AcceptsSupportedPythonExecutionModes) {
+  EXPECT_FALSE(ModelConfig::validate_python_speculative_decode(
+                   "python", "qwen3_5_text", 0)
+                   .has_value());
+  EXPECT_FALSE(ModelConfig::validate_python_speculative_decode(
+                   "native", "qwen3_5_text", 4)
+                   .has_value());
+  EXPECT_FALSE(
+      ModelConfig::validate_python_speculative_decode("python", "qwen3", 4)
+          .has_value());
+}
+
 TEST(ConfigJsonTest, FromJsonUsesParsedOverrides) {
   const JsonReader json = config::parse_json_string(kInlineConfig);
   ConfigFlagGuard flag_guard;

--- a/tests/core/framework/hf_model_loader_test.cpp
+++ b/tests/core/framework/hf_model_loader_test.cpp
@@ -108,6 +108,7 @@ TEST(HFModelLoaderTest, Qwen35DenseBackendAwareModelTypeSelection) {
   EXPECT_EQ(util::get_model_type(reader, fake_model_path, "llm"),
             "qwen3_5_text");
   EXPECT_EQ(util::get_model_type(reader, fake_model_path, "vlm"), "qwen3_5");
+  EXPECT_EQ(ModelRegistry::get_model_backend("qwen3_5_text"), "llm");
 }
 
 TEST(HFModelLoaderTest, Qwen35MoeBackendAwareModelTypeSelection) {
@@ -135,6 +136,7 @@ TEST(HFModelLoaderTest, Qwen35MoeBackendAwareModelTypeSelection) {
             "qwen3_5_moe_text");
   EXPECT_EQ(util::get_model_type(reader, fake_model_path, "vlm"),
             "qwen3_5_moe");
+  EXPECT_EQ(ModelRegistry::get_model_backend("qwen3_5_moe_text"), "llm");
 }
 
 #if defined(USE_MLU)

--- a/tests/core/framework/kv_cache/CMakeLists.txt
+++ b/tests/core/framework/kv_cache/CMakeLists.txt
@@ -60,3 +60,4 @@ cc_test(
     :linear_state_restore
     GTest::gtest_main
 )
+target_link_libraries(linear_state_restore_test PUBLIC Python::Python)

--- a/tests/core/framework/kv_cache/linear_state_restore_test.cpp
+++ b/tests/core/framework/kv_cache/linear_state_restore_test.cpp
@@ -218,9 +218,8 @@ TEST(LinearStateRestoreTest, MixedResetAndRestorePreserveMetadata) {
   reset_four.reset_requested = true;
   std::vector<int64_t> validity_mask = {1, 0, 1};
 
-  restore_linear_state_slots(cache.kv_caches,
-                             {reset_two, restore_three, reset_four},
-                             validity_mask);
+  restore_linear_state_slots(
+      cache.kv_caches, {reset_two, restore_three, reset_four}, validity_mask);
 
   EXPECT_EQ(validity_mask, std::vector<int64_t>({0, 1, 0}));
   EXPECT_EQ(cache.conv_cache.select(0, 2).count_nonzero().item<int64_t>(), 0);
@@ -305,9 +304,9 @@ TEST(LinearStateRestoreTest, OutOfRangeSlotFailsClosed) {
   continued.linear_state_id = 4;
   std::vector<int64_t> validity_mask = {1};
 
-  EXPECT_DEATH(restore_linear_state_slots(
-                   cache.kv_caches, {continued}, validity_mask),
-               "live slot must be a real non-padding slot");
+  EXPECT_DEATH(
+      restore_linear_state_slots(cache.kv_caches, {continued}, validity_mask),
+      "live slot must be a real non-padding slot");
 }
 
 TEST(LinearStateRestoreTest, PartialLinearCacheLayoutFailsClosed) {
@@ -318,9 +317,9 @@ TEST(LinearStateRestoreTest, PartialLinearCacheLayoutFailsClosed) {
   continued.linear_state_id = 2;
   std::vector<int64_t> validity_mask = {1};
 
-  EXPECT_DEATH(restore_linear_state_slots(
-                   cache.kv_caches, {continued}, validity_mask),
-               "must provide both conv and ssm caches");
+  EXPECT_DEATH(
+      restore_linear_state_slots(cache.kv_caches, {continued}, validity_mask),
+      "must provide both conv and ssm caches");
 }
 
 TEST(LinearStateRestoreTest, EmptySsmCheckpointLayoutFailsClosed) {

--- a/tests/core/framework/kv_cache/linear_state_restore_test.cpp
+++ b/tests/core/framework/kv_cache/linear_state_restore_test.cpp
@@ -73,5 +73,271 @@ TEST(LinearStateRestoreTest, ModelInputConversionPreservesValidityMask) {
             std::vector<int64_t>({0, 1, 1, 0}));
 }
 
+struct LinearStateTestCache {
+  std::vector<KVCache> kv_caches;
+  torch::Tensor conv_cache;
+  torch::Tensor ssm_cache;
+};
+
+LinearStateTestCache make_cache(int64_t num_slots = 4,
+                                int64_t checkpoint_stride = 1) {
+  LinearStateTestCache cache;
+  cache.conv_cache = torch::full({num_slots, 2, 3}, 7.0, torch::kFloat32);
+  cache.ssm_cache =
+      torch::full({num_slots * checkpoint_stride, 2, 2}, 11.0, torch::kFloat32);
+  cache.kv_caches.emplace_back(
+      LinearAttentionKVCacheTensors{cache.conv_cache, cache.ssm_cache});
+  return cache;
+}
+
+TEST(LinearStateRestoreTest, ColdStartClearsOnlyLiveSlotAndMarksItCold) {
+  LinearStateTestCache cache = make_cache(/*num_slots=*/4,
+                                          /*checkpoint_stride=*/2);
+  const torch::Tensor untouched_conv = cache.conv_cache.select(0, 1).clone();
+  const torch::Tensor untouched_ssm = cache.ssm_cache.narrow(0, 2, 2).clone();
+
+  LinearStateCacheOp reset;
+  reset.linear_state_id = 2;
+  reset.reset_requested = true;
+  std::vector<int64_t> validity_mask = {1};
+  restore_linear_state_slots(cache.kv_caches, {reset}, validity_mask);
+
+  EXPECT_EQ(validity_mask[0], 0);
+  EXPECT_EQ(cache.conv_cache.select(0, 2).count_nonzero().item<int64_t>(), 0);
+  EXPECT_EQ(cache.ssm_cache.narrow(0, 4, 2).count_nonzero().item<int64_t>(), 0);
+  EXPECT_TRUE(torch::equal(cache.conv_cache.select(0, 1), untouched_conv));
+  EXPECT_TRUE(torch::equal(cache.ssm_cache.narrow(0, 2, 2), untouched_ssm));
+}
+
+TEST(LinearStateRestoreTest, ColdStartsBatchContiguousSlotsAcrossLayers) {
+  LinearStateTestCache cache = make_cache(/*num_slots=*/6,
+                                          /*checkpoint_stride=*/2);
+  torch::Tensor second_conv = torch::full({6, 2, 3}, 13.0, torch::kFloat32);
+  torch::Tensor second_ssm = torch::full({12, 2, 2}, 17.0, torch::kFloat32);
+  cache.kv_caches.emplace_back(
+      LinearAttentionKVCacheTensors{second_conv, second_ssm});
+  const torch::Tensor untouched_conv = cache.conv_cache.select(0, 5).clone();
+  const torch::Tensor untouched_ssm = cache.ssm_cache.narrow(0, 10, 2).clone();
+  const torch::Tensor untouched_second_conv = second_conv.select(0, 1).clone();
+  const torch::Tensor untouched_second_ssm = second_ssm.narrow(0, 2, 2).clone();
+
+  std::vector<LinearStateCacheOp> resets(3);
+  for (size_t i = 0; i < resets.size(); ++i) {
+    resets[i].linear_state_id = static_cast<int32_t>(i + 2);
+    resets[i].reset_requested = true;
+  }
+  std::vector<int64_t> validity_mask = {1, 1, 1};
+  restore_linear_state_slots(cache.kv_caches, resets, validity_mask);
+
+  EXPECT_EQ(validity_mask, std::vector<int64_t>({0, 0, 0}));
+  EXPECT_EQ(cache.conv_cache.narrow(0, 2, 3).count_nonzero().item<int64_t>(),
+            0);
+  EXPECT_EQ(cache.ssm_cache.narrow(0, 4, 6).count_nonzero().item<int64_t>(), 0);
+  EXPECT_EQ(second_conv.narrow(0, 2, 3).count_nonzero().item<int64_t>(), 0);
+  EXPECT_EQ(second_ssm.narrow(0, 4, 6).count_nonzero().item<int64_t>(), 0);
+  EXPECT_TRUE(torch::equal(cache.conv_cache.select(0, 5), untouched_conv));
+  EXPECT_TRUE(torch::equal(cache.ssm_cache.narrow(0, 10, 2), untouched_ssm));
+  EXPECT_TRUE(torch::equal(second_conv.select(0, 1), untouched_second_conv));
+  EXPECT_TRUE(torch::equal(second_ssm.narrow(0, 2, 2), untouched_second_ssm));
+}
+
+TEST(LinearStateRestoreTest, ColdStartsBatchDisjointRanges) {
+  LinearStateTestCache cache = make_cache(/*num_slots=*/7,
+                                          /*checkpoint_stride=*/2);
+  const torch::Tensor untouched_conv_two =
+      cache.conv_cache.select(0, 2).clone();
+  const torch::Tensor untouched_conv_five =
+      cache.conv_cache.select(0, 5).clone();
+  const torch::Tensor untouched_ssm_two =
+      cache.ssm_cache.narrow(0, 4, 2).clone();
+  const torch::Tensor untouched_ssm_five =
+      cache.ssm_cache.narrow(0, 10, 2).clone();
+
+  std::vector<LinearStateCacheOp> resets(4);
+  const std::vector<int32_t> reset_slots = {1, 3, 4, 6};
+  for (size_t i = 0; i < resets.size(); ++i) {
+    resets[i].linear_state_id = reset_slots[i];
+    resets[i].reset_requested = true;
+  }
+  std::vector<int64_t> validity_mask = {1, 1, 1, 1};
+  restore_linear_state_slots(cache.kv_caches, resets, validity_mask);
+
+  EXPECT_EQ(validity_mask, std::vector<int64_t>({0, 0, 0, 0}));
+  for (const int32_t slot_id : reset_slots) {
+    EXPECT_EQ(
+        cache.conv_cache.select(0, slot_id).count_nonzero().item<int64_t>(), 0);
+    EXPECT_EQ(cache.ssm_cache.narrow(0, slot_id * 2, 2)
+                  .count_nonzero()
+                  .item<int64_t>(),
+              0);
+  }
+  EXPECT_TRUE(torch::equal(cache.conv_cache.select(0, 2), untouched_conv_two));
+  EXPECT_TRUE(torch::equal(cache.conv_cache.select(0, 5), untouched_conv_five));
+  EXPECT_TRUE(torch::equal(cache.ssm_cache.narrow(0, 4, 2), untouched_ssm_two));
+  EXPECT_TRUE(
+      torch::equal(cache.ssm_cache.narrow(0, 10, 2), untouched_ssm_five));
+}
+
+TEST(LinearStateRestoreTest, RestoreCopiesCheckpointAndMarksItWarm) {
+  LinearStateTestCache cache = make_cache(/*num_slots=*/4,
+                                          /*checkpoint_stride=*/2);
+  cache.conv_cache.select(0, 1).fill_(17.0);
+  cache.conv_cache.select(0, 2).zero_();
+  cache.ssm_cache.narrow(0, 2, 2).fill_(23.0);
+  cache.ssm_cache.narrow(0, 4, 2).zero_();
+
+  LinearStateCacheOp restore;
+  restore.linear_state_id = 2;
+  restore.restore_requested = true;
+  restore.restore_src_slot_id = 1;
+  std::vector<int64_t> validity_mask = {0};
+  restore_linear_state_slots(cache.kv_caches, {restore}, validity_mask);
+
+  EXPECT_EQ(validity_mask[0], 1);
+  EXPECT_TRUE(torch::equal(cache.conv_cache.select(0, 2),
+                           cache.conv_cache.select(0, 1)));
+  EXPECT_TRUE(torch::equal(cache.ssm_cache.narrow(0, 4, 2),
+                           cache.ssm_cache.narrow(0, 2, 2)));
+}
+
+TEST(LinearStateRestoreTest, MixedResetAndRestorePreserveMetadata) {
+  LinearStateTestCache cache = make_cache(/*num_slots=*/6,
+                                          /*checkpoint_stride=*/2);
+  cache.conv_cache.select(0, 1).fill_(17.0);
+  cache.ssm_cache.narrow(0, 2, 2).fill_(23.0);
+
+  LinearStateCacheOp reset_two;
+  reset_two.linear_state_id = 2;
+  reset_two.reset_requested = true;
+  LinearStateCacheOp restore_three;
+  restore_three.linear_state_id = 3;
+  restore_three.restore_requested = true;
+  restore_three.restore_src_slot_id = 1;
+  LinearStateCacheOp reset_four;
+  reset_four.linear_state_id = 4;
+  reset_four.reset_requested = true;
+  std::vector<int64_t> validity_mask = {1, 0, 1};
+
+  restore_linear_state_slots(cache.kv_caches,
+                             {reset_two, restore_three, reset_four},
+                             validity_mask);
+
+  EXPECT_EQ(validity_mask, std::vector<int64_t>({0, 1, 0}));
+  EXPECT_EQ(cache.conv_cache.select(0, 2).count_nonzero().item<int64_t>(), 0);
+  EXPECT_EQ(cache.ssm_cache.narrow(0, 4, 2).count_nonzero().item<int64_t>(), 0);
+  EXPECT_TRUE(torch::equal(cache.conv_cache.select(0, 3),
+                           cache.conv_cache.select(0, 1)));
+  EXPECT_TRUE(torch::equal(cache.ssm_cache.narrow(0, 6, 2),
+                           cache.ssm_cache.narrow(0, 2, 2)));
+  EXPECT_EQ(cache.conv_cache.select(0, 4).count_nonzero().item<int64_t>(), 0);
+  EXPECT_EQ(cache.ssm_cache.narrow(0, 8, 2).count_nonzero().item<int64_t>(), 0);
+}
+
+TEST(LinearStateRestoreTest, ResetAndRestoreTogetherFailsClosed) {
+  LinearStateTestCache cache = make_cache();
+  LinearStateCacheOp invalid;
+  invalid.linear_state_id = 2;
+  invalid.reset_requested = true;
+  invalid.restore_requested = true;
+  invalid.restore_src_slot_id = 1;
+  std::vector<int64_t> validity_mask = {1};
+
+  EXPECT_DEATH(
+      restore_linear_state_slots(cache.kv_caches, {invalid}, validity_mask),
+      "reset and restore are mutually exclusive");
+}
+
+TEST(LinearStateRestoreTest, ContinuedRequestPreservesStateAndMetadata) {
+  LinearStateTestCache cache = make_cache();
+  const torch::Tensor original_conv = cache.conv_cache.clone();
+  const torch::Tensor original_ssm = cache.ssm_cache.clone();
+
+  LinearStateCacheOp continued;
+  continued.linear_state_id = 2;
+  std::vector<int64_t> validity_mask = {1};
+  restore_linear_state_slots(cache.kv_caches, {continued}, validity_mask);
+
+  EXPECT_EQ(validity_mask[0], 1);
+  EXPECT_TRUE(torch::equal(cache.conv_cache, original_conv));
+  EXPECT_TRUE(torch::equal(cache.ssm_cache, original_ssm));
+}
+
+TEST(LinearStateRestoreTest, MissingRestoreSourceFailsClosed) {
+  LinearStateTestCache cache = make_cache();
+  LinearStateCacheOp restore;
+  restore.linear_state_id = 2;
+  restore.restore_requested = true;
+  std::vector<int64_t> validity_mask = {1};
+
+  EXPECT_DEATH(
+      restore_linear_state_slots(cache.kv_caches, {restore}, validity_mask),
+      "restore source must be a real non-padding slot");
+}
+
+TEST(LinearStateRestoreTest, PaddingLiveSlotFailsClosed) {
+  LinearStateTestCache cache = make_cache();
+  LinearStateCacheOp reset;
+  reset.linear_state_id = 0;
+  reset.reset_requested = true;
+  std::vector<int64_t> validity_mask = {0};
+
+  EXPECT_DEATH(
+      restore_linear_state_slots(cache.kv_caches, {reset}, validity_mask),
+      "live slot must be a real non-padding slot");
+}
+
+TEST(LinearStateRestoreTest, PaddingRestoreSourceFailsClosed) {
+  LinearStateTestCache cache = make_cache();
+  LinearStateCacheOp restore;
+  restore.linear_state_id = 2;
+  restore.restore_requested = true;
+  restore.restore_src_slot_id = 0;
+  std::vector<int64_t> validity_mask = {0};
+
+  EXPECT_DEATH(
+      restore_linear_state_slots(cache.kv_caches, {restore}, validity_mask),
+      "restore source must be a real non-padding slot");
+}
+
+TEST(LinearStateRestoreTest, OutOfRangeSlotFailsClosed) {
+  LinearStateTestCache cache = make_cache();
+  LinearStateCacheOp continued;
+  continued.linear_state_id = 4;
+  std::vector<int64_t> validity_mask = {1};
+
+  EXPECT_DEATH(restore_linear_state_slots(
+                   cache.kv_caches, {continued}, validity_mask),
+               "live slot must be a real non-padding slot");
+}
+
+TEST(LinearStateRestoreTest, PartialLinearCacheLayoutFailsClosed) {
+  LinearStateTestCache cache = make_cache();
+  cache.kv_caches.emplace_back(LinearAttentionKVCacheTensors{
+      torch::zeros({4, 2, 3}, torch::kFloat32), torch::Tensor()});
+  LinearStateCacheOp continued;
+  continued.linear_state_id = 2;
+  std::vector<int64_t> validity_mask = {1};
+
+  EXPECT_DEATH(restore_linear_state_slots(
+                   cache.kv_caches, {continued}, validity_mask),
+               "must provide both conv and ssm caches");
+}
+
+TEST(LinearStateRestoreTest, EmptySsmCheckpointLayoutFailsClosed) {
+  LinearStateTestCache cache = make_cache();
+  cache.kv_caches.clear();
+  cache.kv_caches.emplace_back(
+      LinearAttentionKVCacheTensors{torch::zeros({4, 2, 3}, torch::kFloat32),
+                                    torch::zeros({0, 2, 2}, torch::kFloat32)});
+  LinearStateCacheOp reset;
+  reset.linear_state_id = 2;
+  reset.reset_requested = true;
+  std::vector<int64_t> validity_mask = {0};
+
+  EXPECT_DEATH(
+      restore_linear_state_slots(cache.kv_caches, {reset}, validity_mask),
+      "ssm cache must contain checkpoint rows");
+}
+
 }  // namespace
 }  // namespace xllm

--- a/tests/core/kernels/cuda/xllm_ops_test.cpp
+++ b/tests/core/kernels/cuda/xllm_ops_test.cpp
@@ -33,6 +33,7 @@ limitations under the License.
 #include <filesystem>
 
 #include "core/kernels/cuda/cuda_ops_library.h"
+#include "core/platform/platform.h"
 
 namespace py = pybind11;
 
@@ -75,6 +76,7 @@ class XllmOpsTest : public ::testing::Test {
     if (!torch::cuda::is_available()) {
       GTEST_SKIP() << "CUDA not available; skipping xllm_ops CUDA test.";
     }
+    Platform::init_capabilities(Platform::current_device());
   }
 };
 
@@ -128,6 +130,65 @@ TEST_F(XllmOpsTest, EmbeddedInterpreterSeesOps) {
              .item<float>();
 }
 
+TEST_F(XllmOpsTest, EmbeddedInterpreterMoeOpsMatchTorchReference) {
+  if (!Py_IsInitialized()) {
+    Py_InitializeEx(0);
+  }
+  py::gil_scoped_acquire gil;
+
+  py::exec(R"PY(
+import torch
+import torch.nn.functional as F
+
+torch.manual_seed(2026)
+device = "cuda"
+dtype = torch.bfloat16
+num_tokens = 7
+num_experts = 8
+top_k = 2
+hidden_size = 128
+intermediate_size = 128
+
+router_logits = torch.randn(
+    num_tokens, num_experts, device=device, dtype=dtype
+)
+topk_weights, topk_ids = torch.ops.xllm_ops.moe_fused_topk(
+    router_logits, top_k, True, "softmax"
+)
+expected_weights, expected_ids = torch.topk(
+    torch.softmax(router_logits.float(), dim=-1), top_k, dim=-1
+)
+expected_weights /= expected_weights.sum(dim=-1, keepdim=True)
+torch.testing.assert_close(topk_ids, expected_ids.to(torch.int32), rtol=0, atol=0)
+torch.testing.assert_close(topk_weights, expected_weights, rtol=2e-3, atol=2e-3)
+
+hidden = torch.randn(num_tokens, hidden_size, device=device, dtype=dtype)
+scale = hidden_size**-0.5
+up = torch.randn(
+    num_experts, intermediate_size, hidden_size, device=device, dtype=dtype
+) * scale
+gate = torch.randn_like(up) * scale
+w13 = torch.cat((up, gate), dim=1).contiguous()
+w2 = torch.randn(
+    num_experts, hidden_size, intermediate_size, device=device, dtype=dtype
+) * intermediate_size**-0.5
+
+actual = torch.ops.xllm_ops.cutlass_fused_moe(
+    hidden, topk_ids, topk_weights, w13, w2, 1, 0, 1, 0
+)
+expected = torch.zeros_like(actual)
+for token in range(num_tokens):
+    for choice in range(top_k):
+        expert = int(topk_ids[token, choice])
+        expert_hidden = F.linear(hidden[token], gate[expert])
+        expert_hidden = F.silu(expert_hidden) * F.linear(hidden[token], up[expert])
+        expert_output = F.linear(expert_hidden, w2[expert])
+        expected[token] += expert_output * topk_weights[token, choice]
+
+torch.testing.assert_close(actual, expected, rtol=3e-2, atol=3e-2)
+)PY");
+}
+
 TEST_F(XllmOpsTest, EmbeddedPythonCollectivesUseTorchDistributed) {
   if (!Py_IsInitialized()) {
     Py_InitializeEx(0);
@@ -135,9 +196,12 @@ TEST_F(XllmOpsTest, EmbeddedPythonCollectivesUseTorchDistributed) {
   py::gil_scoped_acquire gil;
   prepend_python_model_path();
 
-  py::module_ collectives = py::module_::import("xllm.python.ops.collectives");
-  py::object group =
-      collectives.attr("init_tp_group")("127.0.0.1", 0, 0, 1, "cuda:0");
+  py::module_ collectives =
+      py::module_::import("xllm.python.distributed.collectives");
+  py::object group = collectives.attr("init_tp_group")(
+      "127.0.0.1", 0, 0, 1, "cuda:0", 0, 1, 0);
+  py::object ep_group = collectives.attr("init_process_group")(
+      "moe_ep", "127.0.0.1", 0, 0, 1, "cuda:0", 0, 1, 0);
 
   auto options =
       torch::TensorOptions().dtype(torch::kFloat32).device(torch::kCUDA);
@@ -148,12 +212,15 @@ TEST_F(XllmOpsTest, EmbeddedPythonCollectivesUseTorchDistributed) {
       py::str(all_reduce.attr("_opoverload").attr("_schema"))
           .cast<std::string>();
   EXPECT_NE(all_reduce_schema.find("Tensor(a0!) x"), std::string::npos);
+  EXPECT_NE(all_reduce_schema.find("str group_name=\"tp\""), std::string::npos);
   EXPECT_TRUE(all_reduce(input).is_none());
+  EXPECT_TRUE(all_reduce(input, "moe_ep").is_none());
   EXPECT_TRUE(torch::equal(input, torch::ones_like(input)));
 
   auto gathered =
       collectives.attr("all_gather")(input, -1, 1).cast<torch::Tensor>();
   group.attr("shutdown")();
+  ep_group.attr("shutdown")();
 
   ASSERT_EQ(gathered.sizes(), torch::IntArrayRef({2, 3}));
   EXPECT_TRUE(torch::equal(gathered, input));

--- a/tests/core/runtime/acl_graph_executor_test.cpp
+++ b/tests/core/runtime/acl_graph_executor_test.cpp
@@ -32,7 +32,6 @@ limitations under the License.
 #include "core/framework/config/speculative_config.h"
 #include "core/framework/kv_cache/kv_cache.h"
 #include "core/framework/kv_cache/kv_cache_utils.h"
-#include "core/framework/kv_cache/linear_state_restore.h"
 #include "core/framework/model/model_args.h"
 #include "core/framework/model/model_output.h"
 #include "core/framework/model_context.h"
@@ -937,51 +936,6 @@ TEST_F(AclGraphExecutorTest, BatchInputCarriesLinearStateIds) {
   ASSERT_EQ(params_for_capture->linear_state_validity_mask.size(), 2);
   EXPECT_EQ(params_for_capture->linear_state_validity_mask[0], 1);
   EXPECT_EQ(params_for_capture->linear_state_validity_mask[1], 0);
-}
-
-TEST(LinearStateRestoreTest, RestoreCopiesCheckpointSlot) {
-  std::vector<KVCache> kv_caches;
-  torch::Tensor conv_cache = torch::zeros({3, 2, 2}, torch::kFloat32);
-  torch::Tensor ssm_cache = torch::zeros({3, 2, 2}, torch::kFloat32);
-  conv_cache.select(0, 1).fill_(7.0);
-  ssm_cache.select(0, 1).fill_(11.0);
-  kv_caches.emplace_back(LinearAttentionKVCacheTensors{conv_cache, ssm_cache});
-
-  LinearStateCacheOp restore;
-  restore.linear_state_id = 2;
-  restore.restore_requested = true;
-  restore.restore_src_slot_id = 1;
-  std::vector<int64_t> has_initial_state(1, 0);
-  restore_linear_state_slots(kv_caches, {restore}, has_initial_state);
-
-  EXPECT_EQ(has_initial_state[0], 1);
-  EXPECT_TRUE(
-      torch::allclose(conv_cache.select(0, 2), conv_cache.select(0, 1)));
-  EXPECT_TRUE(torch::allclose(ssm_cache.select(0, 2), ssm_cache.select(0, 1)));
-}
-
-TEST(LinearStateRestoreTest, RestoreRequestedButUnresolvedColdStarts) {
-  std::vector<KVCache> kv_caches;
-  kv_caches.emplace_back(LinearAttentionKVCacheTensors{
-      torch::zeros({2, 4, 3}, torch::dtype(torch::kFloat32)),
-      torch::zeros({2, 4, 4}, torch::dtype(torch::kFloat32))});
-
-  LinearStateCacheOp no_restore;
-  no_restore.linear_state_id = 1;
-  LinearStateCacheOp missing_restore;
-  missing_restore.linear_state_id = 1;
-  missing_restore.restore_requested = true;
-  missing_restore.restore_src_slot_id = -1;
-
-  const std::vector<LinearStateCacheOp> cache_ops = {no_restore,
-                                                     missing_restore};
-  // Pre-fill both entries with the kv-cache default of 1 so the test can
-  // distinguish "SKIPPED leaves the default untouched" from "COLD_START
-  // overrides it to 0".
-  std::vector<int64_t> has_initial_state = {1, 1};
-  restore_linear_state_slots(kv_caches, cache_ops, has_initial_state);
-  EXPECT_EQ(has_initial_state[0], 1);
-  EXPECT_EQ(has_initial_state[1], 0);
 }
 
 TEST_F(AclGraphExecutorTest, GraphDoubleBufferFlagControlsSlotCount) {

--- a/tests/python/test_collectives.py
+++ b/tests/python/test_collectives.py
@@ -1,0 +1,225 @@
+# Copyright 2026 The xLLM Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://github.com/xLLM-AI/xllm/blob/main/LICENSE
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for Python process-group rendezvous ownership."""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+import torch
+import torch.distributed as dist
+
+
+_MODULE_PATH = (
+    Path(__file__).parents[2] / "xllm" / "python" / "distributed" / "collectives.py"
+)
+_SPEC = importlib.util.spec_from_file_location(
+    "_xllm_collectives_under_test", _MODULE_PATH
+)
+assert _SPEC is not None and _SPEC.loader is not None
+collectives = importlib.util.module_from_spec(_SPEC)
+_SPEC.loader.exec_module(collectives)
+
+
+class _FakeGroup:
+    def __init__(self, rank: int, size: int) -> None:
+        self._rank = rank
+        self._size = size
+
+    def rank(self) -> int:
+        return self._rank
+
+    def size(self) -> int:
+        return self._size
+
+
+@pytest.fixture(autouse=True)
+def _clear_collective_state():
+    def reset():
+        collectives._groups.clear()
+        collectives._stores.clear()
+        collectives._symm_eligible.clear()
+        collectives._symm_buffers.clear()
+        collectives._world_topology = None
+        collectives._world_initialized = False
+
+    reset()
+    yield
+    reset()
+
+
+class _FakeStore:
+    def __init__(self, topology: list[dict[str, object]] | None = None) -> None:
+        self.values: dict[str, bytes] = {}
+        if topology is not None:
+            for rank, entry in enumerate(topology):
+                self.values[
+                    f"xllm/python_collectives/topology/v1/{rank}"
+                ] = json.dumps(entry).encode("utf-8")
+
+    def set(self, key: str, value: str) -> None:
+        self.values[key] = value.encode("utf-8")
+
+    def get(self, key: str) -> bytes:
+        return self.values[key]
+
+
+def _mock_process_groups(
+    monkeypatch: pytest.MonkeyPatch,
+    global_rank: int,
+    topology: list[dict[str, object]] | None = None,
+):
+    """Stand in for c10d so the rendezvous can be inspected without a world.
+
+    ``new_group`` reports this rank's position inside the membership it is
+    handed, which is what the module checks its caller's rank against.
+    """
+    if topology is None:
+        topology = [
+            {"hostname": "node-0", "device_index": rank} for rank in range(16)
+        ]
+    base_store = _FakeStore(topology)
+    tcp_store = MagicMock(return_value=base_store)
+    init_world = MagicMock()
+    new_group = MagicMock(
+        side_effect=lambda ranks, timeout, backend: _FakeGroup(
+            ranks.index(global_rank) if global_rank in ranks else -1, len(ranks)
+        )
+    )
+    monkeypatch.setattr(dist, "TCPStore", tcp_store)
+    monkeypatch.setattr(dist, "init_process_group", init_world)
+    monkeypatch.setattr(dist, "new_group", new_group)
+    monkeypatch.setattr(collectives.socket, "gethostname", lambda: "node-0")
+    monkeypatch.setattr(torch.cuda, "can_device_access_peer", lambda _a, _b: True)
+    return base_store, tcp_store, init_world, new_group
+
+
+def test_parallel_groups_share_one_multitenant_tcp_store(monkeypatch):
+    base_store, tcp_store, init_world, new_group = _mock_process_groups(
+        monkeypatch, global_rank=0
+    )
+
+    collectives.init_process_group(
+        "tp", "127.0.0.1", 46001, 0, 2, "cuda:0", 0, 2, 0
+    )
+    collectives.init_process_group(
+        "moe_tp", "127.0.0.1", 46001, 0, 2, "cuda:0", 0, 2, 0
+    )
+
+    tcp_store.assert_called_once()
+    assert tcp_store.call_args.args[:4] == ("127.0.0.1", 46001, 2, True)
+    assert tcp_store.call_args.kwargs["wait_for_workers"] is False
+    assert tcp_store.call_args.kwargs["multi_tenant"] is True
+
+    # Every parallel group is a subgroup of one world, so the world rendezvous
+    # happens once no matter how many groups the caller asks for.
+    init_world.assert_called_once()
+    assert init_world.call_args.kwargs["store"] is base_store
+    assert init_world.call_args.kwargs["rank"] == 0
+    assert init_world.call_args.kwargs["world_size"] == 2
+    assert [call.kwargs["ranks"] for call in new_group.call_args_list] == [
+        [0, 1],
+        [0, 1],
+    ]
+
+
+def test_tcp_store_master_is_global_rank_zero_not_group_rank_zero(monkeypatch):
+    _, tcp_store, _, _ = _mock_process_groups(monkeypatch, global_rank=2)
+
+    collectives.init_process_group(
+        "tp", "127.0.0.1", 46001, 0, 2, "cuda:0", 2, 4, 1
+    )
+
+    assert tcp_store.call_args.args[:4] == ("127.0.0.1", 46001, 4, False)
+
+
+def test_symmetric_memory_rejects_cross_host_group(monkeypatch):
+    collectives._world_topology = [
+        {"hostname": "node-0", "device_index": 0},
+        {"hostname": "node-1", "device_index": 0},
+    ]
+    can_access_peer = MagicMock(return_value=True)
+    monkeypatch.setattr(torch.cuda, "can_device_access_peer", can_access_peer)
+
+    assert not collectives._supports_symmetric_memory(
+        torch.device("cuda:0"), [0, 1]
+    )
+    can_access_peer.assert_not_called()
+
+
+def test_symmetric_memory_rejects_incomplete_peer_domain(monkeypatch):
+    collectives._world_topology = [
+        {"hostname": "node-0", "device_index": 0},
+        {"hostname": "node-0", "device_index": 1},
+    ]
+    monkeypatch.setattr(
+        torch.cuda,
+        "can_device_access_peer",
+        lambda source, destination: (source, destination) != (1, 0),
+    )
+
+    assert not collectives._supports_symmetric_memory(
+        torch.device("cuda:0"), [0, 1]
+    )
+
+
+@pytest.mark.parametrize("dtype", [torch.float16, torch.float64, torch.int32])
+def test_symmetric_buffer_rejects_unsupported_dtype(monkeypatch, dtype):
+    group_name = "tp"
+    device = torch.device("cuda:0")
+    collectives._symm_eligible[(group_name, str(device))] = True
+    tensor = MagicMock()
+    tensor.device = device
+    tensor.dtype = dtype
+    tensor.is_contiguous.return_value = True
+    tensor.numel.return_value = 8
+    tensor.element_size.return_value = torch.empty((), dtype=dtype).element_size()
+    empty = MagicMock()
+    rendezvous = MagicMock()
+    monkeypatch.setattr(collectives.symm_mem, "empty", empty)
+    monkeypatch.setattr(collectives.symm_mem, "rendezvous", rendezvous)
+
+    assert collectives._symm_buffer(_FakeGroup(0, 2), group_name, tensor) is None
+    empty.assert_not_called()
+    rendezvous.assert_not_called()
+
+
+@pytest.mark.parametrize("dtype", [torch.float32, torch.bfloat16])
+def test_symmetric_buffer_accepts_supported_dtype(monkeypatch, dtype):
+    group_name = "tp"
+    device = torch.device("cuda:0")
+    collectives._symm_eligible[(group_name, str(device))] = True
+    tensor = MagicMock()
+    tensor.device = device
+    tensor.dtype = dtype
+    tensor.is_contiguous.return_value = True
+    tensor.numel.return_value = 8
+    tensor.element_size.return_value = torch.empty((), dtype=dtype).element_size()
+    buffer = object()
+    group = _FakeGroup(0, 2)
+    group.group_name = "tp-group"
+    empty = MagicMock(return_value=buffer)
+    rendezvous = MagicMock()
+    monkeypatch.setattr(torch.cuda, "is_current_stream_capturing", lambda: False)
+    monkeypatch.setattr(collectives.symm_mem, "empty", empty)
+    monkeypatch.setattr(collectives.symm_mem, "rendezvous", rendezvous)
+
+    assert collectives._symm_buffer(group, group_name, tensor) is buffer
+    empty.assert_called_once_with(8, dtype=dtype, device=device)
+    rendezvous.assert_called_once_with(buffer, "tp-group")

--- a/tests/python/test_model_executor.py
+++ b/tests/python/test_model_executor.py
@@ -32,7 +32,11 @@ import torch.nn as nn
 
 # conftest.py stands in for xllm.python, whose import would bind the active
 # platform's kernel package and reach for operators from the C++ binary.
-from xllm.python.attention.backend import AttentionBackend, AttentionMetadata, KVCache  # noqa: E402
+from xllm.python.attention.backend import (  # noqa: E402
+    AttentionBackend,
+    AttentionMetadata,
+    LayerCache,
+)
 from xllm.python.layers.attention import Attention  # noqa: E402
 from xllm.python.model_executor.executor import (  # noqa: E402
     ModelExecutor,
@@ -51,10 +55,10 @@ class StubAttentionBackend(AttentionBackend):
 
     def __init__(self, **kwargs):
         self.init_kwargs = kwargs
-        self._kv_caches: list[KVCache] = []
+        self._kv_caches: list[LayerCache] = []
         self._prepared = False
 
-    def bind_kv_caches(self, kv_caches: list[KVCache]) -> None:
+    def bind_kv_caches(self, kv_caches: list[LayerCache]) -> None:
         self._kv_caches = kv_caches
 
     def prepare(self, metadata: AttentionMetadata, *, graph_mode: bool = False) -> None:
@@ -307,10 +311,18 @@ class TestExecuteRouting:
 
         metadata = MagicMock(spec=AttentionMetadata)
         executor.eager_runner = MagicMock()
-        executor.eager_runner.execute.return_value = torch.ones(5)
+        grad_enabled = None
+
+        def execute(*_args):
+            nonlocal grad_enabled
+            grad_enabled = torch.is_grad_enabled()
+            return torch.ones(5)
+
+        executor.eager_runner.execute.side_effect = execute
 
         result = executor.execute(torch.zeros(1), torch.zeros(1), metadata)
         executor.eager_runner.execute.assert_called_once()
+        assert grad_enabled is False
         assert torch.equal(result, torch.ones(5))
 
     @patch(

--- a/tests/python/test_model_executor.py
+++ b/tests/python/test_model_executor.py
@@ -23,6 +23,7 @@ from __future__ import annotations
 import sys
 import types
 from dataclasses import dataclass
+from types import SimpleNamespace
 from typing import List
 from unittest.mock import MagicMock, patch
 
@@ -42,6 +43,10 @@ from xllm.python.model_executor.executor import (  # noqa: E402
     ModelExecutor,
     _create_attention_backend,
     _resolve_graph_backend,
+)
+from xllm.python.model_executor.runners.decode_cuda_graph import (  # noqa: E402
+    DecodeCudaGraphRunner,
+    _decode_graph_buckets,
 )
 
 
@@ -233,6 +238,136 @@ class TestModelExecutorConstruction:
             )
             assert executor.decode_graph_runner is None
             assert executor.inductor_runner is None
+
+    @patch(
+        "xllm.python.model_executor.runners.decode_cuda_graph."
+        "DecodeCudaGraphRunner"
+    )
+    @patch("xllm.python.model_executor.executor._create_attention_backend")
+    def test_data_parallel_cuda_graph_is_supported(
+        self, mock_create, mock_graph_runner
+    ):
+        mock_create.return_value = StubAttentionBackend()
+        model = _FakeModel(num_layers=1)
+
+        ModelExecutor(
+            model,
+            {
+                "dp_size": 2,
+                "dp_rank": 1,
+                "max_position_embeddings": 128,
+                "python_graph_backend": "cudagraphs",
+            },
+            max_seqs_per_batch=4,
+        )
+
+        mock_graph_runner.assert_called_once_with(
+            model.model,
+            mock_create.return_value,
+            torch.device("cpu"),
+            4,
+            128,
+            2,
+            1,
+        )
+
+    @patch("xllm.python.model_executor.executor._create_attention_backend")
+    def test_data_parallel_rejects_non_cuda_graph_backend(self, mock_create):
+        mock_create.return_value = StubAttentionBackend()
+        model = _FakeModel(num_layers=1)
+
+        with pytest.raises(NotImplementedError, match="supports cudagraphs only"):
+            ModelExecutor(
+                model,
+                {
+                    "dp_size": 2,
+                    "max_position_embeddings": 128,
+                    "python_graph_backend": "inductor",
+                },
+                max_seqs_per_batch=4,
+            )
+
+
+class TestDecodeCudaGraphDataParallelKeys:
+    @staticmethod
+    def _runner(dp_rank: int = 0) -> DecodeCudaGraphRunner:
+        runner = object.__new__(DecodeCudaGraphRunner)
+        runner.max_batch = 16
+        runner.dp_size = 2
+        runner.dp_rank = dp_rank
+        runner._graphs = {}
+        return runner
+
+    @staticmethod
+    def _metadata(token_counts: list[int]) -> SimpleNamespace:
+        return SimpleNamespace(
+            is_prefill=False,
+            is_chunked_prefill=False,
+            dp_token_counts=token_counts,
+        )
+
+    def test_graph_key_uses_global_max_data_parallel_bucket(self):
+        runner = self._runner()
+        input_ids = torch.zeros(3, dtype=torch.int32)
+
+        first = runner._graph_key(input_ids, self._metadata([3, 1]))
+        second = runner._graph_key(input_ids, self._metadata([3, 2]))
+
+        assert first == (4, (4, 4))
+        assert second == first
+
+    def test_data_parallel_warmup_uses_local_batch_capacity(self):
+        assert _decode_graph_buckets(16, 2) == [1, 2, 4, 8]
+        assert _decode_graph_buckets(20, 2) == [1, 2, 4, 8, 16]
+
+    def test_single_rank_graph_key_reuses_padded_bucket(self):
+        runner = self._runner()
+        runner.dp_size = 1
+        runner.dp_rank = 0
+
+        first = runner._graph_key(
+            torch.zeros(3, dtype=torch.int32), self._metadata([3])
+        )
+        second = runner._graph_key(
+            torch.zeros(4, dtype=torch.int32), self._metadata([4])
+        )
+
+        assert first == (4, (4,))
+        assert second == first
+
+    def test_graph_key_accepts_empty_data_parallel_rank(self):
+        runner = self._runner(dp_rank=1)
+        input_ids = torch.zeros(1, dtype=torch.int32)
+
+        assert runner._graph_key(input_ids, self._metadata([5, 0])) == (
+            8,
+            (8, 8),
+        )
+
+    def test_graph_key_rejects_unbalanced_unwarmed_bucket(self):
+        runner = self._runner()
+        input_ids = torch.zeros(9, dtype=torch.int32)
+
+        assert runner._graph_key(input_ids, self._metadata([9, 7])) is None
+
+    def test_can_execute_requires_warmed_graph(self):
+        runner = self._runner()
+        input_ids = torch.zeros(3, dtype=torch.int32)
+        metadata = self._metadata([3, 1])
+        graph_key = runner._graph_key(input_ids, metadata)
+
+        assert not runner.can_execute(input_ids, metadata)
+        runner._graphs[graph_key] = object()
+        assert runner.can_execute(input_ids, metadata)
+
+    @pytest.mark.parametrize("token_counts", ([3], [3, -1], [3, 2]))
+    def test_graph_key_rejects_invalid_data_parallel_metadata(
+        self, token_counts
+    ):
+        runner = self._runner(dp_rank=1)
+        input_ids = torch.zeros(1, dtype=torch.int32)
+
+        assert runner._graph_key(input_ids, self._metadata(token_counts)) is None
 
 
 # ---------------------------------------------------------------------------

--- a/tests/python/test_qwen3_5_parallel.py
+++ b/tests/python/test_qwen3_5_parallel.py
@@ -1,0 +1,360 @@
+# Copyright 2026 The xLLM Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://github.com/xLLM-AI/xllm/blob/main/LICENSE
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Parallel-layout tests for the Qwen3.5 Python CUDA model."""
+
+from __future__ import annotations
+
+import sys
+import types
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+import torch
+
+# conftest.py binds xllm.python.kernels and .distributed to empty stubs. Bind the
+# CUDA MoE module without executing its package __init__, which would reach for
+# operators from the C++ binary, so the architecture gate under test is the real
+# one; the remaining kernels and collectives are mocked.
+_python_root = Path(__file__).parents[2] / "xllm" / "python"
+_kernels_cuda = types.ModuleType("xllm.python.kernels_cuda")
+_kernels_cuda.__path__ = [str(_python_root / "kernels_cuda")]
+sys.modules.setdefault("xllm.python.kernels_cuda", _kernels_cuda)
+
+from xllm.python import distributed, kernels  # noqa: E402
+from xllm.python.kernels_cuda.moe import supports_cutlass_moe  # noqa: E402
+
+kernels.supports_cutlass_moe = supports_cutlass_moe
+kernels.moe_fused_topk = MagicMock()
+kernels.cutlass_fused_moe = MagicMock()
+kernels.fused_moe = MagicMock()
+distributed.all_gather_variable = MagicMock()
+distributed.all_reduce_ = MagicMock()
+
+from xllm.python.layers.fused_moe import FusedMoE  # noqa: E402
+from xllm.python.layers.gated_mlp import GatedMLP  # noqa: E402
+from xllm.python.layers.layernorm import GemmaRMSNorm  # noqa: E402
+from xllm.python.models.qwen3_5 import (  # noqa: E402
+    Qwen3_5Config,
+    Qwen3_5ForCausalLM,
+    Qwen3_5Model,
+    Qwen3_5SparseMoEBlock,
+)
+
+
+def _config(**overrides) -> Qwen3_5Config:
+    values = {
+        "hidden_size": 64,
+        "num_hidden_layers": 1,
+        "num_attention_heads": 4,
+        "num_key_value_heads": 2,
+        "head_dim": 16,
+        "intermediate_size": 128,
+        "layer_types": ["full_attention"],
+        "linear_num_key_heads": 4,
+        "linear_num_value_heads": 4,
+        "linear_key_head_dim": 16,
+        "linear_value_head_dim": 16,
+        "vocab_size": 128,
+        "num_experts": 8,
+        "num_experts_per_tok": 2,
+        "moe_intermediate_size": 32,
+        "shared_expert_intermediate_size": 64,
+        "tp_size": 2,
+        "tp_rank": 0,
+        "dp_size": 1,
+        "dp_rank": 0,
+        "world_size": 2,
+        "moe_tp_size": 2,
+        "moe_tp_rank": 0,
+        "ep_size": 1,
+        "ep_rank": 0,
+    }
+    values.update(overrides)
+    return Qwen3_5Config.from_dict(values)
+
+
+def _make_moe_layer(
+    cfg: Qwen3_5Config, device: torch.device | None = None
+) -> FusedMoE:
+    return FusedMoE(
+        hidden_size=cfg.hidden_size,
+        intermediate_size=cfg.moe_intermediate_size,
+        num_experts=cfg.num_experts,
+        top_k=cfg.num_experts_per_tok,
+        renormalize=True,
+        moe_tp_size=cfg.moe_tp_size,
+        moe_tp_rank=cfg.moe_tp_rank,
+        ep_size=cfg.ep_size,
+        ep_rank=cfg.ep_rank,
+        dp_size=cfg.dp_size,
+        dp_rank=cfg.dp_rank,
+        dtype=torch.float32,
+        device=device or torch.device("cpu"),
+    )
+
+
+def test_moe_layer_schedule_matches_config() -> None:
+    cfg = _config(
+        num_hidden_layers=4,
+        layer_types=["full_attention"] * 4,
+        decoder_sparse_step=2,
+        mlp_only_layers=[3],
+    )
+
+    assert not cfg.is_moe_layer(0)
+    assert cfg.is_moe_layer(1)
+    assert not cfg.is_moe_layer(2)
+    assert not cfg.is_moe_layer(3)
+
+    model = Qwen3_5Model(cfg, torch.float32, torch.device("cpu"))
+    assert isinstance(model.layers[0].mlp, GatedMLP)
+    assert isinstance(model.layers[1].mlp, Qwen3_5SparseMoEBlock)
+    assert isinstance(model.layers[2].mlp, GatedMLP)
+    assert isinstance(model.layers[3].mlp, GatedMLP)
+
+
+class _StateDict:
+    def __init__(self, tensors: dict[str, torch.Tensor]) -> None:
+        self._tensors = tensors
+
+    def has(self, name: str) -> bool:
+        return name in self._tensors
+
+    def get_tensor(self, name: str) -> torch.Tensor:
+        return self._tensors[name]
+
+
+def test_attention_biases_are_loaded() -> None:
+    cfg_values = {
+        "hidden_size": 8,
+        "num_hidden_layers": 1,
+        "num_attention_heads": 2,
+        "num_key_value_heads": 1,
+        "head_dim": 4,
+        "partial_rotary_factor": 0.5,
+        "max_position_embeddings": 16,
+        "intermediate_size": 16,
+        "layer_types": ["full_attention"],
+        "linear_num_key_heads": 2,
+        "linear_num_value_heads": 2,
+        "linear_key_head_dim": 4,
+        "linear_value_head_dim": 4,
+        "vocab_size": 8,
+        "attention_bias": True,
+        "attn_output_gate": False,
+        "num_experts": 0,
+        "num_experts_per_tok": 0,
+        "moe_intermediate_size": 0,
+        "shared_expert_intermediate_size": 0,
+        "tp_size": 1,
+        "world_size": 1,
+        "moe_tp_size": 1,
+        "dtype": "float32",
+        "device": "cpu",
+    }
+    model = Qwen3_5ForCausalLM(cfg_values)
+    tensors = {
+        "model.embed_tokens.weight": torch.zeros(8, 8),
+        "model.layers.0.input_layernorm.weight": torch.zeros(8),
+        "model.layers.0.post_attention_layernorm.weight": torch.zeros(8),
+        "model.layers.0.self_attn.q_proj.weight": torch.zeros(8, 8),
+        "model.layers.0.self_attn.k_proj.weight": torch.zeros(4, 8),
+        "model.layers.0.self_attn.v_proj.weight": torch.zeros(4, 8),
+        "model.layers.0.self_attn.o_proj.weight": torch.zeros(8, 8),
+        "model.layers.0.self_attn.q_proj.bias": torch.arange(8.0),
+        "model.layers.0.self_attn.k_proj.bias": torch.arange(4.0) + 10,
+        "model.layers.0.self_attn.v_proj.bias": torch.arange(4.0) + 20,
+        "model.layers.0.self_attn.o_proj.bias": torch.arange(8.0) + 30,
+        "model.layers.0.self_attn.q_norm.weight": torch.zeros(4),
+        "model.layers.0.self_attn.k_norm.weight": torch.zeros(4),
+        "model.layers.0.mlp.gate_proj.weight": torch.zeros(16, 8),
+        "model.layers.0.mlp.up_proj.weight": torch.zeros(16, 8),
+        "model.layers.0.mlp.down_proj.weight": torch.zeros(8, 16),
+        "model.norm.weight": torch.zeros(8),
+        "lm_head.weight": torch.zeros(8, 8),
+    }
+
+    model.load_weights([_StateDict(tensors)], tp_rank=0, tp_size=1)
+
+    expected_qkv_bias = torch.cat(
+        (
+            tensors["model.layers.0.self_attn.q_proj.bias"],
+            tensors["model.layers.0.self_attn.k_proj.bias"],
+            tensors["model.layers.0.self_attn.v_proj.bias"],
+        )
+    )
+    torch.testing.assert_close(
+        model.model.layers[0].self_attn.qkv_proj.bias, expected_qkv_bias
+    )
+    torch.testing.assert_close(
+        model.model.layers[0].self_attn.o_proj.bias,
+        tensors["model.layers.0.self_attn.o_proj.bias"],
+    )
+
+
+def test_full_attention_layers_share_rotary_table() -> None:
+    cfg = _config(
+        num_hidden_layers=2,
+        layer_types=["full_attention", "full_attention"],
+        num_experts=0,
+        num_experts_per_tok=0,
+        moe_intermediate_size=0,
+        shared_expert_intermediate_size=0,
+        max_position_embeddings=16,
+    )
+
+    model = Qwen3_5Model(cfg, torch.float32, torch.device("cpu"))
+
+    assert model.layers[0].self_attn.rotary is model.rotary
+    assert model.layers[1].self_attn.rotary is model.rotary
+
+
+def test_pre_sm90_moe_uses_triton_fallback(monkeypatch) -> None:
+    monkeypatch.setattr(torch.cuda, "is_available", lambda: True)
+    monkeypatch.setattr(
+        torch.cuda, "get_device_capability", lambda _device=None: (8, 0)
+    )
+    assert not kernels.supports_cutlass_moe(torch.device("cuda:0"))
+    cfg = _config(
+        tp_size=1,
+        world_size=1,
+        moe_tp_size=1,
+        num_experts=2,
+        num_experts_per_tok=1,
+        moe_intermediate_size=8,
+    )
+    layer = _make_moe_layer(cfg)
+    assert not layer._use_cutlass
+    layer.gate = torch.nn.Identity()
+    monkeypatch.setattr(
+        kernels,
+        "moe_fused_topk",
+        MagicMock(
+            return_value=(
+                torch.ones(3, 1, dtype=torch.float32),
+                torch.zeros(3, 1, dtype=torch.int32),
+            )
+        ),
+    )
+    triton_output = torch.ones(3, cfg.hidden_size)
+    triton_moe = MagicMock(return_value=triton_output)
+    monkeypatch.setattr(kernels, "fused_moe", triton_moe)
+
+    output = layer(torch.zeros(3, cfg.hidden_size))
+
+    assert output is triton_output
+    triton_moe.assert_called_once()
+
+
+def test_attention_tp_and_moe_tp_use_distinct_valid_topology():
+    cfg = _config()
+    cfg.validate()
+
+    layer = _make_moe_layer(cfg)
+
+    assert cfg.tp_size == 2
+    assert cfg.dp_size == 1
+    assert cfg.moe_tp_size == 2
+    assert cfg.ep_size == 1
+    assert layer.w13.shape == (8, 32, 64)
+    assert layer.w2.shape == (8, 64, 16)
+
+
+def test_attention_dp_and_moe_tp_use_distinct_valid_topology():
+    cfg = _config(tp_size=1, dp_size=2)
+    cfg.validate()
+
+    layer = _make_moe_layer(cfg)
+
+    assert cfg.tp_size == 1
+    assert cfg.dp_size == 2
+    assert cfg.moe_tp_size == 2
+    assert cfg.ep_size == 1
+    assert layer.w13.shape == (8, 32, 64)
+    assert layer.w2.shape == (8, 64, 16)
+
+
+def test_full_world_ep_partitions_experts_without_inner_tp_sharding():
+    cfg = _config(
+        world_size=4,
+        ep_size=4,
+        ep_rank=3,
+        dp_size=2,
+        moe_tp_size=1,
+        moe_tp_rank=0,
+    )
+    cfg.validate()
+
+    layer = _make_moe_layer(cfg)
+
+    assert layer.w13.shape == (2, 64, 64)
+    assert layer.w2.shape == (2, 64, 32)
+
+
+def test_partial_world_ep_is_rejected():
+    cfg = _config(world_size=4, dp_size=2, ep_size=2, moe_tp_size=2)
+
+    with pytest.raises(ValueError, match="ep_size=1 or world_size"):
+        cfg.validate()
+
+
+def test_dense_model_does_not_require_expert_parallelism():
+    cfg = _config(
+        num_experts=0,
+        num_experts_per_tok=0,
+        moe_intermediate_size=0,
+        shared_expert_intermediate_size=0,
+    )
+
+    cfg.validate()
+
+
+def test_moe_parallel_product_must_equal_world_size():
+    cfg = _config(world_size=4, dp_size=2, ep_size=4, moe_tp_size=2)
+
+    with pytest.raises(ValueError, match=r"moe_tp_size \* ep_size"):
+        cfg.validate()
+
+
+def test_attention_parallel_product_must_equal_world_size():
+    cfg = _config(world_size=4)
+
+    with pytest.raises(ValueError, match=r"tp_size \* dp_size"):
+        cfg.validate()
+
+
+def test_gemma_rms_norm_matches_fp32_weight_reference():
+    layer = GemmaRMSNorm(4, dtype=torch.bfloat16, device=torch.device("cpu"))
+    with torch.no_grad():
+        layer.weight.copy_(torch.tensor([0.3242, -0.8164, 2.4844, -0.2383]))
+
+    hidden = torch.tensor(
+        [[0.4258, -0.2656, 1.4922, -0.7344]], dtype=torch.bfloat16
+    )
+    residual = torch.tensor(
+        [[-0.1064, 0.9844, -0.3789, 0.5469]], dtype=torch.bfloat16
+    )
+    actual, actual_residual = layer(hidden, residual)
+
+    summed = hidden.float() + residual.float()
+    expected_residual = summed.to(torch.bfloat16)
+    variance = summed.pow(2).mean(dim=-1, keepdim=True)
+    expected = summed * torch.rsqrt(variance + layer.eps)
+    expected = (expected * (layer.weight + 1.0)).to(torch.bfloat16)
+
+    assert layer.weight.dtype == torch.float32
+    torch.testing.assert_close(actual_residual, expected_residual, rtol=0, atol=0)
+    torch.testing.assert_close(actual, expected, rtol=0, atol=0)

--- a/xllm/core/distributed_runtime/master.cpp
+++ b/xllm/core/distributed_runtime/master.cpp
@@ -300,12 +300,21 @@ Master::Master(const Options& options, EngineType type)
   const std::vector<torch::Device> devices = {visible_devices[device_idx]};
   // World size is the node count (one worker per process).
   const int32_t global_world_size = options_.nnodes();
-  std::string cp_model_type;
-  if (options_.cp_size() > 1 && Platform::uses_model_cp_sharding()) {
-    cp_model_type = util::get_model_type(model_path, options_.backend());
+  std::string model_type;
+  if ((options_.cp_size() > 1 && Platform::uses_model_cp_sharding()) ||
+      (ModelConfig::is_python_model_impl(
+           ModelConfig::get_instance().model_impl()) &&
+       options_.num_speculative_tokens() > 0)) {
+    model_type = util::get_model_type(model_path, options_.backend());
   }
+  const std::optional<std::string> speculative_error =
+      ModelConfig::validate_python_speculative_decode(
+          ModelConfig::get_instance().model_impl(),
+          model_type,
+          options_.num_speculative_tokens());
+  CHECK(!speculative_error.has_value()) << speculative_error.value();
   const std::optional<std::string> cp_error =
-      validate_model_cp(options_, type, cp_model_type, global_world_size);
+      validate_model_cp(options_, type, model_type, global_world_size);
   CHECK(!cp_error.has_value()) << cp_error.value();
   options_.enable_mla(util::should_enable_mla(model_path, options_.backend()));
   print_startup_banner(model_path, options_.backend(), options_.node_rank());

--- a/xllm/core/framework/batch/batch_input_builder.cpp
+++ b/xllm/core/framework/batch/batch_input_builder.cpp
@@ -860,6 +860,7 @@ void BatchInputBuilder::append_linear_state_row(Sequence* sequence,
 
   LinearStateCacheOp linear_state_cache_op;
   linear_state_cache_op.linear_state_id = state.linear_state_ids.back();
+  linear_state_cache_op.reset_requested = n_kv_cache_tokens == 0;
   // Linear-state checkpoints live on chunk-end boundaries, so the prefix hash
   // is chained per chunk (stride = max_tokens_per_chunk_for_prefill), not per
   // KV block. The engine enforces this stride is a positive multiple of
@@ -904,14 +905,15 @@ void BatchInputBuilder::append_linear_state_row(Sequence* sequence,
   if (needs_restore_hash) {
     const size_t restore_chunk_idx =
         static_cast<size_t>(n_kv_cache_tokens) / chunk_stride - 1;
-    if (restore_chunk_idx < linear_state_hashes.size()) {
-      linear_state_cache_op.restore_requested = true;
-      if (mounted_restore_src.has_value()) {
-        linear_state_cache_op.restore_src_slot_id = mounted_restore_src->id();
-        state.linear_restore_src_blocks.emplace_back(
-            std::move(*mounted_restore_src));
-      }
-    }
+    CHECK_LT(restore_chunk_idx, linear_state_hashes.size())
+        << "mounted linear-state checkpoint must have a matching chunk hash";
+    CHECK(mounted_restore_src.has_value())
+        << "linear-state restore must resolve its checkpoint slot before "
+           "building worker input";
+    linear_state_cache_op.restore_requested = true;
+    linear_state_cache_op.restore_src_slot_id = mounted_restore_src->id();
+    state.linear_restore_src_blocks.emplace_back(
+        std::move(*mounted_restore_src));
   }
   if (needs_save_hash) {
     const size_t save_chunk_idx =

--- a/xllm/core/framework/config/model_config.cpp
+++ b/xllm/core/framework/config/model_config.cpp
@@ -112,6 +112,12 @@ bool is_cpp_chat_template_supported_model(const std::string& model_type) {
   return model_type == "deepseek_v32" || model_type == "deepseek_v4";
 }
 
+bool is_qwen3_5_model_type(std::string_view model_type) {
+  return model_type == "qwen3_5" || model_type == "qwen3_5_moe" ||
+         model_type == "qwen3_5_text" || model_type == "qwen3_5_moe_text" ||
+         model_type.rfind("qwen3_5_", 0) == 0;
+}
+
 }  // namespace
 
 void ModelConfig::from_flags() {
@@ -139,6 +145,18 @@ bool ModelConfig::is_python_model_impl(std::string_view model_impl) {
   // their model_impl comparison through here, so the raw config value is never
   // normalized: no separate canonicalization step is needed.
   return model_impl == "python" || model_impl == "py";
+}
+
+std::optional<std::string> ModelConfig::validate_python_speculative_decode(
+    std::string_view model_impl,
+    std::string_view model_type,
+    int32_t num_speculative_tokens) {
+  if (!is_python_model_impl(model_impl) || num_speculative_tokens <= 0 ||
+      !is_qwen3_5_model_type(model_type)) {
+    return std::nullopt;
+  }
+  return "Qwen3.5 Python model executor does not support speculative decoding; "
+         "set num_speculative_tokens=0 or use the native model executor";
 }
 
 void ModelConfig::normalize_cpp_chat_template(const std::string& model_type) {

--- a/xllm/core/framework/config/model_config.h
+++ b/xllm/core/framework/config/model_config.h
@@ -17,6 +17,7 @@ limitations under the License.
 
 #include <cstdint>
 #include <nlohmann/json_fwd.hpp>
+#include <optional>
 #include <string>
 #include <string_view>
 
@@ -41,6 +42,10 @@ class ModelConfig final {
   void normalize_cpp_chat_template(const std::string& model_type);
 
   [[nodiscard]] static bool is_python_model_impl(std::string_view model_impl);
+  [[nodiscard]] static std::optional<std::string>
+  validate_python_speculative_decode(std::string_view model_impl,
+                                     std::string_view model_type,
+                                     int32_t num_speculative_tokens);
 
   [[nodiscard]] static const OptionCategory& option_category() {
     static const OptionCategory kOptionCategory = {

--- a/xllm/core/framework/kv_cache/linear_state_restore.cpp
+++ b/xllm/core/framework/kv_cache/linear_state_restore.cpp
@@ -17,27 +17,109 @@ limitations under the License.
 
 #include <glog/logging.h>
 
+#include <algorithm>
+
+#include "core/common/constants.h"
+
 namespace xllm {
 
 namespace {
 
-// Copy conv + ssm recurrent state between two physical slots across all
-// linear-attention layers. Pure-attention layers are skipped. Returns true
-// if at least one layer was copied; false means the caller's
-// `discover_num_slots > 0` invariant was violated (e.g. a future refactor
-// decoupled cache layout from layer presence). Treat false as a soft
-// failure at the call site — fall back to cold start, do not crash the
-// service.
-bool copy_slot_across_layers(std::vector<KVCache>& kv_caches,
+int32_t discover_num_slots(const std::vector<KVCache>& kv_caches) {
+  int32_t num_slots = 0;
+  for (const KVCache& kv_cache : kv_caches) {
+    const torch::Tensor conv_cache = kv_cache.get_conv_cache();
+    const torch::Tensor ssm_cache = kv_cache.get_ssm_cache();
+    if (!conv_cache.defined() && !ssm_cache.defined()) {
+      continue;
+    }
+    CHECK(conv_cache.defined() && ssm_cache.defined())
+        << "linear-attention layers must provide both conv and ssm caches";
+    CHECK_GT(conv_cache.size(0), kPaddingLinearStateId)
+        << "linear-attention cache must include the reserved padding slot";
+    CHECK_GT(ssm_cache.size(0), 0)
+        << "linear-attention ssm cache must contain checkpoint rows";
+    CHECK_EQ(ssm_cache.size(0) % conv_cache.size(0), 0)
+        << "ssm cache checkpoint layout mismatch, ssm_rows="
+        << ssm_cache.size(0) << ", conv_rows=" << conv_cache.size(0);
+    if (num_slots == 0) {
+      num_slots = static_cast<int32_t>(conv_cache.size(0));
+      continue;
+    }
+    CHECK_EQ(num_slots, static_cast<int32_t>(conv_cache.size(0)))
+        << "linear-attention cache slot count must match across layers";
+  }
+  return num_slots;
+}
+
+struct SlotRange {
+  int64_t start = 0;
+  int64_t length = 0;
+};
+
+std::vector<SlotRange> coalesce_slot_ranges(std::vector<int32_t> slot_ids) {
+  CHECK(!slot_ids.empty());
+  std::sort(slot_ids.begin(), slot_ids.end());
+  slot_ids.erase(std::unique(slot_ids.begin(), slot_ids.end()), slot_ids.end());
+
+  std::vector<SlotRange> ranges;
+  ranges.reserve(slot_ids.size());
+  int64_t range_start = slot_ids.front();
+  int64_t previous_slot = range_start;
+  for (size_t i = 1; i < slot_ids.size(); ++i) {
+    const int64_t slot_id = slot_ids[i];
+    if (slot_id == previous_slot + 1) {
+      previous_slot = slot_id;
+      continue;
+    }
+    ranges.push_back({range_start, previous_slot - range_start + 1});
+    range_start = slot_id;
+    previous_slot = slot_id;
+  }
+  ranges.push_back({range_start, previous_slot - range_start + 1});
+  return ranges;
+}
+
+void zero_slots_across_layers(std::vector<KVCache>& kv_caches,
+                              const std::vector<int32_t>& slot_ids) {
+  const std::vector<SlotRange> ranges = coalesce_slot_ranges(slot_ids);
+  bool cleared = false;
+  for (const KVCache& kv_cache : kv_caches) {
+    const torch::Tensor conv_cache = kv_cache.get_conv_cache();
+    const torch::Tensor ssm_cache = kv_cache.get_ssm_cache();
+    if (!conv_cache.defined() && !ssm_cache.defined()) {
+      continue;
+    }
+    CHECK(conv_cache.defined() && ssm_cache.defined());
+    const int64_t checkpoint_stride = ssm_cache.size(0) / conv_cache.size(0);
+    for (const SlotRange& range : ranges) {
+      if (range.length == 1) {
+        conv_cache.select(0, range.start).zero_();
+      } else {
+        conv_cache.narrow(0, range.start, range.length).zero_();
+      }
+      ssm_cache
+          .narrow(0,
+                  range.start * checkpoint_stride,
+                  range.length * checkpoint_stride)
+          .zero_();
+    }
+    cleared = true;
+  }
+  CHECK(cleared) << "linear-state reset found no recurrent cache to clear";
+}
+
+void copy_slot_across_layers(std::vector<KVCache>& kv_caches,
                              int32_t dst_slot_id,
                              int32_t src_slot_id) {
   bool copied = false;
-  for (const auto& kv_cache : kv_caches) {
-    torch::Tensor conv_cache = kv_cache.get_conv_cache();
-    torch::Tensor ssm_cache = kv_cache.get_ssm_cache();
-    if (!conv_cache.defined() || !ssm_cache.defined()) {
+  for (const KVCache& kv_cache : kv_caches) {
+    const torch::Tensor conv_cache = kv_cache.get_conv_cache();
+    const torch::Tensor ssm_cache = kv_cache.get_ssm_cache();
+    if (!conv_cache.defined() && !ssm_cache.defined()) {
       continue;
     }
+    CHECK(conv_cache.defined() && ssm_cache.defined());
     const int64_t checkpoint_stride = ssm_cache.size(0) / conv_cache.size(0);
     conv_cache.select(0, dst_slot_id).copy_(conv_cache.select(0, src_slot_id));
     ssm_cache
@@ -50,31 +132,7 @@ bool copy_slot_across_layers(std::vector<KVCache>& kv_caches,
             checkpoint_stride));
     copied = true;
   }
-  return copied;
-}
-
-// Discover the slot count from any linear-attention layer in `kv_caches`.
-// Returns 0 when no linear-attention layer is present, which short-circuits
-// restore. CHECKs slot-count consistency across layers.
-int32_t discover_num_slots(const std::vector<KVCache>& kv_caches) {
-  int32_t num_slots = 0;
-  for (const auto& kv_cache : kv_caches) {
-    torch::Tensor conv_cache = kv_cache.get_conv_cache();
-    torch::Tensor ssm_cache = kv_cache.get_ssm_cache();
-    if (!conv_cache.defined() || !ssm_cache.defined()) {
-      continue;
-    }
-    CHECK_GT(conv_cache.size(0), 0) << "conv cache must have positive slots.";
-    CHECK_EQ(ssm_cache.size(0) % conv_cache.size(0), 0)
-        << "ssm cache checkpoint layout mismatch, ssm_rows="
-        << ssm_cache.size(0) << ", conv_rows=" << conv_cache.size(0);
-    if (num_slots == 0) {
-      num_slots = static_cast<int32_t>(conv_cache.size(0));
-      continue;
-    }
-    CHECK_EQ(num_slots, static_cast<int32_t>(conv_cache.size(0)));
-  }
-  return num_slots;
+  CHECK(copied) << "linear-state restore found no recurrent cache to copy";
 }
 
 }  // namespace
@@ -108,64 +166,78 @@ void restore_linear_state_slots(
   if (cache_ops.empty()) {
     return;
   }
-  const int32_t num_slots = discover_num_slots(kv_caches);
-  if (num_slots == 0) {
-    return;
-  }
+
   CHECK_EQ(cache_ops.size(), validity_mask.size())
-      << "linear state validity mask must be sized to the cache_ops batch "
-         "before "
-      << "restore, cache_ops=" << cache_ops.size()
+      << "validity_mask must match the linear-state operation batch, "
+      << "cache_ops=" << cache_ops.size()
       << ", validity_mask=" << validity_mask.size();
-  const auto slot_in_range = [num_slots](int32_t slot_id) {
-    return slot_id >= 0 && slot_id < num_slots;
+
+  const int32_t num_slots = discover_num_slots(kv_caches);
+  CHECK_GT(num_slots, kPaddingLinearStateId)
+      << "linear-state operations require an allocated recurrent cache";
+  const auto is_real_slot = [num_slots](int32_t slot_id) {
+    return slot_id > kPaddingLinearStateId && slot_id < num_slots;
+  };
+
+  for (const LinearStateCacheOp& cache_op : cache_ops) {
+    const int32_t live_slot_id = cache_op.linear_state_id;
+    CHECK(!(cache_op.reset_requested && cache_op.restore_requested))
+        << "linear-state reset and restore are mutually exclusive";
+    CHECK(is_real_slot(live_slot_id))
+        << "linear-state live slot must be a real non-padding slot, slot="
+        << live_slot_id << ", num_slots=" << num_slots;
+    if (cache_op.reset_requested) {
+      CHECK_LT(cache_op.restore_src_slot_id, 0)
+          << "linear-state reset must not carry a restore source";
+      continue;
+    }
+    if (!cache_op.restore_requested) {
+      CHECK_LT(cache_op.restore_src_slot_id, 0)
+          << "linear-state source requires restore_requested=true";
+      continue;
+    }
+    const int32_t src_slot_id = cache_op.restore_src_slot_id;
+    CHECK(is_real_slot(src_slot_id))
+        << "linear-state restore source must be a real non-padding slot, slot="
+        << src_slot_id << ", num_slots=" << num_slots;
+  }
+
+  std::vector<int32_t> pending_reset_slots;
+  std::vector<size_t> pending_reset_rows;
+  pending_reset_slots.reserve(cache_ops.size());
+  pending_reset_rows.reserve(cache_ops.size());
+  const auto flush_resets = [&]() {
+    if (pending_reset_slots.empty()) {
+      return;
+    }
+    zero_slots_across_layers(kv_caches, pending_reset_slots);
+    for (const size_t row : pending_reset_rows) {
+      validity_mask[row] = 0;
+    }
+    pending_reset_slots.clear();
+    pending_reset_rows.clear();
   };
 
   for (size_t i = 0; i < cache_ops.size(); ++i) {
     const LinearStateCacheOp& cache_op = cache_ops[i];
+    if (cache_op.reset_requested) {
+      pending_reset_slots.push_back(cache_op.linear_state_id);
+      pending_reset_rows.push_back(i);
+      continue;
+    }
+    if (!cache_op.restore_requested) {
+      continue;
+    }
+
+    flush_resets();
     const int32_t live_slot_id = cache_op.linear_state_id;
     const int32_t src_slot_id = cache_op.restore_src_slot_id;
-    const bool restore_requested = cache_op.restore_requested;
-
-    // Continued requests and cold starts have no checkpoint to restore; leave
-    // validity_mask at its kv-cache default.
-    if (!restore_requested && src_slot_id < 0) {
-      continue;
-    }
-    // Restore requested but unservable: scheduler could not resolve a
-    // checkpoint, or slot ids are out of range. Force cold start so the
-    // forward does not treat reused kv blocks as warm recurrent state.
-    if (src_slot_id < 0 || !slot_in_range(live_slot_id) ||
-        !slot_in_range(src_slot_id)) {
-      validity_mask[i] = 0;
-      continue;
-    }
-    // Scheduler invariant: a resolved src slot implies a restore request. The
-    // batch builder only mounts restore_src_slot_id when it flags a restore
-    // (batch_input_builder.cpp).
-    DCHECK(restore_requested);
-
-    if (!copy_slot_across_layers(kv_caches, live_slot_id, src_slot_id)) {
-      // discover_num_slots > 0 said at least one linear layer was copyable;
-      // landing here means that invariant broke. Log every occurrence so the
-      // regression is impossible to miss, and fall back to cold start so
-      // the request still produces correct (uncached) output.
-      LOG(ERROR) << "Linear state restore: discover_num_slots > 0 but no "
-                    "layer was copied; falling back to cold start. "
-                    "live_slot_id="
-                 << live_slot_id << ", src_slot_id=" << src_slot_id;
-      validity_mask[i] = 0;
-      continue;
-    }
+    copy_slot_across_layers(kv_caches, live_slot_id, src_slot_id);
     validity_mask[i] = 1;
     VLOG(1) << "Qwen3.5 linear state checkpoint restored; live_slot_id="
             << live_slot_id << ", src_slot_id=" << src_slot_id;
   }
-  // The copies above are enqueued on whichever stream is current at the call
-  // site (today the worker's dedicated prepare stream). The caller must
-  // insert a cross-stream event barrier so the model forward — which runs on
-  // a different stream — observes them as completed; no host sync is added
-  // here.
+  flush_resets();
 }
 
 }  // namespace xllm

--- a/xllm/core/framework/model/model_input_params.h
+++ b/xllm/core/framework/model/model_input_params.h
@@ -902,14 +902,16 @@ using LinearStateValidityMask = std::vector<int64_t>;
 struct LinearStateCacheOp {
   // Live slot the sequence advances its recurrent state in.
   int32_t linear_state_id = -1;
+  // A newly admitted sequence has no recurrent history. The physical slot may
+  // have been used by an earlier request, so the worker must clear it before
+  // the first forward instead of relying on allocator contents.
+  bool reset_requested = false;
   // Restore request flag and the checkpoint slot the scheduler resolved it to.
   // The worker copies `restore_src_slot_id` -> `linear_state_id`. This mirrors
-  // KV, which sends the worker only the resolved block-swap descriptor and
-  // never the prefix hash. Kept as a bool (not derived from
-  // `restore_src_slot_id >= 0`) so the "restore requested but the scheduler
-  // could not resolve a source -> force cold start" state survives the IPC
-  // boundary; the worker's copy-in relies on that bit
-  // (linear_state_restore.cpp).
+  // KV, which sends the worker only a fully resolved block-swap descriptor and
+  // never the prefix hash. A restore request without a valid source is an
+  // invariant violation because the full-attention KV prefix has already been
+  // reused and cannot be paired with a cold recurrent state.
   bool restore_requested = false;
   int32_t restore_src_slot_id = -1;
 };

--- a/xllm/core/framework/parallel_state/collective_communicator.cpp
+++ b/xllm/core/framework/parallel_state/collective_communicator.cpp
@@ -15,6 +15,8 @@ limitations under the License.
 
 #include "core/framework/parallel_state/collective_communicator.h"
 
+#include <algorithm>
+
 #include "core/framework/parallel_state/mapping_npu.h"
 
 #if defined(USE_NPU)
@@ -356,15 +358,18 @@ void CollectiveCommunicator::create_process_groups(
   }
 #endif
 
+  const int32_t world_group_port = ++port;
   process_group_ = create_process_group(global_rank,
                                         world_size,
                                         world_size,
-                                        ++port,
+                                        world_group_port,
                                         false,
                                         host,
                                         "world_group",
                                         device);
   parallel_args_->process_group_ = process_group_.get();
+  parallel_args_->python_rendezvous_host_ = host;
+  parallel_args_->python_rendezvous_port_ = world_group_port;
 
   // Orthogonal CP x TP (NPU TORCH only): the rank layout is
   //   rank = dp_rank * (cp_size * tp_size) + cp_rank * tp_size + tp_rank
@@ -582,12 +587,6 @@ void CollectiveCommunicator::create_process_groups(
       port += moe_tp_size;
     }
   }
-
-  const int32_t tp_group_index = global_rank / tp_size;
-  parallel_args_->python_tp_rendezvous_host_ = host;
-  parallel_args_->python_tp_rendezvous_port_ = port + tp_group_index + 1;
-  CHECK_LE(parallel_args_->python_tp_rendezvous_port_, 65535)
-      << "No TCP port remains for the Python TP rendezvous.";
 
 #if defined(USE_NPU)
   if (::xllm::KernelConfig::get_instance().npu_kernel_backend() == "TORCH" &&

--- a/xllm/core/framework/parallel_state/parallel_args.h
+++ b/xllm/core/framework/parallel_state/parallel_args.h
@@ -227,10 +227,10 @@ struct ParallelArgs {
   ProcessGroup* mc2_group_ = nullptr;
   ProcessGroup* moe_tp_group_ = nullptr;
 
-  // PyTorch creates its own TP process group. These fields only reserve the
-  // TCPStore endpoint after the native process-group port range.
-  std::string python_tp_rendezvous_host_;
-  int32_t python_tp_rendezvous_port_ = 0;
+  // Python process groups reuse the native world TCPStore. PrefixStore keeps
+  // the bootstrap keys for each logical group independent.
+  std::string python_rendezvous_host_;
+  int32_t python_rendezvous_port_ = 0;
 
   // ProcessGroups for DiT models
   ProcessGroup* dit_tp_group_ = nullptr;

--- a/xllm/core/framework/parallel_state/process_group.cpp
+++ b/xllm/core/framework/parallel_state/process_group.cpp
@@ -210,6 +210,7 @@ c10::intrusive_ptr<c10d::Store> create_tcp_store(const std::string& host,
   c10d::TCPStoreOptions tcp_options;
   tcp_options.isServer = (rank == 0);
   tcp_options.port = port;
+  tcp_options.multiTenant = true;
   return c10::make_intrusive<c10d::TCPStore>(host, tcp_options);
 }
 

--- a/xllm/core/framework/request/sequence.cpp
+++ b/xllm/core/framework/request/sequence.cpp
@@ -320,6 +320,9 @@ Sequence::Sequence(const Sequence& other)
   // is private: drop the copied Embedding and Linear blocks so this sequence
   // allocates its own on the next allocate. Preserves the pre-map behavior
   // where the private slot was never copied by this constructor.
+  // TODO: Linear-attention beam search is not supported yet. A beam child that
+  // keeps its parent's KV progress must clone the parent's recurrent state into
+  // its newly allocated private LINEAR slot before the next forward.
   kv_state_.erase_blocks(BlockType::EMBEDDING);
   kv_state_.erase_blocks(BlockType::LINEAR);
   host_kv_state_.erase_blocks(BlockType::EMBEDDING);

--- a/xllm/core/kernels/cuda/cuda_ops_library.cpp
+++ b/xllm/core/kernels/cuda/cuda_ops_library.cpp
@@ -83,6 +83,41 @@ torch::Tensor silu_and_mul(const torch::Tensor& input) {
   return out;
 }
 
+std::tuple<torch::Tensor, torch::Tensor> moe_fused_topk(
+    const torch::Tensor& gating_output,
+    int64_t topk,
+    bool renormalize,
+    const std::string& scoring_func) {
+  auto logits = gating_output;
+  return xllm::kernel::cuda::moe_fused_topk(
+      logits, topk, renormalize, std::nullopt, scoring_func);
+}
+
+torch::Tensor cutlass_fused_moe(const torch::Tensor& input,
+                                const torch::Tensor& token_selected_experts,
+                                const torch::Tensor& token_final_scales,
+                                const torch::Tensor& fc1_expert_weights,
+                                const torch::Tensor& fc2_expert_weights,
+                                int64_t tp_size,
+                                int64_t tp_rank,
+                                int64_t ep_size,
+                                int64_t ep_rank) {
+  std::vector<torch::Tensor> quant_scales;
+  return xllm::kernel::cuda::cutlass_fused_moe(input,
+                                               token_selected_experts,
+                                               token_final_scales,
+                                               fc1_expert_weights,
+                                               fc2_expert_weights,
+                                               input.scalar_type(),
+                                               quant_scales,
+                                               static_cast<int32_t>(tp_size),
+                                               static_cast<int32_t>(tp_rank),
+                                               static_cast<int32_t>(ep_size),
+                                               static_cast<int32_t>(ep_rank),
+                                               /*cluster_size=*/1,
+                                               /*cluster_rank=*/0);
+}
+
 // Qwen3 fused q/k RMSNorm (on head_dim) + RoPE. `qkv` is [num_tokens,
 // (nq+nk+nv)*head_dim]. IN-PLACE: q/k slices are normalized+roped in `qkv`, v
 // left untouched. Returns the mutated qkv so piecewise cudagraph segments have
@@ -235,6 +270,14 @@ TORCH_LIBRARY(xllm_ops, m) {
       "float eps) -> (Tensor, Tensor)");
   m.def("silu_and_mul(Tensor input) -> Tensor");
   m.def(
+      "moe_fused_topk(Tensor gating_output, int topk, bool renormalize, str "
+      "scoring_func) -> (Tensor, Tensor)");
+  m.def(
+      "cutlass_fused_moe(Tensor input, Tensor token_selected_experts, Tensor "
+      "token_final_scales, Tensor fc1_expert_weights, Tensor "
+      "fc2_expert_weights, int tp_size, int tp_rank, int ep_size, int ep_rank) "
+      "-> Tensor");
+  m.def(
       "fused_qk_norm_rope(Tensor(a!) qkv, int num_heads_q, int num_heads_k, "
       "int "
       "num_heads_v, int head_dim, float eps, Tensor q_weight, Tensor k_weight, "
@@ -256,6 +299,8 @@ TORCH_LIBRARY_IMPL(xllm_ops, CUDA, m) {
   m.impl("rms_norm", TORCH_FN(xllm::rms_norm));
   m.impl("fused_add_rms_norm", TORCH_FN(xllm::fused_add_rms_norm));
   m.impl("silu_and_mul", TORCH_FN(xllm::silu_and_mul));
+  m.impl("moe_fused_topk", TORCH_FN(xllm::moe_fused_topk));
+  m.impl("cutlass_fused_moe", TORCH_FN(xllm::cutlass_fused_moe));
   m.impl("fused_qk_norm_rope", TORCH_FN(xllm::fused_qk_norm_rope));
   m.impl("reshape_paged_cache", TORCH_FN(xllm::reshape_paged_cache_op));
 #if defined(USE_CUDA)

--- a/xllm/core/layers/common/attention_metadata.h
+++ b/xllm/core/layers/common/attention_metadata.h
@@ -163,6 +163,8 @@ struct AttentionMetadata {
   torch::Tensor chunk_indices;
   torch::Tensor batch;
   torch::Tensor token_block_offset;
+  // Per-sequence recurrent-state validity for prefill/chunked-prefill only.
+  // Decode advances already-initialized states selected by linear state ids.
   torch::Tensor has_initial_states;
   int32_t tot = 0;
 

--- a/xllm/core/layers/common/attention_metadata_builder.cpp
+++ b/xllm/core/layers/common/attention_metadata_builder.cpp
@@ -291,12 +291,20 @@ AttentionMetadata build_attention_metadata(
              "undefined";
       options = options.device(device.value());
     }
-    attn_metadata.slot_mapping = torch::tensor({1}, options);
+    attn_metadata.slot_mapping = torch::tensor({0}, options);
     attn_metadata.q_cu_seq_lens = torch::tensor({0, 1}, options);
+    attn_metadata.kv_cu_seq_lens = torch::tensor({0, 1}, options);
     attn_metadata.q_seq_lens = torch::tensor({1}, options);
     attn_metadata.kv_seq_lens = torch::tensor({1}, options);
+    attn_metadata.q_seq_lens_vec = {0, 1};
+    attn_metadata.kv_seq_lens_vec = {0, 1};
+    attn_metadata.paged_kv_indptr = torch::tensor({0, 1}, options);
+    attn_metadata.paged_kv_indices = torch::tensor({0}, options);
+    attn_metadata.paged_kv_last_page_len = torch::tensor({1}, options);
+    attn_metadata.block_table = torch::zeros({1, 1}, options);
     attn_metadata.max_query_len = 1;
     attn_metadata.max_seq_len = std::max<int64_t>(attn_metadata.max_seq_len, 1);
+    attn_metadata.total_kv_len = 1;
   }
   materialize_linear_state_validity(params, device, attn_metadata);
 

--- a/xllm/core/runtime/forward_shared_memory_manager.cpp
+++ b/xllm/core/runtime/forward_shared_memory_manager.cpp
@@ -426,6 +426,7 @@ inline void write_linear_state_cache_ops(
   write_data(context.descriptor, static_cast<uint64_t>(cache_ops.size()));
   for (const LinearStateCacheOp& cache_op : cache_ops) {
     write_data(context.descriptor, cache_op.linear_state_id);
+    write_data(context.descriptor, cache_op.reset_requested);
     write_data(context.descriptor, cache_op.restore_requested);
     write_data(context.descriptor, cache_op.restore_src_slot_id);
   }
@@ -1214,6 +1215,7 @@ inline void read_linear_state_cache_ops(
   cache_ops.resize(size);
   for (LinearStateCacheOp& cache_op : cache_ops) {
     read_data(context, cache_op.linear_state_id);
+    read_data(context, cache_op.reset_requested);
     read_data(context, cache_op.restore_requested);
     read_data(context, cache_op.restore_src_slot_id);
   }

--- a/xllm/core/runtime/llm_worker_impl.cpp
+++ b/xllm/core/runtime/llm_worker_impl.cpp
@@ -223,7 +223,6 @@ LLMWorkerImpl::step_async_no_sync(const ForwardInput& input) {
 
 std::optional<ForwardOutput> LLMWorkerImpl::step_for_schedule_overlap(
     const ForwardInput& input) {
-#if defined(USE_NPU) || defined(USE_MLU)
   // Restore live recurrent-state slots from saved checkpoints here (worker
   // thread, on compute_stream_) instead of in prepare_work_before_execute on
   // prepare_stream_. The single-threaded worker pool guarantees the previous
@@ -238,7 +237,6 @@ std::optional<ForwardOutput> LLMWorkerImpl::step_for_schedule_overlap(
                                mutable_params.linear_state_cache_ops,
                                mutable_params.linear_state_validity_mask);
   }
-#endif
   return execute_no_sync_on_stream(input, *compute_stream_);
 }
 

--- a/xllm/core/runtime/py_executor_impl.cpp
+++ b/xllm/core/runtime/py_executor_impl.cpp
@@ -21,6 +21,7 @@ limitations under the License.
 #include <torch/extension.h>
 
 #include <memory>
+#include <optional>
 #include <vector>
 
 #include "common/metrics.h"
@@ -40,12 +41,21 @@ namespace xllm {
 
 namespace {
 
+py::object optional_tensor(const torch::Tensor& tensor) {
+  return tensor.defined() ? py::cast(tensor) : py::none();
+}
+
 class AttentionMetadataView final {
  public:
   explicit AttentionMetadataView(
-      std::shared_ptr<layer::AttentionMetadata> metadata)
+      std::shared_ptr<layer::AttentionMetadata> metadata,
+      const ModelInputParams& params)
       : metadata_(std::move(metadata)),
-        kv_seq_lens_host_(make_kv_seq_lens_host(metadata_)) {}
+        kv_seq_lens_host_(make_kv_seq_lens_host(metadata_)),
+        linear_state_indices_(params.embedding.linear_state_indices),
+        dp_token_counts_(params.parallel.raw_dp_global_token_nums.empty()
+                             ? params.parallel.dp_global_token_nums
+                             : params.parallel.raw_dp_global_token_nums) {}
 
   const torch::Tensor& slot_mapping() const { return metadata_->slot_mapping; }
   const torch::Tensor& paged_kv_indptr() const {
@@ -78,6 +88,15 @@ class AttentionMetadataView final {
   py::object kv_seq_lens() const {
     return optional_tensor(metadata_->kv_seq_lens);
   }
+  py::object linear_state_indices() const {
+    return optional_tensor(linear_state_indices_);
+  }
+  py::object has_initial_state() const {
+    return optional_tensor(metadata_->has_initial_states);
+  }
+  const std::vector<int32_t>& dp_token_counts() const {
+    return dp_token_counts_;
+  }
   bool is_prefill() const { return metadata_->is_prefill; }
   bool is_chunked_prefill() const { return metadata_->is_chunked_prefill; }
 
@@ -96,12 +115,10 @@ class AttentionMetadataView final {
         torch::TensorOptions().dtype(torch::kInt32).device(torch::kCPU));
   }
 
-  static py::object optional_tensor(const torch::Tensor& tensor) {
-    return tensor.defined() ? py::cast(tensor) : py::none();
-  }
-
   std::shared_ptr<layer::AttentionMetadata> metadata_;
   torch::Tensor kv_seq_lens_host_;
+  torch::Tensor linear_state_indices_;
+  std::vector<int32_t> dp_token_counts_;
 };
 
 }  // namespace
@@ -125,6 +142,12 @@ PYBIND11_EMBEDDED_MODULE(xllm_runtime, m) {
                              &AttentionMetadataView::kv_seq_lens_host)
       .def_property_readonly("block_table", &AttentionMetadataView::block_table)
       .def_property_readonly("kv_seq_lens", &AttentionMetadataView::kv_seq_lens)
+      .def_property_readonly("linear_state_indices",
+                             &AttentionMetadataView::linear_state_indices)
+      .def_property_readonly("has_initial_state",
+                             &AttentionMetadataView::has_initial_state)
+      .def_property_readonly("dp_token_counts",
+                             &AttentionMetadataView::dp_token_counts)
       .def_property_readonly("is_prefill", &AttentionMetadataView::is_prefill)
       .def_property_readonly("is_chunked_prefill",
                              &AttentionMetadataView::is_chunked_prefill);
@@ -147,6 +170,7 @@ PyExecutorImpl::PyExecutorImpl(CausalLM* model,
                                const runtime::Options& options)
     : py_causal_lm_(dynamic_cast<PyCausalLM*>(model)),
       args_(args),
+      device_(device),
       options_(options),
       enable_mla_(args.enable_mla()) {
   CHECK(py_causal_lm_ != nullptr) << "PyExecutorImpl requires PyCausalLM";
@@ -183,7 +207,8 @@ ModelOutput PyExecutorImpl::run(const torch::Tensor& tokens,
       params.attn_metadata;
   if (!attn_metadata) {
     attn_metadata = std::make_shared<layer::AttentionMetadata>(
-        layer::AttentionMetadataBuilder::build(params, enable_mla_));
+        layer::AttentionMetadataBuilder::build(
+            params, enable_mla_, std::nullopt, device_));
   }
 
   py::gil_scoped_acquire gil;
@@ -193,8 +218,12 @@ ModelOutput PyExecutorImpl::run(const torch::Tensor& tokens,
   if (!kv_bound_) {
     py::list kv_caches_py;
     for (auto& kv : kv_caches) {
-      kv_caches_py.append(py::make_tuple(
-          kv.get_k_cache(), kv.get_v_cache(), kv.get_index_cache()));
+      // Slot order must match ``LayerCache`` on the Python side.
+      kv_caches_py.append(py::make_tuple(optional_tensor(kv.get_k_cache()),
+                                         optional_tensor(kv.get_v_cache()),
+                                         optional_tensor(kv.get_index_cache()),
+                                         optional_tensor(kv.get_conv_cache()),
+                                         optional_tensor(kv.get_ssm_cache())));
     }
     py_executor_.attr("bind_kv_caches")(kv_caches_py);
     kv_bound_ = true;
@@ -204,7 +233,8 @@ ModelOutput PyExecutorImpl::run(const torch::Tensor& tokens,
         << "KV cache layer count changed after initial bind";
   }
 
-  py::object py_metadata = py::cast(AttentionMetadataView(attn_metadata));
+  py::object py_metadata =
+      py::cast(AttentionMetadataView(attn_metadata, params));
 
   py::object py_sync = py::none();
 #if defined(USE_NPU)

--- a/xllm/core/runtime/py_executor_impl.h
+++ b/xllm/core/runtime/py_executor_impl.h
@@ -53,6 +53,7 @@ class __attribute__((visibility("hidden"))) PyExecutorImpl final
  private:
   PyCausalLM* py_causal_lm_;
   ModelArgs args_;
+  torch::Device device_;
   runtime::Options options_;
   bool enable_mla_ = false;
 

--- a/xllm/core/runtime/worker_impl.cpp
+++ b/xllm/core/runtime/worker_impl.cpp
@@ -189,7 +189,7 @@ void ensure_forward_input_device_tensors(ForwardInput& input,
                                   device);
 }
 
-#if defined(USE_NPU) || defined(USE_MLU)
+#if defined(USE_NPU) || defined(USE_MLU) || defined(USE_CUDA)
 struct LinearStateInputRows {
   std::vector<int32_t> cached_tokens;
   int64_t active_rows = 0;
@@ -197,8 +197,11 @@ struct LinearStateInputRows {
 };
 #endif
 
-#if defined(USE_NPU)
-LinearStateInputRows get_npu_linear_state_rows(ModelInputParams& input_params) {
+#if defined(USE_NPU) || defined(USE_CUDA)
+// NPU and CUDA workers carry the same host attention views, so they derive the
+// linear-state rows identically; only the NPU model reads back
+// parallel.query_start_loc.
+LinearStateInputRows get_host_linear_state_rows(ModelInputParams& input_params) {
   // Early-return on dummy/empty-shard inputs. Under dp>1, an empty shard is
   // padded with a fake token by worker_impl but its GDN-related tensors
   // (attention.device.kv_cache_tokens_nums etc.) are left undefined. Reading
@@ -223,9 +226,15 @@ LinearStateInputRows get_npu_linear_state_rows(ModelInputParams& input_params) {
   if (batch_size == 0 && input_params.attention.device.block_tables.defined()) {
     batch_size = input_params.attention.device.block_tables.size(0);
   }
+  if (batch_size == 0 &&
+      input_params.embedding.linear_state_indices.defined()) {
+    batch_size = input_params.embedding.linear_state_indices.numel();
+  }
+
+#if defined(USE_NPU)
   input_params.parallel.query_start_loc.resize(batch_size + 1, 0);
   for (int64_t i = 0; i < batch_size; ++i) {
-    int64_t seq_len =
+    const int64_t seq_len =
         has_leading_zero
             ? static_cast<int64_t>(host_q_seq_lens[static_cast<size_t>(i + 1)] -
                                    host_q_seq_lens[static_cast<size_t>(i)])
@@ -233,11 +242,12 @@ LinearStateInputRows get_npu_linear_state_rows(ModelInputParams& input_params) {
     input_params.parallel.query_start_loc[i + 1] =
         input_params.parallel.query_start_loc[i] + seq_len;
   }
+#endif
 
   const std::vector<int32_t>& cached_tokens =
       input_params.attention.host.kv_cache_tokens_nums;
   CHECK(!cached_tokens.empty())
-      << "NPU linear-state input requires host kv cache token counts";
+      << "linear-state input requires host kv cache token counts";
   return {cached_tokens, batch_size, /*empty_shard=*/false};
 }
 #endif
@@ -281,12 +291,12 @@ LinearStateInputRows get_mlu_linear_state_rows(ModelInputParams& input_params) {
 }
 #endif
 
-#if defined(USE_NPU) || defined(USE_MLU)
+#if defined(USE_NPU) || defined(USE_MLU) || defined(USE_CUDA)
 void prepare_input_params_for_linear_attention(ModelInputParams& input_params) {
-#if defined(USE_NPU)
-  LinearStateInputRows rows = get_npu_linear_state_rows(input_params);
-#elif defined(USE_MLU)
+#if defined(USE_MLU)
   LinearStateInputRows rows = get_mlu_linear_state_rows(input_params);
+#else
+  LinearStateInputRows rows = get_host_linear_state_rows(input_params);
 #endif
   if (rows.empty_shard) {
     input_params.linear_state_validity_mask.clear();
@@ -848,6 +858,8 @@ void WorkerImpl::prepare_work_before_execute_on_stream(
           torch::ones({1}, token_options.device(device_));
       processed_input.positions =
           torch::zeros({1}, position_options.device(device_));
+      processed_input.input_params.embedding.linear_state_indices =
+          torch::zeros({1}, token_options.dtype(torch::kInt32).device(device_));
       empty_shard = false;
     }
     if (empty_shard) {
@@ -899,7 +911,7 @@ void WorkerImpl::prepare_work_before_execute_on_stream(
     }
 #endif
 
-#if defined(USE_NPU) || defined(USE_MLU)
+#if defined(USE_NPU) || defined(USE_MLU) || defined(USE_CUDA)
     if (has_linear_attention_layers(context_.get_model_args())) {
       prepare_input_params_for_linear_attention(input_params);
       // Under schedule_overlap chunked prefill the previous chunk's forward
@@ -1242,13 +1254,14 @@ bool WorkerImpl::update_weights(const std::string& weights_path) {
 bool WorkerImpl::start_profile() {
   const auto& cfg = ProfileConfig::get_instance();
   LOG(INFO) << "Starting profiling with backend: " << cfg.profile_backend();
-#if defined(USE_CUDA) || defined(USE_DCU) || defined(USE_MUSA)
 #if defined(USE_CUDA)
   if (cfg.profile_backend() == "cuda") {
     // Capture-range only; requires the server to run under nsys.
     return CudaProfiler::get_instance().start();
   }
-#endif
+  LOG(ERROR) << "Unsupported CUDA profiling backend: " << cfg.profile_backend();
+  return false;
+#elif defined(USE_DCU) || defined(USE_MUSA)
   // Default "torch" backend records in-process via Kineto. CPU-op capture uses
   // thread-local callbacks, so enable it on the compute thread that runs the
   // forward pass rather than on the RPC handler thread.
@@ -1267,12 +1280,13 @@ bool WorkerImpl::start_profile() {
 bool WorkerImpl::stop_profile() {
   const auto& cfg = ProfileConfig::get_instance();
   LOG(INFO) << "Stopping profiling with backend: " << cfg.profile_backend();
-#if defined(USE_CUDA) || defined(USE_DCU) || defined(USE_MUSA)
 #if defined(USE_CUDA)
   if (cfg.profile_backend() == "cuda") {
     return CudaProfiler::get_instance().stop();
   }
-#endif
+  LOG(ERROR) << "Unsupported CUDA profiling backend: " << cfg.profile_backend();
+  return false;
+#elif defined(USE_DCU) || defined(USE_MUSA)
   const std::string profile_dir = cfg.profile_dir();
   const int32_t rank = parallel_args_.rank();
   folly::Promise<bool> promise;

--- a/xllm/core/runtime/worker_impl.cpp
+++ b/xllm/core/runtime/worker_impl.cpp
@@ -201,7 +201,8 @@ struct LinearStateInputRows {
 // NPU and CUDA workers carry the same host attention views, so they derive the
 // linear-state rows identically; only the NPU model reads back
 // parallel.query_start_loc.
-LinearStateInputRows get_host_linear_state_rows(ModelInputParams& input_params) {
+LinearStateInputRows get_host_linear_state_rows(
+    ModelInputParams& input_params) {
   // Early-return on dummy/empty-shard inputs. Under dp>1, an empty shard is
   // padded with a fake token by worker_impl but its GDN-related tensors
   // (attention.device.kv_cache_tokens_nums etc.) are left undefined. Reading

--- a/xllm/models/llm/py_causal_lm.cpp
+++ b/xllm/models/llm/py_causal_lm.cpp
@@ -44,17 +44,75 @@ PyCausalLM::PyCausalLM(const ModelContext& context)
   tp_group_ = parallel_args.tp_group_;
   tp_size_ = (tp_group_ != nullptr) ? tp_group_->world_size() : 1;
   tp_rank_ = (tp_group_ != nullptr) ? tp_group_->rank() : 0;
+  ProcessGroup* dp_group = parallel_args.dp_local_process_group_;
+  dp_size_ = (dp_group != nullptr) ? dp_group->world_size() : 1;
+  dp_rank_ = (dp_group != nullptr) ? dp_group->rank() : 0;
+  ep_size_ = parallel_args.ep_size();
+  CHECK(ep_size_ == 1 || ep_size_ == parallel_args.world_size())
+      << "Python models support only ep_size=1 or ep_size=world_size.";
+
+  CHECK(parallel_args.moe_tp_group_ != nullptr);
+  ProcessGroup* moe_tp_group = parallel_args.moe_tp_group_;
+  ProcessGroup* ep_group = nullptr;
+  if (ep_size_ > 1) {
+    CHECK(parallel_args.moe_ep_group_ != nullptr);
+    ep_group = parallel_args.moe_ep_group_;
+  }
+  moe_tp_size_ = (moe_tp_group != nullptr) ? moe_tp_group->world_size() : 1;
+  moe_tp_rank_ = (moe_tp_group != nullptr) ? moe_tp_group->rank() : 0;
+  ep_rank_ = (ep_group != nullptr) ? ep_group->rank() : 0;
 
   py::gil_scoped_acquire gil;
+  py::object init_process_group =
+      py::module_::import("xllm.python.distributed")
+          .attr("init_process_group");
+  CHECK(!parallel_args.python_rendezvous_host_.empty());
+  CHECK_GT(parallel_args.python_rendezvous_port_, 0);
+  const int32_t global_rank = parallel_args.rank();
+  const int32_t global_world_size = parallel_args.world_size();
   if (tp_size_ > 1) {
-    CHECK(!parallel_args.python_tp_rendezvous_host_.empty());
-    CHECK_GT(parallel_args.python_tp_rendezvous_port_, 0);
-    py::module_::import("xllm.python.distributed")
-        .attr("init_tp_group")(parallel_args.python_tp_rendezvous_host_,
-                               parallel_args.python_tp_rendezvous_port_,
-                               tp_rank_,
-                               tp_size_,
-                               c10::str(device_));
+    init_process_group("tp",
+                       parallel_args.python_rendezvous_host_,
+                       parallel_args.python_rendezvous_port_,
+                       tp_rank_,
+                       tp_size_,
+                       c10::str(device_),
+                       global_rank,
+                       global_world_size,
+                       global_rank / tp_size_);
+  }
+  if (dp_size_ > 1) {
+    init_process_group("dp",
+                       parallel_args.python_rendezvous_host_,
+                       parallel_args.python_rendezvous_port_,
+                       dp_rank_,
+                       dp_size_,
+                       c10::str(device_),
+                       global_rank,
+                       global_world_size,
+                       global_rank % tp_size_);
+  }
+  if (moe_tp_size_ > 1) {
+    init_process_group("moe_tp",
+                       parallel_args.python_rendezvous_host_,
+                       parallel_args.python_rendezvous_port_,
+                       moe_tp_rank_,
+                       moe_tp_size_,
+                       c10::str(device_),
+                       global_rank,
+                       global_world_size,
+                       global_rank / moe_tp_size_);
+  }
+  if (ep_size_ > 1) {
+    init_process_group("moe_ep",
+                       parallel_args.python_rendezvous_host_,
+                       parallel_args.python_rendezvous_port_,
+                       ep_rank_,
+                       ep_size_,
+                       c10::str(device_),
+                       global_rank,
+                       global_world_size,
+                       global_rank % moe_tp_size_);
   }
   const std::string module_name = context.get_model_args().model_type().empty()
                                       ? std::string("Qwen3ForCausalLM")
@@ -83,6 +141,12 @@ py::dict PyCausalLM::build_config_dict(
   d["device"] = c10::str(device_);
   d["tp_size"] = tp_size_;
   d["tp_rank"] = tp_rank_;
+  d["dp_size"] = dp_size_;
+  d["dp_rank"] = dp_rank_;
+  d["moe_tp_size"] = moe_tp_size_;
+  d["moe_tp_rank"] = moe_tp_rank_;
+  d["ep_size"] = ep_size_;
+  d["ep_rank"] = ep_rank_;
   d["enable_graph"] = ExecutionConfig::get_instance().enable_graph();
   d["python_graph_backend"] =
       ExecutionConfig::get_instance().python_graph_backend();

--- a/xllm/models/llm/py_causal_lm.cpp
+++ b/xllm/models/llm/py_causal_lm.cpp
@@ -64,8 +64,7 @@ PyCausalLM::PyCausalLM(const ModelContext& context)
 
   py::gil_scoped_acquire gil;
   py::object init_process_group =
-      py::module_::import("xllm.python.distributed")
-          .attr("init_process_group");
+      py::module_::import("xllm.python.distributed").attr("init_process_group");
   CHECK(!parallel_args.python_rendezvous_host_.empty());
   CHECK_GT(parallel_args.python_rendezvous_port_, 0);
   const int32_t global_rank = parallel_args.rank();

--- a/xllm/models/llm/py_causal_lm.h
+++ b/xllm/models/llm/py_causal_lm.h
@@ -63,6 +63,12 @@ class __attribute__((visibility("hidden"))) PyCausalLM : public CausalLM {
 
   int64_t tp_size_ = 1;
   int64_t tp_rank_ = 0;
+  int64_t dp_size_ = 1;
+  int64_t dp_rank_ = 0;
+  int64_t moe_tp_size_ = 1;
+  int64_t moe_tp_rank_ = 0;
+  int64_t ep_size_ = 1;
+  int64_t ep_rank_ = 0;
   ProcessGroup* tp_group_ = nullptr;
 
   pybind11::object py_model_;

--- a/xllm/models/llm/qwen3_5.h
+++ b/xllm/models/llm/qwen3_5.h
@@ -22,12 +22,17 @@ limitations under the License.
 #include <utility>
 #include <vector>
 
-#include "core/layers/qwen3_5_decoder_layer.h"
 #include "models/model_registry.h"
+#if defined(USE_NPU) || defined(USE_MLU) || defined(USE_MUSA) || \
+    defined(USE_DCU)
+#include "core/layers/qwen3_5_decoder_layer.h"
 #include "qwen3_next.h"
+#endif
 
 namespace xllm {
 
+#if defined(USE_NPU) || defined(USE_MLU) || defined(USE_MUSA) || \
+    defined(USE_DCU)
 class Qwen3_5ModelImpl : public Qwen3NextModelImpl {
  public:
   explicit Qwen3_5ModelImpl(const ModelContext& context)
@@ -64,6 +69,7 @@ class Qwen3_5ForCausalLMImpl : public Qwen3NextForCausalLMImpl {
   }
 };
 TORCH_MODULE(Qwen3_5ForCausalLM);
+#endif
 
 #define LOAD_ARG_TEXT_OR_ROOT(arg_name, json_key, default_value) \
   LOAD_ARG_OR(arg_name, "text_config." json_key, default_value); \
@@ -190,7 +196,11 @@ TORCH_MODULE(Qwen3_5ForCausalLM);
   LOAD_ARG_OR(dtype, "text_config.torch_dtype", args->dtype()); \
   LOAD_ARG_OR(dtype, "torch_dtype", args->dtype())
 
+REGISTER_MODEL_BACKEND(qwen3_5_text, "llm");
+#if defined(USE_NPU) || defined(USE_MLU) || defined(USE_MUSA) || \
+    defined(USE_DCU)
 REGISTER_CAUSAL_MODEL(qwen3_5_text, Qwen3_5ForCausalLM);
+#endif
 REGISTER_MODEL_ARGS(qwen3_5_text, [&] {
   LOAD_QWEN3_5_TEXT_TYPE_AND_DTYPE("qwen3_5_text");
   LOAD_QWEN3_5_NEXT_COMPAT_ARGS(/*moe_intermediate_size=*/0,
@@ -199,7 +209,11 @@ REGISTER_MODEL_ARGS(qwen3_5_text, [&] {
                                 /*shared_expert_intermediate_size=*/0);
 });
 
+REGISTER_MODEL_BACKEND(qwen3_5_moe_text, "llm");
+#if defined(USE_NPU) || defined(USE_MLU) || defined(USE_MUSA) || \
+    defined(USE_DCU)
 REGISTER_CAUSAL_MODEL(qwen3_5_moe_text, Qwen3_5ForCausalLM);
+#endif
 REGISTER_MODEL_ARGS(qwen3_5_moe_text, [&] {
   LOAD_QWEN3_5_TEXT_TYPE_AND_DTYPE("qwen3_5_moe_text");
   LOAD_QWEN3_5_NEXT_COMPAT_ARGS(/*moe_intermediate_size=*/512,

--- a/xllm/models/model_registry.cpp
+++ b/xllm/models/model_registry.cpp
@@ -253,6 +253,17 @@ void ModelRegistry::register_dit_model_factory(const std::string& name,
   }
 }
 
+void ModelRegistry::register_model_backend(const std::string& name,
+                                           const std::string& backend) {
+  ModelRegistry* instance = get_instance();
+  auto [it, inserted] = instance->model_backend_.emplace(name, backend);
+  if (!inserted && it->second != backend) {
+    SAFE_LOG_WARNING("model backend for "
+                     << name << " already registered as " << it->second
+                     << "; ignoring conflicting backend " << backend << ".");
+  }
+}
+
 void ModelRegistry::register_multimodal_processor_factory(
     const std::string& name,
     MultimodalProcessorFactory factory) {

--- a/xllm/models/model_registry.h
+++ b/xllm/models/model_registry.h
@@ -98,6 +98,9 @@ class ModelRegistry {
   static void register_dit_model_factory(const std::string& name,
                                          DiTModelFactory factory);
 
+  static void register_model_backend(const std::string& name,
+                                     const std::string& backend);
+
   static void register_model_args_loader(const std::string& name,
                                          ModelArgsLoader loader);
 
@@ -231,6 +234,15 @@ std::unique_ptr<DiTModel> create_dit_model(const DiTModelContext& context);
 
 #define REGISTER_DIT_MODEL(ModelType, ModelClass) \
   REGISTER_DIT_MODEL_WITH_VARNAME(ModelType, ModelType, ModelClass)
+
+#define REGISTER_MODEL_BACKEND_WITH_VARNAME(VarName, ModelType, Backend) \
+  const bool VarName##_backend_registered = []() {                       \
+    ModelRegistry::register_model_backend(#ModelType, Backend);          \
+    return true;                                                         \
+  }()
+
+#define REGISTER_MODEL_BACKEND(ModelType, Backend) \
+  REGISTER_MODEL_BACKEND_WITH_VARNAME(ModelType, ModelType, Backend)
 
 #define REGISTER_MULTIMODAL_PROCESSOR_WITH_VARNAME(              \
     VarName, ModelType, ProcessorClass)                          \

--- a/xllm/models/models.h
+++ b/xllm/models/models.h
@@ -112,6 +112,7 @@ limitations under the License.
 #include "llm/mimo_mtp.h"                               // IWYU pragma: keep
 #include "llm/qwen2.h"                                  // IWYU pragma: keep
 #include "llm/qwen3.h"                                  // IWYU pragma: keep
+#include "llm/qwen3_5.h"                                // IWYU pragma: keep
 #include "llm/qwen3_moe.h"                              // IWYU pragma: keep
 #include "llm/rwkv7.h"                                  // IWYU pragma: keep
 #include "vlm/qwen2_5_vl.h"                             // IWYU pragma: keep

--- a/xllm/python/attention/backend.py
+++ b/xllm/python/attention/backend.py
@@ -80,7 +80,7 @@ class AttentionMetadata(Protocol):
     kv_seq_lens: torch.Tensor | None
     linear_state_indices: torch.Tensor | None
     has_initial_state: torch.Tensor | None
-    dp_token_counts: list[int]
+    dp_token_counts: Sequence[int]
     is_prefill: bool
     is_chunked_prefill: bool
 

--- a/xllm/python/attention/backend.py
+++ b/xllm/python/attention/backend.py
@@ -16,14 +16,53 @@ from __future__ import annotations
 
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Protocol
+from typing import TYPE_CHECKING, Protocol, Sequence
 
 import torch
 
 if TYPE_CHECKING:
     from xllm.python.layers.attention import Attention
 
-KVCache = tuple[torch.Tensor, torch.Tensor, torch.Tensor]
+@dataclass(frozen=True, slots=True)
+class LayerCache:
+    """Every cache a layer may own, named rather than positional.
+
+    A layer holds a subset: full attention uses ``key``/``value``, the MLA
+    sparse indexer adds ``index``, and a linear-attention layer uses
+    ``conv``/``ssm`` instead of K/V. An absent slot is ``None`` rather than an
+    empty tensor, so a layer that reads the wrong slot fails loudly.
+    """
+
+    key: torch.Tensor | None
+    value: torch.Tensor | None
+    index: torch.Tensor | None = None
+    conv: torch.Tensor | None = None
+    ssm: torch.Tensor | None = None
+
+
+#: Field order of the tuple form, which is what the C++ executor hands over.
+_LAYER_CACHE_SLOTS = ("key", "value", "index", "conv", "ssm")
+
+LayerCacheInput = LayerCache | tuple[torch.Tensor | None, ...]
+
+
+def normalize_layer_caches(caches: Sequence[LayerCacheInput]) -> list[LayerCache]:
+    """Accept the tuple form and return named caches with empty slots dropped."""
+    normalized: list[LayerCache] = []
+    for cache in caches:
+        if isinstance(cache, LayerCache):
+            normalized.append(cache)
+            continue
+        if not 2 <= len(cache) <= len(_LAYER_CACHE_SLOTS):
+            raise ValueError(
+                "layer cache must hold between K/V and "
+                f"{'/'.join(_LAYER_CACHE_SLOTS)} tensors"
+            )
+        slots = [None if tensor is None or not tensor.numel() else tensor
+                 for tensor in cache]
+        slots.extend([None] * (len(_LAYER_CACHE_SLOTS) - len(slots)))
+        normalized.append(LayerCache(*slots))
+    return normalized
 
 
 class AttentionMetadata(Protocol):
@@ -39,6 +78,9 @@ class AttentionMetadata(Protocol):
     paged_kv_last_page_len_host: torch.Tensor | None
     block_table: torch.Tensor | None
     kv_seq_lens: torch.Tensor | None
+    linear_state_indices: torch.Tensor | None
+    has_initial_state: torch.Tensor | None
+    dp_token_counts: list[int]
     is_prefill: bool
     is_chunked_prefill: bool
 
@@ -48,9 +90,9 @@ class MlaIndexContext:
     """Public contract handed to an optional LightningIndexer.
 
     Replaces direct model access to ``backend._metadata`` / ``backend._kv_caches``
-    for MLA layers. The backend owns the paged index cache (the third slot of
-    ``KVCache``) and prepares the paging / sequence-length metadata once per
-    step; the indexer receives this view and produces ``topk``.
+    for MLA layers. The backend owns the paged index cache (``LayerCache.index``)
+    and prepares the paging / sequence-length metadata once per step; the indexer
+    receives this view and produces ``topk``.
     """
 
     index_cache: torch.Tensor
@@ -62,7 +104,7 @@ class MlaIndexContext:
 
 class AttentionBackend(ABC):
     @abstractmethod
-    def bind_kv_caches(self, kv_caches: list[KVCache]) -> None:
+    def bind_kv_caches(self, kv_caches: list[LayerCache]) -> None:
         pass
 
     @abstractmethod
@@ -117,7 +159,7 @@ class AttentionBackend(ABC):
     def mla_index_context(self, layer: "Attention") -> MlaIndexContext:
         """Public hook for an optional LightningIndexer.
 
-        Hands out the paged index cache view (third ``KVCache`` slot) plus the
+        Hands out the paged index cache view (``LayerCache.index``) plus the
         paging / sequence-length metadata the indexer needs, so the model never
         touches ``backend._metadata`` / ``backend._kv_caches`` directly.
         Backends that do not support the sparse MLA indexer raise.

--- a/xllm/python/attention/flashinfer.py
+++ b/xllm/python/attention/flashinfer.py
@@ -26,13 +26,39 @@ from xllm.python import kernels
 from xllm.python.attention.backend import (
     AttentionBackend,
     AttentionMetadata,
-    KVCache,
+    LayerCache,
 )
 
 if TYPE_CHECKING:
     from xllm.python.layers.attention import Attention
 
 _WORKSPACE_SIZE = 128 * 1024 * 1024
+
+
+def _should_use_tensor_core_decode(
+    dtype: torch.dtype,
+    num_heads: int,
+    num_kv_heads: int,
+) -> bool:
+    return (
+        dtype in (torch.float16, torch.bfloat16)
+        and num_heads // num_kv_heads >= 4
+    )
+
+
+def _pack_head_axes(tensor: torch.Tensor) -> torch.Tensor:
+    """Satisfy the ``reshape_paged_cache`` layout precondition.
+
+    The kernel indexes keys and values as if the head and head-dim axes were
+    packed, and only the token stride is free. Eager execution happens to hand
+    it such a layout, so the contract used to hold by accident.
+
+    This materializes instead of testing the strides: a stride test is folded
+    away while Dynamo traces, which is before the compiler picks layouts for
+    the tensors it produces, so the test would pass at trace time and the
+    kernel would still be handed an unpacked tensor at run time.
+    """
+    return tensor.contiguous()
 
 
 class FlashInferBackend(AttentionBackend):
@@ -52,12 +78,17 @@ class FlashInferBackend(AttentionBackend):
         self.scale = scale
         self.sliding_window = sliding_window
         self.dtype = dtype
+        self._decode_use_tensor_cores = _should_use_tensor_core_decode(
+            dtype, num_heads, num_kv_heads
+        )
 
         self._decode_workspace = torch.empty(
             _WORKSPACE_SIZE, dtype=torch.uint8, device=device
         )
         self._decode_wrapper = flashinfer.BatchDecodeWithPagedKVCacheWrapper(
-            self._decode_workspace, "NHD"
+            self._decode_workspace,
+            "NHD",
+            use_tensor_cores=self._decode_use_tensor_cores,
         )
         self._prefill_ragged_wrapper = (
             flashinfer.BatchPrefillWithRaggedKVCacheWrapper(
@@ -72,7 +103,7 @@ class FlashInferBackend(AttentionBackend):
             )
         )
 
-        self._kv_caches: list[KVCache] = []
+        self._kv_caches: list[LayerCache] = []
         self._metadata: AttentionMetadata | None = None
         self._active_decode_wrapper = self._decode_wrapper
         self._graph_decode_wrappers: dict[
@@ -81,7 +112,7 @@ class FlashInferBackend(AttentionBackend):
         self._graph_decode_buffer_ptrs: dict[int, tuple[int, int, int]] = {}
         self._planned_graph_batches: set[int] = set()
 
-    def bind_kv_caches(self, kv_caches: list[KVCache]) -> None:
+    def bind_kv_caches(self, kv_caches: list[LayerCache]) -> None:
         if not kv_caches:
             raise ValueError("FlashInferBackend requires at least one KV cache")
         self._kv_caches = kv_caches
@@ -90,13 +121,33 @@ class FlashInferBackend(AttentionBackend):
     def num_kv_blocks(self) -> int:
         if not self._kv_caches:
             raise RuntimeError("KV caches are not bound")
-        return self._kv_caches[0][0].size(0)
+        cache = next(
+            (
+                cache
+                for cache in self._kv_caches
+                if cache.key is not None and cache.key.numel()
+            ),
+            None,
+        )
+        if cache is None:
+            raise RuntimeError("no full-attention KV cache is bound")
+        return cache.key.size(0)
 
     @property
     def page_size(self) -> int:
         if not self._kv_caches:
             raise RuntimeError("KV caches are not bound")
-        k_cache = self._kv_caches[0][0]
+        cache = next(
+            (
+                cache
+                for cache in self._kv_caches
+                if cache.key is not None and cache.key.numel()
+            ),
+            None,
+        )
+        if cache is None:
+            raise RuntimeError("no full-attention KV cache is bound")
+        k_cache = cache.key
         return k_cache.size(1) if k_cache.dim() >= 2 else 1
 
     def prepare(
@@ -217,6 +268,7 @@ class FlashInferBackend(AttentionBackend):
                 paged_kv_indptr_buffer=metadata.paged_kv_indptr,
                 paged_kv_indices_buffer=metadata.paged_kv_indices,
                 paged_kv_last_page_len_buffer=metadata.paged_kv_last_page_len,
+                use_tensor_cores=self._decode_use_tensor_cores,
             )
             self._graph_decode_wrappers[batch_size] = wrapper
             self._graph_decode_buffer_ptrs[batch_size] = self._buffer_ptrs(
@@ -249,10 +301,15 @@ class FlashInferBackend(AttentionBackend):
         if metadata is None:
             raise RuntimeError("FlashInferBackend.prepare() was not called")
 
-        k_cache, v_cache, _ = self._kv_caches[layer.layer_id]
+        layer_cache = self._kv_caches[layer.layer_id]
+        k_cache, v_cache = layer_cache.key, layer_cache.value
+        if k_cache is None or v_cache is None:
+            raise RuntimeError(
+                f"full-attention KV cache is missing for layer {layer.layer_id}"
+            )
         q_3d = q.view(-1, layer.num_heads, layer.head_dim)
-        k_3d = k.view(-1, layer.num_kv_heads, layer.head_dim)
-        v_3d = v.view(-1, layer.num_kv_heads, layer.head_dim)
+        k_3d = _pack_head_axes(k.view(-1, layer.num_kv_heads, layer.head_dim))
+        v_3d = _pack_head_axes(v.view(-1, layer.num_kv_heads, layer.head_dim))
 
         kernels.reshape_paged_cache(
             metadata.slot_mapping, k_3d, v_3d, k_cache, v_cache

--- a/xllm/python/attention/npu_paged_attention.py
+++ b/xllm/python/attention/npu_paged_attention.py
@@ -29,7 +29,7 @@ from xllm.python import kernels
 from xllm.python.attention.backend import (
     AttentionBackend,
     AttentionMetadata,
-    KVCache,
+    LayerCache,
     MlaIndexContext,
 )
 from xllm.python.model_executor.forward_context import (
@@ -62,7 +62,7 @@ class NpuPagedAttentionBackend(AttentionBackend):
         self.dtype = dtype
         self.device = device
 
-        self._kv_caches: list[KVCache] = []
+        self._kv_caches: list[LayerCache] = []
         self._metadata: AttentionMetadata | None = None
         self._graph_workspace: torch.Tensor | None = None
         self._graph_outputs: dict[int, torch.Tensor] = {}
@@ -82,15 +82,17 @@ class NpuPagedAttentionBackend(AttentionBackend):
     def num_kv_blocks(self) -> int:
         if not self._kv_caches:
             return 0
-        return self._kv_caches[0][0].shape[0]
+        key_cache = self._kv_caches[0].key
+        return key_cache.shape[0] if key_cache is not None else 0
 
     @property
     def page_size(self) -> int:
         if not self._kv_caches:
             return 1
-        return self._kv_caches[0][0].shape[1]
+        key_cache = self._kv_caches[0].key
+        return key_cache.shape[1] if key_cache is not None else 1
 
-    def bind_kv_caches(self, kv_caches: list[KVCache]) -> None:
+    def bind_kv_caches(self, kv_caches: list[LayerCache]) -> None:
         self._kv_caches = kv_caches
 
     def prepare(
@@ -203,7 +205,10 @@ class NpuPagedAttentionBackend(AttentionBackend):
         assert metadata is not None
 
         layer_id = layer.layer_id
-        k_cache, v_cache, _ = self._kv_caches[layer_id]
+        layer_cache = self._kv_caches[layer_id]
+        k_cache, v_cache = layer_cache.key, layer_cache.value
+        if k_cache is None or v_cache is None:
+            raise RuntimeError(f"KV cache is missing for layer {layer_id}")
         num_tokens = q.shape[0]
 
         # Write KV to paged cache (kernel expects [T, kv_heads, head_dim]).
@@ -237,7 +242,11 @@ class NpuPagedAttentionBackend(AttentionBackend):
                 "NpuPagedAttentionBackend"
             )
         layer_id = layer.layer_id
-        nope_cache, rope_cache, _ = self._kv_caches[layer_id]
+        layer_cache = self._kv_caches[layer_id]
+        # MLA reuses the K/V slots for the latent (nope) and rope caches.
+        nope_cache, rope_cache = layer_cache.key, layer_cache.value
+        if nope_cache is None or rope_cache is None:
+            raise RuntimeError(f"MLA latent cache is missing for layer {layer_id}")
 
         torch.ops.xllm_ops.reshape_paged_cache(
             metadata.slot_mapping, k_latent_3d, k_pe_3d, nope_cache, rope_cache
@@ -249,7 +258,11 @@ class NpuPagedAttentionBackend(AttentionBackend):
     def mla_index_context(self, layer: "Attention") -> MlaIndexContext:
         metadata = self._metadata
         assert metadata is not None, "mla_index_context called before prepare()"
-        _, _, index_cache = self._kv_caches[layer.layer_id]
+        index_cache = self._kv_caches[layer.layer_id].index
+        if index_cache is None:
+            raise RuntimeError(
+                f"MLA index cache is missing for layer {layer.layer_id}"
+            )
         return MlaIndexContext(
             index_cache=index_cache,
             slot_mapping=metadata.slot_mapping,

--- a/xllm/python/distributed/__init__.py
+++ b/xllm/python/distributed/__init__.py
@@ -18,9 +18,18 @@ from __future__ import annotations
 
 from xllm.python.distributed.collectives import (
     all_gather,
+    all_gather_variable,
     all_reduce_,
+    init_process_group,
     init_tp_group,
     tp_rank,
 )
 
-__all__ = ["init_tp_group", "tp_rank", "all_reduce_", "all_gather"]
+__all__ = [
+    "init_process_group",
+    "init_tp_group",
+    "tp_rank",
+    "all_reduce_",
+    "all_gather",
+    "all_gather_variable",
+]

--- a/xllm/python/distributed/collectives.py
+++ b/xllm/python/distributed/collectives.py
@@ -22,36 +22,205 @@ place instead of splitting around it.
 
 from __future__ import annotations
 
+import json
+import socket
 from datetime import timedelta
 
 import torch
 import torch.distributed as dist
+import torch.distributed._symmetric_memory as symm_mem
+from torch.distributed import ProcessGroup
 
-_tp_groups = {}
-_tp_stores = {}
+_GROUP_NAMES = frozenset(("tp", "dp", "moe_tp", "moe_ep"))
+# ``tp`` and ``moe_tp`` own a contiguous block of global ranks, while ``dp`` and
+# ``moe_ep`` stride across those blocks. Both layouts follow from how the caller
+# derives a rank within each group, so a group's full membership is determined
+# by its own size and needs no extra information from the caller.
+_CONTIGUOUS_GROUPS = frozenset(("tp", "moe_tp"))
+
+_groups = {}
+_stores = {}
+_world_topology = None
+_symm_eligible = {}
+_symm_buffers = {}
+_world_initialized = False
 
 
-def _create_process_group(
-    host: str, port: int, rank: int, world_size: int, device: str
-):
-    """Create HCCL or NCCL ProcessGroup depending on device type."""
-    store = dist.TCPStore(
-        host,
-        port,
-        world_size,
-        rank == 0,
-        timedelta(minutes=5),
-        wait_for_workers=False,
+def _backend_for(device: torch.device) -> str:
+    if device.type == "cuda":
+        return "nccl"
+    import torch_npu  # noqa: F401
+
+    return "hccl"
+
+
+def _shared_store(
+    host: str, port: int, global_rank: int, global_world_size: int
+) -> dist.Store:
+    store_key = (host, port)
+    store = _stores.get(store_key)
+    if store is None:
+        store = dist.TCPStore(
+            host,
+            port,
+            global_world_size,
+            global_rank == 0,
+            timedelta(minutes=5),
+            wait_for_workers=False,
+            multi_tenant=True,
+        )
+        _stores[store_key] = store
+    return store
+
+
+def _exchange_world_topology(
+    store: dist.Store,
+    device: torch.device,
+    global_rank: int,
+    global_world_size: int,
+) -> list[dict[str, object]]:
+    device_index = device.index
+    if device.type == "cuda" and device_index is None:
+        device_index = torch.cuda.current_device()
+    local = {"hostname": socket.gethostname(), "device_index": device_index}
+    key_prefix = "xllm/python_collectives/topology/v1"
+    store.set(f"{key_prefix}/{global_rank}", json.dumps(local))
+    return [
+        json.loads(store.get(f"{key_prefix}/{rank}").decode("utf-8"))
+        for rank in range(global_world_size)
+    ]
+
+
+def _ensure_world(
+    host: str,
+    port: int,
+    device: torch.device,
+    global_rank: int,
+    global_world_size: int,
+) -> None:
+    """Initialize the default process group covering every rank.
+
+    The parallel groups are subgroups of it. Building them with ``new_group``
+    instead of constructing communicators directly registers them with c10d,
+    which is what lets a group back a symmetric-memory allocation.
+    """
+    global _world_initialized, _world_topology
+    if _world_initialized:
+        return
+    store = _shared_store(host, port, global_rank, global_world_size)
+    dist.init_process_group(
+        backend=_backend_for(device),
+        store=store,
+        rank=global_rank,
+        world_size=global_world_size,
+        timeout=timedelta(minutes=5),
     )
-    device_obj = torch.device(device)
-    if device_obj.type == "cuda":
-        group = dist.ProcessGroupNCCL(store, rank, world_size, timedelta(minutes=5))
-    else:
-        import torch_npu  # noqa: F401
-        from torch_npu._C._distributed_c10d import ProcessGroupHCCL
+    _world_topology = _exchange_world_topology(
+        store, device, global_rank, global_world_size
+    )
+    _world_initialized = True
 
-        group = ProcessGroupHCCL(store, rank, world_size, timedelta(minutes=5))
-    return store, group
+
+def _group_memberships(
+    group_name: str, world_size: int, global_world_size: int
+) -> list[list[int]]:
+    """Every group of this kind, in an order all ranks agree on.
+
+    ``new_group`` is collective over the whole world, so each rank has to create
+    all groups of a kind in the same order, not only the one it belongs to.
+    """
+    if world_size <= 0 or global_world_size % world_size:
+        raise ValueError(
+            f"{group_name} size {world_size} does not divide the world size "
+            f"{global_world_size}"
+        )
+    count = global_world_size // world_size
+    if group_name in _CONTIGUOUS_GROUPS:
+        return [
+            [index * world_size + offset for offset in range(world_size)]
+            for index in range(count)
+        ]
+    return [
+        [index + offset * count for offset in range(world_size)]
+        for index in range(count)
+    ]
+
+
+def _supports_symmetric_memory(device: torch.device, ranks: list[int]) -> bool:
+    if device.type != "cuda" or _world_topology is None:
+        return False
+    topology = [_world_topology[rank] for rank in ranks]
+    hostnames = {entry["hostname"] for entry in topology}
+    if len(hostnames) != 1:
+        return False
+    device_indices = [entry["device_index"] for entry in topology]
+    if any(not isinstance(index, int) or index < 0 for index in device_indices):
+        return False
+    if len(set(device_indices)) != len(device_indices):
+        return False
+    return all(
+        torch.cuda.can_device_access_peer(source, destination)
+        for source in device_indices
+        for destination in device_indices
+        if source != destination
+    )
+
+
+def init_process_group(
+    group_name: str,
+    host: str,
+    port: int,
+    rank: int,
+    world_size: int,
+    device: str,
+    global_rank: int,
+    global_world_size: int,
+    group_index: int,
+) -> ProcessGroup:
+    if group_name not in _GROUP_NAMES:
+        raise ValueError(f"unsupported parallel group: {group_name}")
+    device_obj = torch.device(device)
+    group_key = (group_name, str(device_obj))
+    group = _groups.get(group_key)
+    if group is not None:
+        if group.rank() != rank or group.size() != world_size:
+            raise RuntimeError(
+                f"{group_name} group for {group_key[1]} is already initialized as "
+                f"rank {group.rank()}/{group.size()}, requested "
+                f"rank {rank}/{world_size}"
+            )
+        return group
+
+    _ensure_world(host, port, device_obj, global_rank, global_world_size)
+    backend = _backend_for(device_obj)
+
+    own = None
+    own_ranks = None
+    memberships = _group_memberships(group_name, world_size, global_world_size)
+    for index, ranks in enumerate(memberships):
+        candidate = dist.new_group(
+            ranks=ranks, timeout=timedelta(minutes=5), backend=backend
+        )
+        if global_rank in ranks:
+            own = candidate
+            own_index = index
+            own_ranks = ranks
+    if own is None or own.rank() != rank:
+        raise RuntimeError(
+            f"derived {group_name} membership disagrees with the caller: global "
+            f"rank {global_rank} of {global_world_size} expected rank {rank} of "
+            f"{world_size}, got {None if own is None else own.rank()}"
+        )
+    if own_index != group_index:
+        raise RuntimeError(
+            f"derived {group_name} group index {own_index} does not match the "
+            f"caller's {group_index}"
+        )
+
+    assert own_ranks is not None
+    _groups[group_key] = own
+    _symm_eligible[group_key] = _supports_symmetric_memory(device_obj, own_ranks)
+    return own
 
 
 def init_tp_group(
@@ -60,54 +229,108 @@ def init_tp_group(
     rank: int,
     world_size: int,
     device: str,
-):
-    device_key = str(torch.device(device))
-    group = _tp_groups.get(device_key)
-    if group is not None:
-        if group.rank() != rank or group.size() != world_size:
-            raise RuntimeError(
-                f"TP group for {device_key} is already initialized as "
-                f"rank {group.rank()}/{group.size()}, requested "
-                f"rank {rank}/{world_size}"
-            )
-        return group
+    global_rank: int,
+    global_world_size: int,
+    group_index: int,
+) -> ProcessGroup:
+    return init_process_group(
+        "tp",
+        host,
+        port,
+        rank,
+        world_size,
+        device,
+        global_rank,
+        global_world_size,
+        group_index,
+    )
 
-    store, group = _create_process_group(host, port, rank, world_size, device)
-    _tp_stores[device_key] = store
-    _tp_groups[device_key] = group
-    return group
 
-
-def _require_tp_group(x: torch.Tensor):
-    group = _tp_groups.get(str(x.device))
+def _require_group(x: torch.Tensor, group_name: str) -> ProcessGroup:
+    group = _groups.get((group_name, str(x.device)))
     if group is None:
         raise RuntimeError(
-            "tensor-parallel collective called before the TP process group "
-            f"was initialized for {x.device}"
+            f"{group_name} collective called before its process group was "
+            f"initialized for {x.device}"
         )
     return group
 
 
-def tp_rank(device) -> int:
+def tp_rank(device: torch.device | str) -> int:
     """Rank in the TP group for ``device`` (0 when no TP group exists)."""
-    group = _tp_groups.get(str(torch.device(device)))
+    group = _groups.get(("tp", str(torch.device(device))))
     return group.rank() if group is not None else 0
 
 
+# A one-shot symmetric-memory reduction is an ordinary kernel on the current
+# stream, so a captured graph runs it inline. NCCL runs collectives on its own
+# stream, which costs a fork/join per call -- measured at ~32us of device idle
+# before every all-reduce in the decode graph, and there are dozens per step.
+# Past this size the staging copy stops paying for itself and NCCL's ring wins,
+# and the bound also keeps the buffer cache to decode-sized shapes rather than
+# one entry per distinct prefill length.
+_SYMM_MEM_MAX_BYTES = 512 * 1024
+# Distinct shapes still accumulate one buffer each; stop allocating rather than
+# grow without limit when a workload sweeps many small shapes.
+_SYMM_MEM_MAX_BUFFERS = 64
+_SYMM_MEM_DTYPES = frozenset((torch.float32, torch.bfloat16))
+
+
+def _symm_buffer(
+    group: ProcessGroup, group_name: str, x: torch.Tensor
+) -> torch.Tensor | None:
+    """Return a symmetric-memory staging buffer for ``x``, or None.
+
+    Allocation and rendezvous are collective and cannot run inside a graph
+    capture, so a shape first seen during capture falls back to NCCL. The
+    capture path is warmed up eagerly beforehand, which is where the decode
+    shapes get their buffers.
+    """
+    group_key = (group_name, str(x.device))
+    if not _symm_eligible.get(group_key, False):
+        return None
+    if not x.is_contiguous() or x.dtype not in _SYMM_MEM_DTYPES:
+        return None
+    if x.numel() * x.element_size() > _SYMM_MEM_MAX_BYTES:
+        return None
+
+    key = (group_name, str(x.device), x.dtype, x.numel())
+    buffer = _symm_buffers.get(key)
+    if buffer is not None:
+        return buffer
+    if torch.cuda.is_current_stream_capturing():
+        return None
+    if len(_symm_buffers) >= _SYMM_MEM_MAX_BUFFERS:
+        return None
+
+    buffer = symm_mem.empty(x.numel(), dtype=x.dtype, device=x.device)
+    symm_mem.rendezvous(buffer, group.group_name)
+    _symm_buffers[key] = buffer
+    return buffer
+
+
 @torch.library.custom_op("xllm_ops::all_reduce_", mutates_args={"x"})
-def all_reduce_(x: torch.Tensor) -> None:
-    group = _require_tp_group(x)
-    dist.all_reduce(x, group=group)
+def all_reduce_(x: torch.Tensor, group_name: str = "tp") -> None:
+    group = _require_group(x, group_name)
+    buffer = _symm_buffer(group, group_name, x)
+    if buffer is None:
+        dist.all_reduce(x, group=group)
+        return
+    flat = x.view(-1)
+    buffer.copy_(flat)
+    torch.ops.symm_mem.one_shot_all_reduce_out(
+        buffer, "sum", group.group_name, flat
+    )
 
 
 @all_reduce_.register_fake
-def _(x: torch.Tensor) -> None:
+def _(x: torch.Tensor, group_name: str = "tp") -> None:
     return None
 
 
 @torch.library.custom_op("xllm_ops::all_gather", mutates_args=())
 def all_gather(x: torch.Tensor, dim: int, world_size: int) -> torch.Tensor:
-    group = _require_tp_group(x)
+    group = _require_group(x, "tp")
     if group.size() != world_size:
         raise RuntimeError(
             f"TP world-size mismatch: expected {world_size}, "
@@ -125,4 +348,64 @@ def _(x: torch.Tensor, dim: int, world_size: int) -> torch.Tensor:
     return x.new_empty(shape)
 
 
-__all__ = ["init_tp_group", "tp_rank", "all_reduce_", "all_gather"]
+@torch.library.custom_op("xllm_ops::all_gather_variable", mutates_args=())
+def all_gather_variable(
+    x: torch.Tensor,
+    token_counts: list[int],
+    rank: int,
+    group_name: str,
+) -> torch.Tensor:
+    group = _require_group(x, group_name)
+    if group.size() != len(token_counts):
+        raise RuntimeError(
+            f"{group_name} size mismatch: group has {group.size()} ranks, "
+            f"but token_counts has {len(token_counts)} entries"
+        )
+    if not 0 <= rank < len(token_counts):
+        raise RuntimeError(f"invalid {group_name} rank {rank}")
+
+    local_tokens = token_counts[rank]
+    if local_tokens < 0 or local_tokens > x.shape[0]:
+        raise RuntimeError(
+            f"invalid local token count {local_tokens} for input with {x.shape[0]} rows"
+        )
+    padded_tokens = max(max(token_counts, default=0), 1)
+    padded_shape = list(x.shape)
+    padded_shape[0] = padded_tokens
+    padded = x.new_zeros(padded_shape)
+    if local_tokens:
+        padded[:local_tokens].copy_(x[:local_tokens])
+
+    chunks = [torch.empty_like(padded) for _ in token_counts]
+    dist.all_gather(chunks, padded, group=group)
+    valid_chunks = [
+        chunk[:count] for chunk, count in zip(chunks, token_counts) if count
+    ]
+    if not valid_chunks:
+        empty_shape = list(x.shape)
+        empty_shape[0] = 0
+        return x.new_empty(empty_shape)
+    return torch.cat(valid_chunks, dim=0)
+
+
+@all_gather_variable.register_fake
+def _(
+    x: torch.Tensor,
+    token_counts: list[int],
+    rank: int,
+    group_name: str,
+) -> torch.Tensor:
+    del rank, group_name
+    shape = list(x.shape)
+    shape[0] = sum(token_counts)
+    return x.new_empty(shape)
+
+
+__all__ = [
+    "init_process_group",
+    "init_tp_group",
+    "tp_rank",
+    "all_reduce_",
+    "all_gather",
+    "all_gather_variable",
+]

--- a/xllm/python/kernels_cuda/moe.py
+++ b/xllm/python/kernels_cuda/moe.py
@@ -30,7 +30,7 @@ def supports_cutlass_moe(device: torch.device) -> bool:
     Returns:
         ``True`` when the CUDA architecture has a CUTLASS expert GEMM.
     """
-    if not torch.cuda.is_available():
+    if device.type != "cuda" or not torch.cuda.is_available():
         return False
     device_index = device.index
     if device_index is None:

--- a/xllm/python/layers/__init__.py
+++ b/xllm/python/layers/__init__.py
@@ -22,13 +22,18 @@ direction is ``models -> layers -> kernels``.
 
 from xllm.python.layers.attention import Attention
 from xllm.python.layers.embedding import HiddenParallelEmbedding
-from xllm.python.layers.layernorm import RMSNorm
+from xllm.python.layers.fused_moe import FusedMoE
+from xllm.python.layers.gated_mlp import GatedMLP
+from xllm.python.layers.layernorm import GemmaRMSNorm, RMSNorm
 from xllm.python.layers.linear import ColumnParallelLinear, RowParallelLinear
 from xllm.python.layers.rotary_embedding import RotaryEmbedding
 
 __all__ = [
     "Attention",
+    "FusedMoE",
+    "GatedMLP",
     "RMSNorm",
+    "GemmaRMSNorm",
     "RotaryEmbedding",
     "ColumnParallelLinear",
     "RowParallelLinear",

--- a/xllm/python/layers/fused_moe.py
+++ b/xllm/python/layers/fused_moe.py
@@ -1,0 +1,172 @@
+# Copyright 2026 The xLLM Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://github.com/xLLM-AI/xllm/blob/main/LICENSE
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Fused MoE layer shared by Python model implementations."""
+
+from __future__ import annotations
+
+import torch
+import torch.nn as nn
+
+from xllm.python import distributed, kernels
+from xllm.python.model_executor.forward_context import get_forward_context
+
+
+class FusedMoE(nn.Module):
+    """Routed experts backed by the active platform's MoE kernels.
+
+    This mirrors ``layers/cuda/FusedMoEImpl``: the router is replicated, the
+    expert intermediate dimension is tensor-parallel, and the CUTLASS fc1
+    weight layout is ``[up, gate]``.
+    """
+
+    def __init__(
+        self,
+        hidden_size: int,
+        intermediate_size: int,
+        num_experts: int,
+        top_k: int,
+        renormalize: bool,
+        moe_tp_size: int,
+        moe_tp_rank: int,
+        ep_size: int,
+        ep_rank: int,
+        dp_size: int,
+        dp_rank: int,
+        dtype: torch.dtype,
+        device: torch.device,
+        scoring_func: str = "softmax",
+        reduce_results: bool = True,
+    ) -> None:
+        super().__init__()
+        if intermediate_size % moe_tp_size:
+            raise ValueError("MoE intermediate_size must be divisible by moe_tp_size")
+        if num_experts % ep_size:
+            raise ValueError("num_experts must be divisible by ep_size")
+        if not reduce_results and dp_size > 1:
+            # The DP path slices the gathered output down to this rank's tokens,
+            # which is only meaningful once every rank's partial sums have been
+            # combined, so the reduction cannot be deferred past this layer.
+            raise ValueError(
+                "a deferred reduction cannot be combined with data parallelism"
+            )
+
+        num_experts_per_rank = num_experts // ep_size
+        local_intermediate_size = intermediate_size // moe_tp_size
+        self.top_k = top_k
+        self.renormalize = renormalize
+        self.scoring_func = scoring_func
+        self.moe_tp_size = moe_tp_size
+        self.moe_tp_rank = moe_tp_rank
+        self.ep_size = ep_size
+        self.ep_rank = ep_rank
+        self.dp_size = dp_size
+        self.dp_rank = dp_rank
+        self.reduce_results = reduce_results
+        # Top-k routing runs on every architecture; only the native expert GEMMs
+        # need Hopper/Blackwell, so the kernel package decides per device.
+        self._use_cutlass = kernels.supports_cutlass_moe(device)
+
+        self.gate = nn.Linear(
+            hidden_size,
+            num_experts,
+            bias=False,
+            dtype=dtype,
+            device=device,
+        )
+        self.w13 = nn.Parameter(
+            torch.empty(
+                num_experts_per_rank,
+                2 * local_intermediate_size,
+                hidden_size,
+                dtype=dtype,
+                device=device,
+            )
+        )
+        self.w2 = nn.Parameter(
+            torch.empty(
+                num_experts_per_rank,
+                hidden_size,
+                local_intermediate_size,
+                dtype=dtype,
+                device=device,
+            )
+        )
+
+    def forward(self, hidden_states: torch.Tensor) -> torch.Tensor:
+        local_hidden_states = hidden_states
+        token_counts: list[int] | None = None
+        if self.dp_size > 1:
+            token_counts = list(get_forward_context().metadata.dp_token_counts)
+            if len(token_counts) != self.dp_size:
+                raise RuntimeError(
+                    f"expected {self.dp_size} DP token counts, got {token_counts}"
+                )
+            hidden_states = distributed.all_gather_variable(
+                hidden_states,
+                token_counts,
+                self.dp_rank,
+                "dp",
+            )
+
+        router_logits = self.gate(hidden_states)
+        topk_weights, topk_ids = kernels.moe_fused_topk(
+            router_logits,
+            self.top_k,
+            self.renormalize,
+            self.scoring_func,
+        )
+        if self._use_cutlass:
+            output = kernels.cutlass_fused_moe(
+                hidden_states,
+                topk_ids,
+                topk_weights,
+                self.w13,
+                self.w2,
+                self.moe_tp_size,
+                self.moe_tp_rank,
+                self.ep_size,
+                self.ep_rank,
+            )
+        elif self.moe_tp_size == 1 and self.ep_size == 1:
+            output = kernels.fused_moe(
+                hidden_states,
+                topk_ids,
+                topk_weights,
+                self.w13,
+                self.w2,
+            )
+        else:
+            raise NotImplementedError(
+                "pre-SM90 Python MoE fallback does not support TP or EP"
+            )
+        if self.reduce_results:
+            if self.moe_tp_size > 1:
+                distributed.all_reduce_(output, "moe_tp")
+            if self.ep_size > 1:
+                distributed.all_reduce_(output, "moe_ep")
+        if token_counts is not None:
+            local_tokens = token_counts[self.dp_rank]
+            if local_tokens == 0:
+                return torch.zeros_like(local_hidden_states)
+            start = sum(token_counts[: self.dp_rank])
+            local_output = output.narrow(0, start, local_tokens)
+            if local_tokens == local_hidden_states.shape[0]:
+                return local_output
+            padding_shape = list(local_hidden_states.shape)
+            padding_shape[0] -= local_tokens
+            return torch.cat(
+                [local_output, local_hidden_states.new_zeros(padding_shape)], dim=0
+            )
+        return output

--- a/xllm/python/layers/gated_delta_net.py
+++ b/xllm/python/layers/gated_delta_net.py
@@ -1,0 +1,302 @@
+# Copyright 2026 The xLLM Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://github.com/xLLM-AI/xllm/blob/main/LICENSE
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Qwen3.5 gated delta network layer for the Python executor."""
+
+from __future__ import annotations
+
+from typing import Protocol
+
+import torch
+import torch.nn as nn
+
+from xllm.python import kernels
+from xllm.python.layers.linear import ColumnParallelLinear, RowParallelLinear
+from xllm.python.model_executor.forward_context import get_forward_context
+
+
+class GatedDeltaNetConfig(Protocol):
+    hidden_size: int
+    rms_norm_eps: float
+    linear_conv_kernel_dim: int
+    linear_key_head_dim: int
+    linear_value_head_dim: int
+    linear_num_key_heads: int
+    linear_num_value_heads: int
+    tp_size: int
+
+
+class Qwen3_5GatedDeltaNet(nn.Module):
+    def __init__(
+        self,
+        cfg: GatedDeltaNetConfig,
+        layer_id: int,
+        dtype: torch.dtype,
+        device: torch.device,
+    ) -> None:
+        super().__init__()
+        self.layer_id = layer_id
+        self.num_k_heads = cfg.linear_num_key_heads // cfg.tp_size
+        self.num_v_heads = cfg.linear_num_value_heads // cfg.tp_size
+        self.key_head_dim = cfg.linear_key_head_dim
+        self.value_head_dim = cfg.linear_value_head_dim
+        self.key_dim = self.num_k_heads * self.key_head_dim
+        self.value_dim = self.num_v_heads * self.value_head_dim
+        self.conv_dim = 2 * self.key_dim + self.value_dim
+        self.conv_kernel_size = cfg.linear_conv_kernel_dim
+        self.norm_eps = cfg.rms_norm_eps
+        self.gdn_prefill_backend = kernels.resolve_gdn_prefill_backend()
+
+        self.in_proj_qkv = ColumnParallelLinear(
+            cfg.hidden_size,
+            self.conv_dim,
+            cfg.tp_size,
+            dtype=dtype,
+            device=device,
+        )
+        self.in_proj_z = ColumnParallelLinear(
+            cfg.hidden_size,
+            self.value_dim,
+            cfg.tp_size,
+            dtype=dtype,
+            device=device,
+        )
+        self.in_proj_b = ColumnParallelLinear(
+            cfg.hidden_size,
+            self.num_v_heads,
+            cfg.tp_size,
+            dtype=dtype,
+            device=device,
+        )
+        self.in_proj_a = ColumnParallelLinear(
+            cfg.hidden_size,
+            self.num_v_heads,
+            cfg.tp_size,
+            dtype=dtype,
+            device=device,
+        )
+        self.conv1d_weight = nn.Parameter(
+            torch.empty(
+                self.conv_dim,
+                self.conv_kernel_size,
+                dtype=dtype,
+                device=device,
+            )
+        )
+        self.A_log = nn.Parameter(
+            torch.empty(self.num_v_heads, dtype=torch.float32, device=device)
+        )
+        self.dt_bias = nn.Parameter(
+            torch.empty(self.num_v_heads, dtype=dtype, device=device)
+        )
+        self.norm_weight = nn.Parameter(
+            torch.ones(self.value_head_dim, dtype=dtype, device=device)
+        )
+        self.out_proj = RowParallelLinear(
+            self.value_dim,
+            cfg.hidden_size,
+            cfg.tp_size,
+            dtype=dtype,
+            device=device,
+        )
+
+    def _cache(self):
+        cache = get_forward_context().layer_caches[self.layer_id]
+        if cache.conv is None or cache.ssm is None:
+            raise RuntimeError(
+                f"linear-attention cache is missing for layer {self.layer_id}"
+            )
+        return cache.conv, cache.ssm
+
+    def _conv_state_dim_first(self, conv_state: torch.Tensor) -> bool:
+        if conv_state.size(1) == self.conv_dim:
+            return True
+        if conv_state.size(2) == self.conv_dim:
+            return False
+        raise ValueError("linear-attention conv cache has an unexpected shape")
+
+    def _conv_prefill(
+        self,
+        mixed_qkv: torch.Tensor,
+        conv_state: torch.Tensor,
+        state_indices: torch.Tensor,
+        has_initial_state: torch.Tensor,
+        cu_seqlens: torch.Tensor,
+    ) -> torch.Tensor:
+        self._conv_state_dim_first(conv_state)
+        return kernels.causal_conv1d_prefill(
+            mixed_qkv,
+            self.conv1d_weight,
+            conv_state,
+            state_indices,
+            has_initial_state,
+            cu_seqlens,
+        )
+
+    def _conv_decode(
+        self,
+        mixed_qkv: torch.Tensor,
+        conv_state: torch.Tensor,
+        state_indices: torch.Tensor,
+    ) -> torch.Tensor:
+        self._conv_state_dim_first(conv_state)
+        return kernels.causal_conv1d_decode(
+            mixed_qkv,
+            self.conv1d_weight,
+            conv_state,
+            state_indices,
+        )
+
+    def _gdn_prefill(
+        self,
+        mixed_qkv: torch.Tensor,
+        a: torch.Tensor,
+        b: torch.Tensor,
+        ssm_state: torch.Tensor,
+        state_indices: torch.Tensor,
+        has_initial_state: torch.Tensor,
+        cu_seqlens: torch.Tensor,
+    ) -> torch.Tensor:
+        # TODO: Fuse cache gather/zero/scatter and null-row output masking into
+        # the GDN kernels. The current staging is intentionally kept for this
+        # correctness PR and should be removed in the next performance PR.
+        non_null_state = state_indices > 0
+        use_initial_state = non_null_state & has_initial_state
+        cache_indices = state_indices.to(torch.long)
+        null_state = ssm_state[0].clone()
+        initial_state = ssm_state.index_select(0, cache_indices).float().contiguous()
+        initial_state = torch.where(
+            use_initial_state[:, None, None, None],
+            initial_state,
+            torch.zeros_like(initial_state),
+        )
+        q, k, v, g, beta = kernels.fused_gdn_prefill_post_conv(
+            mixed_qkv=mixed_qkv,
+            a=a,
+            b=b,
+            a_log=self.A_log,
+            dt_bias=self.dt_bias,
+            num_key_heads=self.num_k_heads,
+            key_head_dim=self.key_head_dim,
+            value_head_dim=self.value_head_dim,
+        )
+        output, final_state = kernels.chunk_gated_delta_rule(
+            q,
+            k,
+            v.contiguous(),
+            g,
+            beta,
+            initial_state,
+            cu_seqlens,
+            self.gdn_prefill_backend,
+        )
+        sequence_lengths = cu_seqlens.diff().to(dtype=torch.long)
+        token_mask = torch.repeat_interleave(
+            non_null_state,
+            sequence_lengths,
+            output_size=mixed_qkv.shape[0],
+        )
+        output = torch.where(token_mask[:, None, None], output, 0.0)
+        ssm_state.index_copy_(
+            0,
+            cache_indices,
+            final_state.to(dtype=ssm_state.dtype),
+        )
+        ssm_state[0].copy_(null_state)
+        return output
+
+    def _gdn_decode(
+        self,
+        mixed_qkv: torch.Tensor,
+        a: torch.Tensor,
+        b: torch.Tensor,
+        ssm_state: torch.Tensor,
+        state_indices: torch.Tensor,
+    ) -> torch.Tensor:
+        output = kernels.fused_recurrent_gated_delta_rule_packed_decode(
+            mixed_qkv.contiguous(),
+            a.contiguous(),
+            b.contiguous(),
+            self.A_log,
+            self.dt_bias,
+            ssm_state,
+            state_indices.contiguous(),
+            self.key_head_dim**-0.5,
+        )
+        return output.view(-1, self.num_v_heads, self.value_head_dim)
+
+    def forward(self, hidden: torch.Tensor) -> torch.Tensor:
+        context = get_forward_context()
+        metadata = context.metadata
+        state_indices = metadata.linear_state_indices
+        if state_indices is None:
+            raise RuntimeError("linear_state_indices are required by Qwen3.5")
+        state_indices = state_indices.to(device=hidden.device, dtype=torch.int32)
+        has_initial_state = metadata.has_initial_state
+        cu_seqlens = metadata.q_cu_seq_lens
+        if cu_seqlens is None:
+            cu_seqlens = torch.arange(
+                state_indices.numel() + 1,
+                dtype=torch.int32,
+                device=hidden.device,
+            )
+
+        conv_state, ssm_state = self._cache()
+        mixed_qkv = self.in_proj_qkv(hidden)
+        z = self.in_proj_z(hidden).view(
+            -1, self.num_v_heads, self.value_head_dim
+        )
+        b = self.in_proj_b(hidden)
+        a = self.in_proj_a(hidden)
+        is_prefill = metadata.is_prefill or metadata.is_chunked_prefill
+        if is_prefill:
+            if has_initial_state is None:
+                raise RuntimeError(
+                    "has_initial_state is required by Qwen3.5 prefill"
+                )
+            has_initial_state = has_initial_state.to(
+                device=hidden.device, dtype=torch.bool
+            )
+            if has_initial_state.shape != state_indices.shape:
+                raise ValueError(
+                    "has_initial_state must match linear_state_indices"
+                )
+            mixed_qkv = self._conv_prefill(
+                mixed_qkv,
+                conv_state,
+                state_indices,
+                has_initial_state,
+                cu_seqlens,
+            )
+        else:
+            mixed_qkv = self._conv_decode(
+                mixed_qkv, conv_state, state_indices
+            )
+
+        if is_prefill:
+            output = self._gdn_prefill(
+                mixed_qkv,
+                a,
+                b,
+                ssm_state,
+                state_indices,
+                has_initial_state,
+                cu_seqlens,
+            )
+        else:
+            output = self._gdn_decode(
+                mixed_qkv, a, b, ssm_state, state_indices
+            )
+        output = kernels.rms_norm_gated(output, z, self.norm_weight, self.norm_eps)
+        return self.out_proj(output.reshape(-1, self.value_dim))

--- a/xllm/python/layers/gated_mlp.py
+++ b/xllm/python/layers/gated_mlp.py
@@ -1,0 +1,57 @@
+# Copyright 2026 The xLLM Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://github.com/xLLM-AI/xllm/blob/main/LICENSE
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tensor-parallel gated MLP shared by Python model implementations."""
+
+from __future__ import annotations
+
+import torch
+import torch.nn as nn
+
+from xllm.python import kernels
+from xllm.python.layers.linear import ColumnParallelLinear, RowParallelLinear
+
+
+class GatedMLP(nn.Module):
+    def __init__(
+        self,
+        hidden_size: int,
+        intermediate_size: int,
+        tp_size: int,
+        dtype: torch.dtype,
+        device: torch.device,
+        reduce_results: bool = True,
+    ) -> None:
+        super().__init__()
+        if intermediate_size % tp_size:
+            raise ValueError("intermediate_size must be divisible by tp_size")
+        local_intermediate_size = intermediate_size // tp_size
+        self.gate_up_proj = ColumnParallelLinear(
+            hidden_size,
+            2 * local_intermediate_size,
+            tp_size,
+            dtype=dtype,
+            device=device,
+        )
+        self.down_proj = RowParallelLinear(
+            local_intermediate_size,
+            hidden_size,
+            tp_size,
+            dtype=dtype,
+            device=device,
+            reduce_results=reduce_results,
+        )
+
+    def forward(self, hidden_states: torch.Tensor) -> torch.Tensor:
+        return self.down_proj(kernels.silu_and_mul(self.gate_up_proj(hidden_states)))

--- a/xllm/python/layers/layernorm.py
+++ b/xllm/python/layers/layernorm.py
@@ -47,3 +47,43 @@ class RMSNorm(nn.Module):
         if residual is None:
             return kernels.rms_norm(x, self.weight, self.eps)
         return kernels.fused_add_rms_norm(x, residual, self.weight, self.eps)
+
+
+class GemmaRMSNorm(nn.Module):
+    """Gemma-style RMSNorm used by Qwen3.5.
+
+    Checkpoints store the offset from one, so the effective scale is
+    ``1 + weight`` rather than ``weight``.
+    """
+
+    def __init__(
+        self,
+        dim: int,
+        eps: float = 1e-6,
+        dtype: torch.dtype | None = None,
+        device: torch.device | str | None = None,
+    ) -> None:
+        super().__init__()
+        self.eps = eps
+        self.weight = nn.Parameter(
+            torch.zeros(dim, dtype=torch.float32, device=device)
+        )
+
+    def forward(
+        self, x: torch.Tensor, residual: torch.Tensor | None = None
+    ) -> torch.Tensor | tuple[torch.Tensor, torch.Tensor]:
+        # TODO: Extend the fused RMSNorm/residual-add op with Gemma's FP32
+        # (weight + 1) semantics to remove eager decode kernels in a performance PR.
+        original_dtype = x.dtype
+        normalized = x.float()
+        if residual is not None:
+            normalized = normalized + residual.float()
+            residual = normalized.to(original_dtype)
+
+        variance = normalized.pow(2).mean(dim=-1, keepdim=True)
+        normalized = normalized * torch.rsqrt(variance + self.eps)
+        normalized = normalized * (self.weight + 1.0)
+        output = normalized.to(original_dtype)
+        if residual is None:
+            return output
+        return output, residual

--- a/xllm/python/layers/linear.py
+++ b/xllm/python/layers/linear.py
@@ -92,10 +92,18 @@ class RowParallelLinear(nn.Module):
         bias: bool = False,
         dtype: torch.dtype | None = None,
         device: torch.device | str | None = None,
+        reduce_results: bool = True,
     ) -> None:
         super().__init__()
         self.tp_size = tp_size
         self._weight_is_transposed = False
+        self.reduce_results = reduce_results
+        if bias and not reduce_results:
+            # The bias is replicated and must be added exactly once, which is
+            # only possible here when this layer owns the reduction.
+            raise ValueError(
+                "a deferred reduction cannot be combined with a replicated bias"
+            )
         self.weight = nn.Parameter(
             torch.empty(
                 out_features,
@@ -124,7 +132,7 @@ class RowParallelLinear(nn.Module):
             out = torch.matmul(x, self.weight)
         else:
             out = torch.nn.functional.linear(x, self.weight)
-        if self.tp_size > 1:
+        if self.tp_size > 1 and self.reduce_results:
             distributed.all_reduce_(out)
         if self.bias is not None:
             out = out + self.bias

--- a/xllm/python/model_executor/executor.py
+++ b/xllm/python/model_executor/executor.py
@@ -110,14 +110,17 @@ class ModelExecutor:
         self.inductor_runner = None
 
         graph_backend = _resolve_graph_backend(config)
-        if int(config.get("dp_size", 1)) > 1 and graph_backend not in (
+        dp_size = int(config.get("dp_size", 1))
+        dp_rank = int(config.get("dp_rank", 0))
+        if dp_size > 1 and graph_backend not in (
             "",
             "off",
             "none",
             "0",
+            "cudagraphs",
         ):
             raise NotImplementedError(
-                "Python data parallel execution currently supports eager mode only"
+                "Python data parallel graph execution supports cudagraphs only"
             )
         if graph_backend in ("", "off", "none", "0"):
             pass
@@ -131,6 +134,8 @@ class ModelExecutor:
                 device,
                 max_seqs_per_batch,
                 int(config["max_position_embeddings"]),
+                dp_size,
+                dp_rank,
             )
         elif graph_backend == "aclgraph":
             from xllm.python.model_executor.runners.decode_acl_graph import (

--- a/xllm/python/model_executor/executor.py
+++ b/xllm/python/model_executor/executor.py
@@ -17,7 +17,12 @@ from __future__ import annotations
 import torch
 import torch.nn as nn
 
-from xllm.python.attention.backend import AttentionBackend, AttentionMetadata, KVCache
+from xllm.python.attention.backend import (
+    AttentionBackend,
+    AttentionMetadata,
+    LayerCacheInput,
+    normalize_layer_caches,
+)
 from xllm.python.layers.attention import Attention
 from xllm.python.model_executor.forward_context import LayerSynchronizer
 from xllm.python.model_executor.runners.eager import EagerRunner
@@ -105,6 +110,15 @@ class ModelExecutor:
         self.inductor_runner = None
 
         graph_backend = _resolve_graph_backend(config)
+        if int(config.get("dp_size", 1)) > 1 and graph_backend not in (
+            "",
+            "off",
+            "none",
+            "0",
+        ):
+            raise NotImplementedError(
+                "Python data parallel execution currently supports eager mode only"
+            )
         if graph_backend in ("", "off", "none", "0"):
             pass
         elif graph_backend == "cudagraphs":
@@ -145,16 +159,28 @@ class ModelExecutor:
             layer.sliding_window,
         )
 
-    def bind_kv_caches(self, kv_caches: list[KVCache]) -> None:
-        if len(kv_caches) != self._num_attention_layers:
+    def bind_kv_caches(self, kv_caches: list[LayerCacheInput]) -> None:
+        layer_caches = normalize_layer_caches(kv_caches)
+        required_layers = max(
+            layer.layer_id
+            for layer in self.model.modules()
+            if isinstance(layer, Attention)
+        ) + 1
+        if len(layer_caches) < required_layers:
             raise ValueError(
-                "KV cache layer count does not match model attention layer count"
+                "cache layer count does not match the model layer layout"
             )
         if self._kv_bound:
             return
-        self.attention_backend.bind_kv_caches(kv_caches)
+        self.attention_backend.bind_kv_caches(layer_caches)
+        self.eager_runner.bind_layer_caches(layer_caches)
+        if self.decode_graph_runner is not None:
+            self.decode_graph_runner.bind_layer_caches(layer_caches)
+        if self.inductor_runner is not None:
+            self.inductor_runner.bind_layer_caches(layer_caches)
         self._kv_bound = True
 
+    @torch.inference_mode()
     def execute(
         self,
         input_ids: torch.Tensor,

--- a/xllm/python/model_executor/forward_context.py
+++ b/xllm/python/model_executor/forward_context.py
@@ -22,7 +22,11 @@ from typing import TYPE_CHECKING, Callable, Protocol
 import torch
 
 if TYPE_CHECKING:
-    from xllm.python.attention.backend import AttentionBackend
+    from xllm.python.attention.backend import (
+        AttentionBackend,
+        AttentionMetadata,
+        LayerCache,
+    )
 
 
 class LayerSynchronizer(Protocol):
@@ -54,6 +58,8 @@ class AclGraphCaptureContext:
 class ForwardContext:
     attention_backend: AttentionBackend
     device: torch.device
+    metadata: AttentionMetadata
+    layer_caches: list[LayerCache]
     acl_graph: AclGraphCaptureContext | None = None
     layer_synchronizer: LayerSynchronizer | None = None
 

--- a/xllm/python/model_executor/runners/base.py
+++ b/xllm/python/model_executor/runners/base.py
@@ -19,7 +19,7 @@ from abc import ABC, abstractmethod
 import torch
 import torch.nn as nn
 
-from xllm.python.attention.backend import AttentionBackend, AttentionMetadata
+from xllm.python.attention.backend import AttentionBackend, AttentionMetadata, LayerCache
 
 
 class BaseRunner(ABC):
@@ -29,6 +29,10 @@ class BaseRunner(ABC):
         self.model = model
         self.attention_backend = attention_backend
         self.device = device
+        self.layer_caches: list[LayerCache] = []
+
+    def bind_layer_caches(self, layer_caches: list[LayerCache]) -> None:
+        self.layer_caches = layer_caches
 
     @abstractmethod
     def execute(

--- a/xllm/python/model_executor/runners/decode_acl_graph.py
+++ b/xllm/python/model_executor/runners/decode_acl_graph.py
@@ -64,6 +64,8 @@ class _StaticAttentionMetadata:
     paged_kv_last_page_len_host: torch.Tensor | None = None
     block_table: torch.Tensor | None = None
     kv_seq_lens: torch.Tensor | None = None
+    linear_state_indices: torch.Tensor | None = None
+    has_initial_state: torch.Tensor | None = None
     is_prefill: bool = False
     is_chunked_prefill: bool = False
 
@@ -426,7 +428,12 @@ class DecodeAclGraphRunner(BaseRunner):
             ].fill_(int(cumulative_seq_lens[-1]))
 
     def _capture(self, entry: _DecodeGraphEntry) -> None:
-        context = ForwardContext(self.attention_backend, self.device)
+        context = ForwardContext(
+            self.attention_backend,
+            self.device,
+            entry.static_metadata,
+            self.layer_caches,
+        )
         with forward_context(context):
             for _ in range(_CAPTURE_WARMUP_STEPS):
                 self.model(entry.static_input_ids, entry.static_positions)
@@ -436,6 +443,8 @@ class DecodeAclGraphRunner(BaseRunner):
         context = ForwardContext(
             self.attention_backend,
             self.device,
+            entry.static_metadata,
+            self.layer_caches,
             acl_graph=capture_context,
         )
         with forward_context(context):

--- a/xllm/python/model_executor/runners/decode_cuda_graph.py
+++ b/xllm/python/model_executor/runners/decode_cuda_graph.py
@@ -56,6 +56,8 @@ class _StaticAttentionMetadata:
     paged_kv_last_page_len_host: torch.Tensor | None = None
     is_prefill: bool = False
     is_chunked_prefill: bool = False
+    linear_state_indices: torch.Tensor | None = None
+    has_initial_state: torch.Tensor | None = None
 
 
 class _DecodeGraphEntry:
@@ -158,7 +160,14 @@ class DecodeCudaGraphRunner(BaseRunner):
         with torch.cuda.stream(self._stream):
             self._fill_entry(entry, input_ids, positions, metadata, batch_size)
             self.attention_backend.prepare(entry.static_metadata, graph_mode=True)
-            with forward_context(ForwardContext(self.attention_backend, self.device)):
+            with forward_context(
+                ForwardContext(
+                    self.attention_backend,
+                    self.device,
+                    entry.static_metadata,
+                    self.layer_caches,
+                )
+            ):
                 if first_capture:
                     self._capture(entry)
                 entry.graph.replay()
@@ -218,6 +227,9 @@ class DecodeCudaGraphRunner(BaseRunner):
                 dtype=torch.int32,
                 device=device,
             ),
+            linear_state_indices=torch.zeros(
+                padded_batch_size, dtype=torch.int32, device=device
+            ),
             paged_kv_indptr_host=torch.zeros(
                 padded_batch_size + 1, dtype=torch.int32, device="cpu"
             ),
@@ -267,6 +279,13 @@ class DecodeCudaGraphRunner(BaseRunner):
             static_metadata.paged_kv_last_page_len,
             padded_batch_size,
         )
+        linear_state_indices = getattr(metadata, "linear_state_indices", None)
+        if linear_state_indices is not None:
+            static_metadata.linear_state_indices[:batch_size].copy_(
+                linear_state_indices
+            )
+        if padded_batch_size > batch_size:
+            static_metadata.linear_state_indices[batch_size:].zero_()
         self._fill_host_metadata(entry, metadata, batch_size)
 
     def _fill_host_metadata(

--- a/xllm/python/model_executor/runners/decode_cuda_graph.py
+++ b/xllm/python/model_executor/runners/decode_cuda_graph.py
@@ -42,6 +42,14 @@ def _decode_bucket(batch_size: int) -> int:
     return ((batch_size + 15) // 16) * 16
 
 
+def _decode_graph_buckets(max_batch: int, dp_size: int) -> list[int]:
+    max_local_batch = (max_batch + dp_size - 1) // dp_size
+    max_graph_batch = min(_decode_bucket(max_local_batch), max_batch)
+    buckets = [size for size in (1, 2, 4, 8) if size <= max_graph_batch]
+    buckets.extend(range(16, max_graph_batch + 1, 16))
+    return buckets
+
+
 @dataclass(slots=True)
 class _StaticAttentionMetadata:
     slot_mapping: torch.Tensor
@@ -58,6 +66,7 @@ class _StaticAttentionMetadata:
     is_chunked_prefill: bool = False
     linear_state_indices: torch.Tensor | None = None
     has_initial_state: torch.Tensor | None = None
+    dp_token_counts: tuple[int, ...] = ()
 
 
 class _DecodeGraphEntry:
@@ -82,11 +91,19 @@ class DecodeCudaGraphRunner(BaseRunner):
         device: torch.device,
         max_batch: int,
         max_model_len: int,
+        dp_size: int = 1,
+        dp_rank: int = 0,
     ) -> None:
         super().__init__(model, attention_backend, device)
+        if dp_size <= 0:
+            raise ValueError("dp_size must be positive")
+        if not 0 <= dp_rank < dp_size:
+            raise ValueError("dp_rank must be in [0, dp_size)")
         self.max_batch = max_batch
         self.max_model_len = max_model_len
-        self._graphs: dict[int, _DecodeGraphEntry] = {}
+        self.dp_size = dp_size
+        self.dp_rank = dp_rank
+        self._graphs: dict[tuple[int, tuple[int, ...]], _DecodeGraphEntry] = {}
         self._paged_kv_indices_buffer: torch.Tensor | None = None
         self._stream: torch.cuda.Stream | None = None
         self._warmed_up = False
@@ -94,20 +111,24 @@ class DecodeCudaGraphRunner(BaseRunner):
     def can_execute(
         self, input_ids: torch.Tensor, metadata: AttentionMetadata
     ) -> bool:
+        graph_key = self._graph_key(input_ids, metadata)
         return (
             not metadata.is_prefill
             and not metadata.is_chunked_prefill
-            and _decode_bucket(input_ids.shape[0]) <= self.max_batch
+            and graph_key is not None
+            and graph_key in self._graphs
         )
 
     def warmup(self, device: torch.device, _dtype: torch.dtype) -> None:
         if self._warmed_up:
             return
-        self._warmed_up = True
 
-        buckets = [size for size in (1, 2, 4, 8) if size <= self.max_batch]
-        buckets.extend(range(16, self.max_batch + 1, 16))
-        for batch_size in buckets:
+        if self._stream is None:
+            self._stream = torch.cuda.Stream(device=device)
+        self._stream.wait_stream(torch.cuda.current_stream())
+        for batch_size in reversed(
+            _decode_graph_buckets(self.max_batch, self.dp_size)
+        ):
             metadata = _StaticAttentionMetadata(
                 slot_mapping=torch.zeros(
                     batch_size, dtype=torch.int32, device=device
@@ -127,12 +148,40 @@ class DecodeCudaGraphRunner(BaseRunner):
                 kv_cu_seq_lens=torch.arange(
                     batch_size + 1, dtype=torch.int32, device=device
                 ),
+                dp_token_counts=(batch_size,) * self.dp_size,
             )
-            self.execute(
-                torch.zeros(batch_size, dtype=torch.int32, device=device),
-                torch.zeros(batch_size, dtype=torch.int32, device=device),
+            input_ids = torch.zeros(batch_size, dtype=torch.int32, device=device)
+            positions = torch.zeros(batch_size, dtype=torch.int32, device=device)
+            graph_key = self._graph_key(input_ids, metadata)
+            if graph_key is None:
+                raise RuntimeError("invalid decode CUDA graph warmup bucket")
+            entry = self._allocate_entry(
+                batch_size,
+                input_ids,
+                positions,
                 metadata,
+                graph_key[1],
             )
+            with torch.cuda.stream(self._stream):
+                self._fill_entry(
+                    entry, input_ids, positions, metadata, batch_size
+                )
+                self.attention_backend.prepare(
+                    entry.static_metadata, graph_mode=True
+                )
+                with forward_context(
+                    ForwardContext(
+                        self.attention_backend,
+                        self.device,
+                        entry.static_metadata,
+                        self.layer_caches,
+                    )
+                ):
+                    self._capture(entry)
+            self._graphs[graph_key] = entry
+
+        torch.cuda.current_stream().wait_stream(self._stream)
+        self._warmed_up = True
 
     def execute(
         self,
@@ -141,17 +190,14 @@ class DecodeCudaGraphRunner(BaseRunner):
         metadata: AttentionMetadata,
     ) -> torch.Tensor:
         batch_size = input_ids.shape[0]
-        padded_batch_size = _decode_bucket(batch_size)
-        if padded_batch_size > self.max_batch:
+        graph_key = self._graph_key(input_ids, metadata)
+        if graph_key is None:
             raise ValueError("decode batch exceeds CUDA graph capacity")
+        padded_batch_size, _ = graph_key
 
-        entry = self._graphs.get(padded_batch_size)
-        first_capture = entry is None
-        if first_capture:
-            entry = self._allocate_entry(
-                padded_batch_size, input_ids, positions, metadata
-            )
-            self._graphs[padded_batch_size] = entry
+        entry = self._graphs.get(graph_key)
+        if entry is None:
+            raise RuntimeError("decode CUDA graph bucket was not warmed up")
 
         if self._stream is None:
             self._stream = torch.cuda.Stream(device=input_ids.device)
@@ -168,13 +214,38 @@ class DecodeCudaGraphRunner(BaseRunner):
                     self.layer_caches,
                 )
             ):
-                if first_capture:
-                    self._capture(entry)
                 entry.graph.replay()
                 output = entry.static_output[:batch_size].clone()
 
         torch.cuda.current_stream().wait_stream(self._stream)
         return output
+
+    def _graph_key(
+        self,
+        input_ids: torch.Tensor,
+        metadata: AttentionMetadata,
+    ) -> tuple[int, tuple[int, ...]] | None:
+        max_graph_batch = _decode_graph_buckets(
+            self.max_batch, self.dp_size
+        )[-1]
+        if self.dp_size == 1:
+            padded_batch_size = _decode_bucket(input_ids.shape[0])
+            if padded_batch_size > max_graph_batch:
+                return None
+            return padded_batch_size, (padded_batch_size,)
+
+        dp_token_counts = tuple(int(count) for count in metadata.dp_token_counts)
+        if len(dp_token_counts) != self.dp_size:
+            return None
+        if any(count < 0 for count in dp_token_counts):
+            return None
+        if dp_token_counts[self.dp_rank] > input_ids.shape[0]:
+            return None
+        global_batch_size = max(max(dp_token_counts, default=0), input_ids.shape[0])
+        padded_batch_size = _decode_bucket(global_batch_size)
+        if padded_batch_size > max_graph_batch:
+            return None
+        return padded_batch_size, (padded_batch_size,) * self.dp_size
 
     def _allocate_entry(
         self,
@@ -182,6 +253,7 @@ class DecodeCudaGraphRunner(BaseRunner):
         input_ids: torch.Tensor,
         positions: torch.Tensor,
         metadata: AttentionMetadata,
+        dp_token_counts: tuple[int, ...],
     ) -> _DecodeGraphEntry:
         device = input_ids.device
         if self._paged_kv_indices_buffer is None:
@@ -230,6 +302,7 @@ class DecodeCudaGraphRunner(BaseRunner):
             linear_state_indices=torch.zeros(
                 padded_batch_size, dtype=torch.int32, device=device
             ),
+            dp_token_counts=dp_token_counts,
             paged_kv_indptr_host=torch.zeros(
                 padded_batch_size + 1, dtype=torch.int32, device="cpu"
             ),

--- a/xllm/python/model_executor/runners/eager.py
+++ b/xllm/python/model_executor/runners/eager.py
@@ -36,7 +36,10 @@ class EagerRunner(BaseRunner):
         self.attention_backend.prepare(metadata)
         with forward_context(
             ForwardContext(
-                self.attention_backend, self.device,
+                self.attention_backend,
+                self.device,
+                metadata,
+                self.layer_caches,
                 layer_synchronizer=layer_synchronizer,
             )
         ):

--- a/xllm/python/model_executor/runners/inductor.py
+++ b/xllm/python/model_executor/runners/inductor.py
@@ -40,7 +40,10 @@ class InductorRunner(BaseRunner):
         self.attention_backend.prepare(metadata)
         with forward_context(
             ForwardContext(
-                self.attention_backend, self.device,
+                self.attention_backend,
+                self.device,
+                metadata,
+                self.layer_caches,
                 layer_synchronizer=layer_synchronizer,
             )
         ):

--- a/xllm/python/models/qwen3.py
+++ b/xllm/python/models/qwen3.py
@@ -33,6 +33,7 @@ from xllm.python import kernels
 from xllm.python.layers import (
     Attention,
     ColumnParallelLinear,
+    GatedMLP,
     HiddenParallelEmbedding,
     RMSNorm,
     RotaryEmbedding,
@@ -114,35 +115,6 @@ class Qwen3Config:
             num_kv_heads = 1
             replicas = tp // self.n_kv_heads
         return num_heads, num_kv_heads, replicas
-
-
-class Qwen3MLP(nn.Module):
-    def __init__(
-        self, cfg: Qwen3Config, dtype: torch.dtype, device: torch.device
-    ) -> None:
-        super().__init__()
-        tp = cfg.tp_size
-        assert cfg.intermediate_size % tp == 0
-        inter_per_rank = cfg.intermediate_size // tp
-        self.gate_up_proj = ColumnParallelLinear(
-            cfg.hidden_size,
-            2 * inter_per_rank,
-            tp,
-            dtype=dtype,
-            device=device,
-        )
-        self.down_proj = RowParallelLinear(
-            inter_per_rank,
-            cfg.hidden_size,
-            tp,
-            dtype=dtype,
-            device=device,
-        )
-
-    def forward(self, x: torch.Tensor) -> torch.Tensor:
-        gate_up = self.gate_up_proj(x)
-        act = kernels.silu_and_mul(gate_up)
-        return self.down_proj(act)
 
 
 class Qwen3Attention(nn.Module):
@@ -236,7 +208,13 @@ class Qwen3DecoderLayer(nn.Module):
         self.post_attention_layernorm = RMSNorm(
             cfg.hidden_size, cfg.rms_norm_eps, dtype=dtype, device=device
         )
-        self.mlp = Qwen3MLP(cfg, dtype, device)
+        self.mlp = GatedMLP(
+            cfg.hidden_size,
+            cfg.intermediate_size,
+            cfg.tp_size,
+            dtype,
+            device,
+        )
 
     def forward(
         self,

--- a/xllm/python/models/qwen3_5.py
+++ b/xllm/python/models/qwen3_5.py
@@ -1,0 +1,681 @@
+# Copyright 2025-2026 The xLLM Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://github.com/xLLM-AI/xllm/blob/main/LICENSE
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Qwen3.5 hybrid-attention causal LM for the Python executor."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Optional, Tuple
+
+import torch
+import torch.nn as nn
+
+from xllm.python import distributed
+from xllm.python.layers import (
+    Attention,
+    ColumnParallelLinear,
+    FusedMoE,
+    GatedMLP,
+    GemmaRMSNorm,
+    HiddenParallelEmbedding,
+    RowParallelLinear,
+)
+from xllm.python.layers.gated_delta_net import Qwen3_5GatedDeltaNet
+from xllm.python.models.base import PyModelBase
+
+
+@dataclass
+class Qwen3_5Config:
+    hidden_size: int
+    n_layers: int
+    n_heads: int
+    n_kv_heads: int
+    head_dim: int
+    intermediate_size: int
+    rms_norm_eps: float
+    rope_theta: float
+    partial_rotary_factor: float
+    max_position_embeddings: int
+    vocab_size: int
+    layer_types: list[str]
+    linear_conv_kernel_dim: int
+    linear_key_head_dim: int
+    linear_value_head_dim: int
+    linear_num_key_heads: int
+    linear_num_value_heads: int
+    attention_bias: bool
+    attn_output_gate: bool
+    tie_word_embeddings: bool
+    num_experts: int
+    num_experts_per_tok: int
+    decoder_sparse_step: int
+    mlp_only_layers: list[int]
+    norm_topk_prob: bool
+    moe_intermediate_size: int
+    shared_expert_intermediate_size: int
+    tp_size: int
+    tp_rank: int
+    dp_size: int
+    dp_rank: int
+    world_size: int
+    moe_tp_size: int
+    moe_tp_rank: int
+    ep_size: int
+    ep_rank: int
+
+    @classmethod
+    def from_dict(cls, d: dict) -> "Qwen3_5Config":
+        def pick(*keys, default=None):
+            for key in keys:
+                if key in d and d[key] is not None:
+                    return d[key]
+            return default
+
+        n_layers = int(pick("n_layers", "num_hidden_layers", default=0))
+        interval = int(pick("full_attention_interval", default=4))
+        layer_types = list(pick("layer_types", default=[]))
+        if not layer_types:
+            layer_types = [
+                "full_attention" if (i + 1) % interval == 0 else "linear_attention"
+                for i in range(n_layers)
+            ]
+        if len(layer_types) != n_layers:
+            raise ValueError("layer_types must contain one entry per hidden layer")
+
+        hidden_size = int(pick("hidden_size", default=0))
+        n_heads = int(pick("n_heads", "num_attention_heads", default=0))
+        tp_size = int(pick("tp_size", default=1))
+        dp_size = int(pick("dp_size", default=1))
+        world_size = int(pick("world_size", default=tp_size * dp_size))
+        ep_size = int(pick("ep_size", default=1))
+        return cls(
+            hidden_size=hidden_size,
+            n_layers=n_layers,
+            n_heads=n_heads,
+            n_kv_heads=int(pick("n_kv_heads", "num_key_value_heads", default=0)),
+            head_dim=int(pick("head_dim", default=hidden_size // n_heads)),
+            intermediate_size=int(pick("intermediate_size", default=0)),
+            rms_norm_eps=float(pick("rms_norm_eps", default=1e-6)),
+            rope_theta=float(pick("rope_theta", default=1e7)),
+            partial_rotary_factor=float(pick("partial_rotary_factor", default=0.25)),
+            max_position_embeddings=int(
+                pick("max_position_embeddings", default=262144)
+            ),
+            vocab_size=int(pick("vocab_size", default=248320)),
+            layer_types=layer_types,
+            linear_conv_kernel_dim=int(pick("linear_conv_kernel_dim", default=4)),
+            linear_key_head_dim=int(pick("linear_key_head_dim", default=128)),
+            linear_value_head_dim=int(pick("linear_value_head_dim", default=128)),
+            linear_num_key_heads=int(pick("linear_num_key_heads", default=16)),
+            linear_num_value_heads=int(pick("linear_num_value_heads", default=32)),
+            attention_bias=bool(pick("attention_bias", default=False)),
+            attn_output_gate=bool(pick("attn_output_gate", default=True)),
+            tie_word_embeddings=bool(pick("tie_word_embeddings", default=False)),
+            num_experts=int(pick("num_experts", "n_routed_experts", default=0)),
+            num_experts_per_tok=int(pick("num_experts_per_tok", default=0)),
+            decoder_sparse_step=int(pick("decoder_sparse_step", default=1)),
+            mlp_only_layers=[
+                int(layer_id)
+                for layer_id in pick("mlp_only_layers", default=[])
+            ],
+            norm_topk_prob=bool(pick("norm_topk_prob", default=True)),
+            moe_intermediate_size=int(pick("moe_intermediate_size", default=0)),
+            shared_expert_intermediate_size=int(
+                pick("shared_expert_intermediate_size", default=0)
+            ),
+            tp_size=tp_size,
+            tp_rank=int(pick("tp_rank", default=0)),
+            dp_size=dp_size,
+            dp_rank=int(pick("dp_rank", default=0)),
+            world_size=world_size,
+            moe_tp_size=int(
+                pick("moe_tp_size", default=world_size // max(ep_size, 1))
+            ),
+            moe_tp_rank=int(pick("moe_tp_rank", default=0)),
+            ep_size=ep_size,
+            ep_rank=int(pick("ep_rank", default=0)),
+        )
+
+    def validate(self) -> None:
+        if self.hidden_size <= 0 or self.n_heads <= 0 or self.n_layers <= 0:
+            raise ValueError("invalid Qwen3.5 model dimensions")
+        if min(self.tp_size, self.dp_size, self.moe_tp_size, self.ep_size) <= 0:
+            raise ValueError("parallel sizes must be positive")
+        if self.tp_size * self.dp_size != self.world_size:
+            raise ValueError("world_size must equal tp_size * dp_size")
+        if self.ep_size not in (1, self.world_size):
+            raise ValueError("Qwen3.5 Python supports only ep_size=1 or world_size")
+        if self.moe_tp_size * self.ep_size != self.world_size:
+            raise ValueError("world_size must equal moe_tp_size * ep_size")
+        if not 0 <= self.dp_rank < self.dp_size:
+            raise ValueError("dp_rank must be in [0, dp_size)")
+        if not 0 <= self.tp_rank < self.tp_size:
+            raise ValueError("tp_rank must be in [0, tp_size)")
+        if not 0 <= self.moe_tp_rank < self.moe_tp_size:
+            raise ValueError("moe_tp_rank must be in [0, moe_tp_size)")
+        if not 0 <= self.ep_rank < self.ep_size:
+            raise ValueError("ep_rank must be in [0, ep_size)")
+        for name, count in (
+            ("attention heads", self.n_heads),
+            ("linear key heads", self.linear_num_key_heads),
+            ("linear value heads", self.linear_num_value_heads),
+        ):
+            if count % self.tp_size:
+                raise ValueError(f"{name} must be divisible by tp_size")
+        if self.decoder_sparse_step <= 0:
+            raise ValueError("decoder_sparse_step must be positive")
+        if self.num_experts:
+            if self.num_experts_per_tok <= 0:
+                raise ValueError("num_experts_per_tok must be positive for MoE")
+            if self.num_experts % self.ep_size:
+                raise ValueError("num_experts must be divisible by ep_size")
+            if self.moe_intermediate_size <= 0:
+                raise ValueError("moe_intermediate_size must be positive for MoE")
+            if self.moe_intermediate_size % self.moe_tp_size:
+                raise ValueError(
+                    "moe_intermediate_size must be divisible by moe_tp_size"
+                )
+            if self.shared_expert_intermediate_size <= 0:
+                raise ValueError(
+                    "shared_expert_intermediate_size must be positive for Qwen3.5 MoE"
+                )
+
+    def is_moe_layer(self, layer_id: int) -> bool:
+        return (
+            self.num_experts > 0
+            and (layer_id + 1) % self.decoder_sparse_step == 0
+            and layer_id not in self.mlp_only_layers
+        )
+
+    def full_head_split(self) -> Tuple[int, int, int]:
+        num_heads = self.n_heads // self.tp_size
+        if self.n_kv_heads >= self.tp_size:
+            if self.n_kv_heads % self.tp_size:
+                raise ValueError("num_key_value_heads must be divisible by tp_size")
+            return num_heads, self.n_kv_heads // self.tp_size, 1
+        if self.tp_size % self.n_kv_heads:
+            raise ValueError("tp_size must be divisible by num_key_value_heads")
+        return num_heads, 1, self.tp_size // self.n_kv_heads
+
+
+class Qwen3_5SparseMoEBlock(nn.Module):
+    def __init__(
+        self, cfg: Qwen3_5Config, dtype: torch.dtype, device: torch.device
+    ) -> None:
+        super().__init__()
+        # The routed and shared branches each produce a partial sum over the same
+        # set of ranks whenever every group spans the whole world, and the gate is
+        # computed from replicated hidden states so it is bit-identical on every
+        # rank. Summing first then reducing once is therefore exact, and removes
+        # one of the three all-reduces this block would otherwise issue per layer.
+        # With dp_size > 1 the groups no longer coincide, so each branch keeps its
+        # own reduction.
+        self.fuse_reductions = cfg.dp_size == 1 and cfg.tp_size > 1
+        self.experts = FusedMoE(
+            hidden_size=cfg.hidden_size,
+            intermediate_size=cfg.moe_intermediate_size,
+            num_experts=cfg.num_experts,
+            top_k=cfg.num_experts_per_tok,
+            renormalize=cfg.norm_topk_prob,
+            moe_tp_size=cfg.moe_tp_size,
+            moe_tp_rank=cfg.moe_tp_rank,
+            ep_size=cfg.ep_size,
+            ep_rank=cfg.ep_rank,
+            dp_size=cfg.dp_size,
+            dp_rank=cfg.dp_rank,
+            dtype=dtype,
+            device=device,
+            reduce_results=not self.fuse_reductions,
+        )
+        self.shared_expert = GatedMLP(
+            cfg.hidden_size,
+            cfg.shared_expert_intermediate_size,
+            cfg.tp_size,
+            dtype,
+            device,
+            reduce_results=not self.fuse_reductions,
+        )
+        self.shared_expert_gate = nn.Linear(
+            cfg.hidden_size, 1, bias=False, dtype=dtype, device=device
+        )
+
+    def forward(self, hidden: torch.Tensor) -> torch.Tensor:
+        routed = self.experts(hidden)
+        shared = self.shared_expert(hidden)
+        shared_gate = torch.sigmoid(self.shared_expert_gate(hidden))
+        output = routed + shared * shared_gate
+        if self.fuse_reductions:
+            distributed.all_reduce_(output)
+        return output
+
+
+class PartialRotaryEmbedding(nn.Module):
+    def __init__(
+        self,
+        head_dim: int,
+        rotary_dim: int,
+        max_position: int,
+        rope_theta: float,
+        dtype: torch.dtype,
+        device: torch.device,
+    ) -> None:
+        super().__init__()
+        if rotary_dim <= 0 or rotary_dim % 2:
+            raise ValueError("partial rotary dimension must be positive and even")
+        self.head_dim = head_dim
+        self.rotary_dim = rotary_dim
+        inv_freq = 1.0 / (
+            rope_theta
+            ** (
+                torch.arange(0, rotary_dim, 2, dtype=torch.float32, device=device)
+                / rotary_dim
+            )
+        )
+        freqs = torch.outer(
+            torch.arange(max_position, dtype=torch.float32, device=device), inv_freq
+        )
+        self.register_buffer("cos", freqs.cos().to(dtype), persistent=False)
+        self.register_buffer("sin", freqs.sin().to(dtype), persistent=False)
+
+    @staticmethod
+    def _rotate_half(x: torch.Tensor) -> torch.Tensor:
+        first, second = x.chunk(2, dim=-1)
+        return torch.cat((-second, first), dim=-1)
+
+    def forward(self, positions: torch.Tensor, x: torch.Tensor) -> torch.Tensor:
+        rotary, passthrough = x.split(
+            [self.rotary_dim, self.head_dim - self.rotary_dim], dim=-1
+        )
+        pos = positions.to(torch.long)
+        cos = torch.cat((self.cos[pos], self.cos[pos]), dim=-1).unsqueeze(1)
+        sin = torch.cat((self.sin[pos], self.sin[pos]), dim=-1).unsqueeze(1)
+        rotary = rotary * cos + self._rotate_half(rotary) * sin
+        return torch.cat((rotary, passthrough), dim=-1)
+
+
+class Qwen3_5Attention(nn.Module):
+    def __init__(
+        self,
+        cfg: Qwen3_5Config,
+        layer_id: int,
+        dtype: torch.dtype,
+        device: torch.device,
+        rotary: PartialRotaryEmbedding,
+    ) -> None:
+        super().__init__()
+        self.layer_id = layer_id
+        self.num_heads, self.num_kv_heads, _ = cfg.full_head_split()
+        self.head_dim = cfg.head_dim
+        self.q_size = self.num_heads * self.head_dim
+        self.kv_size = self.num_kv_heads * self.head_dim
+        q_multiplier = 2 if cfg.attn_output_gate else 1
+        self.attn_output_gate = cfg.attn_output_gate
+        self.qkv_proj = ColumnParallelLinear(
+            cfg.hidden_size,
+            q_multiplier * self.q_size + 2 * self.kv_size,
+            cfg.tp_size,
+            bias=cfg.attention_bias,
+            dtype=dtype,
+            device=device,
+        )
+        self.o_proj = RowParallelLinear(
+            self.q_size,
+            cfg.hidden_size,
+            cfg.tp_size,
+            bias=cfg.attention_bias,
+            dtype=dtype,
+            device=device,
+        )
+        self.q_norm = GemmaRMSNorm(
+            self.head_dim, cfg.rms_norm_eps, dtype=dtype, device=device
+        )
+        self.k_norm = GemmaRMSNorm(
+            self.head_dim, cfg.rms_norm_eps, dtype=dtype, device=device
+        )
+        self.rotary = rotary
+        self.attn = Attention(
+            self.num_heads,
+            self.num_kv_heads,
+            self.head_dim,
+            self.head_dim**-0.5,
+            0,
+            layer_id,
+        )
+
+    def forward(self, positions: torch.Tensor, hidden: torch.Tensor) -> torch.Tensor:
+        qkv = self.qkv_proj(hidden)
+        if self.attn_output_gate:
+            q_gate, k, v = qkv.split(
+                [2 * self.q_size, self.kv_size, self.kv_size], dim=-1
+            )
+            q_gate = q_gate.view(-1, self.num_heads, 2 * self.head_dim)
+            q, gate = q_gate.chunk(2, dim=-1)
+        else:
+            q, k, v = qkv.split(
+                [self.q_size, self.kv_size, self.kv_size], dim=-1
+            )
+            q = q.view(-1, self.num_heads, self.head_dim)
+            gate = None
+        k = k.view(-1, self.num_kv_heads, self.head_dim)
+        q = self.q_norm(q)
+        k = self.k_norm(k)
+        q = self.rotary(positions, q).reshape(-1, self.q_size)
+        k = self.rotary(positions, k).reshape(-1, self.kv_size)
+        output = self.attn(q, k, v)
+        if gate is not None:
+            output = output * torch.sigmoid(gate.reshape(-1, self.q_size))
+        return self.o_proj(output)
+
+
+class Qwen3_5DecoderLayer(nn.Module):
+    def __init__(
+        self,
+        cfg: Qwen3_5Config,
+        layer_id: int,
+        dtype: torch.dtype,
+        device: torch.device,
+        rotary: PartialRotaryEmbedding,
+    ) -> None:
+        super().__init__()
+        self.layer_type = cfg.layer_types[layer_id]
+        self.input_layernorm = GemmaRMSNorm(
+            cfg.hidden_size, cfg.rms_norm_eps, dtype=dtype, device=device
+        )
+        if self.layer_type == "full_attention":
+            self.self_attn = Qwen3_5Attention(
+                cfg, layer_id, dtype, device, rotary
+            )
+        elif self.layer_type == "linear_attention":
+            self.linear_attn = Qwen3_5GatedDeltaNet(cfg, layer_id, dtype, device)
+        else:
+            raise ValueError(f"unsupported Qwen3.5 layer type: {self.layer_type}")
+        self.post_attention_layernorm = GemmaRMSNorm(
+            cfg.hidden_size, cfg.rms_norm_eps, dtype=dtype, device=device
+        )
+        if cfg.is_moe_layer(layer_id):
+            self.mlp = Qwen3_5SparseMoEBlock(cfg, dtype, device)
+        else:
+            self.mlp = GatedMLP(
+                cfg.hidden_size,
+                cfg.intermediate_size,
+                cfg.tp_size,
+                dtype,
+                device,
+            )
+
+    def forward(
+        self,
+        hidden: torch.Tensor,
+        residual: Optional[torch.Tensor],
+        positions: torch.Tensor,
+    ) -> Tuple[torch.Tensor, torch.Tensor]:
+        if residual is None:
+            residual = hidden
+            hidden = self.input_layernorm(hidden)
+        else:
+            hidden, residual = self.input_layernorm(hidden, residual)
+        if self.layer_type == "full_attention":
+            hidden = self.self_attn(positions, hidden)
+        else:
+            hidden = self.linear_attn(hidden)
+        hidden, residual = self.post_attention_layernorm(hidden, residual)
+        return self.mlp(hidden), residual
+
+
+class Qwen3_5Model(nn.Module):
+    def __init__(
+        self, cfg: Qwen3_5Config, dtype: torch.dtype, device: torch.device
+    ) -> None:
+        super().__init__()
+        if cfg.hidden_size % cfg.tp_size:
+            raise ValueError("hidden_size must be divisible by tp_size")
+        self.embed_tokens = HiddenParallelEmbedding(
+            cfg.vocab_size,
+            cfg.hidden_size // cfg.tp_size,
+            cfg.tp_size,
+            dtype=dtype,
+            device=device,
+        )
+        rotary_dim = int(cfg.head_dim * cfg.partial_rotary_factor)
+        self.rotary = PartialRotaryEmbedding(
+            cfg.head_dim,
+            rotary_dim,
+            cfg.max_position_embeddings,
+            cfg.rope_theta,
+            dtype,
+            device,
+        )
+        self.layers = nn.ModuleList(
+            Qwen3_5DecoderLayer(cfg, i, dtype, device, self.rotary)
+            for i in range(cfg.n_layers)
+        )
+        self.norm = GemmaRMSNorm(
+            cfg.hidden_size, cfg.rms_norm_eps, dtype=dtype, device=device
+        )
+
+    def forward(self, input_ids: torch.Tensor, positions: torch.Tensor) -> torch.Tensor:
+        hidden = self.embed_tokens(input_ids)
+        residual: Optional[torch.Tensor] = None
+        for layer in self.layers:
+            hidden, residual = layer(hidden, residual, positions)
+        hidden, _ = self.norm(hidden, residual)
+        return hidden
+
+
+class Qwen3_5ForCausalLM(PyModelBase):
+    def __init__(self, config: dict) -> None:
+        super().__init__()
+        self.cfg = Qwen3_5Config.from_dict(config)
+        self.cfg.validate()
+        dtype = self.resolve_dtype(config.get("dtype") or config.get("torch_dtype"))
+        device = torch.device(config.get("device", "cuda"))
+        self.dtype = dtype
+        self.device = device
+        if self.cfg.vocab_size % self.cfg.tp_size:
+            raise ValueError("vocab_size must be divisible by tp_size")
+        self.model = Qwen3_5Model(self.cfg, dtype, device)
+        self.lm_head = ColumnParallelLinear(
+            self.cfg.hidden_size,
+            self.cfg.vocab_size // self.cfg.tp_size,
+            self.cfg.tp_size,
+            gather_output=True,
+            dtype=dtype,
+            device=device,
+        )
+
+    def load_weights(self, state_dicts: list, tp_rank: int, tp_size: int) -> None:
+        cfg = self.cfg
+
+        def find(name: str):
+            for state_dict in state_dicts:
+                if state_dict.has(name):
+                    return state_dict
+            return None
+
+        prefixes = ("model.language_model.", "model.", "")
+        model_prefix = next(
+            (prefix for prefix in prefixes if find(prefix + "embed_tokens.weight")),
+            None,
+        )
+        if model_prefix is None:
+            raise KeyError("Qwen3.5 embedding weight was not found")
+
+        def tensor(name: str) -> torch.Tensor:
+            state_dict = find(name)
+            if state_dict is None:
+                raise KeyError(f"checkpoint tensor not found: {name}")
+            return state_dict.get_tensor(name)
+
+        def shard_tensor(
+            name: str, dim: int, rank: int = tp_rank, world: int = tp_size
+        ) -> torch.Tensor:
+            value = tensor(name)
+            if world == 1:
+                return value
+            if value.size(dim) % world:
+                raise ValueError(f"cannot shard {name} across {world} ranks")
+            return value.chunk(world, dim=dim)[rank].contiguous()
+
+        def copy_in(name: str, value: torch.Tensor) -> None:
+            parameter = self.get_parameter(name)
+            parameter.data.copy_(value)
+
+        def shard_kv(name: str, dim: int = 0) -> torch.Tensor:
+            if cfg.n_kv_heads >= tp_size:
+                return shard_tensor(name, dim)
+            replicas = tp_size // cfg.n_kv_heads
+            return shard_tensor(name, dim, tp_rank // replicas, cfg.n_kv_heads)
+
+        copy_in(
+            "model.embed_tokens.weight",
+            shard_tensor(model_prefix + "embed_tokens.weight", 1),
+        )
+        for layer_id, layer_type in enumerate(cfg.layer_types):
+            source = f"{model_prefix}layers.{layer_id}."
+            target = f"model.layers.{layer_id}."
+            for norm in ("input_layernorm.weight", "post_attention_layernorm.weight"):
+                copy_in(target + norm, tensor(source + norm))
+
+            if layer_type == "full_attention":
+                q = shard_tensor(source + "self_attn.q_proj.weight", 0)
+                k = shard_kv(source + "self_attn.k_proj.weight")
+                v = shard_kv(source + "self_attn.v_proj.weight")
+                copy_in(target + "self_attn.qkv_proj.weight", torch.cat((q, k, v)))
+                copy_in(
+                    target + "self_attn.o_proj.weight",
+                    shard_tensor(source + "self_attn.o_proj.weight", 1),
+                )
+                if cfg.attention_bias:
+                    q_bias = shard_tensor(source + "self_attn.q_proj.bias", 0)
+                    k_bias = shard_kv(source + "self_attn.k_proj.bias")
+                    v_bias = shard_kv(source + "self_attn.v_proj.bias")
+                    copy_in(
+                        target + "self_attn.qkv_proj.bias",
+                        torch.cat((q_bias, k_bias, v_bias)),
+                    )
+                    copy_in(
+                        target + "self_attn.o_proj.bias",
+                        tensor(source + "self_attn.o_proj.bias"),
+                    )
+                copy_in(
+                    target + "self_attn.q_norm.weight",
+                    tensor(source + "self_attn.q_norm.weight"),
+                )
+                copy_in(
+                    target + "self_attn.k_norm.weight",
+                    tensor(source + "self_attn.k_norm.weight"),
+                )
+            else:
+                linear = source + "linear_attn."
+                qkv = tensor(linear + "in_proj_qkv.weight")
+                global_key = cfg.linear_num_key_heads * cfg.linear_key_head_dim
+                global_value = cfg.linear_num_value_heads * cfg.linear_value_head_dim
+                q, k, v = qkv.split((global_key, global_key, global_value), dim=0)
+                q = q.chunk(tp_size, dim=0)[tp_rank]
+                k = k.chunk(tp_size, dim=0)[tp_rank]
+                v = v.chunk(tp_size, dim=0)[tp_rank]
+                copy_in(
+                    target + "linear_attn.in_proj_qkv.weight", torch.cat((q, k, v))
+                )
+                for projection in ("in_proj_z", "in_proj_b", "in_proj_a"):
+                    copy_in(
+                        target + f"linear_attn.{projection}.weight",
+                        shard_tensor(linear + f"{projection}.weight", 0),
+                    )
+                conv = tensor(linear + "conv1d.weight").squeeze(1)
+                cq, ck, cv = conv.split(
+                    (global_key, global_key, global_value), dim=0
+                )
+                copy_in(
+                    target + "linear_attn.conv1d_weight",
+                    torch.cat(
+                        (
+                            cq.chunk(tp_size)[tp_rank],
+                            ck.chunk(tp_size)[tp_rank],
+                            cv.chunk(tp_size)[tp_rank],
+                        )
+                    ),
+                )
+                for name in ("A_log", "dt_bias"):
+                    copy_in(
+                        target + f"linear_attn.{name}",
+                        shard_tensor(linear + name, 0),
+                    )
+                copy_in(
+                    target + "linear_attn.norm_weight",
+                    tensor(linear + "norm.weight"),
+                )
+                copy_in(
+                    target + "linear_attn.out_proj.weight",
+                    shard_tensor(linear + "out_proj.weight", 1),
+                )
+
+            if cfg.is_moe_layer(layer_id):
+                moe = source + "mlp."
+                copy_in(
+                    target + "mlp.experts.gate.weight", tensor(moe + "gate.weight")
+                )
+                copy_in(
+                    target + "mlp.shared_expert_gate.weight",
+                    tensor(moe + "shared_expert_gate.weight"),
+                )
+
+                gate_up = tensor(moe + "experts.gate_up_proj")
+                start_expert = cfg.ep_rank * (cfg.num_experts // cfg.ep_size)
+                gate_up = gate_up.narrow(
+                    0, start_expert, cfg.num_experts // cfg.ep_size
+                )
+                gate, up = gate_up.chunk(2, dim=1)
+                gate = gate.chunk(cfg.moe_tp_size, dim=1)[cfg.moe_tp_rank]
+                up = up.chunk(cfg.moe_tp_size, dim=1)[cfg.moe_tp_rank]
+                # The checkpoint is [gate, up]; xLLM CUTLASS SwiGLU
+                # consumes [linear/up, gate].
+                copy_in(
+                    target + "mlp.experts.w13", torch.cat((up, gate), dim=1)
+                )
+
+                down = tensor(moe + "experts.down_proj").narrow(
+                    0, start_expert, cfg.num_experts // cfg.ep_size
+                )
+                copy_in(
+                    target + "mlp.experts.w2",
+                    down.chunk(cfg.moe_tp_size, dim=2)[cfg.moe_tp_rank],
+                )
+
+                shared = moe + "shared_expert."
+                shared_gate = shard_tensor(shared + "gate_proj.weight", 0)
+                shared_up = shard_tensor(shared + "up_proj.weight", 0)
+                copy_in(
+                    target + "mlp.shared_expert.gate_up_proj.weight",
+                    torch.cat((shared_gate, shared_up)),
+                )
+                copy_in(
+                    target + "mlp.shared_expert.down_proj.weight",
+                    shard_tensor(shared + "down_proj.weight", 1),
+                )
+            else:
+                gate = shard_tensor(source + "mlp.gate_proj.weight", 0)
+                up = shard_tensor(source + "mlp.up_proj.weight", 0)
+                copy_in(target + "mlp.gate_up_proj.weight", torch.cat((gate, up)))
+                copy_in(
+                    target + "mlp.down_proj.weight",
+                    shard_tensor(source + "mlp.down_proj.weight", 1),
+                )
+
+        copy_in("model.norm.weight", tensor(model_prefix + "norm.weight"))
+        lm_head_name = "lm_head.weight"
+        if cfg.tie_word_embeddings or find(lm_head_name) is None:
+            lm_head_name = model_prefix + "embed_tokens.weight"
+        copy_in("lm_head.weight", shard_tensor(lm_head_name, 0))

--- a/xllm/python/registry.py
+++ b/xllm/python/registry.py
@@ -67,6 +67,18 @@ def _register_builtin_models() -> None:
         "qwen3",
     )
     _register_model_path(
+        "xllm.python.models.qwen3_5",
+        "Qwen3_5ForCausalLM",
+        "Qwen3_5ForConditionalGeneration",
+        "Qwen3_5ForCausalLM",
+        "qwen3_5",
+        "qwen3_5_text",
+        "Qwen3_5MoeForConditionalGeneration",
+        "Qwen3_5MoeForCausalLM",
+        "qwen3_5_moe",
+        "qwen3_5_moe_text",
+    )
+    _register_model_path(
         "xllm.python.models.deepseek_v32",
         "DeepseekV3ForCausalLM",
         "deepseek_v32",


### PR DESCRIPTION
## Description

Add CUDA support for the Qwen3.5 Python executor, including dense and MoE variants, hybrid full/linear attention, recurrent-state caches, parallel topology handling, and Python-owned decode CUDA Graph execution.

## Related Issues

<!-- Link related issues here. Use "Fixes #123" when this PR closes an issue. -->

## Change Type

- [ ] Bug fix
- [x] New feature
- [ ] Performance improvement
- [ ] Refactor
- [ ] Documentation
- [x] Test
- [ ] Build or CI

## Pull Request Checklist

Thank you for contributing to xLLM. Before requesting review, please make sure the following items are complete.

### PR Title and Commit Messages

- [x] The PR title and each commit message follow the xLLM commit format: `<type>: <subject>`.

> Allowed types: feat, bugfix, docs, test, refactor, chore, style, revert, perf, model, build, release.
> The subject should use clear English, start with a verb, include at least 4 words, and end with `.`.

### Pre-commit Checks

- [ ] I have installed `pre-commit` by running `pip install pre-commit` or an equivalent command.
- [ ] I have installed the hooks with `pre-commit install`.
- [ ] I have run `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

### Self Review

- [x] I have self-reviewed the code according to `.agents/skills/code-review/references/custom-code-style.md`, especially code written or assisted by AI.
- [x] I have rebased this PR onto the latest `main` branch.

### Build and Test Coverage

- [x] Tests have been added or updated as needed.
- [x] CUDA: targeted build and tests passed on a CUDA machine.
- [ ] NPU: `python setup.py build test` has passed on an NPU machine.
- [ ] MLU: `python setup.py build test` has passed on an MLU machine.

## Reviewer Notes

- `ep_size` supports only `1` (EP disabled) or `world_size` (global EP); partial EP is rejected.
- DP execution currently supports eager mode only; DP + Python CUDA Graph is not supported.
- The validated DP2 + global EP2 run includes the empty-shard recurrent-state metadata fix; that one-line fix is not yet pushed to this PR branch.
- Linear attention and beam search are not yet compatible because beam cloning does not clone recurrent state.

---

## Qwen3.5 Python Executor 回归

### GSM8K 配置

- 数据：标准 GSM8K test 全量 1319 题
- Prompt：zero-shot，要求逐步推理并将最终答案放入 `\boxed{}`
- 判分：从最后一个 `\boxed{}` 中提取整数，与标准答案做 exact match
- 生成参数：BF16、`temperature=0`、`top_p=1.0`、`max_tokens=1024`、`seed=0`
- 请求并发：32

### 同拓扑 GSM8K 得分

| 模型 | 拓扑 | vLLM | xLLM | xLLM − vLLM |
|---|---|---:|---:|---:|
| Qwen3.5-27B | attention TP1 | 1231/1319（93.3283%） | 1235/1319（93.6315%） | +0.3033 pp |
| Qwen3.5-27B | attention TP2 | 1232/1319（93.4041%） | 1232/1319（93.4041%） | 0.0000 pp |
| Qwen3.5-35B-A3B | attention TP1 + MoE TP1 + EP1 | 1209/1319（91.6603%） | 1209/1319（91.6603%） | 0.0000 pp |
| Qwen3.5-35B-A3B | attention TP2 + MoE TP2 + EP1 | 1207/1319（91.5087%） | 1213/1319（91.9636%） | +0.4549 pp |
| Qwen3.5-35B-A3B | attention TP1 + DP2 + MoE TP1 + EP2 | 1209/1319（91.6603%） | 1213/1319（91.9636%） | +0.3033 pp |

五组严格同拓扑对比中，xLLM 与 vLLM 的差值为 0.0000 至 +0.4549 个百分点。

### 功能覆盖

- Qwen3.5-27B 与 Qwen3.5-35B-A3B 均可加载并完成推理。
- 已覆盖 attention TP、attention DP、MoE TP 和 global EP。
- Python CUDA Graph 已覆盖 Qwen3.5-27B TP2 和 Qwen3.5-35B-A3B attention TP2 + MoE TP2。

### 自动化测试

```text
51 passed in 23.91s
```
