### PR TITLE
bugfix: align local worker shared memory decisions.

### DIFF
--- a/tests/core/util/net_test.cpp
+++ b/tests/core/util/net_test.cpp
@@ -29,6 +29,15 @@ TEST(NetTest, ResolvesRemoteHostname) {
   EXPECT_EQ(get_route_ip("localhost:19888"), "127.0.0.1");
 }
 
+TEST(NetTest, NormalizesLocalBindHosts) {
+  const std::string local_ip = get_local_ip_addr();
+  ASSERT_FALSE(local_ip.empty());
+
+  EXPECT_EQ(extract_ip("0.0.0.0"), local_ip);
+  EXPECT_EQ(extract_ip("127.0.0.1"), local_ip);
+  EXPECT_EQ(extract_ip("localhost"), local_ip);
+}
+
 TEST(NetTest, ReturnsEmptyWhenRemoteHasNoUsableRoute) {
   EXPECT_TRUE(get_route_ip("255.255.255.255:19888").empty());
 }

--- a/xllm/xllm.cpp
+++ b/xllm/xllm.cpp
@@ -455,15 +455,16 @@ int run() {
     model_config.backend(xllm::util::get_model_backend(model_path));
   }
 
+  const std::string local_ip = net::get_local_ip_addr();
   if (service_config.host().empty()) {
     // set the host to the local IP when the host is empty
-    service_config.host(net::get_local_ip_addr());
+    service_config.host(local_ip);
   }
 
-  const bool is_local =
-      !service_config.host().empty() &&
-      net::extract_ip(distributed_config.master_node_addr()) ==
-          service_config.host();
+  const std::string master_ip =
+      net::extract_ip(distributed_config.master_node_addr());
+  const bool is_local = !service_config.host().empty() &&
+                        master_ip == net::extract_ip(service_config.host());
 
   LOG(INFO) << "set worker role to "
             << (is_local ? "local worker" : "remote worker");


### PR DESCRIPTION
## Description

This branch fixes incorrect local-worker detection when the service binds to 0.0.0.0,
  127.0.0.1, or localhost. The mismatch could make the master use shared-memory transport while the worker
  did not initialize shared memory. Both sides now rely on the existing address-normalization logic, with
  regression coverage added.

## Related Issues

<!-- Link related issues here. Use "Fixes #123" when this PR closes an issue. -->

## Change Type

- [x] Bug fix
- [ ] New feature
- [ ] Performance improvement
- [ ] Refactor
- [ ] Documentation
- [ ] Test
- [ ] Build or CI

## Pull Request Checklist

Thank you for contributing to xLLM. Before requesting review, please make sure the following items are complete.

### PR Title and Commit Messages

- [x] The PR title and each commit message follow the xLLM commit format: `<type>: <subject>`.

> Allowed types: feat, bugfix, docs, test, refactor, chore, style, revert, perf, model, build, release.
> The subject should use clear English, start with a verb, include at least 4 words, and end with `.`.

### Pre-commit Checks

- [x] I have installed `pre-commit` by running `pip install pre-commit` or an equivalent command.
- [x] I have installed the hooks with `pre-commit install`.
- [x] I have run `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

### Self Review

- [x] I have self-reviewed the code according to `.agents/skills/code-review/references/custom-code-style.md`, especially code written or assisted by AI.
- [x] I have rebased this PR onto the latest `main` branch.

### Build and Test Coverage

- [ ] Tests have been added or updated as needed.
- [ ] CUDA: `python setup.py build test` has passed on a CUDA machine.
- [x] NPU: `python setup.py build test` has passed on an NPU machine.
- [x] MLU: `python setup.py build test` has passed on an MLU machine.

## Reviewer Notes

<!-- Optional: anything reviewers should focus on, known risks, follow-ups, or validation gaps. -->
