### PR TITLE
bugfix: align repository model names with model_path names and versions.

### DIFF
--- a/tests/api_service/CMakeLists.txt
+++ b/tests/api_service/CMakeLists.txt
@@ -106,6 +106,17 @@ cc_test(
     GTest::gtest_main
 )
 
+cc_test(
+  NAME
+    models_service_impl_test
+  SRCS
+    models_service_impl_test.cpp
+  DEPS
+    api_service
+    GTest::gtest_main
+    nlohmann_json::nlohmann_json
+)
+
 # Integration smoke tests for OpenAI-compatible endpoints. These require a
 # running server and are disabled by default in code.
 cc_test(

--- a/tests/api_service/models_service_impl_test.cpp
+++ b/tests/api_service/models_service_impl_test.cpp
@@ -1,0 +1,58 @@
+/* Copyright 2026 The xLLM Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://github.com/jd-opensource/xllm/blob/main/LICENSE
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include "xllm/api_service/models_service_impl.h"
+
+#include <gtest/gtest.h>
+
+#include <cstddef>
+#include <nlohmann/json.hpp>
+#include <string>
+#include <vector>
+
+namespace xllm {
+namespace {
+
+TEST(ModelsServiceImplTest, RepositoryIndexUsesPublicModelIds) {
+  const std::vector<std::string> model_names = {"GLM-5.1", "Qwen3-8B"};
+  const std::vector<std::string> model_versions = {"2", "3"};
+  ModelsServiceImpl service(model_names, model_versions);
+
+  proto::ModelListRequest request;
+  proto::ModelListResponse response;
+  ASSERT_TRUE(service.list_models(&request, &response));
+  ASSERT_EQ(response.data_size(), static_cast<int>(model_names.size()));
+
+  const nlohmann::json repository_index =
+      nlohmann::json::parse(service.list_model_versions());
+  ASSERT_TRUE(repository_index.is_array());
+  ASSERT_EQ(repository_index.size(), model_names.size());
+
+  for (std::size_t i = 0; i < model_names.size(); ++i) {
+    ASSERT_EQ(response.data(static_cast<int>(i)).id(), model_names[i]);
+    ASSERT_TRUE(repository_index[i].is_object());
+    ASSERT_TRUE(repository_index[i].contains("name"));
+    ASSERT_TRUE(repository_index[i].contains("version"));
+    ASSERT_TRUE(repository_index[i].contains("state"));
+    ASSERT_TRUE(repository_index[i].contains("reason"));
+    EXPECT_EQ(repository_index[i]["name"], model_names[i]);
+    EXPECT_EQ(repository_index[i]["version"], model_versions[i]);
+    EXPECT_EQ(repository_index[i]["state"], "READY");
+    EXPECT_EQ(repository_index[i]["reason"], "normal");
+  }
+}
+
+}  // namespace
+}  // namespace xllm

--- a/tests/api_service/models_service_impl_test.cpp
+++ b/tests/api_service/models_service_impl_test.cpp
@@ -25,10 +25,13 @@ limitations under the License.
 namespace xllm {
 namespace {
 
-TEST(ModelsServiceImplTest, RepositoryIndexUsesPublicModelIds) {
+TEST(ModelsServiceImplTest, RepositoryIndexUsesRepositoryMetadata) {
   const std::vector<std::string> model_names = {"GLM-5.1", "Qwen3-8B"};
+  const std::vector<std::string> model_repository_names = {"glm-51-w8a8-npu",
+                                                           "qwen3"};
   const std::vector<std::string> model_versions = {"2", "3"};
-  ModelsServiceImpl service(model_names, model_versions);
+  ModelsServiceImpl service(
+      model_names, model_repository_names, model_versions);
 
   proto::ModelListRequest request;
   proto::ModelListResponse response;
@@ -47,7 +50,7 @@ TEST(ModelsServiceImplTest, RepositoryIndexUsesPublicModelIds) {
     ASSERT_TRUE(repository_index[i].contains("version"));
     ASSERT_TRUE(repository_index[i].contains("state"));
     ASSERT_TRUE(repository_index[i].contains("reason"));
-    EXPECT_EQ(repository_index[i]["name"], model_names[i]);
+    EXPECT_EQ(repository_index[i]["name"], model_repository_names[i]);
     EXPECT_EQ(repository_index[i]["version"], model_versions[i]);
     EXPECT_EQ(repository_index[i]["state"], "READY");
     EXPECT_EQ(repository_index[i]["reason"], "normal");

--- a/tests/core/util/CMakeLists.txt
+++ b/tests/core/util/CMakeLists.txt
@@ -7,6 +7,7 @@ cc_test(
     blocking_counter_test.cpp
     device_name_utils_test.cpp
     http_downloader_test.cpp
+    model_path_utils_test.cpp
     net_test.cpp
     suffix_decoding_cache_test.cpp
     threadpool_test.cpp

--- a/tests/core/util/model_path_utils_test.cpp
+++ b/tests/core/util/model_path_utils_test.cpp
@@ -1,0 +1,39 @@
+/* Copyright 2026 The xLLM Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://github.com/jd-opensource/xllm/blob/main/LICENSE
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include <gtest/gtest.h>
+
+#include <filesystem>
+
+#include "core/util/utils.h"
+
+namespace xllm::util {
+
+TEST(ModelPathUtilsTest, ExtractsRepositoryNameFromVersionedPath) {
+  const std::filesystem::path model_path =
+      std::filesystem::path("/export/App/model_repository/glm-51-w8a8-npu/2/")
+          .lexically_normal();
+
+  EXPECT_EQ(get_model_name(model_path), "2");
+  EXPECT_EQ(get_model_repository_name(model_path), "glm-51-w8a8-npu");
+}
+
+TEST(ModelPathUtilsTest, FallsBackToModelNameForNonVersionedPath) {
+  const std::filesystem::path model_path = "/export/home/models/Qwen3-0.6B";
+
+  EXPECT_EQ(get_model_repository_name(model_path), "Qwen3-0.6B");
+}
+
+}  // namespace xllm::util

--- a/xllm/api_service/api_service.cpp
+++ b/xllm/api_service/api_service.cpp
@@ -110,13 +110,15 @@ void process_typed_brpc_request(std::unique_ptr<Service>& service_impl,
 
 APIService::APIService(Master* master,
                        const std::vector<std::string>& model_names,
+                       const std::vector<std::string>& model_repository_names,
                        const std::vector<std::string>& model_versions)
     : master_(master) {
   set_model_master(model_names[0], master);
   if (::xllm::DistributedConfig::get_instance().node_rank() != 0) {
     return;
   }
-  ServiceImplFactory::create(this, master, model_names, model_versions);
+  ServiceImplFactory::create(
+      this, master, model_names, model_repository_names, model_versions);
   register_chat_completions_handler();
 }
 

--- a/xllm/api_service/api_service.h
+++ b/xllm/api_service/api_service.h
@@ -46,6 +46,7 @@ class APIService : public proto::XllmAPIService {
  public:
   APIService(Master* master,
              const std::vector<std::string>& model_names,
+             const std::vector<std::string>& model_repository_names,
              const std::vector<std::string>& model_versions);
   ~APIService() = default;
 

--- a/xllm/api_service/models_service_impl.cpp
+++ b/xllm/api_service/models_service_impl.cpp
@@ -27,8 +27,10 @@ namespace xllm {
 
 ModelsServiceImpl::ModelsServiceImpl(
     const std::vector<std::string>& model_names,
+    const std::vector<std::string>& model_repository_names,
     const std::vector<std::string>& model_versions)
     : model_names_(model_names),
+      model_repository_names_(model_repository_names),
       model_versions_(model_versions),
       created_(absl::ToUnixSeconds(absl::Now())) {}
 
@@ -49,8 +51,7 @@ std::string ModelsServiceImpl::list_model_versions() {
 
   for (size_t i = 0; i < model_versions_.size(); ++i) {
     nlohmann::json model_state;
-    // Keep the repository model identity aligned with the OpenAI model ID.
-    model_state["name"] = model_names_[i];
+    model_state["name"] = model_repository_names_[i];
     model_state["version"] = model_versions_[i];
     model_state["state"] = "READY";
     model_state["reason"] = "normal";

--- a/xllm/api_service/models_service_impl.cpp
+++ b/xllm/api_service/models_service_impl.cpp
@@ -49,10 +49,8 @@ std::string ModelsServiceImpl::list_model_versions() {
 
   for (size_t i = 0; i < model_versions_.size(); ++i) {
     nlohmann::json model_state;
-    // The repository index reports the model directory name (carried by
-    // model_versions_), so it stays stable regardless of a user-provided
-    // --model_id.
-    model_state["name"] = model_versions_[i];
+    // Keep the repository model identity aligned with the OpenAI model ID.
+    model_state["name"] = model_names_[i];
     model_state["version"] = model_versions_[i];
     model_state["state"] = "READY";
     model_state["reason"] = "normal";

--- a/xllm/api_service/models_service_impl.h
+++ b/xllm/api_service/models_service_impl.h
@@ -26,6 +26,7 @@ namespace xllm {
 class ModelsServiceImpl final {
  public:
   ModelsServiceImpl(const std::vector<std::string>& model_names,
+                    const std::vector<std::string>& model_repository_names,
                     const std::vector<std::string>& model_versions);
 
   bool list_models(const proto::ModelListRequest* request,
@@ -36,6 +37,7 @@ class ModelsServiceImpl final {
   DISALLOW_COPY_AND_ASSIGN(ModelsServiceImpl);
 
   std::vector<std::string> model_names_;
+  std::vector<std::string> model_repository_names_;
   std::vector<std::string> model_versions_;
   uint32_t created_;
 };

--- a/xllm/api_service/service_impl_factory.cpp
+++ b/xllm/api_service/service_impl_factory.cpp
@@ -46,6 +46,7 @@ void ServiceImplFactory::create(
     APIService* service,
     Master* master,
     const std::vector<std::string>& model_names,
+    const std::vector<std::string>& model_repository_names,
     const std::vector<std::string>& model_versions) {
   using InitFn = std::function<void(
       APIService*, Master*, const std::vector<std::string>&)>;
@@ -119,13 +120,17 @@ void ServiceImplFactory::create(
                << master->engine_type().to_string();
   }
 
+  CHECK_EQ(model_names.size(), model_repository_names.size())
+      << "Models and model_repository_names size mismatch: "
+      << "model_names.size()=" << model_names.size()
+      << ", model_repository_names.size()=" << model_repository_names.size();
   CHECK_EQ(model_names.size(), model_versions.size())
       << "Models and model_versions size mismatch: model_names.size()="
       << model_names.size()
       << ", model_versions.size()=" << model_versions.size();
 
-  service->models_service_impl_ =
-      std::make_unique<ModelsServiceImpl>(model_names, model_versions);
+  service->models_service_impl_ = std::make_unique<ModelsServiceImpl>(
+      model_names, model_repository_names, model_versions);
 }
 
 }  // namespace xllm

--- a/xllm/api_service/service_impl_factory.h
+++ b/xllm/api_service/service_impl_factory.h
@@ -31,6 +31,7 @@ class ServiceImplFactory {
   static void create(APIService* service,
                      Master* master,
                      const std::vector<std::string>& model_names,
+                     const std::vector<std::string>& model_repository_names,
                      const std::vector<std::string>& model_versions);
 };
 

--- a/xllm/core/util/utils.h
+++ b/xllm/core/util/utils.h
@@ -19,6 +19,7 @@ limitations under the License.
 #include <torch/torch.h>
 
 #include <algorithm>
+#include <cctype>
 #include <filesystem>
 #include <numeric>
 #include <optional>
@@ -196,6 +197,32 @@ inline std::string get_model_name(
   }
 
   return model_name;
+}
+
+inline std::string get_model_repository_name(
+    const std::filesystem::path& normalized_model_path) {
+  std::filesystem::path version_path = normalized_model_path;
+  if (!version_path.has_filename()) {
+    version_path = version_path.parent_path();
+  }
+
+  const std::string model_version = version_path.filename().string();
+  const bool is_numeric_version =
+      !model_version.empty() &&
+      std::all_of(
+          model_version.begin(), model_version.end(), [](char character) {
+            return std::isdigit(static_cast<unsigned char>(character)) != 0;
+          });
+  if (!is_numeric_version) {
+    return get_model_name(normalized_model_path);
+  }
+
+  const std::string repository_name =
+      version_path.parent_path().filename().string();
+  if (repository_name.empty()) {
+    return get_model_name(normalized_model_path);
+  }
+  return repository_name;
 }
 
 inline std::string get_model_backend(const std::filesystem::path& model_path) {

--- a/xllm/xllm.cpp
+++ b/xllm/xllm.cpp
@@ -417,6 +417,8 @@ int run() {
   std::filesystem::path model_path =
       std::filesystem::path(model_config.model()).lexically_normal();
   const std::string default_model_name = xllm::util::get_model_name(model_path);
+  const std::string model_repository_name =
+      xllm::util::get_model_repository_name(model_path);
 
   if (model_config.model_id().empty()) {
     // use last part of the path as model id
@@ -531,12 +533,13 @@ int run() {
 
   // supported models
   std::vector<std::string> model_names = {model_config.model_id()};
+  std::vector<std::string> model_repository_names = {model_repository_name};
   std::string model_version = default_model_name;
   std::vector<std::string> model_versions = {model_version};
 
   if (distributed_config.node_rank() == 0 || kv_cache_config.enable_xtensor()) {
-    auto api_service =
-        std::make_unique<APIService>(master.get(), model_names, model_versions);
+    auto api_service = std::make_unique<APIService>(
+        master.get(), model_names, model_repository_names, model_versions);
     auto xllm_server =
         ServerRegistry::get_instance().register_server("HttpServer");
 


### PR DESCRIPTION
## Description

<!-- What does this PR do? Briefly describe the changes and why they are needed. -->

This PR makes /v2/repository/index report Triton model repository metadata independently from the public model ID.
For a versioned model path such as <repository-name>/<version>/, the endpoint now returns the parent directory as name and the final directory as version. The explicitly configured --model_id remains the ID returned by /v1/models and continues to be used for request routing. This is needed because the previous implementation conflated the public model ID, repository name, and version directory, producing incorrect repository metadata for deployments such as .../glm-51-w8a8-npu/2/. The PR also adds regression tests for repository metadata mapping and versioned/non-versioned model path parsing.

## Related Issues

<!-- Link related issues here. Use "Fixes #123" when this PR closes an issue. -->

## Change Type

- [x] Bug fix
- [ ] New feature
- [ ] Performance improvement
- [ ] Refactor
- [ ] Documentation
- [ ] Test
- [ ] Build or CI

## Pull Request Checklist

Thank you for contributing to xLLM. Before requesting review, please make sure the following items are complete.

### PR Title and Commit Messages

- [x] The PR title and each commit message follow the xLLM commit format: `<type>: <subject>`.

> Allowed types: feat, bugfix, docs, test, refactor, chore, style, revert, perf, model, build, release.
> The subject should use clear English, start with a verb, include at least 4 words, and end with `.`.

### Pre-commit Checks

- [x] I have installed `pre-commit` by running `pip install pre-commit` or an equivalent command.
- [x] I have installed the hooks with `pre-commit install`.
- [x] I have run `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

### Self Review

- [x] I have self-reviewed the code according to `.agents/skills/code-review/references/custom-code-style.md`, especially code written or assisted by AI.
- [x] I have rebased this PR onto the latest `main` branch.

### Build and Test Coverage

- [ ] Tests have been added or updated as needed.
- [ ] CUDA: `python setup.py build test` has passed on a CUDA machine.
- [ ] NPU: `python setup.py build test` has passed on an NPU machine.
- [ ] MLU: `python setup.py build test` has passed on an MLU machine.

## Reviewer Notes

<!-- Optional: anything reviewers should focus on, known risks, follow-ups, or validation gaps. -->
