### PR TITLE
bugfix: omit empty tool calls from chat responses.

### DIFF
--- a/tests/api_service/usage_json_test.cpp
+++ b/tests/api_service/usage_json_test.cpp
@@ -18,12 +18,21 @@ limitations under the License.
 
 #include <nlohmann/json.hpp>
 #include <string>
+#include <vector>
 
+#include "api_service/stream_call.h"
 #include "api_service/utils.h"
 #include "chat.pb.h"
 
 namespace xllm {
 namespace {
+
+std::vector<JsonTool> make_test_tools() {
+  return {JsonTool("function",
+                   JsonFunction("get_weather",
+                                "Get the weather",
+                                nlohmann::json{{"type", "object"}}))};
+}
 
 TEST(UsageJsonTest, ChatUsageSerializesOpenAICachedTokensField) {
   Usage usage;
@@ -89,6 +98,116 @@ TEST(UsageJsonTest, ChatUsagePrintsZeroCachedTokens) {
   EXPECT_EQ(json["usage"]["completion_tokens_details"]["reasoning_tokens"], 0);
   EXPECT_EQ(json["usage"]["completion_tokens_details"]["audio_tokens"], 0);
   EXPECT_EQ(json["usage"]["completion_tokens_details"].size(), 2);
+}
+
+TEST(ToolCallResultTest, KeepsNormalTextWhenNoToolCallMarkerExists) {
+  const std::string text = "The weather is sunny.";
+
+  const auto result =
+      api_service::process_tool_calls(text, make_test_tools(), "glm45", "stop");
+
+  EXPECT_FALSE(result.tool_calls.has_value());
+  EXPECT_EQ(result.text, text);
+  EXPECT_EQ(result.finish_reason, "stop");
+}
+
+TEST(ToolCallResultTest, KeepsNormalTextWhenMarkerDoesNotParse) {
+  const std::string text =
+      "The weather is sunny. <tool_call>unknown_tool\n"
+      "<arg_key>location</arg_key>\n"
+      "<arg_value>Beijing</arg_value>\n"
+      "</tool_call>";
+
+  const auto result =
+      api_service::process_tool_calls(text, make_test_tools(), "glm45", "stop");
+
+  EXPECT_FALSE(result.tool_calls.has_value());
+  EXPECT_EQ(result.text, text);
+  EXPECT_EQ(result.finish_reason, "stop");
+}
+
+TEST(ToolCallResultTest, PreservesParsedToolCall) {
+  const auto result = api_service::process_tool_calls(
+      "I will check. <tool_call>get_weather\n"
+      "<arg_key>location</arg_key>\n"
+      "<arg_value>Beijing</arg_value>\n"
+      "</tool_call>",
+      make_test_tools(),
+      "glm45",
+      "stop");
+
+  ASSERT_TRUE(result.tool_calls.has_value());
+  ASSERT_EQ(result.tool_calls->size(), 1);
+  EXPECT_EQ(result.tool_calls->at(0).function().name(), "get_weather");
+  EXPECT_EQ(result.finish_reason, "tool_calls");
+}
+
+TEST(ChatResponseJsonTest, OmitsEmptyToolCallsForNormalText) {
+  auto* request = new proto::ChatRequest();
+  request->set_stream(false);
+  auto* response = new proto::ChatResponse();
+  auto* choice = response->add_choices();
+  auto* message = choice->mutable_message();
+  message->set_role("assistant");
+  message->set_content("The weather is sunny.");
+
+  brpc::Controller controller;
+  {
+    StreamCall<proto::ChatRequest, proto::ChatResponse> call(
+        &controller, brpc::DoNothing(), request, response);
+    ASSERT_TRUE(call.write_and_finish(*response));
+  }
+
+  const nlohmann::json json =
+      nlohmann::json::parse(controller.response_attachment().to_string());
+  ASSERT_TRUE(json["choices"][0].contains("message"));
+  EXPECT_FALSE(json["choices"][0]["message"].contains("tool_calls"));
+}
+
+TEST(ChatResponseJsonTest, KeepsNonEmptyToolCalls) {
+  proto::ChatResponse response;
+  auto* choice = response.add_choices();
+  auto* message = choice->mutable_message();
+  message->set_role("assistant");
+  auto* tool_call = message->add_tool_calls();
+  tool_call->set_id("call_test");
+  tool_call->set_type("function");
+  tool_call->mutable_function()->set_name("get_weather");
+  tool_call->mutable_function()->set_arguments("{\"location\":\"Beijing\"}");
+
+  json2pb::Pb2JsonOptions options;
+  options.bytes_to_base64 = false;
+  options.jsonify_empty_array = false;
+
+  std::string json_text;
+  std::string error_message;
+  ASSERT_TRUE(json2pb::ProtoMessageToJson(
+      response, &json_text, options, &error_message))
+      << error_message;
+
+  const nlohmann::json json = nlohmann::json::parse(json_text);
+  const auto& tool_calls = json["choices"][0]["message"]["tool_calls"];
+  ASSERT_TRUE(tool_calls.is_array());
+  ASSERT_EQ(tool_calls.size(), 1);
+  EXPECT_EQ(tool_calls[0]["function"]["name"], "get_weather");
+}
+
+TEST(AnthropicCallJsonTest, KeepsEmptyContentArray) {
+  auto* request = new proto::AnthropicMessagesRequest();
+  request->set_stream(false);
+  auto* response = new proto::AnthropicMessagesResponse();
+
+  brpc::Controller controller;
+  {
+    AnthropicCall call(&controller, brpc::DoNothing(), request, response);
+    ASSERT_TRUE(call.write_and_finish(*response));
+  }
+
+  const nlohmann::json json =
+      nlohmann::json::parse(controller.response_attachment().to_string());
+  ASSERT_TRUE(json.contains("content"));
+  EXPECT_TRUE(json["content"].is_array());
+  EXPECT_TRUE(json["content"].empty());
 }
 
 }  // namespace

--- a/xllm/api_service/stream_call.h
+++ b/xllm/api_service/stream_call.h
@@ -68,7 +68,7 @@ class StreamCall : public Call {
     }
 
     json_options_.bytes_to_base64 = false;
-    json_options_.jsonify_empty_array = true;
+    json_options_.jsonify_empty_array = false;
   }
 
   ~StreamCall() override {
@@ -186,7 +186,10 @@ class AnthropicCall : public StreamCall<proto::AnthropicMessagesRequest,
                                                      request,
                                                      response,
                                                      use_arena,
-                                                     is_http_request) {}
+                                                     is_http_request) {
+    // Anthropic responses require empty content arrays to remain visible.
+    this->json_options_.jsonify_empty_array = true;
+  }
 
   ~AnthropicCall() {}
 

--- a/xllm/api_service/utils.h
+++ b/xllm/api_service/utils.h
@@ -117,15 +117,20 @@ inline ToolCallResult process_tool_calls(
     return result;
   }
 
-  if (finish_reason == "stop") {
-    result.finish_reason = "tool_calls";
-  } else {
-    result.finish_reason = std::move(finish_reason);
-  }
+  result.text = text;
+  result.finish_reason = finish_reason;
 
   try {
     auto [parsed_text, call_info_list] = parser.parse_non_stream(text);
     result.text = std::move(parsed_text);
+
+    if (call_info_list.empty()) {
+      return result;
+    }
+
+    if (finish_reason == "stop") {
+      result.finish_reason = "tool_calls";
+    }
 
     google::protobuf::RepeatedPtrField<proto::ToolCall> tool_calls;
 


### PR DESCRIPTION
## Description

<!-- What does this PR do? Briefly describe the changes and why they are needed. -->

This PR fixes an OpenAI-compatible chat completion serialization bug that occurs when the assistant returns normal text after a tool result.

Previously, the protobuf-to-JSON serializer could emit an empty `tool_calls` array:

```json
"tool_calls": []
```

The OpenAI SDK treats the presence of `tool_calls` as a tool-call response and may enter the tool-call handling path, where accessing the empty array causes an error.

The changes:

- Omit empty arrays from OpenAI-compatible `StreamCall` responses.
- Preserve Anthropic’s required empty `content` arrays.
- Only populate `tool_calls` and set `finish_reason` to `tool_calls` when the parser produces at least one valid tool call.
- Add regression tests covering normal text responses, invalid tool-call markers, valid non-empty tool calls, JSON serialization, and Anthropic compatibility.
## Related Issues

<!-- Link related issues here. Use "Fixes #123" when this PR closes an issue. -->

## Change Type

- [ ] Bug fix
- [ ] New feature
- [ ] Performance improvement
- [ ] Refactor
- [ ] Documentation
- [ ] Test
- [ ] Build or CI

## Pull Request Checklist

Thank you for contributing to xLLM. Before requesting review, please make sure the following items are complete.

### PR Title and Commit Messages

- [ ] The PR title and each commit message follow the xLLM commit format: `<type>: <subject>`.

> Allowed types: feat, bugfix, docs, test, refactor, chore, style, revert, perf, model, build, release.
> The subject should use clear English, start with a verb, include at least 4 words, and end with `.`.

### Pre-commit Checks

- [ ] I have installed `pre-commit` by running `pip install pre-commit` or an equivalent command.
- [ ] I have installed the hooks with `pre-commit install`.
- [ ] I have run `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

### Self Review

- [ ] I have self-reviewed the code according to `.agents/skills/code-review/references/custom-code-style.md`, especially code written or assisted by AI.
- [ ] I have rebased this PR onto the latest `main` branch.

### Build and Test Coverage

- [ ] Tests have been added or updated as needed.
- [ ] CUDA: `python setup.py build test` has passed on a CUDA machine.
- [ ] NPU: `python setup.py build test` has passed on an NPU machine.
- [ ] MLU: `python setup.py build test` has passed on an MLU machine.

## Reviewer Notes

<!-- Optional: anything reviewers should focus on, known risks, follow-ups, or validation gaps. -->
