### PR TITLE
bugfix: fix negative max_concurrent_requests for pd disagg setup.

### DIFF
--- a/tests/core/common/rate_limiter_test.cpp
+++ b/tests/core/common/rate_limiter_test.cpp
@@ -1,6 +1,11 @@
-#include "rate_limiter.h"
+#include "core/common/rate_limiter.h"
 
 #include <gtest/gtest.h>
+
+#include <atomic>
+#include <barrier>
+#include <thread>
+#include <vector>
 
 #include "core/framework/config/service_config.h"
 
@@ -21,6 +26,48 @@ TEST(RequestLimiterTest, Basic) {
   // The current number of concurrent requests is 0, no rate limiting is
   // applied.
   EXPECT_EQ(rate_limiter.is_limited(), false);
+}
+
+TEST(RequestLimiterTest, ConcurrentAdmissionDoesNotExceedCapacity) {
+  constexpr int32_t kMaxConcurrentRequests = 8;
+  constexpr int32_t kNumThreads = 128;
+  ServiceConfig::get_instance().max_concurrent_requests(kMaxConcurrentRequests);
+  RateLimiter rate_limiter;
+  std::barrier start_barrier(kNumThreads);
+  std::atomic<int32_t> admitted_requests{0};
+
+  std::vector<std::thread> threads;
+  threads.reserve(kNumThreads);
+  for (int32_t i = 0; i < kNumThreads; ++i) {
+    threads.emplace_back([&]() {
+      start_barrier.arrive_and_wait();
+      if (!rate_limiter.is_limited()) {
+        admitted_requests.fetch_add(1, std::memory_order_relaxed);
+      }
+    });
+  }
+  for (std::thread& thread : threads) {
+    thread.join();
+  }
+
+  EXPECT_EQ(admitted_requests.load(std::memory_order_relaxed),
+            kMaxConcurrentRequests);
+  EXPECT_EQ(rate_limiter.get_num_concurrent_requests(), kMaxConcurrentRequests);
+}
+
+TEST(RequestLimiterTest, UnmatchedReleaseDoesNotUnderflow) {
+  ServiceConfig::get_instance().max_concurrent_requests(1);
+  RateLimiter rate_limiter;
+
+  rate_limiter.decrease_one_request();
+  rate_limiter.decrease_requests(4);
+  EXPECT_EQ(rate_limiter.get_num_concurrent_requests(), 0);
+
+  ASSERT_TRUE(rate_limiter.try_set_sleeping());
+  rate_limiter.decrease_one_request();
+  rate_limiter.decrease_requests(4);
+  EXPECT_TRUE(rate_limiter.is_sleeping());
+  EXPECT_EQ(rate_limiter.get_num_concurrent_requests(), RateLimiter::kSleeping);
 }
 
 }  // namespace xllm

--- a/tests/core/common/rate_limiter_test.cpp
+++ b/tests/core/common/rate_limiter_test.cpp
@@ -1,3 +1,18 @@
+/* Copyright 2025-2026 The xLLM Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://github.com/jd-opensource/xllm/blob/main/LICENSE
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
 #include "core/common/rate_limiter.h"
 
 #include <gtest/gtest.h>
@@ -35,13 +50,15 @@ TEST(RequestLimiterTest, ConcurrentAdmissionDoesNotExceedCapacity) {
   RateLimiter rate_limiter;
   std::barrier start_barrier(kNumThreads);
   std::atomic<int32_t> admitted_requests{0};
+  std::vector<RateLimiter::AdmissionSlotPtr> admission_slots(kNumThreads);
 
   std::vector<std::thread> threads;
   threads.reserve(kNumThreads);
-  for (int32_t i = 0; i < kNumThreads; ++i) {
-    threads.emplace_back([&]() {
+  for (size_t i = 0; i < kNumThreads; ++i) {
+    threads.emplace_back([&, i]() {
       start_barrier.arrive_and_wait();
-      if (!rate_limiter.is_limited()) {
+      admission_slots[i] = rate_limiter.try_acquire();
+      if (admission_slots[i] != nullptr) {
         admitted_requests.fetch_add(1, std::memory_order_relaxed);
       }
     });
@@ -53,6 +70,75 @@ TEST(RequestLimiterTest, ConcurrentAdmissionDoesNotExceedCapacity) {
   EXPECT_EQ(admitted_requests.load(std::memory_order_relaxed),
             kMaxConcurrentRequests);
   EXPECT_EQ(rate_limiter.get_num_concurrent_requests(), kMaxConcurrentRequests);
+}
+
+TEST(RequestLimiterTest, AdmissionSlotReleaseIsIdempotent) {
+  ServiceConfig::get_instance().max_concurrent_requests(1);
+  RateLimiter rate_limiter;
+  RateLimiter::AdmissionSlotPtr admission_slot = rate_limiter.try_acquire();
+
+  ASSERT_NE(admission_slot, nullptr);
+  admission_slot->release_once();
+  admission_slot->release_once();
+
+  EXPECT_EQ(rate_limiter.get_num_concurrent_requests(), 0);
+}
+
+TEST(RequestLimiterTest, ConcurrentReleaseReturnsCapacityOnce) {
+  ServiceConfig::get_instance().max_concurrent_requests(1);
+  RateLimiter rate_limiter;
+  RateLimiter::AdmissionSlotPtr admission_slot = rate_limiter.try_acquire();
+  ASSERT_NE(admission_slot, nullptr);
+
+  constexpr int32_t kNumThreads = 128;
+  std::barrier start_barrier(kNumThreads);
+  std::vector<std::thread> threads;
+  threads.reserve(kNumThreads);
+  for (int32_t i = 0; i < kNumThreads; ++i) {
+    threads.emplace_back([&]() {
+      start_barrier.arrive_and_wait();
+      admission_slot->release_once();
+    });
+  }
+  for (std::thread& thread : threads) {
+    thread.join();
+  }
+
+  EXPECT_EQ(rate_limiter.get_num_concurrent_requests(), 0);
+}
+
+TEST(RequestLimiterTest, AdmissionSlotDestructorReturnsCapacity) {
+  ServiceConfig::get_instance().max_concurrent_requests(1);
+  RateLimiter rate_limiter;
+  {
+    RateLimiter::AdmissionSlotPtr admission_slot = rate_limiter.try_acquire();
+    ASSERT_NE(admission_slot, nullptr);
+    EXPECT_EQ(rate_limiter.get_num_concurrent_requests(), 1);
+  }
+
+  EXPECT_EQ(rate_limiter.get_num_concurrent_requests(), 0);
+}
+
+TEST(RequestLimiterTest, AdmissionSlotCanOutliveRateLimiter) {
+  ServiceConfig::get_instance().max_concurrent_requests(1);
+  RateLimiter::AdmissionSlotPtr admission_slot;
+  {
+    RateLimiter rate_limiter;
+    admission_slot = rate_limiter.try_acquire();
+    ASSERT_NE(admission_slot, nullptr);
+  }
+
+  admission_slot->release_once();
+}
+
+TEST(RequestLimiterTest, SleepingRejectsAdmissionWithoutChangingState) {
+  ServiceConfig::get_instance().max_concurrent_requests(1);
+  RateLimiter rate_limiter;
+  ASSERT_TRUE(rate_limiter.try_set_sleeping());
+
+  EXPECT_EQ(rate_limiter.try_acquire(), nullptr);
+  EXPECT_TRUE(rate_limiter.is_sleeping());
+  EXPECT_EQ(rate_limiter.get_num_concurrent_requests(), RateLimiter::kSleeping);
 }
 
 TEST(RequestLimiterTest, UnmatchedReleaseDoesNotUnderflow) {

--- a/tests/core/scheduler/continuous_scheduler_test.cpp
+++ b/tests/core/scheduler/continuous_scheduler_test.cpp
@@ -7,8 +7,12 @@
 #include <limits>
 #include <optional>
 
+#include "core/common/rate_limiter.h"
 #include "core/framework/config/kv_cache_config.h"
+#include "core/framework/config/rec_config.h"
 #include "core/framework/config/scheduler_config.h"
+#include "core/framework/config/service_config.h"
+#include "core/framework/request/request_params.h"
 #include "distributed_runtime/engine.h"
 #include "scheduler_factory.h"
 #include "util/utils.h"
@@ -90,6 +94,17 @@ class TestContinuousScheduler final : public ContinuousScheduler {
     response_processor_->batch_process_stream_requests(request_copy);
     response_processor_->wait_completion();
   }
+
+  void process_completed_request(const std::shared_ptr<Request>& request) {
+    response_processor_->process_completed_request(request);
+  }
+
+  void process_failed_request(const std::shared_ptr<Request>& request) {
+    response_processor_->process_failed_request(
+        request, {StatusCode::CANCELLED, "Request cancelled"});
+  }
+
+  void wait_for_responses() { response_processor_->wait_completion(); }
 };
 
 template <typename T>
@@ -619,7 +634,84 @@ TEST(ContinuousSchedulerTest, RejectedStreamCancelsAtSchedulingBoundary) {
             initial_free_blocks);
 }
 
+TEST(ContinuousSchedulerTest, InvalidParamsReturnAdmissionSlotOnEarlyExit) {
+  ServiceConfig::get_instance().max_concurrent_requests(2);
+  RateLimiter rate_limiter;
+  RateLimiter::AdmissionSlotPtr occupied_slot = rate_limiter.try_acquire();
+  ASSERT_NE(occupied_slot, nullptr);
+
+  auto verify_params = [](RequestParams params,
+                          RateLimiter::AdmissionSlotPtr admission_slot) {
+    EXPECT_NE(admission_slot, nullptr);
+    params.n = 0;
+    return params.verify_params([](const RequestOutput&) { return true; });
+  };
+
+  RateLimiter::AdmissionSlotPtr admission_slot = rate_limiter.try_acquire();
+  ASSERT_NE(admission_slot, nullptr);
+  EXPECT_FALSE(verify_params(RequestParams{}, std::move(admission_slot)));
+  EXPECT_EQ(rate_limiter.get_num_concurrent_requests(), 1);
+}
+
+TEST(ContinuousSchedulerTest, RejectedRequestDestructionReturnsAdmissionSlot) {
+  ServiceConfig::get_instance().max_concurrent_requests(2);
+  RateLimiter rate_limiter;
+  RateLimiter::AdmissionSlotPtr occupied_slot = rate_limiter.try_acquire();
+  ASSERT_NE(occupied_slot, nullptr);
+
+  ScopedConfigValue<int32_t> request_queue_size(
+      RecConfig::get_instance().request_queue_size(), 1);
+  ContinuousScheduler::Options opt =
+      create_scheduler_options(1024, 16, 0, 1024, 1);
+  auto engine = std::make_unique<FakeEngine>(32, 4);
+  auto scheduler = std::make_unique<TestContinuousScheduler>(engine.get(), opt);
+  std::shared_ptr<Request> accepted_request =
+      generate_request_with_prompt_tokens({1, 2, 3, 4}, 4, 30000);
+  ASSERT_TRUE(scheduler->add_request(accepted_request));
+
+  std::shared_ptr<Request> rejected_request =
+      generate_request_with_prompt_tokens({1, 2, 3, 4}, 4, 30000);
+  rejected_request->state().admission_slot = rate_limiter.try_acquire();
+  ASSERT_NE(rejected_request->state().admission_slot, nullptr);
+  ASSERT_FALSE(scheduler->add_request(rejected_request));
+  EXPECT_EQ(rate_limiter.get_num_concurrent_requests(), 2);
+
+  rejected_request.reset();
+
+  EXPECT_EQ(rate_limiter.get_num_concurrent_requests(), 1);
+}
+
+TEST(ContinuousSchedulerTest,
+     DuplicateTerminalResponsePathsReturnAdmissionSlotOnce) {
+  ServiceConfig::get_instance().max_concurrent_requests(2);
+  RateLimiter rate_limiter;
+  RateLimiter::AdmissionSlotPtr occupied_slot = rate_limiter.try_acquire();
+  ASSERT_NE(occupied_slot, nullptr);
+
+  ContinuousScheduler::Options opt =
+      create_scheduler_options(1024, 16, 0, 1024, 1);
+  auto engine = std::make_unique<FakeEngine>(32, 4);
+  auto scheduler = std::make_unique<TestContinuousScheduler>(engine.get(), opt);
+  std::shared_ptr<Request> request =
+      generate_request_with_prompt_tokens({1, 2, 3, 4}, 4, 30000);
+  request->state().admission_slot = rate_limiter.try_acquire();
+  ASSERT_NE(request->state().admission_slot, nullptr);
+  request->state().output_func = [](const RequestOutput&) { return true; };
+  request->sequences()[0]->finish();
+
+  scheduler->process_completed_request(request);
+  scheduler->process_failed_request(request);
+  scheduler->wait_for_responses();
+
+  EXPECT_EQ(rate_limiter.get_num_concurrent_requests(), 1);
+}
+
 TEST(ContinuousSchedulerTest, BatchRejectedStreamsCancelAtSchedulingBoundary) {
+  ServiceConfig::get_instance().max_concurrent_requests(3);
+  RateLimiter rate_limiter;
+  RateLimiter::AdmissionSlotPtr occupied_slot = rate_limiter.try_acquire();
+  ASSERT_NE(occupied_slot, nullptr);
+
   ContinuousScheduler::Options opt =
       create_scheduler_options(1024, 16, 0, 1024, 1);
   opt.enable_schedule_overlap() = false;
@@ -638,6 +730,8 @@ TEST(ContinuousSchedulerTest, BatchRejectedStreamsCancelAtSchedulingBoundary) {
   for (std::shared_ptr<Request>& request : requests) {
     request->state().stream = true;
     request->state().output_func = [](const RequestOutput&) { return true; };
+    request->state().admission_slot = rate_limiter.try_acquire();
+    ASSERT_NE(request->state().admission_slot, nullptr);
     make_request_decode_ready(request);
     scheduler->add_request(request);
   }
@@ -654,6 +748,7 @@ TEST(ContinuousSchedulerTest, BatchRejectedStreamsCancelAtSchedulingBoundary) {
   scheduler->reject_streams(requests);
   scheduler->reject_streams(requests);
 
+  EXPECT_EQ(rate_limiter.get_num_concurrent_requests(), 1);
   EXPECT_FALSE(requests[0]->cancelled());
   EXPECT_FALSE(requests[1]->cancelled());
 
@@ -786,12 +881,17 @@ TEST(ContinuousSchedulerTest, ResumeReschedulesPreemptedRequests) {
 // TEST: ABORT mode cancels running requests, frees KV cache, and does NOT
 // push them back to the waiting queue (clients must retry).
 TEST(ContinuousSchedulerTest, PauseAbortCancelsRunningRequests) {
+  ServiceConfig::get_instance().max_concurrent_requests(3);
+  RateLimiter rate_limiter;
+  RateLimiter::AdmissionSlotPtr occupied_slot = rate_limiter.try_acquire();
+  ASSERT_NE(occupied_slot, nullptr);
+
   int block_num = 33;
   int block_size = 32;
   ContinuousScheduler::Options opt =
       create_scheduler_options(10000, 256, 0, 1024, 1);
   auto engine = std::make_unique<FakeEngine>(block_num, block_size);
-  auto scheduler = std::make_unique<ContinuousScheduler>(engine.get(), opt);
+  auto scheduler = std::make_unique<TestContinuousScheduler>(engine.get(), opt);
   BlockManagerPool* block_manager_pool = engine->block_manager_pool();
   ASSERT_TRUE(scheduler != nullptr);
 
@@ -807,6 +907,8 @@ TEST(ContinuousSchedulerTest, PauseAbortCancelsRunningRequests) {
     // process_failed_request invokes the requests output callback; give it a
     // no-op so ABORT can notify completion without a real client.
     req->state().output_func = [](const RequestOutput&) { return true; };
+    req->state().admission_slot = rate_limiter.try_acquire();
+    ASSERT_NE(req->state().admission_slot, nullptr);
     scheduler->add_request(req);
   }
   auto batch = scheduler->prepare_batch_test();
@@ -818,11 +920,13 @@ TEST(ContinuousSchedulerTest, PauseAbortCancelsRunningRequests) {
   int free_blocks_before = util::max(block_manager_pool->num_free_blocks());
 
   scheduler->abort_all_running_requests_test();
+  scheduler->wait_for_responses();
 
   int free_blocks_after = util::max(block_manager_pool->num_free_blocks());
   EXPECT_GT(free_blocks_after, free_blocks_before);        // KV cache freed
   EXPECT_EQ(scheduler->get_running_requests().size(), 0);  // running cleared
   EXPECT_EQ(scheduler->get_waiting_requests_num(), 0);     // NOT requeued
+  EXPECT_EQ(rate_limiter.get_num_concurrent_requests(), 1);
 
   (void)engine.release();
 }

--- a/tests/core/scheduler/continuous_scheduler_test.cpp
+++ b/tests/core/scheduler/continuous_scheduler_test.cpp
@@ -706,6 +706,51 @@ TEST(ContinuousSchedulerTest,
   EXPECT_EQ(rate_limiter.get_num_concurrent_requests(), 1);
 }
 
+TEST(ContinuousSchedulerTest, FailedResponseReturnsAdmissionSlot) {
+  ServiceConfig::get_instance().max_concurrent_requests(1);
+  RateLimiter rate_limiter;
+
+  ContinuousScheduler::Options opt =
+      create_scheduler_options(1024, 16, 0, 1024, 1);
+  auto engine = std::make_unique<FakeEngine>(32, 4);
+  auto scheduler = std::make_unique<TestContinuousScheduler>(engine.get(), opt);
+  std::shared_ptr<Request> request =
+      generate_request_with_prompt_tokens({1, 2, 3, 4}, 4, 30000);
+  request->state().admission_slot = rate_limiter.try_acquire();
+  ASSERT_NE(request->state().admission_slot, nullptr);
+  request->state().output_func = [](const RequestOutput&) { return true; };
+
+  scheduler->process_failed_request(request);
+  scheduler->wait_for_responses();
+
+  EXPECT_EQ(rate_limiter.get_num_concurrent_requests(), 0);
+}
+
+TEST(ContinuousSchedulerTest, IntermediateStreamOutputRetainsAdmissionSlot) {
+  ServiceConfig::get_instance().max_concurrent_requests(1);
+  RateLimiter rate_limiter;
+
+  ContinuousScheduler::Options opt =
+      create_scheduler_options(1024, 16, 0, 1024, 1);
+  auto engine = std::make_unique<FakeEngine>(32, 4);
+  auto scheduler = std::make_unique<TestContinuousScheduler>(engine.get(), opt);
+  std::shared_ptr<Request> request =
+      generate_request_with_prompt_tokens({1, 2, 3, 4}, 4, 30000);
+  request->state().stream = true;
+  request->state().admission_slot = rate_limiter.try_acquire();
+  ASSERT_NE(request->state().admission_slot, nullptr);
+  request->state().outputs_func = [](const std::vector<RequestOutput>&) {
+    return std::vector<bool>{true};
+  };
+  make_request_decode_ready(request);
+  request->sequences()[0]->append_token(/*token_id=*/2);
+
+  std::vector<std::shared_ptr<Request>> requests{request};
+  scheduler->reject_streams(requests);
+
+  EXPECT_EQ(rate_limiter.get_num_concurrent_requests(), 1);
+}
+
 TEST(ContinuousSchedulerTest, BatchRejectedStreamsCancelAtSchedulingBoundary) {
   ServiceConfig::get_instance().max_concurrent_requests(3);
   RateLimiter rate_limiter;

--- a/tests/core/scheduler/disagg_pd_scheduler_test.cpp
+++ b/tests/core/scheduler/disagg_pd_scheduler_test.cpp
@@ -18,16 +18,21 @@ limitations under the License.
 #include <gtest/gtest.h>
 #include <torch/torch.h>
 
+#include <chrono>
+#include <condition_variable>
 #include <cstdint>
 #include <memory>
+#include <mutex>
 #include <optional>
 #include <string>
 #include <vector>
 
 #include "common/metrics.h"
+#include "common/rate_limiter.h"
 #include "distributed_runtime/engine.h"
 #include "framework/block/block_manager_impl.h"
 #include "framework/block/block_manager_pool.h"
+#include "framework/config/service_config.h"
 #include "framework/model/model_args.h"
 #include "framework/request/request.h"
 #include "framework/request/request_state.h"
@@ -46,7 +51,7 @@ class FakeTokenizer final : public Tokenizer {
 
   std::string decode(const Slice<int32_t>& /*ids*/,
                      bool /*skip_special_tokens*/) const override {
-    NOT_IMPLEMENTED();
+    return "decoded";
   }
 
   std::optional<int32_t> token_to_id(
@@ -142,6 +147,27 @@ class TestDisaggPDScheduler final : public DisaggPDScheduler {
   void update_metrics(std::vector<Sequence*>& sequences) {
     update_token_latency_metrics(sequences);
   }
+
+  void set_running_request(std::shared_ptr<Request> request) {
+    running_requests_ = {request};
+    running_sequences_ = {request->sequences()[0].get()};
+  }
+
+  void enable_batch_response() {
+    response_processor_ = std::make_unique<AsyncResponseProcessor>(
+        engine_->tokenizer(),
+        options_.instance_role(),
+        /*enable_service_routing=*/true,
+        /*disable_log_stats=*/true,
+        [](std::shared_ptr<Request> /*request*/) {});
+  }
+};
+
+struct CallbackStats {
+  std::mutex mutex;
+  std::condition_variable cv;
+  int32_t completed = 0;
+  int32_t failed = 0;
 };
 
 DisaggPDScheduler::Options make_options() {
@@ -170,7 +196,9 @@ DisaggPDScheduler::Options make_decode_options() {
 }
 
 std::shared_ptr<Request> make_request(
-    const std::vector<int32_t>& prompt_token_ids) {
+    const std::vector<int32_t>& prompt_token_ids,
+    const OutputFunc& output_func = nullptr,
+    const OutputsFunc& outputs_func = nullptr) {
   RequestSamplingParam sampling_param;
   SchedulerParam scheduler_param;
 
@@ -187,13 +215,13 @@ std::shared_ptr<Request> make_request(
                      prompt_token_ids.size() + 8,
                      /*n=*/1,
                      /*best_of=*/1,
+                     /*logprobs=*/false,
                      /*stream=*/false,
                      /*echo=*/false,
-                     /*logprobs=*/false,
                      /*skip_special_tokens=*/false,
-                     /*include_usage=*/false,
-                     /*mm_data=*/nullptr,
-                     /*service_request_id=*/nullptr);
+                     /*enable_schedule_overlap=*/false,
+                     output_func,
+                     outputs_func);
 
   return std::make_shared<Request>(
       "req", "x-request-id", "x-request-time", state, "service-req");
@@ -250,7 +278,81 @@ bool recv_first_generation(DisaggPDScheduler* scheduler,
       num_cached_tokens);
 }
 
+bool wait_callbacks(CallbackStats* stats, int32_t count) {
+  CHECK(stats != nullptr);
+  std::unique_lock<std::mutex> lock(stats->mutex);
+  return stats->cv.wait_for(lock, std::chrono::seconds(5), [stats, count]() {
+    return stats->completed + stats->failed >= count;
+  });
+}
+
 }  // namespace
+
+TEST(DisaggPDSchedulerTest, MtpFailureReleasesAdmissionOnce) {
+  ServiceConfig::get_instance().max_concurrent_requests(1);
+  RateLimiter rate_limiter;
+  ASSERT_FALSE(rate_limiter.is_limited());
+  ASSERT_EQ(rate_limiter.get_num_concurrent_requests(), 1);
+
+  CallbackStats stats;
+  OutputFunc output_func = [&rate_limiter,
+                            &stats](const RequestOutput& output) -> bool {
+    if (output.status.has_value() && !output.status->ok()) {
+      rate_limiter.decrease_one_request();
+      {
+        std::lock_guard<std::mutex> lock(stats.mutex);
+        ++stats.failed;
+      }
+      stats.cv.notify_all();
+    }
+    return true;
+  };
+  OutputsFunc outputs_func =
+      [&rate_limiter, &stats](const std::vector<RequestOutput>& outputs) {
+        std::vector<bool> callback_status(outputs.size(), true);
+        for (const RequestOutput& output : outputs) {
+          if (output.finished || output.cancelled ||
+              output.finished_on_prefill_instance) {
+            rate_limiter.decrease_one_request();
+            {
+              std::lock_guard<std::mutex> lock(stats.mutex);
+              ++stats.completed;
+            }
+            stats.cv.notify_all();
+          }
+        }
+        return callback_status;
+      };
+
+  FakeEngine engine(/*num_blocks=*/8,
+                    /*block_size=*/2,
+                    /*num_speculative_tokens=*/1);
+  DisaggPDScheduler::Options options = make_options();
+  options.num_speculative_tokens(1).disable_log_stats(true);
+  TestDisaggPDScheduler scheduler(&engine, options);
+  scheduler.enable_batch_response();
+  std::shared_ptr<Request> request =
+      make_request({1, 2, 3, 4}, output_func, outputs_func);
+  finish_prefill(request->sequences()[0].get());
+  scheduler.set_running_request(request);
+
+  scheduler.prefill_send_first_generation();
+  ASSERT_TRUE(wait_callbacks(&stats, /*count=*/2));
+
+  int32_t completed = 0;
+  int32_t failed = 0;
+  {
+    std::lock_guard<std::mutex> lock(stats.mutex);
+    completed = stats.completed;
+    failed = stats.failed;
+  }
+  EXPECT_EQ(completed, 1);
+  EXPECT_EQ(failed, 1);
+  EXPECT_EQ(completed + failed, 1)
+      << "the request was accounted as terminal more than once";
+  EXPECT_EQ(rate_limiter.get_num_concurrent_requests(), 0)
+      << "the same admission was released more than once";
+}
 
 TEST(DisaggPDSchedulerTest, CachesPrefillBlocksBeforeRelease) {
   FakeEngine engine(/*num_blocks=*/8, /*block_size=*/2);

--- a/tests/core/scheduler/disagg_pd_scheduler_test.cpp
+++ b/tests/core/scheduler/disagg_pd_scheduler_test.cpp
@@ -15,6 +15,7 @@ limitations under the License.
 
 #include "scheduler/disagg_pd_scheduler.h"
 
+#include <google/protobuf/service.h>
 #include <gtest/gtest.h>
 #include <torch/torch.h>
 
@@ -126,6 +127,21 @@ class FakeEngine final : public Engine {
   ModelArgs model_args_;
 };
 
+class FakeRpcChannel final : public google::protobuf::RpcChannel {
+ public:
+  void CallMethod(const google::protobuf::MethodDescriptor* /*method*/,
+                  google::protobuf::RpcController* /*controller*/,
+                  const google::protobuf::Message* /*request*/,
+                  google::protobuf::Message* response,
+                  google::protobuf::Closure* done) override {
+    proto::Status* status = static_cast<proto::Status*>(response);
+    status->set_ok(true);
+    if (done != nullptr) {
+      done->Run();
+    }
+  }
+};
+
 class TestDisaggPDScheduler final : public DisaggPDScheduler {
  public:
   TestDisaggPDScheduler(Engine* engine, const Options& options)
@@ -160,6 +176,11 @@ class TestDisaggPDScheduler final : public DisaggPDScheduler {
         /*enable_service_routing=*/true,
         /*disable_log_stats=*/true,
         [](std::shared_ptr<Request> /*request*/) {});
+  }
+
+  void set_rpc_channel(const std::string& request_id,
+                       proto::DisaggPDService_Stub* stub) {
+    req_to_channel_map_[request_id] = stub;
   }
 };
 
@@ -288,7 +309,7 @@ bool wait_callbacks(CallbackStats* stats, int32_t count) {
 
 }  // namespace
 
-TEST(DisaggPDSchedulerTest, MtpFailureReleasesAdmissionOnce) {
+TEST(DisaggPDSchedulerTest, RejectedRequestKeepsActiveAdmission) {
   ServiceConfig::get_instance().max_concurrent_requests(1);
   RateLimiter rate_limiter;
   ASSERT_FALSE(rate_limiter.is_limited());
@@ -324,18 +345,33 @@ TEST(DisaggPDSchedulerTest, MtpFailureReleasesAdmissionOnce) {
         return callback_status;
       };
 
-  FakeEngine engine(/*num_blocks=*/8,
-                    /*block_size=*/2,
-                    /*num_speculative_tokens=*/1);
+  // A second RPC reaches the Prefill node while the first request is active.
+  // is_limited() rejects it without acquiring an admission, then the service's
+  // CALLBACK_WITH_ERROR path invokes the regular error callback.
+  ASSERT_TRUE(rate_limiter.is_limited());
+  RequestOutput rejected_output;
+  rejected_output.status =
+      Status{StatusCode::RESOURCE_EXHAUSTED,
+             "The number of concurrent requests has reached the limit."};
+  output_func(rejected_output);
+  EXPECT_EQ(rate_limiter.get_num_concurrent_requests(), 1)
+      << "a rejected request did not acquire an admission to release";
+
+  FakeEngine engine(/*num_blocks=*/8, /*block_size=*/2);
   DisaggPDScheduler::Options options = make_options();
-  options.num_speculative_tokens(1).disable_log_stats(true);
+  options.disable_log_stats(true);
+  FakeRpcChannel rpc_channel;
+  proto::DisaggPDService_Stub rpc_stub(&rpc_channel);
   TestDisaggPDScheduler scheduler(&engine, options);
   scheduler.enable_batch_response();
+  scheduler.set_rpc_channel("req", &rpc_stub);
   std::shared_ptr<Request> request =
       make_request({1, 2, 3, 4}, output_func, outputs_func);
   finish_prefill(request->sequences()[0].get());
   scheduler.set_running_request(request);
 
+  // The scheduler naturally emits the active request's Prefill completion.
+  // No MTP error or second terminal callback for this request is injected.
   scheduler.prefill_send_first_generation();
   ASSERT_TRUE(wait_callbacks(&stats, /*count=*/2));
 
@@ -348,10 +384,8 @@ TEST(DisaggPDSchedulerTest, MtpFailureReleasesAdmissionOnce) {
   }
   EXPECT_EQ(completed, 1);
   EXPECT_EQ(failed, 1);
-  EXPECT_EQ(completed + failed, 1)
-      << "the request was accounted as terminal more than once";
   EXPECT_EQ(rate_limiter.get_num_concurrent_requests(), 0)
-      << "the same admission was released more than once";
+      << "the rejected request released the active request's admission";
 }
 
 TEST(DisaggPDSchedulerTest, CachesPrefillBlocksBeforeRelease) {

--- a/xllm/api_service/chat_service_impl.cpp
+++ b/xllm/api_service/chat_service_impl.cpp
@@ -630,7 +630,9 @@ void ChatServiceImpl::process_async_rpc_impl(
   // LLMMaster path (existing logic)
   // Check if the request is being rate-limited.
   CHECK(master_ != nullptr);
-  if (master_->get_rate_limiter()->is_limited()) {
+  RateLimiter::AdmissionSlotPtr admission_slot =
+      master_->get_rate_limiter()->try_acquire();
+  if (admission_slot == nullptr) {
     master_->handle_rpc_response(RequestOutput{
         Status{StatusCode::RESOURCE_EXHAUSTED,
                "The number of concurrent requests has reached the limit."},
@@ -643,7 +645,6 @@ void ChatServiceImpl::process_async_rpc_impl(
   const auto& rpc_request = *request;
   const auto& model = rpc_request.model();
   if (unlikely(!models_.contains(model))) {
-    master_->get_rate_limiter()->decrease_one_request();
     CALLBACK_WITH_ERROR(StatusCode::UNKNOWN,
                         "Model not supported",
                         service_request_id,
@@ -703,7 +704,7 @@ void ChatServiceImpl::process_async_rpc_impl(
                           std::move(request_params),
                           std::nullopt,
                           callback,
-                          /*owns_request_slot=*/true);
+                          std::move(admission_slot));
 }
 
 // chat_async for brpc

--- a/xllm/api_service/chat_service_impl.cpp
+++ b/xllm/api_service/chat_service_impl.cpp
@@ -624,21 +624,6 @@ void ChatServiceImpl::process_async_rpc_impl(
   const auto& target_xservice_addr = request->source_xservice_addr();
   auto callback = [master = master_](const RequestOutput& req_output) -> bool {
     req_output.log_request_status();
-    if (req_output.status.has_value()) {
-      const auto& status = req_output.status.value();
-      if (!status.ok()) {
-        // Reduce the number of concurrent requests when a request is
-        // finished with error.
-        master->get_rate_limiter()->decrease_one_request();
-        return master->handle_rpc_response(req_output);
-      }
-    }
-    // Reduce the number of concurrent requests when a request is finished
-    // or canceled.
-    if (req_output.finished || req_output.cancelled ||
-        req_output.finished_on_prefill_instance) {
-      master->get_rate_limiter()->decrease_one_request();
-    }
     return master->handle_rpc_response(req_output);
   };
 
@@ -646,11 +631,11 @@ void ChatServiceImpl::process_async_rpc_impl(
   // Check if the request is being rate-limited.
   CHECK(master_ != nullptr);
   if (master_->get_rate_limiter()->is_limited()) {
-    CALLBACK_WITH_ERROR(
-        StatusCode::RESOURCE_EXHAUSTED,
-        "The number of concurrent requests has reached the limit.",
+    master_->handle_rpc_response(RequestOutput{
+        Status{StatusCode::RESOURCE_EXHAUSTED,
+               "The number of concurrent requests has reached the limit."},
         service_request_id,
-        target_xservice_addr);
+        target_xservice_addr});
     return;
   }
 
@@ -658,6 +643,7 @@ void ChatServiceImpl::process_async_rpc_impl(
   const auto& rpc_request = *request;
   const auto& model = rpc_request.model();
   if (unlikely(!models_.contains(model))) {
+    master_->get_rate_limiter()->decrease_one_request();
     CALLBACK_WITH_ERROR(StatusCode::UNKNOWN,
                         "Model not supported",
                         service_request_id,
@@ -716,7 +702,8 @@ void ChatServiceImpl::process_async_rpc_impl(
                           std::move(prompt_tokens),
                           std::move(request_params),
                           std::nullopt,
-                          callback);
+                          callback,
+                          /*owns_request_slot=*/true);
 }
 
 // chat_async for brpc

--- a/xllm/api_service/completion_service_impl.cpp
+++ b/xllm/api_service/completion_service_impl.cpp
@@ -188,31 +188,16 @@ void CompletionServiceImpl::process_async_rpc_impl(
   const auto& target_xservice_addr = request->source_xservice_addr();
   auto callback = [master = master_](const RequestOutput& req_output) -> bool {
     req_output.log_request_status();
-    if (req_output.status.has_value()) {
-      const auto& status = req_output.status.value();
-      if (!status.ok()) {
-        // Reduce the number of concurrent requests when a request is
-        // finished with error.
-        master->get_rate_limiter()->decrease_one_request();
-        return master->handle_rpc_response(req_output);
-      }
-    }
-    // Reduce the number of concurrent requests when a request is finished
-    // or canceled.
-    if (req_output.finished || req_output.cancelled ||
-        req_output.finished_on_prefill_instance) {
-      master->get_rate_limiter()->decrease_one_request();
-    }
     return master->handle_rpc_response(req_output);
   };
 
   // Check if the request is being rate-limited.
   if (unlikely(master_->get_rate_limiter()->is_limited())) {
-    CALLBACK_WITH_ERROR(
-        StatusCode::RESOURCE_EXHAUSTED,
-        "The number of concurrent requests has reached the limit.",
+    master_->handle_rpc_response(RequestOutput{
+        Status{StatusCode::RESOURCE_EXHAUSTED,
+               "The number of concurrent requests has reached the limit."},
         service_request_id,
-        target_xservice_addr);
+        target_xservice_addr});
     return;
   }
 
@@ -220,6 +205,7 @@ void CompletionServiceImpl::process_async_rpc_impl(
   const auto& rpc_request = *request;
   const auto& model = rpc_request.model();
   if (unlikely(!models_.contains(model))) {
+    master_->get_rate_limiter()->decrease_one_request();
     CALLBACK_WITH_ERROR(StatusCode::UNKNOWN,
                         "Model not supported",
                         service_request_id,
@@ -243,7 +229,8 @@ void CompletionServiceImpl::process_async_rpc_impl(
                           std::move(prompt_tokens),
                           std::move(request_params),
                           std::nullopt,
-                          callback);
+                          callback,
+                          /*owns_request_slot=*/true);
 }
 
 // complete_async for brpc

--- a/xllm/api_service/completion_service_impl.cpp
+++ b/xllm/api_service/completion_service_impl.cpp
@@ -192,7 +192,9 @@ void CompletionServiceImpl::process_async_rpc_impl(
   };
 
   // Check if the request is being rate-limited.
-  if (unlikely(master_->get_rate_limiter()->is_limited())) {
+  RateLimiter::AdmissionSlotPtr admission_slot =
+      master_->get_rate_limiter()->try_acquire();
+  if (unlikely(admission_slot == nullptr)) {
     master_->handle_rpc_response(RequestOutput{
         Status{StatusCode::RESOURCE_EXHAUSTED,
                "The number of concurrent requests has reached the limit."},
@@ -205,7 +207,6 @@ void CompletionServiceImpl::process_async_rpc_impl(
   const auto& rpc_request = *request;
   const auto& model = rpc_request.model();
   if (unlikely(!models_.contains(model))) {
-    master_->get_rate_limiter()->decrease_one_request();
     CALLBACK_WITH_ERROR(StatusCode::UNKNOWN,
                         "Model not supported",
                         service_request_id,
@@ -230,7 +231,7 @@ void CompletionServiceImpl::process_async_rpc_impl(
                           std::move(request_params),
                           std::nullopt,
                           callback,
-                          /*owns_request_slot=*/true);
+                          std::move(admission_slot));
 }
 
 // complete_async for brpc

--- a/xllm/core/common/rate_limiter.cpp
+++ b/xllm/core/common/rate_limiter.cpp
@@ -17,13 +17,28 @@ limitations under the License.
 
 #include <gflags/gflags.h>
 
+#include <utility>
+
 #include "common/global_flags.h"
 #include "common/metrics.h"
 #include "core/framework/config/service_config.h"
 
 namespace xllm {
 
-bool RateLimiter::is_limited() {
+class RateLimiter::SharedState final {
+ public:
+  bool try_acquire();
+  void release_requests(size_t decrease_requests_num);
+  int32_t num_concurrent_requests() const;
+  bool try_set_sleeping();
+  bool try_wakeup();
+  bool is_sleeping() const;
+
+ private:
+  std::atomic<int32_t> num_concurrent_requests_{0};
+};
+
+bool RateLimiter::SharedState::try_acquire() {
   int32_t num_requests =
       num_concurrent_requests_.load(std::memory_order_relaxed);
   const int32_t max_concurrent_requests =
@@ -34,14 +49,14 @@ bool RateLimiter::is_limited() {
     // negative value as unavailable as well, instead of acquiring from an
     // invalid state.
     if (num_requests < 0) {
-      return true;
+      return false;
     }
 
     if ((max_concurrent_requests > 0 &&
          num_requests >= max_concurrent_requests) ||
         num_requests == INT32_MAX) {
       COUNTER_INC(server_request_total_limit);
-      return true;
+      return false;
     }
 
     if (num_concurrent_requests_.compare_exchange_weak(
@@ -51,14 +66,12 @@ bool RateLimiter::is_limited() {
             std::memory_order_relaxed)) {
       GAUGE_SET(num_concurrent_requests,
                 num_concurrent_requests_.load(std::memory_order_relaxed));
-      return false;
+      return true;
     }
   }
 }
 
-void RateLimiter::decrease_one_request() { decrease_requests(1); }
-
-void RateLimiter::decrease_requests(size_t decrease_requests_num) {
+void RateLimiter::SharedState::release_requests(size_t decrease_requests_num) {
   if (decrease_requests_num == 0) {
     return;
   }
@@ -82,18 +95,74 @@ void RateLimiter::decrease_requests(size_t decrease_requests_num) {
   }
 }
 
-bool RateLimiter::try_set_sleeping() {
+int32_t RateLimiter::SharedState::num_concurrent_requests() const {
+  return num_concurrent_requests_.load(std::memory_order_relaxed);
+}
+
+bool RateLimiter::SharedState::try_set_sleeping() {
   int32_t expected = 0;
   // CAS: only succeed if current value is 0.
   return num_concurrent_requests_.compare_exchange_strong(
       expected, kSleeping, std::memory_order_acq_rel);
 }
 
-bool RateLimiter::try_wakeup() {
+bool RateLimiter::SharedState::try_wakeup() {
   int32_t expected = kSleeping;
   // CAS: only succeed if current value is kSleeping.
   return num_concurrent_requests_.compare_exchange_strong(
       expected, 0, std::memory_order_acq_rel);
 }
+
+bool RateLimiter::SharedState::is_sleeping() const {
+  return num_concurrent_requests_.load(std::memory_order_relaxed) == kSleeping;
+}
+
+RateLimiter::AdmissionSlot::AdmissionSlot(std::shared_ptr<SharedState> state)
+    : state_(std::move(state)) {
+  CHECK(state_ != nullptr);
+}
+
+RateLimiter::AdmissionSlot::~AdmissionSlot() { release_once(); }
+
+void RateLimiter::AdmissionSlot::release_once() {
+  if (!released_.exchange(true, std::memory_order_acq_rel)) {
+    state_->release_requests(1);
+  }
+}
+
+RateLimiter::RateLimiter() : state_(std::make_shared<SharedState>()) {}
+
+RateLimiter::~RateLimiter() = default;
+
+RateLimiter::AdmissionSlotPtr RateLimiter::try_acquire() {
+  if (!state_->try_acquire()) {
+    return nullptr;
+  }
+
+  try {
+    return std::make_shared<AdmissionSlot>(state_);
+  } catch (...) {
+    state_->release_requests(1);
+    throw;
+  }
+}
+
+bool RateLimiter::is_limited() { return !state_->try_acquire(); }
+
+void RateLimiter::decrease_one_request() { state_->release_requests(1); }
+
+void RateLimiter::decrease_requests(size_t decrease_requests_num) {
+  state_->release_requests(decrease_requests_num);
+}
+
+int32_t RateLimiter::get_num_concurrent_requests() const {
+  return state_->num_concurrent_requests();
+}
+
+bool RateLimiter::try_set_sleeping() { return state_->try_set_sleeping(); }
+
+bool RateLimiter::try_wakeup() { return state_->try_wakeup(); }
+
+bool RateLimiter::is_sleeping() const { return state_->is_sleeping(); }
 
 }  // namespace xllm

--- a/xllm/core/common/rate_limiter.cpp
+++ b/xllm/core/common/rate_limiter.cpp
@@ -13,7 +13,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
 
-#include "rate_limiter.h"
+#include "core/common/rate_limiter.h"
 
 #include <gflags/gflags.h>
 
@@ -26,38 +26,60 @@ namespace xllm {
 bool RateLimiter::is_limited() {
   int32_t num_requests =
       num_concurrent_requests_.load(std::memory_order_relaxed);
+  const int32_t max_concurrent_requests =
+      ServiceConfig::get_instance().max_concurrent_requests();
 
-  // Check if sleeping.
-  if (num_requests == kSleeping) {
-    return true;
+  while (true) {
+    // Sleeping is represented by a negative sentinel. Treat any unexpected
+    // negative value as unavailable as well, instead of acquiring from an
+    // invalid state.
+    if (num_requests < 0) {
+      return true;
+    }
+
+    if ((max_concurrent_requests > 0 &&
+         num_requests >= max_concurrent_requests) ||
+        num_requests == INT32_MAX) {
+      COUNTER_INC(server_request_total_limit);
+      return true;
+    }
+
+    if (num_concurrent_requests_.compare_exchange_weak(
+            num_requests,
+            num_requests + 1,
+            std::memory_order_acq_rel,
+            std::memory_order_relaxed)) {
+      GAUGE_SET(num_concurrent_requests,
+                num_concurrent_requests_.load(std::memory_order_relaxed));
+      return false;
+    }
   }
-
-  // Check rate limit.
-  if (::xllm::ServiceConfig::get_instance().max_concurrent_requests() > 0 &&
-      num_requests >=
-          ::xllm::ServiceConfig::get_instance().max_concurrent_requests()) {
-    COUNTER_INC(server_request_total_limit);
-    return true;
-  }
-
-  num_concurrent_requests_.fetch_add(1, std::memory_order_relaxed);
-  GAUGE_SET(num_concurrent_requests,
-            num_concurrent_requests_.load(std::memory_order_relaxed));
-
-  return false;
 }
 
-void RateLimiter::decrease_one_request() {
-  num_concurrent_requests_.fetch_sub(1, std::memory_order_relaxed);
-  GAUGE_SET(num_concurrent_requests,
-            num_concurrent_requests_.load(std::memory_order_relaxed));
-}
+void RateLimiter::decrease_one_request() { decrease_requests(1); }
 
 void RateLimiter::decrease_requests(size_t decrease_requests_num) {
-  num_concurrent_requests_.fetch_sub(decrease_requests_num,
-                                     std::memory_order_relaxed);
-  GAUGE_SET(num_concurrent_requests,
-            num_concurrent_requests_.load(std::memory_order_relaxed));
+  if (decrease_requests_num == 0) {
+    return;
+  }
+
+  int32_t num_requests =
+      num_concurrent_requests_.load(std::memory_order_relaxed);
+  while (num_requests > 0) {
+    const int32_t updated_num_requests =
+        decrease_requests_num >= static_cast<size_t>(num_requests)
+            ? 0
+            : num_requests - static_cast<int32_t>(decrease_requests_num);
+    if (num_concurrent_requests_.compare_exchange_weak(
+            num_requests,
+            updated_num_requests,
+            std::memory_order_acq_rel,
+            std::memory_order_relaxed)) {
+      GAUGE_SET(num_concurrent_requests,
+                num_concurrent_requests_.load(std::memory_order_relaxed));
+      return;
+    }
+  }
 }
 
 bool RateLimiter::try_set_sleeping() {

--- a/xllm/core/common/rate_limiter.h
+++ b/xllm/core/common/rate_limiter.h
@@ -18,17 +18,49 @@ limitations under the License.
 #include <atomic>
 #include <cstddef>
 #include <cstdint>
+#include <memory>
 
 namespace xllm {
 
 class RateLimiter final {
+  class SharedState;
+
  public:
   // Special value indicating sleep state.
   static constexpr int32_t kSleeping = INT32_MIN;
 
-  RateLimiter() = default;
+  class AdmissionSlot final {
+   public:
+    explicit AdmissionSlot(std::shared_ptr<SharedState> state);
+    ~AdmissionSlot();
 
-  ~RateLimiter() = default;
+    AdmissionSlot(const AdmissionSlot&) = delete;
+    AdmissionSlot& operator=(const AdmissionSlot&) = delete;
+    AdmissionSlot(AdmissionSlot&&) = delete;
+    AdmissionSlot& operator=(AdmissionSlot&&) = delete;
+
+    // Returns this slot's capacity at most once.
+    void release_once();
+
+   private:
+    std::shared_ptr<SharedState> state_;
+    std::atomic<bool> released_{false};
+  };
+
+  using AdmissionSlotPtr = std::shared_ptr<AdmissionSlot>;
+
+  RateLimiter();
+
+  ~RateLimiter();
+
+  RateLimiter(const RateLimiter&) = delete;
+  RateLimiter& operator=(const RateLimiter&) = delete;
+  RateLimiter(RateLimiter&&) = delete;
+  RateLimiter& operator=(RateLimiter&&) = delete;
+
+  // Atomically acquires request capacity. Returns nullptr if the concurrency
+  // limit has been reached or the service is sleeping.
+  [[nodiscard]] AdmissionSlotPtr try_acquire();
 
   // Returns true if request is rate-limited or sleeping.
   // If not limited and not sleeping, increments the counter.
@@ -40,9 +72,7 @@ class RateLimiter final {
   // Releases up to decrease_requests_num acquired slots without underflowing.
   void decrease_requests(size_t decrease_requests_num);
 
-  int32_t get_num_concurrent_requests() const {
-    return num_concurrent_requests_.load(std::memory_order_relaxed);
-  }
+  int32_t get_num_concurrent_requests() const;
 
   // CAS: only succeeds if num_concurrent_requests == 0.
   // Sets to kSleeping on success. Returns true on success.
@@ -52,13 +82,10 @@ class RateLimiter final {
   // Sets to 0 on success. Returns true on success.
   bool try_wakeup();
 
-  bool is_sleeping() const {
-    return num_concurrent_requests_.load(std::memory_order_relaxed) ==
-           kSleeping;
-  }
+  bool is_sleeping() const;
 
  private:
-  std::atomic<int32_t> num_concurrent_requests_{0};
+  std::shared_ptr<SharedState> state_;
 };
 
 }  // namespace xllm

--- a/xllm/core/common/rate_limiter.h
+++ b/xllm/core/common/rate_limiter.h
@@ -16,6 +16,8 @@ limitations under the License.
 #pragma once
 
 #include <atomic>
+#include <cstddef>
+#include <cstdint>
 
 namespace xllm {
 
@@ -32,8 +34,10 @@ class RateLimiter final {
   // If not limited and not sleeping, increments the counter.
   bool is_limited();
 
+  // Releases an acquired slot. A release at zero or while sleeping is ignored.
   void decrease_one_request();
 
+  // Releases up to decrease_requests_num acquired slots without underflowing.
   void decrease_requests(size_t decrease_requests_num);
 
   int32_t get_num_concurrent_requests() const {

--- a/xllm/core/distributed_runtime/llm_master.cpp
+++ b/xllm/core/distributed_runtime/llm_master.cpp
@@ -185,7 +185,7 @@ void LLMMaster::handle_request(std::string prompt,
                  std::move(sp),
                  call,
                  std::move(callback),
-                 /*owns_request_slot=*/false);
+                 /*admission_slot=*/nullptr);
 }
 
 void LLMMaster::handle_request(std::string prompt,
@@ -193,28 +193,8 @@ void LLMMaster::handle_request(std::string prompt,
                                RequestParams sp,
                                std::optional<Call*> call,
                                OutputCallback callback,
-                               bool owns_request_slot) {
-  std::function<void()> release_request_slot;
-  if (owns_request_slot) {
-    CHECK(options_.enable_service_routing());
-    auto slot_released = std::make_shared<std::atomic<bool>>(false);
-    release_request_slot = [rate_limiter = get_rate_limiter(),
-                            slot_released]() {
-      if (!slot_released->exchange(true, std::memory_order_acq_rel)) {
-        rate_limiter->decrease_one_request();
-      }
-    };
-    callback = [callback = std::move(callback),
-                release_request_slot](RequestOutput output) {
-      const bool failed =
-          output.status.has_value() && !output.status.value().ok();
-      if (failed || output.finished || output.cancelled ||
-          output.finished_on_prefill_instance) {
-        release_request_slot();
-      }
-      return callback(std::move(output));
-    };
-  }
+                               RateLimiter::AdmissionSlotPtr admission_slot) {
+  CHECK(admission_slot == nullptr || options_.enable_service_routing());
   scheduler_->incr_pending_requests(1);
   // add into the queue
   threadpool_->schedule([this,
@@ -222,7 +202,7 @@ void LLMMaster::handle_request(std::string prompt,
                          prompt_token = std::move(prompt_tokens),
                          sp = std::move(sp),
                          callback = std::move(callback),
-                         release_request_slot = std::move(release_request_slot),
+                         admission_slot = std::move(admission_slot),
                          call]() mutable {
     AUTO_COUNTER(request_handling_latency_seconds_completion);
 
@@ -240,7 +220,7 @@ void LLMMaster::handle_request(std::string prompt,
                                     sp,
                                     call,
                                     callback,
-                                    release_request_slot);
+                                    std::move(admission_slot));
     if (!request) {
       return;
     }
@@ -264,7 +244,7 @@ void LLMMaster::handle_request(std::vector<Message> messages,
                  std::move(sp),
                  call,
                  std::move(callback),
-                 /*owns_request_slot=*/false);
+                 /*admission_slot=*/nullptr);
 }
 
 void LLMMaster::handle_request(std::vector<Message> messages,
@@ -272,28 +252,8 @@ void LLMMaster::handle_request(std::vector<Message> messages,
                                RequestParams sp,
                                std::optional<Call*> call,
                                OutputCallback callback,
-                               bool owns_request_slot) {
-  std::function<void()> release_request_slot;
-  if (owns_request_slot) {
-    CHECK(options_.enable_service_routing());
-    auto slot_released = std::make_shared<std::atomic<bool>>(false);
-    release_request_slot = [rate_limiter = get_rate_limiter(),
-                            slot_released]() {
-      if (!slot_released->exchange(true, std::memory_order_acq_rel)) {
-        rate_limiter->decrease_one_request();
-      }
-    };
-    callback = [callback = std::move(callback),
-                release_request_slot](RequestOutput output) {
-      const bool failed =
-          output.status.has_value() && !output.status.value().ok();
-      if (failed || output.finished || output.cancelled ||
-          output.finished_on_prefill_instance) {
-        release_request_slot();
-      }
-      return callback(std::move(output));
-    };
-  }
+                               RateLimiter::AdmissionSlotPtr admission_slot) {
+  CHECK(admission_slot == nullptr || options_.enable_service_routing());
   scheduler_->incr_pending_requests(1);
   // add into the queue
   threadpool_->schedule([this,
@@ -301,7 +261,7 @@ void LLMMaster::handle_request(std::vector<Message> messages,
                          prompt_token = std::move(prompt_tokens),
                          sp = std::move(sp),
                          callback = std::move(callback),
-                         release_request_slot = std::move(release_request_slot),
+                         admission_slot = std::move(admission_slot),
                          call]() mutable {
     AUTO_COUNTER(request_handling_latency_seconds_chat);
 
@@ -318,7 +278,7 @@ void LLMMaster::handle_request(std::vector<Message> messages,
                                     sp,
                                     call,
                                     callback,
-                                    release_request_slot);
+                                    std::move(admission_slot));
     if (!request) {
       return;
     }
@@ -369,7 +329,7 @@ std::shared_ptr<Request> LLMMaster::generate_request(
     const RequestParams& sp,
     std::optional<Call*> call,
     OutputCallback callback,
-    std::function<void()> release_request_slot) {
+    RateLimiter::AdmissionSlotPtr admission_slot) {
   // A request is valid as long as it carries either text or pre-tokenized
   // prompt tokens; pure-token input (no text) is a first-class input.
   const bool has_prompt_tokens = prompt_tokens.has_value();
@@ -576,7 +536,7 @@ std::shared_ptr<Request> LLMMaster::generate_request(
                          call);
   req_state.include_stop_str_in_output = sp.include_stop_str_in_output;
   req_state.sample_slots = sp.sample_slots;
-  req_state.release_request_slot = std::move(release_request_slot);
+  req_state.admission_slot = std::move(admission_slot);
 
   auto request = std::make_shared<Request>(sp.request_id,
                                            sp.x_request_id,
@@ -595,7 +555,7 @@ std::shared_ptr<Request> LLMMaster::generate_request(
     const RequestParams& sp,
     std::optional<Call*> call,
     OutputCallback callback,
-    std::function<void()> release_request_slot) {
+    RateLimiter::AdmissionSlotPtr admission_slot) {
   Timer timer;
 
   std::optional<std::string> prompt;
@@ -616,7 +576,7 @@ std::shared_ptr<Request> LLMMaster::generate_request(
                           sp,
                           call,
                           callback,
-                          std::move(release_request_slot));
+                          std::move(admission_slot));
 }
 
 bool LLMMaster::handle_rpc_response(const RequestOutput& output) {

--- a/xllm/core/distributed_runtime/llm_master.cpp
+++ b/xllm/core/distributed_runtime/llm_master.cpp
@@ -180,6 +180,41 @@ void LLMMaster::handle_request(std::string prompt,
                                RequestParams sp,
                                std::optional<Call*> call,
                                OutputCallback callback) {
+  handle_request(std::move(prompt),
+                 std::move(prompt_tokens),
+                 std::move(sp),
+                 call,
+                 std::move(callback),
+                 /*owns_request_slot=*/false);
+}
+
+void LLMMaster::handle_request(std::string prompt,
+                               std::optional<std::vector<int>> prompt_tokens,
+                               RequestParams sp,
+                               std::optional<Call*> call,
+                               OutputCallback callback,
+                               bool owns_request_slot) {
+  std::function<void()> release_request_slot;
+  if (owns_request_slot) {
+    CHECK(options_.enable_service_routing());
+    auto slot_released = std::make_shared<std::atomic<bool>>(false);
+    release_request_slot = [rate_limiter = get_rate_limiter(),
+                            slot_released]() {
+      if (!slot_released->exchange(true, std::memory_order_acq_rel)) {
+        rate_limiter->decrease_one_request();
+      }
+    };
+    callback = [callback = std::move(callback),
+                release_request_slot](RequestOutput output) {
+      const bool failed =
+          output.status.has_value() && !output.status.value().ok();
+      if (failed || output.finished || output.cancelled ||
+          output.finished_on_prefill_instance) {
+        release_request_slot();
+      }
+      return callback(std::move(output));
+    };
+  }
   scheduler_->incr_pending_requests(1);
   // add into the queue
   threadpool_->schedule([this,
@@ -187,6 +222,7 @@ void LLMMaster::handle_request(std::string prompt,
                          prompt_token = std::move(prompt_tokens),
                          sp = std::move(sp),
                          callback = std::move(callback),
+                         release_request_slot = std::move(release_request_slot),
                          call]() mutable {
     AUTO_COUNTER(request_handling_latency_seconds_completion);
 
@@ -199,8 +235,12 @@ void LLMMaster::handle_request(std::string prompt,
       return;
     }
 
-    auto request = generate_request(
-        std::move(prompt), std::move(prompt_token), sp, call, callback);
+    auto request = generate_request(std::move(prompt),
+                                    std::move(prompt_token),
+                                    sp,
+                                    call,
+                                    callback,
+                                    release_request_slot);
     if (!request) {
       return;
     }
@@ -219,6 +259,41 @@ void LLMMaster::handle_request(std::vector<Message> messages,
                                RequestParams sp,
                                std::optional<Call*> call,
                                OutputCallback callback) {
+  handle_request(std::move(messages),
+                 std::move(prompt_tokens),
+                 std::move(sp),
+                 call,
+                 std::move(callback),
+                 /*owns_request_slot=*/false);
+}
+
+void LLMMaster::handle_request(std::vector<Message> messages,
+                               std::optional<std::vector<int>> prompt_tokens,
+                               RequestParams sp,
+                               std::optional<Call*> call,
+                               OutputCallback callback,
+                               bool owns_request_slot) {
+  std::function<void()> release_request_slot;
+  if (owns_request_slot) {
+    CHECK(options_.enable_service_routing());
+    auto slot_released = std::make_shared<std::atomic<bool>>(false);
+    release_request_slot = [rate_limiter = get_rate_limiter(),
+                            slot_released]() {
+      if (!slot_released->exchange(true, std::memory_order_acq_rel)) {
+        rate_limiter->decrease_one_request();
+      }
+    };
+    callback = [callback = std::move(callback),
+                release_request_slot](RequestOutput output) {
+      const bool failed =
+          output.status.has_value() && !output.status.value().ok();
+      if (failed || output.finished || output.cancelled ||
+          output.finished_on_prefill_instance) {
+        release_request_slot();
+      }
+      return callback(std::move(output));
+    };
+  }
   scheduler_->incr_pending_requests(1);
   // add into the queue
   threadpool_->schedule([this,
@@ -226,6 +301,7 @@ void LLMMaster::handle_request(std::vector<Message> messages,
                          prompt_token = std::move(prompt_tokens),
                          sp = std::move(sp),
                          callback = std::move(callback),
+                         release_request_slot = std::move(release_request_slot),
                          call]() mutable {
     AUTO_COUNTER(request_handling_latency_seconds_chat);
 
@@ -237,8 +313,12 @@ void LLMMaster::handle_request(std::vector<Message> messages,
       return;
     }
 
-    auto request =
-        generate_request(messages, std::move(prompt_token), sp, call, callback);
+    auto request = generate_request(messages,
+                                    std::move(prompt_token),
+                                    sp,
+                                    call,
+                                    callback,
+                                    release_request_slot);
     if (!request) {
       return;
     }
@@ -288,7 +368,8 @@ std::shared_ptr<Request> LLMMaster::generate_request(
     std::optional<std::vector<int>> prompt_tokens,
     const RequestParams& sp,
     std::optional<Call*> call,
-    OutputCallback callback) {
+    OutputCallback callback,
+    std::function<void()> release_request_slot) {
   // A request is valid as long as it carries either text or pre-tokenized
   // prompt tokens; pure-token input (no text) is a first-class input.
   const bool has_prompt_tokens = prompt_tokens.has_value();
@@ -469,21 +550,9 @@ std::shared_ptr<Request> LLMMaster::generate_request(
   OutputsFunc batch_callback = nullptr;
   if (options_.enable_service_routing()) {
     batch_callback = [this](const std::vector<RequestOutput>& req_outputs) {
-      size_t decrease_requests_num = 0;
       for (const auto& req_output : req_outputs) {
         req_output.log_request_status();
-        if (req_output.status.has_value() && !req_output.status.value().ok()) {
-          decrease_requests_num++;
-          continue;
-        }
-        // Reduce the number of concurrent requests when a request is
-        // finished or canceled.
-        if (req_output.finished || req_output.cancelled ||
-            req_output.finished_on_prefill_instance) {
-          decrease_requests_num++;
-        }
       }
-      get_rate_limiter()->decrease_requests(decrease_requests_num);
       return handle_rpc_responses(req_outputs);
     };
   }
@@ -507,6 +576,7 @@ std::shared_ptr<Request> LLMMaster::generate_request(
                          call);
   req_state.include_stop_str_in_output = sp.include_stop_str_in_output;
   req_state.sample_slots = sp.sample_slots;
+  req_state.release_request_slot = std::move(release_request_slot);
 
   auto request = std::make_shared<Request>(sp.request_id,
                                            sp.x_request_id,
@@ -524,7 +594,8 @@ std::shared_ptr<Request> LLMMaster::generate_request(
     std::optional<std::vector<int>> prompt_tokens,
     const RequestParams& sp,
     std::optional<Call*> call,
-    OutputCallback callback) {
+    OutputCallback callback,
+    std::function<void()> release_request_slot) {
   Timer timer;
 
   std::optional<std::string> prompt;
@@ -540,8 +611,12 @@ std::shared_ptr<Request> LLMMaster::generate_request(
 
   COUNTER_ADD(chat_template_latency_seconds, timer.elapsed_seconds());
 
-  return generate_request(
-      std::move(prompt.value()), std::move(prompt_tokens), sp, call, callback);
+  return generate_request(std::move(prompt.value()),
+                          std::move(prompt_tokens),
+                          sp,
+                          call,
+                          callback,
+                          std::move(release_request_slot));
 }
 
 bool LLMMaster::handle_rpc_response(const RequestOutput& output) {

--- a/xllm/core/distributed_runtime/llm_master.h
+++ b/xllm/core/distributed_runtime/llm_master.h
@@ -55,7 +55,7 @@ class LLMMaster : public Master {
                       RequestParams sp,
                       std::optional<Call*> call,
                       OutputCallback callback,
-                      bool owns_request_slot);
+                      RateLimiter::AdmissionSlotPtr admission_slot);
 
   // chat
   void handle_request(std::vector<Message> messages,
@@ -69,7 +69,7 @@ class LLMMaster : public Master {
                       RequestParams sp,
                       std::optional<Call*> call,
                       OutputCallback callback,
-                      bool owns_request_slot);
+                      RateLimiter::AdmissionSlotPtr admission_slot);
 
   // batch completion
   void handle_batch_request(std::vector<std::string> prompts,
@@ -121,7 +121,7 @@ class LLMMaster : public Master {
       const RequestParams& sp,
       std::optional<Call*> call,
       OutputCallback callback,
-      std::function<void()> release_request_slot);
+      RateLimiter::AdmissionSlotPtr admission_slot);
 
   std::shared_ptr<Request> generate_request(
       const std::vector<Message>& messages,
@@ -129,7 +129,7 @@ class LLMMaster : public Master {
       const RequestParams& sp,
       std::optional<Call*> call,
       OutputCallback callback,
-      std::function<void()> release_request_slot);
+      RateLimiter::AdmissionSlotPtr admission_slot);
 
  private:
   XServiceClient* xservice_client_ = nullptr;

--- a/xllm/core/distributed_runtime/llm_master.h
+++ b/xllm/core/distributed_runtime/llm_master.h
@@ -50,12 +50,26 @@ class LLMMaster : public Master {
                       std::optional<Call*> call,
                       OutputCallback callback);
 
+  void handle_request(std::string prompt,
+                      std::optional<std::vector<int>> prompt_tokens,
+                      RequestParams sp,
+                      std::optional<Call*> call,
+                      OutputCallback callback,
+                      bool owns_request_slot);
+
   // chat
   void handle_request(std::vector<Message> messages,
                       std::optional<std::vector<int>> prompt_tokens,
                       RequestParams sp,
                       std::optional<Call*> call,
                       OutputCallback callback);
+
+  void handle_request(std::vector<Message> messages,
+                      std::optional<std::vector<int>> prompt_tokens,
+                      RequestParams sp,
+                      std::optional<Call*> call,
+                      OutputCallback callback,
+                      bool owns_request_slot);
 
   // batch completion
   void handle_batch_request(std::vector<std::string> prompts,
@@ -106,14 +120,16 @@ class LLMMaster : public Master {
       std::optional<std::vector<int>> prompt_tokens,
       const RequestParams& sp,
       std::optional<Call*> call,
-      OutputCallback callback);
+      OutputCallback callback,
+      std::function<void()> release_request_slot);
 
   std::shared_ptr<Request> generate_request(
       const std::vector<Message>& messages,
       std::optional<std::vector<int>> prompt_tokens,
       const RequestParams& sp,
       std::optional<Call*> call,
-      OutputCallback callback);
+      OutputCallback callback,
+      std::function<void()> release_request_slot);
 
  private:
   XServiceClient* xservice_client_ = nullptr;

--- a/xllm/core/framework/request/request_state.h
+++ b/xllm/core/framework/request/request_state.h
@@ -20,6 +20,7 @@ limitations under the License.
 
 #include <cstdint>
 #include <deque>
+#include <functional>
 #include <limits>
 #include <string>
 #include <vector>
@@ -146,6 +147,11 @@ struct RequestState final {
   // function to call when batch outputs is generated in disagg pd mode,
   // decode will send the batch outputs to prefill.
   OutputsFunc outputs_func;
+
+  // Releases the service-routing admission slot. The callable owns a shared
+  // once-token, so output_func and batched outputs can safely invoke it for
+  // the same request.
+  std::function<void()> release_request_slot;
 
   // decode address.
   std::string decode_address;

--- a/xllm/core/framework/request/request_state.h
+++ b/xllm/core/framework/request/request_state.h
@@ -25,6 +25,7 @@ limitations under the License.
 #include <string>
 #include <vector>
 
+#include "core/common/rate_limiter.h"
 #include "core/framework/multimodal/mm_data.h"
 #include "core/framework/sampling/sampling_params.h"
 #include "rec_type.h"
@@ -148,10 +149,9 @@ struct RequestState final {
   // decode will send the batch outputs to prefill.
   OutputsFunc outputs_func;
 
-  // Releases the service-routing admission slot. The callable owns a shared
-  // once-token, so output_func and batched outputs can safely invoke it for
-  // the same request.
-  std::function<void()> release_request_slot;
+  // Owns service-routing request capacity until a terminal response releases
+  // it. Destruction is the fallback for early exits and dropped requests.
+  RateLimiter::AdmissionSlotPtr admission_slot;
 
   // decode address.
   std::string decode_address;

--- a/xllm/core/scheduler/async_response_processor.cpp
+++ b/xllm/core/scheduler/async_response_processor.cpp
@@ -19,6 +19,7 @@ limitations under the License.
 #include <absl/time/clock.h>
 #include <glog/logging.h>
 
+#include <functional>
 #include <memory>
 
 #include "common/global_flags.h"
@@ -31,6 +32,30 @@ limitations under the License.
 #include "util/env_var.h"
 
 namespace xllm {
+
+namespace {
+
+void release_terminal_request_slots(
+    const std::vector<std::shared_ptr<Request>>& requests,
+    const std::vector<RequestOutput>& outputs) {
+  CHECK_EQ(requests.size(), outputs.size());
+  for (size_t i = 0; i < requests.size(); ++i) {
+    const RequestOutput& output = outputs[i];
+    const bool failed =
+        output.status.has_value() && !output.status.value().ok();
+    if (!failed && !output.finished && !output.cancelled &&
+        !output.finished_on_prefill_instance) {
+      continue;
+    }
+    const std::function<void()>& release_slot =
+        requests[i]->state().release_request_slot;
+    if (release_slot) {
+      release_slot();
+    }
+  }
+}
+
+}  // namespace
 
 AsyncResponseProcessor::AsyncResponseProcessor(
     const Tokenizer* tokenizer,
@@ -170,6 +195,7 @@ void AsyncResponseProcessor::batch_process_completed_requests(
        requests = std::move(requests),
        request_outputs = std::move(request_outputs)]() mutable {
         counter->wait();
+        release_terminal_request_slots(requests, request_outputs);
         auto& resp_callback = requests[0]->state().outputs_func;
         resp_callback(request_outputs);
       });
@@ -337,6 +363,7 @@ void AsyncResponseProcessor::batch_process_stream_requests(
     auto& resp_callback = requests[0]->state().outputs_func;
     const absl::Time wait_start_time = absl::Now();
     counter->wait();
+    release_terminal_request_slots(requests, request_outputs);
     const double wait_ms =
         absl::ToDoubleMilliseconds(absl::Now() - wait_start_time);
     const absl::Time rpc_start_time = absl::Now();

--- a/xllm/core/scheduler/async_response_processor.cpp
+++ b/xllm/core/scheduler/async_response_processor.cpp
@@ -41,8 +41,8 @@ bool is_terminal_output(const RequestOutput& output) {
          output.finished_on_prefill_instance;
 }
 
-void release_admission_slot_if_terminal(const std::shared_ptr<Request>& request,
-                                        const RequestOutput& output) {
+void release_terminal_slot(const std::shared_ptr<Request>& request,
+                           const RequestOutput& output) {
   if (!is_terminal_output(output)) {
     return;
   }
@@ -54,12 +54,12 @@ void release_admission_slot_if_terminal(const std::shared_ptr<Request>& request,
   }
 }
 
-void release_admission_slots_if_terminal(
+void release_terminal_slots(
     const std::vector<std::shared_ptr<Request>>& requests,
     const std::vector<RequestOutput>& outputs) {
   CHECK_EQ(requests.size(), outputs.size());
   for (size_t i = 0; i < requests.size(); ++i) {
-    release_admission_slot_if_terminal(requests[i], outputs[i]);
+    release_terminal_slot(requests[i], outputs[i]);
   }
 }
 
@@ -105,7 +105,7 @@ void AsyncResponseProcessor::process_failed_request(
     output.service_request_id = request->service_request_id();
     output.target_xservice_addr = request->source_xservice_addr();
     output.status = status;
-    release_admission_slot_if_terminal(request, output);
+    release_terminal_slot(request, output);
     request->state().output_func(output);
   };
   if (request->state().response_thread_id < 0) {
@@ -148,7 +148,7 @@ void AsyncResponseProcessor::process_completed_request(
     if (!disable_log_stats_) {
       request->log_statistic(end_2_end_latency_seconds);
     }
-    release_admission_slot_if_terminal(request, req_output);
+    release_terminal_slot(request, req_output);
     request->state().output_func(req_output);
   };
   if (request->state().response_thread_id < 0) {
@@ -205,7 +205,7 @@ void AsyncResponseProcessor::batch_process_completed_requests(
        requests = std::move(requests),
        request_outputs = std::move(request_outputs)]() mutable {
         counter->wait();
-        release_admission_slots_if_terminal(requests, request_outputs);
+        release_terminal_slots(requests, request_outputs);
         auto& resp_callback = requests[0]->state().outputs_func;
         resp_callback(request_outputs);
       });
@@ -280,7 +280,7 @@ void AsyncResponseProcessor::process_stream_request(
       }
       req_output.finished = request_finished;
       req_output.cancelled = request_cancelled;
-      release_admission_slot_if_terminal(request, req_output);
+      release_terminal_slot(request, req_output);
       if (!request->state().output_func(req_output)) {
         cancel_request(request);
       }
@@ -388,7 +388,7 @@ void AsyncResponseProcessor::batch_process_stream_requests(
     auto& resp_callback = requests[0]->state().outputs_func;
     const absl::Time wait_start_time = absl::Now();
     counter->wait();
-    release_admission_slots_if_terminal(requests, request_outputs);
+    release_terminal_slots(requests, request_outputs);
     const double wait_ms =
         absl::ToDoubleMilliseconds(absl::Now() - wait_start_time);
     const absl::Time rpc_start_time = absl::Now();

--- a/xllm/core/scheduler/async_response_processor.cpp
+++ b/xllm/core/scheduler/async_response_processor.cpp
@@ -35,23 +35,31 @@ namespace xllm {
 
 namespace {
 
-void release_terminal_request_slots(
+bool is_terminal_output(const RequestOutput& output) {
+  const bool failed = output.status.has_value() && !output.status.value().ok();
+  return failed || output.finished || output.cancelled ||
+         output.finished_on_prefill_instance;
+}
+
+void release_admission_slot_if_terminal(const std::shared_ptr<Request>& request,
+                                        const RequestOutput& output) {
+  if (!is_terminal_output(output)) {
+    return;
+  }
+
+  const RateLimiter::AdmissionSlotPtr& admission_slot =
+      request->state().admission_slot;
+  if (admission_slot != nullptr) {
+    admission_slot->release_once();
+  }
+}
+
+void release_admission_slots_if_terminal(
     const std::vector<std::shared_ptr<Request>>& requests,
     const std::vector<RequestOutput>& outputs) {
   CHECK_EQ(requests.size(), outputs.size());
   for (size_t i = 0; i < requests.size(); ++i) {
-    const RequestOutput& output = outputs[i];
-    const bool failed =
-        output.status.has_value() && !output.status.value().ok();
-    if (!failed && !output.finished && !output.cancelled &&
-        !output.finished_on_prefill_instance) {
-      continue;
-    }
-    const std::function<void()>& release_slot =
-        requests[i]->state().release_request_slot;
-    if (release_slot) {
-      release_slot();
-    }
+    release_admission_slot_if_terminal(requests[i], outputs[i]);
   }
 }
 
@@ -97,6 +105,7 @@ void AsyncResponseProcessor::process_failed_request(
     output.service_request_id = request->service_request_id();
     output.target_xservice_addr = request->source_xservice_addr();
     output.status = status;
+    release_admission_slot_if_terminal(request, output);
     request->state().output_func(output);
   };
   if (request->state().response_thread_id < 0) {
@@ -139,6 +148,7 @@ void AsyncResponseProcessor::process_completed_request(
     if (!disable_log_stats_) {
       request->log_statistic(end_2_end_latency_seconds);
     }
+    release_admission_slot_if_terminal(request, req_output);
     request->state().output_func(req_output);
   };
   if (request->state().response_thread_id < 0) {
@@ -195,7 +205,7 @@ void AsyncResponseProcessor::batch_process_completed_requests(
        requests = std::move(requests),
        request_outputs = std::move(request_outputs)]() mutable {
         counter->wait();
-        release_terminal_request_slots(requests, request_outputs);
+        release_admission_slots_if_terminal(requests, request_outputs);
         auto& resp_callback = requests[0]->state().outputs_func;
         resp_callback(request_outputs);
       });
@@ -242,17 +252,23 @@ void AsyncResponseProcessor::process_stream_request(
   }
 
   if (!is_all_seqs_closed) {
+    const bool request_finished = request->finished();
+    const bool request_cancelled = request->cancelled();
     // output the delta text til the end of the sequence to the client
 
     auto runnable = [cancel_request = cancel_request_,
                      request,
                      this,
+                     request_finished,
+                     request_cancelled,
                      indexes = std::move(indexes),
                      num_tokens = std::move(num_tokens)]() {
       AUTO_COUNTER(responsing_latency_seconds_stream);
 
       RequestOutput req_output;
       req_output.request_id = request->request_id();
+      req_output.service_request_id = request->service_request_id();
+      req_output.target_xservice_addr = request->source_xservice_addr();
       for (size_t i = 0; i < indexes.size(); ++i) {
         const size_t index = indexes[i];
         const size_t size = num_tokens[i];
@@ -262,6 +278,9 @@ void AsyncResponseProcessor::process_stream_request(
           req_output.outputs.push_back(std::move(seq_output.value()));
         }
       }
+      req_output.finished = request_finished;
+      req_output.cancelled = request_cancelled;
+      release_admission_slot_if_terminal(request, req_output);
       if (!request->state().output_func(req_output)) {
         cancel_request(request);
       }
@@ -307,10 +326,14 @@ void AsyncResponseProcessor::batch_process_stream_requests(
       }
     }
 
+    const bool request_finished = request->finished();
+    const bool request_cancelled = request->cancelled();
     // output the delta text til the end of the sequence to the client
     auto runnable = [this,
                      counter,
                      request,
+                     request_finished,
+                     request_cancelled,
                      indexes = std::move(indexes),
                      num_tokens = std::move(num_tokens),
                      req_output = &request_outputs[i]]() mutable {
@@ -337,6 +360,8 @@ void AsyncResponseProcessor::batch_process_stream_requests(
           req_output->finished_on_prefill_instance = true;
         }
       }
+      req_output->finished = request_finished;
+      req_output->cancelled = request_cancelled;
       if (req_output->finished_on_prefill_instance) {
         VLOG(1) << "Prefill response generation request_id="
                 << request->request_id() << ", response_thread_id="
@@ -363,7 +388,7 @@ void AsyncResponseProcessor::batch_process_stream_requests(
     auto& resp_callback = requests[0]->state().outputs_func;
     const absl::Time wait_start_time = absl::Now();
     counter->wait();
-    release_terminal_request_slots(requests, request_outputs);
+    release_admission_slots_if_terminal(requests, request_outputs);
     const double wait_ms =
         absl::ToDoubleMilliseconds(absl::Now() - wait_start_time);
     const absl::Time rpc_start_time = absl::Now();


### PR DESCRIPTION
## Description

In pd disagg setup, concurrency quota tracking for max_concurrent_requests is unreliable under high concurrency due to a flawed global counter mechanism.

Root Causes

- Race Condition on Admission: Checking available quota and incrementing the counter is non-atomic. Simultaneous requests read stale counts, resulting in over-quota admissions.
- Flawed Release Logic: Decrement responsibilities are scattered across multiple async completion and error callbacks. This leads to double-decrements or quota leaks, often pushing the counter into negative values.

## Change Type

- [x] Bug fix
- [ ] New feature
- [ ] Performance improvement
- [ ] Refactor
- [ ] Documentation
- [ ] Test
- [ ] Build or CI

## Pull Request Checklist

Thank you for contributing to xLLM. Before requesting review, please make sure the following items are complete.

### PR Title and Commit Messages

- [x] The PR title and each commit message follow the xLLM commit format: `<type>: <subject>`.

> Allowed types: feat, bugfix, docs, test, refactor, chore, style, revert, perf, model, build, release.
> The subject should use clear English, start with a verb, include at least 4 words, and end with `.`.

### Pre-commit Checks

- [x] I have installed `pre-commit` by running `pip install pre-commit` or an equivalent command.
- [x] I have installed the hooks with `pre-commit install`.
- [x] I have run `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

### Self Review

- [x] I have self-reviewed the code according to `.agents/skills/code-review/references/custom-code-style.md`, especially code written or assisted by AI.
- [x] I have rebased this PR onto the latest `main` branch.

### Build and Test Coverage

- [ ] Tests have been added or updated as needed.
- [ ] CUDA: `python setup.py build test` has passed on a CUDA machine.
- [x] NPU: `python setup.py build test` has passed on an NPU machine.
- [x] MLU: `python setup.py build test` has passed on an MLU machine.

## Reviewer Notes

<!-- Optional: anything reviewers should focus on, known risks, follow-ups, or validation gaps. -->
