### PR TITLE
feat: add asynchronous verbose request trace logging.

### DIFF
--- a/tests/core/util/CMakeLists.txt
+++ b/tests/core/util/CMakeLists.txt
@@ -10,6 +10,7 @@ cc_test(
     net_test.cpp
     suffix_decoding_cache_test.cpp
     threadpool_test.cpp
+    verbose_trace_logger_test.cpp
     vocab_validation_test.cpp
   DEPS
     util

--- a/tests/core/util/verbose_trace_logger_test.cpp
+++ b/tests/core/util/verbose_trace_logger_test.cpp
@@ -1,0 +1,81 @@
+/* Copyright 2026 The xLLM Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://github.com/jd-opensource/xllm/blob/main/LICENSE
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include "core/util/verbose_trace_logger.h"
+
+#include <gtest/gtest.h>
+
+#include <filesystem>
+#include <fstream>
+#include <string>
+
+namespace xllm {
+namespace {
+
+TEST(VerboseTraceLoggerTest, FlushesQueuedEntryOnShutdown) {
+  const std::filesystem::path log_path =
+      std::filesystem::temp_directory_path() /
+      "xllm_verbose_trace_logger_test.log";
+  std::error_code ec;
+  std::filesystem::remove(log_path, ec);
+
+  VerboseTraceLogger& logger = VerboseTraceLogger::get_instance();
+  logger.initialize(/*enabled=*/true,
+                    log_path.string(),
+                    /*max_size_mb=*/1,
+                    /*max_files=*/1);
+  logger.log("event=test_entry");
+  logger.shutdown();
+
+  std::ifstream log_file(log_path);
+  std::string line;
+  ASSERT_TRUE(std::getline(log_file, line));
+  EXPECT_NE(line.find("event=test_entry"), std::string::npos);
+
+  log_file.close();
+  std::filesystem::remove(log_path, ec);
+}
+
+TEST(VerboseTraceLogPathTest, SingleRankPreservesConfiguredPath) {
+  EXPECT_EQ(resolve_verbose_trace_log_path(
+                "log/verbose_trace.log", /*nnodes=*/1, /*node_rank=*/0),
+            "log/verbose_trace.log");
+}
+
+TEST(VerboseTraceLogPathTest, MultiRankInsertsRankBeforeLastExtension) {
+  EXPECT_EQ(resolve_verbose_trace_log_path(
+                "log.v1/verbose.trace.log", /*nnodes=*/4, /*node_rank=*/2),
+            "log.v1/verbose.trace_rank_2.log");
+}
+
+TEST(VerboseTraceLogPathTest, MultiRankSuffixesRankZero) {
+  EXPECT_EQ(resolve_verbose_trace_log_path(
+                "log/verbose_trace.log", /*nnodes=*/4, /*node_rank=*/0),
+            "log/verbose_trace_rank_0.log");
+}
+
+TEST(VerboseTraceLogPathTest, MultiRankAppendsRankWithoutExtension) {
+  EXPECT_EQ(resolve_verbose_trace_log_path(
+                "log/verbose_trace", /*nnodes=*/4, /*node_rank=*/3),
+            "log/verbose_trace_rank_3");
+}
+
+TEST(VerboseTraceLogPathTest, EmptyPathRemainsEmpty) {
+  EXPECT_TRUE(resolve_verbose_trace_log_path("", /*nnodes=*/4, /*node_rank=*/1)
+                  .empty());
+}
+
+}  // namespace
+}  // namespace xllm

--- a/xllm/CMakeLists.txt
+++ b/xllm/CMakeLists.txt
@@ -92,6 +92,7 @@ else()
       :config
       :xllm_server
       :master
+      :util
       absl::strings
       Boost::serialization
       gflags::gflags

--- a/xllm/api_service/call.cpp
+++ b/xllm/api_service/call.cpp
@@ -16,6 +16,7 @@ limitations under the License.
 #include "call.h"
 
 #include "core/common/constants.h"
+#include "core/util/verbose_trace_logger.h"
 
 namespace xllm {
 
@@ -35,6 +36,10 @@ void Call::init() {
     x_request_time_ =
         *controller_->http_request().GetHeader("x-request-timems");
   }
+
+  XLLM_VERBOSE_TRACE() << "event=request_received x-request-id="
+                       << x_request_id_
+                       << " path=" << controller_->http_request().uri().path();
 
   init_request_payload();
 }

--- a/xllm/api_service/non_stream_call.h
+++ b/xllm/api_service/non_stream_call.h
@@ -27,6 +27,7 @@ limitations under the License.
 
 #include "call.h"
 #include "core/common/types.h"
+#include "core/util/verbose_trace_logger.h"
 
 namespace xllm {
 
@@ -75,6 +76,8 @@ class NonStreamCall : public Call {
       return finish_with_error(StatusCode::UNKNOWN, err_msg);
     }
 
+    XLLM_VERBOSE_TRACE() << "event=response_serialized x-request-id="
+                         << x_request_id_;
     return true;
   }
 
@@ -102,6 +105,8 @@ class NonStreamCall : public Call {
   // For non stream response
   bool finish_with_error(const StatusCode& code,
                          const std::string& error_message) {
+    XLLM_VERBOSE_TRACE() << "event=request_error x-request-id=" << x_request_id_
+                         << " message=" << error_message;
     controller_->SetFailed(error_message);
     return true;
   }

--- a/xllm/api_service/stream_call.h
+++ b/xllm/api_service/stream_call.h
@@ -29,6 +29,7 @@ limitations under the License.
 #include "api_service/anthropic_json.h"
 #include "api_service/call.h"
 #include "core/common/types.h"
+#include "core/util/verbose_trace_logger.h"
 
 namespace xllm {
 
@@ -88,11 +89,15 @@ class StreamCall : public Call {
             response, &json_output, json_options_, &err_msg)) {
       return finish_with_error(StatusCode::UNKNOWN, err_msg);
     }
+    XLLM_VERBOSE_TRACE() << "event=response_serialized x-request-id="
+                         << x_request_id_;
     return true;
   }
 
   bool finish_with_error(const StatusCode& code,
                          const std::string& error_message) {
+    XLLM_VERBOSE_TRACE() << "event=request_error x-request-id=" << x_request_id_
+                         << " message=" << error_message;
     if (!stream_) {
       controller_->SetFailed(error_message);
 
@@ -128,6 +133,8 @@ class StreamCall : public Call {
     io_buf_.append("data: [DONE]\n\n");
 
     pa_->Write(io_buf_);
+    XLLM_VERBOSE_TRACE() << "event=stream_closed x-request-id="
+                         << x_request_id_;
     return true;
   }
 
@@ -188,6 +195,8 @@ class AnthropicCall : public StreamCall<proto::AnthropicMessagesRequest,
       return this->finish_with_error(StatusCode::UNKNOWN, err_msg);
     }
     this->controller_->response_attachment().append(json);
+    XLLM_VERBOSE_TRACE() << "event=response_serialized x-request-id="
+                         << this->x_request_id_;
     return true;
   }
 

--- a/xllm/core/common/global_flags.h
+++ b/xllm/core/common/global_flags.h
@@ -410,3 +410,12 @@ DECLARE_string(mmrs_comm_mode);
 DECLARE_bool(use_cpp_chat_template);
 
 DECLARE_int32(health_check_interval_ms);
+
+// --- verbose trace logging config ---
+DECLARE_bool(enable_verbose_trace_log);
+
+DECLARE_string(verbose_trace_log_path);
+
+DECLARE_int32(verbose_trace_log_max_size_mb);
+
+DECLARE_int32(verbose_trace_log_max_files);

--- a/xllm/core/framework/config/service_config.cpp
+++ b/xllm/core/framework/config/service_config.cpp
@@ -55,6 +55,35 @@ DEFINE_int32(health_check_interval_ms,
              3000,
              "Worker health check interval in milliseconds.");
 
+DEFINE_bool(enable_verbose_trace_log,
+            false,
+            "Enable asynchronous verbose request-trace logging to a file. When "
+            "enabled, request and response trace events are "
+            "written off the serving hot path by a background thread.");
+
+DEFINE_string(
+    verbose_trace_log_path,
+    "log/verbose_trace.log",
+    "Base file path for the verbose request-trace log. When nnodes is greater "
+    "than 1, _rank_<node_rank> is inserted before the final extension (for "
+    "example, log/verbose_trace_rank_2.log). Single-rank serving uses this "
+    "path "
+    "unchanged. Used only when verbose trace logging is enabled. Defaults to "
+    "log/verbose_trace.log, so it sits alongside node_<rank>.log.");
+
+DEFINE_int32(verbose_trace_log_max_size_mb,
+             1024,
+             "Max size in MiB of a single verbose request-trace log file "
+             "before it is rotated. Defaults to 1024 (1 GiB).");
+
+DEFINE_int32(
+    verbose_trace_log_max_files,
+    1000,
+    "Max number of verbose request-trace log files to keep per rank, including "
+    "the active file. Each rank rotates independently and removes its oldest "
+    "file once this many exist; this is not a deployment-wide limit. Defaults "
+    "to 1000.");
+
 namespace xllm {
 
 void ServiceConfig::from_flags() {
@@ -68,6 +97,10 @@ void ServiceConfig::from_flags() {
   XLLM_CONFIG_ASSIGN_FROM_FLAG(num_request_handling_threads);
   XLLM_CONFIG_ASSIGN_FROM_FLAG(num_response_handling_threads);
   XLLM_CONFIG_ASSIGN_FROM_FLAG(health_check_interval_ms);
+  XLLM_CONFIG_ASSIGN_FROM_FLAG(enable_verbose_trace_log);
+  XLLM_CONFIG_ASSIGN_FROM_FLAG(verbose_trace_log_path);
+  XLLM_CONFIG_ASSIGN_FROM_FLAG(verbose_trace_log_max_size_mb);
+  XLLM_CONFIG_ASSIGN_FROM_FLAG(verbose_trace_log_max_files);
 }
 
 void ServiceConfig::from_json(const JsonReader& json) {
@@ -82,6 +115,10 @@ void ServiceConfig::from_json(const JsonReader& json) {
   XLLM_CONFIG_ASSIGN_FROM_JSON(num_request_handling_threads);
   XLLM_CONFIG_ASSIGN_FROM_JSON(num_response_handling_threads);
   XLLM_CONFIG_ASSIGN_FROM_JSON(health_check_interval_ms);
+  XLLM_CONFIG_ASSIGN_FROM_JSON(enable_verbose_trace_log);
+  XLLM_CONFIG_ASSIGN_FROM_JSON(verbose_trace_log_path);
+  XLLM_CONFIG_ASSIGN_FROM_JSON(verbose_trace_log_max_size_mb);
+  XLLM_CONFIG_ASSIGN_FROM_JSON(verbose_trace_log_max_files);
 }
 
 void ServiceConfig::append_config_json(
@@ -106,6 +143,14 @@ void ServiceConfig::append_config_json(
       config_json, default_config, num_response_handling_threads);
   APPEND_CONFIG_JSON_VALUE_IF_NOT_DEFAULT(
       config_json, default_config, health_check_interval_ms);
+  APPEND_CONFIG_JSON_VALUE_IF_NOT_DEFAULT(
+      config_json, default_config, enable_verbose_trace_log);
+  APPEND_CONFIG_JSON_VALUE_IF_NOT_DEFAULT(
+      config_json, default_config, verbose_trace_log_path);
+  APPEND_CONFIG_JSON_VALUE_IF_NOT_DEFAULT(
+      config_json, default_config, verbose_trace_log_max_size_mb);
+  APPEND_CONFIG_JSON_VALUE_IF_NOT_DEFAULT(
+      config_json, default_config, verbose_trace_log_max_files);
 }
 
 ServiceConfig& ServiceConfig::get_instance() {

--- a/xllm/core/framework/config/service_config.h
+++ b/xllm/core/framework/config/service_config.h
@@ -50,7 +50,11 @@ class ServiceConfig final {
          "max_concurrent_requests",
          "num_request_handling_threads",
          "num_response_handling_threads",
-         "health_check_interval_ms"}};
+         "health_check_interval_ms",
+         "enable_verbose_trace_log",
+         "verbose_trace_log_path",
+         "verbose_trace_log_max_size_mb",
+         "verbose_trace_log_max_files"}};
     return kOptionCategory;
   }
 
@@ -73,6 +77,14 @@ class ServiceConfig final {
   PROPERTY(int32_t, num_response_handling_threads) = 4;
 
   PROPERTY(int32_t, health_check_interval_ms) = 3000;
+
+  PROPERTY(bool, enable_verbose_trace_log) = false;
+
+  PROPERTY(std::string, verbose_trace_log_path);
+
+  PROPERTY(int32_t, verbose_trace_log_max_size_mb) = 1024;
+
+  PROPERTY(int32_t, verbose_trace_log_max_files) = 1000;
 };
 
 }  // namespace xllm

--- a/xllm/core/util/CMakeLists.txt
+++ b/xllm/core/util/CMakeLists.txt
@@ -34,6 +34,7 @@ cc_library(
     type_traits.h
     utils.h
     uuid.h
+    verbose_trace_logger.h
     shared_memory_manager.h
   SRCS
     cpu_affinity.cpp
@@ -53,6 +54,7 @@ cc_library(
     timer.cpp
     utils.cpp
     uuid.cpp
+    verbose_trace_logger.cpp
     shared_memory_manager.cpp
   DEPS
     Folly::folly

--- a/xllm/core/util/verbose_trace_logger.cpp
+++ b/xllm/core/util/verbose_trace_logger.cpp
@@ -1,0 +1,157 @@
+/* Copyright 2025-2026 The xLLM Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://github.com/jd-opensource/xllm/blob/main/LICENSE
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include "core/util/verbose_trace_logger.h"
+
+#include <glog/logging.h>
+#include <spdlog/async_logger.h>
+#include <spdlog/details/thread_pool.h>
+#include <spdlog/sinks/rotating_file_sink.h>
+
+#include <algorithm>
+#include <cstddef>
+#include <filesystem>
+
+namespace xllm {
+
+namespace {
+
+// Background queue capacity (entries) and writer-thread count for the async
+// logger. One writer keeps file output strictly ordered.
+constexpr size_t kQueueSize = 8192;
+constexpr size_t kWriterThreads = 1;
+
+constexpr int64_t kBytesPerMiB = 1024 * 1024;
+
+}  // namespace
+
+std::string resolve_verbose_trace_log_path(const std::string& configured_path,
+                                           int32_t nnodes,
+                                           int32_t node_rank) {
+  if (configured_path.empty() || nnodes <= 1) {
+    return configured_path;
+  }
+
+  const std::filesystem::path path(configured_path);
+  const std::string extension = path.extension().string();
+  const size_t extension_position = configured_path.size() - extension.size();
+  std::string resolved_path = configured_path;
+  resolved_path.insert(extension_position,
+                       "_rank_" + std::to_string(node_rank));
+  return resolved_path;
+}
+
+VerboseTraceLogger& VerboseTraceLogger::get_instance() {
+  static VerboseTraceLogger instance;
+  return instance;
+}
+
+VerboseTraceLogger::~VerboseTraceLogger() { shutdown(); }
+
+void VerboseTraceLogger::initialize(bool enabled,
+                                    const std::string& file_path,
+                                    int32_t max_size_mb,
+                                    int32_t max_files) {
+  if (!enabled) {
+    LOG(INFO) << "Verbose trace logging is disabled.";
+    return;
+  }
+  if (enabled_.load(std::memory_order_relaxed)) {
+    LOG(WARNING) << "Verbose trace logger already initialized; ignoring.";
+    return;
+  }
+  if (file_path.empty()) {
+    LOG(ERROR) << "Verbose trace logging enabled but no file path provided; "
+                  "verbose trace logging stays disabled.";
+    return;
+  }
+
+  std::error_code ec;
+  const std::filesystem::path path(file_path);
+  if (path.has_parent_path()) {
+    std::filesystem::create_directories(path.parent_path(), ec);
+    if (ec) {
+      LOG(ERROR) << "Failed to create directory for verbose trace log "
+                 << file_path << ": " << ec.message()
+                 << "; verbose trace logging stays disabled.";
+      return;
+    }
+  }
+
+  // Guard against non-positive configuration that spdlog would reject.
+  const size_t max_size_bytes =
+      static_cast<size_t>(std::max(1, max_size_mb)) * kBytesPerMiB;
+  const size_t total_files = static_cast<size_t>(std::max(1, max_files));
+  // spdlog's max_files parameter counts rotated backups and excludes the
+  // active file. The service option is the total on-disk file limit.
+  const size_t backup_files = total_files - 1;
+
+  try {
+    thread_pool_ = std::make_shared<spdlog::details::thread_pool>(
+        kQueueSize, kWriterThreads);
+    auto sink = std::make_shared<spdlog::sinks::rotating_file_sink_mt>(
+        file_path, max_size_bytes, backup_files);
+    logger_ = std::make_shared<spdlog::async_logger>(
+        "verbose_trace",
+        std::move(sink),
+        thread_pool_,
+        // Never block the serving hot path: drop the oldest queued entry if the
+        // background writer cannot keep up.
+        spdlog::async_overflow_policy::overrun_oldest);
+    // Prefix each entry with a millisecond wall-clock timestamp; the entry body
+    // is emitted verbatim and spdlog appends the trailing newline.
+    logger_->set_pattern("%Y-%m-%d %H:%M:%S.%e %v");
+    logger_->set_level(spdlog::level::info);
+    // Flush each entry so a live tail and post-crash inspection see it
+    // promptly; this runs on the background thread, off the serving hot path.
+    logger_->flush_on(spdlog::level::info);
+  } catch (const std::exception& e) {
+    LOG(ERROR) << "Failed to open verbose trace log file " << file_path << ": "
+               << e.what() << "; verbose trace logging stays disabled.";
+    logger_.reset();
+    thread_pool_.reset();
+    return;
+  }
+
+  enabled_.store(true, std::memory_order_release);
+  LOG(INFO) << "Verbose trace logging enabled, writing to " << file_path
+            << " (rotating at " << max_size_mb << " MiB, keeping up to "
+            << total_files << " files).";
+}
+
+void VerboseTraceLogger::log(const std::string& entry) {
+  if (!enabled_.load(std::memory_order_relaxed)) {
+    return;
+  }
+  // spdlog copies the message into its async ring buffer internally, so passing
+  // by const-ref is safe (the thread-local source buffer can be reused
+  // immediately after this returns).
+  logger_->info(entry);
+}
+
+void VerboseTraceLogger::shutdown() {
+  if (!enabled_.exchange(false, std::memory_order_acq_rel)) {
+    return;
+  }
+  if (logger_) {
+    logger_->flush();
+    logger_.reset();
+  }
+  // Destroying the thread pool drains any queued entries, then joins the
+  // background writer.
+  thread_pool_.reset();
+}
+
+}  // namespace xllm

--- a/xllm/core/util/verbose_trace_logger.h
+++ b/xllm/core/util/verbose_trace_logger.h
@@ -1,0 +1,138 @@
+/* Copyright 2025-2026 The xLLM Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://github.com/jd-opensource/xllm/blob/main/LICENSE
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#pragma once
+
+#include <atomic>
+#include <charconv>
+#include <cstdint>
+#include <memory>
+#include <string>
+#include <string_view>
+
+namespace spdlog {
+class logger;
+namespace details {
+class thread_pool;
+}  // namespace details
+}  // namespace spdlog
+
+namespace xllm {
+
+[[nodiscard]] std::string resolve_verbose_trace_log_path(
+    const std::string& configured_path,
+    int32_t nnodes,
+    int32_t node_rank);
+
+// Asynchronous request-trace logger.
+//
+// When enabled, serving threads format an entry into a thread-local buffer and
+// hand it to spdlog's async queue with a single non-blocking memcpy (no file
+// I/O, no heap allocation after the first call per thread). A dedicated
+// background thread drains the queue and appends entries to a rotating file.
+// When disabled, the only cost is one relaxed atomic load.
+class VerboseTraceLogger final {
+ public:
+  static VerboseTraceLogger& get_instance();
+
+  VerboseTraceLogger(const VerboseTraceLogger&) = delete;
+  VerboseTraceLogger& operator=(const VerboseTraceLogger&) = delete;
+
+  void initialize(bool enabled,
+                  const std::string& file_path,
+                  int32_t max_size_mb,
+                  int32_t max_files);
+
+  bool enabled() const { return enabled_.load(std::memory_order_relaxed); }
+
+  void log(const std::string& entry);
+
+  void shutdown();
+
+ private:
+  VerboseTraceLogger() = default;
+  ~VerboseTraceLogger();
+
+  std::atomic<bool> enabled_{false};
+  std::shared_ptr<spdlog::details::thread_pool> thread_pool_;
+  std::shared_ptr<spdlog::logger> logger_;
+};
+
+namespace detail {
+
+// Lightweight message builder that accumulates into a thread-local pre-
+// allocated string buffer. Eliminates std::ostringstream overhead (no locale,
+// no virtual dispatch, no per-call heap allocation after the first invocation
+// on each thread). On destruction the buffer content is handed to spdlog's
+// async queue (one memcpy into the ring buffer).
+class VerboseTraceMessage final {
+ public:
+  VerboseTraceMessage() { buf().clear(); }
+
+  VerboseTraceMessage& operator<<(std::string_view val) {
+    buf().append(val);
+    return *this;
+  }
+
+  VerboseTraceMessage& operator<<(int32_t val) {
+    char tmp[12];
+    auto [ptr, ec] = std::to_chars(tmp, tmp + sizeof(tmp), val);
+    buf().append(tmp, static_cast<size_t>(ptr - tmp));
+    return *this;
+  }
+
+  VerboseTraceMessage& operator<<(int64_t val) {
+    char tmp[24];
+    auto [ptr, ec] = std::to_chars(tmp, tmp + sizeof(tmp), val);
+    buf().append(tmp, static_cast<size_t>(ptr - tmp));
+    return *this;
+  }
+
+  VerboseTraceMessage& operator<<(uint64_t val) {
+    char tmp[24];
+    auto [ptr, ec] = std::to_chars(tmp, tmp + sizeof(tmp), val);
+    buf().append(tmp, static_cast<size_t>(ptr - tmp));
+    return *this;
+  }
+
+  ~VerboseTraceMessage() { VerboseTraceLogger::get_instance().log(buf()); }
+
+ private:
+  static constexpr size_t kDefaultCapacity = 512;
+
+  static std::string& buf() {
+    thread_local std::string tl_buf = [] {
+      std::string s;
+      s.reserve(kDefaultCapacity);
+      return s;
+    }();
+    return tl_buf;
+  }
+};
+
+class VerboseTraceVoidify final {
+ public:
+  void operator&(const VerboseTraceMessage&) {}
+};
+
+}  // namespace detail
+
+#define XLLM_VERBOSE_TRACE()                            \
+  !::xllm::VerboseTraceLogger::get_instance().enabled() \
+      ? (void)0                                         \
+      : ::xllm::detail::VerboseTraceVoidify() &         \
+            ::xllm::detail::VerboseTraceMessage()
+
+}  // namespace xllm

--- a/xllm/xllm.cpp
+++ b/xllm/xllm.cpp
@@ -63,6 +63,7 @@ namespace py = pybind11;
 #include "core/platform/device_name_utils.h"
 #include "core/util/net.h"
 #include "core/util/utils.h"
+#include "core/util/verbose_trace_logger.h"
 #include "function_call/function_call_parser.h"
 #include "parser/reasoning_parser.h"
 #include "server/xllm_server_registry.h"
@@ -576,6 +577,19 @@ int main(int argc, char** argv) {
   google::ParseCommandLineFlags(&argc, &argv, true);
   google::InitGoogleLogging("xllm");
   initialize_configs();
+
+  const ServiceConfig& service_config = ServiceConfig::get_instance();
+  const DistributedConfig& distributed_config =
+      DistributedConfig::get_instance();
+  const std::string verbose_trace_log_path =
+      resolve_verbose_trace_log_path(service_config.verbose_trace_log_path(),
+                                     distributed_config.nnodes(),
+                                     distributed_config.node_rank());
+  VerboseTraceLogger::get_instance().initialize(
+      service_config.enable_verbose_trace_log(),
+      verbose_trace_log_path,
+      service_config.verbose_trace_log_max_size_mb(),
+      service_config.verbose_trace_log_max_files());
 
   // Check if model path is provided
   if (::xllm::ModelConfig::get_instance().model().empty()) {


### PR DESCRIPTION
## Description

Add an opt-in asynchronous verbose request-trace logger backed by spdlog.

The logger uses a bounded asynchronous queue and a dedicated writer thread so serving threads do not perform file I/O. When the queue is full, the oldest queued entry is dropped instead of blocking request handling. Logging is disabled by default.

This PR:

- adds flags and service configuration for enabling the logger, choosing the output path, and controlling file rotation;
- writes `request_received`, `response_serialized`, `request_error`, and `stream_closed` trace events from the existing call paths;
- isolates log files by node rank for multi-rank deployments while preserving the configured path for single-rank deployments;
- flushes queued entries during shutdown;
- adds unit coverage for shutdown flushing and rank-aware path resolution.

The following are intentionally out of scope and will be handled separately:

- request ID generation, validation, response headers, and end-to-end propagation;
- asynchronous completion, cancellation, and request metrics lifecycle changes;
- structured error responses or raw request-body tracing.

## Related Issues

N/A

## Change Type

- [ ] Bug fix
- [x] New feature
- [ ] Performance improvement
- [ ] Refactor
- [ ] Documentation
- [ ] Test
- [ ] Build or CI

## Pull Request Checklist

### PR Title and Commit Messages

- [x] The PR title and commit message follow the xLLM commit format: `<type>: <subject>`.

### Pre-commit Checks

- [x] `pre-commit` is installed.
- [x] The pre-commit hook is installed.
- [ ] `pre-commit run --all-files` has passed.

The clang-format hook passed for the files changed by this PR.

### Self Review

- [x] The changed code has been self-reviewed.
- [ ] This PR has been rebased onto the latest `main` branch.

### Build and Test Coverage

- [x] Tests have been added or updated as needed.
- [ ] CUDA: `python setup.py build test` has passed on a CUDA machine.
- [ ] NPU: `python setup.py build test` has passed on an NPU machine.
- [ ] MLU: `python setup.py build test` has passed on an MLU machine.

## Reviewer Notes

- NPU compilation passed.
- `util_test` passed: 60/60 tests.
- Full NPU CTest is not marked as passed because four subprocess tests aborted.
- CUDA and MLU validation were not run.
