### PR TITLE
bugfix: fix aspect_ratio scope error in QwenImageEditPlus pipeline.

### DIFF
--- a/xllm/models/dit/pipelines/pipeline_qwenimage_edit_plus.h
+++ b/xllm/models/dit/pipelines/pipeline_qwenimage_edit_plus.h
@@ -936,7 +936,7 @@ class QwenImageEditPlusPipelineImpl : public torch::nn::Module {
     std::vector<std::pair<int64_t, int64_t>> vae_image_sizes;
     if (!image_list.empty() && image_list[0].size(1) != latent_channels_) {
       for (size_t i = 0; i < image_list.size(); i++) {
-        aspect_ratio =
+        double aspect_ratio =
             static_cast<double>(image_list[i].size(3)) / image_list[i].size(2);
         auto [condition_width, condition_height] =
             xllm::dit::calculate_dimensions(CONDITION_IMAGE_SIZE, aspect_ratio);


### PR DESCRIPTION
The per-image aspect_ratio in the condition/VAE preprocessing loop was used as an assignment to a name declared in an earlier, now-closed if block, causing a "not declared in this scope" compile error. Declare it locally within the loop where it is first used.

## Description

<!-- What does this PR do? Briefly describe the changes and why they are needed. -->

## Related Issues

<!-- Link related issues here. Use "Fixes #123" when this PR closes an issue. -->

## Change Type

- [ ] Bug fix
- [ ] New feature
- [ ] Performance improvement
- [ ] Refactor
- [ ] Documentation
- [ ] Test
- [ ] Build or CI

## Pull Request Checklist

Thank you for contributing to xLLM. Before requesting review, please make sure the following items are complete.

### PR Title and Commit Messages

- [ ] The PR title and each commit message follow the xLLM commit format: `<type>: <subject>`.

> Allowed types: feat, bugfix, docs, test, refactor, chore, style, revert, perf, model, build, release.
> The subject should use clear English, start with a verb, include at least 4 words, and end with `.`.

### Pre-commit Checks

- [ ] I have installed `pre-commit` by running `pip install pre-commit` or an equivalent command.
- [ ] I have installed the hooks with `pre-commit install`.
- [ ] I have run `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

### Self Review

- [ ] I have self-reviewed the code according to `.agents/skills/code-review/references/custom-code-style.md`, especially code written or assisted by AI.
- [ ] I have rebased this PR onto the latest `main` branch.

### Build and Test Coverage

- [ ] Tests have been added or updated as needed.
- [ ] CUDA: `python setup.py build test` has passed on a CUDA machine.
- [ ] NPU: `python setup.py build test` has passed on an NPU machine.
- [ ] MLU: `python setup.py build test` has passed on an MLU machine.

## Reviewer Notes

<!-- Optional: anything reviewers should focus on, known risks, follow-ups, or validation gaps. -->
