### PR TITLE
feat: support DeepSeek-V4 prefill context parallelism.

### DIFF
--- a/tests/core/framework/parallel_state/npu_cp_capability_test.cpp
+++ b/tests/core/framework/parallel_state/npu_cp_capability_test.cpp
@@ -23,9 +23,14 @@ namespace xllm {
 namespace {
 
 TEST(NpuCpCapabilityTest, RegisteredCpCapableModels) {
-  // The four models that opt into the NPU ATB model-side CP pipeline.
+  // The models that opt into NPU model-side CP. deepseek_v32 / glm_moe_dsa
+  // drive it through the ATB NpuCpPlan pipeline; deepseek_v4 owns its split
+  // inside the model on the TORCH backend. Both are advertised here because
+  // this is the master-side startup gate, not the worker-side sharding switch.
   EXPECT_TRUE(is_npu_model_cp_capable("deepseek_v32"));
   EXPECT_TRUE(is_npu_model_cp_capable("deepseek_v32_mtp"));
+  EXPECT_TRUE(is_npu_model_cp_capable("deepseek_v4"));
+  EXPECT_TRUE(is_npu_model_cp_capable("deepseek_v4_mtp"));
   EXPECT_TRUE(is_npu_model_cp_capable("glm_moe_dsa"));
   EXPECT_TRUE(is_npu_model_cp_capable("glm_moe_dsa_mtp"));
   // The registry must advertise NPU_MODEL for these and NONE for the rest.
@@ -41,10 +46,13 @@ TEST(NpuCpCapabilityTest, UnregisteredModelsAreNotCapable) {
   // validate_model_cp rejects deepseek_v3_mtp + cp_size>1 at startup.
   EXPECT_FALSE(is_npu_model_cp_capable("deepseek_v3_mtp"));
   EXPECT_FALSE(is_npu_model_cp_capable("deepseek_v3"));
-  // TORCH-only / unrelated NPU models are not CP-capable.
+  // Unrelated NPU models are not CP-capable.
   EXPECT_FALSE(is_npu_model_cp_capable("qwen3"));
   EXPECT_FALSE(is_npu_model_cp_capable("qwen3_atb"));
-  EXPECT_FALSE(is_npu_model_cp_capable("deepseek_v4"));
+  // Hybrid linear attention models are the only ones the graph executor takes
+  // through spec-verify chunked prefill; none of them is CP-capable, which is
+  // what keeps that capture path CP-free.
+  EXPECT_FALSE(is_npu_model_cp_capable("qwen3_next"));
   // Unknown model names default to NONE.
   EXPECT_FALSE(is_npu_model_cp_capable("definitely_not_a_model"));
   EXPECT_EQ(ModelRegistry::get_cp_sharding_mode("deepseek_v3_mtp"),

--- a/tests/core/layers/CMakeLists.txt
+++ b/tests/core/layers/CMakeLists.txt
@@ -24,6 +24,21 @@ cc_test(
     GTest::gtest_main
 )
 
+# DeepSeek-V4 prefill CP split arithmetic. Kept outside the platform
+# subdirectories: the split math has no accelerator or ProcessGroup dependency,
+# so every platform build can verify it.
+cc_test(
+  NAME
+    deepseek_v4_cp_split_test
+  SRCS
+    deepseek_v4_cp_split_test.cpp
+  DEPS
+    :parallel_state
+    glog::glog
+    torch
+    GTest::gtest_main
+)
+
 if(USE_CUDA)
   add_subdirectory(cuda)
 endif()

--- a/tests/core/layers/deepseek_v4_cp_split_test.cpp
+++ b/tests/core/layers/deepseek_v4_cp_split_test.cpp
@@ -1,0 +1,270 @@
+/* Copyright 2025-2026 The xLLM Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://github.com/jd-opensource/xllm/blob/main/LICENSE
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include <gtest/gtest.h>
+
+#include <algorithm>
+#include <numeric>
+#include <set>
+#include <vector>
+
+#include "layers/npu_torch/deepseek_v4_cp_context.h"
+
+namespace xllm::layer::v4_cp {
+namespace {
+
+int64_t total_tokens(const std::vector<int32_t>& q_seq_lens) {
+  return std::accumulate(q_seq_lens.begin(), q_seq_lens.end(), int64_t{0});
+}
+
+// Every global row must be owned by exactly one rank. A duplicated row would be
+// written to the KV cache twice; a dropped one would leave a zero row in the
+// gathered output, and neither shows up as a crash.
+TEST(DeepseekV4CpSplit, PartitionsEveryRowExactlyOnce) {
+  const std::vector<std::vector<int32_t>> cases = {
+      {8}, {8, 4}, {1}, {7, 3, 11}, {128, 1, 1, 64}, {0, 5}};
+  for (const auto& q_seq_lens : cases) {
+    for (const int32_t cp_size : {2, 3, 4, 8}) {
+      const auto rows_by_rank = compute_cp_rows_by_rank(cp_size, q_seq_lens);
+      ASSERT_EQ(static_cast<int32_t>(rows_by_rank.size()), cp_size);
+
+      std::vector<int64_t> seen;
+      for (const auto& rows : rows_by_rank) {
+        seen.insert(seen.end(), rows.begin(), rows.end());
+      }
+      std::sort(seen.begin(), seen.end());
+      const int64_t expected = total_tokens(q_seq_lens);
+      ASSERT_EQ(static_cast<int64_t>(seen.size()), expected)
+          << "cp_size=" << cp_size;
+      for (int64_t i = 0; i < expected; ++i) {
+        EXPECT_EQ(seen[i], i) << "cp_size=" << cp_size << ", row " << i;
+      }
+    }
+  }
+}
+
+// Each rank's rows must be contiguous per sequence -- that is the property that
+// lets one sequence stay at a single metadata row.
+TEST(DeepseekV4CpSplit, RowsAreContiguousWithinEachSequence) {
+  const std::vector<int32_t> q_seq_lens = {10, 5, 7};
+  const int32_t cp_size = 3;
+  const auto rows_by_rank = compute_cp_rows_by_rank(cp_size, q_seq_lens);
+
+  for (int32_t r = 0; r < cp_size; ++r) {
+    int64_t seq_base = 0;
+    size_t cursor = 0;
+    for (const int32_t q_i : q_seq_lens) {
+      const int32_t seg = (q_i + cp_size - 1) / cp_size;
+      const int32_t start = std::min(r * seg, q_i);
+      const int32_t end = std::min(start + seg, q_i);
+      for (int32_t j = start; j < end; ++j) {
+        ASSERT_LT(cursor, rows_by_rank[r].size());
+        EXPECT_EQ(rows_by_rank[r][cursor], seq_base + j);
+        ++cursor;
+      }
+      seq_base += q_i;
+    }
+    EXPECT_EQ(cursor, rows_by_rank[r].size());
+  }
+}
+
+// Sequences shorter than cp_size leave the higher ranks empty. Chunked prefill
+// schedules such chunks routinely, so an empty segment must stay legal.
+TEST(DeepseekV4CpSplit, ShortSequenceLeavesTrailingRanksEmpty) {
+  const std::vector<int32_t> q_seq_lens = {2};
+  const int32_t cp_size = 4;
+  const auto rows_by_rank = compute_cp_rows_by_rank(cp_size, q_seq_lens);
+
+  ASSERT_EQ(rows_by_rank.size(), 4u);
+  // seg = ceil(2/4) = 1, so ranks 0 and 1 take one row each.
+  EXPECT_EQ(rows_by_rank[0], std::vector<int64_t>({0}));
+  EXPECT_EQ(rows_by_rank[1], std::vector<int64_t>({1}));
+  EXPECT_TRUE(rows_by_rank[2].empty());
+  EXPECT_TRUE(rows_by_rank[3].empty());
+}
+
+// cp_size == 1 must be the identity split, so the non-CP path is unaffected.
+TEST(DeepseekV4CpSplit, SingleRankKeepsAllRowsInOrder) {
+  const std::vector<int32_t> q_seq_lens = {4, 6};
+  const auto rows_by_rank = compute_cp_rows_by_rank(/*cp_size=*/1, q_seq_lens);
+
+  ASSERT_EQ(rows_by_rank.size(), 1u);
+  ASSERT_EQ(static_cast<int64_t>(rows_by_rank[0].size()),
+            total_tokens(q_seq_lens));
+  for (size_t i = 0; i < rows_by_rank[0].size(); ++i) {
+    EXPECT_EQ(rows_by_rank[0][i], static_cast<int64_t>(i));
+  }
+}
+
+// The rank-major gather order and the restore permutation must be mutual
+// inverses, otherwise merged hidden states come back scrambled.
+TEST(DeepseekV4CpSplit, RestorePermutationInvertsGatherOrder) {
+  const std::vector<int32_t> q_seq_lens = {9, 4};
+  const int32_t cp_size = 3;
+  const auto rows_by_rank = compute_cp_rows_by_rank(cp_size, q_seq_lens);
+  const int64_t expected = total_tokens(q_seq_lens);
+
+  // Mirror build_deepseek_v4_cp_context's inversion.
+  std::vector<int64_t> restore(static_cast<size_t>(expected), -1);
+  int64_t gathered_pos = 0;
+  for (int32_t r = 0; r < cp_size; ++r) {
+    for (const int64_t global_row : rows_by_rank[r]) {
+      restore[static_cast<size_t>(global_row)] = gathered_pos++;
+    }
+  }
+  ASSERT_EQ(gathered_pos, expected);
+
+  // restore must be a permutation of [0, expected).
+  std::set<int64_t> unique(restore.begin(), restore.end());
+  EXPECT_EQ(static_cast<int64_t>(unique.size()), expected);
+  for (const int64_t v : restore) {
+    EXPECT_GE(v, 0);
+    EXPECT_LT(v, expected);
+  }
+
+  // gathered[restore[i]] == global row i, so applying restore to a gathered
+  // buffer that holds its own global row ids yields the identity.
+  std::vector<int64_t> gathered(static_cast<size_t>(expected), -1);
+  gathered_pos = 0;
+  for (int32_t r = 0; r < cp_size; ++r) {
+    for (const int64_t global_row : rows_by_rank[r]) {
+      gathered[static_cast<size_t>(gathered_pos++)] = global_row;
+    }
+  }
+  for (int64_t i = 0; i < expected; ++i) {
+    const auto slot = static_cast<size_t>(restore[static_cast<size_t>(i)]);
+    EXPECT_EQ(gathered[slot], i);
+  }
+}
+
+// The kv extent handed to attention must end where this rank's query rows end.
+// A global kv length instead relocates every non-last rank's queries to the
+// tail of the sequence, because sparse_attn_sharedkv aligns the query block to
+// the end of the kv window. That is an accuracy bug with no crash.
+TEST(DeepseekV4CpLocalSeqLens, KvExtentEndsAtThisRanksLastRow) {
+  // One 145-token prompt, no cached prefix, cp=2 -> seg = 73.
+  const std::vector<int32_t> q_seq_lens = {145};
+  const std::vector<int32_t> kv_seq_lens = {145};
+  const int32_t cp_size = 2;
+
+  std::vector<int32_t> local_q;
+  std::vector<int32_t> local_kv;
+
+  compute_cp_local_seq_lens(
+      cp_size, /*cp_rank=*/0, q_seq_lens, kv_seq_lens, &local_q, &local_kv);
+  EXPECT_EQ(local_q, std::vector<int32_t>({73}));
+  EXPECT_EQ(local_kv, std::vector<int32_t>({73}));
+
+  compute_cp_local_seq_lens(
+      cp_size, /*cp_rank=*/1, q_seq_lens, kv_seq_lens, &local_q, &local_kv);
+  EXPECT_EQ(local_q, std::vector<int32_t>({72}));
+  // The last rank alone sees the full sequence.
+  EXPECT_EQ(local_kv, std::vector<int32_t>({145}));
+}
+
+// Chunked prefill and prefix cache put a cached prefix in front of the query
+// rows. The prefix belongs to every rank's window; only the tail is split.
+TEST(DeepseekV4CpLocalSeqLens, CachedPrefixStaysInEveryRanksWindow) {
+  // 20 new query rows on top of an 80-token cached prefix, cp=2 -> seg = 10.
+  const std::vector<int32_t> q_seq_lens = {20};
+  const std::vector<int32_t> kv_seq_lens = {100};
+  const int32_t cp_size = 2;
+
+  std::vector<int32_t> local_q;
+  std::vector<int32_t> local_kv;
+
+  compute_cp_local_seq_lens(
+      cp_size, /*cp_rank=*/0, q_seq_lens, kv_seq_lens, &local_q, &local_kv);
+  EXPECT_EQ(local_q, std::vector<int32_t>({10}));
+  EXPECT_EQ(local_kv, std::vector<int32_t>({90}));
+
+  compute_cp_local_seq_lens(
+      cp_size, /*cp_rank=*/1, q_seq_lens, kv_seq_lens, &local_q, &local_kv);
+  EXPECT_EQ(local_q, std::vector<int32_t>({10}));
+  EXPECT_EQ(local_kv, std::vector<int32_t>({100}));
+}
+
+// A rank whose segment is empty must still advertise a legal window: it closes
+// where its rows would have started, and never reaches past the global length.
+TEST(DeepseekV4CpLocalSeqLens, EmptySegmentKeepsWindowLegal) {
+  const std::vector<int32_t> q_seq_lens = {2};
+  const std::vector<int32_t> kv_seq_lens = {2};
+  const int32_t cp_size = 4;  // seg = 1, so ranks 2 and 3 are empty.
+
+  std::vector<int32_t> local_q;
+  std::vector<int32_t> local_kv;
+  for (int32_t rank = 0; rank < cp_size; ++rank) {
+    compute_cp_local_seq_lens(
+        cp_size, rank, q_seq_lens, kv_seq_lens, &local_q, &local_kv);
+    if (rank < 2) {
+      EXPECT_EQ(local_q[0], 1) << "rank=" << rank;
+      EXPECT_EQ(local_kv[0], rank + 1) << "rank=" << rank;
+    } else {
+      EXPECT_EQ(local_q[0], 0) << "rank=" << rank;
+      // No rows, so the window closes right where the rows ran out.
+      EXPECT_EQ(local_kv[0], 2) << "rank=" << rank;
+    }
+  }
+}
+
+// cp_size == 1 must leave both axes at their global values, so the non-CP path
+// is bit-identical.
+TEST(DeepseekV4CpLocalSeqLens, SingleRankIsIdentity) {
+  const std::vector<int32_t> q_seq_lens = {4, 6};
+  const std::vector<int32_t> kv_seq_lens = {4, 30};
+
+  std::vector<int32_t> local_q;
+  std::vector<int32_t> local_kv;
+  compute_cp_local_seq_lens(
+      /*cp_size=*/1,
+      /*cp_rank=*/0,
+      q_seq_lens,
+      kv_seq_lens,
+      &local_q,
+      &local_kv);
+
+  EXPECT_EQ(local_q, q_seq_lens);
+  EXPECT_EQ(local_kv, kv_seq_lens);
+}
+
+// Multi-sequence batches must stay per-row consistent: local_kv[i] - local_q[i]
+// is the position of this rank's first row, which is what start_pos-style
+// reasoning downstream assumes.
+TEST(DeepseekV4CpLocalSeqLens, WindowMinusQueriesIsThisRanksFirstPosition) {
+  const std::vector<int32_t> q_seq_lens = {10, 5, 7};
+  const std::vector<int32_t> kv_seq_lens = {10, 25, 7};
+  const int32_t cp_size = 3;
+
+  std::vector<int32_t> local_q;
+  std::vector<int32_t> local_kv;
+  for (int32_t rank = 0; rank < cp_size; ++rank) {
+    compute_cp_local_seq_lens(
+        cp_size, rank, q_seq_lens, kv_seq_lens, &local_q, &local_kv);
+    ASSERT_EQ(local_q.size(), q_seq_lens.size());
+    ASSERT_EQ(local_kv.size(), q_seq_lens.size());
+    for (size_t i = 0; i < q_seq_lens.size(); ++i) {
+      const int32_t q_i = q_seq_lens[i];
+      const int32_t seg = (q_i + cp_size - 1) / cp_size;
+      const int32_t start = std::min(rank * seg, q_i);
+      const int32_t prefix = kv_seq_lens[i] - q_i;
+      EXPECT_EQ(local_kv[i] - local_q[i], prefix + start)
+          << "rank=" << rank << ", seq=" << i;
+      EXPECT_LE(local_kv[i], kv_seq_lens[i]) << "rank=" << rank;
+    }
+  }
+}
+
+}  // namespace
+}  // namespace xllm::layer::v4_cp

--- a/xllm/core/distributed_runtime/master.cpp
+++ b/xllm/core/distributed_runtime/master.cpp
@@ -130,20 +130,27 @@ std::optional<std::string> validate_model_cp(const Options& options,
              "speculative algorithms (Eagle3/DFlash); disable CP or disable "
              "the speculative algorithm. MTP and Suffix are supported.";
     }
-    // CP is prefill-only; reject graph/non-prefill roles.
-    if (options.enable_graph()) {
-      return "Model-side CP does not support graph capture "
-             "(enable_graph=true); disable graph or disable CP (cp_size=1).";
-    }
+    // enable_graph is compatible with CP because the two are phase-disjoint:
+    // CP only engages on batch_forward_type.no_decode() (both the model-owned
+    // split in deepseek_v4 and NpuCpPlan::prepare return early on decode),
+    // while ACL graph only captures/replays pure decode -- AclGraphExecutorImpl
+    // ::run() falls back to eager for anything else, and params.enable_graph is
+    // set only by the decode capture path. Graph-mode decode therefore runs
+    // with CP inactive, which is the same non-CP decode CP already relies on.
+    //
+    // The one batch that satisfies both gates is spec-verify chunked prefill.
+    // The graph executor only takes it for hybrid-linear-attention models, and
+    // no CP-capable model is one, so it falls back to eager today; the guard in
+    // AclGraphExecutorImpl::run() keeps that true if a future model is both.
     if (options.instance_role() != InstanceRole::DEFAULT &&
         options.instance_role() != InstanceRole::PREFILL) {
       return "Model-side CP supports only DEFAULT or PREFILL roles";
     }
-    if (options.dp_size() != 1) {
-      return "Model-side CP requires dp_size == 1";
-    }
 
-    // Require registered NPU model-side CP capability + ATB backend.
+    // Require registered NPU model-side CP capability. The backend is not
+    // constrained: ATB models drive CP through NpuCpPlan, while TORCH models
+    // (deepseek_v4) own their CP split inside the model. Both rely on the
+    // orthogonal dp * cp * attn_tp == world layout validated below.
     std::string effective_backend;
     std::string resolved_name;
     std::string resolve_error;
@@ -157,16 +164,12 @@ std::optional<std::string> validate_model_cp(const Options& options,
       return "Model-side CP rejected model_type=" + model_type + ": " +
              resolve_error;
     }
-    if (effective_backend != "ATB") {
-      return "NPU model-side CP requires --npu_kernel_backend=ATB for "
-             "model_type=" +
-             model_type + " (resolved backend=" + effective_backend + ")";
-    }
     if (!is_npu_model_cp_capable(resolved_name)) {
       return "NPU model-side CP does not support model_type=" + model_type +
              " (resolved=" + resolved_name +
-             "); only deepseek_v32, deepseek_v32_mtp, glm_moe_dsa, "
-             "glm_moe_dsa_mtp are registered as CP-capable.";
+             "); only deepseek_v32, deepseek_v32_mtp, deepseek_v4, "
+             "deepseek_v4_mtp, glm_moe_dsa, glm_moe_dsa_mtp are registered as "
+             "CP-capable.";
     }
     if (global_world_size % (options.dp_size() * options.cp_size()) != 0) {
       return "NPU CP requires world_size divisible by dp_size * cp_size "

--- a/xllm/core/framework/parallel_state/collective_communicator.cpp
+++ b/xllm/core/framework/parallel_state/collective_communicator.cpp
@@ -366,13 +366,40 @@ void CollectiveCommunicator::create_process_groups(
                                         device);
   parallel_args_->process_group_ = process_group_.get();
 
-  int32_t tp_size = world_size / dp_size;
-  CHECK_EQ(tp_size * dp_size, world_size);
+  // Orthogonal CP x TP (NPU TORCH only): the rank layout is
+  //   rank = dp_rank * (cp_size * tp_size) + cp_rank * tp_size + tp_rank
+  // so tensor parallelism spans world_size / (dp_size * cp_size), NOT
+  // world_size / dp_size. Narrowing tp_size here is what makes attention head
+  // sharding and the o_proj all-reduce use the attention-TP width: consumers
+  // read it back through tp_group_->world_size(). Leaving it at world/dp would
+  // make ranks r and r + tp_size hold the same heads and double-accumulate in
+  // the all-reduce, which is a silent numerical error rather than a crash.
+  const int32_t normalized_cp_size = cp_size > 0 ? cp_size : 1;
+  bool use_orthogonal_cp = false;
+#if defined(USE_NPU)
+  use_orthogonal_cp =
+      ::xllm::KernelConfig::get_instance().npu_kernel_backend() == "TORCH" &&
+      normalized_cp_size > 1;
+#endif
+  int32_t tp_size = use_orthogonal_cp
+                        ? world_size / (dp_size * normalized_cp_size)
+                        : world_size / dp_size;
+  CHECK_GT(tp_size, 0) << "attention tp_size must be positive: world_size="
+                       << world_size << ", dp_size=" << dp_size
+                       << ", cp_size=" << normalized_cp_size;
+  CHECK_EQ(tp_size * dp_size * (use_orthogonal_cp ? normalized_cp_size : 1),
+           world_size)
+      << "world_size (" << world_size << ") must equal dp_size * cp_size * "
+      << "tp_size (" << dp_size << " * " << normalized_cp_size << " * "
+      << tp_size << ")";
+  // Group counts stop tracking dp_size once tp_size narrows, so derive every
+  // TCPStore window from the group width instead of assuming world/dp.
+  const int32_t tp_group_count = world_size / tp_size;
   port_offset = global_rank / tp_size + 1;
   std::string tp_host = host;
 #if defined(USE_NPU)
   if (::xllm::KernelConfig::get_instance().npu_kernel_backend() == "TORCH" &&
-      dp_size > 1) {
+      tp_group_count > 1) {
     const int32_t tp_group_start = (global_rank / tp_size) * tp_size;
     tp_host = get_rank_table_server_host(tp_group_start, host);
   }
@@ -386,6 +413,9 @@ void CollectiveCommunicator::create_process_groups(
                                    "tp_group",
                                    device);
   parallel_args_->tp_group_ = tp_group_.get();
+  // Publish the narrowed width so consumers that read tp_size() (rather than
+  // tp_group_->world_size()) agree with the group actually created above.
+  parallel_args_->tp_size(tp_size);
   // Single-rank group is used for modules that don't need tensor parallel (TP)
   // communication. This avoids unnecessary communication. When tp_size > 1,
   // create a process group of size 1 for each rank. Otherwise, reuse tp_group
@@ -401,7 +431,7 @@ void CollectiveCommunicator::create_process_groups(
         global_rank,
         world_size,
         1,
-        port + dp_size + single_rank_group_port_gap + global_rank + 1,
+        port + tp_group_count + single_rank_group_port_gap + global_rank + 1,
         false,
         host,
         "single_rank_group",
@@ -411,14 +441,59 @@ void CollectiveCommunicator::create_process_groups(
   } else {
     parallel_args_->single_rank_group_ = tp_group_.get();
   }
-  // The current MLU model-side CP path spans the full DP-local rank set, which
-  // is also represented by tp_group_ today. Keep a distinct CP handle so a
-  // future orthogonal CP x TP topology can provide its own process group.
-  parallel_args_->cp_group_ = tp_group_.get();
-  port += dp_size + single_rank_group_port_gap + single_rank_group_count;
+  port += tp_group_count + single_rank_group_port_gap + single_rank_group_count;
+
+#if defined(USE_NPU)
+  if (use_orthogonal_cp) {
+    // A CP group varies cp_rank while holding (dp_rank, tp_rank) fixed, so its
+    // members are strided by tp_size and cannot be expressed by the contiguous
+    // or `trans` groupings of the size-only overload. Enumerate the ranks
+    // explicitly instead.
+    const std::vector<int32_t> cp_ranks =
+        parallel_state::compute_cp_group_ranks(
+            global_rank, world_size, dp_size, normalized_cp_size);
+    const int32_t cp_local_rank = parallel_args_->cp_rank();
+    CHECK_EQ(static_cast<int32_t>(cp_ranks.size()), normalized_cp_size);
+    CHECK_GE(cp_local_rank, 0);
+    CHECK_LT(cp_local_rank, normalized_cp_size);
+    CHECK_EQ(cp_ranks[cp_local_rank], global_rank)
+        << "cp_rank() must index this rank inside its own CP group";
+    // One CP group per (dp_rank, tp_rank) pair. tp_rank alone is not unique:
+    // with dp=2/cp=2/tp=4 the groups {0,4} and {8,12} both have tp_rank 0 and
+    // would race for the same TCPStore port.
+    const int32_t dp_stride = normalized_cp_size * tp_size;
+    const int32_t cp_group_index =
+        (global_rank / dp_stride) * tp_size + global_rank % tp_size;
+    const int32_t cp_group_count = dp_size * tp_size;
+    cp_group_ =
+        create_process_group(global_rank,
+                             cp_local_rank,
+                             cp_ranks,
+                             world_size,
+                             normalized_cp_size,
+                             port + cp_group_index + 1,
+                             get_rank_table_server_host(cp_ranks.front(), host),
+                             "cp_group",
+                             device);
+    parallel_args_->cp_group_ = cp_group_.get();
+    port += cp_group_count;
+  } else
+#endif
+  {
+    // The current MLU model-side CP path spans the full DP-local rank set,
+    // which is also represented by tp_group_ today. Keep a distinct CP handle
+    // so an orthogonal CP x TP topology can provide its own process group.
+    parallel_args_->cp_group_ = tp_group_.get();
+  }
 
   if (dp_size > 1) {
-    port_offset = global_rank % tp_size + 1;
+    // A DP group varies dp_rank while preserving the full local model-shard
+    // index. Under orthogonal CP that index spans cp_rank AND tp_rank, so the
+    // grouping key is global_rank % (world_size / dp_size) -- matching the
+    // `trans` grouping below. Keying on tp_size alone was equivalent only
+    // while tp_size == world/dp; after narrowing it collides.
+    const int32_t dp_group_count = world_size / dp_size;
+    port_offset = global_rank % dp_group_count + 1;
     dp_local_process_group_ = create_process_group(global_rank,
                                                    world_size,
                                                    dp_size,
@@ -428,7 +503,7 @@ void CollectiveCommunicator::create_process_groups(
                                                    "dp_group",
                                                    device);
     parallel_args_->dp_local_process_group_ = dp_local_process_group_.get();
-    port += tp_size;
+    port += dp_group_count;
   }
 
   int32_t moe_tp_size = world_size / ep_size;

--- a/xllm/core/layers/common/dsa_metadata.h
+++ b/xllm/core/layers/common/dsa_metadata.h
@@ -47,6 +47,11 @@ struct DSAGroupInfo {
 
 namespace layer {
 
+namespace v4_cp {
+// Forward-declared so this header stays independent of the npu_torch layer.
+struct DeepseekV4CpContext;
+}  // namespace v4_cp
+
 struct DSACompressedAttentionMetadata {
   torch::Tensor context_lens;
   torch::Tensor block_table_for_attn;
@@ -83,10 +88,21 @@ struct DSAMetadata {
   // cp_input_dict: context-parallel inputs placeholder (reserved, optional)
   std::unordered_map<std::string, torch::Tensor> cp_input_dict;
 
+  // Prefill context-parallel plan for DeepSeek-V4, non-owning. Set by the model
+  // for the duration of the layer loop and cleared afterwards; null means CP is
+  // off and every path runs on full tokens.
+  const v4_cp::DeepseekV4CpContext* v4_cp_context = nullptr;
+
   // NPU-only DSA metadata fields.
   // RoPE caches selected for the current layer's q/kv/output RoPE.
   torch::Tensor cos;
   torch::Tensor sin;
+  // Global-position RoPE for the KV path under CP. `cos`/`sin` above are
+  // localized to this rank's query rows, but KV/compressor/index-cache writes
+  // cover all tokens and need the global table. Undefined when CP is off, in
+  // which case consumers fall back to `cos`/`sin`.
+  torch::Tensor kv_cos;
+  torch::Tensor kv_sin;
   // RoPE caches for compressor/indexer paths, indexed by compressed positions.
   torch::Tensor c4_cos;
   torch::Tensor c4_sin;

--- a/xllm/core/layers/deepseek_v4_decoder_layer.cpp
+++ b/xllm/core/layers/deepseek_v4_decoder_layer.cpp
@@ -19,6 +19,7 @@ limitations under the License.
 
 #include "common/flash_comm1_context.h"
 #include "kernels/ops_api.h"
+#include "npu_torch/deepseek_v4_cp_context.h"
 
 namespace xllm {
 namespace layer {
@@ -184,6 +185,19 @@ torch::Tensor DeepseekV4DecoderLayerImpl::forward(
     ffn_input = gather_sequence(ffn_input, *fc1_ctx);
   }
 
+  // Prefill CP shards the query axis, so ffn_input holds only this rank's rows.
+  // MoE cannot run on that shard: its expert reduce spans moe_ep_group, which
+  // crosses cp_rank, and partial expert sums are only addable when every group
+  // member holds the same tokens. Gather back to the full DP-local token set
+  // for the gate and the experts, then re-shard so the residual path stays
+  // CP-local. This mirrors what the ATB CP path does through
+  // CpEpMeta::ffn_padding_indices.
+  const v4_cp::DeepseekV4CpContext* cp_ctx = dsa.v4_cp_context;
+  const bool cp_bridge_ffn = cp_ctx != nullptr && cp_ctx->enabled();
+  if (cp_bridge_ffn) {
+    ffn_input = cp_ctx->gather_restore(ffn_input);
+  }
+
   auto ffn_input_2d = ffn_input.reshape({-1, ffn_input.size(-1)});
   std::optional<torch::Tensor> gate_input_ids = std::nullopt;
   if (input_ids.has_value() && input_ids.value().defined()) {
@@ -207,6 +221,10 @@ torch::Tensor DeepseekV4DecoderLayerImpl::forward(
   auto [topk_weights, topk_ids] = gate_->forward(ffn_input_2d, gate_input_ids);
   ffn_input = moe_mlp_->forward_with_selected_experts(
       ffn_input, topk_weights, topk_ids, input_params);
+
+  if (cp_bridge_ffn) {
+    ffn_input = cp_ctx->shard_rows(ffn_input);
+  }
 
   if (fc1_ctx && is_sequence_sharded(*fc1_ctx)) {
     ffn_input = shard_sequence(ffn_input, *fc1_ctx);

--- a/xllm/core/layers/npu_torch/deepseek_sparse_attention.cpp
+++ b/xllm/core/layers/npu_torch/deepseek_sparse_attention.cpp
@@ -26,6 +26,7 @@ limitations under the License.
 
 #include "common/flash_comm1_context.h"
 #include "kernels/ops_api.h"
+#include "layers/npu_torch/deepseek_v4_cp_context.h"
 #include "xllm/core/kernels/npu/xllm_ops/xllm_ops_api.h"
 
 DECLARE_bool(enable_chunked_prefill);
@@ -256,29 +257,57 @@ void scatter_by_slot(torch::Tensor& cache,
 // [num_blocks + 1, block_size, n, d]. This mirrors vllm-ascend's
 // pad_to_blocks path and lets sparse_attn_sharedkv read prefill KV through a
 // block table without depending on the persistent SWA ring cache.
+//
+// cu_seqlens_src locates each request's rows inside `kv`. cu_seqlens_dst, when
+// given, overrides how many rows each request exposes to the kernel; it exists
+// for prefill CP, where `kv` holds the gathered global rows of every rank but a
+// request must expose only the window its local queries may attend to, so the
+// packed extent matches the seqused_kv the metadata advertises.
+//
+// Both are (batch+1,) leading-zero cumsums. Copied rows are aligned to the END
+// of each request's window, which is where sparse_attn_sharedkv expects the
+// newest tokens. Like the non-CP path this assumes the window holds no cached
+// prefix -- prefix rows live in the persistent SWA cache, which the chunked
+// branch reads instead of calling this at all.
 std::tuple<torch::Tensor, torch::Tensor> build_prefill_pa_nd_kv(
     const torch::Tensor& kv,
-    const torch::Tensor& cu_seqlens_q,
+    const torch::Tensor& cu_seqlens_src,
     const torch::Tensor& block_table_hint,
-    int64_t block_size) {
-  if (!kv.defined() || !cu_seqlens_q.defined() || cu_seqlens_q.numel() <= 1 ||
-      block_size <= 0) {
+    int64_t block_size,
+    const torch::Tensor& cu_seqlens_dst = torch::Tensor()) {
+  if (!kv.defined() || !cu_seqlens_src.defined() ||
+      cu_seqlens_src.numel() <= 1 || block_size <= 0) {
     return {torch::Tensor(), torch::Tensor()};
   }
 
-  const int64_t batch_size = cu_seqlens_q.numel() - 1;
-  const auto cu_cpu = cu_seqlens_q.to(torch::kCPU).to(torch::kInt64);
+  const int64_t batch_size = cu_seqlens_src.numel() - 1;
+  const auto cu_cpu = cu_seqlens_src.to(torch::kCPU).to(torch::kInt64);
   std::vector<int64_t> q_starts(batch_size + 1);
   auto cu_acc = cu_cpu.accessor<int64_t, 1>();
+
+  const bool has_dst =
+      cu_seqlens_dst.defined() && cu_seqlens_dst.numel() == batch_size + 1;
+  std::vector<int64_t> dst_lens_vec(batch_size, 0);
+  if (has_dst) {
+    const auto dst_cpu = cu_seqlens_dst.to(torch::kCPU).to(torch::kInt64);
+    auto dst_acc = dst_cpu.accessor<int64_t, 1>();
+    for (int64_t i = 1; i <= batch_size; ++i) {
+      dst_lens_vec[i - 1] = dst_acc[i] - dst_acc[i - 1];
+    }
+  }
+
   int64_t total_blocks = 0;
   int64_t max_blocks_per_req = 0;
-  // cu_seqlens_q describes the packed token ranges for each request. Convert
+  // cu_seqlens_src describes the packed token ranges for each request. Convert
   // those ranges into the number of PA_ND blocks each request needs.
   for (int64_t i = 0; i <= batch_size; ++i) {
     q_starts[i] = cu_acc[i];
     if (i > 0) {
-      const int64_t q_len = q_starts[i] - q_starts[i - 1];
-      const int64_t blocks = (q_len + block_size - 1) / block_size;
+      if (!has_dst) {
+        dst_lens_vec[i - 1] = q_starts[i] - q_starts[i - 1];
+      }
+      const int64_t blocks =
+          (dst_lens_vec[i - 1] + block_size - 1) / block_size;
       total_blocks += blocks;
       max_blocks_per_req = std::max(max_blocks_per_req, blocks);
     }
@@ -303,7 +332,8 @@ std::tuple<torch::Tensor, torch::Tensor> build_prefill_pa_nd_kv(
   int64_t next_block = 1;
   for (int64_t req = 0; req < batch_size; ++req) {
     const int64_t q_start = q_starts[req];
-    const int64_t q_len = q_starts[req + 1] - q_start;
+    const int64_t src_len = q_starts[req + 1] - q_start;
+    const int64_t q_len = dst_lens_vec[req];
     const int64_t blocks = (q_len + block_size - 1) / block_size;
     if (q_len <= 0 || blocks <= 0) {
       continue;
@@ -313,14 +343,20 @@ std::tuple<torch::Tensor, torch::Tensor> build_prefill_pa_nd_kv(
           static_cast<int32_t>(next_block + j);
     }
     // Copy this request's contiguous prefill KV into its temporary PA_ND block
-    // range. The zero-initialized tail of the last block is padding.
-    auto target = packed_kv
-                      .slice(/*dim=*/0,
-                             /*start=*/next_block,
-                             /*end=*/next_block + blocks)
-                      .view({blocks * block_size, kv.size(1), kv.size(2)});
-    target.narrow(/*dim=*/0, /*start=*/0, /*length=*/q_len)
-        .copy_(kv.narrow(/*dim=*/0, /*start=*/q_start, /*length=*/q_len));
+    // range. The zero-initialized tail of the last block is padding. Under CP
+    // the window is shorter than the gathered rows kv holds for this request
+    // (it stops where this rank's queries stop), so clamp instead of reading
+    // past the window.
+    const int64_t copy_len = std::min(q_len, src_len);
+    if (copy_len > 0) {
+      auto target = packed_kv
+                        .slice(/*dim=*/0,
+                               /*start=*/next_block,
+                               /*end=*/next_block + blocks)
+                        .view({blocks * block_size, kv.size(1), kv.size(2)});
+      target.narrow(/*dim=*/0, /*start=*/q_len - copy_len, /*length=*/copy_len)
+          .copy_(kv.narrow(/*dim=*/0, /*start=*/q_start, /*length=*/copy_len));
+    }
     next_block += blocks;
   }
 
@@ -347,7 +383,14 @@ Dsv4PreprocessOutputs run_dsv4_preprocess_fallback(
     double eps,
     const torch::Tensor& q_rms_gamma,
     const torch::Tensor& cos,
-    const torch::Tensor& sin) {
+    const torch::Tensor& sin,
+    // Prefill CP: q runs on this rank's rows while kv must cover all tokens,
+    // so the kv projection takes its own input and its own global-position
+    // RoPE. All undefined (the default) means q and kv share one input, which
+    // is the non-CP path and stays byte-identical.
+    const torch::Tensor& kv_hidden_states = torch::Tensor(),
+    const torch::Tensor& kv_cos = torch::Tensor(),
+    const torch::Tensor& kv_sin = torch::Tensor()) {
   Dsv4PreprocessOutputs outputs;
 
   auto q_down = q_a_proj->forward(hidden_states);
@@ -382,12 +425,17 @@ Dsv4PreprocessOutputs run_dsv4_preprocess_fallback(
   xllm::kernel::fused_layernorm(q_rmsnorm_params);
   outputs.q = q_rmsnorm_params.output;
 
-  auto kv_down = kv_proj->forward(hidden_states);
+  const torch::Tensor& kv_input =
+      kv_hidden_states.defined() ? kv_hidden_states : hidden_states;
+  auto kv_down = kv_proj->forward(kv_input);
   outputs.kv = std::get<0>(kv_layernorm->forward(kv_down));
   outputs.kv = outputs.kv.view({-1, 1, qk_head_dim});
 
   apply_partial_rope(outputs.q, nope_head_dim, rope_head_dim, cos, sin);
-  apply_partial_rope(outputs.kv, nope_head_dim, rope_head_dim, cos, sin);
+  const torch::Tensor& kv_rope_cos = kv_cos.defined() ? kv_cos : cos;
+  const torch::Tensor& kv_rope_sin = kv_sin.defined() ? kv_sin : sin;
+  apply_partial_rope(
+      outputs.kv, nope_head_dim, rope_head_dim, kv_rope_cos, kv_rope_sin);
 
   return outputs;
 }
@@ -623,6 +671,30 @@ DSAttentionImpl::forward(const DSAMetadata& attn_metadata,
       compress_metadata;
   auto cos = attn_metadata.cos;
   auto sin = attn_metadata.sin;
+
+  // Prefill CP: hidden_states holds only this rank's query rows, but the KV,
+  // compressor and index-cache writes must cover every token so each rank ends
+  // up with a full KV replica and local queries can attend to the whole prefix.
+  // Rebuild the global-ordered hidden once per layer here. RoPE is per-token
+  // and each rank's rows carry their true global positions, so gathering after
+  // the projections would be equivalent -- gathering the input keeps the
+  // downstream call sites unchanged.
+  const auto* cp_ctx = attn_metadata.v4_cp_context;
+  const bool cp_enabled = cp_ctx != nullptr && cp_ctx->enabled();
+  torch::Tensor kv_hidden_states;
+  torch::Tensor kv_cos;
+  torch::Tensor kv_sin;
+  // Cumulative row count of kv_hidden_states, in the compressor's (batch+1,)
+  // leading-zero layout. Stays empty when CP is off so every consumer falls
+  // back to the metadata's own query cumsum.
+  std::optional<torch::Tensor> kv_cu_seq_lens;
+  if (cp_enabled) {
+    kv_hidden_states = cp_ctx->gather_restore(hidden_states);
+    kv_cos = attn_metadata.kv_cos;
+    kv_sin = attn_metadata.kv_sin;
+    kv_cu_seq_lens = cp_ctx->global_q_cu_seq_lens;
+  }
+
   Dsv4PreprocessOutputs preprocess_outputs =
       run_dsv4_preprocess_fallback(q_a_proj_,
                                    q_layernorm_,
@@ -638,7 +710,10 @@ DSAttentionImpl::forward(const DSAMetadata& attn_metadata,
                                    eps_,
                                    q_rms_gamma_,
                                    cos,
-                                   sin);
+                                   sin,
+                                   kv_hidden_states,
+                                   kv_cos,
+                                   kv_sin);
   auto qr = preprocess_outputs.qr;
   auto qr_pertoken_scale = preprocess_outputs.qr_pertoken_scale;
   auto q = preprocess_outputs.q;
@@ -720,11 +795,19 @@ DSAttentionImpl::forward(const DSAMetadata& attn_metadata,
   if (use_temporary_prefill_kv) {
     const int64_t block_size =
         ori_kv.defined() && ori_kv.dim() > 1 ? ori_kv.size(1) : 128;
+    // Under CP `kv` was projected from the gathered global rows, so its request
+    // offsets are the global query cumsum -- actual_seq_lengths_query is this
+    // rank's localized view and would slice the wrong rows. The window each
+    // request exposes is the localized kv extent, matching the seqused_kv
+    // passed to sparse_attn_sharedkv below.
     std::tie(ori_kv_for_attn, ori_block_table_for_attn) =
-        build_prefill_pa_nd_kv(kv,
-                               attn_metadata.actual_seq_lengths_query,
-                               ori_block_table,
-                               block_size);
+        build_prefill_pa_nd_kv(
+            kv,
+            cp_enabled ? cp_ctx->global_q_cu_seq_lens
+                       : attn_metadata.actual_seq_lengths_query,
+            ori_block_table,
+            block_size,
+            cp_enabled ? cp_ctx->local_kv_cu_seq_lens : torch::Tensor());
     CHECK(ori_kv_for_attn.defined())
         << "Failed to build PA_ND KV for DeepSeek V4 prefill attention.";
   } else {
@@ -754,14 +837,19 @@ DSAttentionImpl::forward(const DSAMetadata& attn_metadata,
     std::tuple<torch::Tensor, torch::Tensor> compressor_block_tables{
         kv_block_table, score_block_table};
 
-    auto compressed_kv =
-        compressor_->forward(attn_metadata,
-                             hidden_states,
-                             compressor_states,
-                             compressor_block_tables,
-                             compress_sin,
-                             compress_cos,
-                             attn_metadata.actual_seq_lengths_query);
+    auto compressed_kv = compressor_->forward(
+        attn_metadata,
+        // The compressor projects compressed KV from hidden with its own
+        // wkv, so under CP it needs every token -- its cache must be a full
+        // replica, addressed by the global cu_seqlens rather than the
+        // query-localized one.
+        cp_enabled ? kv_hidden_states : hidden_states,
+        compressor_states,
+        compressor_block_tables,
+        compress_sin,
+        compress_cos,
+        cp_enabled ? cp_ctx->global_q_cu_seq_lens
+                   : attn_metadata.actual_seq_lengths_query);
     scatter_by_slot(cmp_kv, cmp_slot, compressed_kv);
     cmp_kv_for_attn = cmp_kv;
   }
@@ -803,7 +891,14 @@ DSAttentionImpl::forward(const DSAMetadata& attn_metadata,
                              qli_metadata_opt,
                              use_prefill_attn,
                              &indexer_states,
-                             &indexer_block_tables);
+                             &indexer_block_tables,
+                             // Global-ordered hidden for the index-cache write;
+                             // the first arg stays local for build_weights.
+                             kv_hidden_states,
+                             // Cumulative lengths of kv_hidden_states' rows.
+                             // actual_seq_lengths_query above is this rank's
+                             // localized view and would under-count them.
+                             kv_cu_seq_lens);
     CHECK(compress_topk_idxs.defined())
         << "DSAttention indexer returned undefined topk indices for "
            "compress_ratio==4.";
@@ -825,9 +920,14 @@ DSAttentionImpl::forward(const DSAMetadata& attn_metadata,
 
   std::optional<torch::Tensor> cu_seqlens_ori_kv_for_attn = std::nullopt;
   if (use_prefill_attn) {
-    // Prefill-style sparse metadata uses query cu-seqlens for ori_kv.
+    // Prefill-style sparse metadata uses query cu-seqlens for ori_kv. Without
+    // CP the two coincide (one query row per new kv row); under CP the kv
+    // window is longer than this rank's query block, and it is the window that
+    // describes ori_kv. Must match the cu_seqlens_ori_kv that
+    // build_precomputed_metadata baked into the sparse metadata tiling.
     cu_seqlens_ori_kv_for_attn =
-        as_optional(attn_metadata.actual_seq_lengths_query);
+        cp_enabled ? as_optional(cp_ctx->local_kv_cu_seq_lens)
+                   : as_optional(attn_metadata.actual_seq_lengths_query);
   }
 
   auto [attn_output, output_lse] = xllm::kernel::npu::sparse_attn_sharedkv(

--- a/xllm/core/layers/npu_torch/deepseek_v4_cp_context.h
+++ b/xllm/core/layers/npu_torch/deepseek_v4_cp_context.h
@@ -1,0 +1,289 @@
+/* Copyright 2025-2026 The xLLM Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://github.com/jd-opensource/xllm/blob/main/LICENSE
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#pragma once
+
+#include <glog/logging.h>
+#include <torch/torch.h>
+
+#include <algorithm>
+#include <cstdint>
+#include <numeric>
+#include <unordered_map>
+#include <utility>
+#include <vector>
+
+#include "framework/parallel_state/parallel_state.h"
+#include "framework/parallel_state/process_group.h"
+
+namespace xllm::layer::v4_cp {
+
+// Per-forward prefill context-parallel plan for DeepSeek-V4.
+//
+// Why not reuse the framework's NpuCpPlan: that substrate localizes
+// kv_seq_lens in apply_attention_meta(), but V4 derives every cache group's
+// slot_mapping from kv_seq_lens (expand_blocks_to_slots / compute_slot_num
+// scale it by the group's ratio and block_size). Shortening kv lengths would
+// write KV to the wrong slots. This plan keeps kv global on purpose and
+// localizes only the query axis. NpuCpPlan also splits zigzag (two chunks per
+// rank, so a sequence's local rows are non-contiguous, needing two metadata
+// rows) and asserts 2D hidden, while V4 metadata is one row per sequence and
+// its hidden is 3D.
+struct DeepseekV4CpContext {
+  // Global row indices this rank owns, in ascending (global) order.
+  torch::Tensor local_row_indices;
+  // Maps global row -> its position in the rank-major gathered buffer, so
+  // gathered.index_select(0, restore_indices) restores global order.
+  torch::Tensor restore_indices;
+  // Row count per rank; segments may differ in length, so the gather is uneven.
+  std::vector<int32_t> tokens_per_rank;
+  // True global positions of the local rows (never renumbered), so query RoPE
+  // stays correct without a separate position table.
+  torch::Tensor local_positions;
+
+  // Query axis is localized; KV axis stays global. Both are needed because the
+  // KV/compressor/index-cache write path runs on all tokens while attention
+  // runs on this rank's queries only.
+  std::vector<int32_t> global_q_seq_lens;
+  std::vector<int32_t> global_kv_seq_lens;
+  std::vector<int32_t> local_q_seq_lens;
+  // Per-sequence kv extent this rank's queries may attend to, in global
+  // coordinates: cached prefix + one past this rank's last local row.
+  //
+  // sparse_attn_sharedkv and the lightning indexer align the query block to the
+  // END of the kv window, so the query at local row j is treated as sitting at
+  // global position kv_len - local_q + j. With a contiguous split that only
+  // holds for the last cp_rank. Handing every rank the global kv length shifts
+  // rank r's queries to the tail of the whole sequence: rank 0 of a 145-token
+  // prompt at cp=2 attends as if its rows were at 72..144 instead of 0..72, so
+  // its causal mask, its window and its top-k all address the wrong prefix.
+  // Only the attention / indexer read path uses this; slot_mapping, the block
+  // tables, the compressor and the index-cache writes stay global because each
+  // rank holds a full KV replica written from all tokens.
+  std::vector<int32_t> local_kv_seq_lens;
+  // (batch+1,) leading-zero cumsum of local_kv_seq_lens, matching the layout
+  // DSAMetadataBuilder gives kv_cu_seq_lens.
+  torch::Tensor local_kv_cu_seq_lens;
+  // Global q cumulative lengths (leading 0), matching the layout
+  // DSAMetadataBuilder gives actual_seq_lengths_query. The model localizes that
+  // field for the attention path, so the compressor / index-cache writes --
+  // which run on all tokens -- read their global view from here instead. Cached
+  // at build time so the layer loop does not redo a cumsum per layer.
+  torch::Tensor global_q_cu_seq_lens;
+
+  // Global-position RoPE tables keyed by the layer's compression ratio, saved
+  // before the query axis is localized. A c4 or c128 layer swaps dsa.cos to its
+  // own ratio table, so the KV path needs the global table of that same ratio;
+  // capturing only the ratio-1 table would apply the wrong RoPE on compressed
+  // layers. Populated by the model; empty when CP is off.
+  std::unordered_map<int32_t, std::pair<torch::Tensor, torch::Tensor>>
+      global_rope_by_ratio;
+
+  // Returns the global RoPE pair for `ratio`, falling back to ratio 1.
+  std::pair<torch::Tensor, torch::Tensor> global_rope(int32_t ratio) const {
+    auto it = global_rope_by_ratio.find(ratio);
+    if (it == global_rope_by_ratio.end()) {
+      it = global_rope_by_ratio.find(1);
+    }
+    if (it == global_rope_by_ratio.end()) {
+      return {torch::Tensor(), torch::Tensor()};
+    }
+    return it->second;
+  }
+
+  int32_t cp_size = 1;
+  int32_t cp_rank = 0;
+  int32_t global_token_count = 0;
+  int32_t local_token_count = 0;
+  ProcessGroup* cp_group = nullptr;
+
+  bool enabled() const { return cp_size > 1 && cp_group != nullptr; }
+
+  // Select this rank's rows from a global-ordered tensor (dim 0).
+  torch::Tensor shard_rows(const torch::Tensor& global_tensor) const {
+    if (!global_tensor.defined() || !enabled()) {
+      return global_tensor;
+    }
+    return global_tensor.index_select(/*dim=*/0,
+                                      local_row_indices.to(torch::kLong));
+  }
+
+  // AllGather local rows across the CP group, then restore global order.
+  torch::Tensor gather_restore(const torch::Tensor& local_tensor) const {
+    if (!local_tensor.defined() || !enabled()) {
+      return local_tensor;
+    }
+    torch::Tensor gathered = xllm::parallel_state::gather(
+        local_tensor.contiguous(), cp_group, tokens_per_rank);
+    return gathered.index_select(/*dim=*/0, restore_indices.to(torch::kLong));
+  }
+};
+
+// Splits each sequence into cp_size contiguous segments and keeps segment
+// cp_rank. Contiguous (rather than zigzag) keeps every sequence at one
+// metadata row, which is what V4's c1/c4/c128/qli metadata expects. The cost is
+// causal load imbalance: rank 0 gets short prefixes, the last rank long ones.
+//
+// Short sequences yield empty segments on the higher ranks. That is legal and
+// must stay working -- chunked prefill routinely schedules chunks smaller than
+// cp_size.
+// Pure split arithmetic, factored out so it is unit-testable without a
+// ProcessGroup or an accelerator: returns the global row indices owned by each
+// rank, outer index = cp_rank.
+inline std::vector<std::vector<int64_t>> compute_cp_rows_by_rank(
+    int32_t cp_size,
+    const std::vector<int32_t>& global_q_seq_lens) {
+  CHECK_GT(cp_size, 0);
+  std::vector<std::vector<int64_t>> rows_by_rank(cp_size);
+  int64_t seq_base = 0;
+  for (const int32_t q_i : global_q_seq_lens) {
+    const int32_t seg = (q_i + cp_size - 1) / cp_size;
+    for (int32_t r = 0; r < cp_size; ++r) {
+      const int32_t start = std::min(r * seg, q_i);
+      const int32_t end = std::min(start + seg, q_i);
+      for (int32_t j = start; j < end; ++j) {
+        rows_by_rank[r].push_back(seq_base + j);
+      }
+    }
+    seq_base += q_i;
+  }
+  return rows_by_rank;
+}
+
+// Per-sequence local q length and the kv extent that q block ends at, for one
+// rank. Factored out of build_deepseek_v4_cp_context for the same reason as
+// compute_cp_rows_by_rank: it is pure arithmetic and the accuracy of the whole
+// CP path hinges on it, so it must be unit-testable without a ProcessGroup.
+//
+// local_kv[i] is a GLOBAL position count, not a row count: cached prefix +
+// one past this rank's last row in sequence i. That is what makes the kernel's
+// end-of-window query alignment land on this rank's true global positions.
+inline void compute_cp_local_seq_lens(
+    int32_t cp_size,
+    int32_t cp_rank,
+    const std::vector<int32_t>& global_q_seq_lens,
+    const std::vector<int32_t>& global_kv_seq_lens,
+    std::vector<int32_t>* local_q_seq_lens,
+    std::vector<int32_t>* local_kv_seq_lens) {
+  CHECK_GT(cp_size, 0);
+  CHECK_EQ(global_q_seq_lens.size(), global_kv_seq_lens.size());
+  local_q_seq_lens->clear();
+  local_kv_seq_lens->clear();
+  local_q_seq_lens->reserve(global_q_seq_lens.size());
+  local_kv_seq_lens->reserve(global_q_seq_lens.size());
+  for (size_t i = 0; i < global_q_seq_lens.size(); ++i) {
+    const int32_t q_i = global_q_seq_lens[i];
+    const int32_t seg = (q_i + cp_size - 1) / cp_size;
+    const int32_t start = std::min(cp_rank * seg, q_i);
+    const int32_t end = std::min(start + seg, q_i);
+    local_q_seq_lens->push_back(end - start);
+    // prefix = global_kv - global_q is the cached context in front of this
+    // forward's query rows; end is one past this rank's last row within them.
+    const int32_t prefix = global_kv_seq_lens[i] - q_i;
+    local_kv_seq_lens->push_back(prefix + end);
+  }
+}
+
+inline DeepseekV4CpContext build_deepseek_v4_cp_context(
+    int32_t cp_size,
+    int32_t cp_rank,
+    ProcessGroup* cp_group,
+    const std::vector<int32_t>& global_q_seq_lens,
+    const std::vector<int32_t>& global_kv_seq_lens,
+    const torch::Tensor& global_positions) {
+  DeepseekV4CpContext ctx;
+  ctx.cp_size = cp_size;
+  ctx.cp_rank = cp_rank;
+  ctx.cp_group = cp_group;
+  ctx.global_q_seq_lens = global_q_seq_lens;
+  ctx.global_kv_seq_lens = global_kv_seq_lens;
+  if (cp_size <= 1 || cp_group == nullptr) {
+    return ctx;
+  }
+  CHECK_GE(cp_rank, 0);
+  CHECK_LT(cp_rank, cp_size);
+  CHECK_EQ(global_q_seq_lens.size(), global_kv_seq_lens.size())
+      << "V4 CP expects one kv length per q length";
+
+  const int32_t global_token_count = std::accumulate(
+      global_q_seq_lens.begin(), global_q_seq_lens.end(), int32_t{0});
+  ctx.global_token_count = global_token_count;
+
+  const std::vector<std::vector<int64_t>> rows_by_rank =
+      compute_cp_rows_by_rank(cp_size, global_q_seq_lens);
+
+  // Local per-sequence q lengths, in the same sequence order as the input, and
+  // the kv extent each of those local query blocks ends at.
+  compute_cp_local_seq_lens(cp_size,
+                            cp_rank,
+                            global_q_seq_lens,
+                            global_kv_seq_lens,
+                            &ctx.local_q_seq_lens,
+                            &ctx.local_kv_seq_lens);
+
+  // gather() concatenates rank-major, so walk ranks in order to learn where
+  // each global row lands, then invert: index_select needs
+  // restore[global_row] = gathered_position.
+  std::vector<int64_t> restore(static_cast<size_t>(global_token_count), 0);
+  ctx.tokens_per_rank.reserve(cp_size);
+  int64_t gathered_pos = 0;
+  for (int32_t r = 0; r < cp_size; ++r) {
+    ctx.tokens_per_rank.push_back(static_cast<int32_t>(rows_by_rank[r].size()));
+    for (const int64_t global_row : rows_by_rank[r]) {
+      restore[static_cast<size_t>(global_row)] = gathered_pos++;
+    }
+  }
+  CHECK_EQ(gathered_pos, global_token_count)
+      << "V4 CP segments must cover every global row exactly once";
+
+  const auto cpu_i64 =
+      torch::TensorOptions().dtype(torch::kInt64).device(torch::kCPU);
+  const torch::Device device =
+      global_positions.defined() ? global_positions.device() : torch::kCPU;
+  ctx.local_token_count = static_cast<int32_t>(rows_by_rank[cp_rank].size());
+  ctx.local_row_indices =
+      torch::tensor(rows_by_rank[cp_rank], cpu_i64).to(device);
+  ctx.restore_indices = torch::tensor(restore, cpu_i64).to(device);
+
+  // Leading 0 then cumsum, matching DSAMetadataBuilder's convention.
+  std::vector<int32_t> q_cu;
+  q_cu.reserve(global_q_seq_lens.size() + 1);
+  q_cu.push_back(0);
+  int32_t q_running = 0;
+  for (const int32_t q_i : global_q_seq_lens) {
+    q_running += q_i;
+    q_cu.push_back(q_running);
+  }
+  const auto cpu_i32 =
+      torch::TensorOptions().dtype(torch::kInt32).device(torch::kCPU);
+  ctx.global_q_cu_seq_lens = torch::tensor(q_cu, cpu_i32).to(device);
+
+  std::vector<int32_t> kv_cu;
+  kv_cu.reserve(ctx.local_kv_seq_lens.size() + 1);
+  kv_cu.push_back(0);
+  int32_t kv_running = 0;
+  for (const int32_t kv_i : ctx.local_kv_seq_lens) {
+    kv_running += kv_i;
+    kv_cu.push_back(kv_running);
+  }
+  ctx.local_kv_cu_seq_lens = torch::tensor(kv_cu, cpu_i32).to(device);
+  if (global_positions.defined()) {
+    ctx.local_positions = global_positions.index_select(
+        /*dim=*/0, ctx.local_row_indices.to(torch::kLong));
+  }
+  return ctx;
+}
+
+}  // namespace xllm::layer::v4_cp

--- a/xllm/core/layers/npu_torch/deepseek_v4_indexer.cpp
+++ b/xllm/core/layers/npu_torch/deepseek_v4_indexer.cpp
@@ -406,7 +406,9 @@ torch::Tensor DeepseekV4IndexerImpl::select_qli(
     const std::optional<torch::Tensor>& qli_metadata,
     bool with_prefill,
     std::tuple<torch::Tensor, torch::Tensor>* compressor_states,
-    std::tuple<torch::Tensor, torch::Tensor>* compressor_block_tables) {
+    std::tuple<torch::Tensor, torch::Tensor>* compressor_block_tables,
+    const torch::Tensor& x_kv,
+    const std::optional<torch::Tensor>& x_kv_cu_seq_lens) {
   CHECK(index_cache.defined())
       << "DeepseekV4Indexer::select_qli: index_cache is undefined";
 
@@ -421,11 +423,30 @@ torch::Tensor DeepseekV4IndexerImpl::select_qli(
   auto hadamard = get_hadamard_matrix(attn_metadata, hadamard_matrix_);
   q = rotate_activation_with_hadamard(q, hadamard, hadamard_scale_);
 
-  auto kv = compress_kv(x,
+  // The index cache must cover every token so that top-k indices and the sparse
+  // attention block-table addressing share one global compressed coordinate
+  // space. Under CP, x_kv holds the global-ordered hidden; x stays local so
+  // build_weights() below keeps one weight row per local query.
+  const bool cp_split_inputs = x_kv.defined();
+  const torch::Tensor& kv_source = cp_split_inputs ? x_kv : x;
+  // The cu_seqlens must count the rows of the tensor it is paired with, in the
+  // compressor's (batch+1,) leading-zero cumulative layout. x_kv holds the
+  // gathered query rows of every CP rank, so it pairs with the global query
+  // cumsum -- not with actual_seq_lengths_query, which the model localized to
+  // this rank's shard, and not with actual_seq_lengths_key, which is
+  // per-sequence rather than cumulative. Feeding either of those makes the
+  // kernel's tiling read past the end and launch with blockDim == 0.
+  if (cp_split_inputs) {
+    CHECK(x_kv_cu_seq_lens.has_value() && x_kv_cu_seq_lens->defined())
+        << "DeepseekV4Indexer::select_qli: x_kv requires x_kv_cu_seq_lens";
+  }
+  const std::optional<torch::Tensor>& compress_cu_seqlens =
+      cp_split_inputs ? x_kv_cu_seq_lens : actual_seq_lengths_query;
+  auto kv = compress_kv(kv_source,
                         attn_metadata,
                         compressed_cos,
                         compressed_sin,
-                        actual_seq_lengths_query,
+                        compress_cu_seqlens,
                         compressor_states,
                         compressor_block_tables);
   if (kv.numel() > 0) {
@@ -548,7 +569,11 @@ torch::Tensor DeepseekV4IndexerImpl::select_qli(
     const std::optional<torch::Tensor>& qli_metadata,
     bool with_prefill,
     std::tuple<torch::Tensor, torch::Tensor>* compressor_states,
-    std::tuple<torch::Tensor, torch::Tensor>* compressor_block_tables) {
+    std::tuple<torch::Tensor, torch::Tensor>* compressor_block_tables,
+    const torch::Tensor& x_kv,
+    const std::optional<torch::Tensor>& x_kv_cu_seq_lens) {
+  // Must forward x_kv and its cu_seqlens, otherwise callers using this overload
+  // would silently lose CP and write a partial index cache.
   return select_qli(x,
                     qr,
                     qr_pertoken_scale,
@@ -564,7 +589,9 @@ torch::Tensor DeepseekV4IndexerImpl::select_qli(
                     qli_metadata,
                     with_prefill,
                     compressor_states,
-                    compressor_block_tables);
+                    compressor_block_tables,
+                    x_kv,
+                    x_kv_cu_seq_lens);
 }
 
 void DeepseekV4IndexerImpl::load_state_dict(const StateDict& state_dict) {

--- a/xllm/core/layers/npu_torch/deepseek_v4_indexer.h
+++ b/xllm/core/layers/npu_torch/deepseek_v4_indexer.h
@@ -65,7 +65,21 @@ class DeepseekV4IndexerImpl : public torch::nn::Module {
       bool with_prefill = false,
       std::tuple<torch::Tensor, torch::Tensor>* compressor_states = nullptr,
       std::tuple<torch::Tensor, torch::Tensor>* compressor_block_tables =
-          nullptr);
+          nullptr,
+      // Under prefill CP, `x` serves two conflicting roles: compress_kv(x)
+      // writes the index cache and must see all tokens, while build_weights(x)
+      // emits one weight row per query and must match this rank's query shard.
+      // x_kv carries the global-ordered hidden; undefined (the default) makes
+      // both paths use `x`, keeping non-CP callers unchanged. Appended last so
+      // existing positional calls keep binding to the same parameters.
+      const torch::Tensor& x_kv = torch::Tensor(),
+      // Cumulative query lengths describing x_kv's row axis: (batch+1,) with a
+      // leading 0, the same layout the compressor expects from
+      // actual_seq_lengths_query. Must be supplied whenever x_kv is, because
+      // actual_seq_lengths_query has been localized to this rank's shard and
+      // would under-count x_kv's rows. Do not substitute
+      // actual_seq_lengths_key: that one is per-sequence, not cumulative.
+      const std::optional<torch::Tensor>& x_kv_cu_seq_lens = std::nullopt);
 
   torch::Tensor select_qli(
       const torch::Tensor& x,
@@ -84,7 +98,10 @@ class DeepseekV4IndexerImpl : public torch::nn::Module {
       bool with_prefill = false,
       std::tuple<torch::Tensor, torch::Tensor>* compressor_states = nullptr,
       std::tuple<torch::Tensor, torch::Tensor>* compressor_block_tables =
-          nullptr);
+          nullptr,
+      // Forwarded to the full overload; see its declaration above.
+      const torch::Tensor& x_kv = torch::Tensor(),
+      const std::optional<torch::Tensor>& x_kv_cu_seq_lens = std::nullopt);
 
   torch::Tensor build_query(const torch::Tensor& qr);
   torch::Tensor build_query(

--- a/xllm/core/runtime/acl_graph_executor_impl.cpp
+++ b/xllm/core/runtime/acl_graph_executor_impl.cpp
@@ -801,6 +801,21 @@ ModelOutput AclGraphExecutorImpl::run(const torch::Tensor& tokens,
     COUNTER_INC(num_model_execution_total_eager);
     return forward_eager(model_, tokens, positions, kv_caches, params);
   }
+  // CP shards the query rows of a prefill batch and gathers them per layer, so
+  // token counts and collectives differ from the captured decode shape. Decode
+  // itself runs with CP inactive (both CP paths return early on decode), which
+  // is why graph mode and CP can coexist -- but spec-verify chunked prefill is
+  // a non-decode batch that reaches capture, so it must stay eager under CP.
+  if (in_spec_verify_phase && options_.cp_size() > 1) {
+    LOG_FIRST_N(WARNING, 1)
+        << "Falling back to eager mode for spec verify because context "
+           "parallel (cp_size="
+        << options_.cp_size()
+        << ") shards prefill rows, which the captured graph shape does not "
+           "describe.";
+    COUNTER_INC(num_model_execution_total_eager);
+    return model_->forward(tokens, positions, kv_caches, params);
+  }
 
   if (in_decoding_phase &&
       params_single.parallel.dp_global_token_nums.size() > 1) {

--- a/xllm/core/runtime/mtp_worker_impl.cpp
+++ b/xllm/core/runtime/mtp_worker_impl.cpp
@@ -50,21 +50,55 @@ constexpr uint64_t MBUF_SIZE = 128 * 1024 * 1024;
 
 namespace {
 
-constexpr int64_t kMaxSpecVerifyGraphUpdateBlockTableWidth = (1 << 15) - 1;
-
-ProcessGroup* spec_broadcast_group(const ParallelArgs& parallel_args) {
-  return parallel_args.tp_group_ != nullptr ? parallel_args.tp_group_
-                                            : parallel_args.process_group_;
-}
-
-void broadcast_spec_tokens(torch::Tensor& tokens,
-                           ProcessGroup* pg,
-                           int32_t root_rank = 0) {
-  if (pg == nullptr || pg->world_size() <= 1 || !tokens.defined()) {
+void broadcast_tokens_in_group(torch::Tensor& tokens,
+                               ProcessGroup* process_group,
+                               int32_t root_rank = 0) {
+  if (process_group == nullptr || process_group->world_size() <= 1 ||
+      !tokens.defined()) {
     return;
   }
   tokens = tokens.contiguous();
-  pg->broadcast(tokens, root_rank);
+  process_group->broadcast(tokens, root_rank);
+}
+
+bool should_broadcast_spec_tokens(const ParallelArgs& parallel_args,
+                                  bool enable_spec_token_broadcast,
+                                  bool all_greedy_sample) {
+  const bool use_orthogonal_cp_consensus =
+      parallel_args.cp_size() > 1 && parallel_args.tp_group_ != nullptr &&
+      parallel_args.cp_group_ != nullptr &&
+      parallel_args.cp_group_ != parallel_args.tp_group_;
+  return use_orthogonal_cp_consensus ||
+         (enable_spec_token_broadcast && !all_greedy_sample);
+}
+
+constexpr int64_t kMaxSpecVerifyGraphUpdateBlockTableWidth = (1 << 15) - 1;
+
+// Speculative state is replicated across every model rank within one DP
+// replica. With orthogonal CP x TP, tp_group_ covers only one CP shard, while
+// cp_group_ connects the same TP rank across CP shards. Broadcast along both
+// axes so every replica caches and consumes the same sampled token, without
+// crossing into another DP replica through the world group.
+void broadcast_spec_tokens(torch::Tensor& tokens,
+                           const ParallelArgs& parallel_args) {
+  // DeepSeek-V4 TORCH publishes orthogonal TP and CP groups. Other backends
+  // retain their existing single-group speculative broadcast behavior.
+  ProcessGroup* tp_group = parallel_args.tp_group_ != nullptr
+                               ? parallel_args.tp_group_
+                               : parallel_args.process_group_;
+  const bool use_orthogonal_cp_consensus =
+      parallel_args.cp_size() > 1 && parallel_args.tp_group_ != nullptr &&
+      parallel_args.cp_group_ != nullptr &&
+      parallel_args.cp_group_ != parallel_args.tp_group_;
+  if (!use_orthogonal_cp_consensus) {
+    broadcast_tokens_in_group(tokens, tp_group);
+    return;
+  }
+
+  broadcast_tokens_in_group(tokens, parallel_args.tp_group_);
+  if (parallel_args.cp_group_ != parallel_args.tp_group_) {
+    broadcast_tokens_in_group(tokens, parallel_args.cp_group_);
+  }
 }
 
 int64_t get_dp_local_tp_size(const ParallelArgs& parallel_args) {
@@ -937,6 +971,16 @@ std::optional<ForwardOutput> MTPWorkerImpl::step_prefill(
 
   {
     c10::StreamGuard stream_guard = compute_stream_->set_stream_guard();
+    // Target prefill seeds the MTP decode cache. Under orthogonal CP x TP each
+    // CP shard samples independently unless this token is synchronized across
+    // both axes; caching divergent tokens makes the first decode input disagree
+    // with the non-driver CP shard's DecodeState.
+    if (should_broadcast_spec_tokens(
+            parallel_args_,
+            get_optimization_config().enable_spec_token_broadcast,
+            input.sampling_params.all_greedy_sample)) {
+      broadcast_spec_tokens(output.sample_output.next_tokens, parallel_args_);
+    }
     if (embeddings.defined()) {
       prefill_input.input_params.embedding.input_embedding = embeddings.clone();
     }
@@ -1284,11 +1328,12 @@ std::optional<ForwardOutput> MTPWorkerImpl::step_decode(
       // process_draft_sample_output() compresses the still-full [batch, vocab]
       // probs into the cache: gathering the cached prob with a unified token
       // yields a unified prob, so we only broadcast the [batch] token tensor.
-      if (get_optimization_config().enable_spec_token_broadcast &&
-          !current_draft_input.sampling_params.all_greedy_sample) {
+      if (should_broadcast_spec_tokens(
+              parallel_args_,
+              get_optimization_config().enable_spec_token_broadcast,
+              current_draft_input.sampling_params.all_greedy_sample)) {
         SampleOutput& draft_sample = draft_outputs.back().sample_output;
-        broadcast_spec_tokens(draft_sample.next_tokens,
-                              spec_broadcast_group(parallel_args_));
+        broadcast_spec_tokens(draft_sample.next_tokens, parallel_args_);
       }
       process_draft_sample_output(draft_outputs.back().sample_output);
     }
@@ -1444,10 +1489,11 @@ std::optional<ForwardOutput> MTPWorkerImpl::run_validate(
 
     // Catch-all for cross-rank RNG divergence: unify accepted tokens before
     // deriving any device-resident state used by the next draft iteration.
-    if (get_optimization_config().enable_spec_token_broadcast &&
-        !input.sampling_params.all_greedy_sample) {
-      broadcast_spec_tokens(val_output.next_tokens,
-                            spec_broadcast_group(parallel_args_));
+    if (should_broadcast_spec_tokens(
+            parallel_args_,
+            get_optimization_config().enable_spec_token_broadcast,
+            input.sampling_params.all_greedy_sample)) {
+      broadcast_spec_tokens(val_output.next_tokens, parallel_args_);
     }
 
     base_positions = validate_input.positions.view({batch_size, num_val_tokens})

--- a/xllm/core/runtime/worker_impl.cpp
+++ b/xllm/core/runtime/worker_impl.cpp
@@ -47,6 +47,7 @@ limitations under the License.
 #include "core/framework/config/disagg_pd_config.h"
 #include "core/framework/config/eplb_config.h"
 #include "core/framework/config/execution_config.h"
+#include "core/framework/config/kernel_config.h"
 #include "core/framework/config/kv_cache_config.h"
 #include "core/framework/config/load_config.h"
 #include "core/framework/config/profile_config.h"
@@ -706,9 +707,15 @@ const CpPlanRuntimeConfig& WorkerImpl::npu_cp_plan_runtime_config() const {
     return npu_cp_runtime_config_;
   }
   CpPlanRuntimeConfig cfg;
-  cfg.enabled = parallel_args_.cp_size() > 1 &&
-                Platform::uses_model_cp_sharding() &&
-                owns_npu_cp_plan_build() && model_supports_model_cp();
+  // NpuCpPlan is the ATB-side CP substrate: it emits cp_ep_meta for ATB graph
+  // nodes and reads attn tp/cp widths out of MappingNPU's json, which only the
+  // ATB branch populates. TORCH models (deepseek_v4) own their CP split inside
+  // the model, so the worker must not shard a second time here -- and must not
+  // reach the mapping CHECK below with an empty mapping.
+  cfg.enabled =
+      parallel_args_.cp_size() > 1 && Platform::uses_model_cp_sharding() &&
+      ::xllm::KernelConfig::get_instance().npu_kernel_backend() == "ATB" &&
+      owns_npu_cp_plan_build() && model_supports_model_cp();
   cfg.has_prefix_slots =
       KVCacheConfig::get_instance().enable_prefix_cache() ||
       SchedulerConfig::get_instance().enable_chunked_prefill();

--- a/xllm/models/llm/deepseek_v4.h
+++ b/xllm/models/llm/deepseek_v4.h
@@ -44,6 +44,7 @@ limitations under the License.
 #include "core/layers/deepseek_v4_decoder_layer.h"
 #include "core/util/tensor_helper.h"
 #include "layers/npu/deepseek_v4_rotary_embedding.h"
+#include "layers/npu_torch/deepseek_v4_cp_context.h"
 #include "llm_model_base.h"
 
 namespace xllm {
@@ -424,15 +425,23 @@ class DeepseekV4ModelImpl
 
     num_heads_ = model_args.n_heads();
     head_dim_ = model_args.o_lora_rank() + model_args.qk_rope_head_dim();
-    dp_local_tp_size_ =
-        std::max<int64_t>(parallel_args.world_size() /
-                              std::max<int64_t>(parallel_args.dp_size(), 1),
-                          1);
+    // Attention TP width under the orthogonal dp * cp * attn_tp == world
+    // layout. This must match the width DSAttention actually shards heads by
+    // (it reads tp_group_->world_size(), narrowed in
+    // CollectiveCommunicator::create_process_groups). Dividing by dp alone
+    // would make the precomputed sparse metadata below advertise a head count
+    // the kernels never see.
+    cp_size_ = std::max<int64_t>(parallel_args.cp_size(), 1);
+    cp_group_ = parallel_args.cp_group_;
+    dp_local_tp_size_ = std::max<int64_t>(
+        parallel_args.world_size() /
+            std::max<int64_t>(parallel_args.dp_size(), 1) / cp_size_,
+        1);
     CHECK_EQ(num_heads_ % dp_local_tp_size_, 0)
-        << "[DSV4][Init] n_heads must be divisible by local tp size. n_heads="
-        << num_heads_ << ", local_tp_size=" << dp_local_tp_size_
+        << "[DSV4][Init] n_heads must be divisible by attn tp size. n_heads="
+        << num_heads_ << ", attn_tp_size=" << dp_local_tp_size_
         << ", world_size=" << parallel_args.world_size()
-        << ", dp_size=" << parallel_args.dp_size();
+        << ", dp_size=" << parallel_args.dp_size() << ", cp_size=" << cp_size_;
     tp_num_heads_ = num_heads_ / dp_local_tp_size_;
     window_size_ = model_args.window_size();
     index_n_heads_ = model_args.index_n_heads();
@@ -760,6 +769,46 @@ class DeepseekV4ModelImpl
       h = shard_sequence(h, fc1_ctx);
     }
 
+    // Prefill context parallel. Built here, after the global DSA metadata is
+    // complete, because the KV / compressor / index-cache write path keeps the
+    // global kv_seq_lens and slot_mapping: only the query axis is localized.
+    layer::v4_cp::DeepseekV4CpContext cp_ctx;
+    const bool cp_enabled = cp_size_ > 1 && cp_group_ != nullptr &&
+                            !is_empty_dp_rank &&
+                            input_params.meta.batch_forward_type.no_decode() &&
+                            attn_metadata.dsa_metadata != nullptr;
+    if (cp_enabled) {
+      // FlashComm1 SP and CP both shard tokens; running both would shard twice.
+      CHECK(!is_sequence_sharded(fc1_ctx))
+          << "DeepSeek V4 cannot combine FlashComm1 sequence parallel with "
+             "context parallel; build_flash_comm1_context must disable itself "
+             "when cp_size > 1.";
+      auto& dsa = *(attn_metadata.dsa_metadata);
+      cp_ctx = layer::v4_cp::build_deepseek_v4_cp_context(
+          static_cast<int32_t>(cp_size_),
+          cp_group_->rank(),
+          cp_group_,
+          modified_input_params.attention.host.q_seq_lens,
+          modified_input_params.attention.host.kv_seq_lens,
+          dsa.input_positions);
+      if (cp_ctx.enabled()) {
+        // Save the global-position RoPE per ratio before the query side is
+        // rebuilt against local rows. The layer loop below picks the KV table
+        // for the layer's own ratio out of this map.
+        cp_ctx.global_rope_by_ratio = input_rope_by_ratio;
+        rebuild_cp_local_query_metadata(
+            dsa, modified_input_params, cp_ctx, input_rope_by_ratio);
+        h = cp_ctx.shard_rows(h);
+        positions = cp_ctx.shard_rows(positions);
+        // tokens stays global on purpose. The decoder layer gathers the FFN
+        // input back to the full DP-local token set before the MoE gate, so the
+        // gate's input_ids must stay global to match those rows. Likewise
+        // dp_global_token_nums keeps the unsharded counts the engine published,
+        // because the MoE DP gather runs on the already CP-gathered rows.
+        dsa.v4_cp_context = &cp_ctx;
+      }
+    }
+
     std::optional<torch::Tensor> residual;
     for (size_t i = 0; i < layers_.size(); i++) {
       if (attn_metadata.dsa_metadata) {
@@ -791,6 +840,14 @@ class DeepseekV4ModelImpl
           // the attention kernel reads them from dsa.
           dsa.cos = rope_it->second.first;
           dsa.sin = rope_it->second.second;
+        }
+        if (cp_ctx.enabled()) {
+          // Under CP the tables above are localized to this rank's query rows.
+          // The KV / compressor / index-cache writes span all tokens, so pair
+          // them with the global table of the same ratio.
+          auto [kv_cos, kv_sin] = cp_ctx.global_rope(layer_compress_ratio);
+          dsa.kv_cos = kv_cos;
+          dsa.kv_sin = kv_sin;
         }
 
         if (layer_id < static_cast<int32_t>(dsa.block_tables.size()) &&
@@ -840,6 +897,15 @@ class DeepseekV4ModelImpl
     }
     if (is_sequence_sharded(fc1_ctx)) {
       h = gather_sequence(h, fc1_ctx);
+    }
+    if (cp_ctx.enabled()) {
+      // Restore full global-order tokens before hc_head / norm / lm_head, which
+      // are not CP-aware. Done before capturing pre_hc_head_hidden_states so
+      // MTP receives full-length aux hidden states.
+      h = cp_ctx.gather_restore(h);
+      if (attn_metadata.dsa_metadata) {
+        attn_metadata.dsa_metadata->v4_cp_context = nullptr;
+      }
     }
     torch::Tensor pre_hc_head_hidden_states;
     if (model_args_.num_speculative_tokens() > 0) {
@@ -1301,6 +1367,107 @@ class DeepseekV4ModelImpl
     }
   }
 
+  // Rewrites the query axis to this rank's local rows, shortens the kv extent
+  // the attention / indexer kernels read to where those rows end, and rebuilds
+  // the sparse metadata derived from both. slot_mapping and block_tables stay
+  // global on purpose: every CP rank holds a full KV replica and writes it from
+  // all tokens, which is what lets local queries attend to the whole prefix
+  // without any cross-rank KV exchange.
+  //
+  // The kv lengths must shrink even though the replica is full, because
+  // sparse_attn_sharedkv aligns the query block to the END of the kv window.
+  // See DeepseekV4CpContext::local_kv_seq_lens for why a global kv length
+  // silently relocates every non-last rank's queries.
+  //
+  // Getting this wrong degrades accuracy rather than crashing, so keep the two
+  // views strictly separated: the attention read path takes both axes from
+  // cp_ctx; the write path takes its global view from cp_ctx too
+  // (global_q_cu_seq_lens) and from start_pos, which stays global below.
+  void rebuild_cp_local_query_metadata(
+      layer::DSAMetadata& dsa,
+      ModelInputParams& params,
+      const layer::v4_cp::DeepseekV4CpContext& cp_ctx,
+      std::unordered_map<int32_t, layer::DeepseekV4RotaryEmbedding::CosSinPair>&
+          input_rope_by_ratio) const {
+    const auto& local_q = cp_ctx.local_q_seq_lens;
+    const torch::Device device =
+        dsa.seq_lens_q.defined() ? dsa.seq_lens_q.device() : device_;
+    const auto int_options =
+        torch::TensorOptions().dtype(torch::kInt32).device(device);
+
+    params.attention.host.q_seq_lens = local_q;
+    torch::Tensor q_lens = torch::tensor(local_q, int_options);
+    params.attention.device.q_seq_lens = q_lens;
+    dsa.seq_lens_q = q_lens;
+    torch::Tensor q_cumsum =
+        torch::cumsum(q_lens, /*dim=*/0, /*dtype=*/torch::kInt32);
+    dsa.actual_seq_lengths_query =
+        torch::cat({torch::zeros({1}, int_options), q_cumsum});
+    params.attention.device.q_cu_seq_lens = dsa.actual_seq_lengths_query;
+    std::vector<int32_t> q_cu_host;
+    q_cu_host.reserve(local_q.size());
+    int32_t running = 0;
+    for (const int32_t len : local_q) {
+      running += len;
+      q_cu_host.push_back(running);
+    }
+    params.attention.host.q_cu_seq_lens = q_cu_host;
+
+    const int64_t local_q_max = vector_max_or_zero(local_q);
+    params.meta.q_max_seq_len = static_cast<int32_t>(local_q_max);
+    dsa.max_seqlen_q = q_lens.numel() > 0
+                           ? torch::max(q_lens).to(torch::kInt32).reshape({1})
+                           : torch::zeros({1}, int_options);
+    dsa.max_query_len = local_q_max;
+
+    // Attention-side kv view: prefix + this rank's last local row. Everything
+    // written above and below stays on the global view.
+    const auto& local_kv = cp_ctx.local_kv_seq_lens;
+    torch::Tensor kv_lens = torch::tensor(local_kv, int_options);
+    params.attention.host.kv_seq_lens = local_kv;
+    params.attention.device.kv_seq_lens = kv_lens;
+    dsa.actual_seq_lengths_kv = kv_lens;
+    dsa.seq_lens = kv_lens;
+    dsa.kv_cu_seq_lens = cp_ctx.local_kv_cu_seq_lens;
+    const int64_t local_kv_max = vector_max_or_zero(local_kv);
+    params.meta.kv_max_seq_len = static_cast<int32_t>(local_kv_max);
+    dsa.max_seqlen_kv = kv_lens.numel() > 0
+                            ? torch::max(kv_lens).to(torch::kInt32).reshape({1})
+                            : torch::zeros({1}, int_options);
+    dsa.max_seq_len = local_kv_max;
+
+    // Query RoPE follows the local rows. local_positions keeps true global
+    // positions, so RoPE values are unchanged -- only the row set shrinks.
+    if (cp_ctx.local_positions.defined()) {
+      dsa.input_positions = cp_ctx.local_positions;
+    }
+    // The layer loop reassigns dsa.cos/dsa.sin from input_rope_by_ratio, so the
+    // map itself must be rebuilt or the first layer would restore the global
+    // table and silently undo the localization.
+    input_rope_by_ratio.clear();
+    build_dsa_rope_metadata(dsa, &input_rope_by_ratio);
+
+    // start_pos deliberately keeps the global value computed before this
+    // rebuild. Its only consumers are the compressor and the indexer's
+    // compress_kv, and under CP both run on the CP-gathered global token set:
+    // start_pos is the absolute position of the first token they process, which
+    // is global_kv - global_q. Localizing it to global_kv - local_q tells them
+    // to skip a prefix that is not there, which drives the compressed block
+    // count to zero and the kernel launches with blockDim == 0.
+    // build_precomputed_metadata does not read start_pos, so nothing between
+    // here and the layer loop needs the localized form.
+    //
+    // (start_pos must not be recomputed after this point: the
+    // two fields it is derived from (actual_seq_lengths_kv - seq_lens_q) are
+    // both localized above, so re-deriving it would yield the local value the
+    // paragraph above rules out. Both call sites that build it
+    // (prepare_dsa_metadata_for_forward and the eager branch in forward()) run
+    // before the CP block, and neither prepare_forward_dsa_runtime_metadata nor
+    // build_precomputed_metadata touches it.)
+
+    build_precomputed_metadata(dsa, params, cp_ctx.local_kv_cu_seq_lens);
+  }
+
   void prepare_forward_dsa_runtime_metadata(
       layer::DSAMetadata& dsa,
       const ModelInputParams& params,
@@ -1348,8 +1515,16 @@ class DeepseekV4ModelImpl
     return *std::max_element(values.begin(), values.end());
   }
 
-  void build_precomputed_metadata(layer::DSAMetadata& dsa,
-                                  const ModelInputParams& params) const {
+  // cu_seqlens_ori_kv_override, when defined, replaces the query cumsum the
+  // prefill sparse metadata normally uses to describe ori_kv. Only prefill CP
+  // passes it: there the kv window is longer than this rank's query block, so
+  // the two stop coinciding and the kernel's baked tiling must follow the
+  // window. It has to agree with the cu_seqlens_ori_kv the attention layer
+  // passes at call time.
+  void build_precomputed_metadata(
+      layer::DSAMetadata& dsa,
+      const ModelInputParams& params,
+      const torch::Tensor& cu_seqlens_ori_kv_override = torch::Tensor()) const {
     dsa.c1_metadata = torch::Tensor();
     dsa.c4_metadata = torch::Tensor();
     dsa.c128_metadata = torch::Tensor();
@@ -1393,9 +1568,11 @@ class DeepseekV4ModelImpl
 
     const char* layout_kv = "PA_ND";
     auto empty_int32_opt = as_empty_int32_tensor(dsa.actual_seq_lengths_query);
+    const torch::Tensor& ori_kv_cu = cu_seqlens_ori_kv_override.defined()
+                                         ? cu_seqlens_ori_kv_override
+                                         : dsa.actual_seq_lengths_query;
     auto cu_seqlens_ori_kv_opt =
-        is_prefill ? as_optional_tensor(dsa.actual_seq_lengths_query)
-                   : empty_int32_opt;
+        is_prefill ? as_optional_tensor(ori_kv_cu) : empty_int32_opt;
 
     xllm::kernel::SparseAttnSharedkvMetadataParams c1_params;
     c1_params.num_heads_q = tp_num_heads_;
@@ -1560,6 +1737,9 @@ class DeepseekV4ModelImpl
   int64_t num_heads_ = 0;
   int64_t tp_num_heads_ = 0;
   int64_t dp_local_tp_size_ = 1;
+  // Prefill CP geometry. cp_size_ == 1 means CP is off everywhere below.
+  int64_t cp_size_ = 1;
+  ProcessGroup* cp_group_ = nullptr;
   int64_t head_dim_ = 0;
   int64_t window_size_ = 128;
   int64_t index_n_heads_ = 0;

--- a/xllm/models/llm/deepseek_v4_mtp.h
+++ b/xllm/models/llm/deepseek_v4_mtp.h
@@ -39,6 +39,7 @@ limitations under the License.
 #include "core/layers/common/word_embedding.h"
 #include "core/layers/deepseek_v4_decoder_layer.h"
 #include "layers/npu/deepseek_v4_rotary_embedding.h"
+#include "layers/npu_torch/deepseek_v4_cp_context.h"
 #include "models/llm/deepseek_v4.h"
 #include "models/llm/llm_model_base.h"
 #include "models/llm/mtp_model_base.h"
@@ -94,10 +95,15 @@ class DeepseekV4MtpModelImpl final : public torch::nn::Module {
 
     num_heads_ = model_args_.n_heads();
     head_dim_ = model_args_.o_lora_rank() + model_args_.qk_rope_head_dim();
-    dp_local_tp_size_ =
-        std::max<int64_t>(parallel_args.world_size() /
-                              std::max<int64_t>(parallel_args.dp_size(), 1),
-                          1);
+    // Attention TP width under the orthogonal dp * cp * attn_tp == world
+    // layout, matching the narrowed tp_group_ the draft's DSAttention shards
+    // heads by. See DeepseekV4ModelImpl for why dividing by dp alone is wrong.
+    cp_size_ = std::max<int64_t>(parallel_args.cp_size(), 1);
+    cp_group_ = parallel_args.cp_group_;
+    dp_local_tp_size_ = std::max<int64_t>(
+        parallel_args.world_size() /
+            std::max<int64_t>(parallel_args.dp_size(), 1) / cp_size_,
+        1);
     CHECK_EQ(num_heads_ % dp_local_tp_size_, 0)
         << "[DeepseekV4Mtp] n_heads must be divisible by local tp "
            "size. n_heads="
@@ -294,10 +300,67 @@ class DeepseekV4MtpModelImpl final : public torch::nn::Module {
              static_cast<int32_t>(mtp_layers_.size()))
         << "deepseek_v4_mtp requires kv_caches size >= mtp layer count";
 
+    // Prefill CP, symmetric with the main model. The draft owns its own
+    // DSAttention instances whose heads are sharded by the same narrowed
+    // tp_group_, so it must localize its query rows too -- otherwise its
+    // metadata advertises global q lengths while attention runs local rows.
+    // previous_hidden_states arrives already gathered to full global order (it
+    // is the main model's aux output), so re-splitting it here is well defined.
+    layer::v4_cp::DeepseekV4CpContext cp_ctx;
+    const bool cp_enabled =
+        cp_size_ > 1 && cp_group_ != nullptr && !is_empty_dp_rank &&
+        input_params.meta.batch_forward_type.no_decode() &&
+        modified_input_params.attn_metadata != nullptr &&
+        modified_input_params.attn_metadata->dsa_metadata != nullptr;
+    if (cp_enabled) {
+      auto& dsa = *(modified_input_params.attn_metadata->dsa_metadata);
+      cp_ctx = layer::v4_cp::build_deepseek_v4_cp_context(
+          static_cast<int32_t>(cp_size_),
+          cp_group_->rank(),
+          cp_group_,
+          modified_input_params.attention.host.q_seq_lens,
+          modified_input_params.attention.host.kv_seq_lens,
+          dsa.input_positions);
+      if (cp_ctx.enabled()) {
+        // Save global-position RoPE per ratio before localizing.
+        // prepare_for_layer swaps dsa.cos to the layer's ratio table, so the
+        // KV path must pair with the global table of that same ratio.
+        cp_ctx.global_rope_by_ratio[1] = {dsa.cos, dsa.sin};
+        if (dsa.c4_cos.defined()) {
+          cp_ctx.global_rope_by_ratio[4] = {dsa.c4_cos, dsa.c4_sin};
+        }
+        if (dsa.c128_cos.defined()) {
+          cp_ctx.global_rope_by_ratio[128] = {dsa.c128_cos, dsa.c128_sin};
+        }
+        rebuild_cp_local_query_metadata(dsa, modified_input_params, cp_ctx);
+        hidden_states = cp_ctx.shard_rows(hidden_states);
+        previous_hidden_states = cp_ctx.shard_rows(previous_hidden_states);
+        positions = cp_ctx.shard_rows(positions);
+        // tokens stays global on purpose: see the matching note in
+        // deepseek_v4.h. The decoder layer re-gathers before the MoE gate, so
+        // input_ids and dp_global_token_nums both stay on the global token set.
+        dsa.v4_cp_context = &cp_ctx;
+      }
+    }
+
     torch::Tensor aux_hidden_states;
     for (size_t i = 0; i < mtp_layers_.size(); ++i) {
       const int32_t layer_id = static_cast<int32_t>(i);
       prepare_for_layer(*modified_input_params.attn_metadata, layer_id);
+      if (cp_ctx.enabled()) {
+        // prepare_for_layer just picked the localized table for this ratio;
+        // pair it with the global table of the same ratio for the KV path.
+        auto& dsa = *(modified_input_params.attn_metadata->dsa_metadata);
+        auto [kv_cos, kv_sin] =
+            cp_ctx.global_rope(deepseek_v4_normalize_compress_ratio(
+                (layer_id <
+                 static_cast<int32_t>(model_args_.compress_ratios().size()))
+                    ? model_args_
+                          .compress_ratios()[static_cast<size_t>(layer_id)]
+                    : 1));
+        dsa.kv_cos = kv_cos;
+        dsa.kv_sin = kv_sin;
+      }
       hidden_states = mtp_layers_[i](hidden_states,
                                      previous_hidden_states,
                                      positions,
@@ -313,6 +376,18 @@ class DeepseekV4MtpModelImpl final : public torch::nn::Module {
         return ModelOutput();
       }
 #endif
+    }
+
+    if (cp_ctx.enabled()) {
+      // Restore global order before final_norm / lm_head, which are not
+      // CP-aware. aux_hidden_states feeds the next draft step, so it has to be
+      // restored as well or its row count would not match the batch.
+      hidden_states = cp_ctx.gather_restore(hidden_states);
+      if (aux_hidden_states.defined()) {
+        aux_hidden_states = cp_ctx.gather_restore(aux_hidden_states);
+      }
+      modified_input_params.attn_metadata->dsa_metadata->v4_cp_context =
+          nullptr;
     }
 
     auto [output, _] = final_norm_(hidden_states, std::nullopt);
@@ -625,6 +700,79 @@ class DeepseekV4MtpModelImpl final : public torch::nn::Module {
     build_precomputed_metadata(dsa, input_params);
   }
 
+  // Draft-side twin of DeepseekV4ModelImpl::rebuild_cp_local_query_metadata:
+  // localizes the query axis plus the kv extent the attention / indexer kernels
+  // read, and leaves slot_mapping and block_tables global because every CP rank
+  // holds a full KV replica. See DeepseekV4CpContext::local_kv_seq_lens for why
+  // the kv extent has to shrink even though the replica is full.
+  void rebuild_cp_local_query_metadata(
+      layer::DSAMetadata& dsa,
+      ModelInputParams& params,
+      layer::v4_cp::DeepseekV4CpContext& cp_ctx) const {
+    const auto& local_q = cp_ctx.local_q_seq_lens;
+    const torch::Device device =
+        dsa.seq_lens_q.defined() ? dsa.seq_lens_q.device() : device_;
+    const auto int_options =
+        torch::TensorOptions().dtype(torch::kInt32).device(device);
+
+    params.attention.host.q_seq_lens = local_q;
+    torch::Tensor q_lens = torch::tensor(local_q, int_options);
+    params.attention.device.q_seq_lens = q_lens;
+    dsa.seq_lens_q = q_lens;
+    torch::Tensor q_cumsum =
+        torch::cumsum(q_lens, /*dim=*/0, /*dtype=*/torch::kInt32);
+    dsa.actual_seq_lengths_query =
+        torch::cat({torch::zeros({1}, int_options), q_cumsum});
+    params.attention.device.q_cu_seq_lens = dsa.actual_seq_lengths_query;
+    std::vector<int32_t> q_cu_host;
+    q_cu_host.reserve(local_q.size());
+    int32_t running = 0;
+    for (const int32_t len : local_q) {
+      running += len;
+      q_cu_host.push_back(running);
+    }
+    params.attention.host.q_cu_seq_lens = q_cu_host;
+
+    const int64_t local_q_max = vector_max_or_zero(local_q);
+    params.meta.q_max_seq_len = static_cast<int32_t>(local_q_max);
+    dsa.max_seqlen_q = q_lens.numel() > 0
+                           ? torch::max(q_lens).to(torch::kInt32).reshape({1})
+                           : torch::zeros({1}, int_options);
+    dsa.max_query_len = local_q_max;
+
+    // Attention-side kv view: prefix + this rank's last local row.
+    const auto& local_kv = cp_ctx.local_kv_seq_lens;
+    torch::Tensor kv_lens = torch::tensor(local_kv, int_options);
+    params.attention.host.kv_seq_lens = local_kv;
+    params.attention.device.kv_seq_lens = kv_lens;
+    dsa.actual_seq_lengths_kv = kv_lens;
+    dsa.seq_lens = kv_lens;
+    dsa.kv_cu_seq_lens = cp_ctx.local_kv_cu_seq_lens;
+    const int64_t local_kv_max = vector_max_or_zero(local_kv);
+    params.meta.kv_max_seq_len = static_cast<int32_t>(local_kv_max);
+    dsa.max_seqlen_kv = kv_lens.numel() > 0
+                            ? torch::max(kv_lens).to(torch::kInt32).reshape({1})
+                            : torch::zeros({1}, int_options);
+    dsa.max_seq_len = local_kv_max;
+
+    if (cp_ctx.local_positions.defined()) {
+      dsa.input_positions = cp_ctx.local_positions;
+    }
+    // Rebuild all ratio tables from local positions. prepare_for_layer() swaps
+    // dsa.cos to dsa.c4_cos / dsa.c128_cos, so those must be localized too or a
+    // compressed layer would silently fall back to the global table.
+    build_dsa_rope_metadata(dsa);
+
+    // start_pos deliberately keeps the global value: see the matching note in
+    // deepseek_v4.h. The compressor and the indexer's compress_kv are its only
+    // consumers and both run on the CP-gathered global token set, so localizing
+    // it makes them skip a nonexistent prefix and launch with blockDim == 0.
+    // It must not be recomputed after this point either, since both fields it
+    // derives from are localized above.
+
+    build_precomputed_metadata(dsa, params, cp_ctx.local_kv_cu_seq_lens);
+  }
+
   void build_dsa_rope_metadata(layer::DSAMetadata& dsa) const {
     if (!dsa_rotary_embedding_) {
       return;
@@ -701,8 +849,13 @@ class DeepseekV4MtpModelImpl final : public torch::nn::Module {
     }
   }
 
-  void build_precomputed_metadata(layer::DSAMetadata& dsa,
-                                  const ModelInputParams& params) const {
+  // cu_seqlens_ori_kv_override: see the matching note in deepseek_v4.h. Only
+  // prefill CP passes it, and it has to agree with the cu_seqlens_ori_kv the
+  // attention layer passes at call time.
+  void build_precomputed_metadata(
+      layer::DSAMetadata& dsa,
+      const ModelInputParams& params,
+      const torch::Tensor& cu_seqlens_ori_kv_override = torch::Tensor()) const {
     dsa.c1_metadata = torch::Tensor();
     dsa.c4_metadata = torch::Tensor();
     dsa.c128_metadata = torch::Tensor();
@@ -745,9 +898,11 @@ class DeepseekV4MtpModelImpl final : public torch::nn::Module {
 
     const char* layout_kv = "PA_ND";
     auto empty_int32_opt = as_empty_int32_tensor(dsa.actual_seq_lengths_query);
+    const torch::Tensor& ori_kv_cu = cu_seqlens_ori_kv_override.defined()
+                                         ? cu_seqlens_ori_kv_override
+                                         : dsa.actual_seq_lengths_query;
     auto cu_seqlens_ori_kv_opt =
-        is_prefill ? as_optional_tensor(dsa.actual_seq_lengths_query)
-                   : empty_int32_opt;
+        is_prefill ? as_optional_tensor(ori_kv_cu) : empty_int32_opt;
 
     xllm::kernel::SparseAttnSharedkvMetadataParams c1_params;
     c1_params.num_heads_q = tp_num_heads_;
@@ -948,6 +1103,9 @@ class DeepseekV4MtpModelImpl final : public torch::nn::Module {
   int64_t num_heads_ = 0;
   int64_t tp_num_heads_ = 0;
   int64_t dp_local_tp_size_ = 1;
+  // Prefill CP geometry. cp_size_ == 1 means CP is off everywhere below.
+  int64_t cp_size_ = 1;
+  ProcessGroup* cp_group_ = nullptr;
   int64_t head_dim_ = 0;
   int64_t window_size_ = 128;
   int64_t index_n_heads_ = 0;

--- a/xllm/models/model_registry.cpp
+++ b/xllm/models/model_registry.cpp
@@ -169,9 +169,16 @@ bool resolve_model_registration_name(const std::string& model_type,
 }
 
 bool is_npu_model_cp_capable(const std::string& resolved_name) {
+  // Registers model-side CP capability for master-side validation. Note this
+  // is not the same switch as the worker-side NpuCpPlan gate: deepseek_v4 and
+  // deepseek_v4_mtp own their CP split inside the model (TORCH backend) and
+  // deliberately keep model_supports_model_cp() false so the worker does not
+  // shard a second time.
   static const std::unordered_set<std::string> kCpCapableModels = {
       "deepseek_v32",
       "deepseek_v32_mtp",
+      "deepseek_v4",
+      "deepseek_v4_mtp",
       "glm_moe_dsa",
       "glm_moe_dsa_mtp",
   };


### PR DESCRIPTION
# NPU TORCH 后端 DeepSeek-V4 / V4-MTP Prefill Context Parallelism (PCP) 支持

## 概述

本 PR 为 NPU TORCH 后端的 DeepSeek-V4 和 DeepSeek-V4-MTP 增加 Prefill Context Parallelism（PCP）支持。

采用正交的 DP × CP × TP 并行拓扑：

```
tp_size = world_size / dp_size / cp_size

rank =
    dp_rank * (cp_size * tp_size)
    + cp_rank * tp_size
    + tp_rank
```

Prefill 阶段将 query token 切分到不同 CP rank。每个 Decoder Layer 执行完成后，对 CP-local hidden state 进行 all-gather，并恢复全局 token 顺序后继续执行。Decode 阶段保持非 CP 执行。

## 主要修改

### 1. 正交 CP × TP 通信组

NPU TORCH 后端的 TP group 缩小为：

```
world_size / (dp_size * cp_size)
```

- 创建独立的 CP group，组内保持 `dp_rank` 和 `tp_rank` 不变，仅改变 `cp_rank`
- 不同 DP replica 的 CP group 相互隔离
- 通过 `ParallelArgs` 暴露实际生效的 TP size
- ATB 后端保持原有通信组行为不变

### 2. DeepSeek-V4 Prefill 切分

新增 DeepSeek-V4 CP context，用于计算：

- 每个 CP rank 的本地 query 范围
- local-to-global token row 映射
- all-gather 与全局顺序恢复所需的 permutation
- CP-local query sequence lengths
- CP-local KV attention extents

**Prefill 执行流程：**

1. Decoder Layer 前按 CP rank 切分输入 token rows
2. 每个 Decoder Layer 在本地 token rows 上执行
3. Layer 执行完成后对 hidden states 进行 CP all-gather
4. 恢复原始全局 token 顺序
5. Decode 阶段不启用 CP 切分

### 3. Sparse Attention 与 Indexer 元数据

将 CP-local attention read view 与全局 KV write metadata 分离：

- **读取路径**（CP-local）：Sparse Attention 和 Indexer 使用 CP-local query/KV sequence lengths
- **写入路径**（全局）：slot mapping、block tables、KV cache 写入、compressor metadata、index-cache 写入、start positions 继续使用全局元数据

同时修复 CP-local query block 与 KV window 末尾的对齐关系，覆盖普通 Prefill 和 cached-prefix 场景。

### 4. DeepSeek-V4-MTP 兼容

- DeepSeek-V4-MTP 使用与主模型一致的 CP-local query/KV 元数据规则
- 对于 speculative token，在写入缓存或进入下一步 MTP 计算前，按以下顺序执行共识：
  1. 在 TP group 内广播
  2. 在正交 CP group 内广播
- 共识覆盖以下三个位置：
  - Target Prefill 生成的首个 token
  - 每一个 Draft step 生成的 token
  - Target Validate 生成的 accepted tokens
- 正交 CP 下，即使使用 greedy sampling 也会执行 token 共识，避免不同 CP shard 缓存不同的 token

该修改用于修复以下错误：

> MTP decode target state token mismatch

该错误的原因是不同 CP shard 独立生成了 speculative token，导致 scheduler 输入 token 与非 driver CP shard 缓存的 target state token 不一致。

### 5. ACL Graph 兼容

- 移除 `cp_size > 1` 与 `enable_graph=true` 不能同时启用的全局限制
- CP Prefill 保持 eager 执行
- Decode 阶段 CP 不生效，因此可以继续使用 ACL graph capture/replay
- CP 开启时，spec-verify chunked-prefill batch 显式回退到 eager 模式

### 6. 测试

新增单元测试，覆盖：

- 每个 token row 只属于一个 CP rank
- 每条序列在单个 rank 内保持连续切分
- `q_len < cp_size` 时允许出现空 CP segment
- `cp_size=1` 时保持 identity
- gather/restore permutation 互逆
- 非均匀 sequence length
- cached-prefix KV extent
- CP-local query/KV 对齐关系
- DeepSeek-V4 和 DeepSeek-V4-MTP 的 CP capability 注册

## 已知限制

当前 DeepSeek-V4 CP 路径不支持：

```
enable_schedule_overlap=true
```
