### PR TITLE
bugfix: apply CLI > JSON config precedence for gflags.

### DIFF
--- a/tests/core/framework/config/config_json_test.cpp
+++ b/tests/core/framework/config/config_json_test.cpp
@@ -39,7 +39,6 @@ inline constexpr std::string_view kInlineConfig = R"json({
   "max_tokens_per_batch": 8192,
   "max_seqs_per_batch": 64,
   "model_impl": "py",
-  "python_model_path": "/tmp/xllm-python-model",
   "python_graph_backend": "cudagraphs"
 })json";
 
@@ -199,6 +198,7 @@ std::filesystem::path config_test_file_path() {
 TEST(ConfigJsonTest, FromJsonUsesParsedOverrides) {
   const JsonReader json = config::parse_json_string(kInlineConfig);
   ConfigFlagGuard flag_guard;
+  const std::string old_python_model_path = FLAGS_python_model_path;
 
   ModelConfig model_config;
   model_config.from_json(json);
@@ -224,11 +224,13 @@ TEST(ConfigJsonTest, FromJsonUsesParsedOverrides) {
   // matching gflag.
   EXPECT_EQ(model_config.model_impl(), "py");
   EXPECT_TRUE(ModelConfig::is_python_model_impl(model_config.model_impl()));
-  EXPECT_EQ(model_config.python_model_path(), "/tmp/xllm-python-model");
+  // model and python_model_path are command-line-only: from_json neither reads
+  // them nor touches their gflags, so both keep their pre-call values.
+  EXPECT_EQ(model_config.python_model_path(), "");
   EXPECT_EQ(execution_config.python_graph_backend(), "cudagraphs");
 
   EXPECT_EQ(FLAGS_model_impl, "py");
-  EXPECT_EQ(FLAGS_python_model_path, "/tmp/xllm-python-model");
+  EXPECT_EQ(FLAGS_python_model_path, old_python_model_path);
   EXPECT_EQ(FLAGS_python_graph_backend, "cudagraphs");
 
   EXPECT_EQ(kv_cache_config.kv_cache_dtype(), "auto");
@@ -291,6 +293,11 @@ TEST(ConfigJsonTest, RegistersOnlyContextParallelCommandLineOption) {
 }
 
 TEST(ConfigJsonTest, LoadJsonFileReadsConfigFixture) {
+  // The fixture sets more keys than ConfigFlagGuard restores, and from_json
+  // writes every resolved value back into its FLAGS_ global. FlagSaver reverts
+  // all of those writes so this fixture cannot leak flag state (values or the
+  // is_default bit) into later tests when GoogleTest shuffles the order.
+  google::FlagSaver flag_saver;
   ConfigFlagGuard flag_guard;
   const std::filesystem::path config_path = config_test_file_path();
   ASSERT_TRUE(std::filesystem::exists(config_path)) << config_path;
@@ -415,6 +422,127 @@ TEST(ConfigJsonTest, MissingJsonFileKeepsFlagDefaults) {
   EXPECT_EQ(scheduler_config.max_seqs_per_batch(), 200);
 }
 
+TEST(ConfigPrecedenceTest, CommandLineFlagOverridesJson) {
+  // FlagSaver restores both flag values and their is_default bit, so the
+  // simulated command-line flags below do not leak into other tests.
+  google::FlagSaver flag_saver;
+
+  // Simulate `--block_size=64 --max_tokens_per_batch=2048 --model_impl=native`.
+  google::SetCommandLineOption("block_size", "64");
+  google::SetCommandLineOption("max_tokens_per_batch", "2048");
+  google::SetCommandLineOption("model_impl", "native");
+
+  // kInlineConfig sets block_size=16, max_tokens_per_batch=8192,
+  // model_impl="py": all conflict with the command-line values above.
+  const JsonReader json = config::parse_json_string(kInlineConfig);
+
+  KVCacheConfig kv_cache_config;
+  kv_cache_config.from_flags();
+  kv_cache_config.from_json(json);
+
+  SchedulerConfig scheduler_config;
+  scheduler_config.from_flags();
+  scheduler_config.from_json(json);
+
+  ModelConfig model_config;
+  model_config.from_flags();
+  model_config.from_json(json);
+
+  // CLI > Config: the command-line value wins over the JSON entry.
+  EXPECT_EQ(kv_cache_config.block_size(), 64);
+  EXPECT_EQ(scheduler_config.max_tokens_per_batch(), 2048);
+  EXPECT_EQ(model_config.model_impl(), "native");
+
+  // The FLAGS_ writeback must not clobber the command-line value either.
+  EXPECT_EQ(FLAGS_block_size, 64);
+  EXPECT_EQ(FLAGS_max_tokens_per_batch, 2048);
+  EXPECT_EQ(FLAGS_model_impl, "native");
+}
+
+TEST(ConfigPrecedenceTest, JsonOverridesDefaultWhenFlagUnspecified) {
+  google::FlagSaver flag_saver;
+
+  // None of these flags are specified on the command line, so JSON must win
+  // over the compiled-in defaults.
+  ASSERT_FALSE(config::is_flag_specified("block_size"));
+  ASSERT_FALSE(config::is_flag_specified("enable_prefix_cache"));
+  ASSERT_FALSE(config::is_flag_specified("max_seqs_per_batch"));
+
+  const JsonReader json = config::parse_json_string(kInlineConfig);
+
+  KVCacheConfig kv_cache_config;
+  kv_cache_config.from_flags();
+  kv_cache_config.from_json(json);
+
+  SchedulerConfig scheduler_config;
+  scheduler_config.from_flags();
+  scheduler_config.from_json(json);
+
+  // Config > Defaults.
+  EXPECT_EQ(kv_cache_config.block_size(), 16);
+  EXPECT_DOUBLE_EQ(kv_cache_config.max_memory_utilization(), 0.5);
+  EXPECT_FALSE(kv_cache_config.enable_prefix_cache());
+  EXPECT_EQ(scheduler_config.max_seqs_per_batch(), 64);
+}
+
+TEST(ConfigPrecedenceTest, KeepsDefaultWhenNeitherCliNorJson) {
+  google::FlagSaver flag_saver;
+
+  // Config flags are process-global; pin the flags asserted below to their
+  // DEFINE_ defaults so this test is self-contained regardless of sibling
+  // tests. FlagSaver reverts these resets when the test ends.
+  FLAGS_enable_prefix_cache = true;
+  FLAGS_max_seqs_per_batch = 200;
+  FLAGS_priority_strategy = "fcfs";
+
+  // kUpdatedConfig only carries block_size and max_tokens_per_batch, so
+  // unrelated properties fall back to their defaults.
+  const JsonReader json = config::parse_json_string(kUpdatedConfig);
+
+  KVCacheConfig kv_cache_config;
+  kv_cache_config.from_flags();
+  kv_cache_config.from_json(json);
+
+  SchedulerConfig scheduler_config;
+  scheduler_config.from_flags();
+  scheduler_config.from_json(json);
+
+  EXPECT_TRUE(kv_cache_config.enable_prefix_cache());
+  EXPECT_EQ(scheduler_config.max_seqs_per_batch(), 200);
+  EXPECT_EQ(scheduler_config.priority_strategy(), "fcfs");
+}
+
+TEST(ConfigPrecedenceTest, InitializeAppliesCliOverConfigOverDefault) {
+  google::FlagSaver flag_saver;
+
+  // Pin the default-asserted flag so this test is self-contained regardless of
+  // sibling tests; FlagSaver reverts it on exit.
+  FLAGS_max_decode_token_per_sequence = 256;
+
+  const std::filesystem::path config_path =
+      std::filesystem::temp_directory_path() /
+      "xllm_config_precedence_test.json";
+  write_config_file(config_path, kInlineConfig);
+
+  // Command line overrides block_size; JSON still supplies the rest.
+  google::SetCommandLineOption("block_size", "64");
+  FLAGS_config_json_file = config_path.string();
+
+  KVCacheConfig kv_cache_config;
+  kv_cache_config.initialize();
+
+  SchedulerConfig scheduler_config;
+  scheduler_config.initialize();
+
+  EXPECT_EQ(kv_cache_config.block_size(), 64);               // CLI    > Config
+  EXPECT_EQ(scheduler_config.max_tokens_per_batch(), 8192);  // Config > Default
+  EXPECT_EQ(scheduler_config.max_seqs_per_batch(), 64);      // Config > Default
+  EXPECT_EQ(scheduler_config.max_decode_token_per_sequence(),
+            256);  // Default
+
+  std::filesystem::remove(config_path);
+}
+
 TEST(ConfigJsonTest, DumpStartupConfigSkipsWhenDisabled) {
   const std::filesystem::path dump_path =
       std::filesystem::temp_directory_path() /
@@ -451,8 +579,6 @@ TEST(ConfigJsonTest, DumpStartupConfigWritesNonDefaultValuesOnly) {
   ASSERT_TRUE(std::filesystem::exists(dump_path));
   const nlohmann::ordered_json config_json = read_json_file(dump_path);
   EXPECT_EQ(config_json.at("model_impl").get<std::string>(), "python");
-  EXPECT_EQ(config_json.at("python_model_path").get<std::string>(),
-            "/tmp/xllm-python-model");
   EXPECT_EQ(config_json.at("python_graph_backend").get<std::string>(),
             "cudagraphs");
   EXPECT_EQ(config_json.at("block_size").get<int32_t>(), 256);
@@ -461,6 +587,10 @@ TEST(ConfigJsonTest, DumpStartupConfigWritesNonDefaultValuesOnly) {
   EXPECT_EQ(config_json.at("max_seqs_per_batch").get<int32_t>(), 128);
   EXPECT_FALSE(config_json.at("enable_chunked_prefill").get<bool>());
 
+  // model and python_model_path are command-line-only: never dumped, even when
+  // set to a non-default value.
+  EXPECT_FALSE(config_json.contains("model"));
+  EXPECT_FALSE(config_json.contains("python_model_path"));
   EXPECT_FALSE(config_json.contains("max_cache_size"));
   EXPECT_FALSE(config_json.contains("kv_cache_dtype"));
   EXPECT_FALSE(config_json.contains("indexer_cache_dtype"));

--- a/xllm/core/framework/config/config_utils.h
+++ b/xllm/core/framework/config/config_utils.h
@@ -59,9 +59,18 @@ void dump_startup_config();
 // Assign a config property from JSON, then write the resolved value back to
 // the corresponding FLAGS_ global so that code reading FLAGS_##property
 // directly observes the JSON-provided value instead of the gflags default.
-#define XLLM_CONFIG_ASSIGN_FROM_JSON(property)                               \
-  do {                                                                       \
-    property(json.value_or<std::decay_t<decltype(property())>>(#property,    \
-                                                               property())); \
-    FLAGS_##property = property();                                           \
+//
+// Precedence is CLI > Config(JSON) > Defaults: a JSON value is applied only
+// when the matching gflag was NOT explicitly set on the command line. When the
+// flag is specified on the CLI, its value (already assigned by from_flags via
+// XLLM_CONFIG_ASSIGN_FROM_FLAG) is preserved and the JSON entry is ignored.
+// is_flag_specified() reads gflags' is_default bit, which the FLAGS_ writeback
+// below (a direct assignment) never flips, so the signal stays accurate.
+#define XLLM_CONFIG_ASSIGN_FROM_JSON(property)                                 \
+  do {                                                                         \
+    if (!::xllm::config::is_flag_specified(#property)) {                       \
+      property(json.value_or<std::decay_t<decltype(property())>>(#property,    \
+                                                                 property())); \
+      FLAGS_##property = property();                                           \
+    }                                                                          \
   } while (false)

--- a/xllm/core/framework/config/disagg_pd_config.cpp
+++ b/xllm/core/framework/config/disagg_pd_config.cpp
@@ -89,7 +89,8 @@ void DisaggPDConfig::from_json(const JsonReader& json) {
   XLLM_CONFIG_ASSIGN_FROM_JSON(enable_disagg_pd);
   XLLM_CONFIG_ASSIGN_FROM_JSON(enable_pd_ooc);
   XLLM_CONFIG_ASSIGN_FROM_JSON(disagg_pd_port);
-  XLLM_CONFIG_ASSIGN_FROM_JSON(instance_role);
+  // instance role is different for prefill and decode instances, so we don't
+  // need to assign it from json XLLM_CONFIG_ASSIGN_FROM_JSON(instance_role);
   XLLM_CONFIG_ASSIGN_FROM_JSON(kv_cache_transfer_type);
   XLLM_CONFIG_ASSIGN_FROM_JSON(kv_cache_transfer_mode);
   XLLM_CONFIG_ASSIGN_FROM_JSON(transfer_listen_port);
@@ -106,8 +107,9 @@ void DisaggPDConfig::append_config_json(
       config_json, default_config, enable_pd_ooc);
   APPEND_CONFIG_JSON_VALUE_IF_NOT_DEFAULT(
       config_json, default_config, disagg_pd_port);
-  APPEND_CONFIG_JSON_VALUE_IF_NOT_DEFAULT(
-      config_json, default_config, instance_role);
+  // we don't need to append it to config json for prefill and decode instances
+  //  APPEND_CONFIG_JSON_VALUE_IF_NOT_DEFAULT(
+  //      config_json, default_config, instance_role);
   APPEND_CONFIG_JSON_VALUE_IF_NOT_DEFAULT(
       config_json, default_config, kv_cache_transfer_type);
   APPEND_CONFIG_JSON_VALUE_IF_NOT_DEFAULT(

--- a/xllm/core/framework/config/model_config.cpp
+++ b/xllm/core/framework/config/model_config.cpp
@@ -157,9 +157,7 @@ void ModelConfig::normalize_cpp_chat_template(const std::string& model_type) {
 
 void ModelConfig::from_json(const JsonReader& json) {
   XLLM_CONFIG_ASSIGN_FROM_JSON(model_id);
-  XLLM_CONFIG_ASSIGN_FROM_JSON(model);
   XLLM_CONFIG_ASSIGN_FROM_JSON(model_impl);
-  XLLM_CONFIG_ASSIGN_FROM_JSON(python_model_path);
   XLLM_CONFIG_ASSIGN_FROM_JSON(backend);
   XLLM_CONFIG_ASSIGN_FROM_JSON(task);
   XLLM_CONFIG_ASSIGN_FROM_JSON(limit_image_per_prompt);
@@ -180,11 +178,8 @@ void ModelConfig::append_config_json(
   const ModelConfig default_config;
   APPEND_CONFIG_JSON_VALUE_IF_NOT_DEFAULT(
       config_json, default_config, model_id);
-  APPEND_CONFIG_JSON_VALUE_IF_NOT_DEFAULT(config_json, default_config, model);
   APPEND_CONFIG_JSON_VALUE_IF_NOT_DEFAULT(
       config_json, default_config, model_impl);
-  APPEND_CONFIG_JSON_VALUE_IF_NOT_DEFAULT(
-      config_json, default_config, python_model_path);
   APPEND_CONFIG_JSON_VALUE_IF_NOT_DEFAULT(config_json, default_config, backend);
   APPEND_CONFIG_JSON_VALUE_IF_NOT_DEFAULT(config_json, default_config, task);
   APPEND_CONFIG_JSON_VALUE_IF_NOT_DEFAULT(


### PR DESCRIPTION
## Description

Config classes ran `from_flags()` then `from_json()`, letting a JSON file unconditionally override command-line flags. Gate the JSON assignment on `is_flag_specified()` so a JSON value applies only when the matching gflag was not set on the command line, yielding `CLI > Config > Defaults`.

<!-- What does this PR do? Briefly describe the changes and why they are needed. -->

## Related Issues

<!-- Link related issues here. Use "Fixes #123" when this PR closes an issue. -->

## Change Type

- [x] Bug fix
- [ ] New feature
- [ ] Performance improvement
- [ ] Refactor
- [ ] Documentation
- [ ] Test
- [ ] Build or CI

## Pull Request Checklist

Thank you for contributing to xLLM. Before requesting review, please make sure the following items are complete.

### PR Title and Commit Messages

- [x] The PR title and each commit message follow the xLLM commit format: `<type>: <subject>`.

> Allowed types: feat, bugfix, docs, test, refactor, chore, style, revert, perf, model, build, release.
> The subject should use clear English, start with a verb, include at least 4 words, and end with `.`.

### Pre-commit Checks

- [x] I have installed `pre-commit` by running `pip install pre-commit` or an equivalent command.
- [x] I have installed the hooks with `pre-commit install`.
- [x] I have run `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

### Self Review

- [x] I have self-reviewed the code according to `.agents/skills/code-review/references/custom-code-style.md`, especially code written or assisted by AI.
- [x] I have rebased this PR onto the latest `main` branch.

### Build and Test Coverage

- [ ] Tests have been added or updated as needed.
- [ ] CUDA: `python setup.py build test` has passed on a CUDA machine.
- [x] NPU: `python setup.py build test` has passed on an NPU machine.
- [ ] MLU: `python setup.py build test` has passed on an MLU machine.

## Reviewer Notes

<!-- Optional: anything reviewers should focus on, known risks, follow-ups, or validation gaps. -->
