### PR TITLE
chore: add unreachable return stubs after LOG(FATAL) for -Wreturn-type.

### DIFF
--- a/xllm/core/framework/kv_cache/kv_cache.cpp
+++ b/xllm/core/framework/kv_cache/kv_cache.cpp
@@ -122,6 +122,7 @@ std::unique_ptr<KVCacheImpl> create_host_kv_cache_impl(
       LOG(FATAL) << "Unsupported non-DSV4 host block type: "
                  << static_cast<int32_t>(type);
   }
+  return nullptr;
 }
 
 std::string int32_vector_string(const std::vector<int32_t>& values) {

--- a/xllm/core/runtime/worker_client.cpp
+++ b/xllm/core/runtime/worker_client.cpp
@@ -168,6 +168,7 @@ void WorkerClient::transfer_kv_blocks(
 
 folly::SemiFuture<bool> WorkerClient::sleep_async(MasterStatus master_status) {
   LOG(FATAL) << "WorkerClient Method sleep is UnImplemented.";
+  return folly::makeSemiFuture(false);
 }
 
 folly::SemiFuture<bool> WorkerClient::wakeup_async(
@@ -178,6 +179,7 @@ folly::SemiFuture<bool> WorkerClient::wakeup_async(
 folly::SemiFuture<bool> WorkerClient::update_weights_async(
     const std::string& /*weights_path*/) {
   LOG(FATAL) << "WorkerClient Method update_weights is UnImplemented.";
+  return folly::makeSemiFuture(false);
 }
 
 folly::SemiFuture<bool> WorkerClient::start_profile_async() {

--- a/xllm/core/util/utils.cpp
+++ b/xllm/core/util/utils.cpp
@@ -174,6 +174,7 @@ torch::ScalarType convert_rec_type_to_torch(proto::DataType data_type) {
     default:
       LOG(FATAL) << "Unsupported data type: " << static_cast<int>(data_type);
   }
+  return torch::kFloat;
 }
 
 torch::Tensor convert_rec_tensor_to_torch(
@@ -242,6 +243,7 @@ torch::Tensor convert_rec_tensor_to_torch(
       LOG(FATAL) << "Unhandled data type conversion for: "
                  << static_cast<int>(dtype);
   }
+  return torch::Tensor();
 }
 
 torch::ScalarType datatype_proto_to_torch(const std::string& proto_datatype) {


### PR DESCRIPTION
## Summary

Small chore: add unreachable `return` statements after `LOG(FATAL)` calls to satisfy strict `-Wreturn-type` toolchains.

`LOG(FATAL)` in glog is effectively `[[noreturn]]` at runtime — the process aborts before the missing return would execute — but glog does not annotate `FATAL` as `noreturn` on all builds, so some front-ends (e.g. gcc 12.3 on openEuler 24.03 aarch64 with `-Werror=return-type`) refuse to compile functions that end in a `switch` whose `default:` arm only calls `LOG(FATAL)`.

Sites touched:
- `xllm/core/framework/kv_cache/kv_cache.cpp::create_host_kv_cache_impl` default arm (`return nullptr;`)
- `xllm/core/runtime/worker_client.cpp::sleep_async` and `update_weights_async` unimplemented stubs (`return folly::makeSemiFuture(false);`)
- `xllm/core/util/utils.cpp::convert_rec_type_to_torch` and `convert_rec_tensor_to_torch` default arms (`return torch::kFloat` / `return torch::Tensor()`)

## Test plan

- [x] Tree builds under `-Werror` on openEuler 24.03 aarch64 (gcc 12.3, torch 2.9.0) — used as the baseline for the LoRA PR chain build validation
- [x] No runtime semantic change: `LOG(FATAL)` still aborts before the sentinel return is reached

Standalone chore, independent of the LoRA PR chain (#2014/#2015/#2047/qwen3-next-lora/qwen35-122b-lora).

@HuHeng small chore, quick to review.
