### PR TITLE
bugfix: pin NPU python runtime to the process own device.

### DIFF
--- a/xllm/xllm.cpp
+++ b/xllm/xllm.cpp
@@ -287,8 +287,18 @@ void init_npu_python_runtime() {
     we_initialized_python = true;
   }
 
-  const auto first_device = DeviceNameUtils::parse_devices("auto").front();
-  const int device_index = first_device.index();
+  // Select the same logical device this process's worker will run on. Multi-
+  // process single-card serving lets every process see all TP cards and picks
+  // its own via node_rank (see Master ctor). Using .front() here would pin an
+  // extra context on logical device 0 for every node_rank != 0 process, piling
+  // small allocations onto die0. Mirror master.cpp's get_device_idx instead.
+  const auto& distributed_config = DistributedConfig::get_instance();
+  const int32_t visible_device_count =
+      DeviceNameUtils::parse_devices("auto").size();
+  const int32_t device_index =
+      DeviceNameUtils::get_device_idx(distributed_config.node_rank(),
+                                      distributed_config.nnodes(),
+                                      visible_device_count);
 
   {
     py::gil_scoped_acquire gil;


### PR DESCRIPTION
init_npu_python_runtime() ran _npu_setDevice on the first visible logical device for every NPU process. In multi-process single-card serving each process sees all TP cards and selects its own via node_rank, so every node_rank != 0 process created an extra small context on die0 before its worker ran on the real card, piling ~112MB per rank onto die0.

Select the target device with the same get_device_idx logic used by the Master constructor so each process initializes its context on its own card.

## Description

<!-- What does this PR do? Briefly describe the changes and why they are needed. -->

## Related Issues

<!-- Link related issues here. Use "Fixes #123" when this PR closes an issue. -->

## Change Type

- [ ] Bug fix
- [ ] New feature
- [ ] Performance improvement
- [ ] Refactor
- [ ] Documentation
- [ ] Test
- [ ] Build or CI

## Pull Request Checklist

Thank you for contributing to xLLM. Before requesting review, please make sure the following items are complete.

### PR Title and Commit Messages

- [ ] The PR title and each commit message follow the xLLM commit format: `<type>: <subject>`.

> Allowed types: feat, bugfix, docs, test, refactor, chore, style, revert, perf, model, build, release.
> The subject should use clear English, start with a verb, include at least 4 words, and end with `.`.

### Pre-commit Checks

- [ ] I have installed `pre-commit` by running `pip install pre-commit` or an equivalent command.
- [ ] I have installed the hooks with `pre-commit install`.
- [ ] I have run `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

### Self Review

- [ ] I have self-reviewed the code according to `.agents/skills/code-review/references/custom-code-style.md`, especially code written or assisted by AI.
- [ ] I have rebased this PR onto the latest `main` branch.

### Build and Test Coverage

- [ ] Tests have been added or updated as needed.
- [ ] CUDA: `python setup.py build test` has passed on a CUDA machine.
- [ ] NPU: `python setup.py build test` has passed on an NPU machine.
- [ ] MLU: `python setup.py build test` has passed on an MLU machine.

## Reviewer Notes

<!-- Optional: anything reviewers should focus on, known risks, follow-ups, or validation gaps. -->
