### PR TITLE
feat: support MegaMoe kernel for Qwen3.5/3.6.

### DIFF
--- a/xllm/core/framework/config/kernel_config.cpp
+++ b/xllm/core/framework/config/kernel_config.cpp
@@ -54,6 +54,10 @@ DEFINE_bool(enable_aclnn_swiglu,
             false,
             "enable ACLNN SwiGLU backend for supported NPU ATB layers.");
 
+DEFINE_bool(enable_mega_moe,
+            false,
+            "enable mega_moe fused operator for MoE expert parallel.");
+
 DEFINE_bool(enable_flashcomm1,
             false,
             "Enable Flash Communication 1 sequence-parallel optimization.");
@@ -103,6 +107,7 @@ void KernelConfig::from_flags() {
   XLLM_CONFIG_ASSIGN_FROM_FLAG(enable_split_rmsnorm_rope);
   XLLM_CONFIG_ASSIGN_FROM_FLAG(enable_aclnn_matmul);
   XLLM_CONFIG_ASSIGN_FROM_FLAG(enable_aclnn_swiglu);
+  XLLM_CONFIG_ASSIGN_FROM_FLAG(enable_mega_moe);
   XLLM_CONFIG_ASSIGN_FROM_FLAG(enable_flashcomm1);
   XLLM_CONFIG_ASSIGN_FROM_FLAG(flashcomm1_min_prefill_tokens);
   XLLM_CONFIG_ASSIGN_FROM_FLAG(enable_mmrs_fusion);
@@ -120,6 +125,7 @@ void KernelConfig::from_json(const JsonReader& json) {
   XLLM_CONFIG_ASSIGN_FROM_JSON(enable_split_rmsnorm_rope);
   XLLM_CONFIG_ASSIGN_FROM_JSON(enable_aclnn_matmul);
   XLLM_CONFIG_ASSIGN_FROM_JSON(enable_aclnn_swiglu);
+  XLLM_CONFIG_ASSIGN_FROM_JSON(enable_mega_moe);
   XLLM_CONFIG_ASSIGN_FROM_JSON(enable_flashcomm1);
   XLLM_CONFIG_ASSIGN_FROM_JSON(flashcomm1_min_prefill_tokens);
   XLLM_CONFIG_ASSIGN_FROM_JSON(enable_mmrs_fusion);
@@ -147,6 +153,8 @@ void KernelConfig::append_config_json(
       config_json, default_config, enable_aclnn_matmul);
   APPEND_CONFIG_JSON_VALUE_IF_NOT_DEFAULT(
       config_json, default_config, enable_aclnn_swiglu);
+  APPEND_CONFIG_JSON_VALUE_IF_NOT_DEFAULT(
+      config_json, default_config, enable_mega_moe);
   APPEND_CONFIG_JSON_VALUE_IF_NOT_DEFAULT(
       config_json, default_config, enable_flashcomm1);
   APPEND_CONFIG_JSON_VALUE_IF_NOT_DEFAULT(

--- a/xllm/core/framework/config/kernel_config.h
+++ b/xllm/core/framework/config/kernel_config.h
@@ -48,6 +48,7 @@ class KernelConfig final {
          "enable_split_rmsnorm_rope",
          "enable_aclnn_matmul",
          "enable_aclnn_swiglu",
+         "enable_mega_moe",
          "enable_flashcomm1",
          "flashcomm1_min_prefill_tokens",
          "enable_mmrs_fusion",
@@ -71,6 +72,8 @@ class KernelConfig final {
   PROPERTY(bool, enable_aclnn_matmul) = false;
 
   PROPERTY(bool, enable_aclnn_swiglu) = false;
+
+  PROPERTY(bool, enable_mega_moe) = false;
 
   PROPERTY(bool, enable_flashcomm1) = false;
 

--- a/xllm/core/framework/parallel_state/CMakeLists.txt
+++ b/xllm/core/framework/parallel_state/CMakeLists.txt
@@ -21,6 +21,7 @@ cc_library(
     collective_communicator_base.h
     collective_communicator.h
     dit_collective_communicator.h
+    $<$<BOOL:${USE_NPU}>:mega_moe_comm_resource.h>
   SRCS
     mapping_npu.cpp
     npu_cp_plan.cpp
@@ -31,6 +32,7 @@ cc_library(
     process_group.cpp
     $<$<BOOL:${USE_NPU}>:npu_rank_table_env.cpp>
     $<$<BOOL:${USE_NPU}>:npu_process_group.cpp>
+    $<$<BOOL:${USE_NPU}>:mega_moe_comm_resource.cpp>
     collective_communicator.cpp
     dit_collective_communicator.cpp
   DEPS

--- a/xllm/core/framework/parallel_state/mega_moe_comm_resource.cpp
+++ b/xllm/core/framework/parallel_state/mega_moe_comm_resource.cpp
@@ -1,0 +1,394 @@
+/* Copyright 2025-2026 The xLLM Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://github.com/jd-opensource/xllm/blob/main/LICENSE
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include "framework/parallel_state/mega_moe_comm_resource.h"
+
+#include <ATen/ATen.h>
+#include <dlfcn.h>
+#include <glog/logging.h>
+
+#include <array>
+#include <cstring>
+#include <utility>
+#include <vector>
+
+namespace xllm {
+namespace {
+
+constexpr uint32_t kHcclMaxRankSize = 1024;
+constexpr uint8_t kCommEngineAiv = 4;
+constexpr uint8_t kAllToAllOpType = 8;
+constexpr char kHcclLibrary[] = "libhccl.so";
+constexpr char kHcclFrameworkLibrary[] = "libhccl_fwk.so";
+constexpr char kAllToAllAlgorithm[] =
+    "AlltoAll=level0:fullmesh;level1:pairwise";
+
+struct MegaMoeCommContext {
+  uint32_t ep_rank_id = 0;
+  uint32_t rank_size_per_server = 0;
+  uint64_t kfc_context_addr = 0;
+  std::array<uint64_t, kHcclMaxRankSize> ep_hccl_buffer = {};
+  std::array<uint64_t, kHcclMaxRankSize> hcomm_handle = {};
+};
+
+static_assert(sizeof(MegaMoeCommContext) % sizeof(int32_t) == 0);
+
+using HcclKfcAllocOpArgs = HcclResult (*)(void**);
+using HcclKfcFreeOpArgs = HcclResult (*)(void*);
+using HcclKfcOpArgsSetAlgConfig = HcclResult (*)(void*, char*);
+using HcclKfcOpArgsSetCommEngine = HcclResult (*)(void*, uint8_t);
+using HcclCreateOpResCtx = HcclResult (*)(HcclComm, uint8_t, void*, void**);
+using HcclGetRankSize = HcclResult (*)(HcclComm, uint32_t*);
+using HcclGetRankId = HcclResult (*)(HcclComm, uint32_t*);
+using HcclGetHcclBuffer = HcclResult (*)(HcclComm, void**, uint64_t*);
+using HcclGetRemoteIpcHcclBuf = HcclResult (*)(HcclComm,
+                                               uint64_t,
+                                               void**,
+                                               uint64_t*);
+using HcclCommGetHandleWithName = HcclResult (*)(const char*, HcclComm*);
+
+template <typename Function>
+Function load_symbol(void* library, const char* symbol) {
+  return reinterpret_cast<Function>(dlsym(library, symbol));
+}
+
+class MegaMoeCommApis final {
+ public:
+  MegaMoeCommApis() {
+    hccl_library_ = dlopen(kHcclLibrary, RTLD_NOW | RTLD_LOCAL);
+    if (hccl_library_ == nullptr) {
+      missing_symbol_ = kHcclLibrary;
+      return;
+    }
+    hccl_framework_library_ =
+        dlopen(kHcclFrameworkLibrary, RTLD_NOW | RTLD_LOCAL);
+    if (hccl_framework_library_ == nullptr) {
+      missing_symbol_ = kHcclFrameworkLibrary;
+      return;
+    }
+    if (!load_hccl_symbol(kfc_alloc_op_args_, "HcclKfcAllocOpArgs") ||
+        !load_hccl_symbol(kfc_free_op_args_, "HcclKfcFreeOpArgs") ||
+        !load_hccl_symbol(kfc_set_alg_config_, "HcclKfcOpArgsSetAlgConfig") ||
+        !load_hccl_symbol(kfc_set_comm_engine_, "HcclKfcOpArgsSetCommEngine") ||
+        !load_hccl_symbol(create_op_res_ctx_, "HcclCreateOpResCtx") ||
+        !load_hccl_symbol(get_rank_size_, "HcclGetRankSize") ||
+        !load_hccl_symbol(get_rank_id_, "HcclGetRankId") ||
+        !load_hccl_symbol(get_hccl_buffer_, "HcclGetHcclBuffer") ||
+        !load_framework_symbol(get_remote_ipc_hccl_buffer_,
+                               "HcclGetRemoteIpcHcclBuf") ||
+        !load_framework_symbol(get_handle_with_name_,
+                               "HcclCommGetHandleWithName")) {
+      return;
+    }
+    available_ = true;
+  }
+
+  bool available() const { return available_; }
+  const std::string& missing_symbol() const { return missing_symbol_; }
+
+  HcclKfcAllocOpArgs kfc_alloc_op_args() const { return kfc_alloc_op_args_; }
+  HcclKfcFreeOpArgs kfc_free_op_args() const { return kfc_free_op_args_; }
+  HcclKfcOpArgsSetAlgConfig kfc_set_alg_config() const {
+    return kfc_set_alg_config_;
+  }
+  HcclKfcOpArgsSetCommEngine kfc_set_comm_engine() const {
+    return kfc_set_comm_engine_;
+  }
+  HcclCreateOpResCtx create_op_res_ctx() const { return create_op_res_ctx_; }
+  HcclGetRankSize get_rank_size() const { return get_rank_size_; }
+  HcclGetRankId get_rank_id() const { return get_rank_id_; }
+  HcclGetHcclBuffer get_hccl_buffer() const { return get_hccl_buffer_; }
+  HcclGetRemoteIpcHcclBuf get_remote_ipc_hccl_buffer() const {
+    return get_remote_ipc_hccl_buffer_;
+  }
+  HcclCommGetHandleWithName get_handle_with_name() const {
+    return get_handle_with_name_;
+  }
+
+ private:
+  template <typename Function>
+  bool load_hccl_symbol(Function& function, const char* symbol) {
+    function = load_symbol<Function>(hccl_library_, symbol);
+    return record_missing_symbol(function, symbol);
+  }
+  template <typename Function>
+  bool load_framework_symbol(Function& function, const char* symbol) {
+    function = load_symbol<Function>(hccl_framework_library_, symbol);
+    return record_missing_symbol(function, symbol);
+  }
+  template <typename Function>
+  bool record_missing_symbol(Function function, const char* symbol) {
+    if (function != nullptr) return true;
+    missing_symbol_ = symbol;
+    return false;
+  }
+
+  void* hccl_library_ = nullptr;
+  void* hccl_framework_library_ = nullptr;
+  bool available_ = false;
+  std::string missing_symbol_;
+  HcclKfcAllocOpArgs kfc_alloc_op_args_ = nullptr;
+  HcclKfcFreeOpArgs kfc_free_op_args_ = nullptr;
+  HcclKfcOpArgsSetAlgConfig kfc_set_alg_config_ = nullptr;
+  HcclKfcOpArgsSetCommEngine kfc_set_comm_engine_ = nullptr;
+  HcclCreateOpResCtx create_op_res_ctx_ = nullptr;
+  HcclGetRankSize get_rank_size_ = nullptr;
+  HcclGetRankId get_rank_id_ = nullptr;
+  HcclGetHcclBuffer get_hccl_buffer_ = nullptr;
+  HcclGetRemoteIpcHcclBuf get_remote_ipc_hccl_buffer_ = nullptr;
+  HcclCommGetHandleWithName get_handle_with_name_ = nullptr;
+};
+
+MegaMoeCommApis& comm_apis() {
+  static MegaMoeCommApis apis;
+  return apis;
+}
+
+class OpArgsGuard final {
+ public:
+  OpArgsGuard(void* op_args, HcclKfcFreeOpArgs free_op_args)
+      : op_args_(op_args), free_op_args_(free_op_args) {}
+  ~OpArgsGuard() {
+    if (op_args_ == nullptr) return;
+    const HcclResult result = free_op_args_(op_args_);
+    if (result != HCCL_SUCCESS) {
+      LOG(ERROR) << "HcclKfcFreeOpArgs failed during cleanup, result="
+                 << static_cast<int32_t>(result);
+    }
+  }
+  OpArgsGuard(const OpArgsGuard&) = delete;
+  OpArgsGuard& operator=(const OpArgsGuard&) = delete;
+  void release() { op_args_ = nullptr; }
+
+ private:
+  void* op_args_ = nullptr;
+  HcclKfcFreeOpArgs free_op_args_ = nullptr;
+};
+
+void check_hccl_result(HcclResult result, const char* operation) {
+  CHECK_EQ(result, HCCL_SUCCESS)
+      << operation << " failed, result=" << static_cast<int32_t>(result);
+}
+
+HcclComm resolve_hccl_comm(const MegaMoeCommSpec& spec) {
+  if (spec.hccl_comm != nullptr) {
+    return spec.hccl_comm;
+  }
+  MegaMoeCommApis& apis = comm_apis();
+  CHECK(apis.available()) << "missing MegaMoe communication symbol: "
+                          << apis.missing_symbol();
+  HcclComm comm = nullptr;
+  check_hccl_result(apis.get_handle_with_name()(spec.group_name.c_str(), &comm),
+                    "HcclCommGetHandleWithName");
+  CHECK(comm != nullptr)
+      << "HcclCommGetHandleWithName returned null for group '"
+      << spec.group_name << "'";
+  return comm;
+}
+
+MegaMoeCommContext build_context(const MegaMoeCommSpec& spec,
+                                 int64_t& ccl_buffer_size) {
+  MegaMoeCommApis& apis = comm_apis();
+  CHECK(apis.available()) << "missing MegaMoe communication symbol: "
+                          << apis.missing_symbol();
+
+  HcclComm comm = resolve_hccl_comm(spec);
+
+  void* op_args = nullptr;
+  check_hccl_result(apis.kfc_alloc_op_args()(&op_args), "HcclKfcAllocOpArgs");
+  CHECK(op_args != nullptr) << "HcclKfcAllocOpArgs returned null";
+  OpArgsGuard op_args_guard(op_args, apis.kfc_free_op_args());
+
+  check_hccl_result(apis.kfc_set_comm_engine()(op_args, kCommEngineAiv),
+                    "HcclKfcOpArgsSetCommEngine");
+  check_hccl_result(
+      apis.kfc_set_alg_config()(op_args, const_cast<char*>(kAllToAllAlgorithm)),
+      "HcclKfcOpArgsSetAlgConfig");
+
+  MegaMoeCommContext context;
+  void* op_resource_context = nullptr;
+  check_hccl_result(apis.create_op_res_ctx()(
+                        comm, kAllToAllOpType, op_args, &op_resource_context),
+                    "HcclCreateOpResCtx");
+  CHECK(op_resource_context != nullptr) << "HcclCreateOpResCtx returned null";
+  context.kfc_context_addr = reinterpret_cast<uint64_t>(op_resource_context);
+
+  const HcclResult free_result = apis.kfc_free_op_args()(op_args);
+  op_args_guard.release();
+  check_hccl_result(free_result, "HcclKfcFreeOpArgs");
+
+  uint32_t rank_size = 0;
+  uint32_t rank_id = 0;
+  check_hccl_result(apis.get_rank_size()(comm, &rank_size), "HcclGetRankSize");
+  check_hccl_result(apis.get_rank_id()(comm, &rank_id), "HcclGetRankId");
+  CHECK_EQ(rank_size, static_cast<uint32_t>(spec.ep_world_size));
+  CHECK_LT(rank_id, rank_size);
+  context.ep_rank_id = rank_id;
+
+  std::vector<void*> rank_buffer_addresses(rank_size, nullptr);
+  std::vector<uint64_t> rank_accessible_spans(rank_size, 0);
+  for (uint32_t remote_rank_id = 0; remote_rank_id < rank_size;
+       ++remote_rank_id) {
+    void* remote_address = nullptr;
+    uint64_t remote_size = 0;
+    const char* buffer_query = nullptr;
+    HcclResult result = HCCL_E_INTERNAL;
+    if (remote_rank_id == rank_id) {
+      result = apis.get_hccl_buffer()(comm, &remote_address, &remote_size);
+      ccl_buffer_size = static_cast<int64_t>(remote_size);
+      buffer_query = "HcclGetHcclBuffer";
+    } else {
+      result = apis.get_remote_ipc_hccl_buffer()(
+          comm, remote_rank_id, &remote_address, &remote_size);
+      buffer_query = "HcclGetRemoteIpcHcclBuf";
+    }
+    check_hccl_result(result, buffer_query);
+    CHECK(remote_address != nullptr);
+    rank_buffer_addresses[remote_rank_id] = remote_address;
+    rank_accessible_spans[remote_rank_id] = remote_size;
+  }
+
+  const auto span_validation = validate_mega_moe_buffer_accessible_spans(
+      static_cast<uint64_t>(ccl_buffer_size), rank_accessible_spans);
+  CHECK(span_validation.valid)
+      << "MegaMoe HCCL accessible span is smaller than the local payload at "
+         "rank "
+      << span_validation.mismatched_rank
+      << ": required_payload=" << span_validation.required_payload_size
+      << ", accessible_span=" << span_validation.accessible_span;
+
+  for (uint32_t remote_rank_id = 0; remote_rank_id < rank_size;
+       ++remote_rank_id) {
+    context.ep_hccl_buffer[remote_rank_id] =
+        reinterpret_cast<uint64_t>(rank_buffer_addresses[remote_rank_id]);
+  }
+  return context;
+}
+
+}  // namespace
+
+MegaMoeBufferSpanValidation validate_mega_moe_buffer_accessible_spans(
+    uint64_t local_payload_size,
+    const std::vector<uint64_t>& rank_accessible_spans) {
+  if (local_payload_size == 0) {
+    return {false, -1, local_payload_size, 0};
+  }
+  if (rank_accessible_spans.empty()) {
+    return {false, -1, local_payload_size, 0};
+  }
+  for (size_t rank = 0; rank < rank_accessible_spans.size(); ++rank) {
+    const uint64_t accessible_span = rank_accessible_spans[rank];
+    if (accessible_span < local_payload_size) {
+      return {false,
+              static_cast<int32_t>(rank),
+              local_payload_size,
+              accessible_span};
+    }
+  }
+  return {true, -1, local_payload_size, 0};
+}
+
+class MegaMoeCommResource::Impl final {
+ public:
+  explicit Impl(const MegaMoeCommSpec& spec)
+      : device_index_(spec.device_index),
+        max_num_tokens_per_rank_(spec.max_num_tokens_per_rank) {
+    const MegaMoeCommContext context = build_context(spec, ccl_buffer_size_);
+    const int64_t context_elements =
+        static_cast<int64_t>(sizeof(context) / sizeof(int32_t));
+    host_context_tensor_ =
+        at::empty({context_elements}, at::TensorOptions().dtype(at::kInt));
+    std::memcpy(
+        host_context_tensor_.data_ptr<int32_t>(), &context, sizeof(context));
+    context_tensor_ = host_context_tensor_.to(
+        at::Device(at::kPrivateUse1, spec.device_index), at::kInt, false, true);
+  }
+
+  const at::Tensor& context_tensor() const { return context_tensor_; }
+  int64_t ccl_buffer_size() const { return ccl_buffer_size_; }
+  int64_t max_num_tokens_per_rank() const { return max_num_tokens_per_rank_; }
+
+ private:
+  at::Tensor host_context_tensor_;
+  at::Tensor context_tensor_;
+  int32_t device_index_ = -1;
+  int64_t ccl_buffer_size_ = 0;
+  int64_t max_num_tokens_per_rank_ = 0;
+};
+
+MegaMoeCommResource::MegaMoeCommResource(std::unique_ptr<Impl> impl)
+    : impl_(std::move(impl)) {}
+
+MegaMoeCommResource::~MegaMoeCommResource() = default;
+
+std::unique_ptr<MegaMoeCommResource> MegaMoeCommResource::create(
+    const MegaMoeCommSpec& spec) {
+  CHECK(spec.ep_world_size > 0) << "MegaMoe requires ep_world_size > 0";
+  CHECK(spec.device_index >= 0) << "MegaMoe requires device_index >= 0";
+  CHECK(spec.max_num_tokens_per_rank > 0)
+      << "MegaMoe requires max_num_tokens_per_rank > 0";
+  CHECK(comm_apis().available())
+      << "MegaMoe communication symbols are unavailable: "
+      << comm_apis().missing_symbol();
+  return std::unique_ptr<MegaMoeCommResource>(
+      new MegaMoeCommResource(std::make_unique<Impl>(spec)));
+}
+
+const at::Tensor& MegaMoeCommResource::context_tensor() const {
+  return impl_->context_tensor();
+}
+
+int64_t MegaMoeCommResource::ccl_buffer_size() const {
+  return impl_->ccl_buffer_size();
+}
+
+int64_t MegaMoeCommResource::max_num_tokens_per_rank() const {
+  return impl_->max_num_tokens_per_rank();
+}
+
+bool MegaMoeCommResourceSlot::same_key(const MegaMoeCommSpec& lhs,
+                                       const MegaMoeCommSpec& rhs) {
+  return lhs.hccl_comm == rhs.hccl_comm && lhs.group_name == rhs.group_name &&
+         lhs.ep_world_size == rhs.ep_world_size &&
+         lhs.device_index == rhs.device_index &&
+         lhs.max_num_tokens_per_rank == rhs.max_num_tokens_per_rank;
+}
+
+std::shared_ptr<MegaMoeCommResource> MegaMoeCommResourceSlot::acquire(
+    const MegaMoeCommSpec& spec) {
+  std::lock_guard<std::mutex> lock(mutex_);
+  if (resource_ != nullptr && cached_spec_.has_value() &&
+      same_key(cached_spec_.value(), spec)) {
+    return resource_;
+  }
+  std::shared_ptr<MegaMoeCommResource> candidate =
+      std::shared_ptr<MegaMoeCommResource>(MegaMoeCommResource::create(spec));
+  CHECK(candidate != nullptr)
+      << "MegaMoe communication resource factory returned null.";
+  cached_spec_ = spec;
+  resource_ = std::move(candidate);
+  return resource_;
+}
+
+void MegaMoeCommResourceSlot::reset() {
+  std::shared_ptr<MegaMoeCommResource> released;
+  {
+    std::lock_guard<std::mutex> lock(mutex_);
+    cached_spec_.reset();
+    released = std::move(resource_);
+  }
+}
+
+}  // namespace xllm

--- a/xllm/core/framework/parallel_state/mega_moe_comm_resource.h
+++ b/xllm/core/framework/parallel_state/mega_moe_comm_resource.h
@@ -1,0 +1,87 @@
+/* Copyright 2025-2026 The xLLM Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://github.com/jd-opensource/xllm/blob/main/LICENSE
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#pragma once
+
+#include <cstdint>
+#include <memory>
+#include <mutex>
+#include <optional>
+#include <string>
+#include <vector>
+
+#include "hccl/hccl.h"
+
+namespace at {
+class Tensor;
+}  // namespace at
+
+namespace xllm {
+
+struct MegaMoeCommSpec {
+  std::string group_name;
+  HcclComm hccl_comm = nullptr;
+  int32_t ep_world_size = 0;
+  int32_t device_index = -1;
+  int64_t max_num_tokens_per_rank = 0;
+};
+
+struct MegaMoeBufferSpanValidation {
+  bool valid = false;
+  int32_t mismatched_rank = -1;
+  uint64_t required_payload_size = 0;
+  uint64_t accessible_span = 0;
+};
+
+MegaMoeBufferSpanValidation validate_mega_moe_buffer_accessible_spans(
+    uint64_t local_payload_size,
+    const std::vector<uint64_t>& rank_accessible_spans);
+
+class MegaMoeCommResource final {
+ public:
+  ~MegaMoeCommResource();
+
+  MegaMoeCommResource(const MegaMoeCommResource&) = delete;
+  MegaMoeCommResource& operator=(const MegaMoeCommResource&) = delete;
+  MegaMoeCommResource(MegaMoeCommResource&&) = delete;
+  MegaMoeCommResource& operator=(MegaMoeCommResource&&) = delete;
+
+  static std::unique_ptr<MegaMoeCommResource> create(
+      const MegaMoeCommSpec& spec);
+
+  const at::Tensor& context_tensor() const;
+  int64_t ccl_buffer_size() const;
+  int64_t max_num_tokens_per_rank() const;
+
+ private:
+  class Impl;
+  explicit MegaMoeCommResource(std::unique_ptr<Impl> impl);
+  std::unique_ptr<Impl> impl_;
+};
+
+class MegaMoeCommResourceSlot final {
+ public:
+  std::shared_ptr<MegaMoeCommResource> acquire(const MegaMoeCommSpec& spec);
+  void reset();
+
+ private:
+  static bool same_key(const MegaMoeCommSpec& lhs, const MegaMoeCommSpec& rhs);
+
+  std::mutex mutex_;
+  std::optional<MegaMoeCommSpec> cached_spec_;
+  std::shared_ptr<MegaMoeCommResource> resource_;
+};
+
+}  // namespace xllm

--- a/xllm/core/framework/parallel_state/npu_process_group.cpp
+++ b/xllm/core/framework/parallel_state/npu_process_group.cpp
@@ -223,4 +223,6 @@ std::string ProcessGroupImpl::hccl_comm_name(bool init_comm) {
 #endif
 }
 
+HcclComm ProcessGroupImpl::hccl_comm() { return comm_; }
+
 }  // namespace xllm

--- a/xllm/core/framework/parallel_state/npu_process_group.h
+++ b/xllm/core/framework/parallel_state/npu_process_group.h
@@ -56,6 +56,7 @@ class ProcessGroupImpl : public ProcessGroup {
   ~ProcessGroupImpl() override;
 
   std::string hccl_comm_name(bool init_comm = true) override;
+  HcclComm hccl_comm() override;
 
  private:
   HcclComm comm_ = nullptr;

--- a/xllm/core/framework/parallel_state/process_group.cpp
+++ b/xllm/core/framework/parallel_state/process_group.cpp
@@ -549,6 +549,16 @@ c10::intrusive_ptr<c10d::Work> ProcessGroup::batch_isend_irecv(
              int32_t tag) { return recv_p2p(wave_tensors, peer_rank, tag); },
       [this]() { return synchronize_p2p_staging(); });
 }
+
+HcclComm ProcessGroup::hccl_comm() {
+  CHECK(false) << "hccl_comm is only supported on NPU HCCL process group.";
+  return nullptr;
+}
+
+std::shared_ptr<MegaMoeCommResource>
+ProcessGroup::acquire_mega_moe_comm_resource(const MegaMoeCommSpec& spec) {
+  return mega_moe_comm_slot_.acquire(spec);
+}
 #endif
 
 std::unique_ptr<ProcessGroup> create_process_group(

--- a/xllm/core/framework/parallel_state/process_group.h
+++ b/xllm/core/framework/parallel_state/process_group.h
@@ -25,6 +25,8 @@ limitations under the License.
 
 #if defined(USE_NPU)
 #include <torch_npu/csrc/distributed/ProcessGroupHCCL.hpp>
+
+#include "framework/parallel_state/mega_moe_comm_resource.h"
 #endif
 
 namespace xllm {
@@ -132,6 +134,10 @@ class ProcessGroup {
       std::vector<std::string>& op_types,
       std::vector<torch::Tensor>& tensors,
       std::vector<int64_t> remote_ranks);
+
+  virtual HcclComm hccl_comm();
+  std::shared_ptr<MegaMoeCommResource> acquire_mega_moe_comm_resource(
+      const MegaMoeCommSpec& spec);
 #endif
 
  private:
@@ -169,6 +175,13 @@ class ProcessGroup {
   std::unique_ptr<c10d_npu::ProcessGroupHCCL> pg_{nullptr};
 #else
   std::unique_ptr<c10d::Backend> pg_{nullptr};
+#endif
+
+#if defined(USE_NPU)
+  // Must be declared after pg_ so that it is destroyed first (reverse
+  // declaration order), releasing the context tensor before the HCCL
+  // communicator is torn down.
+  MegaMoeCommResourceSlot mega_moe_comm_slot_;
 #endif
 };
 

--- a/xllm/core/kernels/npu/CMakeLists.txt
+++ b/xllm/core/kernels/npu/CMakeLists.txt
@@ -24,6 +24,7 @@ cc_library(
     npu_rain_fusion_attention.cpp
     npu_grouped_matmul.cpp
     npu_moe_gating_topk_softmax.cpp
+    npu_mega_moe.cpp
     npu_dispatch_ffn_combine.cpp
     npu_dispatch_gmm_combine_decode.cpp
     npu_moe_distribute_combine_v2.cpp

--- a/xllm/core/kernels/npu/aclnn/pytorch_npu_helper.hpp
+++ b/xllm/core/kernels/npu/aclnn/pytorch_npu_helper.hpp
@@ -529,6 +529,14 @@ inline aclTensor* convert_type(const c10::optional<at::Tensor>& opt_tensor) {
   return nullptr;
 }
 
+inline aclTensorList* convert_type(
+    const c10::optional<at::TensorList>& opt_tensor_list) {
+  if (opt_tensor_list.has_value()) {
+    return convert_type(opt_tensor_list.value());
+  }
+  return nullptr;
+}
+
 inline aclIntArray* convert_type(
     const c10::optional<at::IntArrayRef>& opt_array) {
   if (opt_array.has_value()) {
@@ -571,6 +579,9 @@ auto convert_to_op_api_func(const Tuple& params, void* op_api_addr) {
 }
 
 inline void release(aclTensor* p) {
+  if (p == nullptr) {
+    return;
+  }
   static const auto acl_destroy_tensor =
       get_op_api_func<AclDestroyTensorFn>("aclDestroyTensor");
   if (acl_destroy_tensor == nullptr) {
@@ -609,6 +620,9 @@ inline void release(aclBoolArray* p) {
 }
 
 inline void release(aclTensorList* p) {
+  if (p == nullptr) {
+    return;
+  }
   static const auto acl_destroy_tensor_list =
       get_op_api_func<AclDestroyTensorListFn>("aclDestroyTensorList");
   if (acl_destroy_tensor_list == nullptr) {

--- a/xllm/core/kernels/npu/npu_mega_moe.cpp
+++ b/xllm/core/kernels/npu/npu_mega_moe.cpp
@@ -1,0 +1,216 @@
+/* Copyright 2025-2026 The xLLM Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://github.com/jd-opensource/xllm/blob/main/LICENSE
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include <limits>
+#include <optional>
+#include <string>
+#include <tuple>
+
+#include "core/kernels/npu/aclnn/pytorch_npu_helper.hpp"
+#include "graph/types.h"
+
+namespace xllm::kernel::npu {
+
+bool has_mega_moe() {
+  static const bool is_available =
+      aclnn::detail::get_op_api_func_addr("aclnnMegaMoeGetWorkspaceSize") !=
+          nullptr &&
+      aclnn::detail::get_op_api_func_addr("aclnnMegaMoe") != nullptr;
+  return is_available;
+}
+
+// To use the MegaMoe operator, you need to download CANN version 9.1.0 and the
+// corresponding ops package. Download path:
+// https://www.hiascend.com/cann/download?versionId=767&ids=d802%2Ch0501%2Ch0601%2Ch0703
+// If you are using CANN 9.0.0 and an A3 environment, you can upgrade only the
+// ops package to CANN 9.1.0.
+std::tuple<torch::Tensor, torch::Tensor> apply_npu_mega_moe(
+    const torch::Tensor& context,
+    const torch::Tensor& x,
+    const torch::Tensor& topk_ids,
+    const torch::Tensor& topk_weights,
+    const torch::TensorList weight1,
+    const torch::TensorList weight2,
+    int64_t moe_expert_num,
+    int64_t ep_world_size,
+    int64_t ccl_buffer_size,
+    const std::optional<torch::TensorList>& weight_scales1,
+    const std::optional<torch::TensorList>& weight_scales2,
+    const std::optional<torch::TensorList>& bias1,
+    const std::optional<torch::TensorList>& bias2,
+    const std::optional<torch::Tensor>& x_active_mask,
+    int64_t max_recv_token_num,
+    int64_t dispatch_quant_mode,
+    int64_t combine_quant_mode,
+    const std::string& comm_alg,
+    int64_t num_max_tokens_per_rank,
+    const std::string& activation,
+    float activation_clamp,
+    int64_t dispatch_quant_out_dtype,
+    int64_t topo_type,
+    int64_t rank_num_per_server) {
+  TORCH_CHECK(has_mega_moe(), "aclnnMegaMoe is not available in libopapi.");
+  TORCH_CHECK(context.defined(), "MegaMoe expects a defined context tensor.");
+  TORCH_CHECK(context.dim() == 1, "MegaMoe expects 1D context.");
+  TORCH_CHECK(context.scalar_type() == at::kInt,
+              "MegaMoe expects int32 context, got ",
+              c10::toString(context.scalar_type()));
+  TORCH_CHECK(x.dim() == 2, "MegaMoe expects 2D x.");
+  TORCH_CHECK(x.scalar_type() == at::kBFloat16,
+              "MegaMoe A16W16 path expects bf16 x, got ",
+              c10::toString(x.scalar_type()));
+  TORCH_CHECK(topk_ids.dim() == 2, "MegaMoe expects 2D topk_ids.");
+  TORCH_CHECK(topk_ids.scalar_type() == at::kInt,
+              "MegaMoe expects int32 topk_ids, got ",
+              c10::toString(topk_ids.scalar_type()));
+  TORCH_CHECK(topk_weights.dim() == 2, "MegaMoe expects 2D topk_weights.");
+  TORCH_CHECK(topk_weights.scalar_type() == at::kFloat,
+              "MegaMoe expects float32 topk_weights, got ",
+              c10::toString(topk_weights.scalar_type()));
+  TORCH_CHECK(topk_ids.sizes() == topk_weights.sizes(),
+              "MegaMoe topk_ids/topk_weights shape mismatch: ",
+              topk_ids.sizes(),
+              " vs ",
+              topk_weights.sizes());
+  TORCH_CHECK(topk_ids.size(0) == x.size(0),
+              "MegaMoe x/router token count mismatch: ",
+              x.size(0),
+              " vs ",
+              topk_ids.size(0));
+  TORCH_CHECK(!weight1.empty(), "MegaMoe expects non-empty weight1.");
+  TORCH_CHECK(!weight2.empty(), "MegaMoe expects non-empty weight2.");
+  TORCH_CHECK(weight1.size() == weight2.size(),
+              "MegaMoe weight1/weight2 list size mismatch: ",
+              weight1.size(),
+              " vs ",
+              weight2.size());
+  TORCH_CHECK(moe_expert_num > 0, "MegaMoe requires moe_expert_num > 0.");
+  TORCH_CHECK(ep_world_size > 0, "MegaMoe requires ep_world_size > 0.");
+  TORCH_CHECK(moe_expert_num % ep_world_size == 0,
+              "MegaMoe moe_expert_num must be divisible by ep_world_size: ",
+              moe_expert_num,
+              " vs ",
+              ep_world_size);
+  TORCH_CHECK(ccl_buffer_size > 0, "MegaMoe requires ccl_buffer_size > 0.");
+  TORCH_CHECK(activation == "swiglu",
+              "MegaMoe verified path requires swiglu activation, got ",
+              activation);
+  TORCH_CHECK(rank_num_per_server > 0,
+              "MegaMoe requires rank_num_per_server > 0.");
+
+  const int64_t local_expert_num = moe_expert_num / ep_world_size;
+  TORCH_CHECK(static_cast<int64_t>(weight1.size()) == local_expert_num,
+              "MegaMoe expects one weight pair per local expert: ",
+              local_expert_num,
+              ", got ",
+              weight1.size());
+
+  const int64_t hidden_size = x.size(1);
+  for (size_t expert = 0; expert < weight1.size(); ++expert) {
+    const auto& w1 = weight1[expert];
+    const auto& w2 = weight2[expert];
+    TORCH_CHECK(w1.dim() == 2 && w2.dim() == 2,
+                "MegaMoe expert weights must be 2D at local expert ",
+                expert,
+                ".");
+    TORCH_CHECK(
+        w1.scalar_type() == at::kBFloat16 && w2.scalar_type() == at::kBFloat16,
+        "MegaMoe A16W16 expects bf16 weights at local expert ",
+        expert,
+        ".");
+    TORCH_CHECK(w1.size(0) == hidden_size,
+                "MegaMoe W1 hidden dimension mismatch at local expert ",
+                expert,
+                ": expected ",
+                hidden_size,
+                ", got ",
+                w1.size(0));
+    TORCH_CHECK(w2.size(1) == hidden_size,
+                "MegaMoe W2 hidden dimension mismatch at local expert ",
+                expert,
+                ": expected ",
+                hidden_size,
+                ", got ",
+                w2.size(1));
+    TORCH_CHECK(w1.size(1) == 2 * w2.size(0),
+                "MegaMoe W1/W2 intermediate dimension mismatch at local "
+                "expert ",
+                expert,
+                ": W1 columns ",
+                w1.size(1),
+                ", W2 rows ",
+                w2.size(0));
+  }
+
+  auto y = at::empty_like(x);
+  auto expert_token_nums =
+      at::empty({local_expert_num}, x.options().dtype(at::kInt));
+
+  std::string comm_alg_copy = comm_alg;
+  char* comm_alg_ptr = comm_alg_copy.data();
+  std::string activation_copy = activation;
+  char* activation_ptr = activation_copy.data();
+
+  const int64_t resolved_dispatch_quant_out_dtype =
+      dispatch_quant_mode == 0  // DISPATCH_QUANT_MODE_NO_QUANT (A16W16)
+          ? 28
+          : dispatch_quant_out_dtype;
+
+  const std::optional<at::TensorList> no_tensor_list;
+  const int64_t activation_out_dtype_val = 28;
+  const bool transpose_weight1 = false;
+  const bool transpose_weight2 = false;
+  const int64_t weight1_interleave = 0;
+  const int64_t topkWeightsType = 0;
+
+  EXEC_NPU_CMD(aclnnMegaMoe,
+               context,
+               x,
+               topk_ids,
+               topk_weights,
+               weight1,
+               weight2,
+               weight_scales1,  // weight_scales1 (nullptr on A16W16)
+               weight_scales2,  // weight_scales2 (nullptr on A16W16)
+               bias1,           // bias1 (nullptr on A16W16)
+               bias2,           // bias2 (nullptr on A16W16)
+               x_active_mask,
+               //    no_tensor_list,    // shared_weight1 (no shared expert)
+               //    no_tensor_list,    // shared_weight2
+               //    no_tensor_list,    // shared_weight_scales1
+               //    no_tensor_list,    // shared_weight_scales2
+               //    no_tensor_list,    // shared_bias1
+               //    no_tensor_list,    // shared_bias2
+               moe_expert_num,
+               ep_world_size,
+               ccl_buffer_size,
+               max_recv_token_num,
+               dispatch_quant_mode,
+               resolved_dispatch_quant_out_dtype,
+               combine_quant_mode,
+               comm_alg_ptr,
+               num_max_tokens_per_rank,
+               activation_ptr,
+               activation_clamp,
+               //    topo_type,
+               //    rank_num_per_server,
+               //    topkWeightsType,
+               y,
+               expert_token_nums);
+
+  return std::make_tuple(y, expert_token_nums);
+}
+
+}  // namespace xllm::kernel::npu

--- a/xllm/core/kernels/npu/npu_ops_api.h
+++ b/xllm/core/kernels/npu/npu_ops_api.h
@@ -410,4 +410,32 @@ void causal_conv1d_out(const torch::Tensor& output,
                        int64_t activation_mode,
                        int64_t pad_slot_id,
                        int64_t run_mode);
+
+bool has_mega_moe();
+
+std::tuple<torch::Tensor, torch::Tensor> apply_npu_mega_moe(
+    const torch::Tensor& context,
+    const torch::Tensor& x,
+    const torch::Tensor& topk_ids,
+    const torch::Tensor& topk_weights,
+    const torch::TensorList weight1,
+    const torch::TensorList weight2,
+    int64_t moe_expert_num,
+    int64_t ep_world_size,
+    int64_t ccl_buffer_size,
+    const std::optional<torch::TensorList>& weight_scales1 = std::nullopt,
+    const std::optional<torch::TensorList>& weight_scales2 = std::nullopt,
+    const std::optional<torch::TensorList>& bias1 = std::nullopt,
+    const std::optional<torch::TensorList>& bias2 = std::nullopt,
+    const std::optional<torch::Tensor>& x_active_mask = std::nullopt,
+    int64_t max_recv_token_num = 0,
+    int64_t dispatch_quant_mode = 0,
+    int64_t combine_quant_mode = 0,
+    const std::string& comm_alg = "",
+    int64_t num_max_tokens_per_rank = 0,
+    const std::string& activation = "swiglu",
+    float activation_clamp = std::numeric_limits<float>::max(),
+    int64_t dispatch_quant_out_dtype = 0,
+    int64_t topo_type = 0,
+    int64_t rank_num_per_server = 2);
 }  // namespace xllm::kernel::npu

--- a/xllm/core/kernels/ops_api.cpp
+++ b/xllm/core/kernels/ops_api.cpp
@@ -1218,6 +1218,45 @@ bool has_dispatch_gmm_combine_decode() {
 #endif
 }
 
+std::tuple<torch::Tensor, torch::Tensor> mega_moe(MegaMoeParams& params) {
+#if defined(USE_NPU)
+  return npu::apply_npu_mega_moe(params.context,
+                                 params.x,
+                                 params.topk_ids,
+                                 params.topk_weights,
+                                 params.weight1,
+                                 params.weight2,
+                                 params.moe_expert_num,
+                                 params.ep_world_size,
+                                 params.ccl_buffer_size,
+                                 params.weight_scales1,
+                                 params.weight_scales2,
+                                 params.bias1,
+                                 params.bias2,
+                                 params.x_active_mask,
+                                 params.max_recv_token_num,
+                                 params.dispatch_quant_mode,
+                                 params.combine_quant_mode,
+                                 params.comm_alg,
+                                 params.num_max_tokens_per_rank,
+                                 params.activation,
+                                 params.activation_clamp,
+                                 params.dispatch_quant_out_dtype,
+                                 params.topo_type,
+                                 params.rank_num_per_server);
+#else
+  NOT_IMPLEMENTED();
+#endif
+}
+
+bool has_mega_moe() {
+#if defined(USE_NPU)
+  return npu::has_mega_moe();
+#else
+  return false;
+#endif
+}
+
 torch::Tensor hc_post(HcPostParams& params) {
 #if defined(USE_NPU)
   return npu::hc_post(params.x, params.residual, params.post, params.comb);

--- a/xllm/core/kernels/ops_api.h
+++ b/xllm/core/kernels/ops_api.h
@@ -150,6 +150,13 @@ std::tuple<torch::Tensor, torch::Tensor> dispatch_gmm_combine_decode(
 
 bool has_dispatch_gmm_combine_decode();
 
+// Fused expert-parallel mega MoE kernel: dispatch + grouped GEMM (gate/up) +
+// activation + combine grouped GEMM (down) + combine, in one fused call.
+// Returns tuple of (output hidden states, expert token nums).
+std::tuple<torch::Tensor, torch::Tensor> mega_moe(MegaMoeParams& params);
+
+bool has_mega_moe();
+
 // FP8 scaled quantize: quantizes input tensor to FP8 e4m3 format
 // Returns: (quantized_output, scale)
 std::tuple<torch::Tensor, torch::Tensor> fp8_scaled_quantize(

--- a/xllm/core/kernels/param.h
+++ b/xllm/core/kernels/param.h
@@ -1935,4 +1935,58 @@ struct NpuInplacePartialRotaryMulParams {
   std::vector<int64_t> partial_slice;
 };
 
+// Parameters for the fused expert-parallel mega MoE kernel.
+// Wraps the NPU apply_npu_mega_moe op: dispatch + grouped GEMM (gate/up) +
+// activation + combine grouped GEMM (down) + combine, in one fused call.
+struct MegaMoeParams {
+  // HCCL context tensor that carries the communicator handle.
+  torch::Tensor context;
+  // Input hidden states. Shape: [num_tokens, hidden_size].
+  torch::Tensor x;
+  // Routed expert ids. Shape: [num_tokens, topk], dtype int32.
+  torch::Tensor topk_ids;
+  // Router top-k weights. Shape: [num_tokens, topk], dtype fp32.
+  torch::Tensor topk_weights;
+  // First expert weights as TensorList (gate/up projection).
+  torch::TensorList weight1;
+  // Second expert weights as TensorList (down projection).
+  torch::TensorList weight2;
+  // Total number of experts across all ranks.
+  int64_t moe_expert_num = 0;
+  // Expert-parallel world size.
+  int64_t ep_world_size = 1;
+  // HCCL communication buffer size in bytes.
+  int64_t ccl_buffer_size = 0;
+  // Optional W8A8/int8 weight scales for weight1.
+  std::optional<torch::TensorList> weight_scales1 = std::nullopt;
+  // Optional W8A8/int8 weight scales for weight2.
+  std::optional<torch::TensorList> weight_scales2 = std::nullopt;
+  // Optional bias list added to the first matmul output.
+  std::optional<torch::TensorList> bias1 = std::nullopt;
+  // Optional bias list added to the second matmul output.
+  std::optional<torch::TensorList> bias2 = std::nullopt;
+  // Optional active token mask. Shape: [num_tokens], dtype int8/bool.
+  std::optional<torch::Tensor> x_active_mask = std::nullopt;
+  // Maximum number of tokens that can be received from remote ranks.
+  int64_t max_recv_token_num = 0;
+  // Dispatch communication quantization mode.
+  int64_t dispatch_quant_mode = 0;
+  // Combine communication quantization mode.
+  int64_t combine_quant_mode = 0;
+  // HCCL communication algorithm name.
+  std::string comm_alg = "";
+  // Maximum number of tokens per rank for the all-to-all buffer.
+  int64_t num_max_tokens_per_rank = 0;
+  // Activation function name for the gated MLP.
+  std::string activation = "swiglu";
+  // Clamp limit applied to the activation output.
+  float activation_clamp = std::numeric_limits<float>::max();
+  // Output dtype used by dispatch quantization.
+  int64_t dispatch_quant_out_dtype = 0;
+  // Topology type for the expert-parallel communication.
+  int64_t topo_type = 0;
+  // Number of ranks per server node.
+  int64_t rank_num_per_server = 2;
+};
+
 }  // namespace xllm::kernel

--- a/xllm/core/layers/npu_torch/fused_moe.cpp
+++ b/xllm/core/layers/npu_torch/fused_moe.cpp
@@ -21,6 +21,7 @@ limitations under the License.
 #include <cctype>
 #include <cmath>
 #include <cstdint>
+#include <limits>
 #include <numeric>
 #include <string>
 #include <vector>
@@ -34,6 +35,8 @@ limitations under the License.
 
 #include "framework/config/eplb_config.h"
 #include "framework/config/kernel_config.h"
+#include "framework/config/scheduler_config.h"
+#include "framework/parallel_state/mega_moe_comm_resource.h"
 #include "framework/parallel_state/parallel_state.h"
 #include "kernels/ops_api.h"
 #include "layers/common/dp_utils.h"
@@ -63,6 +66,8 @@ std::vector<int32_t> make_moe_dp_token_nums(
   }
   return normalized;
 }
+
+constexpr int64_t kMegaMoeMaxTokens = 4096;
 
 // Generic local tensor helpers.
 torch::Tensor get_tensor_with_weight_suffix(const StateDict& state_dict,
@@ -544,6 +549,7 @@ FusedMoEImpl::FusedMoEImpl(const ModelArgs& model_args,
             options_),
         false);
   }
+  initialize_mega_moe();
 }
 
 void FusedMoEImpl::validate_resolved_quant_method() const {
@@ -762,10 +768,9 @@ void FusedMoEImpl::ensure_group_gemm_weight_layout(torch::Tensor& weight,
       << weight.sizes() << ", expected dim2=" << output_dim;
 }
 
-torch::Tensor FusedMoEImpl::select_experts(
+std::pair<torch::Tensor, torch::Tensor> FusedMoEImpl::select_global_experts(
     const torch::Tensor& hidden_states_2d,
-    const torch::Tensor& router_logits_2d,
-    SelectedExpertInfo& selected_expert_info) {
+    const torch::Tensor& router_logits_2d) {
   torch::Tensor topk_weights;
   torch::Tensor topk_ids;
   std::optional<torch::Tensor> e_score_correction_bias = std::nullopt;
@@ -825,6 +830,16 @@ torch::Tensor FusedMoEImpl::select_experts(
     }
   }
 
+  return std::make_pair(topk_weights.contiguous(), topk_ids.contiguous());
+}
+
+torch::Tensor FusedMoEImpl::select_experts(
+    const torch::Tensor& hidden_states_2d,
+    const torch::Tensor& router_logits_2d,
+    SelectedExpertInfo& selected_expert_info) {
+  auto [topk_weights, topk_ids] =
+      select_global_experts(hidden_states_2d, router_logits_2d);
+
   const int64_t local_expert_start = start_expert_id_;
   const int64_t local_expert_end = start_expert_id_ + num_experts_per_rank_;
   if (parallel_args_.ep_size() > 1) {
@@ -869,10 +884,106 @@ torch::Tensor FusedMoEImpl::select_experts(
   return expand_hidden_states;
 }
 
-torch::Tensor FusedMoEImpl::forward_expert(
+void FusedMoEImpl::initialize_mega_moe() {
+  if (!::xllm::KernelConfig::get_instance().enable_mega_moe()) {
+    return;
+  }
+  CHECK_GT(parallel_args_.ep_size(), 1) << "mega_moe requires ep_size > 1";
+  CHECK(parallel_args_.moe_ep_group_ != nullptr)
+      << "mega_moe requires moe_ep_group";
+  CHECK(xllm::kernel::has_mega_moe()) << "aclnnMegaMoe symbol not available";
+  CHECK(quant_args_.quant_method().empty() && quant_args_.quant_descs().empty())
+      << "mega_moe only supports unquantized weights";
+  CHECK_EQ(options_.dtype(), torch::kBFloat16) << "mega_moe requires bf16";
+
+  ProcessGroup* ep_group = parallel_args_.moe_ep_group_;
+  MegaMoeCommSpec comm_spec;
+  comm_spec.group_name = ep_group->hccl_comm_name(/*init_comm=*/true);
+  comm_spec.hccl_comm = ep_group->hccl_comm();
+  comm_spec.ep_world_size = ep_group->world_size();
+  comm_spec.device_index = options_.device().index();
+  comm_spec.max_num_tokens_per_rank =
+      ::xllm::SchedulerConfig::get_instance().max_tokens_per_batch();
+  mega_moe_comm_resource_ = ep_group->acquire_mega_moe_comm_resource(comm_spec);
+  mega_moe_enabled_ = true;
+}
+
+void FusedMoEImpl::ensure_mega_moe_weights() {
+  if (mega_moe_w1_storage_.defined() && mega_moe_w2_storage_.defined()) {
+    return;
+  }
+  CHECK(w13_is_loaded_ && w2_is_loaded_)
+      << "MegaMoe weights must be loaded before first execution.";
+  mega_moe_w1_storage_ = (w13_.size(1) == hidden_size_)
+                             ? w13_.contiguous()
+                             : w13_.transpose(1, 2).contiguous();
+  mega_moe_w2_storage_ = (w2_.size(2) == hidden_size_)
+                             ? w2_.contiguous()
+                             : w2_.transpose(1, 2).contiguous();
+  mega_moe_w1_list_.reserve(static_cast<size_t>(num_experts_per_rank_));
+  mega_moe_w2_list_.reserve(static_cast<size_t>(num_experts_per_rank_));
+  for (int64_t i = 0; i < num_experts_per_rank_; ++i) {
+    mega_moe_w1_list_.push_back(mega_moe_w1_storage_.select(0, i));
+    mega_moe_w2_list_.push_back(mega_moe_w2_storage_.select(0, i));
+  }
+}
+
+torch::Tensor FusedMoEImpl::forward_mega_moe(
     const torch::Tensor& hidden_states,
     const torch::Tensor& router_logits,
     const std::optional<torch::Tensor>& shared_output) {
+  CHECK(mega_moe_enabled_);
+  auto comm = mega_moe_comm_resource_.lock();
+  CHECK(comm != nullptr)
+      << "MegaMoe communication resource expired before collective launch.";
+
+  ensure_mega_moe_weights();
+  const auto hidden_states_shape = hidden_states.sizes();
+  auto input_2d =
+      hidden_states.reshape({-1, hidden_states.size(-1)}).contiguous();
+  auto router_logits_2d = router_logits.reshape({-1, router_logits.size(-1)});
+
+  auto [topk_weights, topk_ids] =
+      select_global_experts(input_2d, router_logits_2d);
+  topk_weights = topk_weights.to(torch::kFloat32).contiguous();
+  topk_ids = topk_ids.to(torch::kInt32).contiguous();
+
+  const int64_t ep_world_size = parallel_args_.ep_size();
+
+  xllm::kernel::MegaMoeParams params;
+  params.context = comm->context_tensor();
+  params.x = input_2d;
+  params.topk_ids = topk_ids;
+  params.topk_weights = topk_weights;
+  params.weight1 = torch::TensorList(mega_moe_w1_list_);
+  params.weight2 = torch::TensorList(mega_moe_w2_list_);
+  params.moe_expert_num = num_total_experts_;
+  params.ep_world_size = ep_world_size;
+  params.ccl_buffer_size = comm->ccl_buffer_size();
+  params.num_max_tokens_per_rank = comm->max_num_tokens_per_rank();
+
+  auto [y, expert_token_nums] = xllm::kernel::mega_moe(params);
+
+  (void)expert_token_nums;
+  auto output = y.reshape(hidden_states_shape);
+  if (shared_output.has_value()) {
+    auto shared = shared_output.value();
+    if (tp_pg_->world_size() > 1) {
+      shared = parallel_state::reduce(shared, tp_pg_);
+    }
+    output = output + shared;
+  }
+  return output;
+}
+
+torch::Tensor FusedMoEImpl::forward_expert(
+    const torch::Tensor& hidden_states,
+    const torch::Tensor& router_logits,
+    const std::optional<torch::Tensor>& shared_output,
+    bool use_mega_moe) {
+  if (use_mega_moe) {
+    return forward_mega_moe(hidden_states, router_logits, shared_output);
+  }
   // prepare the parameters for MoE computation
   torch::IntArrayRef hidden_states_shape = hidden_states.sizes();
   torch::ScalarType hidden_states_dtype = hidden_states.dtype().toScalarType();
@@ -1166,7 +1277,10 @@ torch::Tensor FusedMoEImpl::forward(const torch::Tensor& hidden_states,
     }
   }
   auto router_logits = gate_(input);
-  auto output = forward_expert(input, router_logits, shared_output);
+  const bool use_mega_moe =
+      mega_moe_enabled_ && input.size(0) <= kMegaMoeMaxTokens;
+  auto output =
+      forward_expert(input, router_logits, shared_output, use_mega_moe);
 
   if (need_slice) {
     const int64_t dp_rank = parallel_args_.dp_local_process_group_->rank();
@@ -1685,7 +1799,10 @@ torch::Tensor FusedMoEImpl::forward_with_selected_experts(
   std::vector<int64_t> router_shape = input.sizes().vec();
   router_shape.back() = num_total_experts_;
   torch::Tensor router_logits = torch::empty(router_shape, input.options());
-  torch::Tensor output = forward_expert(input, router_logits, shared_output);
+  const bool use_mega_moe =
+      mega_moe_enabled_ && input.size(0) <= kMegaMoeMaxTokens;
+  torch::Tensor output =
+      forward_expert(input, router_logits, shared_output, use_mega_moe);
   preselected_experts_ = std::nullopt;
 
   if (need_slice) {

--- a/xllm/core/layers/npu_torch/fused_moe.h
+++ b/xllm/core/layers/npu_torch/fused_moe.h
@@ -23,6 +23,7 @@ limitations under the License.
 
 #include "framework/model/model_args.h"
 #include "framework/model/model_input_params.h"
+#include "framework/parallel_state/mega_moe_comm_resource.h"
 #include "framework/parallel_state/parallel_args.h"
 #include "framework/quant_args.h"
 #include "framework/state_dict/state_dict.h"
@@ -47,7 +48,8 @@ class FusedMoEImpl : public torch::nn::Module {
   torch::Tensor forward_expert(
       const torch::Tensor& hidden_states,
       const torch::Tensor& router_logits,
-      const std::optional<torch::Tensor>& shared_output);
+      const std::optional<torch::Tensor>& shared_output,
+      bool use_mega_moe);
   torch::Tensor forward_with_selected_experts(
       const torch::Tensor& hidden_states,
       const torch::Tensor& topk_weights,
@@ -71,6 +73,19 @@ class FusedMoEImpl : public torch::nn::Module {
   torch::Tensor select_experts(const torch::Tensor& hidden_states_2d,
                                const torch::Tensor& router_logits_2d,
                                SelectedExpertInfo& selected_expert_info);
+
+  // Computes router choices in the global expert-id space. MegaMoe consumes
+  // these values before the legacy per-rank expert mask is applied.
+  std::pair<torch::Tensor, torch::Tensor> select_global_experts(
+      const torch::Tensor& hidden_states_2d,
+      const torch::Tensor& router_logits_2d);
+
+  void initialize_mega_moe();
+  void ensure_mega_moe_weights();
+  torch::Tensor forward_mega_moe(
+      const torch::Tensor& hidden_states,
+      const torch::Tensor& router_logits,
+      const std::optional<torch::Tensor>& shared_output);
 
  private:
   int64_t num_total_experts_;
@@ -172,6 +187,13 @@ class FusedMoEImpl : public torch::nn::Module {
   torch::Tensor dispatch_ffn_w13_scale_;
   torch::Tensor dispatch_ffn_w2_scale_;
   std::string moe_ep_group_name_;
+
+  bool mega_moe_enabled_ = false;
+  std::weak_ptr<MegaMoeCommResource> mega_moe_comm_resource_;
+  torch::Tensor mega_moe_w1_storage_;
+  torch::Tensor mega_moe_w2_storage_;
+  std::vector<torch::Tensor> mega_moe_w1_list_;
+  std::vector<torch::Tensor> mega_moe_w2_list_;
 };
 TORCH_MODULE(FusedMoE);
 


### PR DESCRIPTION
## Description

- Add enable_mega_moe kernel config flag (DEFINE, from_flags/from_json/append_config_json)
- Add MegaMoeCommResource: HCCL all-to-all context setup via libhccl/libhccl_fwk
- Add apply_npu_mega_moe kernel wrapping aclnnMegaMoe with full arg validation
- Integrate forward_mega_moe path into FusedMoEImpl (decode-only, bf16, swiglu)
- Expose hccl_comm() on ProcessGroup/ProcessGroupImpl for resource acquisition
- Add null-safe release() overloads for aclTensor/aclTensorList in NPU helper

To use the MegaMoe operator, you need to download CANN version 9.1.0 and the corresponding ops package. Download path: https://www.hiascend.com/cann/download?versionId=767&ids=d802%2Ch0501%2Ch0601%2Ch0703
If you are using CANN 9.0.0 and an A3 environment, you can upgrade only the ops package to CANN 9.1.0.

## Related Issues

<!-- Link related issues here. Use "Fixes #123" when this PR closes an issue. -->

## Change Type

- [ ] Bug fix
- [x] New feature
- [ ] Performance improvement
- [ ] Refactor
- [ ] Documentation
- [ ] Test
- [ ] Build or CI

## Pull Request Checklist

Thank you for contributing to xLLM. Before requesting review, please make sure the following items are complete.

### PR Title and Commit Messages

- [ ] The PR title and each commit message follow the xLLM commit format: `<type>: <subject>`.

> Allowed types: feat, bugfix, docs, test, refactor, chore, style, revert, perf, model, build, release.
> The subject should use clear English, start with a verb, include at least 4 words, and end with `.`.

### Pre-commit Checks

- [ ] I have installed `pre-commit` by running `pip install pre-commit` or an equivalent command.
- [ ] I have installed the hooks with `pre-commit install`.
- [ ] I have run `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

### Self Review

- [ ] I have self-reviewed the code according to `.agents/skills/code-review/references/custom-code-style.md`, especially code written or assisted by AI.
- [ ] I have rebased this PR onto the latest `main` branch.

### Build and Test Coverage

- [ ] Tests have been added or updated as needed.
- [ ] CUDA: `python setup.py build test` has passed on a CUDA machine.
- [ ] NPU: `python setup.py build test` has passed on an NPU machine.
- [ ] MLU: `python setup.py build test` has passed on an MLU machine.

## Reviewer Notes

<!-- Optional: anything reviewers should focus on, known risks, follow-ups, or validation gaps. -->
