### PR TITLE
[WIP]feat: add context-parallel sequence sharding for Qwen3 Python model.

### DIFF
--- a/tests/core/kernels/npu/npu_xllm_ops_test.cpp
+++ b/tests/core/kernels/npu/npu_xllm_ops_test.cpp
@@ -358,6 +358,87 @@ TEST_F(NpuXllmOpsTest, Qwen35_27B_TP4_KvCacheCrosses128TokenBoundary) {
              .item<float>();
 }
 
+// DCP shard-write correctness hinge: the Python decode/prefill KV-shard plan
+// marks tokens this rank does not own with slot == -1 and relies on
+// reshape_paged_cache skipping them. On Ascend950 the a5 kernel skips negative
+// slots (verified in source). Every other SoC — including this box
+// (Ascend910_9382) — routes to atb::npu_reshape_and_cache, a precompiled
+// black box with no documented -1 behavior. Probe it empirically: any -1 token
+// leaking into the cache (or an out-of-bounds write) would make the -1
+// shard-write plan silently corrupt KV, so DCP would instead need a compacted
+// index_select write.
+TEST_F(NpuXllmOpsTest, AtbReshapePagedCacheSkipsNegativeSlot) {
+  py::gil_scoped_acquire gil;
+  if (is_ascend950_device()) {
+    GTEST_SKIP() << "Ascend950 routes to the a5 kernel (known to skip -1); "
+                    "this probe targets the atb fallback path.";
+  }
+
+  constexpr int64_t kBlockSize = 128;
+  constexpr int64_t kNumBlocks = 4;
+  constexpr int64_t kKvHeads = 1;
+  constexpr int64_t kHeadDim = 16;
+
+  const auto npu_bf16 = torch::TensorOptions()
+                            .dtype(torch::kBFloat16)
+                            .device(torch::kPrivateUse1);
+
+  auto key_cache =
+      torch::zeros({kNumBlocks, kBlockSize, kKvHeads, kHeadDim}, npu_bf16);
+  auto value_cache_tensor = torch::zeros_like(key_cache);
+  std::optional<torch::Tensor> value_cache = value_cache_tensor;
+
+  // Four tokens carrying distinct non-zero sentinels 1,2,3,4. Tokens 1 and 3
+  // (sentinels 2,4) are handed slot -1: they must not touch the cache. Tokens
+  // 0 and 2 (sentinels 1,3) go to slots 5 and 300 (300 = block 2, offset 44).
+  constexpr int64_t kNumTokens = 4;
+  auto key_cpu =
+      torch::empty({kNumTokens, kKvHeads, kHeadDim}, torch::kFloat32);
+  for (int64_t t = 0; t < kNumTokens; ++t) {
+    key_cpu[t].fill_(static_cast<float>(t + 1));
+  }
+  const auto value_cpu = key_cpu + 100.0f;
+  auto key = key_cpu.to(torch::kBFloat16).to(torch::kPrivateUse1);
+  auto value_tensor = value_cpu.to(torch::kBFloat16).to(torch::kPrivateUse1);
+  std::optional<torch::Tensor> value = value_tensor;
+
+  const auto slot_mapping =
+      torch::tensor({5, -1, 300, -1},
+                    torch::TensorOptions().dtype(torch::kInt32))
+          .to(torch::kPrivateUse1);
+
+  xllm::kernel::npu::reshape_paged_cache(
+      key, value, key_cache, value_cache, slot_mapping);
+  aclrtSynchronizeDevice();
+
+  const auto key_cache_cpu = key_cache.cpu().to(torch::kFloat32);
+  const auto value_cache_cpu = value_cache.value().cpu().to(torch::kFloat32);
+
+  auto slot_key = [&](int64_t slot) {
+    return key_cache_cpu[slot / kBlockSize][slot % kBlockSize][0][0]
+        .item<float>();
+  };
+  auto slot_value = [&](int64_t slot) {
+    return value_cache_cpu[slot / kBlockSize][slot % kBlockSize][0][0]
+        .item<float>();
+  };
+
+  // Owned tokens landed at their slots.
+  EXPECT_FLOAT_EQ(slot_key(5), 1.0f);
+  EXPECT_FLOAT_EQ(slot_value(5), 101.0f);
+  EXPECT_FLOAT_EQ(slot_key(300), 3.0f);
+  EXPECT_FLOAT_EQ(slot_value(300), 103.0f);
+
+  // The -1 tokens (sentinels 2 and 4) leaked nowhere in the cache.
+  const auto key_flat = key_cache_cpu.reshape({-1});
+  for (float leaked : {2.0f, 4.0f}) {
+    const auto hits = (key_flat == leaked).sum().item<int64_t>();
+    EXPECT_EQ(hits, 0) << "slot -1 token with sentinel " << leaked
+                       << " was written into the KV cache: atb does NOT skip "
+                          "-1, so DCP must use a compacted index_select write.";
+  }
+}
+
 TEST_F(NpuXllmOpsTest, ModelExecutorUsesExplicitRuntimeBatchLimit) {
   py::gil_scoped_acquire gil;
   prepend_python_model_path();

--- a/tests/python/test_cp_utils.py
+++ b/tests/python/test_cp_utils.py
@@ -1,0 +1,184 @@
+# Copyright 2026 The xLLM Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://github.com/jd-opensource/xllm/blob/main/LICENSE
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""CPU unit tests for xllm.python.model_executor.cp_utils (zigzag CP).
+
+Validates the pure index math with no NPU or live process group: the
+shard/all-gather/merge round-trip is exact, sharding is load-balanced, and the
+packed query/KV gather indices reproduce full causal attention. ``all_gather``
+is emulated on CPU by stacking every rank's shard in rank-major order.
+"""
+
+from __future__ import annotations
+
+import sys
+from unittest.mock import MagicMock
+
+import pytest
+import torch
+
+# cp_utils imports ``from xllm.python import ops`` for cp_all_gather at runtime;
+# mock it so the module imports without the C++ binary. The tests emulate the
+# collective directly instead of calling ops.
+sys.modules.setdefault("xllm.python.ops", MagicMock())
+
+from xllm.python.model_executor.cp_utils import (  # noqa: E402
+    build_cp_context,
+    cp_shard_rows,
+)
+
+
+def _emulate_all_gather(per_rank_shards):
+    """Concatenate rank-major shards, mirroring ops.cp_all_gather(dim=0)."""
+    return torch.cat(per_rank_shards, dim=0)
+
+
+def _shard_all_ranks(x, seq_lens, cp_size):
+    """Return each rank's local shard of the global packed tensor ``x``."""
+    return [
+        cp_shard_rows(x, build_cp_context(seq_lens, cp_size, r, x.device))
+        for r in range(cp_size)
+    ]
+
+
+@pytest.mark.parametrize("cp_size", [2, 4])
+@pytest.mark.parametrize(
+    "seq_lens",
+    [
+        [8],  # single, divisible by 2*cp_size for cp_size<=4
+        [16, 24],  # multiple divisible
+        [7],  # single, needs padding
+        [5, 13, 2],  # mixed, all need padding
+        [1],  # degenerate single token
+    ],
+)
+def test_shard_merge_round_trip(seq_lens, cp_size):
+    """merge(all_gather(shard(x))) == x for arbitrary lengths/ranks."""
+    total = sum(seq_lens)
+    x = torch.arange(total * 3, dtype=torch.float32).reshape(total, 3)
+
+    shards = _shard_all_ranks(x, seq_lens, cp_size)
+    gathered = _emulate_all_gather(shards)
+
+    # Any rank's context restores the same global order (restore_index is
+    # rank-independent).
+    ctx0 = build_cp_context(seq_lens, cp_size, 0, x.device)
+    restored = gathered.index_select(0, ctx0.restore_index)
+    assert torch.equal(restored, x)
+
+
+@pytest.mark.parametrize("cp_size", [2, 4])
+def test_shards_are_disjoint_and_complete(cp_size):
+    """Every real global row is owned by exactly one rank."""
+    seq_lens = [10, 7]
+    owners = {}
+    for r in range(cp_size):
+        ctx = build_cp_context(seq_lens, cp_size, r, torch.device("cpu"))
+        real = ctx.shard_index[ctx.shard_valid_mask].tolist()
+        for g in real:
+            assert g not in owners, f"row {g} owned by ranks {owners[g]} and {r}"
+            owners[g] = r
+    assert sorted(owners) == list(range(sum(seq_lens)))
+
+
+@pytest.mark.parametrize("cp_size", [2, 4])
+def test_query_load_is_balanced(cp_size):
+    """Zigzag equalizes per-rank attention work (sum of causal prefixes).
+
+    Contiguous sharding would give rank r a prefix mass of ~(r+1)/cp_size; the
+    head-tail pairing makes every rank's total KV-prefix length equal for a
+    length divisible by 2*cp_size.
+    """
+    seq_lens = [4 * cp_size * 2]  # divisible by 2*cp_size, no padding
+    prefix_mass = []
+    for r in range(cp_size):
+        ctx = build_cp_context(seq_lens, cp_size, r, torch.device("cpu"))
+        prefix_mass.append(ctx.kv_cu_seqlens[-1])
+    assert len(set(prefix_mass)) == 1, f"imbalanced: {prefix_mass}"
+
+
+@pytest.mark.parametrize("cp_size", [2, 4])
+@pytest.mark.parametrize("seq_lens", [[8], [16, 24], [7], [5, 13, 2]])
+def test_packed_attention_matches_reference(seq_lens, cp_size):
+    """Gathering query rows + causal KV prefixes reproduces full attention.
+
+    Emulates one FIA call per segment on CPU (softmax over the segment's causal
+    prefix) and checks the reassembled global output equals a dense causal
+    attention over the whole sequence.
+    """
+    torch.manual_seed(0)
+    total = sum(seq_lens)
+    dim = 4
+    q = torch.randn(total, dim)
+    k = torch.randn(total, dim)
+    v = torch.randn(total, dim)
+
+    # Reference: dense per-sequence causal attention in global order.
+    ref = torch.zeros(total, dim)
+    base = 0
+    for length in seq_lens:
+        for i in range(length):
+            qi = q[base + i]
+            kk = k[base : base + i + 1]
+            vv = v[base : base + i + 1]
+            w = torch.softmax(kk @ qi / (dim**0.5), dim=0)
+            ref[base + i] = w @ vv
+        base += length
+
+    # CP path: each rank gathers its query rows and their causal KV prefixes,
+    # runs segment-local causal attention, scatters back; then merge.
+    out_shards = []
+    for r in range(cp_size):
+        ctx = build_cp_context(seq_lens, cp_size, r, q.device)
+        # Mirror _prefill_cp: q is sharded to this rank's local rows, then the
+        # real query rows are selected from that local layout. KV is replicated
+        # to full global order (all-gather), so segment prefixes index global k/v.
+        q_local = cp_shard_rows(q, ctx)
+        q_real = q_local.index_select(0, ctx.query_index)
+        # Walk segments via cu_seqlens to run per-segment causal softmax.
+        out_real = torch.zeros(q_real.shape[0], dim)
+        q_prev = 0
+        kv_prev = 0
+        for si in range(len(ctx.q_cu_seqlens)):
+            q_end = ctx.q_cu_seqlens[si]
+            kv_end = ctx.kv_cu_seqlens[si]
+            seg_q = q_real[q_prev:q_end]
+            seg_kv_idx = ctx.kv_gather_index[kv_prev:kv_end]
+            seg_k = k.index_select(0, seg_kv_idx)
+            seg_v = v.index_select(0, seg_kv_idx)
+            qcount = q_end - q_prev
+            prefix = kv_end - kv_prev
+            start = prefix - qcount  # segment_start (right-aligned causal)
+            for j in range(qcount):
+                allowed = start + j + 1
+                w = torch.softmax(
+                    seg_k[:allowed] @ seg_q[j] / (dim**0.5), dim=0
+                )
+                out_real[q_prev + j] = w @ seg_v[:allowed]
+            q_prev = q_end
+            kv_prev = kv_end
+        # Scatter into padded local layout.
+        out_local = torch.zeros(ctx.total_local, dim)
+        out_local.index_copy_(0, ctx.query_index, out_real)
+        out_shards.append(out_local)
+
+    gathered = _emulate_all_gather(out_shards)
+    ctx0 = build_cp_context(seq_lens, cp_size, 0, q.device)
+    merged = gathered.index_select(0, ctx0.restore_index)
+    assert torch.allclose(merged, ref, atol=1e-5), (merged - ref).abs().max()
+
+
+def test_cp_size_one_rejected():
+    with pytest.raises(ValueError):
+        build_cp_context([8], 1, 0, torch.device("cpu"))

--- a/tests/python/test_cp_utils.py
+++ b/tests/python/test_cp_utils.py
@@ -35,7 +35,10 @@ sys.modules.setdefault("xllm.python.ops", MagicMock())
 
 from xllm.python.model_executor.cp_utils import (  # noqa: E402
     build_cp_context,
+    cp_compact_slots,
+    cp_decode_local_kv_lens,
     cp_shard_rows,
+    cp_slot_owner,
 )
 
 
@@ -182,3 +185,142 @@ def test_packed_attention_matches_reference(seq_lens, cp_size):
 def test_cp_size_one_rejected():
     with pytest.raises(ValueError):
         build_cp_context([8], 1, 0, torch.device("cpu"))
+
+
+# ---------------------------------------------------------------------------
+# DCP: KV-storage sharding (cp_compact_slots / owner / decode local kv lens).
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("cp_size", [2, 4])
+@pytest.mark.parametrize("page_size", [1, 4])
+def test_compact_slots_disjoint_and_complete(cp_size, page_size):
+    """Every logical slot is owned by exactly one rank; compaction is a bijection.
+
+    Across all ranks the compacted physical slots must partition the logical
+    space with no collisions, and each rank's owned physical slots stay within
+    its physical cache range ``[0, n_blocks * page_size)``.
+    """
+    n_blocks = 3
+    logical_total = n_blocks * cp_size * page_size
+    logical = torch.arange(logical_total, dtype=torch.int64)
+
+    seen = {}
+    for r in range(cp_size):
+        phys = cp_compact_slots(logical, cp_size, r, page_size)
+        owned = phys >= 0
+        # Each rank owns exactly 1/cp of the logical slots.
+        assert int(owned.sum()) == logical_total // cp_size
+        # Physical slots stay inside this rank's own cache.
+        assert int(phys[owned].max()) < n_blocks * page_size
+        for log_s, phy_s in zip(logical[owned].tolist(), phys[owned].tolist()):
+            key = (r, phy_s)
+            assert key not in seen, f"physical collision {key}"
+            seen[key] = log_s
+
+    # Ownership is exhaustive: every logical slot got exactly one owner.
+    total_owned = sum(
+        int((cp_compact_slots(logical, cp_size, r, page_size) >= 0).sum())
+        for r in range(cp_size)
+    )
+    assert total_owned == logical_total
+
+
+@pytest.mark.parametrize("cp_size", [2, 4])
+def test_compact_slots_preserves_negative(cp_size):
+    """Original ``-1`` (padding) slots stay ``-1`` for every rank."""
+    page_size = 4
+    logical = torch.tensor([-1, 0, 5, -1, 17], dtype=torch.int64)
+    for r in range(cp_size):
+        phys = cp_compact_slots(logical, cp_size, r, page_size)
+        assert phys[0].item() == -1
+        assert phys[3].item() == -1
+
+
+@pytest.mark.parametrize("cp_size", [2, 4])
+@pytest.mark.parametrize("page_size", [1, 4])
+def test_slot_owner_matches_compact(cp_size, page_size):
+    """cp_slot_owner agrees with which rank cp_compact_slots assigns a slot to."""
+    logical = torch.arange(cp_size * page_size * 2, dtype=torch.int64)
+    owner = cp_slot_owner(logical, cp_size, page_size)
+    for r in range(cp_size):
+        owned = cp_compact_slots(logical, cp_size, r, page_size) >= 0
+        assert torch.equal(owner == r, owned)
+
+
+@pytest.mark.parametrize("cp_size", [2, 4])
+@pytest.mark.parametrize("page_size", [1, 4])
+def test_decode_local_kv_lens_sum_to_total(cp_size, page_size):
+    """Per-rank stored KV counts partition each sequence's context length."""
+    kv_seq_lens = torch.tensor([1, 7, 16, 33, 100], dtype=torch.int64)
+    per_rank = [
+        cp_decode_local_kv_lens(kv_seq_lens, cp_size, r, page_size)
+        for r in range(cp_size)
+    ]
+    total = torch.stack(per_rank, dim=0).sum(dim=0)
+    assert torch.equal(total, kv_seq_lens)
+
+
+@pytest.mark.parametrize("cp_size", [2, 4])
+@pytest.mark.parametrize("page_size", [1, 4])
+def test_decode_local_kv_lens_matches_owner_count(cp_size, page_size):
+    """local_kv_len equals the number of positions this rank actually owns.
+
+    Cross-check the closed-form count against explicitly labelling every
+    context position by its block-granular owner.
+    """
+    for L in (1, 5, 8, 15, 40):
+        positions = torch.arange(L, dtype=torch.int64)
+        owner = cp_slot_owner(positions, cp_size, page_size)
+        for r in range(cp_size):
+            expect = int((owner == r).sum())
+            got = int(
+                cp_decode_local_kv_lens(
+                    torch.tensor([L]), cp_size, r, page_size
+                )[0]
+            )
+            assert got == expect, f"L={L} rank={r}: {got} != {expect}"
+
+
+@pytest.mark.parametrize("cp_size", [2, 4])
+@pytest.mark.parametrize("page_size", [1, 4])
+def test_decode_shard_read_is_physically_contiguous(cp_size, page_size):
+    """DCP decode read invariant: each rank's owned physical slots equal the
+    first ``local_kv_len`` slots that FIA reads contiguously across the
+    sequence's block table.
+
+    ``_decode_cp`` runs FIA with ``block_table`` = the logical block ids,
+    ``block_size`` = page_size, and ``actual_seq_lengths_kv`` = local_kv_len, so
+    it reads token ``t`` from physical slot ``block_ids[t // page] * page + t %
+    page``. That is only correct if the tokens this rank actually owns
+    (``cp_compact_slots >= 0``) map to exactly those physical slots — i.e. this
+    rank's shard sits at offsets ``[0, local_kv_len)`` within its physical
+    pages. Verify it against explicit ownership labelling.
+    """
+    block_width = cp_size * page_size
+    for L in (1, 5, 8, 15, 40):
+        num_blocks = (L + block_width - 1) // block_width
+        # Arbitrary but distinct logical block ids for this sequence.
+        block_ids = [10 + b for b in range(num_blocks)]
+        logical = torch.tensor(
+            [block_ids[i // block_width] * block_width + i % block_width
+             for i in range(L)],
+            dtype=torch.int64,
+        )
+        for r in range(cp_size):
+            phys = cp_compact_slots(logical, cp_size, r, page_size)
+            owned_phys = sorted(int(s) for s in phys if int(s) >= 0)
+            local_kv = int(
+                cp_decode_local_kv_lens(
+                    torch.tensor([L]), cp_size, r, page_size
+                )[0]
+            )
+            fia_read = sorted(
+                block_ids[t // page_size] * page_size + t % page_size
+                for t in range(local_kv)
+            )
+            assert owned_phys == fia_read, (
+                f"L={L} rank={r}: owned physical slots {owned_phys} do not "
+                f"match FIA contiguous read {fia_read}"
+            )
+

--- a/xllm/core/distributed_runtime/llm_engine.cpp
+++ b/xllm/core/distributed_runtime/llm_engine.cpp
@@ -566,6 +566,14 @@ bool LLMEngine::allocate_kv_cache(const KVCacheCapacity& kv_cache_cap) {
   // Logical block_size *= kv_split_size.
   const int32_t kv_split_size_eff =
       ::xllm::ParallelConfig::get_instance().kv_split_size_effective();
+  if (kv_split_size_eff > 1) {
+    LOG(INFO) << "DCP KV-split active: logical block_size = " << block_size
+              << " * " << kv_split_size_eff << " = "
+              << block_size * kv_split_size_eff << " (each CP rank stores 1/"
+              << kv_split_size_eff
+              << " of every sequence's KV; a sequence occupies 1/"
+              << kv_split_size_eff << " the physical blocks per rank).";
+  }
   BlockManagerPool::Options options;
   options.num_blocks(kv_cache_cap.n_blocks())
       .block_size(kv_split_size_eff > 1 ? block_size * kv_split_size_eff

--- a/xllm/core/distributed_runtime/master.cpp
+++ b/xllm/core/distributed_runtime/master.cpp
@@ -331,6 +331,17 @@ Master::Master(const Options& options, EngineType type)
   print_startup_banner(model_path, options_.backend(), options_.node_rank());
   LOG(INFO) << "Master init options: " << options_.to_string();
   ParallelConfig::get_instance().cp_size(options_.cp_size());
+  // DCP for the Python model executor: widen the block manager's logical block
+  // to block_size * cp_size (kv_split_size == cp_size) so each CP rank stores
+  // only 1/cp of every sequence's KV. The Python attention backend compacts the
+  // resulting logical slot_mapping to this rank's physical slots (cp_utils
+  // cp_compact_slots), so opening this switch and the Python shard-write must
+  // ship together. Non-Python CP models keep the default (kv_split follows
+  // their own ATB/TORCH plan).
+  if (options_.cp_size() > 1 && ModelConfig::is_python_model_impl(
+                                    ModelConfig::get_instance().model_impl())) {
+    ParallelConfig::get_instance().kv_split_size(options_.cp_size());
+  }
   // cp_size <= 1 -> "disabled", otherwise "model" (model-side CP).
   const char* cp_sharding_stage =
       options_.cp_size() <= 1 ? "disabled" : "model";

--- a/xllm/core/distributed_runtime/master.cpp
+++ b/xllm/core/distributed_runtime/master.cpp
@@ -147,6 +147,24 @@ std::optional<std::string> validate_model_cp(const Options& options,
       return "Model-side CP supports only DEFAULT or PREFILL roles";
     }
 
+    // Python model executor runs a standalone torch CP path (all-gather KV,
+    // eager prefill only) that does not go through the ATB fused-attention op,
+    // so it bypasses the ATB-backend requirement and the ATB CP capability
+    // allowlist below. The safety constraints above (LLM/generate, no graph,
+    // DEFAULT/PREFILL) still apply. Python CP v1 additionally requires
+    // dp_size == 1: unlike the model-owned TORCH split (deepseek_v4), it does
+    // not implement the orthogonal dp * cp layout.
+    if (ModelConfig::is_python_model_impl(
+            ModelConfig::get_instance().model_impl())) {
+      if (options.dp_size() != 1) {
+        return "Python CP requires dp_size == 1";
+      }
+      if (global_world_size % (options.dp_size() * options.cp_size()) != 0) {
+        return "Python CP requires world_size divisible by dp_size * cp_size";
+      }
+      return std::nullopt;
+    }
+
     // Require registered NPU model-side CP capability. The backend is not
     // constrained: ATB models drive CP through NpuCpPlan, while TORCH models
     // (deepseek_v4) own their CP split inside the model. Both rely on the

--- a/xllm/core/distributed_runtime/master.cpp
+++ b/xllm/core/distributed_runtime/master.cpp
@@ -151,9 +151,11 @@ std::optional<std::string> validate_model_cp(const Options& options,
     // eager prefill only) that does not go through the ATB fused-attention op,
     // so it bypasses the ATB-backend requirement and the ATB CP capability
     // allowlist below. The safety constraints above (LLM/generate, no graph,
-    // DEFAULT/PREFILL) still apply. Python CP v1 additionally requires
-    // dp_size == 1: unlike the model-owned TORCH split (deepseek_v4), it does
-    // not implement the orthogonal dp * cp layout.
+    // DEFAULT/PREFILL) still apply. Orthogonal TP x CP is supported (both may
+    // be > 1, sharing world = cp * tp); the collective communicator builds the
+    // narrowed TP group and the strided CP group and reserves a separate torch
+    // rendezvous port for each. DP > 1 stays unsupported: the Python executor
+    // does not implement the dp * cp * tp rank layout.
     if (ModelConfig::is_python_model_impl(
             ModelConfig::get_instance().model_impl())) {
       if (options.dp_size() != 1) {

--- a/xllm/core/framework/parallel_state/collective_communicator.cpp
+++ b/xllm/core/framework/parallel_state/collective_communicator.cpp
@@ -583,25 +583,29 @@ void CollectiveCommunicator::create_process_groups(
     }
   }
 
-  // The Python model executor drives exactly one parallel dimension (v1
-  // supports pure TP or pure CP, not an orthogonal mix). Every rank that shares
-  // a Python collective must rendezvous on one endpoint, and distinct groups
-  // must get distinct ports. Under orthogonal CP the CP group is strided by
-  // tp_size (its members are not contiguous), so index by the CP group when
-  // cp_size > 1; otherwise index by the contiguous TP group.
-  int32_t rendezvous_group_index;
+  // The Python model executor creates its own torch process groups that
+  // rendezvous on TCPStore endpoints reserved after the native port range. TP
+  // and CP are orthogonal dimensions with different rank partitions, so each
+  // gets an independent port window: an orthogonal TP x CP launch brings up
+  // both a TP and a CP torch group at once, and a shared endpoint would collide
+  // on the TCPStore master. A TP group is the contiguous run of tp_size ranks
+  // (index by global_rank / tp_size); a CP group is strided by tp_size -- fixed
+  // (dp_rank, tp_rank), varying cp_rank -- so index by the CP group instead.
+  parallel_args_->python_tp_rendezvous_host_ = host;
+  const int32_t tp_rendezvous_index = global_rank / tp_size;
+  parallel_args_->python_tp_rendezvous_port_ = port + tp_rendezvous_index + 1;
+  port += tp_group_count;
   if (cp_size > 1) {
     const int32_t dp_stride = cp_size * tp_size;
-    rendezvous_group_index =
+    const int32_t cp_rendezvous_index =
         (global_rank / dp_stride) * tp_size + global_rank % tp_size;
-  } else {
-    rendezvous_group_index = global_rank / tp_size;
+    parallel_args_->python_cp_rendezvous_port_ = port + cp_rendezvous_index + 1;
+    port += dp_size * tp_size;
   }
-  parallel_args_->python_tp_rendezvous_host_ = host;
-  parallel_args_->python_tp_rendezvous_port_ =
-      port + rendezvous_group_index + 1;
   CHECK_LE(parallel_args_->python_tp_rendezvous_port_, 65535)
       << "No TCP port remains for the Python TP rendezvous.";
+  CHECK_LE(parallel_args_->python_cp_rendezvous_port_, 65535)
+      << "No TCP port remains for the Python CP rendezvous.";
 
 #if defined(USE_NPU)
   if (::xllm::KernelConfig::get_instance().npu_kernel_backend() == "TORCH" &&

--- a/xllm/core/framework/parallel_state/collective_communicator.cpp
+++ b/xllm/core/framework/parallel_state/collective_communicator.cpp
@@ -583,9 +583,23 @@ void CollectiveCommunicator::create_process_groups(
     }
   }
 
-  const int32_t tp_group_index = global_rank / tp_size;
+  // The Python model executor drives exactly one parallel dimension (v1
+  // supports pure TP or pure CP, not an orthogonal mix). Every rank that shares
+  // a Python collective must rendezvous on one endpoint, and distinct groups
+  // must get distinct ports. Under orthogonal CP the CP group is strided by
+  // tp_size (its members are not contiguous), so index by the CP group when
+  // cp_size > 1; otherwise index by the contiguous TP group.
+  int32_t rendezvous_group_index;
+  if (cp_size > 1) {
+    const int32_t dp_stride = cp_size * tp_size;
+    rendezvous_group_index =
+        (global_rank / dp_stride) * tp_size + global_rank % tp_size;
+  } else {
+    rendezvous_group_index = global_rank / tp_size;
+  }
   parallel_args_->python_tp_rendezvous_host_ = host;
-  parallel_args_->python_tp_rendezvous_port_ = port + tp_group_index + 1;
+  parallel_args_->python_tp_rendezvous_port_ =
+      port + rendezvous_group_index + 1;
   CHECK_LE(parallel_args_->python_tp_rendezvous_port_, 65535)
       << "No TCP port remains for the Python TP rendezvous.";
 

--- a/xllm/core/framework/parallel_state/parallel_args.h
+++ b/xllm/core/framework/parallel_state/parallel_args.h
@@ -221,7 +221,9 @@ struct ParallelArgs {
   ProcessGroup* moe_tp_group_ = nullptr;
 
   // PyTorch creates its own TP process group. These fields only reserve the
-  // TCPStore endpoint after the native process-group port range.
+  // TCPStore endpoint after the native process-group port range. The same
+  // endpoint is reused for the Python CP group, which the Python model executor
+  // derives from the same physical rank set (cp_group_ aliases tp_group_).
   std::string python_tp_rendezvous_host_;
   int32_t python_tp_rendezvous_port_ = 0;
 

--- a/xllm/core/framework/parallel_state/parallel_args.h
+++ b/xllm/core/framework/parallel_state/parallel_args.h
@@ -220,12 +220,15 @@ struct ParallelArgs {
   ProcessGroup* mc2_group_ = nullptr;
   ProcessGroup* moe_tp_group_ = nullptr;
 
-  // PyTorch creates its own TP process group. These fields only reserve the
-  // TCPStore endpoint after the native process-group port range. The same
-  // endpoint is reused for the Python CP group, which the Python model executor
-  // derives from the same physical rank set (cp_group_ aliases tp_group_).
+  // PyTorch creates its own process groups. These fields only reserve TCPStore
+  // endpoints after the native process-group port range. TP and CP are
+  // orthogonal, so each dimension needs its own rendezvous endpoint: an
+  // orthogonal TP x CP launch initializes both a TP and a CP torch group at
+  // once, and two groups sharing one host:port would collide on the TCPStore
+  // master. The CP port stays 0 when cp_size == 1 (no CP group is created).
   std::string python_tp_rendezvous_host_;
   int32_t python_tp_rendezvous_port_ = 0;
+  int32_t python_cp_rendezvous_port_ = 0;
 
   // ProcessGroups for DiT models
   ProcessGroup* dit_tp_group_ = nullptr;

--- a/xllm/models/llm/py_causal_lm.cpp
+++ b/xllm/models/llm/py_causal_lm.cpp
@@ -44,24 +44,17 @@ PyCausalLM::PyCausalLM(const ModelContext& context)
   tp_group_ = parallel_args.tp_group_;
   cp_size_ = parallel_args.cp_size();
   cp_rank_ = parallel_args.cp_rank();
-  // The physical process group (tp_group_) has size world/dp. CP is carved out
-  // of it: the Python model's tensor-parallel degree is the cp-discounted part
-  // and CP consumes the rest (cp_group_ aliases tp_group_ on the TORCH
-  // backend). v1 supports pure CP (model tp == 1) or pure TP (cp == 1), not an
-  // orthogonal mix on the same physical group.
-  const int64_t phys_group_size =
-      (tp_group_ != nullptr) ? tp_group_->world_size() : 1;
-  const int64_t phys_group_rank =
-      (tp_group_ != nullptr) ? tp_group_->rank() : 0;
-  CHECK_EQ(phys_group_size % cp_size_, 0)
-      << "physical group size " << phys_group_size
-      << " not divisible by cp_size " << cp_size_;
-  tp_size_ = phys_group_size / cp_size_;
+  // tp_group_ and cp_group_ are already the final, orthogonally-split groups:
+  // the collective communicator narrows tp_group_ to world/(dp*cp) and builds a
+  // separate cp_group_ over the cp-strided ranks. Read each dimension from its
+  // own group instead of carving CP back out of tp_group_. v1 supports pure CP
+  // (tp_size == 1) or pure TP (cp_size == 1), not an orthogonal mix.
+  tp_size_ = (tp_group_ != nullptr) ? tp_group_->world_size() : 1;
+  tp_rank_ = (tp_group_ != nullptr) ? tp_group_->rank() : 0;
   CHECK(cp_size_ == 1 || tp_size_ == 1)
-      << "Python CP v1 does not support orthogonal TP x CP on one group "
+      << "Python CP v1 does not support orthogonal TP x CP "
          "(tp_size="
       << tp_size_ << ", cp_size=" << cp_size_ << ")";
-  tp_rank_ = (tp_size_ > 1) ? phys_group_rank : 0;
 
   py::gil_scoped_acquire gil;
   // The physical group's rendezvous endpoint (shared by all ranks in the group)

--- a/xllm/models/llm/py_causal_lm.cpp
+++ b/xllm/models/llm/py_causal_lm.cpp
@@ -42,10 +42,31 @@ PyCausalLM::PyCausalLM(const ModelContext& context)
 
   const ParallelArgs& parallel_args = context.get_parallel_args();
   tp_group_ = parallel_args.tp_group_;
-  tp_size_ = (tp_group_ != nullptr) ? tp_group_->world_size() : 1;
-  tp_rank_ = (tp_group_ != nullptr) ? tp_group_->rank() : 0;
+  cp_size_ = parallel_args.cp_size();
+  cp_rank_ = parallel_args.cp_rank();
+  // The physical process group (tp_group_) has size world/dp. CP is carved out
+  // of it: the Python model's tensor-parallel degree is the cp-discounted part
+  // and CP consumes the rest (cp_group_ aliases tp_group_ on the TORCH
+  // backend). v1 supports pure CP (model tp == 1) or pure TP (cp == 1), not an
+  // orthogonal mix on the same physical group.
+  const int64_t phys_group_size =
+      (tp_group_ != nullptr) ? tp_group_->world_size() : 1;
+  const int64_t phys_group_rank =
+      (tp_group_ != nullptr) ? tp_group_->rank() : 0;
+  CHECK_EQ(phys_group_size % cp_size_, 0)
+      << "physical group size " << phys_group_size
+      << " not divisible by cp_size " << cp_size_;
+  tp_size_ = phys_group_size / cp_size_;
+  CHECK(cp_size_ == 1 || tp_size_ == 1)
+      << "Python CP v1 does not support orthogonal TP x CP on one group "
+         "(tp_size="
+      << tp_size_ << ", cp_size=" << cp_size_ << ")";
+  tp_rank_ = (tp_size_ > 1) ? phys_group_rank : 0;
 
   py::gil_scoped_acquire gil;
+  // The physical group's rendezvous endpoint (shared by all ranks in the group)
+  // backs either the TP group or the CP group depending on which dimension owns
+  // it. Init exactly the one that is > 1.
   if (tp_size_ > 1) {
     CHECK(!parallel_args.python_tp_rendezvous_host_.empty());
     CHECK_GT(parallel_args.python_tp_rendezvous_port_, 0);
@@ -54,6 +75,16 @@ PyCausalLM::PyCausalLM(const ModelContext& context)
                                parallel_args.python_tp_rendezvous_port_,
                                tp_rank_,
                                tp_size_,
+                               c10::str(device_));
+  }
+  if (cp_size_ > 1) {
+    CHECK(!parallel_args.python_tp_rendezvous_host_.empty());
+    CHECK_GT(parallel_args.python_tp_rendezvous_port_, 0);
+    py::module_::import("xllm.python.ops")
+        .attr("init_cp_group")(parallel_args.python_tp_rendezvous_host_,
+                               parallel_args.python_tp_rendezvous_port_,
+                               cp_rank_,
+                               cp_size_,
                                c10::str(device_));
   }
   const std::string module_name = context.get_model_args().model_type().empty()
@@ -83,6 +114,9 @@ py::dict PyCausalLM::build_config_dict(
   d["device"] = c10::str(device_);
   d["tp_size"] = tp_size_;
   d["tp_rank"] = tp_rank_;
+  // cp_size is a reflected ParallelArgs PROPERTY (already in d), but cp_rank is
+  // a derived member function, so pass it explicitly for the Python executor.
+  d["cp_rank"] = cp_rank_;
   d["enable_graph"] = ExecutionConfig::get_instance().enable_graph();
   d["python_graph_backend"] =
       ExecutionConfig::get_instance().python_graph_backend();

--- a/xllm/models/llm/py_causal_lm.cpp
+++ b/xllm/models/llm/py_causal_lm.cpp
@@ -47,19 +47,17 @@ PyCausalLM::PyCausalLM(const ModelContext& context)
   // tp_group_ and cp_group_ are already the final, orthogonally-split groups:
   // the collective communicator narrows tp_group_ to world/(dp*cp) and builds a
   // separate cp_group_ over the cp-strided ranks. Read each dimension from its
-  // own group instead of carving CP back out of tp_group_. v1 supports pure CP
-  // (tp_size == 1) or pure TP (cp_size == 1), not an orthogonal mix.
+  // own group instead of carving CP back out of tp_group_. TP and CP are
+  // orthogonal: a rank can shard both attention heads (TP) and sequence tokens
+  // (CP) at once, so both dimensions may be > 1 simultaneously.
   tp_size_ = (tp_group_ != nullptr) ? tp_group_->world_size() : 1;
   tp_rank_ = (tp_group_ != nullptr) ? tp_group_->rank() : 0;
-  CHECK(cp_size_ == 1 || tp_size_ == 1)
-      << "Python CP v1 does not support orthogonal TP x CP "
-         "(tp_size="
-      << tp_size_ << ", cp_size=" << cp_size_ << ")";
 
   py::gil_scoped_acquire gil;
-  // The physical group's rendezvous endpoint (shared by all ranks in the group)
-  // backs either the TP group or the CP group depending on which dimension owns
-  // it. Init exactly the one that is > 1.
+  // The rendezvous endpoint (host/port) is shared by every rank that needs a
+  // torch process group on this device. Init each parallel dimension that is
+  // active: TP (attention-head sharding) and CP (sequence sharding) are
+  // orthogonal and each get their own group off the same endpoint.
   if (tp_size_ > 1) {
     CHECK(!parallel_args.python_tp_rendezvous_host_.empty());
     CHECK_GT(parallel_args.python_tp_rendezvous_port_, 0);
@@ -72,10 +70,10 @@ PyCausalLM::PyCausalLM(const ModelContext& context)
   }
   if (cp_size_ > 1) {
     CHECK(!parallel_args.python_tp_rendezvous_host_.empty());
-    CHECK_GT(parallel_args.python_tp_rendezvous_port_, 0);
+    CHECK_GT(parallel_args.python_cp_rendezvous_port_, 0);
     py::module_::import("xllm.python.ops")
         .attr("init_cp_group")(parallel_args.python_tp_rendezvous_host_,
-                               parallel_args.python_tp_rendezvous_port_,
+                               parallel_args.python_cp_rendezvous_port_,
                                cp_rank_,
                                cp_size_,
                                c10::str(device_));

--- a/xllm/models/llm/py_causal_lm.h
+++ b/xllm/models/llm/py_causal_lm.h
@@ -63,6 +63,8 @@ class __attribute__((visibility("hidden"))) PyCausalLM : public CausalLM {
 
   int64_t tp_size_ = 1;
   int64_t tp_rank_ = 0;
+  int64_t cp_size_ = 1;
+  int64_t cp_rank_ = 0;
   ProcessGroup* tp_group_ = nullptr;
 
   pybind11::object py_model_;

--- a/xllm/python/attention/npu_paged_attention.py
+++ b/xllm/python/attention/npu_paged_attention.py
@@ -32,6 +32,7 @@ from xllm.python.attention.backend import (
     KVCache,
     MlaIndexContext,
 )
+from xllm.python.model_executor.cp_utils import cp_gather_kv
 from xllm.python.model_executor.forward_context import (
     AclGraphTask,
     get_forward_context,
@@ -206,14 +207,24 @@ class NpuPagedAttentionBackend(AttentionBackend):
         k_cache, v_cache, _ = self._kv_caches[layer_id]
         num_tokens = q.shape[0]
 
-        # Write KV to paged cache (kernel expects [T, kv_heads, head_dim]).
         k_3d = k.view(num_tokens, self.num_kv_heads, self.head_dim).contiguous()
         v_3d = v.view(num_tokens, self.num_kv_heads, self.head_dim).contiguous()
+        q_3d = q.view(num_tokens, self.num_heads, self.head_dim).contiguous()
+
+        # Context-Parallel prefill: q/k/v are this rank's sequence shard while the
+        # slot_mapping/metadata still describe the full global sequence (C++ does
+        # not pre-shard the Python qwen3 path). All-gather K/V to the full
+        # sequence, persist it, and attend over this rank's causal prefix.
+        cp_context = get_forward_context().cp_context
+        if cp_context is not None:
+            return self._prefill_cp(
+                q_3d, k_3d, v_3d, metadata, cp_context, k_cache, v_cache
+            )
+
+        # Write KV to paged cache (kernel expects [T, kv_heads, head_dim]).
         ops.reshape_paged_cache(
             metadata.slot_mapping, k_3d, v_3d, k_cache, v_cache
         )
-
-        q_3d = q.view(num_tokens, self.num_heads, self.head_dim).contiguous()
 
         if metadata.is_prefill or metadata.is_chunked_prefill:
             return self._prefill(q_3d, k_3d, v_3d, metadata, num_tokens)
@@ -301,6 +312,64 @@ class NpuPagedAttentionBackend(AttentionBackend):
             softmax_lse_flag=False,
         )
         return output.reshape(num_tokens, self.num_heads * self.head_dim)
+
+    # ------------------------------------------------------------------
+    # Context-Parallel prefill: all-gather KV, attend over causal prefix
+    # ------------------------------------------------------------------
+
+    def _prefill_cp(
+        self,
+        q_3d: torch.Tensor,
+        k_3d: torch.Tensor,
+        v_3d: torch.Tensor,
+        metadata: AttentionMetadata,
+        cp_context,
+        k_cache: torch.Tensor,
+        v_cache: torch.Tensor,
+    ) -> torch.Tensor:
+        """Prefill attention for this rank's sequence shard.
+
+        q/k/v hold only this rank's ``total_local`` rows. We all-gather K/V to
+        the full sequence, write the complete KV into the paged cache (so a
+        later non-CP decode sees every position), then run FIA with this rank's
+        local queries against their causal KV prefix. ``sparse_mode=3`` aligns
+        the causal triangle to the bottom-right, so with ``Sq=seg_len`` and
+        ``Skv=(cp_rank+1)*seg_len`` local-q row ``i`` attends KV ``[0, cp_rank *
+        seg_len + i]`` — exactly its global causal range.
+        """
+        local_tokens = q_3d.shape[0]
+
+        kv_global_k, kv_prefix_k = cp_gather_kv(k_3d, cp_context)
+        kv_global_v, kv_prefix_v = cp_gather_kv(v_3d, cp_context)
+
+        # Persist the full global-order KV into this rank's paged cache.
+        ops.reshape_paged_cache(
+            metadata.slot_mapping,
+            kv_global_k.contiguous(),
+            kv_global_v.contiguous(),
+            k_cache,
+            v_cache,
+        )
+
+        kv_prefix_k = kv_prefix_k.contiguous()
+        kv_prefix_v = kv_prefix_v.contiguous()
+
+        output, _ = torch.ops.npu.npu_fused_infer_attention_score(
+            q_3d,
+            kv_prefix_k,
+            kv_prefix_v,
+            pse_shift=None,
+            atten_mask=self._causal_mask,
+            actual_seq_lengths=cp_context.q_cu_seqlens,
+            actual_seq_lengths_kv=cp_context.kv_cu_seqlens,
+            num_heads=self.num_heads,
+            scale=self.scale,
+            input_layout="TND",
+            num_key_value_heads=self.num_kv_heads,
+            sparse_mode=3,
+            softmax_lse_flag=False,
+        )
+        return output.reshape(local_tokens, self.num_heads * self.head_dim)
 
     # ------------------------------------------------------------------
     # Decode: FIA with block_table (paged KV, no gather)

--- a/xllm/python/attention/npu_paged_attention.py
+++ b/xllm/python/attention/npu_paged_attention.py
@@ -327,20 +327,25 @@ class NpuPagedAttentionBackend(AttentionBackend):
         k_cache: torch.Tensor,
         v_cache: torch.Tensor,
     ) -> torch.Tensor:
-        """Prefill attention for this rank's sequence shard.
+        """Prefill attention for this rank's zigzag sequence shard.
 
-        q/k/v hold only this rank's ``total_local`` rows. We all-gather K/V to
-        the full sequence, write the complete KV into the paged cache (so a
-        later non-CP decode sees every position), then run FIA with this rank's
-        local queries against their causal KV prefix. ``sparse_mode=3`` aligns
-        the causal triangle to the bottom-right, so with ``Sq=seg_len`` and
-        ``Skv=(cp_rank+1)*seg_len`` local-q row ``i`` attends KV ``[0, cp_rank *
-        seg_len + i]`` — exactly its global causal range.
+        q/k/v hold this rank's ``total_local`` rows (two owned chunks per
+        sequence, padding rows zeroed). We all-gather K/V back to the full
+        global-order sequence, write the complete KV into the paged cache (so a
+        later non-CP decode sees every position), then run one FIA over this
+        rank's real queries. Each owned (sequence, half) segment is a packed
+        sub-sequence: its ``real_count`` queries attend the causal prefix
+        ``[0, segment_start + real_count)`` selected by ``kv_gather_index``.
+        With ``sparse_mode=3`` (right-aligned causal) query row ``i`` of a
+        segment attends KV ``[0, segment_start + i]`` — its exact global causal
+        range. Segments are independent sub-sequences delimited by
+        ``q_cu_seqlens`` / ``kv_cu_seqlens``, so both owned chunks resolve in a
+        single call.
         """
         local_tokens = q_3d.shape[0]
 
-        kv_global_k, kv_prefix_k = cp_gather_kv(k_3d, cp_context)
-        kv_global_v, kv_prefix_v = cp_gather_kv(v_3d, cp_context)
+        kv_global_k = cp_gather_kv(k_3d, cp_context)
+        kv_global_v = cp_gather_kv(v_3d, cp_context)
 
         # Persist the full global-order KV into this rank's paged cache.
         ops.reshape_paged_cache(
@@ -351,11 +356,18 @@ class NpuPagedAttentionBackend(AttentionBackend):
             v_cache,
         )
 
-        kv_prefix_k = kv_prefix_k.contiguous()
-        kv_prefix_v = kv_prefix_v.contiguous()
+        # Real queries this rank owns, packed per (sequence, half) segment.
+        q_real = q_3d.index_select(0, cp_context.query_index).contiguous()
+        # Each segment's causal KV prefix, packed in the same segment order.
+        kv_prefix_k = kv_global_k.index_select(
+            0, cp_context.kv_gather_index
+        ).contiguous()
+        kv_prefix_v = kv_global_v.index_select(
+            0, cp_context.kv_gather_index
+        ).contiguous()
 
         output, _ = torch.ops.npu.npu_fused_infer_attention_score(
-            q_3d,
+            q_real,
             kv_prefix_k,
             kv_prefix_v,
             pse_shift=None,
@@ -369,7 +381,14 @@ class NpuPagedAttentionBackend(AttentionBackend):
             sparse_mode=3,
             softmax_lse_flag=False,
         )
-        return output.reshape(local_tokens, self.num_heads * self.head_dim)
+        output = output.reshape(-1, self.num_heads * self.head_dim)
+
+        # Scatter real-query outputs back into the padded [total_local] layout;
+        # padding rows stay zero (they are never selected by restore_index in
+        # the subsequent all-gather merge).
+        out_local = q_3d.new_zeros(local_tokens, self.num_heads * self.head_dim)
+        out_local.index_copy_(0, cp_context.query_index, output)
+        return out_local
 
     # ------------------------------------------------------------------
     # Decode: FIA with block_table (paged KV, no gather)

--- a/xllm/python/attention/npu_paged_attention.py
+++ b/xllm/python/attention/npu_paged_attention.py
@@ -32,7 +32,11 @@ from xllm.python.attention.backend import (
     KVCache,
     MlaIndexContext,
 )
-from xllm.python.model_executor.cp_utils import cp_gather_kv
+from xllm.python.model_executor.cp_utils import (
+    cp_compact_slots,
+    cp_decode_local_kv_lens,
+    cp_gather_kv,
+)
 from xllm.python.model_executor.forward_context import (
     AclGraphTask,
     get_forward_context,
@@ -221,6 +225,17 @@ class NpuPagedAttentionBackend(AttentionBackend):
                 q_3d, k_3d, v_3d, metadata, cp_context, k_cache, v_cache
             )
 
+        # DCP decode: cp_context is None on decode (the query batch is replicated
+        # across CP ranks, not sharded), but with kv_split_size == cp_size each
+        # rank stores only its 1/cp of the KV. Detect the CP group directly and
+        # route to the KV-shard decode path; cp_size == 1 falls through to the
+        # plain single-rank paths.
+        cp_size = ops.cp_world_size(self.device)
+        if cp_size > 1 and not (metadata.is_prefill or metadata.is_chunked_prefill):
+            return self._decode_cp(
+                q_3d, k_3d, v_3d, metadata, k_cache, v_cache, num_tokens, cp_size
+            )
+
         # Write KV to paged cache (kernel expects [T, kv_heads, head_dim]).
         ops.reshape_paged_cache(
             metadata.slot_mapping, k_3d, v_3d, k_cache, v_cache
@@ -347,9 +362,20 @@ class NpuPagedAttentionBackend(AttentionBackend):
         kv_global_k = cp_gather_kv(k_3d, cp_context)
         kv_global_v = cp_gather_kv(v_3d, cp_context)
 
-        # Persist the full global-order KV into this rank's paged cache.
-        ops.reshape_paged_cache(
+        # DCP KV-storage sharding: with kv_split_size == cp_size the block
+        # manager hands down a logical slot_mapping over a block_size * cp_size
+        # space. Compact it to this rank's physical slots (tokens this rank does
+        # not own become -1, which reshape_paged_cache skips) so each rank
+        # persists only its 1/cp of the global-order KV into its own pages.
+        page_size = k_cache.size(1)
+        local_slots = cp_compact_slots(
             metadata.slot_mapping,
+            cp_context.cp_size,
+            cp_context.cp_rank,
+            page_size,
+        )
+        ops.reshape_paged_cache(
+            local_slots,
             kv_global_k.contiguous(),
             kv_global_v.contiguous(),
             k_cache,
@@ -466,6 +492,100 @@ class NpuPagedAttentionBackend(AttentionBackend):
             softmax_lse_flag=False,
         )
         return output.reshape(num_tokens, self.num_heads * self.head_dim)
+
+    # ------------------------------------------------------------------
+    # DCP decode: KV-storage sharding (each rank stores 1/cp of the KV)
+    # ------------------------------------------------------------------
+
+    def _decode_cp(
+        self, q_3d: torch.Tensor, k_3d: torch.Tensor, v_3d: torch.Tensor,
+        metadata: AttentionMetadata, k_cache: torch.Tensor,
+        v_cache: torch.Tensor, num_tokens: int, cp_size: int,
+    ) -> torch.Tensor:
+        """Decode attention when the KV is sharded across the CP group.
+
+        Every CP rank runs the full (replicated) decode query batch, but with
+        ``kv_split_size == cp_size`` each rank physically stores only its 1/cp
+        block-strided slice of every sequence's KV. So each rank:
+
+        1. writes the new token's KV only if it owns that slot (the rest of the
+           compacted slot_mapping is -1, which reshape_paged_cache skips);
+        2. runs FIA over its local shard, reading ``local_kv_len`` tokens from
+           the physical pages (physical block id == logical block id) and asking
+           for the softmax LSE;
+        3. all-gathers every rank's (out, lse) and merges them with
+           npu_attention_update, which is the exact online-softmax reduction
+           ``O = sum_i O_i * exp(lse_i - lse)`` — no accuracy loss versus reading
+           the full KV on one rank.
+
+        Ranks that own no token of a sequence (its context is shorter than this
+        rank's first block) read a single dummy token to keep FIA happy, then
+        force that sequence's LSE to ``-inf`` so the merge discards the dummy.
+        """
+        cp_rank = ops.cp_rank(self.device)
+        page_size = k_cache.size(1)
+
+        # 1. Write the new token's KV into its owner rank's shard.
+        local_slots = cp_compact_slots(
+            metadata.slot_mapping, cp_size, cp_rank, page_size
+        )
+        ops.reshape_paged_cache(local_slots, k_3d, v_3d, k_cache, v_cache)
+
+        # 2. Local FIA over this rank's KV shard.
+        block_size = k_cache.size(1)
+        k_flat = k_cache.view(k_cache.size(0), block_size, -1)
+        v_flat = v_cache.view(v_cache.size(0), block_size, -1)
+
+        # Per-sequence total context length (prepare() built this host list from
+        # kv_seq_lens_host); derive each rank's block-strided share of it.
+        kv_seq_lens = torch.tensor(
+            self._actual_seq_kv[:num_tokens],
+            dtype=torch.int64,
+            device=self.device,
+        )
+        local_kv = cp_decode_local_kv_lens(
+            kv_seq_lens, cp_size, cp_rank, page_size
+        )
+        empty = local_kv == 0
+        # FIA rejects a 0-length KV; read one dummy token there and mask later.
+        local_kv_fia = torch.clamp(local_kv, min=1)
+
+        out, lse = torch.ops.npu.npu_fused_infer_attention_score(
+            q_3d, k_flat, v_flat,
+            pse_shift=None,
+            atten_mask=None,
+            actual_seq_lengths=self._actual_seq_q[:num_tokens],
+            actual_seq_lengths_kv=local_kv_fia.tolist(),
+            block_table=self._block_table_i32,
+            num_heads=self.num_heads,
+            scale=self.scale,
+            input_layout="TND",
+            num_key_value_heads=self.num_kv_heads,
+            sparse_mode=0,
+            block_size=block_size,
+            softmax_lse_flag=True,
+        )
+
+        # 3. Cross-rank merge. npu_attention_update wants a per-shard list of
+        # out [N, head_dim] and lse [N] (N = batch * seq * head), both float32.
+        n_rows = num_tokens * self.num_heads
+        local_out = out.reshape(n_rows, self.head_dim).to(torch.float32)
+        local_lse = lse.reshape(n_rows).to(torch.float32)
+        if bool(empty.any()):
+            # Rows of an empty-shard sequence get LSE -inf so they contribute
+            # nothing to the online-softmax merge.
+            row_empty = empty[:num_tokens].repeat_interleave(self.num_heads)
+            local_lse = local_lse.masked_fill(row_empty, float("-inf"))
+
+        gathered_out = ops.cp_all_gather(local_out, 0, cp_size)
+        gathered_lse = ops.cp_all_gather(local_lse, 0, cp_size)
+        out_list = [gathered_out[r * n_rows:(r + 1) * n_rows] for r in range(cp_size)]
+        lse_list = [gathered_lse[r * n_rows:(r + 1) * n_rows] for r in range(cp_size)]
+
+        merged, _ = torch_npu.npu_attention_update(lse_list, out_list, 1)
+        return merged.reshape(num_tokens, self.num_heads * self.head_dim).to(
+            q_3d.dtype
+        )
 
     # ------------------------------------------------------------------
     # Helpers

--- a/xllm/python/model_executor/cp_utils.py
+++ b/xllm/python/model_executor/cp_utils.py
@@ -16,16 +16,24 @@
 
 CP splits a single request's tokens along the sequence dimension across the CP
 group so each rank runs attention over its own shard. This module owns the pure
-index math: it turns per-sequence lengths into (a) a ``shard_index`` that picks
-this rank's rows out of the global packed hidden state and (b) a
-``restore_index`` that reassembles the rank-major all-gather output back into the
-original global order.
+index math: it turns per-sequence lengths into the shard/restore indices plus
+the packed query/KV gather indices that one FIA call consumes.
 
-First version uses *contiguous* sharding: each sequence is padded up to a
-multiple of ``cp_size`` and split into ``cp_size`` equal contiguous segments;
-rank ``r`` owns segment ``r``. Padding rows (when a length is not divisible by
-``cp_size``) are marked invalid and zeroed after the gather. Load-balanced
-zigzag sharding is a later optimization (see plan P2).
+Sharding is *zigzag* (head-tail balanced): each sequence is padded up to a
+multiple of ``2 * cp_size`` and cut into ``2 * cp_size`` equal chunks; rank ``r``
+owns chunk ``r`` (an early, short-prefix segment) paired with chunk
+``2 * cp_size - 1 - r`` (a late, long-prefix segment). Under causal attention a
+late token attends far more KV than an early one, so pairing a low chunk with
+the mirrored high chunk equalizes per-rank attention work — the load imbalance
+of a plain contiguous split (rank ``r`` attends ``(r+1)/cp_size`` of the
+sequence) is gone.
+
+Attention is computed against the *full* sequence: ``cp_merge_rows`` /
+``cp_gather_kv`` all-gather every rank's shard, so each rank reconstructs the
+complete global-order KV and then attends its two owned segments over their
+exact causal prefixes. Both segments are contiguous real ranges, so a single
+FIA call with per-segment ``actual_seq_lengths`` and ``sparse_mode=3``
+(right-aligned causal) masks every row exactly, with no custom mask.
 
 The shard/merge functions are deliberately backend-agnostic (plain torch index
 ops) so the round-trip ``merge(all_gather(shard(x))) == x`` can be unit-tested on
@@ -44,42 +52,46 @@ from xllm.python import ops
 
 @dataclass(frozen=True)
 class CpContext:
-    """Per-forward CP sharding plan (contiguous split).
+    """Per-forward CP sharding plan (zigzag head-tail split).
 
     All index tensors live on the target device and use int64 (torch gather /
-    index_select require int64 indices).
+    index_select require int64 indices). The ``*_cu_seqlens`` are host int
+    lists (FIA ``actual_seq_lengths`` accepts a list), cumulative and without a
+    leading 0.
     """
 
     cp_size: int
     cp_rank: int
+    # Number of (padded) rows this rank holds; identical across ranks so
+    # all_gather is well-formed. Layout per sequence: [first-half chunk_len
+    # rows, second-half chunk_len rows].
+    total_local: int
     # [total_local] global row for each local row, or -1 for a padding row.
     shard_index: torch.Tensor
-    # [total_local] same as shard_index but -1 replaced by 0 so it is a valid
-    # gather index; pair with shard_valid_mask to zero padding rows afterwards.
+    # [total_local] shard_index with -1 replaced by 0 so it is a valid gather
+    # index; pair with shard_valid_mask to zero padding rows afterwards.
     shard_gather_index: torch.Tensor
     # [total_local] True for real tokens, False for padding rows.
     shard_valid_mask: torch.Tensor
     # [total_global] index into the rank-major all-gather output that restores
     # the original global token order.
     restore_index: torch.Tensor
-    # Number of (padded) rows this rank holds; identical across ranks so
-    # all_gather is well-formed.
-    total_local: int
-    # [num_seqs] real (unpadded) token count this rank holds per sequence.
-    local_seq_lens: torch.Tensor
-    # Cumulative per-seq query lengths of this rank's shard (FIA TND
-    # actual_seq_lengths; excludes the leading 0). Each entry is seg_len_s.
+    # [total_real_local] local rows carrying a real token (this rank's queries),
+    # packed per (sequence, half) in local order. Selects the FIA query rows
+    # from the local packed hidden and, reused as a scatter index, writes the
+    # FIA output back into the [total_local] layout (padding rows stay zero).
+    query_index: torch.Tensor
+    # FIA actual_seq_lengths: real query count of each non-empty (sequence,
+    # half) segment, cumulative.
     q_cu_seqlens: List[int]
-    # Cumulative per-seq KV-prefix lengths for this rank (FIA
-    # actual_seq_lengths_kv). Each per-seq length is (cp_rank+1)*seg_len_s: the
-    # causal prefix rank r needs, since its q segment ends at global position
-    # (r+1)*seg_len_s. Paired with sparse_mode=3 (right-aligned causal) this
-    # yields exact per-row causal masking with no custom mask.
-    kv_cu_seqlens: List[int]
-    # [(cp_rank+1)*total_local] index into the rank-major all-gathered KV
-    # ([cp_size*total_local] rows) selecting this rank's per-seq causal prefix
-    # (segments 0..cp_rank of each sequence, in global position order).
+    # [sum(kv_cu_seqlens)] index into the global-order KV selecting each
+    # segment's causal prefix [0, prefix_len), packed in the same segment order
+    # as query_index.
     kv_gather_index: torch.Tensor
+    # FIA actual_seq_lengths_kv: causal-prefix length of each segment,
+    # cumulative. prefix_len == segment_start + query_count, so with
+    # sparse_mode=3 query row i attends KV [0, segment_start + i] exactly.
+    kv_cu_seqlens: List[int]
 
 
 def _ceil_div(a: int, b: int) -> int:
@@ -92,7 +104,7 @@ def build_cp_context(
     cp_rank: int,
     device: torch.device,
 ) -> CpContext:
-    """Build a contiguous-split CP context from per-sequence lengths.
+    """Build a zigzag CP context from per-sequence lengths.
 
     ``seq_lens`` are the per-request query lengths in the packed batch order.
     Returns index tensors on ``device``.
@@ -100,91 +112,108 @@ def build_cp_context(
     if cp_size <= 1:
         raise ValueError("build_cp_context requires cp_size > 1")
 
-    shard_index: List[int] = []
-    local_seq_lens: List[int] = []
+    num_chunks = cp_size * 2
+    # The two chunk ids this rank owns: an early one and its mirror.
+    first_chunk = cp_rank
+    second_chunk = num_chunks - 1 - cp_rank
 
-    # Layout of this rank's local shard: concatenation of each sequence's
-    # rank-r segment. seg_len_s = padded_len_s / cp_size.
-    global_offset = 0
+    shard_index: List[int] = []
+    query_index: List[int] = []
+    q_cu_seqlens: List[int] = []
+    kv_gather_index: List[int] = []
+    kv_cu_seqlens: List[int] = []
+    # restore_index needs the per-seq local segment offset (same on every rank)
+    # and the ownership map, so accumulate it in a second pass below.
+    chunk_lens: List[int] = []
     local_seg_offsets: List[int] = []
-    seg_lens: List[int] = []
-    running_local = 0
+
+    global_offset = 0
+    local_offset = 0
+    q_run = 0
+    kv_run = 0
     for length in seq_lens:
         length = int(length)
-        padded = _ceil_div(length, cp_size) * cp_size
-        seg_len = padded // cp_size
-        seg_lens.append(seg_len)
-        local_seg_offsets.append(running_local)
-        running_local += seg_len
+        padded = _ceil_div(length, num_chunks) * num_chunks
+        chunk_len = padded // num_chunks
+        chunk_lens.append(chunk_len)
+        local_seg_offsets.append(local_offset)
 
-        real_on_rank = 0
-        for j in range(seg_len):
-            pos_in_seq = cp_rank * seg_len + j
-            if pos_in_seq < length:
-                shard_index.append(global_offset + pos_in_seq)
-                real_on_rank += 1
-            else:
-                shard_index.append(-1)
-        local_seq_lens.append(real_on_rank)
+        # Emit the two owned segments in local order: first half then second
+        # half. For each, the real rows sit at the front (small j) because real
+        # position grows with j, so query_index stays front-packed per segment.
+        for half, chunk_id in ((0, first_chunk), (1, second_chunk)):
+            seg_local_base = local_offset + half * chunk_len
+            seg_start = chunk_id * chunk_len  # first real position of segment
+            real_count = 0
+            for j in range(chunk_len):
+                pos_in_seq = seg_start + j
+                if pos_in_seq < length:
+                    shard_index.append(global_offset + pos_in_seq)
+                    query_index.append(seg_local_base + j)
+                    real_count += 1
+                else:
+                    shard_index.append(-1)
+            if real_count > 0:
+                # Causal prefix ends exactly at the last real query position + 1
+                # = seg_start + real_count (segment is a contiguous real range).
+                prefix_len = seg_start + real_count
+                q_run += real_count
+                q_cu_seqlens.append(q_run)
+                for p in range(prefix_len):
+                    kv_gather_index.append(global_offset + p)
+                kv_run += prefix_len
+                kv_cu_seqlens.append(kv_run)
+
         global_offset += length
+        local_offset += 2 * chunk_len
 
-    total_local = running_local
+    total_local = local_offset
     total_global = global_offset
 
-    # restore_index: for every global (unpadded) row, where it lands in the
+    # restore_index: for every global (real) row, where it lands in the
     # rank-major all-gather output [cp_size * total_local].
     restore_index: List[int] = []
     global_offset = 0
     for s, length in enumerate(seq_lens):
         length = int(length)
-        seg_len = seg_lens[s]
-        for pos_in_seq in range(length):
-            owner_rank = pos_in_seq // seg_len
-            local_pos = local_seg_offsets[s] + (pos_in_seq % seg_len)
+        chunk_len = chunk_lens[s]
+        seg_offset = local_seg_offsets[s]
+        for pos_in_seq in range(int(length)):
+            chunk_id = pos_in_seq // chunk_len
+            row_in_chunk = pos_in_seq % chunk_len
+            if chunk_id < cp_size:
+                owner_rank = chunk_id
+                local_pos = seg_offset + row_in_chunk
+            else:
+                owner_rank = num_chunks - 1 - chunk_id
+                local_pos = seg_offset + chunk_len + row_in_chunk
             restore_index.append(owner_rank * total_local + local_pos)
-        global_offset += length
+        global_offset += int(length)
 
     shard_tensor = torch.tensor(shard_index, dtype=torch.int64, device=device)
     valid_mask = shard_tensor >= 0
-    gather_index = torch.where(valid_mask, shard_tensor, torch.zeros_like(shard_tensor))
-
-    # FIA actual_seq_lengths (cumulative, no leading 0) and the causal-prefix
-    # KV gather index for this rank's local-q attention.
-    q_cu_seqlens: List[int] = []
-    kv_cu_seqlens: List[int] = []
-    kv_gather_index: List[int] = []
-    q_run = 0
-    kv_run = 0
-    for s in range(len(seq_lens)):
-        seg_len = seg_lens[s]
-        q_run += seg_len
-        q_cu_seqlens.append(q_run)
-        kv_run += (cp_rank + 1) * seg_len
-        kv_cu_seqlens.append(kv_run)
-        base = local_seg_offsets[s]
-        for j in range(cp_rank + 1):
-            block = j * total_local + base
-            for k in range(seg_len):
-                kv_gather_index.append(block + k)
+    gather_index = torch.where(
+        valid_mask, shard_tensor, torch.zeros_like(shard_tensor)
+    )
 
     return CpContext(
         cp_size=cp_size,
         cp_rank=cp_rank,
+        total_local=total_local,
         shard_index=shard_tensor,
         shard_gather_index=gather_index,
         shard_valid_mask=valid_mask,
         restore_index=torch.tensor(
             restore_index, dtype=torch.int64, device=device
         ),
-        total_local=total_local,
-        local_seq_lens=torch.tensor(
-            local_seq_lens, dtype=torch.int32, device=device
+        query_index=torch.tensor(
+            query_index, dtype=torch.int64, device=device
         ),
         q_cu_seqlens=q_cu_seqlens,
-        kv_cu_seqlens=kv_cu_seqlens,
         kv_gather_index=torch.tensor(
             kv_gather_index, dtype=torch.int64, device=device
         ),
+        kv_cu_seqlens=kv_cu_seqlens,
     )
 
 
@@ -216,20 +245,14 @@ def cp_merge_rows(local: torch.Tensor, ctx: CpContext) -> torch.Tensor:
     return gathered.index_select(0, ctx.restore_index)
 
 
-def cp_gather_kv(local_kv: torch.Tensor, ctx: CpContext):
-    """All-gather this rank's KV shard and derive the two views CP prefill needs.
+def cp_gather_kv(local_kv: torch.Tensor, ctx: CpContext) -> torch.Tensor:
+    """All-gather this rank's KV shard back to full global token order.
 
-    ``local_kv`` is ``[total_local, ...]`` (this rank's padded segment of every
-    sequence). Returns ``(kv_global, kv_prefix)`` where:
-
-    * ``kv_global`` ``[T_global, ...]`` is the full sequence in original token
-      order, for writing the complete KV into this rank's paged cache (decode
-      stays on the non-CP path and needs every position).
-    * ``kv_prefix`` is the causal prefix this rank's local queries attend over
-      (segments ``0..cp_rank`` of each sequence, per-seq contiguous), consumed
-      by FIA with ``kv_cu_seqlens`` and right-aligned causal masking.
+    ``local_kv`` is ``[total_local, ...]`` (this rank's padded segments of every
+    sequence). Returns ``kv_global`` ``[T_global, ...]``: the complete sequence
+    in original token order, used both to write the full KV into this rank's
+    paged cache (decode stays on the non-CP path and needs every position) and,
+    via ``ctx.kv_gather_index``, to select each owned segment's causal prefix.
     """
     gathered = ops.cp_all_gather(local_kv, 0, ctx.cp_size)
-    kv_global = gathered.index_select(0, ctx.restore_index)
-    kv_prefix = gathered.index_select(0, ctx.kv_gather_index)
-    return kv_global, kv_prefix
+    return gathered.index_select(0, ctx.restore_index)

--- a/xllm/python/model_executor/cp_utils.py
+++ b/xllm/python/model_executor/cp_utils.py
@@ -1,0 +1,235 @@
+# Copyright 2026 The xLLM Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://github.com/jd-opensource/xllm/blob/main/LICENSE
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Context-Parallel (CP) sequence sharding for the Python model executor.
+
+CP splits a single request's tokens along the sequence dimension across the CP
+group so each rank runs attention over its own shard. This module owns the pure
+index math: it turns per-sequence lengths into (a) a ``shard_index`` that picks
+this rank's rows out of the global packed hidden state and (b) a
+``restore_index`` that reassembles the rank-major all-gather output back into the
+original global order.
+
+First version uses *contiguous* sharding: each sequence is padded up to a
+multiple of ``cp_size`` and split into ``cp_size`` equal contiguous segments;
+rank ``r`` owns segment ``r``. Padding rows (when a length is not divisible by
+``cp_size``) are marked invalid and zeroed after the gather. Load-balanced
+zigzag sharding is a later optimization (see plan P2).
+
+The shard/merge functions are deliberately backend-agnostic (plain torch index
+ops) so the round-trip ``merge(all_gather(shard(x))) == x`` can be unit-tested on
+CPU without NPU or a live process group.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import List, Sequence
+
+import torch
+
+from xllm.python import ops
+
+
+@dataclass(frozen=True)
+class CpContext:
+    """Per-forward CP sharding plan (contiguous split).
+
+    All index tensors live on the target device and use int64 (torch gather /
+    index_select require int64 indices).
+    """
+
+    cp_size: int
+    cp_rank: int
+    # [total_local] global row for each local row, or -1 for a padding row.
+    shard_index: torch.Tensor
+    # [total_local] same as shard_index but -1 replaced by 0 so it is a valid
+    # gather index; pair with shard_valid_mask to zero padding rows afterwards.
+    shard_gather_index: torch.Tensor
+    # [total_local] True for real tokens, False for padding rows.
+    shard_valid_mask: torch.Tensor
+    # [total_global] index into the rank-major all-gather output that restores
+    # the original global token order.
+    restore_index: torch.Tensor
+    # Number of (padded) rows this rank holds; identical across ranks so
+    # all_gather is well-formed.
+    total_local: int
+    # [num_seqs] real (unpadded) token count this rank holds per sequence.
+    local_seq_lens: torch.Tensor
+    # Cumulative per-seq query lengths of this rank's shard (FIA TND
+    # actual_seq_lengths; excludes the leading 0). Each entry is seg_len_s.
+    q_cu_seqlens: List[int]
+    # Cumulative per-seq KV-prefix lengths for this rank (FIA
+    # actual_seq_lengths_kv). Each per-seq length is (cp_rank+1)*seg_len_s: the
+    # causal prefix rank r needs, since its q segment ends at global position
+    # (r+1)*seg_len_s. Paired with sparse_mode=3 (right-aligned causal) this
+    # yields exact per-row causal masking with no custom mask.
+    kv_cu_seqlens: List[int]
+    # [(cp_rank+1)*total_local] index into the rank-major all-gathered KV
+    # ([cp_size*total_local] rows) selecting this rank's per-seq causal prefix
+    # (segments 0..cp_rank of each sequence, in global position order).
+    kv_gather_index: torch.Tensor
+
+
+def _ceil_div(a: int, b: int) -> int:
+    return (a + b - 1) // b
+
+
+def build_cp_context(
+    seq_lens: Sequence[int],
+    cp_size: int,
+    cp_rank: int,
+    device: torch.device,
+) -> CpContext:
+    """Build a contiguous-split CP context from per-sequence lengths.
+
+    ``seq_lens`` are the per-request query lengths in the packed batch order.
+    Returns index tensors on ``device``.
+    """
+    if cp_size <= 1:
+        raise ValueError("build_cp_context requires cp_size > 1")
+
+    shard_index: List[int] = []
+    local_seq_lens: List[int] = []
+
+    # Layout of this rank's local shard: concatenation of each sequence's
+    # rank-r segment. seg_len_s = padded_len_s / cp_size.
+    global_offset = 0
+    local_seg_offsets: List[int] = []
+    seg_lens: List[int] = []
+    running_local = 0
+    for length in seq_lens:
+        length = int(length)
+        padded = _ceil_div(length, cp_size) * cp_size
+        seg_len = padded // cp_size
+        seg_lens.append(seg_len)
+        local_seg_offsets.append(running_local)
+        running_local += seg_len
+
+        real_on_rank = 0
+        for j in range(seg_len):
+            pos_in_seq = cp_rank * seg_len + j
+            if pos_in_seq < length:
+                shard_index.append(global_offset + pos_in_seq)
+                real_on_rank += 1
+            else:
+                shard_index.append(-1)
+        local_seq_lens.append(real_on_rank)
+        global_offset += length
+
+    total_local = running_local
+    total_global = global_offset
+
+    # restore_index: for every global (unpadded) row, where it lands in the
+    # rank-major all-gather output [cp_size * total_local].
+    restore_index: List[int] = []
+    global_offset = 0
+    for s, length in enumerate(seq_lens):
+        length = int(length)
+        seg_len = seg_lens[s]
+        for pos_in_seq in range(length):
+            owner_rank = pos_in_seq // seg_len
+            local_pos = local_seg_offsets[s] + (pos_in_seq % seg_len)
+            restore_index.append(owner_rank * total_local + local_pos)
+        global_offset += length
+
+    shard_tensor = torch.tensor(shard_index, dtype=torch.int64, device=device)
+    valid_mask = shard_tensor >= 0
+    gather_index = torch.where(valid_mask, shard_tensor, torch.zeros_like(shard_tensor))
+
+    # FIA actual_seq_lengths (cumulative, no leading 0) and the causal-prefix
+    # KV gather index for this rank's local-q attention.
+    q_cu_seqlens: List[int] = []
+    kv_cu_seqlens: List[int] = []
+    kv_gather_index: List[int] = []
+    q_run = 0
+    kv_run = 0
+    for s in range(len(seq_lens)):
+        seg_len = seg_lens[s]
+        q_run += seg_len
+        q_cu_seqlens.append(q_run)
+        kv_run += (cp_rank + 1) * seg_len
+        kv_cu_seqlens.append(kv_run)
+        base = local_seg_offsets[s]
+        for j in range(cp_rank + 1):
+            block = j * total_local + base
+            for k in range(seg_len):
+                kv_gather_index.append(block + k)
+
+    return CpContext(
+        cp_size=cp_size,
+        cp_rank=cp_rank,
+        shard_index=shard_tensor,
+        shard_gather_index=gather_index,
+        shard_valid_mask=valid_mask,
+        restore_index=torch.tensor(
+            restore_index, dtype=torch.int64, device=device
+        ),
+        total_local=total_local,
+        local_seq_lens=torch.tensor(
+            local_seq_lens, dtype=torch.int32, device=device
+        ),
+        q_cu_seqlens=q_cu_seqlens,
+        kv_cu_seqlens=kv_cu_seqlens,
+        kv_gather_index=torch.tensor(
+            kv_gather_index, dtype=torch.int64, device=device
+        ),
+    )
+
+
+def cp_shard_rows(x: torch.Tensor, ctx: CpContext) -> torch.Tensor:
+    """Select this rank's rows from a global packed tensor ``[T_global, ...]``.
+
+    Padding rows are zeroed. Returns ``[total_local, ...]``.
+    """
+    local = x.index_select(0, ctx.shard_gather_index)
+    if not bool(ctx.shard_valid_mask.all()):
+        mask_shape = [ctx.shard_valid_mask.shape[0]] + [1] * (x.dim() - 1)
+        local = local * ctx.shard_valid_mask.view(mask_shape).to(local.dtype)
+    return local
+
+
+def cp_shard_positions(positions: torch.Tensor, ctx: CpContext) -> torch.Tensor:
+    """Shard 1-D position ids; padding positions become 0."""
+    local = positions.index_select(0, ctx.shard_gather_index)
+    return local * ctx.shard_valid_mask.to(local.dtype)
+
+
+def cp_merge_rows(local: torch.Tensor, ctx: CpContext) -> torch.Tensor:
+    """Reassemble the global packed tensor from this rank's local shard.
+
+    All-gathers the rank-major shards over the CP group then restores the
+    original global token order. Returns ``[T_global, ...]``.
+    """
+    gathered = ops.cp_all_gather(local, 0, ctx.cp_size)
+    return gathered.index_select(0, ctx.restore_index)
+
+
+def cp_gather_kv(local_kv: torch.Tensor, ctx: CpContext):
+    """All-gather this rank's KV shard and derive the two views CP prefill needs.
+
+    ``local_kv`` is ``[total_local, ...]`` (this rank's padded segment of every
+    sequence). Returns ``(kv_global, kv_prefix)`` where:
+
+    * ``kv_global`` ``[T_global, ...]`` is the full sequence in original token
+      order, for writing the complete KV into this rank's paged cache (decode
+      stays on the non-CP path and needs every position).
+    * ``kv_prefix`` is the causal prefix this rank's local queries attend over
+      (segments ``0..cp_rank`` of each sequence, per-seq contiguous), consumed
+      by FIA with ``kv_cu_seqlens`` and right-aligned causal masking.
+    """
+    gathered = ops.cp_all_gather(local_kv, 0, ctx.cp_size)
+    kv_global = gathered.index_select(0, ctx.restore_index)
+    kv_prefix = gathered.index_select(0, ctx.kv_gather_index)
+    return kv_global, kv_prefix

--- a/xllm/python/model_executor/cp_utils.py
+++ b/xllm/python/model_executor/cp_utils.py
@@ -256,3 +256,84 @@ def cp_gather_kv(local_kv: torch.Tensor, ctx: CpContext) -> torch.Tensor:
     """
     gathered = ops.cp_all_gather(local_kv, 0, ctx.cp_size)
     return gathered.index_select(0, ctx.restore_index)
+
+
+# ---------------------------------------------------------------------------
+# DCP (decode context parallel): KV *storage* sharding.
+#
+# CP has two independent shardings. The zigzag split above shards *query
+# compute* during prefill. DCP additionally shards *KV storage*: with the block
+# manager's logical block widened to ``cp_size * page_size`` (kv_split_size ==
+# cp_size), a logical KV slot ``s`` is owned by rank ``(s % (cp*B)) // B`` -- so
+# each logical block's tokens are dealt out to ranks in contiguous runs of
+# ``page_size``. Each rank then stores only its 1/cp of every sequence's KV in
+# its own physical pages, and the physical block id equals the logical block id
+# (the pool keeps the same block count; only the logical width grew).
+#
+# This mirrors the ATB-only C++ ``map_cache_slots_to_kv_shard``
+# (npu_cp_plan.cpp:924-949), reimplemented in pure torch because the Python
+# executor runs on the TORCH backend and never enters NpuCpPlan.
+# ---------------------------------------------------------------------------
+
+
+def cp_slot_owner(logical_slots: torch.Tensor, cp_size: int,
+                  page_size: int) -> torch.Tensor:
+    """KV-storage owner rank of each logical slot (block-granular).
+
+    ``-1`` slots (padding / not-yet-written) map to owner ``-1``.
+    """
+    logical_block_size = cp_size * page_size
+    owner = torch.remainder(logical_slots, logical_block_size).div(
+        page_size, rounding_mode="floor"
+    )
+    return torch.where(logical_slots >= 0, owner, torch.full_like(owner, -1))
+
+
+def cp_compact_slots(logical_slots: torch.Tensor, cp_size: int, cp_rank: int,
+                     page_size: int) -> torch.Tensor:
+    """Map global logical slots to this rank's physical slots (else ``-1``).
+
+    ``logical_slots`` is the full per-token logical ``slot_mapping`` handed down
+    by C++ (its space is ``cp_size`` times the physical cache). A token whose
+    logical slot is owned by ``cp_rank`` maps to physical slot
+    ``logical_block_id * page_size + (logical_slot % page_size)``; every other
+    token (including original ``-1`` slots) maps to ``-1`` so the
+    reshape-and-cache kernel skips it. This rank therefore writes only its 1/cp
+    of the sequence into its own physical pages.
+
+    Mirrors npu_cp_plan.cpp:924-949 exactly (block-granular ownership, physical
+    block id == logical block id).
+    """
+    logical_block_size = cp_size * page_size
+    valid = logical_slots >= 0
+    owner = torch.remainder(logical_slots, logical_block_size).div(
+        page_size, rounding_mode="floor"
+    )
+    owned = valid & (owner == cp_rank)
+    logical_block_id = logical_slots.div(logical_block_size, rounding_mode="floor")
+    physical = logical_block_id * page_size + torch.remainder(
+        logical_slots, page_size
+    )
+    return torch.where(owned, physical, torch.full_like(logical_slots, -1))
+
+
+def cp_decode_local_kv_lens(kv_seq_lens: torch.Tensor, cp_size: int,
+                            cp_rank: int, page_size: int) -> torch.Tensor:
+    """Per-sequence count of KV tokens this rank stores, under DCP.
+
+    With block-granular ownership (runs of ``page_size`` dealt round-robin to
+    ranks), a sequence of context length ``L`` gives rank ``r`` the tokens whose
+    logical position ``p`` satisfies ``(p % (cp*B)) // B == r``. That count is
+    ``full_blocks_of_this_rank * B + tail``, where the sequence has
+    ``L // (cp*B)`` complete logical blocks (each contributing ``B`` to every
+    rank) plus a remainder handed out ``B`` at a time to ranks ``0, 1, ...``.
+    Mirrors vllm-ascend ``_get_cp_local_seq_lens`` (pcp_utils.py:706-713).
+    """
+    stride = cp_size * page_size
+    full = kv_seq_lens.div(stride, rounding_mode="floor")  # complete logical blocks
+    rem = torch.remainder(kv_seq_lens, stride)  # leftover tokens
+    # Leftover goes to ranks in page_size chunks: this rank gets a whole page if
+    # rem > (cp_rank+1)*B, a partial page if it straddles cp_rank*B, else none.
+    tail = torch.clamp(rem - cp_rank * page_size, min=0)
+    tail = torch.clamp(tail, max=page_size)
+    return full * page_size + tail

--- a/xllm/python/model_executor/executor.py
+++ b/xllm/python/model_executor/executor.py
@@ -104,6 +104,10 @@ class ModelExecutor:
 
         execution_model = model.model
         self.eager_runner = EagerRunner(execution_model, self.attention_backend, device)
+        # Context-Parallel: shard prefill sequences across the CP group. Decode
+        # stays on the non-CP path (CP is prefill-only, eager-only in v1).
+        self.eager_runner.cp_size = int(config.get("cp_size", 1))
+        self.eager_runner.cp_rank = int(config.get("cp_rank", 0))
         self.decode_graph_runner = None
         self.inductor_runner = None
 

--- a/xllm/python/model_executor/forward_context.py
+++ b/xllm/python/model_executor/forward_context.py
@@ -56,6 +56,10 @@ class ForwardContext:
     device: torch.device
     acl_graph: AclGraphCaptureContext | None = None
     layer_synchronizer: LayerSynchronizer | None = None
+    # Context-Parallel sharding plan for this forward, or None when CP is off
+    # (cp_size <= 1) or the step is decode (CP is prefill-only in v1). Typed as
+    # object to avoid a circular import with model_executor.cp_utils.CpContext.
+    cp_context: object | None = None
 
 
 _current_context: ContextVar[ForwardContext | None] = ContextVar(

--- a/xllm/python/model_executor/runners/eager.py
+++ b/xllm/python/model_executor/runners/eager.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 import torch
 
 from xllm.python.attention.backend import AttentionMetadata
+from xllm.python.model_executor.cp_utils import build_cp_context
 from xllm.python.model_executor.forward_context import (
     ForwardContext,
     LayerSynchronizer,
@@ -25,7 +26,25 @@ from xllm.python.model_executor.forward_context import (
 from xllm.python.model_executor.runners.base import BaseRunner
 
 
+def _per_seq_lens_from_metadata(metadata: AttentionMetadata) -> list[int] | None:
+    """Per-sequence query lengths for the packed prefill batch, or None.
+
+    Derived from ``q_cu_seq_lens`` (cumulative, leading 0). Returns None when
+    the field is absent so the caller falls back to the non-CP path.
+    """
+    cu = metadata.q_cu_seq_lens
+    if cu is None:
+        return None
+    cu_host = cu.cpu().tolist()
+    return [cu_host[i + 1] - cu_host[i] for i in range(len(cu_host) - 1)]
+
+
 class EagerRunner(BaseRunner):
+    # Context-Parallel config, set by ModelExecutor when cp_size > 1. CP shards
+    # the prefill sequence across these ranks; decode is left on the non-CP path.
+    cp_size: int = 1
+    cp_rank: int = 0
+
     def execute(
         self,
         input_ids: torch.Tensor,
@@ -34,10 +53,20 @@ class EagerRunner(BaseRunner):
         layer_synchronizer: LayerSynchronizer | None = None,
     ) -> torch.Tensor:
         self.attention_backend.prepare(metadata)
+
+        cp_context = None
+        if self.cp_size > 1 and metadata.is_prefill:
+            seq_lens = _per_seq_lens_from_metadata(metadata)
+            if seq_lens is not None:
+                cp_context = build_cp_context(
+                    seq_lens, self.cp_size, self.cp_rank, self.device
+                )
+
         with forward_context(
             ForwardContext(
                 self.attention_backend, self.device,
                 layer_synchronizer=layer_synchronizer,
+                cp_context=cp_context,
             )
         ):
             return self.model(input_ids, positions)

--- a/xllm/python/models/qwen3.py
+++ b/xllm/python/models/qwen3.py
@@ -41,8 +41,10 @@ from xllm.python.layers import (
 from xllm.python.model_executor.forward_context import (
     ForwardContext,
     forward_context,
+    get_forward_context,
     record_layer_event,
 )  # noqa: F401
+from xllm.python.model_executor.cp_utils import cp_merge_rows, cp_shard_positions, cp_shard_rows
 from xllm.python.models.base import PyModelBase
 
 
@@ -63,6 +65,8 @@ class Qwen3Config:
     attention_bias: bool = False
     tp_size: int = 1
     tp_rank: int = 0
+    cp_size: int = 1
+    cp_rank: int = 0
 
     @classmethod
     def from_dict(cls, d: dict) -> "Qwen3Config":
@@ -92,6 +96,8 @@ class Qwen3Config:
             attention_bias=bool(pick("attention_bias", default=False)),
             tp_size=int(pick("tp_size", default=1)),
             tp_rank=int(pick("tp_rank", default=0)),
+            cp_size=int(pick("cp_size", default=1)),
+            cp_rank=int(pick("cp_rank", default=0)),
         )
 
     def head_split(self) -> Tuple[int, int, int]:
@@ -301,6 +307,13 @@ class Qwen3Model(nn.Module):
         # (its output lives in the graph memory pool), so replay re-casts the
         # updated static_positions correctly.
         positions = positions.to(torch.int64).contiguous()
+        # Context-Parallel: shard the sequence across the CP group after embed
+        # and merge back before the final norm (model-side CP semantics). Only
+        # active on prefill with cp_size>1; cp_context is None otherwise.
+        cp_context = get_forward_context().cp_context
+        if cp_context is not None:
+            hidden = cp_shard_rows(hidden, cp_context)
+            positions = cp_shard_positions(positions, cp_context).contiguous()
         residual: Optional[torch.Tensor] = None
         for i, layer in enumerate(self.layers):
             hidden, residual = layer(
@@ -308,6 +321,8 @@ class Qwen3Model(nn.Module):
             )
             record_layer_event(i)
         hidden, _ = self.norm(hidden, residual)
+        if cp_context is not None:
+            hidden = cp_merge_rows(hidden, cp_context)
         return hidden
 
 

--- a/xllm/python/ops/__init__.py
+++ b/xllm/python/ops/__init__.py
@@ -41,6 +41,10 @@ from xllm.python.ops.attention import (
 from xllm.python.ops.collectives import (
     all_gather,
     all_reduce_,
+    cp_all_gather,
+    cp_rank,
+    cp_world_size,
+    init_cp_group,
     init_tp_group,
     tp_rank,
 )
@@ -62,4 +66,8 @@ __all__ = [
     "all_gather",
     "init_tp_group",
     "tp_rank",
+    "cp_all_gather",
+    "cp_rank",
+    "cp_world_size",
+    "init_cp_group",
 ]

--- a/xllm/python/ops/collectives.py
+++ b/xllm/python/ops/collectives.py
@@ -12,9 +12,16 @@ _cp_stores = {}
 
 
 def _create_process_group(
-    host: str, port: int, rank: int, world_size: int, device: str
+    host: str, port: int, rank: int, world_size: int, device: str,
+    group_id: str,
 ):
-    """Create HCCL or NCCL ProcessGroup depending on device type."""
+    """Create HCCL or NCCL ProcessGroup depending on device type.
+
+    ``group_id`` names the underlying HCCL communicator. It must be distinct per
+    logical group (TP vs CP): torch_npu keys each device's HCCL comm by this id,
+    and two comms sharing the default id collide in hcclCommInitRootInfoConfig
+    when an orthogonal TP x CP launch brings up both on the same device.
+    """
     store = dist.TCPStore(
         host,
         port,
@@ -30,7 +37,9 @@ def _create_process_group(
         import torch_npu  # noqa: F401
         from torch_npu._C._distributed_c10d import ProcessGroupHCCL
 
-        group = ProcessGroupHCCL(store, rank, world_size, timedelta(minutes=5))
+        options = ProcessGroupHCCL.Options()
+        options.group_id = group_id
+        group = ProcessGroupHCCL(store, rank, world_size, options)
     return store, group
 
 
@@ -52,7 +61,9 @@ def init_tp_group(
             )
         return group
 
-    store, group = _create_process_group(host, port, rank, world_size, device)
+    store, group = _create_process_group(
+        host, port, rank, world_size, device, "python_tp_group"
+    )
     _tp_stores[device_key] = store
     _tp_groups[device_key] = group
     return group
@@ -92,7 +103,9 @@ def init_cp_group(
             )
         return group
 
-    store, group = _create_process_group(host, port, rank, world_size, device)
+    store, group = _create_process_group(
+        host, port, rank, world_size, device, "python_cp_group"
+    )
     _cp_stores[device_key] = store
     _cp_groups[device_key] = group
     return group

--- a/xllm/python/ops/collectives.py
+++ b/xllm/python/ops/collectives.py
@@ -7,6 +7,8 @@ import torch.distributed as dist
 
 _tp_groups = {}
 _tp_stores = {}
+_cp_groups = {}
+_cp_stores = {}
 
 
 def _create_process_group(
@@ -66,6 +68,46 @@ def _require_tp_group(x: torch.Tensor):
     return group
 
 
+def init_cp_group(
+    host: str,
+    port: int,
+    rank: int,
+    world_size: int,
+    device: str,
+):
+    """Initialize the context-parallel (CP) process group for ``device``.
+
+    Mirrors ``init_tp_group`` but keeps a separate group so CP collectives do
+    not collide with TP ones. CP is orthogonal to TP: a CP group gathers the
+    ranks that hold different sequence shards of the same request.
+    """
+    device_key = str(torch.device(device))
+    group = _cp_groups.get(device_key)
+    if group is not None:
+        if group.rank() != rank or group.size() != world_size:
+            raise RuntimeError(
+                f"CP group for {device_key} is already initialized as "
+                f"rank {group.rank()}/{group.size()}, requested "
+                f"rank {rank}/{world_size}"
+            )
+        return group
+
+    store, group = _create_process_group(host, port, rank, world_size, device)
+    _cp_stores[device_key] = store
+    _cp_groups[device_key] = group
+    return group
+
+
+def _require_cp_group(x: torch.Tensor):
+    group = _cp_groups.get(str(x.device))
+    if group is None:
+        raise RuntimeError(
+            "context-parallel collective called before the CP process group "
+            f"was initialized for {x.device}"
+        )
+    return group
+
+
 def tp_rank(device) -> int:
     """Rank in the TP group for ``device`` (0 when no TP group exists)."""
     group = _tp_groups.get(str(torch.device(device)))
@@ -97,6 +139,38 @@ def all_gather(x: torch.Tensor, dim: int, world_size: int) -> torch.Tensor:
 
 
 @all_gather.register_fake
+def _(x: torch.Tensor, dim: int, world_size: int) -> torch.Tensor:
+    shape = list(x.shape)
+    shape[dim] *= world_size
+    return x.new_empty(shape)
+
+
+def cp_rank(device) -> int:
+    """Rank in the CP group for ``device`` (0 when no CP group exists)."""
+    group = _cp_groups.get(str(torch.device(device)))
+    return group.rank() if group is not None else 0
+
+
+def cp_world_size(device) -> int:
+    """Size of the CP group for ``device`` (1 when no CP group exists)."""
+    group = _cp_groups.get(str(torch.device(device)))
+    return group.size() if group is not None else 1
+
+
+@torch.library.custom_op("xllm_ops::cp_all_gather", mutates_args=())
+def cp_all_gather(x: torch.Tensor, dim: int, world_size: int) -> torch.Tensor:
+    group = _require_cp_group(x)
+    if group.size() != world_size:
+        raise RuntimeError(
+            f"CP world-size mismatch: expected {world_size}, "
+            f"got {group.size()}"
+        )
+    chunks = [torch.empty_like(x) for _ in range(world_size)]
+    dist.all_gather(chunks, x, group=group)
+    return torch.cat(chunks, dim=dim)
+
+
+@cp_all_gather.register_fake
 def _(x: torch.Tensor, dim: int, world_size: int) -> torch.Tensor:
     shape = list(x.shape)
     shape[dim] *= world_size


### PR DESCRIPTION
Shard a single request's prefill tokens along the sequence dimension across a context-parallel (CP) group so each rank runs attention over its own contiguous shard. New cp_utils builds the pure index math (shard/restore/KV-prefix gather) and the executor wires it through the eager prefill path, the qwen3 model, and the NPU paged-attention backend, which all-gathers KV and attends over each rank's causal prefix via FIA sparse_mode=3. C++ carves the CP dimension out of the physical process group and initializes a dedicated Python CP group aliasing the TP rendezvous endpoint. CP is prefill-only, eager-only, LLM/generate, dp_size==1 in v1.

## Description

<!-- What does this PR do? Briefly describe the changes and why they are needed. -->

## Related Issues

<!-- Link related issues here. Use "Fixes #123" when this PR closes an issue. -->

## Change Type

- [ ] Bug fix
- [ ] New feature
- [ ] Performance improvement
- [ ] Refactor
- [ ] Documentation
- [ ] Test
- [ ] Build or CI

## Pull Request Checklist

Thank you for contributing to xLLM. Before requesting review, please make sure the following items are complete.

### PR Title and Commit Messages

- [ ] The PR title and each commit message follow the xLLM commit format: `<type>: <subject>`.

> Allowed types: feat, bugfix, docs, test, refactor, chore, style, revert, perf, model, build, release.
> The subject should use clear English, start with a verb, include at least 4 words, and end with `.`.

### Pre-commit Checks

- [ ] I have installed `pre-commit` by running `pip install pre-commit` or an equivalent command.
- [ ] I have installed the hooks with `pre-commit install`.
- [ ] I have run `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

### Self Review

- [ ] I have self-reviewed the code according to `.agents/skills/code-review/references/custom-code-style.md`, especially code written or assisted by AI.
- [ ] I have rebased this PR onto the latest `main` branch.

### Build and Test Coverage

- [ ] Tests have been added or updated as needed.
- [ ] CUDA: `python setup.py build test` has passed on a CUDA machine.
- [ ] NPU: `python setup.py build test` has passed on an NPU machine.
- [ ] MLU: `python setup.py build test` has passed on an MLU machine.

## Reviewer Notes

<!-- Optional: anything reviewers should focus on, known risks, follow-ups, or validation gaps. -->
