### PR TITLE
feat: FBCache support Sequence Parallel distributed inference.

### DIFF
--- a/xllm/core/framework/dit_cache/CMakeLists.txt
+++ b/xllm/core/framework/dit_cache/CMakeLists.txt
@@ -25,4 +25,5 @@ cc_library(
   torch
   glog::glog
   Folly::folly
+  parallel_state
 )

--- a/xllm/core/framework/dit_cache/dit_cache.cpp
+++ b/xllm/core/framework/dit_cache/dit_cache.cpp
@@ -17,14 +17,15 @@ limitations under the License.
 
 namespace xllm {
 
-bool DiTCache::init(const DiTCacheConfig& cfg) {
+bool DiTCache::init(const DiTCacheConfig& cfg,
+                    const ParallelArgs& parallel_args) {
   active_cache_ = create_dit_cache(cfg);
   active_cond_cache_ = create_dit_cache(cfg);
   if (!active_cache_ || !active_cond_cache_) {
     return false;
   }
-  active_cache_->init(cfg);
-  active_cond_cache_->init(cfg);
+  active_cache_->init(cfg, parallel_args);
+  active_cond_cache_->init(cfg, parallel_args);
   return true;
 }
 

--- a/xllm/core/framework/dit_cache/dit_cache.h
+++ b/xllm/core/framework/dit_cache/dit_cache.h
@@ -33,18 +33,7 @@ class DiTCache {
     return ditcache;
   }
 
-  bool init(const DiTCacheConfig& cfg);
-
-  DiTCache(const DiTCacheConfig& cfg) {
-    active_cache_ = create_dit_cache(cfg);
-    active_cond_cache_ = create_dit_cache(cfg);
-    if (!active_cache_ || !active_cond_cache_) {
-      LOG(ERROR) << "failed to initialized dit cache, "
-                    "please check your config";
-    }
-    active_cache_->init(cfg);
-    active_cond_cache_->init(cfg);
-  }
+  bool init(const DiTCacheConfig& cfg, const ParallelArgs& parallel_args);
 
   bool on_before_block(const CacheBlockIn& blockin, bool use_cfg = false);
 
@@ -55,14 +44,9 @@ class DiTCache {
 
   CacheStepOut on_after_step(const CacheStepIn& stepin, bool use_cfg = false);
 
-  virtual void set_infer_steps(const int64_t& infer_steps) {
-    active_cache_->set_infer_steps(infer_steps);
-    active_cond_cache_->set_infer_steps(infer_steps);
-  }
-
-  virtual void set_num_blocks(const int64_t& num_blocks) {
-    active_cache_->set_num_blocks(num_blocks);
-    active_cond_cache_->set_num_blocks(num_blocks);
+  void set_context(const CacheContext& context) {
+    active_cache_->set_context(context);
+    active_cond_cache_->set_context(context);
   }
 
  private:

--- a/xllm/core/framework/dit_cache/dit_cache_impl.cpp
+++ b/xllm/core/framework/dit_cache/dit_cache_impl.cpp
@@ -18,6 +18,8 @@ limitations under the License.
 #include "dit_non_cache.h"
 #include "fbcache.h"
 #include "fbcache_taylorseer.h"
+#include "framework/parallel_state/parallel_args.h"
+#include "framework/parallel_state/parallel_state.h"
 #include "residual_cache.h"
 #include "taylorseer.h"
 
@@ -32,7 +34,7 @@ torch::Tensor DitCacheImpl::get_tensor_or_empty(const TensorMap& m,
 
 bool DitCacheImpl::is_similar(const torch::Tensor& lhs,
                               const torch::Tensor& rhs,
-                              float threshold) {
+                              float threshold) const {
   if (!lhs.defined() || !rhs.defined()) return false;
   if (lhs.sizes() != rhs.sizes()) return false;
 
@@ -40,9 +42,31 @@ bool DitCacheImpl::is_similar(const torch::Tensor& lhs,
     return torch::allclose(lhs, rhs);
   }
 
-  auto diff = (lhs - rhs).abs();
-  auto mean_diff = diff.mean();
-  auto mean_lhs = lhs.abs().mean();
+  // SP shards the sequence, so a local mean would let ranks disagree on cache
+  // reuse. All-reduce the raw sums + count for an identical global decision on
+  // every rank. Shards are equal-length, so sum/count is the exact global mean.
+  //
+  // The all-reduce is a collective: every early-return above must fire
+  // identically on all SP ranks, or HCCL hangs. Keep new early-outs symmetric.
+  auto sum_abs_diff = (lhs - rhs).abs().to(torch::kFloat32).sum();
+  auto sum_abs_lhs = lhs.abs().to(torch::kFloat32).sum();
+  auto count = torch::full({},
+                           static_cast<float>(lhs.numel()),
+                           torch::dtype(torch::kFloat32).device(lhs.device()));
+
+  ProcessGroup* sp_group =
+      parallel_args_ != nullptr ? parallel_args_->dit_sp_group_ : nullptr;
+  if (sp_group != nullptr && sp_group->world_size() > 1) {
+    // Pack the three scalars into one tensor to do a single all-reduce.
+    auto stats = torch::stack({sum_abs_diff, sum_abs_lhs, count});
+    stats = parallel_state::reduce(stats, sp_group);
+    sum_abs_diff = stats[0];
+    sum_abs_lhs = stats[1];
+    count = stats[2];
+  }
+
+  auto mean_diff = sum_abs_diff / count;
+  auto mean_lhs = sum_abs_lhs / count;
 
   auto rel = mean_diff / (mean_lhs + 1e-6);
   return (rel < threshold).item<bool>();

--- a/xllm/core/framework/dit_cache/dit_cache_impl.h
+++ b/xllm/core/framework/dit_cache/dit_cache_impl.h
@@ -22,6 +22,8 @@ limitations under the License.
 
 namespace xllm {
 
+struct ParallelArgs;
+
 using TensorMap = std::unordered_map<std::string, torch::Tensor>;
 
 class DitCacheImpl {
@@ -29,7 +31,10 @@ class DitCacheImpl {
   DitCacheImpl() = default;
   virtual ~DitCacheImpl() = default;
 
-  virtual void init(const DiTCacheConfig& cfg) = 0;
+  // Startup-time init. parallel_args carries the fixed parallel topology
+  // (e.g. the SP group used to all-reduce the similarity metric).
+  virtual void init(const DiTCacheConfig& cfg,
+                    const ParallelArgs& parallel_args) = 0;
 
   virtual bool on_before_block(const CacheBlockIn& blockin) = 0;
   virtual CacheBlockOut on_after_block(const CacheBlockIn& blockin) = 0;
@@ -37,27 +42,26 @@ class DitCacheImpl {
   virtual bool on_before_step(const CacheStepIn& stepin) = 0;
   virtual CacheStepOut on_after_step(const CacheStepIn& stepin) = 0;
 
-  virtual void set_infer_steps(const int64_t& infer_steps) {
-    infer_steps_ = infer_steps;
-  }
-
-  virtual void set_num_blocks(const int64_t& num_blocks) {
-    num_blocks_ = num_blocks;
+  // Per-generation params, refreshed on every forward().
+  virtual void set_context(const CacheContext& context) {
+    infer_steps_ = context.infer_steps;
+    num_blocks_ = context.num_blocks;
   }
 
  protected:
-  int64_t num_inference_steps_;
   int64_t warmup_steps_;
   int64_t current_step_;
   int64_t infer_steps_;
   int64_t num_blocks_;
   TensorMap buffers;
+  // Non-owning: the worker's ParallelArgs outlives this cache singleton.
+  const ParallelArgs* parallel_args_ = nullptr;
 
   static torch::Tensor get_tensor_or_empty(const TensorMap& m,
                                            const std::string& k);
-  static bool is_similar(const torch::Tensor& lhs,
-                         const torch::Tensor& rhs,
-                         float threshold);
+  bool is_similar(const torch::Tensor& lhs,
+                  const torch::Tensor& rhs,
+                  float threshold) const;
 };
 
 std::unique_ptr<DitCacheImpl> create_dit_cache(const DiTCacheConfig& cfg);

--- a/xllm/core/framework/dit_cache/dit_cache_type.h
+++ b/xllm/core/framework/dit_cache/dit_cache_type.h
@@ -51,4 +51,10 @@ struct CacheBlockOut {
   CacheBlockOut(const TensorMap& tensors) : tensors(tensors) {}
 };
 
+// Per-generation params, refreshed on every forward() before the denoise loop.
+struct CacheContext {
+  int64_t infer_steps = 0;
+  int64_t num_blocks = 0;
+};
+
 }  // namespace xllm

--- a/xllm/core/framework/dit_cache/dit_non_cache.cpp
+++ b/xllm/core/framework/dit_cache/dit_non_cache.cpp
@@ -17,7 +17,8 @@ limitations under the License.
 
 namespace xllm {
 
-void DiTNonCache::init(const DiTCacheConfig& cfg) {
+void DiTNonCache::init(const DiTCacheConfig& /*cfg*/,
+                       const ParallelArgs& /*parallel_args*/) {
   // NonCache: nothing to initialize.
 }
 

--- a/xllm/core/framework/dit_cache/dit_non_cache.h
+++ b/xllm/core/framework/dit_cache/dit_non_cache.h
@@ -28,7 +28,8 @@ class DiTNonCache : public DitCacheImpl {
   DiTNonCache(DiTNonCache&&) = default;
   DiTNonCache& operator=(DiTNonCache&&) = default;
 
-  void init(const DiTCacheConfig& cfg) override;
+  void init(const DiTCacheConfig& cfg,
+            const ParallelArgs& parallel_args) override;
 
   bool on_before_block(const CacheBlockIn& blockin) override;
   CacheBlockOut on_after_block(const CacheBlockIn& blockin) override;

--- a/xllm/core/framework/dit_cache/fbcache.cpp
+++ b/xllm/core/framework/dit_cache/fbcache.cpp
@@ -17,7 +17,9 @@ limitations under the License.
 
 namespace xllm {
 
-void FBCache::init(const DiTCacheConfig& cfg) {
+void FBCache::init(const DiTCacheConfig& cfg,
+                   const ParallelArgs& parallel_args) {
+  parallel_args_ = &parallel_args;
   CHECK_GE(cfg.fbcache.residual_diff_threshold, 0.0)
       << "residual_diff_threshold must be >= 0";
   CHECK_GE(cfg.fbcache.warmup_steps, 0) << "warmup_steps must be >= 0";

--- a/xllm/core/framework/dit_cache/fbcache.h
+++ b/xllm/core/framework/dit_cache/fbcache.h
@@ -29,7 +29,8 @@ class FBCache : public DitCacheImpl {
   FBCache(FBCache&&) = default;
   FBCache& operator=(FBCache&&) = default;
 
-  void init(const DiTCacheConfig& cfg) override;
+  void init(const DiTCacheConfig& cfg,
+            const ParallelArgs& parallel_args) override;
 
   bool on_before_block(const CacheBlockIn& blockin) override;
   CacheBlockOut on_after_block(const CacheBlockIn& blockin) override;

--- a/xllm/core/framework/dit_cache/fbcache_taylorseer.cpp
+++ b/xllm/core/framework/dit_cache/fbcache_taylorseer.cpp
@@ -17,7 +17,9 @@ limitations under the License.
 
 namespace xllm {
 
-void FBCacheTaylorSeer::init(const DiTCacheConfig& cfg) {
+void FBCacheTaylorSeer::init(const DiTCacheConfig& cfg,
+                             const ParallelArgs& parallel_args) {
+  parallel_args_ = &parallel_args;
   CHECK_GE(cfg.fbcachetaylorseer.residual_diff_threshold, 0.0)
       << "residual_diff_threshold must be >= 0";
   CHECK_GE(cfg.fbcachetaylorseer.warmup_steps, 0)
@@ -34,7 +36,7 @@ void FBCacheTaylorSeer::init(const DiTCacheConfig& cfg) {
 
   DiTCacheConfig ts_cfg;
   ts_cfg.taylorseer.n_derivatives = cfg.fbcachetaylorseer.n_derivatives;
-  taylorseer->init(ts_cfg);
+  taylorseer->init(ts_cfg, parallel_args);
 }
 
 bool FBCacheTaylorSeer::on_before_block(const CacheBlockIn& blockin) {
@@ -66,8 +68,8 @@ CacheBlockOut FBCacheTaylorSeer::on_after_block(const CacheBlockIn& blockin) {
 
   if (can_use_cache(first_hidden_states_residual)) {
     use_cache_ = true;
-    auto [new_hidden, new_encoder] =
-        apply_prev_hidden_states_residual(hidden_states, encoder_hidden_states);
+    auto [new_hidden, new_encoder] = apply_prev_hidden_states_residual(
+        original_hidden_states, encoder_hidden_states);
     output_hidden_states = std::move(new_hidden);
     output_encoder_hidden_states = std::move(new_encoder);
   } else {

--- a/xllm/core/framework/dit_cache/fbcache_taylorseer.h
+++ b/xllm/core/framework/dit_cache/fbcache_taylorseer.h
@@ -32,7 +32,8 @@ class FBCacheTaylorSeer : public DitCacheImpl {
   FBCacheTaylorSeer(FBCacheTaylorSeer&&) = default;
   FBCacheTaylorSeer& operator=(FBCacheTaylorSeer&&) = default;
 
-  void init(const DiTCacheConfig& cfg) override;
+  void init(const DiTCacheConfig& cfg,
+            const ParallelArgs& parallel_args) override;
 
   bool on_before_block(const CacheBlockIn& blockin) override;
   CacheBlockOut on_after_block(const CacheBlockIn& blockin) override;

--- a/xllm/core/framework/dit_cache/residual_cache.cpp
+++ b/xllm/core/framework/dit_cache/residual_cache.cpp
@@ -17,7 +17,9 @@ limitations under the License.
 
 namespace xllm {
 
-void ResidualCache::init(const DiTCacheConfig& cfg) {
+void ResidualCache::init(const DiTCacheConfig& cfg,
+                         const ParallelArgs& parallel_args) {
+  parallel_args_ = &parallel_args;
   CHECK_GT(cfg.residual_cache.skip_interval_steps, 0)
       << "skip_interval_steps must be > 0";
   CHECK_GT(cfg.residual_cache.dit_cache_start_steps, 0)

--- a/xllm/core/framework/dit_cache/residual_cache.h
+++ b/xllm/core/framework/dit_cache/residual_cache.h
@@ -36,7 +36,8 @@ class ResidualCache : public DitCacheImpl {
   ResidualCache(ResidualCache&&) = default;
   ResidualCache& operator=(ResidualCache&&) = default;
 
-  void init(const DiTCacheConfig& cfg) override;
+  void init(const DiTCacheConfig& cfg,
+            const ParallelArgs& parallel_args) override;
   // check whether to use cache
   bool cache_validation();
 

--- a/xllm/core/framework/dit_cache/taylorseer.cpp
+++ b/xllm/core/framework/dit_cache/taylorseer.cpp
@@ -21,7 +21,9 @@ namespace {
 double factorial(int k) { return std::tgamma(static_cast<double>(k) + 1.0); }
 }  // namespace
 
-void TaylorSeer::init(const DiTCacheConfig& cfg) {
+void TaylorSeer::init(const DiTCacheConfig& cfg,
+                      const ParallelArgs& parallel_args) {
+  parallel_args_ = &parallel_args;
   CHECK_GE(cfg.taylorseer.warmup_steps, 0) << "warmup_steps must be >= 0";
   CHECK_GE(cfg.taylorseer.skip_interval_steps, 0)
       << "skip_interval_steps must be >= 0";

--- a/xllm/core/framework/dit_cache/taylorseer.h
+++ b/xllm/core/framework/dit_cache/taylorseer.h
@@ -36,7 +36,8 @@ class TaylorSeer : public DitCacheImpl {
   TaylorSeer(TaylorSeer&&) = default;
   TaylorSeer& operator=(TaylorSeer&&) = default;
 
-  void init(const DiTCacheConfig& cfg) override;
+  void init(const DiTCacheConfig& cfg,
+            const ParallelArgs& parallel_args) override;
 
   // Reset all cached derivatives and internal state
   void reset_cache();

--- a/xllm/core/runtime/dit_worker_impl.cpp
+++ b/xllm/core/runtime/dit_worker_impl.cpp
@@ -137,7 +137,7 @@ bool DiTWorkerImpl::init_model(const std::string& model_weights_path,
   dit_model_executor_ =
       std::make_unique<DiTExecutor>(dit_model_.get(), options_);
 
-  DiTCache::get_instance().init(cache_config);
+  DiTCache::get_instance().init(cache_config, parallel_args_);
 
   return true;
 }

--- a/xllm/models/dit/pipelines/pipeline_flux2.h
+++ b/xllm/models/dit/pipelines/pipeline_flux2.h
@@ -286,8 +286,8 @@ class Flux2PipelineImpl final : public Flux2PipelineBaseImpl {
         torch::stack({rot_emb1, rot_emb2}, 0).to(options_.dtype());
 
     // denosing loop
-    DiTCache::get_instance().set_infer_steps(num_inference_steps);
-    DiTCache::get_instance().set_num_blocks(num_single_layers_);
+    DiTCache::get_instance().set_context({/*infer_steps=*/num_inference_steps,
+                                          /*num_blocks=*/num_single_layers_});
     scheduler_->set_begin_index(0);
     torch::Tensor timestep =
         torch::empty({prepared_latents.size(0)}, prepared_latents.options());
@@ -318,7 +318,7 @@ class Flux2PipelineImpl final : public Flux2PipelineBaseImpl {
                                                        timestep,
                                                        guidance,
                                                        image_rotary_emb,
-                                                       /*step_idx=*/i);
+                                                       /*step_idx=*/i + 1);
 
       if (image_latents.defined()) {
         noise_pred = noise_pred.narrow(1, 0, prepared_latents.size(1));

--- a/xllm/models/dit/pipelines/pipeline_qwenimage_edit_plus.h
+++ b/xllm/models/dit/pipelines/pipeline_qwenimage_edit_plus.h
@@ -829,8 +829,8 @@ class QwenImageEditPlusPipelineImpl : public torch::nn::Module {
     auto width = generation_params.width;
     auto true_cfg_scale = generation_params.true_cfg_scale;
     auto num_inference_steps = generation_params.num_inference_steps;
-    DiTCache::get_instance().set_infer_steps(num_inference_steps);
-    DiTCache::get_instance().set_num_blocks(num_layers_);
+    DiTCache::get_instance().set_context(
+        {/*infer_steps=*/num_inference_steps, /*num_blocks=*/num_layers_});
     auto max_sequence_length = generation_params.max_sequence_length;
     auto seed = generation_params.seed >= 0 ? generation_params.seed : 42;
 
@@ -1071,7 +1071,7 @@ class QwenImageEditPlusPipelineImpl : public torch::nn::Module {
                                              txt_seq_lens,
                                              image_rotary_emb_pos,
                                              /*use_cfg=*/false,
-                                             /*step_index=*/i);
+                                             /*step_index=*/i + 1);
           noise_pred = noise_pred.slice(1, 0, final_latents.size(1));
           pos_neg_noise_preds =
               xllm::parallel_state::gather(noise_pred,
@@ -1086,7 +1086,7 @@ class QwenImageEditPlusPipelineImpl : public torch::nn::Module {
                                                  negative_txt_seq_lens,
                                                  image_rotary_emb_neg,
                                                  /*use_cfg=*/true,
-                                                 /*step_index=*/i);
+                                                 /*step_index=*/i + 1);
 
           neg_noise_pred = neg_noise_pred.slice(1, 0, final_latents.size(1));
           pos_neg_noise_preds =
@@ -1110,7 +1110,7 @@ class QwenImageEditPlusPipelineImpl : public torch::nn::Module {
                                            txt_seq_lens,
                                            image_rotary_emb_pos,
                                            /*use_cfg=*/false,
-                                           /*step_index=*/i);
+                                           /*step_index=*/i + 1);
         noise_pred = noise_pred.slice(1, 0, final_latents.size(1));
         if (do_true_cfg) {
           neg_noise_pred = transformer_->forward(latent_model_input,
@@ -1121,7 +1121,7 @@ class QwenImageEditPlusPipelineImpl : public torch::nn::Module {
                                                  negative_txt_seq_lens,
                                                  image_rotary_emb_neg,
                                                  /*use_cfg=*/true,
-                                                 /*step_index=*/i);
+                                                 /*step_index=*/i + 1);
 
           neg_noise_pred = neg_noise_pred.slice(1, 0, final_latents.size(1));
 

--- a/xllm/models/dit/transformers/transformer_wan.h
+++ b/xllm/models/dit/transformers/transformer_wan.h
@@ -1737,7 +1737,8 @@ class WanTransformer3DModelImpl : public torch::nn::Module {
                   bool rolling = false) {
     auto freqs_cos_fp32 = rope_->get_freqs_cos().clone();
     auto freqs_sin_fp32 = rope_->get_freqs_sin().clone();
-    // TODO: check the dtype solution. just use the options' dtype to control, instead of the to dtype.
+    // TODO: check the dtype solution. just use the options' dtype to control,
+    // instead of the to dtype.
     dit::to_bf16_preserve_quant(*this,
                                 rolling ? torch::kCPU : options_.device());
 


### PR DESCRIPTION
## Description

Enable FBCache (feature-reuse cache) to work correctly under Sequence Parallel (SP) distributed inference for the DiT backend.

Under SP, the sequence is sharded across ranks, so each rank only sees a slice of the hidden states. The old cache-similarity check computed a local mean, which let different ranks make different cache-reuse decisions — causing divergence and HCCL hangs. This PR makes the reuse decision globally consistent across all SP ranks:

- DitCacheImpl::is_similar now all-reduces the raw sum(|diff|), sum(|lhs|), and element count across the SP group (packed into one tensor for a single all-reduce), then computes the global mean. Since shards are equal-length, sum/count equals the exact global mean.
- Added DiTCacheParallelContext to carry the SP topology (group/rank/world_size/enabled) into the cache. It is set once at worker init (DiTWorkerImpl::init_model), since SP topology is fixed for the worker's lifetime.
- Changed is_similar from static to a const member so it can read the per-instance parallel context.

Also included (related DiT correctness fixes surfaced during SP bring-up):

- fbcache_taylorseer.cpp: apply the residual to original_hidden_states (not the already-modified hidden_states) when reusing cache.
- pipeline_qwenimage_edit_plus.h: pass step_index = i + 1 (1-based) to the transformer forward across the 4 call sites.

Note: the all-reduce in is_similar is a collective — every early-return in that function must fire identically on all SP ranks or HCCL will hang. This invariant is documented in a code comment; future edits adding early-outs must keep them symmetric.

## Related Issues

## Change Type

- [x] Bug fix
- [ ] New feature
- [ ] Performance improvement
- [ ] Refactor
- [ ] Documentation
- [ ] Test
- [ ] Build or CI

## Pull Request Checklist

Thank you for contributing to xLLM. Before requesting review, please make sure the following items are complete.

### PR Title and Commit Messages

- [x] The PR title and each commit message follow the xLLM commit format: `<type>: <subject>`.

> Allowed types: feat, bugfix, docs, test, refactor, chore, style, revert, perf, model, build, release.
> The subject should use clear English, start with a verb, include at least 4 words, and end with a period.

### Pre-commit Checks

- [x] I have installed `pre-commit` by running `pip install pre-commit` or an equivalent command.
- [x] I have installed the hooks with `pre-commit install`.
- [x] I have run `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

### Self Review

- [x] I have self-reviewed the code according to `.agents/skills/code-review/references/custom-code-style.md`, especially code written or assisted by AI.
- [x] I have rebased this PR onto the latest `main` branch.

### Build and Test Coverage

- [ ] Tests have been added or updated as needed.
- [ ] CUDA: `python setup.py build test` has passed on a CUDA machine.
- [x] NPU: `python setup.py build test` has passed on an NPU machine.
- [ ] MLU: `python setup.py build test` has passed on an MLU machine.

## Reviewer Notes
