### PR TITLE
bugfix: reject stale embedding_id in read_accepted_prefix_lengths.

### DIFF
--- a/tests/core/framework/kv_cache/embedding_cache_test.cpp
+++ b/tests/core/framework/kv_cache/embedding_cache_test.cpp
@@ -143,6 +143,39 @@ TEST(EmbeddingCacheTest, RequestMismatchMaterializesMissingState) {
   EXPECT_FALSE(states[0].embedding.defined());
 }
 
+TEST(EmbeddingCacheTest, ReadAcceptedPrefixLengthsRejectsStaleRequest) {
+  EmbeddingCache cache(/*total_nums=*/2);
+  std::vector<int32_t> ids = {0, 1};
+  std::vector<std::string> request_ids = {"req_0", "req_1"};
+  torch::Tensor accepted_tokens =
+      torch::tensor({{11, 12, 13}, {21, -1, -1}}, torch::kInt);
+  torch::Tensor accepted_embeddings =
+      torch::tensor({{{1.0f, 1.1f}, {1.2f, 1.3f}, {1.4f, 1.5f}},
+                     {{2.0f, 2.1f}, {2.2f, 2.3f}, {2.4f, 2.5f}}});
+
+  // Only embedding_id 0 receives target output; id 1 stays uninitialized.
+  cache.write_target_context({0},
+                             {"req_0"},
+                             accepted_tokens.slice(/*dim=*/0, 0, 1),
+                             accepted_embeddings.slice(/*dim=*/0, 0, 1),
+                             /*num_speculative_tokens=*/2);
+
+  // Matching request_id returns correction_position_offset + 1; an
+  // uninitialized entry returns 1.
+  std::vector<int32_t> lengths =
+      cache.read_accepted_prefix_lengths(ids, request_ids);
+  ASSERT_EQ(lengths.size(), ids.size());
+  EXPECT_EQ(lengths[0], 3);
+  EXPECT_EQ(lengths[1], 1);
+
+  // A preempted-and-reused embedding_id now owned by a fresh request must not
+  // leak the previous request's correction offset.
+  std::vector<int32_t> reused =
+      cache.read_accepted_prefix_lengths({0}, {"new_req"});
+  ASSERT_EQ(reused.size(), 1u);
+  EXPECT_EQ(reused[0], 1);
+}
+
 TEST(EmbeddingCacheTest, WriteMtpBootstrapContextStoresExactDecodeState) {
   EmbeddingCache cache(/*total_nums=*/2);
   torch::Tensor embedding = torch::tensor({1.0f, 2.0f, 3.0f});

--- a/xllm/core/framework/kv_cache/embedding_cache.cpp
+++ b/xllm/core/framework/kv_cache/embedding_cache.cpp
@@ -239,15 +239,28 @@ std::vector<EmbeddingCache::DecodeState> EmbeddingCache::read_decode_states(
 }
 
 std::vector<int32_t> EmbeddingCache::read_accepted_prefix_lengths(
-    const std::vector<int32_t>& ids) const {
+    const std::vector<int32_t>& ids,
+    const std::vector<std::string>& request_ids) const {
   CHECK(!ids.empty()) << "decode ids should not be empty";
+  CHECK(request_ids.empty() || request_ids.size() == ids.size())
+      << "embedding_id / request_id count mismatch";
   std::vector<int32_t> accepted_prefix_lengths;
   accepted_prefix_lengths.reserve(ids.size());
-  for (int32_t id : ids) {
-    const DecodeState& state = get_tail(id);
-    CHECK_GE(state.correction_token_id, 0)
-        << "decode entry missing correction token id";
-    accepted_prefix_lengths.emplace_back(state.correction_position_offset + 1);
+  for (int32_t i = 0; i < static_cast<int32_t>(ids.size()); ++i) {
+    const DecodeState& state = get_tail(ids[i]);
+    // A slot that never received target output, or one whose request_id no
+    // longer matches (embedding_id recycled by a later request), carries no
+    // usable correction offset — fall back to a single accepted token so the
+    // previous request's offset cannot leak into this sequence's spec-verify
+    // metadata. An empty request_ids skips the request_id match.
+    int32_t accepted_length = 1;
+    if (state.valid &&
+        (request_ids.empty() || state.request_id == request_ids[i])) {
+      CHECK_GE(state.correction_token_id, 0)
+          << "decode entry missing correction token id";
+      accepted_length = state.correction_position_offset + 1;
+    }
+    accepted_prefix_lengths.emplace_back(accepted_length);
   }
   return accepted_prefix_lengths;
 }

--- a/xllm/core/framework/kv_cache/embedding_cache.h
+++ b/xllm/core/framework/kv_cache/embedding_cache.h
@@ -99,7 +99,8 @@ class EmbeddingCache final {
       const std::vector<int32_t>& embedding_ids,
       const std::vector<std::string>& request_ids) const;
   std::vector<int32_t> read_accepted_prefix_lengths(
-      const std::vector<int32_t>& embedding_ids) const;
+      const std::vector<int32_t>& embedding_ids,
+      const std::vector<std::string>& request_ids) const;
 
   void clear(const std::vector<int32_t>& embedding_ids);
 

--- a/xllm/core/runtime/mtp_worker_impl.cpp
+++ b/xllm/core/runtime/mtp_worker_impl.cpp
@@ -2097,7 +2097,8 @@ void MTPWorkerImpl::prepare_validate_inputs(const ForwardInput& input,
     if (embedding_cache_ != nullptr &&
         !input.input_params.embedding.embedding_ids.empty()) {
       accepted_prefix_lengths = embedding_cache_->read_accepted_prefix_lengths(
-          input.input_params.embedding.embedding_ids);
+          input.input_params.embedding.embedding_ids,
+          input.input_params.embedding.request_ids);
     }
     input_params.num_accepted_tokens_host.assign(
         accepted_prefix_lengths.begin(), accepted_prefix_lengths.end());
@@ -2248,7 +2249,8 @@ bool MTPWorkerImpl::prepare_static_mtp_graph_tasks_before_final_draft(
   }
   const std::vector<int32_t> accepted_prefix_lengths =
       embedding_cache_->read_accepted_prefix_lengths(
-          input.input_params.embedding.embedding_ids);
+          input.input_params.embedding.embedding_ids,
+          input.input_params.embedding.request_ids);
   if (accepted_prefix_lengths.size() != 1) {
     return false;
   }


### PR DESCRIPTION
## Summary

`EmbeddingCache::read_accepted_prefix_lengths` previously trusted every cached `DecodeState` unconditionally. When an `embedding_id` slot is recycled by a later request (e.g. after preemption), the stale `correction_position_offset` left by the previous owner could leak into the new sequence's speculative-verify metadata, producing an incorrect accepted-prefix length.

This change adds request-ownership validation, mirroring the check already present in `read_decode_states`:

- `read_accepted_prefix_lengths` now takes a parallel `request_ids` argument and only trusts a `DecodeState` when it is `valid` **and** its `request_id` matches the caller's. On mismatch (or an invalid/never-populated slot), it falls back to a single accepted token instead of leaking the previous owner's offset.
- An empty `request_ids` preserves the old behavior (ownership check skipped), keeping call sites that do not track request ids working.
- Both `MTPWorkerImpl` call sites now pass `input.input_params.embedding.request_ids`.

## Test plan

- [x] Added `embedding_cache_test.cpp` coverage asserting a recycled `embedding_id` with a mismatched `request_id` yields the safe fallback length rather than the stale offset.
- [ ] Existing embedding-cache / MTP unit tests pass.