### PR TITLE
feat: support kimi_k25 w4a8 & acl graph.

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -20,7 +20,7 @@
 	fetchRecurseSubmodules = false
 [submodule "third_party/xllm_ops"]
 	path = third_party/xllm_ops
-	url = https://github.com/xLLM-AI/xllm-ops.git
+	url = https://gitcode.com/xLLM-AI/xllm_ops.git
 	fetchRecurseSubmodules = true
 [submodule "third_party/etcd_cpp_apiv3"]
 	path = third_party/etcd_cpp_apiv3

--- a/xllm/core/distributed_runtime/llm_engine.cpp
+++ b/xllm/core/distributed_runtime/llm_engine.cpp
@@ -1220,6 +1220,7 @@ std::vector<ForwardInput> LLMEngine::prepare_inputs(std::vector<Batch>& batch) {
   batched_inputs.reserve(dp_size_ * cp_size_);
   // some dp related variables
   std::vector<int32_t> dp_global_token_nums(dp_size_);
+  std::vector<int32_t> dp_global_kv_max_seq_lens(dp_size_);
   std::vector<int32_t> dp_is_decode(dp_size_, 0);
   // when enable dp, we need to check the forward type of each batch
   // and set the empty forward type of each batch to the same value as the first
@@ -1237,6 +1238,8 @@ std::vector<ForwardInput> LLMEngine::prepare_inputs(std::vector<Batch>& batch) {
         batched_inputs[dp_rank].input_params.meta.batch_forward_type;
     dp_global_token_nums[dp_rank] =
         static_cast<int32_t>(batched_inputs[dp_rank].host_token_ids().numel());
+    dp_global_kv_max_seq_lens[dp_rank] =
+        batched_inputs[dp_rank].input_params.meta.kv_max_seq_len;
     if (util::is_deepseek_v4_model_type(args_.model_type())) {
       const int64_t actual_scheduled_tokens = static_cast<int64_t>(
           batched_inputs[dp_rank].host_token_ids().numel());
@@ -1290,6 +1293,8 @@ std::vector<ForwardInput> LLMEngine::prepare_inputs(std::vector<Batch>& batch) {
         dp_global_token_nums;
     batched_inputs[dp_rank].input_params.parallel.raw_dp_global_token_nums =
         dp_global_token_nums;
+    batched_inputs[dp_rank].input_params.parallel.dp_global_kv_max_seq_lens =
+        dp_global_kv_max_seq_lens;
     batched_inputs[dp_rank].input_params.parallel.dp_is_decode = dp_is_decode;
     if (::xllm::EPLBConfig::get_instance().enable_eplb()) {
       batched_inputs[dp_rank].input_params.expert.eplb_info = eplb_info;

--- a/xllm/core/distributed_runtime/rec_engine.cpp
+++ b/xllm/core/distributed_runtime/rec_engine.cpp
@@ -362,7 +362,6 @@ std::vector<ForwardInput> RecEngine::LlmRecEnginePipeline::prepare_inputs(
 
   // some dp related variables
   std::vector<int32_t> dp_global_token_nums(engine_.dp_size_);
-  std::vector<int32_t> dp_global_kv_max_seq_lens(engine_.dp_size_);
   std::vector<int32_t> dp_is_decode(engine_.dp_size_, 0);
   // when enable dp, we need to check the forward type of each batch
   // and set the empty forward type of each batch to the same value as the first
@@ -377,8 +376,6 @@ std::vector<ForwardInput> RecEngine::LlmRecEnginePipeline::prepare_inputs(
         engine_.args_, engine_.threadpool_.get())));
     dp_global_token_nums[dp_rank] =
         static_cast<int32_t>(batched_inputs[dp_rank].host_token_ids().numel());
-    dp_global_kv_max_seq_lens[dp_rank] =
-        batched_inputs[dp_rank].input_params.meta.kv_max_seq_len;
     if (batch_forward_type.is_empty() &&
         !batched_inputs[dp_rank]
              .input_params.meta.batch_forward_type.is_empty()) {
@@ -395,8 +392,6 @@ std::vector<ForwardInput> RecEngine::LlmRecEnginePipeline::prepare_inputs(
         dp_global_token_nums;
     batched_inputs[dp_rank].input_params.parallel.raw_dp_global_token_nums =
         dp_global_token_nums;
-    batched_inputs[dp_rank].input_params.parallel.dp_global_kv_max_seq_lens =
-        dp_global_kv_max_seq_lens;
     batched_inputs[dp_rank].input_params.parallel.dp_is_decode = dp_is_decode;
     if (batched_inputs[dp_rank]
             .input_params.meta.batch_forward_type.is_empty()) {

--- a/xllm/core/distributed_runtime/rec_engine.cpp
+++ b/xllm/core/distributed_runtime/rec_engine.cpp
@@ -362,6 +362,7 @@ std::vector<ForwardInput> RecEngine::LlmRecEnginePipeline::prepare_inputs(
 
   // some dp related variables
   std::vector<int32_t> dp_global_token_nums(engine_.dp_size_);
+  std::vector<int32_t> dp_global_kv_max_seq_lens(engine_.dp_size_);
   std::vector<int32_t> dp_is_decode(engine_.dp_size_, 0);
   // when enable dp, we need to check the forward type of each batch
   // and set the empty forward type of each batch to the same value as the first
@@ -376,6 +377,8 @@ std::vector<ForwardInput> RecEngine::LlmRecEnginePipeline::prepare_inputs(
         engine_.args_, engine_.threadpool_.get())));
     dp_global_token_nums[dp_rank] =
         static_cast<int32_t>(batched_inputs[dp_rank].host_token_ids().numel());
+    dp_global_kv_max_seq_lens[dp_rank] =
+        batched_inputs[dp_rank].input_params.meta.kv_max_seq_len;
     if (batch_forward_type.is_empty() &&
         !batched_inputs[dp_rank]
              .input_params.meta.batch_forward_type.is_empty()) {
@@ -392,6 +395,8 @@ std::vector<ForwardInput> RecEngine::LlmRecEnginePipeline::prepare_inputs(
         dp_global_token_nums;
     batched_inputs[dp_rank].input_params.parallel.raw_dp_global_token_nums =
         dp_global_token_nums;
+    batched_inputs[dp_rank].input_params.parallel.dp_global_kv_max_seq_lens =
+        dp_global_kv_max_seq_lens;
     batched_inputs[dp_rank].input_params.parallel.dp_is_decode = dp_is_decode;
     if (batched_inputs[dp_rank]
             .input_params.meta.batch_forward_type.is_empty()) {

--- a/xllm/core/distributed_runtime/vlm_engine.cpp
+++ b/xllm/core/distributed_runtime/vlm_engine.cpp
@@ -505,6 +505,7 @@ std::vector<ForwardInput> VLMEngine::prepare_inputs(std::vector<Batch>& batch) {
   batched_inputs.reserve(dp_size_);
   // some dp related variables
   std::vector<int32_t> dp_global_token_nums(dp_size_);
+  std::vector<int32_t> dp_global_kv_max_seq_lens(dp_size_);
   std::vector<int32_t> dp_is_decode(dp_size_, 0);
   // when enable dp, we need to check the forward type of each batch
   // and set the empty forward type of each batch to the same value as the first
@@ -524,6 +525,8 @@ std::vector<ForwardInput> VLMEngine::prepare_inputs(std::vector<Batch>& batch) {
     }
     dp_global_token_nums[dp_rank] =
         static_cast<int32_t>(batched_inputs[dp_rank].host_token_ids().numel());
+    dp_global_kv_max_seq_lens[dp_rank] =
+        batched_inputs[dp_rank].input_params.meta.kv_max_seq_len;
     if (batch_forward_type.is_empty() &&
         !batched_inputs[dp_rank]
              .input_params.meta.batch_forward_type.is_empty()) {
@@ -536,12 +539,26 @@ std::vector<ForwardInput> VLMEngine::prepare_inputs(std::vector<Batch>& batch) {
         batched_inputs[dp_rank].input_params.meta.q_max_seq_len == 1;
   }
 
+  // Empty DP ranks inherit decode below and use fake inputs in WorkerImpl.
+  if (::xllm::ExecutionConfig::get_instance().enable_graph() &&
+      batch_forward_type.is_decode()) {
+    for (int32_t dp_rank = 0; dp_rank < dp_size_; ++dp_rank) {
+      if (batched_inputs[dp_rank]
+              .input_params.meta.batch_forward_type.is_empty() &&
+          dp_global_token_nums[dp_rank] == 0) {
+        dp_is_decode[dp_rank] = 1;
+      }
+    }
+  }
+
   // update dp_global_token_nums and batch_forward_type
   for (auto dp_rank = 0; dp_rank < dp_size_; ++dp_rank) {
     batched_inputs[dp_rank].input_params.parallel.dp_global_token_nums =
         dp_global_token_nums;
     batched_inputs[dp_rank].input_params.parallel.raw_dp_global_token_nums =
         dp_global_token_nums;
+    batched_inputs[dp_rank].input_params.parallel.dp_global_kv_max_seq_lens =
+        dp_global_kv_max_seq_lens;
     batched_inputs[dp_rank].input_params.parallel.dp_is_decode = dp_is_decode;
     if (batched_inputs[dp_rank]
             .input_params.meta.batch_forward_type.is_empty()) {

--- a/xllm/core/distributed_runtime/vlm_master.cpp
+++ b/xllm/core/distributed_runtime/vlm_master.cpp
@@ -377,7 +377,7 @@ std::shared_ptr<Request> VLMMaster::build_request(
   if (sp.stop_token_ids.has_value()) {
     const auto& stop_token_ids = sp.stop_token_ids.value();
     stop_tokens.insert(stop_token_ids.begin(), stop_token_ids.end());
-  } else {
+  } else if (!sp.ignore_eos) {
     stop_tokens = model_args_.stop_token_ids();
   }
   std::vector<std::vector<int32_t>> stop_sequences;

--- a/xllm/core/framework/model/causal_lm.h
+++ b/xllm/core/framework/model/causal_lm.h
@@ -69,6 +69,8 @@ class CausalLM : public torch::nn::Module {
 
   virtual bool is_hybrid_linear_attention() { return false; }
 
+  virtual bool supports_mla_graph_kv_bucketing() const { return false; }
+
   virtual std::unique_ptr<ModelGraphMetadataState>
   create_graph_forward_metadata_state() {
     return nullptr;
@@ -208,6 +210,13 @@ class CausalLMImpl : public CausalLM {
     } else {
       return CausalLM::is_hybrid_linear_attention();
     }
+  }
+
+  bool supports_mla_graph_kv_bucketing() const override {
+    if constexpr (detail::has_supports_mla_graph_kv_bucketing<Model>::value) {
+      return model_->supports_mla_graph_kv_bucketing();
+    }
+    return CausalLM::supports_mla_graph_kv_bucketing();
   }
 
   std::unique_ptr<ModelGraphMetadataState> create_graph_forward_metadata_state()

--- a/xllm/core/framework/model/causal_vlm.h
+++ b/xllm/core/framework/model/causal_vlm.h
@@ -69,6 +69,13 @@ class CausalVLMImpl : public CausalVLM {
     }
   }
 
+  bool supports_mla_graph_kv_bucketing() const override {
+    if constexpr (detail::has_supports_mla_graph_kv_bucketing<Model>::value) {
+      return model_->supports_mla_graph_kv_bucketing();
+    }
+    return CausalLM::supports_mla_graph_kv_bucketing();
+  }
+
   torch::Tensor pooler(const torch::Tensor& hidden_states,
                        const torch::Tensor& seleted_idxes) override {
     if constexpr (detail::has_pooler<Model>::value) {

--- a/xllm/core/framework/model/model_input_params.h
+++ b/xllm/core/framework/model/model_input_params.h
@@ -357,6 +357,9 @@ struct AttentionHostInput {
   std::vector<int32_t> ring_cur_seqlen;
   std::vector<int32_t> ring_cache_seqlen;
   torch::Tensor block_tables;
+
+  const int32_t* graph_q_seq_lens_data = nullptr;
+  const int32_t* graph_kv_seq_lens_data = nullptr;
 };
 
 struct AttentionDeviceInput {
@@ -851,6 +854,9 @@ struct ParallelInput {
   // Attention/FFN paths may need the padded counts, while lm_head output
   // compaction must skip true empty DP ranks.
   std::vector<int32_t> raw_dp_global_token_nums;
+  // max kv seq len of all dp shards. Graph key generation uses this so empty
+  // DP decode ranks pick the same graph as ranks with real decode tokens.
+  std::vector<int32_t> dp_global_kv_max_seq_lens;
   std::vector<int32_t> dp_is_decode;
 
   DpEpPaddingData dp_ep_padding_data;
@@ -874,6 +880,7 @@ struct ParallelInput {
     ParallelInput out;
     out.dp_global_token_nums = dp_global_token_nums;
     out.raw_dp_global_token_nums = raw_dp_global_token_nums;
+    out.dp_global_kv_max_seq_lens = dp_global_kv_max_seq_lens;
     out.dp_is_decode = dp_is_decode;
     out.dp_ep_padding_data = dp_ep_padding_data;
     out.cp_plan = cp_plan.to(device);

--- a/xllm/core/framework/model/model_traits.h
+++ b/xllm/core/framework/model/model_traits.h
@@ -139,6 +139,15 @@ struct has_is_hybrid_linear_attention<
     : std::true_type {};
 
 template <typename T, typename = void>
+struct has_supports_mla_graph_kv_bucketing : std::false_type {};
+
+template <typename T>
+struct has_supports_mla_graph_kv_bucketing<
+    T,
+    std::void_t<decltype(std::declval<T>()->supports_mla_graph_kv_bucketing())>>
+    : std::true_type {};
+
+template <typename T, typename = void>
 struct has_create_graph_forward_metadata_state : std::false_type {};
 
 template <typename T>

--- a/xllm/core/framework/model_context.cpp
+++ b/xllm/core/framework/model_context.cpp
@@ -100,6 +100,20 @@ ModelContext ModelContext::with_parallel_args(
   return derived;
 }
 
+ModelContext ModelContext::with_quant_args(const QuantArgs& quant_args) const {
+#if defined(USE_NPU)
+  ModelContext derived(
+      parallel_args_, model_args_, quant_args, tensor_options_, context_);
+  derived.atb_workspace_ = atb_workspace_;
+#else
+  ModelContext derived(
+      parallel_args_, model_args_, quant_args, tensor_options_);
+#endif
+  derived.model_id_ = model_id_;
+  derived.derive_optimization_config();
+  return derived;
+}
+
 void ModelContext::derive_optimization_config() {
   // default disable fused kernel
   optimization_config_.enable_fused_spec_kernel = false;

--- a/xllm/core/framework/model_context.h
+++ b/xllm/core/framework/model_context.h
@@ -92,6 +92,8 @@ class ModelContext {
 
   ModelContext with_parallel_args(const ParallelArgs& parallel_args) const;
 
+  ModelContext with_quant_args(const QuantArgs& quant_args) const;
+
 #if defined(USE_NPU)
   const atb::Context* get_atb_context() const { return context_; }
   std::shared_ptr<AtbWorkspace> get_atb_workspace() const {

--- a/xllm/core/layers/npu/loader/deepseek_decoder_loader_constants.h
+++ b/xllm/core/layers/npu/loader/deepseek_decoder_loader_constants.h
@@ -170,32 +170,39 @@ inline const std::unordered_map<std::string, int> WEIGHT_MAPPING_W8A8 = {
     {"mlp.gate_proj.weight", IN_MLP_GATEUP_WEIGHT_SHARED_EXPERT},
     {"mlp.gate_proj.weight_offset", IN_MLP_GATEUP_OFFSET_SHARED_EXPERT},
     {"mlp.gate_proj.weight_scale", IN_MLP_GATEUP_SCALE_SHARED_EXPERT},
+    {"mlp.gate_proj.scale_bias", IN_MLP_GATEUP_BIAS_SHARED_EXPERT},
 
     {"mlp.up_proj.weight", IN_MLP_GATEUP_WEIGHT_SHARED_EXPERT},
     {"mlp.up_proj.weight_offset", IN_MLP_GATEUP_OFFSET_SHARED_EXPERT},
     {"mlp.up_proj.weight_scale", IN_MLP_GATEUP_SCALE_SHARED_EXPERT},
+    {"mlp.up_proj.scale_bias", IN_MLP_GATEUP_BIAS_SHARED_EXPERT},
 
     {"mlp.down_proj.weight", IN_MLP_DOWN_WEIGHT_SHARED_EXPERT},
     {"mlp.down_proj.weight_offset", IN_MLP_DOWN_OFFSET_SHARED_EXPERT},
     {"mlp.down_proj.weight_scale", IN_MLP_DOWN_SCALE_SHARED_EXPERT},
+    {"mlp.down_proj.scale_bias", IN_MLP_DOWN_BIAS_SHARED_EXPERT},
 
     {"mlp.shared_experts.gate_proj.weight", IN_MLP_GATEUP_WEIGHT_SHARED_EXPERT},
     {"mlp.shared_experts.gate_proj.weight_offset",
      IN_MLP_GATEUP_OFFSET_SHARED_EXPERT},
     {"mlp.shared_experts.gate_proj.weight_scale",
      IN_MLP_GATEUP_SCALE_SHARED_EXPERT},
+    {"mlp.shared_experts.gate_proj.scale_bias",
+     IN_MLP_GATEUP_BIAS_SHARED_EXPERT},
 
     {"mlp.shared_experts.up_proj.weight", IN_MLP_GATEUP_WEIGHT_SHARED_EXPERT},
     {"mlp.shared_experts.up_proj.weight_offset",
      IN_MLP_GATEUP_OFFSET_SHARED_EXPERT},
     {"mlp.shared_experts.up_proj.weight_scale",
      IN_MLP_GATEUP_SCALE_SHARED_EXPERT},
+    {"mlp.shared_experts.up_proj.scale_bias", IN_MLP_GATEUP_BIAS_SHARED_EXPERT},
 
     {"mlp.shared_experts.down_proj.weight", IN_MLP_DOWN_WEIGHT_SHARED_EXPERT},
     {"mlp.shared_experts.down_proj.weight_offset",
      IN_MLP_DOWN_OFFSET_SHARED_EXPERT},
     {"mlp.shared_experts.down_proj.weight_scale",
      IN_MLP_DOWN_SCALE_SHARED_EXPERT},
+    {"mlp.shared_experts.down_proj.scale_bias", IN_MLP_DOWN_BIAS_SHARED_EXPERT},
 
     {"mlp.gate.weight", IN_BLOCK_SPARSE_MOE_GATE_WEIGHT},
     {"mlp.gate.e_score_correction_bias", IN_BLOCK_SPARSE_MOE_GATE_BIAS},
@@ -203,13 +210,16 @@ inline const std::unordered_map<std::string, int> WEIGHT_MAPPING_W8A8 = {
     {"gate_proj.weight", IN_MLP_GATEUP_WEIGHT_EXPERT},
     {"gate_proj.weight_offset", IN_MLP_GATEUP_OFFSET_EXPERT},
     {"gate_proj.weight_scale", IN_MLP_GATEUP_SCALE_EXPERT},
+    {"gate_proj.scale_bias", IN_MLP_GATEUP_BIAS_EXPERT},
     {"up_proj.weight", IN_MLP_GATEUP_WEIGHT_EXPERT},
     {"up_proj.weight_offset", IN_MLP_GATEUP_OFFSET_EXPERT},
     {"up_proj.weight_scale", IN_MLP_GATEUP_SCALE_EXPERT},
+    {"up_proj.scale_bias", IN_MLP_GATEUP_BIAS_EXPERT},
 
     {"down_proj.weight", IN_MLP_DOWN_WEIGHT_EXPERT},
     {"down_proj.weight_offset", IN_MLP_DOWN_OFFSET_EXPERT},
     {"down_proj.weight_scale", IN_MLP_DOWN_SCALE_EXPERT},
+    {"down_proj.scale_bias", IN_MLP_DOWN_BIAS_EXPERT},
 };
 
 inline const std::map<int, int> WEIGHT_SHARD = {};

--- a/xllm/core/layers/npu/loader/deepseek_v2_decoder_loader.cpp
+++ b/xllm/core/layers/npu/loader/deepseek_v2_decoder_loader.cpp
@@ -30,7 +30,7 @@ namespace layer {
 using namespace deepseek_v2_decoder_constants;
 
 namespace {
-std::string TensorShapeString(const torch::Tensor& tensor) {
+std::string tensor_shape_string(const torch::Tensor& tensor) {
   std::ostringstream oss;
   oss << "[";
   for (int64_t i = 0; i < tensor.dim(); ++i) {
@@ -43,67 +43,67 @@ std::string TensorShapeString(const torch::Tensor& tensor) {
   return oss.str();
 }
 
-std::string TensorDebugString(const torch::Tensor& tensor) {
+std::string tensor_debug_string(const torch::Tensor& tensor) {
   if (!tensor.defined()) {
     return "undefined";
   }
   std::ostringstream oss;
-  oss << "shape=" << TensorShapeString(tensor)
+  oss << "shape=" << tensor_shape_string(tensor)
       << ", dtype=" << tensor.scalar_type() << ", device=" << tensor.device()
       << ", contiguous=" << tensor.is_contiguous();
   return oss.str();
 }
 
-bool IsPlaceholderTensor(const torch::Tensor& tensor) {
+bool is_placeholder_tensor(const torch::Tensor& tensor) {
   return !tensor.defined() || (tensor.dim() == 1 && tensor.size(0) == 1);
 }
 
-bool HasAnyDefinedExpert(const std::vector<torch::Tensor>& experts) {
+bool has_any_defined_expert(const std::vector<torch::Tensor>& experts) {
   return std::any_of(experts.begin(), experts.end(), [](const auto& tensor) {
     return tensor.defined();
   });
 }
 
-void CheckCatInputTensor(const torch::Tensor& tensor,
-                         const std::string& name,
-                         const std::string& cat_name,
-                         int32_t layer_id) {
+void check_cat_input_tensor(const torch::Tensor& tensor,
+                            const std::string& name,
+                            const std::string& cat_name,
+                            int32_t layer_id) {
   CHECK(tensor.defined()) << "Kimi/DeepSeekV2 layer " << layer_id
                           << " missing tensor before cat " << cat_name << ": "
                           << name;
-  CHECK(!IsPlaceholderTensor(tensor))
+  CHECK(!is_placeholder_tensor(tensor))
       << "Kimi/DeepSeekV2 layer " << layer_id
       << " placeholder tensor before cat " << cat_name << ": " << name
-      << ", tensor=" << TensorDebugString(tensor);
+      << ", tensor=" << tensor_debug_string(tensor);
 }
 
-torch::Tensor CatWithDebug(const std::vector<torch::Tensor>& tensors,
-                           int64_t dim,
-                           const std::vector<std::string>& names,
-                           const std::string& cat_name,
-                           int32_t layer_id) {
+torch::Tensor cat_with_debug(const std::vector<torch::Tensor>& tensors,
+                             int64_t dim,
+                             const std::vector<std::string>& names,
+                             const std::string& cat_name,
+                             int32_t layer_id) {
   CHECK_EQ(tensors.size(), names.size())
       << "Kimi/DeepSeekV2 layer " << layer_id
       << " internal cat debug size mismatch for " << cat_name;
   for (size_t i = 0; i < tensors.size(); ++i) {
-    CheckCatInputTensor(tensors[i], names[i], cat_name, layer_id);
+    check_cat_input_tensor(tensors[i], names[i], cat_name, layer_id);
   }
   const int64_t rank = tensors[0].dim();
   const int64_t normalized_dim = dim < 0 ? dim + rank : dim;
   CHECK_GE(normalized_dim, 0)
       << "Kimi/DeepSeekV2 layer " << layer_id << " invalid cat dim for "
       << cat_name << ": dim=" << dim
-      << ", tensor=" << TensorDebugString(tensors[0]);
+      << ", tensor=" << tensor_debug_string(tensors[0]);
   CHECK_LT(normalized_dim, rank)
       << "Kimi/DeepSeekV2 layer " << layer_id << " invalid cat dim for "
       << cat_name << ": dim=" << dim
-      << ", tensor=" << TensorDebugString(tensors[0]);
+      << ", tensor=" << tensor_debug_string(tensors[0]);
   for (size_t i = 1; i < tensors.size(); ++i) {
     CHECK_EQ(tensors[i].dim(), rank)
         << "Kimi/DeepSeekV2 layer " << layer_id
         << " tensor rank mismatch before cat " << cat_name << ": " << names[0]
-        << "=" << TensorDebugString(tensors[0]) << ", " << names[i] << "="
-        << TensorDebugString(tensors[i]);
+        << "=" << tensor_debug_string(tensors[0]) << ", " << names[i] << "="
+        << tensor_debug_string(tensors[i]);
     for (int64_t axis = 0; axis < rank; ++axis) {
       if (axis == normalized_dim) {
         continue;
@@ -111,28 +111,28 @@ torch::Tensor CatWithDebug(const std::vector<torch::Tensor>& tensors,
       CHECK_EQ(tensors[i].size(axis), tensors[0].size(axis))
           << "Kimi/DeepSeekV2 layer " << layer_id
           << " tensor shape mismatch before cat " << cat_name << ": "
-          << names[0] << "=" << TensorDebugString(tensors[0]) << ", "
-          << names[i] << "=" << TensorDebugString(tensors[i])
+          << names[0] << "=" << tensor_debug_string(tensors[0]) << ", "
+          << names[i] << "=" << tensor_debug_string(tensors[i])
           << ", dim=" << dim;
     }
   }
   return torch::cat(tensors, dim);
 }
 
-void CheckRequiredW4A8Tensor(const torch::Tensor& tensor,
-                             const std::string& name,
-                             int32_t layer_id) {
+void check_required_w4a8_tensor(const torch::Tensor& tensor,
+                                const std::string& name,
+                                int32_t layer_id) {
   CHECK(tensor.defined()) << "Kimi/DeepSeekV2 W4A8 layer " << layer_id
                           << " missing required tensor " << name;
-  CHECK(!IsPlaceholderTensor(tensor))
+  CHECK(!is_placeholder_tensor(tensor))
       << "Kimi/DeepSeekV2 W4A8 layer " << layer_id
       << " required tensor still placeholder: " << name
-      << ", tensor=" << TensorDebugString(tensor);
+      << ", tensor=" << tensor_debug_string(tensor);
 }
 
-void CheckExpertVector(const std::vector<torch::Tensor>& experts,
-                       const std::string& name,
-                       int32_t layer_id) {
+void check_expert_vector(const std::vector<torch::Tensor>& experts,
+                         const std::string& name,
+                         int32_t layer_id) {
   CHECK(!experts.empty()) << "Kimi/DeepSeekV2 W4A8 layer " << layer_id
                           << " expert vector is empty: " << name;
   size_t missing_count = 0;
@@ -157,16 +157,16 @@ void CheckExpertVector(const std::vector<torch::Tensor>& experts,
                                           : std::to_string(first_defined));
 }
 
-void CheckExpertVectorPair(const std::vector<torch::Tensor>& experts_gate,
-                           const std::vector<torch::Tensor>& experts_up,
-                           const std::string& name,
-                           int32_t layer_id) {
+void check_expert_vector_pair(const std::vector<torch::Tensor>& experts_gate,
+                              const std::vector<torch::Tensor>& experts_up,
+                              const std::string& name,
+                              int32_t layer_id) {
   CHECK_EQ(experts_gate.size(), experts_up.size())
       << "Kimi/DeepSeekV2 W4A8 layer " << layer_id
       << " expert vector size mismatch for " << name
       << ": gate=" << experts_gate.size() << ", up=" << experts_up.size();
-  CheckExpertVector(experts_gate, name + ".gate", layer_id);
-  CheckExpertVector(experts_up, name + ".up", layer_id);
+  check_expert_vector(experts_gate, name + ".gate", layer_id);
+  check_expert_vector(experts_up, name + ".up", layer_id);
 }
 }  // namespace
 
@@ -324,6 +324,7 @@ void DeekseekV2DecoderLoader::process_expert_weights(
   const std::string suffix = extract_endswith(name);
   const bool is_w4a8_extra = quantize_type_ == "w4a8_dynamic" &&
                              (absl::EndsWith(suffix, "weight_offset") ||
+                              absl::EndsWith(suffix, "weight_scale_second") ||
                               absl::EndsWith(suffix, "scale_bias"));
   int index = -1;
   int shard_dim = -1;
@@ -402,7 +403,7 @@ void DeekseekV2DecoderLoader::process_expert_weights(
       CHECK(experts_it != experts_weights_.end())
           << "Kimi/DeepSeekV2 W4A8 layer " << layer_id_
           << " routed expert suffix is not reserved: " << suffix
-          << ", tensor=" << TensorDebugString(processed_tensor);
+          << ", tensor=" << tensor_debug_string(processed_tensor);
       for (auto pos : matches_pos) {
         CHECK_LT(pos, experts_it->second.size())
             << "Kimi/DeepSeekV2 W4A8 layer " << layer_id_
@@ -579,7 +580,7 @@ void DeekseekV2DecoderLoader::merge_experts_weights() {
              const std::string& offset_key) -> std::vector<torch::Tensor>& {
     auto scale_second_it = experts_weights_.find(scale_second_key);
     if (scale_second_it != experts_weights_.end() &&
-        HasAnyDefinedExpert(scale_second_it->second)) {
+        has_any_defined_expert(scale_second_it->second)) {
       return scale_second_it->second;
     }
     auto offset_it = experts_weights_.find(offset_key);
@@ -590,10 +591,10 @@ void DeekseekV2DecoderLoader::merge_experts_weights() {
     return offset_it->second;
   };
   if (is_w4a8_dynamic) {
-    CheckExpertVectorPair(experts_weights_["gate_proj.weight"],
-                          experts_weights_["up_proj.weight"],
-                          "gateup.weight",
-                          layer_id_);
+    check_expert_vector_pair(experts_weights_["gate_proj.weight"],
+                             experts_weights_["up_proj.weight"],
+                             "gateup.weight",
+                             layer_id_);
   }
   torch::Tensor mlp_gateup_weight =
       merge_experts_weights(experts_weights_["gate_proj.weight"],
@@ -614,17 +615,17 @@ void DeekseekV2DecoderLoader::merge_experts_weights() {
         merge_experts_weights(experts_weights_["gate_proj.weight_scale"],
                               experts_weights_["up_proj.weight_scale"]);
   } else if (is_w4a8_dynamic) {
-    CheckExpertVectorPair(experts_weights_["gate_proj.weight_scale"],
-                          experts_weights_["up_proj.weight_scale"],
-                          "gateup.weight_scale",
-                          layer_id_);
+    check_expert_vector_pair(experts_weights_["gate_proj.weight_scale"],
+                             experts_weights_["up_proj.weight_scale"],
+                             "gateup.weight_scale",
+                             layer_id_);
     t[IN_MLP_GATEUP_SCALE_EXPERT] =
         merge_experts_weights(experts_weights_["gate_proj.weight_scale"],
                               experts_weights_["up_proj.weight_scale"]);
-    CheckExpertVectorPair(experts_weights_["gate_proj.scale_bias"],
-                          experts_weights_["up_proj.scale_bias"],
-                          "gateup.scale_bias",
-                          layer_id_);
+    check_expert_vector_pair(experts_weights_["gate_proj.scale_bias"],
+                             experts_weights_["up_proj.scale_bias"],
+                             "gateup.scale_bias",
+                             layer_id_);
     t[IN_MLP_GATEUP_BIAS_EXPERT] =
         merge_experts_weights(experts_weights_["gate_proj.scale_bias"],
                               experts_weights_["up_proj.scale_bias"]);
@@ -633,7 +634,7 @@ void DeekseekV2DecoderLoader::merge_experts_weights() {
           "gate_proj.weight_scale_second", "gate_proj.weight_offset");
       auto& up_second_scale = select_w4a8_second_scale(
           "up_proj.weight_scale_second", "up_proj.weight_offset");
-      CheckExpertVectorPair(
+      check_expert_vector_pair(
           gate_second_scale, up_second_scale, "gateup.second_scale", layer_id_);
       t[IN_MLP_GATEUP_OFFSET_EXPERT] =
           merge_experts_weights(gate_second_scale, up_second_scale);
@@ -644,7 +645,7 @@ void DeekseekV2DecoderLoader::merge_experts_weights() {
   //   eager: NZ when not quantized, else ND;
   //   manual: NZ when decode is BF16, else ND.
   if (is_w4a8_dynamic) {
-    CheckExpertVector(
+    check_expert_vector(
         experts_weights_["down_proj.weight"], "down.weight", layer_id_);
   }
   torch::Tensor mlp_down_weight = merge_experts_weights(
@@ -680,19 +681,19 @@ void DeekseekV2DecoderLoader::merge_experts_weights() {
     t[IN_MLP_DOWN_SCALE_EXPERT] =
         merge_experts_weights(experts_weights_["down_proj.weight_scale"]);
   } else if (is_w4a8_dynamic) {
-    CheckExpertVector(experts_weights_["down_proj.weight_scale"],
-                      "down.weight_scale",
-                      layer_id_);
+    check_expert_vector(experts_weights_["down_proj.weight_scale"],
+                        "down.weight_scale",
+                        layer_id_);
     t[IN_MLP_DOWN_SCALE_EXPERT] =
         merge_experts_weights(experts_weights_["down_proj.weight_scale"]);
-    CheckExpertVector(
+    check_expert_vector(
         experts_weights_["down_proj.scale_bias"], "down.scale_bias", layer_id_);
     t[IN_MLP_DOWN_BIAS_EXPERT] =
         merge_experts_weights(experts_weights_["down_proj.scale_bias"]);
     if (quant_group_size_ > 0) {
       auto& down_second_scale = select_w4a8_second_scale(
           "down_proj.weight_scale_second", "down_proj.weight_offset");
-      CheckExpertVector(down_second_scale, "down.second_scale", layer_id_);
+      check_expert_vector(down_second_scale, "down.second_scale", layer_id_);
       t[IN_MLP_DOWN_OFFSET_EXPERT] = merge_experts_weights(down_second_scale);
     }
   }
@@ -717,7 +718,7 @@ torch::Tensor DeekseekV2DecoderLoader::merge_experts_weights(
     std::vector<torch::Tensor>& experts_up,
     bool transpose) {
   for (size_t i = 0; i < experts_up.size(); ++i) {
-    experts_gate[i] = CatWithDebug(
+    experts_gate[i] = cat_with_debug(
         {experts_gate[i], experts_up[i]},
         0,
         {"gate expert " + std::to_string(i), "up expert " + std::to_string(i)},
@@ -749,23 +750,23 @@ void DeekseekV2DecoderLoader::preprocess_w4a8_dynamic_experts_weights() {
   }
 
   auto& t = working_tensors();
-  CheckRequiredW4A8Tensor(
+  check_required_w4a8_tensor(
       t[IN_MLP_GATEUP_WEIGHT_EXPERT], "IN_MLP_GATEUP_WEIGHT_EXPERT", layer_id_);
-  CheckRequiredW4A8Tensor(
+  check_required_w4a8_tensor(
       t[IN_MLP_DOWN_WEIGHT_EXPERT], "IN_MLP_DOWN_WEIGHT_EXPERT", layer_id_);
-  CheckRequiredW4A8Tensor(
+  check_required_w4a8_tensor(
       t[IN_MLP_GATEUP_SCALE_EXPERT], "IN_MLP_GATEUP_SCALE_EXPERT", layer_id_);
-  CheckRequiredW4A8Tensor(
+  check_required_w4a8_tensor(
       t[IN_MLP_DOWN_SCALE_EXPERT], "IN_MLP_DOWN_SCALE_EXPERT", layer_id_);
-  CheckRequiredW4A8Tensor(
+  check_required_w4a8_tensor(
       t[IN_MLP_GATEUP_BIAS_EXPERT], "IN_MLP_GATEUP_BIAS_EXPERT", layer_id_);
-  CheckRequiredW4A8Tensor(
+  check_required_w4a8_tensor(
       t[IN_MLP_DOWN_BIAS_EXPERT], "IN_MLP_DOWN_BIAS_EXPERT", layer_id_);
   if (quant_group_size_ > 0) {
-    CheckRequiredW4A8Tensor(t[IN_MLP_GATEUP_OFFSET_EXPERT],
-                            "IN_MLP_GATEUP_OFFSET_EXPERT",
-                            layer_id_);
-    CheckRequiredW4A8Tensor(
+    check_required_w4a8_tensor(t[IN_MLP_GATEUP_OFFSET_EXPERT],
+                               "IN_MLP_GATEUP_OFFSET_EXPERT",
+                               layer_id_);
+    check_required_w4a8_tensor(
         t[IN_MLP_DOWN_OFFSET_EXPERT], "IN_MLP_DOWN_OFFSET_EXPERT", layer_id_);
   }
 
@@ -991,6 +992,9 @@ void DeekseekV2DecoderLoader::reserve_experts_weights(
     weight_names.emplace_back("up_proj.weight_scale");
     weight_names.emplace_back("down_proj.weight_scale");
     if (quantize_type_ == "w4a8_dynamic") {
+      weight_names.emplace_back("gate_proj.weight_scale_second");
+      weight_names.emplace_back("up_proj.weight_scale_second");
+      weight_names.emplace_back("down_proj.weight_scale_second");
       weight_names.emplace_back("gate_proj.scale_bias");
       weight_names.emplace_back("up_proj.scale_bias");
       weight_names.emplace_back("down_proj.scale_bias");

--- a/xllm/core/layers/npu/loader/deepseek_v2_decoder_loader.cpp
+++ b/xllm/core/layers/npu/loader/deepseek_v2_decoder_loader.cpp
@@ -16,13 +16,159 @@ limitations under the License.
 
 #include <torch_npu/csrc/core/npu/NPUFormat.h>
 
+#include <algorithm>
+#include <optional>
+#include <sstream>
+
 #include "core/framework/config/eplb_config.h"
+#include "core/kernels/ops_api.h"
 #include "deepseek_decoder_loader_constants.h"
 
 namespace xllm {
 namespace layer {
 
 using namespace deepseek_v2_decoder_constants;
+
+namespace {
+std::string TensorShapeString(const torch::Tensor& tensor) {
+  std::ostringstream oss;
+  oss << "[";
+  for (int64_t i = 0; i < tensor.dim(); ++i) {
+    if (i > 0) {
+      oss << ", ";
+    }
+    oss << tensor.size(i);
+  }
+  oss << "]";
+  return oss.str();
+}
+
+std::string TensorDebugString(const torch::Tensor& tensor) {
+  if (!tensor.defined()) {
+    return "undefined";
+  }
+  std::ostringstream oss;
+  oss << "shape=" << TensorShapeString(tensor)
+      << ", dtype=" << tensor.scalar_type() << ", device=" << tensor.device()
+      << ", contiguous=" << tensor.is_contiguous();
+  return oss.str();
+}
+
+bool IsPlaceholderTensor(const torch::Tensor& tensor) {
+  return !tensor.defined() || (tensor.dim() == 1 && tensor.size(0) == 1);
+}
+
+bool HasAnyDefinedExpert(const std::vector<torch::Tensor>& experts) {
+  return std::any_of(experts.begin(), experts.end(), [](const auto& tensor) {
+    return tensor.defined();
+  });
+}
+
+void CheckCatInputTensor(const torch::Tensor& tensor,
+                         const std::string& name,
+                         const std::string& cat_name,
+                         int32_t layer_id) {
+  CHECK(tensor.defined()) << "Kimi/DeepSeekV2 layer " << layer_id
+                          << " missing tensor before cat " << cat_name << ": "
+                          << name;
+  CHECK(!IsPlaceholderTensor(tensor))
+      << "Kimi/DeepSeekV2 layer " << layer_id
+      << " placeholder tensor before cat " << cat_name << ": " << name
+      << ", tensor=" << TensorDebugString(tensor);
+}
+
+torch::Tensor CatWithDebug(const std::vector<torch::Tensor>& tensors,
+                           int64_t dim,
+                           const std::vector<std::string>& names,
+                           const std::string& cat_name,
+                           int32_t layer_id) {
+  CHECK_EQ(tensors.size(), names.size())
+      << "Kimi/DeepSeekV2 layer " << layer_id
+      << " internal cat debug size mismatch for " << cat_name;
+  for (size_t i = 0; i < tensors.size(); ++i) {
+    CheckCatInputTensor(tensors[i], names[i], cat_name, layer_id);
+  }
+  const int64_t rank = tensors[0].dim();
+  const int64_t normalized_dim = dim < 0 ? dim + rank : dim;
+  CHECK_GE(normalized_dim, 0)
+      << "Kimi/DeepSeekV2 layer " << layer_id << " invalid cat dim for "
+      << cat_name << ": dim=" << dim
+      << ", tensor=" << TensorDebugString(tensors[0]);
+  CHECK_LT(normalized_dim, rank)
+      << "Kimi/DeepSeekV2 layer " << layer_id << " invalid cat dim for "
+      << cat_name << ": dim=" << dim
+      << ", tensor=" << TensorDebugString(tensors[0]);
+  for (size_t i = 1; i < tensors.size(); ++i) {
+    CHECK_EQ(tensors[i].dim(), rank)
+        << "Kimi/DeepSeekV2 layer " << layer_id
+        << " tensor rank mismatch before cat " << cat_name << ": " << names[0]
+        << "=" << TensorDebugString(tensors[0]) << ", " << names[i] << "="
+        << TensorDebugString(tensors[i]);
+    for (int64_t axis = 0; axis < rank; ++axis) {
+      if (axis == normalized_dim) {
+        continue;
+      }
+      CHECK_EQ(tensors[i].size(axis), tensors[0].size(axis))
+          << "Kimi/DeepSeekV2 layer " << layer_id
+          << " tensor shape mismatch before cat " << cat_name << ": "
+          << names[0] << "=" << TensorDebugString(tensors[0]) << ", "
+          << names[i] << "=" << TensorDebugString(tensors[i])
+          << ", dim=" << dim;
+    }
+  }
+  return torch::cat(tensors, dim);
+}
+
+void CheckRequiredW4A8Tensor(const torch::Tensor& tensor,
+                             const std::string& name,
+                             int32_t layer_id) {
+  CHECK(tensor.defined()) << "Kimi/DeepSeekV2 W4A8 layer " << layer_id
+                          << " missing required tensor " << name;
+  CHECK(!IsPlaceholderTensor(tensor))
+      << "Kimi/DeepSeekV2 W4A8 layer " << layer_id
+      << " required tensor still placeholder: " << name
+      << ", tensor=" << TensorDebugString(tensor);
+}
+
+void CheckExpertVector(const std::vector<torch::Tensor>& experts,
+                       const std::string& name,
+                       int32_t layer_id) {
+  CHECK(!experts.empty()) << "Kimi/DeepSeekV2 W4A8 layer " << layer_id
+                          << " expert vector is empty: " << name;
+  size_t missing_count = 0;
+  size_t first_missing = experts.size();
+  size_t first_defined = experts.size();
+  for (size_t i = 0; i < experts.size(); ++i) {
+    if (!experts[i].defined()) {
+      if (first_missing == experts.size()) {
+        first_missing = i;
+      }
+      ++missing_count;
+    } else if (first_defined == experts.size()) {
+      first_defined = i;
+    }
+  }
+  CHECK_EQ(missing_count, 0)
+      << "Kimi/DeepSeekV2 W4A8 layer " << layer_id
+      << " has missing expert tensors for " << name
+      << ": total=" << experts.size() << ", missing=" << missing_count
+      << ", first_missing=" << first_missing << ", first_defined="
+      << (first_defined == experts.size() ? std::string("<none>")
+                                          : std::to_string(first_defined));
+}
+
+void CheckExpertVectorPair(const std::vector<torch::Tensor>& experts_gate,
+                           const std::vector<torch::Tensor>& experts_up,
+                           const std::string& name,
+                           int32_t layer_id) {
+  CHECK_EQ(experts_gate.size(), experts_up.size())
+      << "Kimi/DeepSeekV2 W4A8 layer " << layer_id
+      << " expert vector size mismatch for " << name
+      << ": gate=" << experts_gate.size() << ", up=" << experts_up.size();
+  CheckExpertVector(experts_gate, name + ".gate", layer_id);
+  CheckExpertVector(experts_up, name + ".up", layer_id);
+}
+}  // namespace
 
 DeekseekV2DecoderLoader::DeekseekV2DecoderLoader(
     uint64_t weight_count,
@@ -54,6 +200,7 @@ DeekseekV2DecoderLoader::DeekseekV2DecoderLoader(
       prefill_isBF16_(prefill_isBF16),
       decode_isBF16_(decode_isBF16) {
   auto model_args = context.get_model_args();
+  auto quant_args = context.get_quant_args();
   auto options = context.get_tensor_options();
   enable_kimi_k25_moe_scale_dtype_fix_ = model_args.model_type() == "kimi_k25";
   norm_has_bias_ = model_args.model_type() == "kimi_k2" ||
@@ -63,6 +210,19 @@ DeekseekV2DecoderLoader::DeekseekV2DecoderLoader(
   first_k_dense_replace_ = model_args.first_k_dense_replace();
   n_layers_ = model_args.n_layers();
   num_experts_ = model_args.n_routed_experts();
+  quant_group_size_ = static_cast<int32_t>(quant_args.group_size());
+  if (quantize_type_ == "w4a8_dynamic") {
+    CHECK_GE(quant_group_size_, 0)
+        << "W4A8_DYNAMIC group_size must be >= 0, got " << quant_group_size_;
+    CHECK_EQ(quant_args.quant_version(), "1.0.0")
+        << "W4A8_DYNAMIC only supports quant_version 1.0.0, got "
+        << (quant_args.quant_version().empty() ? "<empty>"
+                                               : quant_args.quant_version());
+    CHECK(!load_to_host())
+        << "W4A8_DYNAMIC MoE ATB path currently requires eager loader because "
+        << "manual loader cannot preserve the routed expert W4 packed-NZ "
+        << "layout during CPU staging.";
+  }
   localWorldSize_ = parallel_args_.mapping().localWorldSize();
   ep_size_ = parallel_args_.ep_size();
   ep_local_tp_size_ = parallel_args_.world_size() / ep_size_;
@@ -140,18 +300,46 @@ int DeekseekV2DecoderLoader::extract_expert_index(const std::string& name) {
   return -1;
 }
 
+bool DeekseekV2DecoderLoader::use_quant_weight_mapping() const {
+  return quantize_type_ == "w8a8_dynamic" || quantize_type_ == "w4a8_dynamic";
+}
+
+int DeekseekV2DecoderLoader::get_w4a8_expert_shard_dim(
+    const std::string& suffix) const {
+  if (absl::StartsWith(suffix, "gate_proj.") ||
+      absl::StartsWith(suffix, "up_proj.")) {
+    return 0;
+  }
+  if (absl::StartsWith(suffix, "down_proj.")) {
+    return 1;
+  }
+  return -1;
+}
+
 void DeekseekV2DecoderLoader::process_expert_weights(
     const StateDict& state_dict,
     const std::string& name,
     const torch::Tensor& tensor) {
   int expert_index = extract_expert_index(name);
   const std::string suffix = extract_endswith(name);
-  const int index = get_mapped_index(suffix, WEIGHT_MAPPING_W8A8);
-  if (index == -1) {
-    return;
+  const bool is_w4a8_extra = quantize_type_ == "w4a8_dynamic" &&
+                             (absl::EndsWith(suffix, "weight_offset") ||
+                              absl::EndsWith(suffix, "scale_bias"));
+  int index = -1;
+  int shard_dim = -1;
+  if (is_w4a8_extra) {
+    shard_dim = get_w4a8_expert_shard_dim(suffix);
+  } else {
+    index = get_mapped_index(suffix, WEIGHT_MAPPING_W8A8);
+    if (index == -1) {
+      return;
+    }
+    if (WEIGHT_SHARD_W8A8.count(index) > 0) {
+      shard_dim = WEIGHT_SHARD_W8A8.at(index);
+    }
   }
 
-  const bool is_sharded = WEIGHT_SHARD_W8A8.count(index);
+  const bool is_sharded = shard_dim >= 0;
   const bool needs_eplb =
       ::xllm::EPLBConfig::get_instance().enable_eplb() &&
       (rank_ % localWorldSize_ == expert_index % localWorldSize_);
@@ -173,15 +361,14 @@ void DeekseekV2DecoderLoader::process_expert_weights(
   torch::Tensor processed_tensor;
   {
     std::lock_guard<std::mutex> lock(experts_mutex_);
-    processed_tensor = is_sharded
-                           ? get_sharded_tensor(state_dict,
-                                                name,
-                                                WEIGHT_SHARD_W8A8.at(index),
-                                                ep_local_tp_rank_,
-                                                ep_local_tp_size_)
-                           : tensor;
+    processed_tensor = is_sharded ? get_sharded_tensor(state_dict,
+                                                       name,
+                                                       shard_dim,
+                                                       ep_local_tp_rank_,
+                                                       ep_local_tp_size_)
+                                  : tensor;
 
-    if (!decode_isBF16_) {
+    if (quantize_type_ == "w8a8_dynamic" && !decode_isBF16_) {
       if (absl::EndsWith(name, "_offset")) {
         processed_tensor = processed_tensor.to(torch::kFloat16);
       } else if (absl::EndsWith(name, "_scale")) {
@@ -211,8 +398,18 @@ void DeekseekV2DecoderLoader::process_expert_weights(
 
     if (!matches_pos.empty()) {
       std::lock_guard<std::mutex> lock(experts_mutex_);
+      auto experts_it = experts_weights_.find(suffix);
+      CHECK(experts_it != experts_weights_.end())
+          << "Kimi/DeepSeekV2 W4A8 layer " << layer_id_
+          << " routed expert suffix is not reserved: " << suffix
+          << ", tensor=" << TensorDebugString(processed_tensor);
       for (auto pos : matches_pos) {
-        experts_weights_[suffix][pos] = processed_tensor.clone();
+        CHECK_LT(pos, experts_it->second.size())
+            << "Kimi/DeepSeekV2 W4A8 layer " << layer_id_
+            << " routed expert position out of range: suffix=" << suffix
+            << ", pos=" << pos
+            << ", reserved_size=" << experts_it->second.size();
+        experts_it->second[pos] = processed_tensor.clone();
       }
     }
   }
@@ -376,13 +573,39 @@ void DeekseekV2DecoderLoader::process_mlp_common_weights(
 
 void DeekseekV2DecoderLoader::merge_experts_weights() {
   auto& t = working_tensors();
+  const bool is_w4a8_dynamic = quantize_type_ == "w4a8_dynamic";
+  auto select_w4a8_second_scale =
+      [this](const std::string& scale_second_key,
+             const std::string& offset_key) -> std::vector<torch::Tensor>& {
+    auto scale_second_it = experts_weights_.find(scale_second_key);
+    if (scale_second_it != experts_weights_.end() &&
+        HasAnyDefinedExpert(scale_second_it->second)) {
+      return scale_second_it->second;
+    }
+    auto offset_it = experts_weights_.find(offset_key);
+    CHECK(offset_it != experts_weights_.end())
+        << "Kimi/DeepSeekV2 W4A8 layer " << layer_id_ << " neither "
+        << scale_second_key << " nor " << offset_key
+        << " is reserved for second scale";
+    return offset_it->second;
+  };
+  if (is_w4a8_dynamic) {
+    CheckExpertVectorPair(experts_weights_["gate_proj.weight"],
+                          experts_weights_["up_proj.weight"],
+                          "gateup.weight",
+                          layer_id_);
+  }
   torch::Tensor mlp_gateup_weight =
       merge_experts_weights(experts_weights_["gate_proj.weight"],
                             experts_weights_["up_proj.weight"],
-                            /*transpose=*/true);
-  // IN_MLP_GATEUP_WEIGHT_EXPERT: always NZ (both modes agree).
-  t[IN_MLP_GATEUP_WEIGHT_EXPERT] =
-      cast_nz(mlp_gateup_weight, IN_MLP_GATEUP_WEIGHT_EXPERT);
+                            /*transpose=*/!is_w4a8_dynamic);
+  if (is_w4a8_dynamic) {
+    t[IN_MLP_GATEUP_WEIGHT_EXPERT] = mlp_gateup_weight;
+  } else {
+    // IN_MLP_GATEUP_WEIGHT_EXPERT: always NZ (both modes agree).
+    t[IN_MLP_GATEUP_WEIGHT_EXPERT] =
+        cast_nz(mlp_gateup_weight, IN_MLP_GATEUP_WEIGHT_EXPERT);
+  }
   if (quantize_type_ == "w8a8_dynamic") {
     t[IN_MLP_GATEUP_OFFSET_EXPERT] =
         merge_experts_weights(experts_weights_["gate_proj.weight_offset"],
@@ -390,11 +613,40 @@ void DeekseekV2DecoderLoader::merge_experts_weights() {
     t[IN_MLP_GATEUP_SCALE_EXPERT] =
         merge_experts_weights(experts_weights_["gate_proj.weight_scale"],
                               experts_weights_["up_proj.weight_scale"]);
+  } else if (is_w4a8_dynamic) {
+    CheckExpertVectorPair(experts_weights_["gate_proj.weight_scale"],
+                          experts_weights_["up_proj.weight_scale"],
+                          "gateup.weight_scale",
+                          layer_id_);
+    t[IN_MLP_GATEUP_SCALE_EXPERT] =
+        merge_experts_weights(experts_weights_["gate_proj.weight_scale"],
+                              experts_weights_["up_proj.weight_scale"]);
+    CheckExpertVectorPair(experts_weights_["gate_proj.scale_bias"],
+                          experts_weights_["up_proj.scale_bias"],
+                          "gateup.scale_bias",
+                          layer_id_);
+    t[IN_MLP_GATEUP_BIAS_EXPERT] =
+        merge_experts_weights(experts_weights_["gate_proj.scale_bias"],
+                              experts_weights_["up_proj.scale_bias"]);
+    if (quant_group_size_ > 0) {
+      auto& gate_second_scale = select_w4a8_second_scale(
+          "gate_proj.weight_scale_second", "gate_proj.weight_offset");
+      auto& up_second_scale = select_w4a8_second_scale(
+          "up_proj.weight_scale_second", "up_proj.weight_offset");
+      CheckExpertVectorPair(
+          gate_second_scale, up_second_scale, "gateup.second_scale", layer_id_);
+      t[IN_MLP_GATEUP_OFFSET_EXPERT] =
+          merge_experts_weights(gate_second_scale, up_second_scale);
+    }
   }
 
   // IN_MLP_DOWN_WEIGHT_EXPERT:
   //   eager: NZ when not quantized, else ND;
   //   manual: NZ when decode is BF16, else ND.
+  if (is_w4a8_dynamic) {
+    CheckExpertVector(
+        experts_weights_["down_proj.weight"], "down.weight", layer_id_);
+  }
   torch::Tensor mlp_down_weight = merge_experts_weights(
       experts_weights_["down_proj.weight"], /*transpose=*/false);
   bool down_is_nz;
@@ -403,7 +655,9 @@ void DeekseekV2DecoderLoader::merge_experts_weights() {
   } else {
     down_is_nz = (quantize_type_ == "");
   }
-  if (down_is_nz) {
+  if (is_w4a8_dynamic) {
+    t[IN_MLP_DOWN_WEIGHT_EXPERT] = mlp_down_weight;
+  } else if (down_is_nz) {
     if (load_to_host()) {
       nz_indices_.insert(IN_MLP_DOWN_WEIGHT_EXPERT);
       t[IN_MLP_DOWN_WEIGHT_EXPERT] = mlp_down_weight.contiguous();
@@ -425,6 +679,22 @@ void DeekseekV2DecoderLoader::merge_experts_weights() {
         merge_experts_weights(experts_weights_["down_proj.weight_offset"]);
     t[IN_MLP_DOWN_SCALE_EXPERT] =
         merge_experts_weights(experts_weights_["down_proj.weight_scale"]);
+  } else if (is_w4a8_dynamic) {
+    CheckExpertVector(experts_weights_["down_proj.weight_scale"],
+                      "down.weight_scale",
+                      layer_id_);
+    t[IN_MLP_DOWN_SCALE_EXPERT] =
+        merge_experts_weights(experts_weights_["down_proj.weight_scale"]);
+    CheckExpertVector(
+        experts_weights_["down_proj.scale_bias"], "down.scale_bias", layer_id_);
+    t[IN_MLP_DOWN_BIAS_EXPERT] =
+        merge_experts_weights(experts_weights_["down_proj.scale_bias"]);
+    if (quant_group_size_ > 0) {
+      auto& down_second_scale = select_w4a8_second_scale(
+          "down_proj.weight_scale_second", "down_proj.weight_offset");
+      CheckExpertVector(down_second_scale, "down.second_scale", layer_id_);
+      t[IN_MLP_DOWN_OFFSET_EXPERT] = merge_experts_weights(down_second_scale);
+    }
   }
 }
 
@@ -447,7 +717,12 @@ torch::Tensor DeekseekV2DecoderLoader::merge_experts_weights(
     std::vector<torch::Tensor>& experts_up,
     bool transpose) {
   for (size_t i = 0; i < experts_up.size(); ++i) {
-    experts_gate[i] = torch::cat({experts_gate[i], experts_up[i]}, 0);
+    experts_gate[i] = CatWithDebug(
+        {experts_gate[i], experts_up[i]},
+        0,
+        {"gate expert " + std::to_string(i), "up expert " + std::to_string(i)},
+        "routed gateup expert",
+        layer_id_);
   }
 
   torch::Tensor merged_tensor =
@@ -465,6 +740,79 @@ torch::Tensor DeekseekV2DecoderLoader::merge_experts_weights(
     expert = torch::Tensor();
   }
   return merged_tensor;
+}
+
+void DeekseekV2DecoderLoader::preprocess_w4a8_dynamic_experts_weights() {
+  if (quantize_type_ != "w4a8_dynamic" ||
+      layer_id_ < prefill_firstKDenseReplace_) {
+    return;
+  }
+
+  auto& t = working_tensors();
+  CheckRequiredW4A8Tensor(
+      t[IN_MLP_GATEUP_WEIGHT_EXPERT], "IN_MLP_GATEUP_WEIGHT_EXPERT", layer_id_);
+  CheckRequiredW4A8Tensor(
+      t[IN_MLP_DOWN_WEIGHT_EXPERT], "IN_MLP_DOWN_WEIGHT_EXPERT", layer_id_);
+  CheckRequiredW4A8Tensor(
+      t[IN_MLP_GATEUP_SCALE_EXPERT], "IN_MLP_GATEUP_SCALE_EXPERT", layer_id_);
+  CheckRequiredW4A8Tensor(
+      t[IN_MLP_DOWN_SCALE_EXPERT], "IN_MLP_DOWN_SCALE_EXPERT", layer_id_);
+  CheckRequiredW4A8Tensor(
+      t[IN_MLP_GATEUP_BIAS_EXPERT], "IN_MLP_GATEUP_BIAS_EXPERT", layer_id_);
+  CheckRequiredW4A8Tensor(
+      t[IN_MLP_DOWN_BIAS_EXPERT], "IN_MLP_DOWN_BIAS_EXPERT", layer_id_);
+  if (quant_group_size_ > 0) {
+    CheckRequiredW4A8Tensor(t[IN_MLP_GATEUP_OFFSET_EXPERT],
+                            "IN_MLP_GATEUP_OFFSET_EXPERT",
+                            layer_id_);
+    CheckRequiredW4A8Tensor(
+        t[IN_MLP_DOWN_OFFSET_EXPERT], "IN_MLP_DOWN_OFFSET_EXPERT", layer_id_);
+  }
+
+  kernel::W4A8DynamicMoePreprocessParams params;
+  params.w13_weight = t[IN_MLP_GATEUP_WEIGHT_EXPERT];
+  params.w2_weight = t[IN_MLP_DOWN_WEIGHT_EXPERT];
+  params.w13_weight_scale = t[IN_MLP_GATEUP_SCALE_EXPERT];
+  params.w2_weight_scale = t[IN_MLP_DOWN_SCALE_EXPERT];
+  params.w13_weight_scale_second =
+      quant_group_size_ > 0
+          ? std::optional<torch::Tensor>(t[IN_MLP_GATEUP_OFFSET_EXPERT])
+          : std::nullopt;
+  params.w2_weight_scale_second =
+      quant_group_size_ > 0
+          ? std::optional<torch::Tensor>(t[IN_MLP_DOWN_OFFSET_EXPERT])
+          : std::nullopt;
+  params.w13_scale_bias = t[IN_MLP_GATEUP_BIAS_EXPERT];
+  params.w2_scale_bias = t[IN_MLP_DOWN_BIAS_EXPERT];
+  params.group_size = quant_group_size_;
+  params.pack_weight_to_int32 = false;
+
+  torch::Tensor processed_w13;
+  torch::Tensor processed_w2;
+  torch::Tensor processed_w13_scale;
+  torch::Tensor processed_w2_scale;
+  std::optional<torch::Tensor> processed_w13_scale_bias;
+  std::optional<torch::Tensor> processed_w2_scale_bias;
+  std::tie(processed_w13,
+           processed_w2,
+           processed_w13_scale,
+           processed_w2_scale,
+           processed_w13_scale_bias,
+           processed_w2_scale_bias) =
+      kernel::w4a8_dynamic_moe_preprocess(params);
+
+  t[IN_MLP_GATEUP_WEIGHT_EXPERT] = processed_w13;
+  t[IN_MLP_DOWN_WEIGHT_EXPERT] = processed_w2;
+  t[IN_MLP_GATEUP_SCALE_EXPERT] = processed_w13_scale;
+  t[IN_MLP_DOWN_SCALE_EXPERT] = processed_w2_scale;
+  if (processed_w13_scale_bias.has_value()) {
+    t[IN_MLP_GATEUP_BIAS_EXPERT] = processed_w13_scale_bias.value();
+  }
+  if (processed_w2_scale_bias.has_value()) {
+    t[IN_MLP_DOWN_BIAS_EXPERT] = processed_w2_scale_bias.value();
+  }
+  t[IN_MLP_GATEUP_OFFSET_EXPERT] = tensor_placeholder_;
+  t[IN_MLP_DOWN_OFFSET_EXPERT] = tensor_placeholder_;
 }
 
 void DeekseekV2DecoderLoader::process_shared_expert_weights(
@@ -635,13 +983,18 @@ void DeekseekV2DecoderLoader::reserve_experts_weights(
   experts_weights_.clear();
   std::vector<std::string> weight_names = {
       "gate_proj.weight", "up_proj.weight", "down_proj.weight"};
-  if (quantize_type_ == "w8a8_dynamic") {
+  if (use_quant_weight_mapping()) {
     weight_names.emplace_back("gate_proj.weight_offset");
     weight_names.emplace_back("up_proj.weight_offset");
     weight_names.emplace_back("down_proj.weight_offset");
     weight_names.emplace_back("gate_proj.weight_scale");
     weight_names.emplace_back("up_proj.weight_scale");
     weight_names.emplace_back("down_proj.weight_scale");
+    if (quantize_type_ == "w4a8_dynamic") {
+      weight_names.emplace_back("gate_proj.scale_bias");
+      weight_names.emplace_back("up_proj.scale_bias");
+      weight_names.emplace_back("down_proj.scale_bias");
+    }
   }
   std::lock_guard<std::mutex> lock(experts_mutex_);
   for (const auto& weight_name : weight_names) {
@@ -677,7 +1030,7 @@ void DeekseekV2DecoderLoader::merge_shared_experts_weights() {
         IN_MLP_GATEUP_WEIGHT_SHARED_EXPERT,
         shared_experts_weights_["mlp.shared_experts.gate_proj.weight"],
         shared_experts_weights_["mlp.shared_experts.up_proj.weight"]);
-    if (quantize_type_ == "w8a8_dynamic") {
+    if (use_quant_weight_mapping()) {
       merge_and_clear(
           IN_MLP_GATEUP_OFFSET_SHARED_EXPERT,
           shared_experts_weights_["mlp.shared_experts.gate_proj.weight_offset"],
@@ -691,7 +1044,7 @@ void DeekseekV2DecoderLoader::merge_shared_experts_weights() {
     merge_and_clear(IN_MLP_GATEUP_WEIGHT_SHARED_EXPERT,
                     shared_experts_weights_["mlp.gate_proj.weight"],
                     shared_experts_weights_["mlp.up_proj.weight"]);
-    if (quantize_type_ == "w8a8_dynamic") {
+    if (use_quant_weight_mapping()) {
       merge_and_clear(IN_MLP_GATEUP_OFFSET_SHARED_EXPERT,
                       shared_experts_weights_["mlp.gate_proj.weight_offset"],
                       shared_experts_weights_["mlp.up_proj.weight_offset"]);
@@ -704,7 +1057,7 @@ void DeekseekV2DecoderLoader::merge_shared_experts_weights() {
 
 void DeekseekV2DecoderLoader::merge_host_at_weights() {
   auto& t = working_tensors();
-  if (quantize_type_ == "w8a8_dynamic") {
+  if (use_quant_weight_mapping()) {
     if (prefill_isBF16_) {
       convert_descaled_weights_to_float();
     }
@@ -715,6 +1068,7 @@ void DeekseekV2DecoderLoader::merge_host_at_weights() {
   merge_shared_experts_weights();
   if (layer_id_ >= prefill_firstKDenseReplace_) {
     merge_experts_weights();
+    preprocess_w4a8_dynamic_experts_weights();
   }
 
   squeeze_experts_weights();
@@ -724,7 +1078,7 @@ void DeekseekV2DecoderLoader::merge_host_at_weights() {
   t[IN_Q_PROJ_A_WEIGHT] =
       torch::cat({t[IN_KV_PROJ_WITH_MQA_WEIGHT], t[IN_Q_PROJ_A_WEIGHT]}, 0)
           .contiguous();
-  if (quantize_type_ == "w8a8_dynamic") {
+  if (use_quant_weight_mapping()) {
     t[IN_Q_PROJ_A_BIAS] =
         torch::cat({t[IN_KV_PROJ_WITH_MQA_BIAS], t[IN_Q_PROJ_A_BIAS]}, 0)
             .contiguous();
@@ -756,8 +1110,9 @@ void DeekseekV2DecoderLoader::merge_host_at_weights() {
   }
   t[IN_BLOCK_SPARSE_MOE_GATE_WEIGHT] =
       t[IN_BLOCK_SPARSE_MOE_GATE_WEIGHT].to(torch::kFloat32);
-  if (quantize_type_ == "w8a8_dynamic") {
-    if (enable_kimi_k25_moe_scale_dtype_fix_) {
+  if (use_quant_weight_mapping()) {
+    if (enable_kimi_k25_moe_scale_dtype_fix_ &&
+        quantize_type_ == "w8a8_dynamic") {
       t[IN_MLP_GATEUP_SCALE_EXPERT] =
           t[IN_MLP_GATEUP_SCALE_EXPERT].to(torch::kBFloat16);
       t[IN_MLP_DOWN_SCALE_EXPERT] =
@@ -777,14 +1132,16 @@ void DeekseekV2DecoderLoader::merge_host_at_weights() {
           t[IN_MLP_GATEUP_SCALE_SHARED_EXPERT].to(torch::kFloat32);
       t[IN_MLP_DOWN_SCALE_SHARED_EXPERT] =
           t[IN_MLP_DOWN_SCALE_SHARED_EXPERT].to(torch::kFloat32);
-      t[IN_MLP_GATEUP_OFFSET_EXPERT] =
-          t[IN_MLP_GATEUP_OFFSET_EXPERT].to(torch::kFloat16);
-      t[IN_MLP_GATEUP_SCALE_EXPERT] =
-          t[IN_MLP_GATEUP_SCALE_EXPERT].to(torch::kFloat32);
-      t[IN_MLP_DOWN_OFFSET_EXPERT] =
-          t[IN_MLP_DOWN_OFFSET_EXPERT].to(torch::kFloat16);
-      t[IN_MLP_DOWN_SCALE_EXPERT] =
-          t[IN_MLP_DOWN_SCALE_EXPERT].to(torch::kFloat32);
+      if (quantize_type_ == "w8a8_dynamic") {
+        t[IN_MLP_GATEUP_OFFSET_EXPERT] =
+            t[IN_MLP_GATEUP_OFFSET_EXPERT].to(torch::kFloat16);
+        t[IN_MLP_GATEUP_SCALE_EXPERT] =
+            t[IN_MLP_GATEUP_SCALE_EXPERT].to(torch::kFloat32);
+        t[IN_MLP_DOWN_OFFSET_EXPERT] =
+            t[IN_MLP_DOWN_OFFSET_EXPERT].to(torch::kFloat16);
+        t[IN_MLP_DOWN_SCALE_EXPERT] =
+            t[IN_MLP_DOWN_SCALE_EXPERT].to(torch::kFloat32);
+      }
     }
   }
 }

--- a/xllm/core/layers/npu/loader/deepseek_v2_decoder_loader.h
+++ b/xllm/core/layers/npu/loader/deepseek_v2_decoder_loader.h
@@ -102,6 +102,12 @@ class DeekseekV2DecoderLoader : public BaseLoader {
 
   void merge_experts_weights();
 
+  void preprocess_w4a8_dynamic_experts_weights();
+
+  bool use_quant_weight_mapping() const;
+
+  int get_w4a8_expert_shard_dim(const std::string& suffix) const;
+
   torch::Tensor merge_experts_weights(std::vector<torch::Tensor>& experts,
                                       bool transpose = false);
 
@@ -140,6 +146,7 @@ class DeekseekV2DecoderLoader : public BaseLoader {
   int32_t end_expert_id_;
   int32_t ep_rank_;
   int32_t redundant_experts_num_;
+  int32_t quant_group_size_ = 0;
 
   int32_t layer_id_;
   int32_t qk_nope_head_dim_;

--- a/xllm/core/layers/npu/npu_deepseek_v2_decoder_layer_impl.cpp
+++ b/xllm/core/layers/npu/npu_deepseek_v2_decoder_layer_impl.cpp
@@ -22,10 +22,12 @@ limitations under the License.
 
 #include "common/global_flags.h"
 #include "core/framework/config/eplb_config.h"
+#include "core/framework/config/execution_config.h"
 #include "core/framework/config/kernel_config.h"
 #include "core/framework/config/kv_cache_config.h"
 #include "core/framework/config/load_config.h"
 #include "core/framework/config/parallel_config.h"
+#include "core/util/utils.h"
 #include "layers/common/rotary_embedding_util.h"
 #include "loader/deepseek_v2_decoder_loader.h"
 
@@ -36,6 +38,11 @@ namespace {
 
 bool is_kimi_text_model(const ModelArgs& args) {
   return args.model_type() == "kimi_k2" || args.model_type() == "kimi_k25";
+}
+
+bool uses_deepseek_v2_mla_graph(const ModelArgs& args) {
+  return args.enable_mla() &&
+         util::is_deepseek_v2_family_model_type(args.model_type());
 }
 
 }  // namespace
@@ -173,6 +180,7 @@ NpuDeepseekV2DecoderLayerImpl::NpuDeepseekV2DecoderLayerImpl(
   auto model_args = context.get_model_args();
   auto quant_args = context.get_quant_args();
   auto options = context.get_tensor_options();
+  uses_deepseek_v2_mla_graph_ = uses_deepseek_v2_mla_graph(model_args);
 
   rank_ = parallel_args.rank();
   first_k_dense_replace_ = model_args.first_k_dense_replace();
@@ -213,7 +221,9 @@ NpuDeepseekV2DecoderLayerImpl::NpuDeepseekV2DecoderLayerImpl(
   param_from_args(decode_param_, model_args, parallel_args, false, false);
   param_from_args(decode_mla_param_, model_args, parallel_args, false, false);
   decode_mla_param_.enableCustomizeMla =
-      ::xllm::KernelConfig::get_instance().enable_customize_mla_kernel();
+      ::xllm::KernelConfig::get_instance().enable_customize_mla_kernel() ||
+      (uses_deepseek_v2_mla_graph_ &&
+       ::xllm::ExecutionConfig::get_instance().enable_graph());
 
   loader_ = std::make_unique<DeekseekV2DecoderLoader>(
       WEIGHT_COUNT_PER_LAYER,
@@ -852,13 +862,22 @@ torch::Tensor NpuDeepseekV2DecoderLayerImpl::forward(
     LOG_IF(FATAL, st != 0) << model_name_
                            << "execute prefill layer fail, error code: " << st;
   } else {
-    const int num_tokens = x.sizes().at(0);
+    const int32_t num_tokens = static_cast<int32_t>(x.sizes().at(0));
     // decode phase with tokens more than this limit will lead to error in
     // customize mla kernel. once detect any input exceed the limit, fall back
     // to default kernel.
-    const int num_tokens_limit = 230;
-    if (!::xllm::KernelConfig::get_instance().enable_customize_mla_kernel() ||
-        num_tokens >= num_tokens_limit) {
+    constexpr int32_t kNumTokensLimit = 230;
+    const bool use_graph_decode =
+        ::xllm::ExecutionConfig::get_instance().enable_graph() &&
+        input_params_new.enable_graph;
+    const bool use_deepseek_v2_graph_mla =
+        use_graph_decode && uses_deepseek_v2_mla_graph_;
+    const bool enable_custom_mla =
+        ::xllm::KernelConfig::get_instance().enable_customize_mla_kernel() ||
+        use_deepseek_v2_graph_mla;
+    if ((!use_deepseek_v2_graph_mla && use_graph_decode) ||
+        !enable_custom_mla ||
+        (!use_deepseek_v2_graph_mla && num_tokens >= kNumTokensLimit)) {
       build_node_variant_pack(decode_node_,
                               x,
                               cos_pos,
@@ -937,8 +956,13 @@ void NpuDeepseekV2DecoderLayerImpl::build_node_variant_pack(
     node.variantPack.inTensors.at(WEIGHT_COUNT_PER_LAYER + 11) =
         atb_speed::Utils::AtTensor2Tensor(
             input_params.attention.device.kv_seq_lens);
+    const int32_t* kv_seq_lens_host_data =
+        (input_params.enable_graph &&
+         input_params.attention.host.graph_kv_seq_lens_data != nullptr)
+            ? input_params.attention.host.graph_kv_seq_lens_data
+            : input_params.attention.host.kv_seq_lens.data();
     node.variantPack.inTensors.at(WEIGHT_COUNT_PER_LAYER + 11).hostData =
-        const_cast<int32_t*>(input_params.attention.host.kv_seq_lens.data());
+        const_cast<int32_t*>(kv_seq_lens_host_data);
   }
 
   node.variantPack.inTensors.at(WEIGHT_COUNT_PER_LAYER + 12) =
@@ -986,8 +1010,13 @@ void NpuDeepseekV2DecoderLayerImpl::build_node_variant_pack(
       node.variantPack.inTensors.at(WEIGHT_COUNT_PER_LAYER + 17) =
           atb_speed::Utils::AtTensor2Tensor(
               input_params.attention.device.q_seq_lens);
+      const int32_t* q_seq_lens_host_data =
+          (input_params.enable_graph &&
+           input_params.attention.host.graph_q_seq_lens_data != nullptr)
+              ? input_params.attention.host.graph_q_seq_lens_data
+              : input_params.attention.host.q_seq_lens.data();
       node.variantPack.inTensors.at(WEIGHT_COUNT_PER_LAYER + 17).hostData =
-          const_cast<int32_t*>(input_params.attention.host.q_seq_lens.data());
+          const_cast<int32_t*>(q_seq_lens_host_data);
     }
   } else {
     node.variantPack.inTensors.at(WEIGHT_COUNT_PER_LAYER + 17) =

--- a/xllm/core/layers/npu/npu_deepseek_v2_decoder_layer_impl.cpp
+++ b/xllm/core/layers/npu/npu_deepseek_v2_decoder_layer_impl.cpp
@@ -27,7 +27,6 @@ limitations under the License.
 #include "core/framework/config/kv_cache_config.h"
 #include "core/framework/config/load_config.h"
 #include "core/framework/config/parallel_config.h"
-#include "core/util/utils.h"
 #include "layers/common/rotary_embedding_util.h"
 #include "loader/deepseek_v2_decoder_loader.h"
 
@@ -41,8 +40,7 @@ bool is_kimi_text_model(const ModelArgs& args) {
 }
 
 bool uses_deepseek_v2_mla_graph(const ModelArgs& args) {
-  return args.enable_mla() &&
-         util::is_deepseek_v2_family_model_type(args.model_type());
+  return args.enable_mla() && args.model_type() == "kimi_k25";
 }
 
 }  // namespace

--- a/xllm/core/layers/npu/npu_deepseek_v2_decoder_layer_impl.cpp
+++ b/xllm/core/layers/npu/npu_deepseek_v2_decoder_layer_impl.cpp
@@ -171,12 +171,22 @@ NpuDeepseekV2DecoderLayerImpl::NpuDeepseekV2DecoderLayerImpl(
 
   auto parallel_args = context.get_parallel_args();
   auto model_args = context.get_model_args();
+  auto quant_args = context.get_quant_args();
   auto options = context.get_tensor_options();
 
   rank_ = parallel_args.rank();
   first_k_dense_replace_ = model_args.first_k_dense_replace();
   n_layers_ = model_args.n_layers();
   num_experts_ = model_args.n_routed_experts();
+  quant_group_size_ = static_cast<int32_t>(quant_args.group_size());
+  if (quantize_type_ == "w4a8_dynamic") {
+    CHECK_GE(quant_group_size_, 0)
+        << "W4A8_DYNAMIC group_size must be >= 0, got " << quant_group_size_;
+    CHECK_EQ(quant_args.quant_version(), "1.0.0")
+        << "W4A8_DYNAMIC only supports quant_version 1.0.0, got "
+        << (quant_args.quant_version().empty() ? "<empty>"
+                                               : quant_args.quant_version());
+  }
   localWorldSize_ = parallel_args.mapping().localWorldSize();
   ep_size_ = parallel_args.ep_size();
   ep_local_tp_size_ = parallel_args.world_size() / ep_size_;
@@ -296,9 +306,13 @@ void NpuDeepseekV2DecoderLayerImpl::initialize_basic_parameters(
   param.attnLinearTransposeType = {1, 1, 1, 1, 1, 1};
   param.mlpLinearTransposeType = {1, -1, 1, -1};
 
-  param.moeLinearTransposeType = (layer_id_ < args.first_k_dense_replace())
-                                     ? std::vector<int>{-1, -1, -1, -1}
-                                     : std::vector<int>{1, 0, -1, 1};
+  if (layer_id_ < args.first_k_dense_replace()) {
+    param.moeLinearTransposeType = {-1, -1, -1, -1};
+  } else if (quantize_type_ == "w4a8_dynamic") {
+    param.moeLinearTransposeType = {1, 0, -1, 0};
+  } else {
+    param.moeLinearTransposeType = {1, 0, -1, 1};
+  }
 
   param.worldSize = parallel_args.world_size();
   param.normEps = args.rms_norm_eps();
@@ -316,7 +330,7 @@ void NpuDeepseekV2DecoderLayerImpl::initialize_basic_parameters(
   param.numHiddenLayers = args.n_layers();
   param.enableIntraLayerAddNorm = false;
   param.enableInterLayerAddNorm = false;
-  if (quantize_type_ == "") {
+  if (quantize_type_ == "" || quantize_type_ == "w4a8_dynamic") {
     param.enableGMMSwigluQuant = false;
   } else {
     param.enableGMMSwigluQuant =
@@ -394,7 +408,8 @@ void NpuDeepseekV2DecoderLayerImpl::initialize_mlp_parameters(
   param.topkGroups = atb::SVector<int>{args.topk_group()};
   param.isDynamicEp = param.expertParallelDegree == 2 ? true : false;
 
-  param.quantGroupSize = 0;
+  param.quantGroupSize =
+      quantize_type_ == "w4a8_dynamic" ? quant_group_size_ : 0;
   if (quantize_type_ == "") {
     param.enableInitQuant = false;
     param.enableSwigluQuant = false;
@@ -453,8 +468,12 @@ void NpuDeepseekV2DecoderLayerImpl::initialize_kimi_k2_parameters(
   // TODO: Pending confirmation whether kimi_k2 model supports
   // enable_gmmswigluquant set to true
   bool enable_gmmswigluquant = false;
-  param.enableSwigluQuant =
-      quantize_type_ == "w8a8_dynamic" && !enable_gmmswigluquant;
+  if (quantize_type_ == "w4a8_dynamic") {
+    param.enableSwigluQuant = is_prefill && !enable_gmmswigluquant;
+  } else {
+    param.enableSwigluQuant =
+        quantize_type_ == "w8a8_dynamic" && !enable_gmmswigluquant;
+  }
   param.enableGMMSwigluQuant = enable_gmmswigluquant;
 }
 
@@ -499,8 +518,35 @@ void NpuDeepseekV2DecoderLayerImpl::initialize_quantization_parameters(
                                   static_cast<int>(LinearType::INVALID),
                                   static_cast<int>(LinearType::FP)};
     }
-  } else {
+  } else if (quantize_type_ == "w8a8_dynamic") {
     param.moePackQuantType = static_cast<int>(PackType::ALL_W8A8_DYNAMIC);
+    param.packQuantType = {static_cast<int>(PackType::MIX_W8A8),
+                           static_cast<int>(PackType::ALL_W8A8_DYNAMIC)};
+    param.attnLinearQuantType = {static_cast<int>(LinearType::INT),
+                                 static_cast<int>(LinearType::INT),
+                                 static_cast<int>(LinearType::FP),
+                                 static_cast<int>(LinearType::FP),
+                                 static_cast<int>(LinearType::FP),
+                                 static_cast<int>(LinearType::INT)};
+    param.mlpLinearQuantType = {static_cast<int>(LinearType::INT),
+                                static_cast<int>(LinearType::INVALID),
+                                static_cast<int>(LinearType::INT),
+                                static_cast<int>(LinearType::INVALID)};
+    if (layer_id_ < param.firstKDenseReplace) {
+      param.moeLinearQuantType = {static_cast<int>(LinearType::INVALID),
+                                  static_cast<int>(LinearType::INVALID),
+                                  static_cast<int>(LinearType::INVALID),
+                                  static_cast<int>(LinearType::INVALID)};
+    } else {
+      param.moeLinearQuantType = {static_cast<int>(LinearType::FP),
+                                  static_cast<int>(LinearType::INT),
+                                  static_cast<int>(LinearType::INVALID),
+                                  static_cast<int>(LinearType::INT)};
+    }
+  } else if (quantize_type_ == "w4a8_dynamic") {
+    param.moePackQuantType = static_cast<int>(PackType::ALL_W4A8);
+    // Kimi K2.5 keeps attention/dense/shared MLP on W8A8 dynamic; routed
+    // experts use the W4A8 grouped-matmul path.
     param.packQuantType = {static_cast<int>(PackType::MIX_W8A8),
                            static_cast<int>(PackType::ALL_W8A8_DYNAMIC)};
     param.attnLinearQuantType = {static_cast<int>(LinearType::INT),

--- a/xllm/core/layers/npu/npu_deepseek_v2_decoder_layer_impl.h
+++ b/xllm/core/layers/npu/npu_deepseek_v2_decoder_layer_impl.h
@@ -235,6 +235,7 @@ class NpuDeepseekV2DecoderLayerImpl : public BaseLayer {
   float sm_scale_;
   int32_t quant_group_size_ = 0;
   int32_t num_speculative_tokens_ = 0;
+  bool uses_deepseek_v2_mla_graph_ = false;
 
   atb_speed::deepseekV2::DecoderLayerParam prefill_param_;
   atb_speed::deepseekV2::DecoderLayerParam prefill_param_prefixcache_;

--- a/xllm/core/layers/npu/npu_deepseek_v2_decoder_layer_impl.h
+++ b/xllm/core/layers/npu/npu_deepseek_v2_decoder_layer_impl.h
@@ -233,6 +233,7 @@ class NpuDeepseekV2DecoderLayerImpl : public BaseLayer {
   int32_t dp_local_tp_rank_;
 
   float sm_scale_;
+  int32_t quant_group_size_ = 0;
   int32_t num_speculative_tokens_ = 0;
 
   atb_speed::deepseekV2::DecoderLayerParam prefill_param_;

--- a/xllm/core/runtime/acl_graph_executor_impl.cpp
+++ b/xllm/core/runtime/acl_graph_executor_impl.cpp
@@ -52,6 +52,9 @@ constexpr uint64_t kSpecVerifyFieldMask = (1ull << 16) - 1;
 constexpr uint64_t kSpecVerifyExpandedBlockMask = (1ull << 15) - 1;
 constexpr uint64_t kStaticGraphTaskHashSeed = 0x6a09e667f3bcc909ull;
 constexpr size_t kMaxStaticMtpGraphVariantsPerSlot = 16;
+constexpr uint64_t kMlaGraphKeyMask = 1ull << 62;
+constexpr uint64_t kMlaGraphKeyPayloadMask = (1ull << 62) - 1;
+constexpr int32_t kMlaGraphKvLenBucket = 2048;
 
 bool uses_static_mtp_graph_task_variant(const ModelInputParams& params,
                                         uint32_t bucket_num_tokens,
@@ -222,6 +225,53 @@ ModelOutput forward_eager(CausalLM* model,
   return model->forward(materialized_tokens, positions, kv_cache, params);
 }
 
+bool uses_deepseek_v2_mla_graph(const ModelArgs& args) {
+  return args.enable_mla() &&
+         util::is_deepseek_v2_family_model_type(args.model_type());
+}
+
+void hash_graph_key_value(uint64_t& hash, uint64_t value) {
+  constexpr uint64_t kFnvPrime = 1099511628211ull;
+  for (int32_t i = 0; i < 8; ++i) {
+    hash ^= (value >> (i * 8)) & 0xffull;
+    hash *= kFnvPrime;
+  }
+}
+
+int32_t round_up_positive(int32_t value, int32_t bucket) {
+  const int32_t safe_value = std::max<int32_t>(value, 1);
+  return ((safe_value + bucket - 1) / bucket) * bucket;
+}
+
+int32_t get_mla_capture_kv_seq_len_bucket(const ModelInputParams& params,
+                                          const runtime::Options& options) {
+  const int32_t block_size = std::max<int32_t>(options.block_size(), 1);
+  int32_t capture_kv_len =
+      std::max<int32_t>(params.meta.kv_max_seq_len, block_size);
+  if (!params.parallel.dp_global_kv_max_seq_lens.empty()) {
+    capture_kv_len = std::max<int32_t>(
+        capture_kv_len, util::max(params.parallel.dp_global_kv_max_seq_lens));
+    return round_up_positive(capture_kv_len, kMlaGraphKvLenBucket);
+  }
+  const auto& block_tables = params.attention.device.block_tables;
+  if (block_tables.defined() && block_tables.dim() >= 2 &&
+      block_tables.size(1) > 0) {
+    capture_kv_len = std::max<int32_t>(
+        capture_kv_len,
+        static_cast<int32_t>(block_tables.size(1)) * block_size);
+  }
+  return round_up_positive(capture_kv_len, kMlaGraphKvLenBucket);
+}
+
+uint64_t get_mla_graph_key(uint32_t bucket_num_tokens,
+                           int32_t capture_kv_seq_len_bucket) {
+  constexpr uint64_t kFnvOffsetBasis = 1469598103934665603ull;
+  uint64_t hash = kFnvOffsetBasis;
+  hash_graph_key_value(hash, bucket_num_tokens);
+  hash_graph_key_value(hash, static_cast<uint64_t>(capture_kv_seq_len_bucket));
+
+  return kMlaGraphKeyMask | (hash & kMlaGraphKeyPayloadMask);
+}
 }  // namespace
 
 bool AclGraph::capture(CausalLM* model,
@@ -268,7 +318,8 @@ bool AclGraph::capture(CausalLM* model,
                                                num_tokens_,
                                                /*return_capture_params=*/true,
                                                /*skip_token_update=*/
-                                               update_spec_verify_tokens);
+                                               update_spec_verify_tokens,
+                                               /*for_capture=*/true);
   if (update_spec_verify_tokens) {
     persistent_param_.update_spec_verify_inputs(
         tokens,
@@ -369,27 +420,51 @@ bool AclGraph::capture(CausalLM* model,
       graph_stream_ = capture_stream_.value().stream();
       need_restore_stream = true;
     }
-    LOG(INFO) << "capture begin, bucket_num_tokens: " << bucket_num_tokens
-              << ", actual_num_tokens: " << actual_num_tokens;
+    VLOG(kGraphExecutorLogVerboseLevel)
+        << "ACL graph capture begin, bucket_num_tokens=" << bucket_num_tokens
+        << ", actual_num_tokens=" << actual_num_tokens;
 
     // no mempool id, will create a new one; capture mode is thread local, allow
     // other threads to execute synchronous operations
-    graph_.capture_begin(
-        {0, 0}, aclmdlRICaptureMode::ACL_MODEL_RI_CAPTURE_MODE_THREAD_LOCAL);
-    // Execute forward pass - NPUGraph mempool manages temporary tensors
-    auto forward_result =
-        model->forward({persistent_param_.persistent_tokens(num_tokens_)},
-                       {persistent_param_.persistent_positions(num_tokens_)},
-                       kv_cache,
-                       {graph_params.value()});
+    bool capture_started = false;
+    try {
+      graph_.capture_begin(
+          {0, 0}, aclmdlRICaptureMode::ACL_MODEL_RI_CAPTURE_MODE_THREAD_LOCAL);
+      capture_started = true;
+      // Execute forward pass - NPUGraph mempool manages temporary tensors
+      auto forward_result =
+          model->forward({persistent_param_.persistent_tokens(num_tokens_)},
+                         {persistent_param_.persistent_positions(num_tokens_)},
+                         kv_cache,
+                         {graph_params.value()});
 
-    // Store result in persistent buffer owned by NPUGraph mempool
-    persistent_param_.set_hidden_states(forward_result.hidden_states);
-    if (options.enable_graph_aux_hidden_states() &&
-        forward_result.aux_hidden_states.defined()) {
-      persistent_param_.set_aux_hidden_states(forward_result.aux_hidden_states);
+      // Store result in persistent buffer owned by NPUGraph mempool
+      persistent_param_.set_hidden_states(forward_result.hidden_states);
+      if (options.enable_graph_aux_hidden_states() &&
+          forward_result.aux_hidden_states.defined()) {
+        persistent_param_.set_aux_hidden_states(
+            forward_result.aux_hidden_states);
+      }
+      graph_.capture_end();
+      capture_started = false;
+    } catch (...) {
+      if (capture_started) {
+        try {
+          graph_.capture_end();
+        } catch (const std::exception& cleanup_error) {
+          LOG(ERROR) << "ACL graph capture_end during cleanup failed: "
+                     << cleanup_error.what();
+        } catch (...) {
+          LOG(ERROR) << "ACL graph capture_end during cleanup failed.";
+        }
+        graph_.reset();
+      }
+      if (need_restore_stream) {
+        c10_npu::setCurrentNPUStream(
+            c10_npu::getDefaultNPUStream(tensor_options.device().index()));
+      }
+      throw;
     }
-    graph_.capture_end();
     if (graph_task_context_ != nullptr) {
       graph_task_context_->end_capture();
     }
@@ -526,9 +601,10 @@ void AclGraph::initialize_capture_stream(c10::DeviceIndex device_index) {
   CHECK_EQ(aclrtCreateEventWithFlag(&replay_done_event_, ACL_EVENT_SYNC),
            ACL_SUCCESS)
       << "Failed to create ACL graph replay completion event";
-  LOG(INFO) << "Initialized capture_stream"
-            << ", id: " << capture_stream_.value().id()
-            << ", device_index: " << device_index;
+  VLOG(kGraphExecutorLogVerboseLevel)
+      << "Initialized capture_stream"
+      << ", id: " << capture_stream_.value().id()
+      << ", device_index: " << static_cast<int32_t>(device_index);
 }
 
 void AclGraph::make_graph_wait_for_current_stream(aclrtStream current_stream) {
@@ -816,7 +892,6 @@ ModelOutput AclGraphExecutorImpl::run(const torch::Tensor& tokens,
     COUNTER_INC(num_model_execution_total_eager);
     return model_->forward(tokens, positions, kv_caches, params);
   }
-
   if (in_decoding_phase &&
       params_single.parallel.dp_global_token_nums.size() > 1) {
     if (params_single.parallel.dp_is_decode.size() !=
@@ -1012,8 +1087,11 @@ ModelOutput AclGraphExecutorImpl::run(const torch::Tensor& tokens,
                                      bucket_num_tokens);
   } catch (const std::exception& e) {
     LOG(ERROR) << "ACL graph capture threw exception for bucket num_tokens="
-               << bucket_num_tokens << ": " << e.what()
-               << ". Falling back to eager mode.";
+               << bucket_num_tokens << ": " << e.what();
+    if (uses_deepseek_v2_mla_graph(args_)) {
+      throw;
+    }
+    LOG(ERROR) << "Falling back to eager mode.";
     COUNTER_INC(num_model_execution_total_eager);
     return forward_eager(model_, tokens, positions, kv_caches, params);
   }
@@ -1220,7 +1298,7 @@ uint32_t AclGraphExecutorImpl::get_bucket_num_tokens(
   } else if (num_tokens <= 8) {
     return 8;
   } else {
-    // For num_tokens > 16, use multiples of 16
+    // For num_tokens > 8, use multiples of 16.
     return ((num_tokens + 15) / 16) * 16;
   }
 }
@@ -1273,6 +1351,11 @@ uint64_t AclGraphExecutorImpl::get_graph_key(
     }
     return static_cast<uint64_t>(bucket_num_tokens) | kSpecVerifyGraphKeyMask |
            (q_max_seq_len << kSpecVerifyQMaxSeqLenShift);
+  }
+  if (uses_deepseek_v2_mla_graph(args_)) {
+    const int32_t capture_kv_seq_len_bucket =
+        get_mla_capture_kv_seq_len_bucket(params, options_);
+    return get_mla_graph_key(bucket_num_tokens, capture_kv_seq_len_bucket);
   }
   return static_cast<uint64_t>(bucket_num_tokens);
 }

--- a/xllm/core/runtime/acl_graph_executor_impl.cpp
+++ b/xllm/core/runtime/acl_graph_executor_impl.cpp
@@ -54,8 +54,6 @@ constexpr uint64_t kStaticGraphTaskHashSeed = 0x6a09e667f3bcc909ull;
 constexpr size_t kMaxStaticMtpGraphVariantsPerSlot = 16;
 constexpr uint64_t kMlaGraphKeyMask = 1ull << 62;
 constexpr uint64_t kMlaGraphKeyPayloadMask = (1ull << 62) - 1;
-constexpr int32_t kMlaGraphKvLenBucket = 2048;
-
 bool uses_static_mtp_graph_task_variant(const ModelInputParams& params,
                                         uint32_t bucket_num_tokens,
                                         int64_t block_size) {
@@ -225,42 +223,12 @@ ModelOutput forward_eager(CausalLM* model,
   return model->forward(materialized_tokens, positions, kv_cache, params);
 }
 
-bool uses_deepseek_v2_mla_graph(const ModelArgs& args) {
-  return args.enable_mla() &&
-         util::is_deepseek_v2_family_model_type(args.model_type());
-}
-
 void hash_graph_key_value(uint64_t& hash, uint64_t value) {
   constexpr uint64_t kFnvPrime = 1099511628211ull;
   for (int32_t i = 0; i < 8; ++i) {
     hash ^= (value >> (i * 8)) & 0xffull;
     hash *= kFnvPrime;
   }
-}
-
-int32_t round_up_positive(int32_t value, int32_t bucket) {
-  const int32_t safe_value = std::max<int32_t>(value, 1);
-  return ((safe_value + bucket - 1) / bucket) * bucket;
-}
-
-int32_t get_mla_capture_kv_seq_len_bucket(const ModelInputParams& params,
-                                          const runtime::Options& options) {
-  const int32_t block_size = std::max<int32_t>(options.block_size(), 1);
-  int32_t capture_kv_len =
-      std::max<int32_t>(params.meta.kv_max_seq_len, block_size);
-  if (!params.parallel.dp_global_kv_max_seq_lens.empty()) {
-    capture_kv_len = std::max<int32_t>(
-        capture_kv_len, util::max(params.parallel.dp_global_kv_max_seq_lens));
-    return round_up_positive(capture_kv_len, kMlaGraphKvLenBucket);
-  }
-  const auto& block_tables = params.attention.device.block_tables;
-  if (block_tables.defined() && block_tables.dim() >= 2 &&
-      block_tables.size(1) > 0) {
-    capture_kv_len = std::max<int32_t>(
-        capture_kv_len,
-        static_cast<int32_t>(block_tables.size(1)) * block_size);
-  }
-  return round_up_positive(capture_kv_len, kMlaGraphKvLenBucket);
 }
 
 uint64_t get_mla_graph_key(uint32_t bucket_num_tokens,
@@ -828,11 +796,13 @@ AclGraphExecutorImpl::AclGraphExecutorImpl(CausalLM* model,
                                                                            : 1;
   for (int32_t slot_idx = 0; slot_idx < graph_slot_count_; ++slot_idx) {
     graph_slots_[slot_idx].persistent_param =
-        std::make_unique<GraphPersistentParam>(args_,
-                                               device_,
-                                               options_,
-                                               need_update_attn_mask,
-                                               is_hybrid_linear_attn);
+        std::make_unique<GraphPersistentParam>(
+            args_,
+            device_,
+            options_,
+            need_update_attn_mask,
+            is_hybrid_linear_attn,
+            model_->supports_mla_graph_kv_bucketing());
   }
 }
 
@@ -1088,7 +1058,7 @@ ModelOutput AclGraphExecutorImpl::run(const torch::Tensor& tokens,
   } catch (const std::exception& e) {
     LOG(ERROR) << "ACL graph capture threw exception for bucket num_tokens="
                << bucket_num_tokens << ": " << e.what();
-    if (uses_deepseek_v2_mla_graph(args_)) {
+    if (model_->supports_mla_graph_kv_bucketing()) {
       throw;
     }
     LOG(ERROR) << "Falling back to eager mode.";
@@ -1352,7 +1322,7 @@ uint64_t AclGraphExecutorImpl::get_graph_key(
     return static_cast<uint64_t>(bucket_num_tokens) | kSpecVerifyGraphKeyMask |
            (q_max_seq_len << kSpecVerifyQMaxSeqLenShift);
   }
-  if (uses_deepseek_v2_mla_graph(args_)) {
+  if (model_->supports_mla_graph_kv_bucketing()) {
     const int32_t capture_kv_seq_len_bucket =
         get_mla_capture_kv_seq_len_bucket(params, options_);
     return get_mla_graph_key(bucket_num_tokens, capture_kv_seq_len_bucket);

--- a/xllm/core/runtime/acl_graph_executor_impl.h
+++ b/xllm/core/runtime/acl_graph_executor_impl.h
@@ -230,8 +230,8 @@ class AclGraphExecutorImpl : public ExecutorImpl {
   int32_t last_started_replay_slot_ = -1;
 
   // Get bucket num_tokens for given num_tokens
-  // For num_tokens < 8: use 1, 2, 4, 8
-  // For num_tokens >= 8: use multiples of 8
+  // For num_tokens <= 8: use 1, 2, 4, 8
+  // For num_tokens > 8: use multiples of 16
   uint32_t get_bucket_num_tokens(uint32_t num_tokens) const;
 
   uint64_t get_graph_key(uint32_t bucket_num_tokens,

--- a/xllm/core/runtime/acl_graph_persistent_param.cpp
+++ b/xllm/core/runtime/acl_graph_persistent_param.cpp
@@ -46,6 +46,7 @@ limitations under the License.
 namespace xllm::npu {
 
 namespace {
+constexpr int32_t kMlaGraphKvLenBucket = 2048;
 
 int64_t get_decode_graph_capacity(const runtime::Options& options) {
   CHECK_GT(options.num_decoding_tokens(), 0)
@@ -157,45 +158,36 @@ int64_t get_spec_verify_width(const ModelInputParams& params) {
   return spec_width;
 }
 
-bool uses_deepseek_v2_mla_graph(const ModelArgs& args) {
-  return args.enable_mla() &&
-         util::is_deepseek_v2_family_model_type(args.model_type());
-}
+}  // namespace
 
-constexpr int32_t kMlaGraphKvLenBucket = 2048;
-
-int32_t round_up_positive(int32_t value, int32_t bucket) {
-  const int32_t safe_value = std::max<int32_t>(value, 1);
-  return ((safe_value + bucket - 1) / bucket) * bucket;
-}
-
-int32_t graph_mla_capture_kv_seq_len(const ModelInputParams& params,
-                                     const runtime::Options& options) {
+int32_t get_mla_capture_kv_seq_len_bucket(const ModelInputParams& params,
+                                          const runtime::Options& options) {
   const int32_t block_size = std::max<int32_t>(options.block_size(), 1);
   int32_t capture_kv_len =
       std::max<int32_t>(params.meta.kv_max_seq_len, block_size);
   if (!params.parallel.dp_global_kv_max_seq_lens.empty()) {
     capture_kv_len = std::max<int32_t>(
         capture_kv_len, util::max(params.parallel.dp_global_kv_max_seq_lens));
-    return round_up_positive(capture_kv_len, kMlaGraphKvLenBucket);
+  } else {
+    const auto& block_tables = params.attention.device.block_tables;
+    if (block_tables.defined() && block_tables.dim() >= 2 &&
+        block_tables.size(1) > 0) {
+      capture_kv_len = std::max<int32_t>(
+          capture_kv_len,
+          static_cast<int32_t>(block_tables.size(1)) * block_size);
+    }
   }
-  const auto& block_tables = params.attention.device.block_tables;
-  if (block_tables.defined() && block_tables.dim() >= 2 &&
-      block_tables.size(1) > 0) {
-    capture_kv_len = std::max<int32_t>(
-        capture_kv_len,
-        static_cast<int32_t>(block_tables.size(1)) * block_size);
-  }
-  return round_up_positive(capture_kv_len, kMlaGraphKvLenBucket);
+  return static_cast<int32_t>(
+      util::align_up(capture_kv_len, kMlaGraphKvLenBucket));
 }
-}  // namespace
 
 // GraphPersistentParam implementation
 GraphPersistentParam::GraphPersistentParam(const ModelArgs& args,
                                            const torch::Device& device,
                                            const runtime::Options& options,
                                            bool need_update_attn_mask,
-                                           bool is_hybrid_linear_attention)
+                                           bool is_hybrid_linear_attention,
+                                           bool supports_mla_graph_kv_bucketing)
     : args_(args),
       device_(device),
       options_(options),
@@ -203,13 +195,14 @@ GraphPersistentParam::GraphPersistentParam(const ModelArgs& args,
       custom_pa_op_for_plan_(nullptr),
       stream_for_plan_(nullptr),
       need_update_attn_mask_(need_update_attn_mask),
-      is_hybrid_linear_attention_(is_hybrid_linear_attention) {
-  // Determine whether attention plan needs to be updated based on model type
-  // Future logic can be extended here for more complex model-specific behavior
+      is_hybrid_linear_attention_(is_hybrid_linear_attention),
+      supports_mla_graph_kv_bucketing_(supports_mla_graph_kv_bucketing) {
+  // MLA graph KV bucketing uses a fixed capture plan and does not update the
+  // attention plan for each request.
   need_update_attention_plan_ =
       (args.model_type() != "deepseek_v32" &&
        args.model_type() != "deepseek_v4" &&
-       args.model_type() != "glm_moe_dsa" && !uses_deepseek_v2_mla_graph(args));
+       args.model_type() != "glm_moe_dsa" && !supports_mla_graph_kv_bucketing_);
 
   // Check if mRoPE is used (for VLM models like qwen2-vl)
   use_mrope_ = !args.rope_scaling_mrope_section().empty();
@@ -257,14 +250,14 @@ GraphPersistentParam::GraphPersistentParam(const ModelArgs& args,
                                      torch::dtype(torch::kInt).device(device));
   expanded_kv_seq_lens_ = torch::zeros(
       {max_tokens_per_batch}, torch::dtype(torch::kInt).device(device));
-  persistent_host_q_seq_lens_.assign(static_cast<size_t>(max_seqs_per_batch),
-                                     1);
-  persistent_host_kv_seq_lens_.assign(static_cast<size_t>(max_seqs_per_batch),
-                                      1);
-  persistent_host_expanded_kv_seq_lens_.assign(
-      static_cast<size_t>(max_tokens_per_batch), 1);
-  capture_host_q_seq_lens_.assign(static_cast<size_t>(max_seqs_per_batch), 1);
-  capture_host_kv_seq_lens_.assign(static_cast<size_t>(max_seqs_per_batch), 1);
+  if (supports_mla_graph_kv_bucketing_) {
+    persistent_host_q_seq_lens_.assign(static_cast<size_t>(metadata_capacity),
+                                       1);
+    persistent_host_kv_seq_lens_.assign(static_cast<size_t>(metadata_capacity),
+                                        1);
+    capture_host_q_seq_lens_.assign(static_cast<size_t>(metadata_capacity), 1);
+    capture_host_kv_seq_lens_.assign(static_cast<size_t>(metadata_capacity), 1);
+  }
 
   // Block table tensors with maximum possible size
   const int64_t block_size = options.block_size();
@@ -1149,23 +1142,16 @@ std::optional<ModelInputParams> GraphPersistentParam::update(
     // width used by main instead of binding a request-dependent view.
     return block_tables;
   };
-  CHECK_LE(static_cast<size_t>(padded_batch_size),
-           persistent_host_kv_seq_lens_.size())
-      << "padded_batch_size exceeds persistent host seq lens capacity";
-  std::copy(padded_kv_seq_lens_vec.begin(),
-            padded_kv_seq_lens_vec.end(),
-            persistent_host_kv_seq_lens_.begin());
-  std::copy(padded_q_seq_lens_vec.begin(),
-            padded_q_seq_lens_vec.end(),
-            persistent_host_q_seq_lens_.begin());
-  if (use_expanded_spec_decode_attention) {
-    CHECK_LE(static_cast<size_t>(padded_num_tokens),
-             persistent_host_expanded_kv_seq_lens_.size())
-        << "padded_num_tokens exceeds persistent expanded host seq lens "
-           "capacity";
-    std::copy(expanded_kv_seq_lens_vec.begin(),
-              expanded_kv_seq_lens_vec.end(),
-              persistent_host_expanded_kv_seq_lens_.begin());
+  if (supports_mla_graph_kv_bucketing_) {
+    CHECK_LE(static_cast<size_t>(padded_batch_size),
+             persistent_host_kv_seq_lens_.size())
+        << "padded_batch_size exceeds persistent host seq lens capacity";
+    std::copy(padded_kv_seq_lens_vec.begin(),
+              padded_kv_seq_lens_vec.end(),
+              persistent_host_kv_seq_lens_.begin());
+    std::copy(padded_q_seq_lens_vec.begin(),
+              padded_q_seq_lens_vec.end(),
+              persistent_host_q_seq_lens_.begin());
   }
 
   if (uses_paged_attention_tiling()) {
@@ -1226,45 +1212,6 @@ std::optional<ModelInputParams> GraphPersistentParam::update(
   if (return_capture_params) {
     std::optional<ModelInputParams> graph_params =
         std::make_optional<ModelInputParams>(params);
-    std::vector<int32_t> capture_host_kv_seq_lens_vec =
-        persistent_host_kv_seq_lens_;
-    std::vector<int32_t> capture_host_q_seq_lens_vec =
-        persistent_host_q_seq_lens_;
-    const bool use_mla_capture_host_lens =
-        for_capture && is_decode && uses_deepseek_v2_mla_graph(args_);
-    if (use_mla_capture_host_lens) {
-      const int32_t capture_kv_seq_len =
-          graph_mla_capture_kv_seq_len(params, options_);
-      std::fill(capture_host_kv_seq_lens_vec.begin(),
-                capture_host_kv_seq_lens_vec.begin() + padded_batch_size,
-                capture_kv_seq_len);
-      std::fill(capture_host_q_seq_lens_vec.begin(),
-                capture_host_q_seq_lens_vec.begin() + padded_batch_size,
-                1);
-    }
-    CHECK_LE(static_cast<size_t>(padded_batch_size),
-             capture_host_kv_seq_lens_.size())
-        << "padded_batch_size exceeds capture host seq lens capacity";
-    std::copy(capture_host_kv_seq_lens_vec.begin(),
-              capture_host_kv_seq_lens_vec.begin() + padded_batch_size,
-              capture_host_kv_seq_lens_.begin());
-    std::copy(capture_host_q_seq_lens_vec.begin(),
-              capture_host_q_seq_lens_vec.begin() + padded_batch_size,
-              capture_host_q_seq_lens_.begin());
-
-    const int32_t* graph_kv_seq_lens_data =
-        use_mla_capture_host_lens ? capture_host_kv_seq_lens_data()
-                                  : persistent_host_kv_seq_lens_data();
-    const int32_t* graph_q_seq_lens_data =
-        use_mla_capture_host_lens ? capture_host_q_seq_lens_data()
-                                  : persistent_host_q_seq_lens_data();
-    const std::vector<int32_t>& graph_host_kv_seq_lens_vec =
-        use_mla_capture_host_lens ? capture_host_kv_seq_lens_vec
-                                  : persistent_host_kv_seq_lens_;
-    const std::vector<int32_t>& graph_host_q_seq_lens_vec =
-        use_mla_capture_host_lens ? capture_host_q_seq_lens_vec
-                                  : persistent_host_q_seq_lens_;
-
     // Set persistent buffers in graph_params.
     graph_params->attention.device.kv_seq_lens =
         kv_seq_lens(static_cast<uint32_t>(padded_batch_size));
@@ -1272,15 +1219,57 @@ std::optional<ModelInputParams> GraphPersistentParam::update(
         q_seq_lens(static_cast<uint32_t>(padded_batch_size));
     graph_params->meta.actual_num_sequences =
         is_empty_dp_decode_rank ? 0 : static_cast<int32_t>(actual_num_tokens);
-    graph_params->attention.host.kv_seq_lens.assign(
-        graph_host_kv_seq_lens_vec.begin(),
-        graph_host_kv_seq_lens_vec.begin() + padded_batch_size);
-    graph_params->attention.host.q_seq_lens.assign(
-        graph_host_q_seq_lens_vec.begin(),
-        graph_host_q_seq_lens_vec.begin() + padded_batch_size);
-    graph_params->attention.host.graph_kv_seq_lens_data =
-        graph_kv_seq_lens_data;
-    graph_params->attention.host.graph_q_seq_lens_data = graph_q_seq_lens_data;
+    if (supports_mla_graph_kv_bucketing_) {
+      std::vector<int32_t> capture_host_kv_seq_lens_vec =
+          persistent_host_kv_seq_lens_;
+      std::vector<int32_t> capture_host_q_seq_lens_vec =
+          persistent_host_q_seq_lens_;
+      const bool use_mla_capture_host_lens = for_capture && is_decode;
+      if (use_mla_capture_host_lens) {
+        const int32_t capture_kv_seq_len =
+            get_mla_capture_kv_seq_len_bucket(params, options_);
+        std::fill(capture_host_kv_seq_lens_vec.begin(),
+                  capture_host_kv_seq_lens_vec.begin() + padded_batch_size,
+                  capture_kv_seq_len);
+        std::fill(capture_host_q_seq_lens_vec.begin(),
+                  capture_host_q_seq_lens_vec.begin() + padded_batch_size,
+                  1);
+      }
+      CHECK_LE(static_cast<size_t>(padded_batch_size),
+               capture_host_kv_seq_lens_.size())
+          << "padded_batch_size exceeds capture host seq lens capacity";
+      std::copy(capture_host_kv_seq_lens_vec.begin(),
+                capture_host_kv_seq_lens_vec.begin() + padded_batch_size,
+                capture_host_kv_seq_lens_.begin());
+      std::copy(capture_host_q_seq_lens_vec.begin(),
+                capture_host_q_seq_lens_vec.begin() + padded_batch_size,
+                capture_host_q_seq_lens_.begin());
+      const int32_t* graph_kv_seq_lens_data =
+          use_mla_capture_host_lens ? capture_host_kv_seq_lens_data()
+                                    : persistent_host_kv_seq_lens_data();
+      const int32_t* graph_q_seq_lens_data =
+          use_mla_capture_host_lens ? capture_host_q_seq_lens_data()
+                                    : persistent_host_q_seq_lens_data();
+      const std::vector<int32_t>& graph_host_kv_seq_lens_vec =
+          use_mla_capture_host_lens ? capture_host_kv_seq_lens_vec
+                                    : persistent_host_kv_seq_lens_;
+      const std::vector<int32_t>& graph_host_q_seq_lens_vec =
+          use_mla_capture_host_lens ? capture_host_q_seq_lens_vec
+                                    : persistent_host_q_seq_lens_;
+      graph_params->attention.host.kv_seq_lens.assign(
+          graph_host_kv_seq_lens_vec.begin(),
+          graph_host_kv_seq_lens_vec.begin() + padded_batch_size);
+      graph_params->attention.host.q_seq_lens.assign(
+          graph_host_q_seq_lens_vec.begin(),
+          graph_host_q_seq_lens_vec.begin() + padded_batch_size);
+      graph_params->attention.host.graph_kv_seq_lens_data =
+          graph_kv_seq_lens_data;
+      graph_params->attention.host.graph_q_seq_lens_data =
+          graph_q_seq_lens_data;
+    } else {
+      graph_params->attention.host.kv_seq_lens = padded_kv_seq_lens_vec;
+      graph_params->attention.host.q_seq_lens = padded_q_seq_lens_vec;
+    }
     graph_params->meta.num_sequences = static_cast<int32_t>(padded_batch_size);
     graph_params->meta.batch_forward_type = params.meta.batch_forward_type;
     graph_params->enable_graph = true;
@@ -1329,11 +1318,9 @@ std::optional<ModelInputParams> GraphPersistentParam::update(
           static_cast<uint32_t>(padded_batch_size));
     }
     if (use_expanded_spec_decode_attention) {
-      graph_params->graph.use_expanded_decode_for_spec_verify_attention =
-          true;
-      graph_params->graph.expanded_kv_seq_lens =
-          expanded_kv_seq_lens_.slice(
-              /*dim=*/0, /*start=*/0, /*end=*/padded_num_tokens);
+      graph_params->graph.use_expanded_decode_for_spec_verify_attention = true;
+      graph_params->graph.expanded_kv_seq_lens = expanded_kv_seq_lens_.slice(
+          /*dim=*/0, /*start=*/0, /*end=*/padded_num_tokens);
       graph_params->graph.expanded_block_tables =
           expanded_block_tables_for_graph();
       graph_params->graph.expanded_tiling_data =
@@ -1354,9 +1341,8 @@ std::optional<ModelInputParams> GraphPersistentParam::update(
     // dp ep and cp ep are mutually exclusive; when neither is enabled the
     // src fields are all undefined and we leave dst untouched so that the
     // captured graph behaves identically to eager mode.
-    replace_capture_dp_ep_padding(
-        params.parallel.dp_ep_padding_data,
-        graph_params->parallel.dp_ep_padding_data);
+    replace_capture_dp_ep_padding(params.parallel.dp_ep_padding_data,
+                                  graph_params->parallel.dp_ep_padding_data);
     CpEpMeta capture_cp_ep_meta = params.parallel.cp_plan.cp_ep_meta();
     replace_capture_cp_ep_meta(params.parallel.cp_plan.cp_ep_meta(),
                                capture_cp_ep_meta);

--- a/xllm/core/runtime/acl_graph_persistent_param.cpp
+++ b/xllm/core/runtime/acl_graph_persistent_param.cpp
@@ -157,6 +157,37 @@ int64_t get_spec_verify_width(const ModelInputParams& params) {
   return spec_width;
 }
 
+bool uses_deepseek_v2_mla_graph(const ModelArgs& args) {
+  return args.enable_mla() &&
+         util::is_deepseek_v2_family_model_type(args.model_type());
+}
+
+constexpr int32_t kMlaGraphKvLenBucket = 2048;
+
+int32_t round_up_positive(int32_t value, int32_t bucket) {
+  const int32_t safe_value = std::max<int32_t>(value, 1);
+  return ((safe_value + bucket - 1) / bucket) * bucket;
+}
+
+int32_t graph_mla_capture_kv_seq_len(const ModelInputParams& params,
+                                     const runtime::Options& options) {
+  const int32_t block_size = std::max<int32_t>(options.block_size(), 1);
+  int32_t capture_kv_len =
+      std::max<int32_t>(params.meta.kv_max_seq_len, block_size);
+  if (!params.parallel.dp_global_kv_max_seq_lens.empty()) {
+    capture_kv_len = std::max<int32_t>(
+        capture_kv_len, util::max(params.parallel.dp_global_kv_max_seq_lens));
+    return round_up_positive(capture_kv_len, kMlaGraphKvLenBucket);
+  }
+  const auto& block_tables = params.attention.device.block_tables;
+  if (block_tables.defined() && block_tables.dim() >= 2 &&
+      block_tables.size(1) > 0) {
+    capture_kv_len = std::max<int32_t>(
+        capture_kv_len,
+        static_cast<int32_t>(block_tables.size(1)) * block_size);
+  }
+  return round_up_positive(capture_kv_len, kMlaGraphKvLenBucket);
+}
 }  // namespace
 
 // GraphPersistentParam implementation
@@ -175,9 +206,10 @@ GraphPersistentParam::GraphPersistentParam(const ModelArgs& args,
       is_hybrid_linear_attention_(is_hybrid_linear_attention) {
   // Determine whether attention plan needs to be updated based on model type
   // Future logic can be extended here for more complex model-specific behavior
-  need_update_attention_plan_ = (args.model_type() != "deepseek_v32" &&
-                                 args.model_type() != "deepseek_v4" &&
-                                 args.model_type() != "glm_moe_dsa");
+  need_update_attention_plan_ =
+      (args.model_type() != "deepseek_v32" &&
+       args.model_type() != "deepseek_v4" &&
+       args.model_type() != "glm_moe_dsa" && !uses_deepseek_v2_mla_graph(args));
 
   // Check if mRoPE is used (for VLM models like qwen2-vl)
   use_mrope_ = !args.rope_scaling_mrope_section().empty();
@@ -225,6 +257,14 @@ GraphPersistentParam::GraphPersistentParam(const ModelArgs& args,
                                      torch::dtype(torch::kInt).device(device));
   expanded_kv_seq_lens_ = torch::zeros(
       {max_tokens_per_batch}, torch::dtype(torch::kInt).device(device));
+  persistent_host_q_seq_lens_.assign(static_cast<size_t>(max_seqs_per_batch),
+                                     1);
+  persistent_host_kv_seq_lens_.assign(static_cast<size_t>(max_seqs_per_batch),
+                                      1);
+  persistent_host_expanded_kv_seq_lens_.assign(
+      static_cast<size_t>(max_tokens_per_batch), 1);
+  capture_host_q_seq_lens_.assign(static_cast<size_t>(max_seqs_per_batch), 1);
+  capture_host_kv_seq_lens_.assign(static_cast<size_t>(max_seqs_per_batch), 1);
 
   // Block table tensors with maximum possible size
   const int64_t block_size = options.block_size();
@@ -755,7 +795,8 @@ std::optional<ModelInputParams> GraphPersistentParam::update(
     const ModelInputParams& params,
     uint32_t padded_num_tokens,
     bool return_capture_params,
-    bool skip_token_update) {
+    bool skip_token_update,
+    bool for_capture) {
   CHECK_GT(padded_num_tokens, 0) << "padded_num_tokens must be > 0";
   const uint32_t actual_num_tokens = tokens.size(0);
   const bool is_decode = params.meta.batch_forward_type.is_decode();
@@ -1108,6 +1149,24 @@ std::optional<ModelInputParams> GraphPersistentParam::update(
     // width used by main instead of binding a request-dependent view.
     return block_tables;
   };
+  CHECK_LE(static_cast<size_t>(padded_batch_size),
+           persistent_host_kv_seq_lens_.size())
+      << "padded_batch_size exceeds persistent host seq lens capacity";
+  std::copy(padded_kv_seq_lens_vec.begin(),
+            padded_kv_seq_lens_vec.end(),
+            persistent_host_kv_seq_lens_.begin());
+  std::copy(padded_q_seq_lens_vec.begin(),
+            padded_q_seq_lens_vec.end(),
+            persistent_host_q_seq_lens_.begin());
+  if (use_expanded_spec_decode_attention) {
+    CHECK_LE(static_cast<size_t>(padded_num_tokens),
+             persistent_host_expanded_kv_seq_lens_.size())
+        << "padded_num_tokens exceeds persistent expanded host seq lens "
+           "capacity";
+    std::copy(expanded_kv_seq_lens_vec.begin(),
+              expanded_kv_seq_lens_vec.end(),
+              persistent_host_expanded_kv_seq_lens_.begin());
+  }
 
   if (uses_paged_attention_tiling()) {
     aclrtStream stream = c10_npu::getCurrentNPUStream().stream();
@@ -1160,84 +1219,130 @@ std::optional<ModelInputParams> GraphPersistentParam::update(
   update_persistent_cp_ep_meta(params.parallel.cp_plan.cp_ep_meta(),
                                padded_num_tokens);
 
-  // Return ModelInputParams with persistent buffer references if requested
+  // Return ModelInputParams with persistent buffer references if requested.
+  // Capture uses bucketed DeepSeekV2-family MLA host lengths to size ATB
+  // tiling/workspace. Replay uses the same stable hostData addresses, but
+  // refreshes them with the actual per-step lengths above before graph replay.
   if (return_capture_params) {
-    std::optional<ModelInputParams> params_for_capture =
+    std::optional<ModelInputParams> graph_params =
         std::make_optional<ModelInputParams>(params);
-    // Set persistent buffers in params_for_capture
-    params_for_capture->attention.device.kv_seq_lens =
+    std::vector<int32_t> capture_host_kv_seq_lens_vec =
+        persistent_host_kv_seq_lens_;
+    std::vector<int32_t> capture_host_q_seq_lens_vec =
+        persistent_host_q_seq_lens_;
+    const bool use_mla_capture_host_lens =
+        for_capture && is_decode && uses_deepseek_v2_mla_graph(args_);
+    if (use_mla_capture_host_lens) {
+      const int32_t capture_kv_seq_len =
+          graph_mla_capture_kv_seq_len(params, options_);
+      std::fill(capture_host_kv_seq_lens_vec.begin(),
+                capture_host_kv_seq_lens_vec.begin() + padded_batch_size,
+                capture_kv_seq_len);
+      std::fill(capture_host_q_seq_lens_vec.begin(),
+                capture_host_q_seq_lens_vec.begin() + padded_batch_size,
+                1);
+    }
+    CHECK_LE(static_cast<size_t>(padded_batch_size),
+             capture_host_kv_seq_lens_.size())
+        << "padded_batch_size exceeds capture host seq lens capacity";
+    std::copy(capture_host_kv_seq_lens_vec.begin(),
+              capture_host_kv_seq_lens_vec.begin() + padded_batch_size,
+              capture_host_kv_seq_lens_.begin());
+    std::copy(capture_host_q_seq_lens_vec.begin(),
+              capture_host_q_seq_lens_vec.begin() + padded_batch_size,
+              capture_host_q_seq_lens_.begin());
+
+    const int32_t* graph_kv_seq_lens_data =
+        use_mla_capture_host_lens ? capture_host_kv_seq_lens_data()
+                                  : persistent_host_kv_seq_lens_data();
+    const int32_t* graph_q_seq_lens_data =
+        use_mla_capture_host_lens ? capture_host_q_seq_lens_data()
+                                  : persistent_host_q_seq_lens_data();
+    const std::vector<int32_t>& graph_host_kv_seq_lens_vec =
+        use_mla_capture_host_lens ? capture_host_kv_seq_lens_vec
+                                  : persistent_host_kv_seq_lens_;
+    const std::vector<int32_t>& graph_host_q_seq_lens_vec =
+        use_mla_capture_host_lens ? capture_host_q_seq_lens_vec
+                                  : persistent_host_q_seq_lens_;
+
+    // Set persistent buffers in graph_params.
+    graph_params->attention.device.kv_seq_lens =
         kv_seq_lens(static_cast<uint32_t>(padded_batch_size));
-    params_for_capture->attention.device.q_seq_lens =
+    graph_params->attention.device.q_seq_lens =
         q_seq_lens(static_cast<uint32_t>(padded_batch_size));
-    params_for_capture->meta.actual_num_sequences =
+    graph_params->meta.actual_num_sequences =
         is_empty_dp_decode_rank ? 0 : static_cast<int32_t>(actual_num_tokens);
-    params_for_capture->attention.host.kv_seq_lens = padded_kv_seq_lens_vec;
-    params_for_capture->attention.host.q_seq_lens = padded_q_seq_lens_vec;
-    params_for_capture->meta.num_sequences =
-        static_cast<int32_t>(padded_batch_size);
-    params_for_capture->meta.batch_forward_type =
-        params.meta.batch_forward_type;
-    params_for_capture->enable_graph = true;
-    if (params_for_capture->parallel.dp_global_token_nums.size() > 1) {
-      params_for_capture->parallel.dp_global_token_nums = std::vector<int32_t>(
-          params_for_capture->parallel.dp_global_token_nums.size(),
+    graph_params->attention.host.kv_seq_lens.assign(
+        graph_host_kv_seq_lens_vec.begin(),
+        graph_host_kv_seq_lens_vec.begin() + padded_batch_size);
+    graph_params->attention.host.q_seq_lens.assign(
+        graph_host_q_seq_lens_vec.begin(),
+        graph_host_q_seq_lens_vec.begin() + padded_batch_size);
+    graph_params->attention.host.graph_kv_seq_lens_data =
+        graph_kv_seq_lens_data;
+    graph_params->attention.host.graph_q_seq_lens_data = graph_q_seq_lens_data;
+    graph_params->meta.num_sequences = static_cast<int32_t>(padded_batch_size);
+    graph_params->meta.batch_forward_type = params.meta.batch_forward_type;
+    graph_params->enable_graph = true;
+    if (graph_params->parallel.dp_global_token_nums.size() > 1) {
+      graph_params->parallel.dp_global_token_nums = std::vector<int32_t>(
+          graph_params->parallel.dp_global_token_nums.size(),
           static_cast<int32_t>(padded_num_tokens));
     }
-    params_for_capture->attention.device.new_cache_slots =
+    graph_params->attention.device.new_cache_slots =
         persistent_new_cache_slots(padded_num_tokens);
-    params_for_capture->attention.device.block_tables =
+    graph_params->attention.device.block_tables =
         persistent_block_tables(static_cast<uint32_t>(padded_batch_size));
     if (!params.embedding.linear_state_ids.empty()) {
-      params_for_capture->embedding.linear_state_ids =
+      graph_params->embedding.linear_state_ids =
           params.embedding.linear_state_ids;
-      params_for_capture->embedding.linear_state_ids.resize(
+      graph_params->embedding.linear_state_ids.resize(
           static_cast<size_t>(padded_batch_size), kPaddingLinearStateId);
-      params_for_capture->embedding.linear_state_indices =
+      graph_params->embedding.linear_state_indices =
           persistent_linear_state_indices(
               static_cast<uint32_t>(padded_batch_size));
-      params_for_capture->parallel.has_initial_state =
+      graph_params->parallel.has_initial_state =
           params.parallel.has_initial_state;
-      params_for_capture->parallel.has_initial_state.resize(
+      graph_params->parallel.has_initial_state.resize(
           static_cast<size_t>(padded_batch_size), 0);
     }
 
     // Keep the capture contract aligned with replay: the expanded decoder does
     // not consume graph.attn_mask, so do not capture a stale persistent mask.
     if (need_update_attn_mask_ && !skip_unused_expanded_verify_mask) {
-      params_for_capture->graph.attn_mask = persistent_mask(padded_num_tokens);
+      graph_params->graph.attn_mask = persistent_mask(padded_num_tokens);
     } else if (skip_unused_expanded_verify_mask) {
-      params_for_capture->graph.attn_mask = torch::Tensor();
+      graph_params->graph.attn_mask = torch::Tensor();
     }
     if (uses_paged_attention_tiling()) {
-      params_for_capture->graph.tiling_data = tiling_data();
+      graph_params->graph.tiling_data = tiling_data();
     } else {
-      params_for_capture->graph.tiling_data = torch::Tensor();
+      graph_params->graph.tiling_data = torch::Tensor();
     }
     // Set persistent embedding if available
     if (params.embedding.input_embedding.defined()) {
-      params_for_capture->embedding.input_embedding =
+      graph_params->embedding.input_embedding =
           persistent_embedding(padded_num_tokens);
     }
     if (params.num_accepted_tokens.defined()) {
-      params_for_capture->num_accepted_tokens = persistent_num_accepted_tokens(
+      graph_params->num_accepted_tokens = persistent_num_accepted_tokens(
           static_cast<uint32_t>(padded_batch_size));
     }
     if (use_expanded_spec_decode_attention) {
-      params_for_capture->graph.use_expanded_decode_for_spec_verify_attention =
+      graph_params->graph.use_expanded_decode_for_spec_verify_attention =
           true;
-      params_for_capture->graph.expanded_kv_seq_lens =
+      graph_params->graph.expanded_kv_seq_lens =
           expanded_kv_seq_lens_.slice(
               /*dim=*/0, /*start=*/0, /*end=*/padded_num_tokens);
-      params_for_capture->graph.expanded_block_tables =
+      graph_params->graph.expanded_block_tables =
           expanded_block_tables_for_graph();
-      params_for_capture->graph.expanded_tiling_data =
+      graph_params->graph.expanded_tiling_data =
           uses_paged_attention_tiling() ? tiling_data() : torch::Tensor();
-      params_for_capture->graph.expanded_kv_seq_lens_vec =
-          expanded_kv_seq_lens_vec;
+      graph_params->graph.expanded_kv_seq_lens_vec = expanded_kv_seq_lens_vec;
     }
     if (params.attention.device.q_cu_seq_lens.defined()) {
       const bool use_hybrid_query_start_loc = is_hybrid_linear_attention_;
-      params_for_capture->attention.device.q_cu_seq_lens = q_cu_seq_lens_.slice(
+      graph_params->attention.device.q_cu_seq_lens = q_cu_seq_lens_.slice(
           /*dim=*/0,
           /*start=*/0,
           /*end=*/padded_batch_size + (use_hybrid_query_start_loc ? 1 : 0));
@@ -1251,14 +1356,14 @@ std::optional<ModelInputParams> GraphPersistentParam::update(
     // captured graph behaves identically to eager mode.
     replace_capture_dp_ep_padding(
         params.parallel.dp_ep_padding_data,
-        params_for_capture->parallel.dp_ep_padding_data);
+        graph_params->parallel.dp_ep_padding_data);
     CpEpMeta capture_cp_ep_meta = params.parallel.cp_plan.cp_ep_meta();
     replace_capture_cp_ep_meta(params.parallel.cp_plan.cp_ep_meta(),
                                capture_cp_ep_meta);
-    params_for_capture->parallel.cp_plan.replace_cp_ep_meta_storage(
+    graph_params->parallel.cp_plan.replace_cp_ep_meta_storage(
         std::move(capture_cp_ep_meta));
 
-    auto& qsl = params_for_capture->parallel.query_start_loc;
+    auto& qsl = graph_params->parallel.query_start_loc;
     qsl.clear();
     qsl.reserve(static_cast<size_t>(padded_batch_size) + 1);
     qsl.emplace_back(0);
@@ -1268,7 +1373,7 @@ std::optional<ModelInputParams> GraphPersistentParam::update(
     }
 
     if (!params.parallel.has_initial_state.empty()) {
-      auto& his = params_for_capture->parallel.has_initial_state;
+      auto& his = graph_params->parallel.has_initial_state;
       his = params.parallel.has_initial_state;
       if (his.size() > static_cast<size_t>(actual_batch_size)) {
         his.resize(static_cast<size_t>(actual_batch_size));
@@ -1281,7 +1386,7 @@ std::optional<ModelInputParams> GraphPersistentParam::update(
       if (!params.num_accepted_tokens_host.empty()) {
         const int64_t copy_size = std::min<int64_t>(
             actual_batch_size, params.num_accepted_tokens_host.size());
-        params_for_capture->num_accepted_tokens_host.assign(
+        graph_params->num_accepted_tokens_host.assign(
             params.num_accepted_tokens_host.begin(),
             params.num_accepted_tokens_host.begin() + copy_size);
       } else {
@@ -1291,14 +1396,13 @@ std::optional<ModelInputParams> GraphPersistentParam::update(
         const int64_t copy_size =
             std::min<int64_t>(actual_batch_size, nat_host.numel());
         const int64_t* data = nat_host.data_ptr<int64_t>();
-        params_for_capture->num_accepted_tokens_host.assign(data,
-                                                            data + copy_size);
+        graph_params->num_accepted_tokens_host.assign(data, data + copy_size);
       }
-      params_for_capture->num_accepted_tokens_host.resize(
+      graph_params->num_accepted_tokens_host.resize(
           static_cast<size_t>(padded_batch_size), 1);
     }
 
-    return params_for_capture;
+    return graph_params;
   }
   return std::nullopt;
 }

--- a/xllm/core/runtime/acl_graph_persistent_param.h
+++ b/xllm/core/runtime/acl_graph_persistent_param.h
@@ -69,11 +69,11 @@ class GraphPersistentParam final {
   ~GraphPersistentParam();
 
   // Update persistent tensors with new input data
-  // If return_capture_params is true, returns a ModelInputParams with
-  // persistent buffer references. padded_num_tokens must be > 0 when
-  // return_capture_params is true, used for build new ModelInputParams for
-  // capture. If return_capture_params is false, only updates persistent buffers
-  // and returns std::nullopt.
+  // If return_capture_params is true, returns persistent graph inputs.
+  // buffer references. During capture, pass for_capture=true so model-specific
+  // host parameters can be bucketed for graph tiling/workspace. During replay,
+  // return_capture_params may still be true for metadata refresh, but
+  // for_capture must stay false so dynamic host metadata uses actual lengths.
   std::optional<ModelInputParams> update(const torch::Tensor& tokens,
                                          const torch::Tensor& k_cache,
                                          const torch::Tensor& v_cache,
@@ -81,7 +81,8 @@ class GraphPersistentParam final {
                                          const ModelInputParams& params,
                                          uint32_t padded_num_tokens,
                                          bool return_capture_params = false,
-                                         bool skip_token_update = false);
+                                         bool skip_token_update = false,
+                                         bool for_capture = false);
 
   void update_tokens(const torch::Tensor& tokens,
                      const ModelInputParams& params,
@@ -171,6 +172,18 @@ class GraphPersistentParam final {
           /*dim=*/0, /*start=*/0, /*end=*/actual_batch_size);
     }
     return kv_seq_lens_;
+  }
+  const int32_t* persistent_host_q_seq_lens_data() const {
+    return persistent_host_q_seq_lens_.data();
+  }
+  const int32_t* persistent_host_kv_seq_lens_data() const {
+    return persistent_host_kv_seq_lens_.data();
+  }
+  const int32_t* capture_host_q_seq_lens_data() const {
+    return capture_host_q_seq_lens_.data();
+  }
+  const int32_t* capture_host_kv_seq_lens_data() const {
+    return capture_host_kv_seq_lens_.data();
   }
   bool need_update_attn_mask() const { return need_update_attn_mask_; }
   void set_need_update_attn_mask(bool value) { need_update_attn_mask_ = value; }
@@ -264,6 +277,11 @@ class GraphPersistentParam final {
   torch::Tensor q_seq_lens_default_;
   torch::Tensor kv_seq_lens_default_;
   torch::Tensor expanded_kv_seq_lens_;
+  std::vector<int32_t> persistent_host_q_seq_lens_;
+  std::vector<int32_t> persistent_host_kv_seq_lens_;
+  std::vector<int32_t> persistent_host_expanded_kv_seq_lens_;
+  std::vector<int32_t> capture_host_q_seq_lens_;
+  std::vector<int32_t> capture_host_kv_seq_lens_;
 
   // for deepseekv3.2
   torch::Tensor q_cu_seq_lens_;

--- a/xllm/core/runtime/acl_graph_persistent_param.h
+++ b/xllm/core/runtime/acl_graph_persistent_param.h
@@ -39,6 +39,9 @@ struct TilingBufferInfo;
 
 namespace xllm::npu {
 
+int32_t get_mla_capture_kv_seq_len_bucket(const ModelInputParams& params,
+                                          const runtime::Options& options);
+
 struct PagedAttentionPlanDescriptor {
   std::vector<uint32_t> normalized_tiling;
   uint64_t workspace_size = 0;
@@ -64,7 +67,8 @@ class GraphPersistentParam final {
                        const torch::Device& device,
                        const runtime::Options& options,
                        bool need_update_attn_mask = false,
-                       bool is_hybrid_linear_attention = false);
+                       bool is_hybrid_linear_attention = false,
+                       bool supports_mla_graph_kv_bucketing = false);
 
   ~GraphPersistentParam();
 
@@ -279,7 +283,6 @@ class GraphPersistentParam final {
   torch::Tensor expanded_kv_seq_lens_;
   std::vector<int32_t> persistent_host_q_seq_lens_;
   std::vector<int32_t> persistent_host_kv_seq_lens_;
-  std::vector<int32_t> persistent_host_expanded_kv_seq_lens_;
   std::vector<int32_t> capture_host_q_seq_lens_;
   std::vector<int32_t> capture_host_kv_seq_lens_;
 
@@ -318,6 +321,8 @@ class GraphPersistentParam final {
   // Flag indicating whether the model uses hybrid linear attention
   // (e.g., Qwen3.5/Next with gated delta net layers)
   bool is_hybrid_linear_attention_;
+  // Flag indicating whether MLA graph capture uses KV length bucketing.
+  bool supports_mla_graph_kv_bucketing_;
   // Flag indicating whether attention plan needs to be updated based on model
   // type
   bool need_update_attention_plan_;

--- a/xllm/core/runtime/forward_shared_memory_manager.cpp
+++ b/xllm/core/runtime/forward_shared_memory_manager.cpp
@@ -2372,6 +2372,7 @@ inline void deserialize_forward_input_payload(
   read_tensor(context, input_params.embedding.input_embedding, stream);
   read_vector(context, input_params.parallel.dp_global_token_nums);
   read_vector(context, input_params.parallel.raw_dp_global_token_nums);
+  read_vector(context, input_params.parallel.dp_global_kv_max_seq_lens);
   read_vector(context, input_params.parallel.dp_is_decode);
   read_vector(context, input_params.embedding.embedding_ids);
   read_vector(context, input_params.embedding.linear_state_ids);
@@ -2735,6 +2736,8 @@ inline void serialize_forward_input_sections(
   write_vector(context.descriptor, input_params.parallel.dp_global_token_nums);
   write_vector(context.descriptor,
                input_params.parallel.raw_dp_global_token_nums);
+  write_vector(context.descriptor,
+               input_params.parallel.dp_global_kv_max_seq_lens);
   write_vector(context.descriptor, input_params.parallel.dp_is_decode);
   write_vector(context.descriptor, input_params.embedding.embedding_ids);
   write_vector(context.descriptor, input_params.embedding.linear_state_ids);

--- a/xllm/core/scheduler/profile/profile_manager.cpp
+++ b/xllm/core/scheduler/profile/profile_manager.cpp
@@ -42,62 +42,6 @@ limitations under the License.
 #include "util/utils.h"
 
 namespace xllm {
-namespace {
-
-constexpr int32_t kMlaGraphKvLenBucket = 2048;
-
-bool uses_deepseek_v2_mla_graph(const ModelArgs& args) {
-  return args.enable_mla() &&
-         util::is_deepseek_v2_family_model_type(args.model_type());
-}
-
-struct MlaGraphWarmupShape {
-  int32_t decode_seq_len = 0;
-  int32_t target_kv_bucket = 0;
-  int32_t effective_max_decode_seqs = 0;
-  int64_t per_seq_kv_budget = 0;
-};
-
-int32_t effective_graph_decode_max_batch_size(
-    const ProfileManager::Options& options) {
-  const int64_t max_seqs_per_batch =
-      std::max<int64_t>(options.max_seqs_per_batch(), 1);
-  const int64_t dp_size = std::max<int64_t>(options.dp_size(), 1);
-  const int64_t graph_decode_limit_per_dp =
-      std::max<int64_t>(::xllm::ExecutionConfig::get_instance()
-                            .acl_graph_decode_batch_size_limit(),
-                        1);
-  const int64_t graph_decode_limit = graph_decode_limit_per_dp * dp_size;
-  return static_cast<int32_t>(
-      std::min<int64_t>(max_seqs_per_batch, graph_decode_limit));
-}
-
-MlaGraphWarmupShape get_mla_graph_warmup_shape(
-    const ProfileManager::Options& options,
-    int32_t max_context_len,
-    int32_t block_size,
-    int32_t schedule_overlap_slack) {
-  const int32_t effective_max_decode_seqs =
-      effective_graph_decode_max_batch_size(options);
-  const int64_t max_tokens_per_batch =
-      std::max<int64_t>(options.max_tokens_per_batch(), 1);
-  const int64_t per_seq_kv_budget = std::min<int64_t>(
-      util::ceil_div(max_tokens_per_batch,
-                     static_cast<int64_t>(effective_max_decode_seqs)),
-      std::max<int32_t>(max_context_len, 1));
-  const int32_t target_kv_bucket = static_cast<int32_t>(util::align_up(
-      per_seq_kv_budget, static_cast<int64_t>(kMlaGraphKvLenBucket)));
-  const int32_t decode_seq_len = std::min(
-      std::max(2, target_kv_bucket - block_size - schedule_overlap_slack),
-      max_context_len);
-
-  return MlaGraphWarmupShape{decode_seq_len,
-                             target_kv_bucket,
-                             effective_max_decode_seqs,
-                             per_seq_kv_budget};
-}
-
-}  // namespace
 
 ProfileManager::ProfileManager(Engine* engine, const Options& options)
     : options_(options), engine_(engine) {
@@ -640,8 +584,7 @@ double ProfileManager::predict_copy_blocks_time(
 
 std::shared_ptr<Request> ProfileManager::generate_single_request(
     int32_t token_length,
-    int32_t prefix_length,
-    std::optional<int32_t> dp_rank) {
+    int32_t prefix_length) {
   auto& model_args = engine_->model_args();
   int32_t vocab_size = model_args.vocab_size();
   int32_t eos_token_id = model_args.eos_token_id();
@@ -667,25 +610,18 @@ std::shared_ptr<Request> ProfileManager::generate_single_request(
       /*x_request_time=*/"",
       req_state);
 
-  auto* sequence = request->sequences()[0].get();
-  if (dp_rank.has_value()) {
-    CHECK_GE(dp_rank.value(), 0);
-    CHECK_LT(dp_rank.value(), options_.dp_size());
-    sequence->set_dp_rank(dp_rank.value());
-  }
-
   // TODO: better disable prefix cache
   if (prefix_length > 0) {
-    if (!block_manager_pool_->BlockManagerPool::allocate(sequence,
-                                                         prefix_length)) {
+    if (!block_manager_pool_->BlockManagerPool::allocate(
+            request->sequences()[0].get(), prefix_length)) {
       LOG(FATAL) << "Profiling time failed! Not enough blocks, prefix length : "
                  << prefix_length;
     }
-    sequence->kv_state().incr_kv_cache_tokens_num(prefix_length);
+    request->sequences()[0]->kv_state().incr_kv_cache_tokens_num(prefix_length);
   }
 
-  if (!block_manager_pool_->BlockManagerPool::allocate(sequence,
-                                                       token_length)) {
+  if (!block_manager_pool_->BlockManagerPool::allocate(
+          request->sequences()[0].get(), token_length)) {
     LOG(FATAL) << "Profiling time failed! Not enough blocks, token length : "
                << token_length;
   }
@@ -895,48 +831,6 @@ double ProfileManager::run_decode_request(
   return latency;
 }
 
-double ProfileManager::run_graph_prefill_request(int32_t token_length) {
-  CHECK_GT(options_.dp_size(), 0);
-  CHECK_GE(token_length, options_.dp_size())
-      << "Graph prefill warmup requires at least one token per DP rank.";
-
-  std::vector<Sequence*> sequences;
-  std::vector<size_t> sequences_budget;
-  std::vector<std::shared_ptr<Request>> requests;
-  sequences.reserve(static_cast<size_t>(options_.dp_size()));
-  sequences_budget.reserve(static_cast<size_t>(options_.dp_size()));
-  requests.reserve(static_cast<size_t>(options_.dp_size()));
-
-  const int32_t base_tokens = token_length / options_.dp_size();
-  const int32_t remaining_tokens = token_length % options_.dp_size();
-  for (int32_t dp_rank = 0; dp_rank < options_.dp_size(); ++dp_rank) {
-    const int32_t dp_tokens =
-        base_tokens + (dp_rank < remaining_tokens ? 1 : 0);
-    std::shared_ptr<Request> request =
-        generate_single_request(dp_tokens, /*prefix_length=*/0, dp_rank);
-    requests.emplace_back(request);
-    sequences.emplace_back(request->sequences()[0].get());
-    sequences_budget.emplace_back(static_cast<size_t>(dp_tokens));
-  }
-
-  auto batches =
-      BatchFactory::get_instance(options_.dp_size())
-          ->create_batches(requests, sequences, sequences_budget, nullptr);
-
-  absl::Time start_time = absl::Now();
-  engine_->step(batches);
-  if (options_.enable_schedule_overlap()) {
-    engine_->update_last_step_result(batches);
-  }
-  double latency = absl::ToDoubleMilliseconds(absl::Now() - start_time);
-  for (auto& request : requests) {
-    block_manager_pool_->deallocate_without_cache(
-        request->sequences()[0].get());
-  }
-
-  return latency;
-}
-
 double ProfileManager::run_graph_decode_request(
     const std::vector<int32_t>& total_length_vec) {
   CHECK_GT(options_.dp_size(), 0);
@@ -1056,47 +950,9 @@ void ProfileManager::warmup_prefill_for_graph() {
 
   int32_t prefill_tokens =
       std::min(options_.max_tokens_per_batch(), max_context_len);
-  int32_t max_seqs_per_batch = options_.max_seqs_per_batch();
-  int32_t decode_seq_len = std::min(16, max_context_len);
-  MlaGraphWarmupShape mla_graph_warmup_shape;
-  if (uses_deepseek_v2_mla_graph(model_args)) {
-    const int32_t block_size =
-        std::max<int32_t>(block_manager_pool_->options().block_size(), 1);
-    const int32_t schedule_overlap_slack =
-        options_.enable_schedule_overlap()
-            ? (::xllm::SpeculativeConfig::get_instance()
-                   .num_speculative_tokens() +
-               1)
-            : 0;
-    mla_graph_warmup_shape = get_mla_graph_warmup_shape(
-        options_, max_context_len, block_size, schedule_overlap_slack);
-    decode_seq_len = mla_graph_warmup_shape.decode_seq_len;
-    max_seqs_per_batch = std::min(
-        max_seqs_per_batch, mla_graph_warmup_shape.effective_max_decode_seqs);
-    LOG(INFO) << "MLA graph warmup shape: max_tokens_per_batch="
-              << options_.max_tokens_per_batch()
-              << ", max_seqs_per_batch=" << options_.max_seqs_per_batch()
-              << ", effective_max_decode_seqs="
-              << mla_graph_warmup_shape.effective_max_decode_seqs
-              << ", per_seq_kv_budget="
-              << mla_graph_warmup_shape.per_seq_kv_budget
-              << ", target_kv_bucket="
-              << mla_graph_warmup_shape.target_kv_bucket
-              << ", block_size=" << block_size
-              << ", schedule_overlap_slack=" << schedule_overlap_slack
-              << ", decode_seq_len=" << decode_seq_len;
-  }
-
-  if (options_.dp_size() > 1) {
-    prefill_tokens = std::max(prefill_tokens, options_.dp_size());
-  }
-  double prefill_latency = options_.dp_size() > 1
-                               ? run_graph_prefill_request(prefill_tokens)
-                               : run_request(prefill_tokens,
-                                             /*prefix_length=*/0,
-                                             /*batch_size=*/1);
+  double prefill_latency =
+      run_request(prefill_tokens, /*prefix_length=*/0, /*batch_size=*/1);
   LOG(INFO) << "Prefill warmup completed: tokens=" << prefill_tokens
-            << ", dp_size=" << options_.dp_size()
             << ", latency=" << prefill_latency << " ms";
 }
 
@@ -1123,7 +979,6 @@ void ProfileManager::warmup_decode_for_graph() {
       static_cast<int32_t>(decode_batch_sizes.size());
 
   LOG(INFO) << "Graph warmup started: bucket_count=" << decode_bucket_count
-            << ", max_seqs_per_batch=" << max_seqs_per_batch
             << ", decode_seq_len=" << decode_seq_len;
 
   // Capture from the largest bucket down to the smallest so every smaller

--- a/xllm/core/scheduler/profile/profile_manager.cpp
+++ b/xllm/core/scheduler/profile/profile_manager.cpp
@@ -42,6 +42,62 @@ limitations under the License.
 #include "util/utils.h"
 
 namespace xllm {
+namespace {
+
+constexpr int32_t kMlaGraphKvLenBucket = 2048;
+
+bool uses_deepseek_v2_mla_graph(const ModelArgs& args) {
+  return args.enable_mla() &&
+         util::is_deepseek_v2_family_model_type(args.model_type());
+}
+
+struct MlaGraphWarmupShape {
+  int32_t decode_seq_len = 0;
+  int32_t target_kv_bucket = 0;
+  int32_t effective_max_decode_seqs = 0;
+  int64_t per_seq_kv_budget = 0;
+};
+
+int32_t effective_graph_decode_max_batch_size(
+    const ProfileManager::Options& options) {
+  const int64_t max_seqs_per_batch =
+      std::max<int64_t>(options.max_seqs_per_batch(), 1);
+  const int64_t dp_size = std::max<int64_t>(options.dp_size(), 1);
+  const int64_t graph_decode_limit_per_dp =
+      std::max<int64_t>(::xllm::ExecutionConfig::get_instance()
+                            .acl_graph_decode_batch_size_limit(),
+                        1);
+  const int64_t graph_decode_limit = graph_decode_limit_per_dp * dp_size;
+  return static_cast<int32_t>(
+      std::min<int64_t>(max_seqs_per_batch, graph_decode_limit));
+}
+
+MlaGraphWarmupShape get_mla_graph_warmup_shape(
+    const ProfileManager::Options& options,
+    int32_t max_context_len,
+    int32_t block_size,
+    int32_t schedule_overlap_slack) {
+  const int32_t effective_max_decode_seqs =
+      effective_graph_decode_max_batch_size(options);
+  const int64_t max_tokens_per_batch =
+      std::max<int64_t>(options.max_tokens_per_batch(), 1);
+  const int64_t per_seq_kv_budget = std::min<int64_t>(
+      util::ceil_div(max_tokens_per_batch,
+                     static_cast<int64_t>(effective_max_decode_seqs)),
+      std::max<int32_t>(max_context_len, 1));
+  const int32_t target_kv_bucket = static_cast<int32_t>(util::align_up(
+      per_seq_kv_budget, static_cast<int64_t>(kMlaGraphKvLenBucket)));
+  const int32_t decode_seq_len = std::min(
+      std::max(2, target_kv_bucket - block_size - schedule_overlap_slack),
+      max_context_len);
+
+  return MlaGraphWarmupShape{decode_seq_len,
+                             target_kv_bucket,
+                             effective_max_decode_seqs,
+                             per_seq_kv_budget};
+}
+
+}  // namespace
 
 ProfileManager::ProfileManager(Engine* engine, const Options& options)
     : options_(options), engine_(engine) {
@@ -584,7 +640,8 @@ double ProfileManager::predict_copy_blocks_time(
 
 std::shared_ptr<Request> ProfileManager::generate_single_request(
     int32_t token_length,
-    int32_t prefix_length) {
+    int32_t prefix_length,
+    std::optional<int32_t> dp_rank) {
   auto& model_args = engine_->model_args();
   int32_t vocab_size = model_args.vocab_size();
   int32_t eos_token_id = model_args.eos_token_id();
@@ -610,18 +667,25 @@ std::shared_ptr<Request> ProfileManager::generate_single_request(
       /*x_request_time=*/"",
       req_state);
 
+  auto* sequence = request->sequences()[0].get();
+  if (dp_rank.has_value()) {
+    CHECK_GE(dp_rank.value(), 0);
+    CHECK_LT(dp_rank.value(), options_.dp_size());
+    sequence->set_dp_rank(dp_rank.value());
+  }
+
   // TODO: better disable prefix cache
   if (prefix_length > 0) {
-    if (!block_manager_pool_->BlockManagerPool::allocate(
-            request->sequences()[0].get(), prefix_length)) {
+    if (!block_manager_pool_->BlockManagerPool::allocate(sequence,
+                                                         prefix_length)) {
       LOG(FATAL) << "Profiling time failed! Not enough blocks, prefix length : "
                  << prefix_length;
     }
-    request->sequences()[0]->kv_state().incr_kv_cache_tokens_num(prefix_length);
+    sequence->kv_state().incr_kv_cache_tokens_num(prefix_length);
   }
 
-  if (!block_manager_pool_->BlockManagerPool::allocate(
-          request->sequences()[0].get(), token_length)) {
+  if (!block_manager_pool_->BlockManagerPool::allocate(sequence,
+                                                       token_length)) {
     LOG(FATAL) << "Profiling time failed! Not enough blocks, token length : "
                << token_length;
   }
@@ -831,6 +895,48 @@ double ProfileManager::run_decode_request(
   return latency;
 }
 
+double ProfileManager::run_graph_prefill_request(int32_t token_length) {
+  CHECK_GT(options_.dp_size(), 0);
+  CHECK_GE(token_length, options_.dp_size())
+      << "Graph prefill warmup requires at least one token per DP rank.";
+
+  std::vector<Sequence*> sequences;
+  std::vector<size_t> sequences_budget;
+  std::vector<std::shared_ptr<Request>> requests;
+  sequences.reserve(static_cast<size_t>(options_.dp_size()));
+  sequences_budget.reserve(static_cast<size_t>(options_.dp_size()));
+  requests.reserve(static_cast<size_t>(options_.dp_size()));
+
+  const int32_t base_tokens = token_length / options_.dp_size();
+  const int32_t remaining_tokens = token_length % options_.dp_size();
+  for (int32_t dp_rank = 0; dp_rank < options_.dp_size(); ++dp_rank) {
+    const int32_t dp_tokens =
+        base_tokens + (dp_rank < remaining_tokens ? 1 : 0);
+    std::shared_ptr<Request> request =
+        generate_single_request(dp_tokens, /*prefix_length=*/0, dp_rank);
+    requests.emplace_back(request);
+    sequences.emplace_back(request->sequences()[0].get());
+    sequences_budget.emplace_back(static_cast<size_t>(dp_tokens));
+  }
+
+  auto batches =
+      BatchFactory::get_instance(options_.dp_size())
+          ->create_batches(requests, sequences, sequences_budget, nullptr);
+
+  absl::Time start_time = absl::Now();
+  engine_->step(batches);
+  if (options_.enable_schedule_overlap()) {
+    engine_->update_last_step_result(batches);
+  }
+  double latency = absl::ToDoubleMilliseconds(absl::Now() - start_time);
+  for (auto& request : requests) {
+    block_manager_pool_->deallocate_without_cache(
+        request->sequences()[0].get());
+  }
+
+  return latency;
+}
+
 double ProfileManager::run_graph_decode_request(
     const std::vector<int32_t>& total_length_vec) {
   CHECK_GT(options_.dp_size(), 0);
@@ -950,9 +1056,47 @@ void ProfileManager::warmup_prefill_for_graph() {
 
   int32_t prefill_tokens =
       std::min(options_.max_tokens_per_batch(), max_context_len);
-  double prefill_latency =
-      run_request(prefill_tokens, /*prefix_length=*/0, /*batch_size=*/1);
+  int32_t max_seqs_per_batch = options_.max_seqs_per_batch();
+  int32_t decode_seq_len = std::min(16, max_context_len);
+  MlaGraphWarmupShape mla_graph_warmup_shape;
+  if (uses_deepseek_v2_mla_graph(model_args)) {
+    const int32_t block_size =
+        std::max<int32_t>(block_manager_pool_->options().block_size(), 1);
+    const int32_t schedule_overlap_slack =
+        options_.enable_schedule_overlap()
+            ? (::xllm::SpeculativeConfig::get_instance()
+                   .num_speculative_tokens() +
+               1)
+            : 0;
+    mla_graph_warmup_shape = get_mla_graph_warmup_shape(
+        options_, max_context_len, block_size, schedule_overlap_slack);
+    decode_seq_len = mla_graph_warmup_shape.decode_seq_len;
+    max_seqs_per_batch = std::min(
+        max_seqs_per_batch, mla_graph_warmup_shape.effective_max_decode_seqs);
+    LOG(INFO) << "MLA graph warmup shape: max_tokens_per_batch="
+              << options_.max_tokens_per_batch()
+              << ", max_seqs_per_batch=" << options_.max_seqs_per_batch()
+              << ", effective_max_decode_seqs="
+              << mla_graph_warmup_shape.effective_max_decode_seqs
+              << ", per_seq_kv_budget="
+              << mla_graph_warmup_shape.per_seq_kv_budget
+              << ", target_kv_bucket="
+              << mla_graph_warmup_shape.target_kv_bucket
+              << ", block_size=" << block_size
+              << ", schedule_overlap_slack=" << schedule_overlap_slack
+              << ", decode_seq_len=" << decode_seq_len;
+  }
+
+  if (options_.dp_size() > 1) {
+    prefill_tokens = std::max(prefill_tokens, options_.dp_size());
+  }
+  double prefill_latency = options_.dp_size() > 1
+                               ? run_graph_prefill_request(prefill_tokens)
+                               : run_request(prefill_tokens,
+                                             /*prefix_length=*/0,
+                                             /*batch_size=*/1);
   LOG(INFO) << "Prefill warmup completed: tokens=" << prefill_tokens
+            << ", dp_size=" << options_.dp_size()
             << ", latency=" << prefill_latency << " ms";
 }
 
@@ -979,6 +1123,7 @@ void ProfileManager::warmup_decode_for_graph() {
       static_cast<int32_t>(decode_batch_sizes.size());
 
   LOG(INFO) << "Graph warmup started: bucket_count=" << decode_bucket_count
+            << ", max_seqs_per_batch=" << max_seqs_per_batch
             << ", decode_seq_len=" << decode_seq_len;
 
   // Capture from the largest bucket down to the smallest so every smaller

--- a/xllm/core/scheduler/profile/profile_manager.h
+++ b/xllm/core/scheduler/profile/profile_manager.h
@@ -132,10 +132,8 @@ class ProfileManager {
           time_profiling_data,
       bool is_prefill);
 
-  std::shared_ptr<Request> generate_single_request(
-      int32_t token_length,
-      int32_t prefix_length,
-      std::optional<int32_t> dp_rank = std::nullopt);
+  std::shared_ptr<Request> generate_single_request(int32_t token_length,
+                                                   int32_t prefix_length);
   std::shared_ptr<Request> generate_single_decode_request(
       int32_t total_length,
       std::optional<int32_t> dp_rank = std::nullopt);
@@ -172,8 +170,6 @@ class ProfileManager {
                                     std::vector<int32_t>& token_length_vec);
 
   double run_decode_request(const std::vector<int32_t>& total_length_vec);
-
-  double run_graph_prefill_request(int32_t token_length);
 
   double run_graph_decode_request(const std::vector<int32_t>& total_length_vec);
 

--- a/xllm/core/scheduler/profile/profile_manager.h
+++ b/xllm/core/scheduler/profile/profile_manager.h
@@ -132,8 +132,10 @@ class ProfileManager {
           time_profiling_data,
       bool is_prefill);
 
-  std::shared_ptr<Request> generate_single_request(int32_t token_length,
-                                                   int32_t prefix_length);
+  std::shared_ptr<Request> generate_single_request(
+      int32_t token_length,
+      int32_t prefix_length,
+      std::optional<int32_t> dp_rank = std::nullopt);
   std::shared_ptr<Request> generate_single_decode_request(
       int32_t total_length,
       std::optional<int32_t> dp_rank = std::nullopt);
@@ -170,6 +172,8 @@ class ProfileManager {
                                     std::vector<int32_t>& token_length_vec);
 
   double run_decode_request(const std::vector<int32_t>& total_length_vec);
+
+  double run_graph_prefill_request(int32_t token_length);
 
   double run_graph_decode_request(const std::vector<int32_t>& total_length_vec);
 

--- a/xllm/core/util/utils.h
+++ b/xllm/core/util/utils.h
@@ -146,12 +146,6 @@ inline bool is_mla_model_type(std::string_view model_type) {
   return mla_model_type_set().contains(std::string(model_type));
 }
 
-inline bool is_deepseek_v2_family_model_type(std::string_view model_type) {
-  return model_type == "deepseek_v2" || model_type == "deepseek_v3" ||
-         model_type == "deepseek_v3_mtp" || model_type == "kimi_k2" ||
-         model_type == "kimi_k25" || model_type == "joyai_llm_flash";
-}
-
 inline bool has_mtp_model_type_marker(std::string_view model_type) {
   return model_type.find("mtp") != std::string_view::npos;
 }

--- a/xllm/core/util/utils.h
+++ b/xllm/core/util/utils.h
@@ -146,6 +146,12 @@ inline bool is_mla_model_type(std::string_view model_type) {
   return mla_model_type_set().contains(std::string(model_type));
 }
 
+inline bool is_deepseek_v2_family_model_type(std::string_view model_type) {
+  return model_type == "deepseek_v2" || model_type == "deepseek_v3" ||
+         model_type == "deepseek_v3_mtp" || model_type == "kimi_k2" ||
+         model_type == "kimi_k25" || model_type == "joyai_llm_flash";
+}
+
 inline bool has_mtp_model_type_marker(std::string_view model_type) {
   return model_type.find("mtp") != std::string_view::npos;
 }

--- a/xllm/models/vlm/npu/kimi_k25.h
+++ b/xllm/models/vlm/npu/kimi_k25.h
@@ -109,8 +109,8 @@ void load_layernorm_if_defined(const StateDict& state_dict,
 }
 
 bool is_w8a8_dynamic_quant(const QuantArgs& quant_args,
-                           const std::string& tensor_name) {
-  auto quant = quant_args.get_quant_method(tensor_name);
+                           const std::string& module_prefix) {
+  auto quant = quant_args.get_quant_method(module_prefix, "weight");
   return quant.has_value() &&
          (*quant == "W8A8_DYNAMIC" || *quant == "w8a8_dynamic");
 }
@@ -119,9 +119,9 @@ ModelContext make_kimi_k25_vision_context(const ModelContext& context) {
   const auto& quant_args = context.get_quant_args();
   const bool vision_mlp_is_w8a8_dynamic =
       is_w8a8_dynamic_quant(quant_args,
-                            "vision_tower.encoder.blocks.0.mlp.fc0.weight") &&
+                            "vision_tower.encoder.blocks.0.mlp.fc0") &&
       is_w8a8_dynamic_quant(quant_args,
-                            "vision_tower.encoder.blocks.0.mlp.fc1.weight");
+                            "vision_tower.encoder.blocks.0.mlp.fc1");
   if (!vision_mlp_is_w8a8_dynamic) {
     return context;
   }
@@ -999,6 +999,8 @@ class KimiK2_5_VLForConditionalGenerationImpl : public torch::nn::Module {
                       const ModelInputParams& input_params) {
     return language_model_(tokens, positions, kv_caches, input_params);
   }
+
+  bool supports_mla_graph_kv_bucketing() const { return true; }
 
   torch::Tensor logits(const torch::Tensor& hidden_states,
                        const torch::Tensor& seleted_idxes) {

--- a/xllm/models/vlm/npu/kimi_k25.h
+++ b/xllm/models/vlm/npu/kimi_k25.h
@@ -107,6 +107,33 @@ void load_layernorm_if_defined(const StateDict& state_dict,
                          module_name,
                          layernorm_name + ".bias");
 }
+
+bool is_w8a8_dynamic_quant(const QuantArgs& quant_args,
+                           const std::string& tensor_name) {
+  auto quant = quant_args.get_quant_method(tensor_name);
+  return quant.has_value() &&
+         (*quant == "W8A8_DYNAMIC" || *quant == "w8a8_dynamic");
+}
+
+ModelContext make_kimi_k25_vision_context(const ModelContext& context) {
+  const auto& quant_args = context.get_quant_args();
+  const bool vision_mlp_is_w8a8_dynamic =
+      is_w8a8_dynamic_quant(quant_args,
+                            "vision_tower.encoder.blocks.0.mlp.fc0.weight") &&
+      is_w8a8_dynamic_quant(quant_args,
+                            "vision_tower.encoder.blocks.0.mlp.fc1.weight");
+  if (!vision_mlp_is_w8a8_dynamic) {
+    return context;
+  }
+
+  auto vision_quant_args = quant_args;
+  vision_quant_args.quant_method() = kQuantMethodAscendInt8;
+  vision_quant_args.quantize_type() = "w8a8_dynamic";
+  vision_quant_args.bits() = 8;
+  vision_quant_args.moe_weight_bits() = 8;
+  vision_quant_args.activation_dynamic() = true;
+  return context.with_quant_args(vision_quant_args);
+}
 }  // namespace
 
 class KimiK2_5_VisionBlockImpl : public torch::nn::Module {
@@ -773,8 +800,9 @@ class KimiK2_5_VLForConditionalGenerationImpl : public torch::nn::Module {
                          << tp_size
                          << " (world_size=" << parallel_args.world_size()
                          << ", dp_size=" << dp_size << ")";
-    visual_ =
-        register_module("vision_tower", KimiK2_5_VisionTransformer(context));
+    auto vision_context = make_kimi_k25_vision_context(context);
+    visual_ = register_module("vision_tower",
+                              KimiK2_5_VisionTransformer(vision_context));
     auto mm_ptype = model_args_.mm_projector_type();
     if (mm_ptype == "patchmerger") {
       mm_projector_ =
@@ -944,18 +972,24 @@ class KimiK2_5_VLForConditionalGenerationImpl : public torch::nn::Module {
   torch::Tensor get_input_embeddings(const torch::Tensor input_ids,
                                      const ModelInputParams& input_params) {
     const auto& mm_data = input_params.multimodal.mm_data;
-    torch::Tensor multimodal_embeds;
-    if (const auto& emb = mm_data.get<torch::Tensor>("embedding")) {
-      multimodal_embeds = emb.value();
-    }
-    auto inputs_embeds =
+    torch::Tensor inputs_embeds =
         language_model_->get_npu_word_embedding()(input_ids, 0);
-    if (!multimodal_embeds.defined()) {
-      return inputs_embeds;
-    }
-    auto is_multimodal = generate_multimodal_mask(input_ids);
-    inputs_embeds = merge_multimodal_embeddings(
-        inputs_embeds, multimodal_embeds, is_multimodal);
+    auto merge_modality = [&](const std::string& embed_key,
+                              const std::string& mask_key) {
+      auto emb = mm_data.get<torch::Tensor>(embed_key);
+      if (!emb.has_value() || !emb.value().defined()) {
+        return;
+      }
+      auto mask = mm_data.get<torch::Tensor>(mask_key);
+      if (!mask.has_value() || !mask.value().defined()) {
+        return;
+      }
+      inputs_embeds =
+          merge_multimodal_embeddings(inputs_embeds, emb.value(), mask.value());
+    };
+
+    merge_modality("image|embedding", "image|mask");
+    merge_modality("video|embedding", "video|mask");
     return inputs_embeds;
   }
 

--- a/xllm/processors/kimi25_image_processor.cpp
+++ b/xllm/processors/kimi25_image_processor.cpp
@@ -729,6 +729,10 @@ void KimiK25PromptProcessor::find_mm_spans(
         << "media span count exceeds mm item count";
     MMDataItem& item = mm_items[global_mm_index];
     item.mutable_state().mutable_token_pos() = {offset, length};
+    item.mutable_state().mutable_mm_token_mask() = torch::ones(
+        {length},
+        torch::TensorOptions().dtype(torch::kBool).device(torch::kCPU));
+    item.mutable_state().mutable_mm_token_num() = length;
     ++global_mm_index;
     start = std::next(vision_end_it);
   }


### PR DESCRIPTION
适配Kimi k25的w4a8与acl graph特性

W4A8 ：
1. 为 Kimi K2.5 增加 W4A8 模型识别和量化配置解析。
2. 适配 DeepSeek V2/Kimi K2.5 decoder 权重加载，支持 W4A8 权重、量化 scale、offset/bias 等参数的加载和转换。
3. 在 decoder layer 中接入 W4A8 linear、MLP 和 MoE 计算路径。
4. 补充 W4A8 权重加载所需的模型上下文和映射信息。
5. 调整 Kimi K2.5 VLM 模型及图像处理流程，使视觉模型能够使用 W4A8 量化的语言模型部分

ACL Graph ：
1. 为 Kimi K2.5 使用的 DeepSeek V2-family MLA 路径启用 ACL Graph。
2. ACL Graph 的 key 同时考虑 token bucket 和 KV sequence length bucket，避免不同 KV 长度错误复用同一张图。
3. 在 DP 场景中同步各 rank 的最大 KV 长度，使空 rank 和非空 rank 选择一致的计算图。
4. 为 q_seq_lens 和 kv_seq_lens 增加地址稳定的 host buffer，图捕获时使用 bucket 长度，图重放前更新为当前请求的实际长度。
5. 将稳定的 sequence-length host 地址传递到 NPU MLA layer 和 ATB/ACLNN 算子。
6. 完善 ACL Graph 捕获失败后的 stream 和 graph 状态清理。