### PR TITLE
feat: propagate request IDs through inference paths.

### DIFF
--- a/tests/api_service/CMakeLists.txt
+++ b/tests/api_service/CMakeLists.txt
@@ -61,6 +61,16 @@ cc_test(
 
 cc_test(
   NAME
+    request_id_test
+  SRCS
+    request_id_test.cpp
+  DEPS
+    api_service
+    GTest::gtest_main
+)
+
+cc_test(
+  NAME
     anthropic_json_test
   SRCS
     anthropic_json_test.cpp

--- a/tests/api_service/request_id_test.cpp
+++ b/tests/api_service/request_id_test.cpp
@@ -75,6 +75,54 @@ TEST(RequestIdTest, BodyIsUsedWhenHeaderIsMissing) {
   EXPECT_EQ(*controller.http_response().GetHeader("x-request-id"), "body-id");
 }
 
+TEST(RequestIdTest, InvalidPrimaryHeaderFallsBackToSecondaryHeader) {
+  brpc::Controller controller;
+  controller.http_request().SetHeader("x-request-id", "invalid\r\nid");
+  controller.http_request().SetHeader("x-ms-client-request-id", "fallback-id");
+  proto::CompletionRequest request;
+  request.set_x_request_id("body-id");
+  proto::CompletionResponse response;
+  NoopClosure done;
+
+  CompletionCallForTest call(&controller,
+                             &done,
+                             &request,
+                             &response,
+                             /*use_arena=*/true,
+                             /*is_http_request=*/true);
+
+  EXPECT_EQ(call.get_x_request_id(), "fallback-id");
+  ASSERT_NE(controller.http_response().GetHeader("x-request-id"), nullptr);
+  EXPECT_EQ(*controller.http_response().GetHeader("x-request-id"),
+            "fallback-id");
+}
+
+TEST(RequestIdTest, InvalidHeadersAreReplacedBeforeResponseHeader) {
+  brpc::Controller controller;
+  const std::string invalid_primary_id = "invalid\r\nprimary";
+  const std::string invalid_secondary_id = "invalid\nsecondary";
+  controller.http_request().SetHeader("x-request-id", invalid_primary_id);
+  controller.http_request().SetHeader("x-ms-client-request-id",
+                                      invalid_secondary_id);
+  proto::CompletionRequest request;
+  proto::CompletionResponse response;
+  NoopClosure done;
+
+  CompletionCallForTest call(&controller,
+                             &done,
+                             &request,
+                             &response,
+                             /*use_arena=*/true,
+                             /*is_http_request=*/true);
+
+  EXPECT_EQ(call.get_x_request_id().find("req-"), 0);
+  EXPECT_NE(call.get_x_request_id(), invalid_primary_id);
+  EXPECT_NE(call.get_x_request_id(), invalid_secondary_id);
+  ASSERT_NE(controller.http_response().GetHeader("x-request-id"), nullptr);
+  EXPECT_EQ(*controller.http_response().GetHeader("x-request-id"),
+            call.get_x_request_id());
+}
+
 TEST(RequestIdTest, BodyOverridesIdGeneratedBeforeParsing) {
   brpc::Controller controller;
   const std::string early_x_request_id =

--- a/tests/api_service/request_id_test.cpp
+++ b/tests/api_service/request_id_test.cpp
@@ -1,0 +1,187 @@
+/* Copyright 2026 The xLLM Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://github.com/jd-opensource/xllm/blob/main/LICENSE
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include "api_service/request_id.h"
+
+#include <brpc/controller.h>
+#include <gtest/gtest.h>
+
+#include <string>
+
+#include "anthropic.pb.h"
+#include "api_service/non_stream_call.h"
+#include "chat.pb.h"
+#include "completion.pb.h"
+
+namespace xllm {
+namespace {
+
+class NoopClosure final : public google::protobuf::Closure {
+ public:
+  void Run() override {}
+};
+
+using CompletionCallForTest =
+    NonStreamCall<proto::CompletionRequest, proto::CompletionResponse>;
+
+TEST(RequestIdTest, HeaderTakesPrecedenceOverBody) {
+  brpc::Controller controller;
+  controller.http_request().SetHeader("x-request-id", "header-id");
+  proto::CompletionRequest request;
+  request.set_x_request_id("body-id");
+  proto::CompletionResponse response;
+  NoopClosure done;
+
+  CompletionCallForTest call(&controller,
+                             &done,
+                             &request,
+                             &response,
+                             /*use_arena=*/true,
+                             /*is_http_request=*/true);
+
+  EXPECT_EQ(call.get_x_request_id(), "header-id");
+  ASSERT_NE(controller.http_response().GetHeader("x-request-id"), nullptr);
+  EXPECT_EQ(*controller.http_response().GetHeader("x-request-id"), "header-id");
+}
+
+TEST(RequestIdTest, BodyIsUsedWhenHeaderIsMissing) {
+  brpc::Controller controller;
+  proto::CompletionRequest request;
+  request.set_x_request_id("body-id");
+  proto::CompletionResponse response;
+  NoopClosure done;
+
+  CompletionCallForTest call(&controller,
+                             &done,
+                             &request,
+                             &response,
+                             /*use_arena=*/true,
+                             /*is_http_request=*/true);
+
+  EXPECT_EQ(call.get_x_request_id(), "body-id");
+  ASSERT_NE(controller.http_response().GetHeader("x-request-id"), nullptr);
+  EXPECT_EQ(*controller.http_response().GetHeader("x-request-id"), "body-id");
+}
+
+TEST(RequestIdTest, BodyOverridesIdGeneratedBeforeParsing) {
+  brpc::Controller controller;
+  const std::string early_x_request_id =
+      api_service::ensure_http_x_request_id(&controller);
+  proto::CompletionRequest request;
+  request.set_x_request_id("body-id");
+  proto::CompletionResponse response;
+  NoopClosure done;
+
+  CompletionCallForTest call(&controller,
+                             &done,
+                             &request,
+                             &response,
+                             /*use_arena=*/true,
+                             /*is_http_request=*/true);
+
+  EXPECT_NE(early_x_request_id, "body-id");
+  EXPECT_EQ(call.get_x_request_id(), "body-id");
+  ASSERT_NE(controller.http_response().GetHeader("x-request-id"), nullptr);
+  EXPECT_EQ(*controller.http_response().GetHeader("x-request-id"), "body-id");
+}
+
+TEST(RequestIdTest, MissingIdIsGeneratedAndReturned) {
+  brpc::Controller controller;
+  proto::CompletionRequest request;
+  proto::CompletionResponse response;
+  NoopClosure done;
+
+  CompletionCallForTest call(&controller,
+                             &done,
+                             &request,
+                             &response,
+                             /*use_arena=*/true,
+                             /*is_http_request=*/true);
+
+  EXPECT_EQ(call.get_x_request_id().find("req-"), 0);
+  ASSERT_NE(controller.http_response().GetHeader("x-request-id"), nullptr);
+  EXPECT_EQ(*controller.http_response().GetHeader("x-request-id"),
+            call.get_x_request_id());
+}
+
+TEST(RequestIdTest, InvalidBodyIdIsReplacedBeforeResponseHeader) {
+  brpc::Controller controller;
+  proto::CompletionRequest request;
+  request.set_x_request_id("body-id\r\nx-injected: true");
+  proto::CompletionResponse response;
+  NoopClosure done;
+
+  CompletionCallForTest call(&controller,
+                             &done,
+                             &request,
+                             &response,
+                             /*use_arena=*/true,
+                             /*is_http_request=*/true);
+
+  EXPECT_EQ(call.get_x_request_id().find("req-"), 0);
+  EXPECT_EQ(call.get_x_request_id().find('\r'), std::string::npos);
+  EXPECT_EQ(call.get_x_request_id().find('\n'), std::string::npos);
+}
+
+TEST(RequestIdTest, EnforcesLengthLimit) {
+  EXPECT_TRUE(api_service::is_valid_x_request_id(std::string(256, 'a')));
+  EXPECT_FALSE(api_service::is_valid_x_request_id(std::string(257, 'a')));
+}
+
+TEST(RequestIdTest, TypedCallUsesBodyIdWithoutHttpResponseHeader) {
+  brpc::Controller controller;
+  proto::CompletionRequest request;
+  request.set_x_request_id("typed-body-id");
+  proto::CompletionResponse response;
+  NoopClosure done;
+
+  CompletionCallForTest call(&controller,
+                             &done,
+                             &request,
+                             &response,
+                             /*use_arena=*/true);
+
+  EXPECT_EQ(call.get_x_request_id(), "typed-body-id");
+  EXPECT_EQ(controller.http_response().GetHeader("x-request-id"), nullptr);
+}
+
+TEST(RequestIdTest, EarlyHttpIdSurvivesSetFailed) {
+  brpc::Controller controller;
+  const std::string x_request_id =
+      api_service::ensure_http_x_request_id(&controller);
+
+  controller.SetFailed("request failed before parsing");
+
+  ASSERT_NE(controller.http_response().GetHeader("x-request-id"), nullptr);
+  EXPECT_EQ(*controller.http_response().GetHeader("x-request-id"),
+            x_request_id);
+}
+
+TEST(RequestIdTest, ExtractsIdFromSupportedRequestBodies) {
+  proto::CompletionRequest completion;
+  completion.set_x_request_id("completion-id");
+  EXPECT_EQ(request_body_x_request_id(&completion), "completion-id");
+
+  proto::ChatRequest chat;
+  chat.set_x_request_id("chat-id");
+  EXPECT_EQ(request_body_x_request_id(&chat), "chat-id");
+
+  proto::AnthropicMessagesRequest anthropic;
+  anthropic.set_x_request_id("anthropic-id");
+  EXPECT_EQ(request_body_x_request_id(&anthropic), "anthropic-id");
+}
+
+}  // namespace
+}  // namespace xllm

--- a/xllm/api_service/CMakeLists.txt
+++ b/xllm/api_service/CMakeLists.txt
@@ -7,6 +7,7 @@ cc_library(
     api_service.h
     api_service_impl.h
     call.h
+    request_id.h
     chat_json_parser.h
     completion_json_parser.h
     completion_service_impl.h
@@ -37,6 +38,7 @@ cc_library(
     completion_json_parser.cpp
     service_impl_factory.cpp
     call.cpp
+    request_id.cpp
     completion_service_impl.cpp
     rec_completion_service_impl.cpp
     chat_service_impl.cpp

--- a/xllm/api_service/api_service.cpp
+++ b/xllm/api_service/api_service.cpp
@@ -24,6 +24,7 @@ limitations under the License.
 
 #include "api_service/chat_json_parser.h"
 #include "api_service/completion_json_parser.h"
+#include "api_service/request_id.h"
 #include "api_service/service_impl_factory.h"
 #include "api_service/serving_mode.h"
 #include "call.h"
@@ -197,6 +198,7 @@ void APIService::CompletionsHttp(::google::protobuf::RpcController* controller,
       google::protobuf::Arena::CreateMessage<proto::CompletionResponse>(arena);
 
   auto ctrl = reinterpret_cast<brpc::Controller*>(controller);
+  api_service::ensure_http_x_request_id(ctrl);
 
   auto [preprocess_status, processed_json] =
       preprocess_completion_prompt(ctrl->request_attachment().to_string());
@@ -217,8 +219,13 @@ void APIService::CompletionsHttp(::google::protobuf::RpcController* controller,
     return;
   }
 
-  std::shared_ptr<Call> call = std::make_shared<CompletionCall>(
-      ctrl, done_guard.release(), req_pb, resp_pb, arena != nullptr);
+  std::shared_ptr<Call> call =
+      std::make_shared<CompletionCall>(ctrl,
+                                       done_guard.release(),
+                                       req_pb,
+                                       resp_pb,
+                                       arena != nullptr,
+                                       /*is_http_request=*/true);
   if (completion_service_impl_) {
     completion_service_impl_->process_async(call);
   } else if (rec_completion_service_impl_) {
@@ -270,6 +277,7 @@ void APIService::SampleHttp(::google::protobuf::RpcController* controller,
   }
 
   auto ctrl = reinterpret_cast<brpc::Controller*>(controller);
+  api_service::ensure_http_x_request_id(ctrl);
   if (!sample_service_impl_) {
     ctrl->SetFailed(kSampleNotSupportedError);
     return;
@@ -292,8 +300,13 @@ void APIService::SampleHttp(::google::protobuf::RpcController* controller,
     return;
   }
 
-  std::shared_ptr<Call> call = std::make_shared<SampleCall>(
-      ctrl, done_guard.release(), req_pb, resp_pb, arena != nullptr);
+  std::shared_ptr<Call> call =
+      std::make_shared<SampleCall>(ctrl,
+                                   done_guard.release(),
+                                   req_pb,
+                                   resp_pb,
+                                   arena != nullptr,
+                                   /*is_http_request=*/true);
   sample_service_impl_->process_async(call);
 }
 
@@ -360,8 +373,12 @@ void chat_completions_http_impl(std::unique_ptr<Service>& service,
     return;
   }
 
-  auto call = std::make_shared<ChatCall>(
-      ctrl, guard.release(), req_pb, resp_pb, arena != nullptr /*use_arena*/);
+  auto call = std::make_shared<ChatCall>(ctrl,
+                                         guard.release(),
+                                         req_pb,
+                                         resp_pb,
+                                         arena != nullptr /*use_arena*/,
+                                         true /*is_http_request*/);
   service->process_async(call);
 }
 
@@ -435,12 +452,13 @@ void APIService::ChatCompletionsHttp(
     return;
   }
 
+  auto ctrl = reinterpret_cast<brpc::Controller*>(controller);
+  api_service::ensure_http_x_request_id(ctrl);
+
   if (!chat_completions_handler_) {
     LOG(ERROR) << "No chat completions handler registered";
     return;
   }
-
-  auto ctrl = reinterpret_cast<brpc::Controller*>(controller);
   chat_completions_handler_(done_guard, ctrl, request, response);
 }
 
@@ -508,6 +526,7 @@ void handle_embedding_request(std::unique_ptr<Service>& embedding_service_impl_,
           arena);
 
   auto ctrl = reinterpret_cast<brpc::Controller*>(controller);
+  api_service::ensure_http_x_request_id(ctrl);
   std::string error;
   json2pb::Json2PbOptions options;
   butil::IOBuf& buf = ctrl->request_attachment();
@@ -524,8 +543,13 @@ void handle_embedding_request(std::unique_ptr<Service>& embedding_service_impl_,
     req_pb->set_encoding_format("float");
   }
 
-  std::shared_ptr<Call> call = std::make_shared<EmbeddingCall>(
-      ctrl, done_guard.release(), req_pb, resp_pb, arena != nullptr);
+  std::shared_ptr<Call> call =
+      std::make_shared<EmbeddingCall>(ctrl,
+                                      done_guard.release(),
+                                      req_pb,
+                                      resp_pb,
+                                      arena != nullptr,
+                                      /*is_http_request=*/true);
   embedding_service_impl_->process_async(call);
 }
 }  // namespace
@@ -581,6 +605,7 @@ void APIService::ImageGenerationHttp(
           arena);
 
   auto ctrl = reinterpret_cast<brpc::Controller*>(controller);
+  api_service::ensure_http_x_request_id(ctrl);
   std::string error;
   json2pb::Json2PbOptions options;
   butil::IOBuf& buf = ctrl->request_attachment();
@@ -592,8 +617,12 @@ void APIService::ImageGenerationHttp(
     return;
   }
   std::shared_ptr<ImageGenerationCall> call =
-      std::make_shared<ImageGenerationCall>(
-          ctrl, done_guard.release(), req_pb, resp_pb, arena != nullptr);
+      std::make_shared<ImageGenerationCall>(ctrl,
+                                            done_guard.release(),
+                                            req_pb,
+                                            resp_pb,
+                                            arena != nullptr,
+                                            /*is_http_request=*/true);
   image_generation_service_impl_->process_async(call);
 }
 
@@ -635,6 +664,7 @@ void APIService::AudioGenerationHttp(
           arena);
 
   brpc::Controller* ctrl = static_cast<brpc::Controller*>(controller);
+  api_service::ensure_http_x_request_id(ctrl);
   std::string error;
   json2pb::Json2PbOptions options;
   butil::IOBuf& buf = ctrl->request_attachment();
@@ -646,8 +676,12 @@ void APIService::AudioGenerationHttp(
     return;
   }
   std::shared_ptr<AudioGenerationCall> call =
-      std::make_shared<AudioGenerationCall>(
-          ctrl, done_guard.release(), req_pb, resp_pb, arena != nullptr);
+      std::make_shared<AudioGenerationCall>(ctrl,
+                                            done_guard.release(),
+                                            req_pb,
+                                            resp_pb,
+                                            arena != nullptr,
+                                            /*is_http_request=*/true);
   audio_generation_service_impl_->process_async(call);
 }
 
@@ -689,6 +723,7 @@ void APIService::TextGenerationHttp(
           arena);
 
   brpc::Controller* ctrl = static_cast<brpc::Controller*>(controller);
+  api_service::ensure_http_x_request_id(ctrl);
   std::string error;
   json2pb::Json2PbOptions options;
   butil::IOBuf& buf = ctrl->request_attachment();
@@ -700,8 +735,12 @@ void APIService::TextGenerationHttp(
     return;
   }
   std::shared_ptr<TextGenerationCall> call =
-      std::make_shared<TextGenerationCall>(
-          ctrl, done_guard.release(), req_pb, resp_pb, arena != nullptr);
+      std::make_shared<TextGenerationCall>(ctrl,
+                                           done_guard.release(),
+                                           req_pb,
+                                           resp_pb,
+                                           arena != nullptr,
+                                           /*is_http_request=*/true);
   text_generation_service_impl_->process_async(call);
 }
 
@@ -743,6 +782,7 @@ void APIService::VideoGenerationHttp(
           arena);
 
   auto ctrl = reinterpret_cast<brpc::Controller*>(controller);
+  api_service::ensure_http_x_request_id(ctrl);
   std::string error;
   json2pb::Json2PbOptions options;
   butil::IOBuf& buf = ctrl->request_attachment();
@@ -754,8 +794,12 @@ void APIService::VideoGenerationHttp(
     return;
   }
   std::shared_ptr<VideoGenerationCall> call =
-      std::make_shared<VideoGenerationCall>(
-          ctrl, done_guard.release(), req_pb, resp_pb, arena != nullptr);
+      std::make_shared<VideoGenerationCall>(ctrl,
+                                            done_guard.release(),
+                                            req_pb,
+                                            resp_pb,
+                                            arena != nullptr,
+                                            /*is_http_request=*/true);
   video_generation_service_impl_->process_async(call);
 }
 
@@ -789,6 +833,7 @@ void APIService::RerankHttp(::google::protobuf::RpcController* controller,
       google::protobuf::Arena::CreateMessage<proto::RerankResponse>(arena);
 
   auto ctrl = reinterpret_cast<brpc::Controller*>(controller);
+  api_service::ensure_http_x_request_id(ctrl);
   std::string error;
   json2pb::Json2PbOptions options;
   butil::IOBuf& buf = ctrl->request_attachment();
@@ -800,8 +845,13 @@ void APIService::RerankHttp(::google::protobuf::RpcController* controller,
     return;
   }
 
-  std::shared_ptr<Call> call = std::make_shared<RerankCall>(
-      ctrl, done_guard.release(), req_pb, resp_pb, arena != nullptr);
+  std::shared_ptr<Call> call =
+      std::make_shared<RerankCall>(ctrl,
+                                   done_guard.release(),
+                                   req_pb,
+                                   resp_pb,
+                                   arena != nullptr,
+                                   /*is_http_request=*/true);
   rerank_service_impl_->process_async(call);
 }
 
@@ -918,8 +968,12 @@ void handle_anthropic_messages(std::unique_ptr<AnthropicServiceImpl>& service,
     return;
   }
 
-  auto call = std::make_shared<AnthropicCall>(
-      ctrl, guard.release(), req_pb, resp_pb, arena != nullptr /*use_arena*/);
+  auto call = std::make_shared<AnthropicCall>(ctrl,
+                                              guard.release(),
+                                              req_pb,
+                                              resp_pb,
+                                              arena != nullptr /*use_arena*/,
+                                              true /*is_http_request*/);
 
   service->process_async(call);
 }
@@ -944,6 +998,7 @@ void APIService::AnthropicMessagesHttp(
   }
 
   auto ctrl = reinterpret_cast<brpc::Controller*>(controller);
+  api_service::ensure_http_x_request_id(ctrl);
 
   if (anthropic_service_impl_) {
     handle_anthropic_messages(

--- a/xllm/api_service/api_service.cpp
+++ b/xllm/api_service/api_service.cpp
@@ -377,8 +377,8 @@ void chat_completions_http_impl(std::unique_ptr<Service>& service,
                                          guard.release(),
                                          req_pb,
                                          resp_pb,
-                                         arena != nullptr /*use_arena*/,
-                                         true /*is_http_request*/);
+                                         /*use_arena=*/arena != nullptr,
+                                         /*is_http_request=*/true);
   service->process_async(call);
 }
 
@@ -972,8 +972,8 @@ void handle_anthropic_messages(std::unique_ptr<AnthropicServiceImpl>& service,
                                               guard.release(),
                                               req_pb,
                                               resp_pb,
-                                              arena != nullptr /*use_arena*/,
-                                              true /*is_http_request*/);
+                                              /*use_arena=*/arena != nullptr,
+                                              /*is_http_request=*/true);
 
   service->process_async(call);
 }

--- a/xllm/api_service/call.cpp
+++ b/xllm/api_service/call.cpp
@@ -15,26 +15,31 @@ limitations under the License.
 
 #include "call.h"
 
+#include "api_service/request_id.h"
 #include "core/common/constants.h"
 #include "core/util/verbose_trace_logger.h"
 
 namespace xllm {
 
-Call::Call(brpc::Controller* controller) : controller_(controller) { init(); }
+Call::Call(brpc::Controller* controller,
+           std::string body_x_request_id,
+           bool is_http_request)
+    : controller_(controller) {
+  init(std::move(body_x_request_id), is_http_request);
+}
 
-void Call::init() {
-  if (controller_->http_request().GetHeader("x-request-id")) {
-    x_request_id_ = *controller_->http_request().GetHeader("x-request-id");
-  } else if (controller_->http_request().GetHeader("x-ms-client-request-id")) {
-    x_request_id_ =
-        *controller_->http_request().GetHeader("x-ms-client-request-id");
-  }
-
+void Call::init(std::string body_x_request_id, bool is_http_request) {
   if (controller_->http_request().GetHeader("x-request-time")) {
     x_request_time_ = *controller_->http_request().GetHeader("x-request-time");
   } else if (controller_->http_request().GetHeader("x-request-timems")) {
     x_request_time_ =
         *controller_->http_request().GetHeader("x-request-timems");
+  }
+
+  x_request_id_ =
+      api_service::resolve_x_request_id(controller_, body_x_request_id);
+  if (is_http_request) {
+    controller_->http_response().SetHeader("x-request-id", x_request_id_);
   }
 
   XLLM_VERBOSE_TRACE() << "event=request_received x-request-id="

--- a/xllm/api_service/call.h
+++ b/xllm/api_service/call.h
@@ -18,16 +18,32 @@ limitations under the License.
 #include <brpc/controller.h>
 
 #include <string>
+#include <utility>
 
 namespace xllm {
 
+template <typename Request>
+std::string request_body_x_request_id(const Request* request) {
+  if constexpr (requires(const Request& value) {
+                  value.has_x_request_id();
+                  value.x_request_id();
+                }) {
+    if (request != nullptr && request->has_x_request_id()) {
+      return request->x_request_id();
+    }
+  }
+  return "";
+}
+
 class Call {
  public:
-  Call(brpc::Controller* controller);
+  Call(brpc::Controller* controller,
+       std::string body_x_request_id = "",
+       bool is_http_request = false);
   virtual ~Call() = default;
 
-  std::string get_x_request_id() { return x_request_id_; }
-  std::string get_x_request_time() { return x_request_time_; }
+  const std::string& get_x_request_id() const { return x_request_id_; }
+  const std::string& get_x_request_time() const { return x_request_time_; }
 
   std::string take_request_payload() { return std::move(request_payload_); }
   void init_request_payload();
@@ -35,7 +51,7 @@ class Call {
   virtual bool is_disconnected() const = 0;
 
  protected:
-  void init();
+  void init(std::string body_x_request_id, bool is_http_request);
 
  protected:
   brpc::Controller* controller_;

--- a/xllm/api_service/non_stream_call.h
+++ b/xllm/api_service/non_stream_call.h
@@ -40,8 +40,9 @@ class NonStreamCall : public Call {
                 ::google::protobuf::Closure* done,
                 Request* request,
                 Response* response,
-                bool use_arena = false)
-      : Call(controller),
+                bool use_arena = false,
+                bool is_http_request = false)
+      : Call(controller, request_body_x_request_id(request), is_http_request),
         done_(done),
         request_(request),
         response_(response),

--- a/xllm/api_service/request_id.cpp
+++ b/xllm/api_service/request_id.cpp
@@ -1,0 +1,99 @@
+/* Copyright 2026 The xLLM Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://github.com/jd-opensource/xllm/blob/main/LICENSE
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include "api_service/request_id.h"
+
+#include <cstddef>
+#include <string>
+#include <string_view>
+
+#include "core/common/instance_name.h"
+#include "core/util/uuid.h"
+
+namespace xllm::api_service {
+
+namespace {
+
+constexpr size_t kMaxXRequestIdLength = 256;
+
+std::string get_valid_header(const brpc::HttpHeader& header, const char* name) {
+  const std::string* value = header.GetHeader(name);
+  if (value != nullptr && is_valid_x_request_id(*value)) {
+    return *value;
+  }
+  return "";
+}
+
+}  // namespace
+
+bool is_valid_x_request_id(std::string_view x_request_id) {
+  if (x_request_id.empty() || x_request_id.size() > kMaxXRequestIdLength) {
+    return false;
+  }
+  for (char character : x_request_id) {
+    const unsigned char value = static_cast<unsigned char>(character);
+    if (value < 0x20 || value == 0x7f) {
+      return false;
+    }
+  }
+  return true;
+}
+
+std::string get_header_x_request_id(const brpc::Controller* controller) {
+  if (controller == nullptr) {
+    return "";
+  }
+
+  std::string x_request_id =
+      get_valid_header(controller->http_request(), "x-request-id");
+  if (x_request_id.empty()) {
+    x_request_id =
+        get_valid_header(controller->http_request(), "x-ms-client-request-id");
+  }
+  return x_request_id;
+}
+
+std::string generate_x_request_id() {
+  thread_local ShortUUID short_uuid;
+  return "req-" + InstanceName::name()->get_name_hash() + "-" +
+         short_uuid.random();
+}
+
+std::string resolve_x_request_id(const brpc::Controller* controller,
+                                 std::string_view body_x_request_id) {
+  std::string x_request_id = get_header_x_request_id(controller);
+  if (x_request_id.empty() && is_valid_x_request_id(body_x_request_id)) {
+    x_request_id = body_x_request_id;
+  }
+  if (x_request_id.empty() && controller != nullptr) {
+    x_request_id =
+        get_valid_header(controller->http_response(), "x-request-id");
+  }
+  if (x_request_id.empty()) {
+    x_request_id = generate_x_request_id();
+  }
+  return x_request_id;
+}
+
+std::string ensure_http_x_request_id(brpc::Controller* controller) {
+  if (controller == nullptr) {
+    return generate_x_request_id();
+  }
+  std::string x_request_id = resolve_x_request_id(controller);
+  controller->http_response().SetHeader("x-request-id", x_request_id);
+  return x_request_id;
+}
+
+}  // namespace xllm::api_service

--- a/xllm/api_service/request_id.h
+++ b/xllm/api_service/request_id.h
@@ -1,0 +1,37 @@
+/* Copyright 2026 The xLLM Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://github.com/jd-opensource/xllm/blob/main/LICENSE
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#pragma once
+
+#include <brpc/controller.h>
+
+#include <string>
+#include <string_view>
+
+namespace xllm::api_service {
+
+bool is_valid_x_request_id(std::string_view x_request_id);
+
+std::string get_header_x_request_id(const brpc::Controller* controller);
+
+std::string generate_x_request_id();
+
+std::string resolve_x_request_id(
+    const brpc::Controller* controller,
+    std::string_view body_x_request_id = std::string_view{});
+
+std::string ensure_http_x_request_id(brpc::Controller* controller);
+
+}  // namespace xllm::api_service

--- a/xllm/api_service/sample_service_impl.cpp
+++ b/xllm/api_service/sample_service_impl.cpp
@@ -403,6 +403,7 @@ void SampleServiceImpl::process_async_impl(std::shared_ptr<SampleCall> call) {
                             "Failed to build sample selector runtime mapping");
     return;
   }
+  request_params.set_x_request_id_if_absent(call->get_x_request_id());
 
   if (request_params.sample_slots.empty()) {
     if (!sample_service_internal::build_empty_response(

--- a/xllm/api_service/stream_call.h
+++ b/xllm/api_service/stream_call.h
@@ -43,8 +43,9 @@ class StreamCall : public Call {
              ::google::protobuf::Closure* done,
              Request* request,
              Response* response,
-             bool use_arena = false)
-      : Call(controller),
+             bool use_arena = false,
+             bool is_http_request = false)
+      : Call(controller, request_body_x_request_id(request), is_http_request),
         done_(done),
         request_(request),
         response_(response),
@@ -177,13 +178,15 @@ class AnthropicCall : public StreamCall<proto::AnthropicMessagesRequest,
                 ::google::protobuf::Closure* done,
                 proto::AnthropicMessagesRequest* request,
                 proto::AnthropicMessagesResponse* response,
-                bool use_arena = false)
+                bool use_arena = false,
+                bool is_http_request = false)
       : StreamCall<proto::AnthropicMessagesRequest,
                    proto::AnthropicMessagesResponse>(controller,
                                                      done,
                                                      request,
                                                      response,
-                                                     use_arena) {}
+                                                     use_arena,
+                                                     is_http_request) {}
 
   ~AnthropicCall() {}
 

--- a/xllm/core/framework/request/request_params.h
+++ b/xllm/core/framework/request/request_params.h
@@ -62,6 +62,12 @@ struct RequestParams {
                 const std::string& x_rid,
                 const std::string& x_rtime);
 
+  void set_x_request_id_if_absent(const std::string& fallback) {
+    if (x_request_id.empty()) {
+      x_request_id = fallback;
+    }
+  }
+
   bool verify_params(OutputCallback callback) const;
 
   // request id

--- a/xllm/core/kernels/npu/CMakeLists.txt
+++ b/xllm/core/kernels/npu/CMakeLists.txt
@@ -40,5 +40,6 @@ cc_library(
     :torch_npu_kernels
     :tilelang_kernels
     xllm_ops
+    nnopbase
     opapi
 )


### PR DESCRIPTION
## Description

This PR adds end-to-end request ID handling across the API service:

- Resolves request IDs from `x-request-id`, then `x-ms-client-request-id`, then the supported request body field, and generates a `req-...` ID when none is available.
- Validates request IDs before reflecting them in response headers, rejecting control characters and values longer than 256 bytes.
- Returns the resolved ID in the `x-request-id` response header for HTTP requests, including requests that fail before body parsing completes.
- Propagates the resolved ID through streaming, non-streaming, and sample inference paths while preserving IDs already present in `RequestParams`.
- Adds unit coverage for source precedence, generated IDs, validation, HTTP response headers, and typed RPC behavior.
- Links NPU kernels against `nnopbase` to fix the current NPU build dependency.

## Related Issues

N/A

## Change Type

- [x] Bug fix
- [x] New feature
- [ ] Performance improvement
- [ ] Refactor
- [ ] Documentation
- [x] Test
- [x] Build or CI

## Pull Request Checklist

### PR Title and Commit Messages

- [x] The PR title and each commit message follow the xLLM commit format: `<type>: <subject>`.

### Pre-commit Checks

- [ ] I have installed `pre-commit` by running `pip install pre-commit` or an equivalent command.
- [ ] I have installed the hooks with `pre-commit install`.
- [ ] I have run `pre-commit run --all-files` and fixed any reported issues.

### Self Review

- [ ] I have self-reviewed the code according to `.agents/skills/code-review/references/custom-code-style.md`, especially code written or assisted by AI.
- [ ] I have rebased this PR onto the latest `main` branch.

### Build and Test Coverage

- [x] Tests have been added or updated as needed.
- [ ] CUDA: `python setup.py build test` has passed on a CUDA machine.
- [ ] NPU: `python setup.py build test` has passed on an NPU machine.
- [ ] MLU: `python setup.py build test` has passed on an MLU machine.

## Reviewer Notes

The request ID feature is the primary change. The PR also includes a separate one-line NPU build fix that links the NPU kernel target against `nnopbase`.
