### PR TITLE
bugfix: fix qwen35 mlu fused recurrent pack accuracy issue.

### DIFF
--- a/tests/core/kernels/mlu/fused_recurrent_gated_delta_rule_packed_decode_test.cpp
+++ b/tests/core/kernels/mlu/fused_recurrent_gated_delta_rule_packed_decode_test.cpp
@@ -147,5 +147,96 @@ TEST_F(FusedRecurrentGdrPackedDecodeJitTest, SupportsNoL2Norm) {
   EXPECT_TRUE(torch::isfinite(state.to(torch::kFloat32)).all().item<bool>());
 }
 
+TEST_F(FusedRecurrentGdrPackedDecodeJitTest,
+       BatchAbove32MatchesChunkedExecution) {
+  torch::DeviceGuard guard(device());
+  // Match the Qwen3.5-122B-A10B per-rank head layout at TP=8.
+  const int32_t num_k_heads = 2;
+  const int32_t num_v_heads = 8;
+  const int32_t head_k_dim = 128;
+  const int32_t head_v_dim = 128;
+  const int32_t batch_size = 33;
+  const int32_t reference_chunk_size = 32;
+  const int32_t qkv_dim =
+      2 * num_k_heads * head_k_dim + num_v_heads * head_v_dim;
+  const double scale = 1.0 / std::sqrt(static_cast<double>(head_k_dim));
+
+  torch::manual_seed(20260806);
+  torch::Tensor mixed_qkv = bf16_randn({batch_size, qkv_dim}, device());
+  torch::Tensor a = bf16_randn({batch_size, num_v_heads}, device());
+  torch::Tensor b = bf16_randn({batch_size, num_v_heads}, device());
+  torch::Tensor a_log = bf16_randn({num_v_heads}, device());
+  torch::Tensor dt_bias = torch::ones(
+      {num_v_heads},
+      torch::TensorOptions().dtype(torch::kBFloat16).device(device()));
+  torch::Tensor original_cache = fp32_randn(
+      {batch_size + 1, num_v_heads, head_v_dim, head_k_dim}, device());
+  torch::Tensor ssm_state_indices = torch::arange(
+      1,
+      batch_size + 1,
+      torch::TensorOptions().dtype(torch::kInt32).device(device()));
+
+  torch::Tensor full_batch_cache = original_cache.clone();
+  auto [full_batch_out, full_batch_state] =
+      fused_recurrent_gated_delta_rule_packed_decode(
+          mixed_qkv,
+          a,
+          b,
+          a_log,
+          dt_bias,
+          scale,
+          full_batch_cache,
+          ssm_state_indices,
+          /*use_qk_l2norm_in_kernel=*/true);
+
+  // Independent state slots make a 32 + 1 execution a valid reference for
+  // the batch-33 core partitioning regression.
+  torch::Tensor chunked_cache = original_cache.clone();
+  torch::Tensor first_chunk_out =
+      fused_recurrent_gated_delta_rule_packed_decode(
+          mixed_qkv.narrow(/*dim=*/0, /*start=*/0, reference_chunk_size),
+          a.narrow(/*dim=*/0, /*start=*/0, reference_chunk_size),
+          b.narrow(/*dim=*/0, /*start=*/0, reference_chunk_size),
+          a_log,
+          dt_bias,
+          scale,
+          chunked_cache,
+          ssm_state_indices.narrow(
+              /*dim=*/0, /*start=*/0, reference_chunk_size),
+          /*use_qk_l2norm_in_kernel=*/true)
+          .first;
+  const int32_t remaining_batch_size = batch_size - reference_chunk_size;
+  torch::Tensor second_chunk_out =
+      fused_recurrent_gated_delta_rule_packed_decode(
+          mixed_qkv.narrow(/*dim=*/0,
+                           /*start=*/reference_chunk_size,
+                           remaining_batch_size),
+          a.narrow(/*dim=*/0,
+                   /*start=*/reference_chunk_size,
+                   remaining_batch_size),
+          b.narrow(/*dim=*/0,
+                   /*start=*/reference_chunk_size,
+                   remaining_batch_size),
+          a_log,
+          dt_bias,
+          scale,
+          chunked_cache,
+          ssm_state_indices.narrow(/*dim=*/0,
+                                   /*start=*/reference_chunk_size,
+                                   remaining_batch_size),
+          /*use_qk_l2norm_in_kernel=*/true)
+          .first;
+  torch_mlu::synchronize();
+
+  torch::Tensor chunked_out =
+      torch::cat({first_chunk_out, second_chunk_out}, /*dim=*/0);
+  EXPECT_TRUE(tensors_allclose(
+      full_batch_out, chunked_out, /*rtol=*/1e-2, /*atol=*/2e-2))
+      << "batch-33 output differs from the equivalent 32 + 1 execution";
+  EXPECT_TRUE(tensors_allclose(
+      full_batch_state, chunked_cache, /*rtol=*/1e-2, /*atol=*/2e-2))
+      << "batch-33 state update differs from the equivalent 32 + 1 execution";
+}
+
 }  // namespace
 }  // namespace xllm

--- a/xllm/core/kernels/mlu/fused_recurrent_gated_delta_rule_packed_decode.cpp
+++ b/xllm/core/kernels/mlu/fused_recurrent_gated_delta_rule_packed_decode.cpp
@@ -70,22 +70,57 @@ fused_recurrent_gated_delta_rule_packed_decode(
   CHECK(prop != nullptr);
   int32_t core_count = prop->cluster_count * prop->core_num_per_cluster;
 
-  int32_t kBlockN = 1;
-  constexpr int32_t kBlockHv = 1;
-  constexpr int32_t kBlockV = 128;
-  int32_t kBlockB = 128;
-  if (B <= core_count) {
-    kBlockN = 1;
-  } else if (B <= core_count * 2) {
-    kBlockN = 2;
-  } else if (B > 128) {
-    kBlockB = 1024;
-    // to avoid nram out of resource
-    kBlockN = HV > 6 ? 1 : 4;
+  // Pick tunables from the device ISA. arch6 (isa_version >= 600) has a larger
+  // SRAM, so it tolerates bigger HV blocks and more pipeline stages; older
+  // archs cap MAX_HV lower and use fewer stages. split_hv flips on for small B
+  // so the HV-block dimension is fanned across cores to fill them.
+  bool is_arch6 = prop->isa_version >= 600;
+  int32_t max_hv = is_arch6 ? 32 : 8;
+  int32_t num_stage = is_arch6 ? 4 : 3;
+  int32_t split_hv = is_arch6 ? (B < 8 ? 1 : 0) : (B < 26 ? 1 : 0);
+
+  int32_t heads_per_q = HV / H;  // V-heads per Q/K-head
+  // block_hv (non-split path) must satisfy three conditions: (1) <= max_hv;
+  // (2) divides HV (the kernel iterates HV in whole blocks, no tail mask);
+  // (3) is a multiple of heads_per_q (BH = BLOCK_HV / heads_per_q exact, the
+  // Q/K-head load misses no head). Take the largest such value.
+  int32_t upper = std::min(max_hv, HV);
+  int32_t block_hv =
+      heads_per_q;  // min legal value (divides HV, multiple of heads_per_q)
+  for (int32_t cand = upper; cand >= heads_per_q; --cand) {
+    if (cand % heads_per_q == 0 && HV % cand == 0) {
+      block_hv = cand;
+      break;
+    }
   }
 
-  int32_t num_v_blocks = (V + kBlockV - 1) / kBlockV;
-  int32_t total_blocks = B * num_v_blocks;
+  // Small B: also split HV across cores (SPLIT_HV=1) to fill cores: force
+  // block_hv=1 → num_hv=HV, 1 HV block per core.
+  if (split_hv) {
+    block_hv = 1;
+  }
+  int32_t block_v = (split_hv && B * HV < core_count) ? 64 : 128;
+
+  // Validate the actually-launched block_hv (after the split_hv override). The
+  // two paths constrain BLOCK_HV differently:
+  //   - non-split: must divide HV and be a multiple of heads_per_q.
+  //   - split (BLOCK_HV=1): the kernel guards the tail with mask_hvb + gi_hv<
+  //   HV,
+  //     so it need not divide HV or be a multiple of heads_per_q.
+  CHECK(HV % H == 0) << "HV must be divisible by H";
+  if (split_hv) {
+    CHECK(block_hv >= 1 && block_hv <= HV)
+        << "BLOCK_HV out of range for split path";
+  } else {
+    CHECK(block_hv % heads_per_q == 0)
+        << "block_hv must be divisible by (HV / H)";
+    CHECK(HV % block_hv == 0) << "block_hv must divide HV";
+  }
+
+  int32_t num_v_blocks = (V + block_v - 1) / block_v;
+  int32_t num_hv_blocks = (HV + block_hv - 1) / block_hv;
+  int32_t total_blocks =
+      split_hv ? num_hv_blocks * num_v_blocks * B : num_v_blocks * B;
 
   cnrtQueue_t queue = torch_mlu::getCurMLUStream();
 
@@ -98,7 +133,7 @@ fused_recurrent_gated_delta_rule_packed_decode(
   f.launch(static_cast<void*>(queue),
            /*grid=*/
            {static_cast<uint32_t>(std::min(total_blocks, core_count)), 1, 1},
-           /*cfg=*/{/*num_warps=*/1, /*num_stages=*/2},
+           /*cfg=*/{/*num_warps=*/1, /*num_stages=*/num_stage},
            mixed_qkv_contig,
            a_contig,
            b_contig,
@@ -120,13 +155,13 @@ fused_recurrent_gated_delta_rule_packed_decode(
            HV,
            K,
            V,
-           /*BLOCK_N=*/kBlockN,
-           /*BLOCK_HV=*/kBlockHv,
-           /*BLOCK_V=*/kBlockV,
+           /*BLOCK_N=*/4,
+           /*BLOCK_HV=*/block_hv,
+           /*BLOCK_V=*/block_v,
            /*BLOCK_K=*/K,
            /*SOFTPLUS_THRESHOLD=*/20.0f,
            /*USE_QK_L2NORM_IN_KERNEL=*/use_qk_l2norm_in_kernel ? 1 : 0,
-           /*BLOCK_B=*/kBlockB);
+           /*SPLIT_HV=*/split_hv);
 
   return std::make_pair(out, ssm_cache);
 }

--- a/xllm/core/kernels/mlu/triton_kernel/fused_recurrent_gated_delta_rule_packed_decode.py
+++ b/xllm/core/kernels/mlu/triton_kernel/fused_recurrent_gated_delta_rule_packed_decode.py
@@ -20,7 +20,6 @@
 import torch
 import triton
 import triton.language as tl
-from triton.backends.mlu import driver
 
 
 @triton.jit
@@ -52,34 +51,30 @@ def tmo_fused_recurrent_gated_delta_rule_packed_decode_kernel(
     BLOCK_K: tl.constexpr,
     SOFTPLUS_THRESHOLD: tl.constexpr,
     USE_QK_L2NORM_IN_KERNEL: tl.constexpr,
-    BLOCK_B: tl.constexpr = 1024,
+    SPLIT_HV: tl.constexpr = 0,  # 1=split HV across cores (small B); 0=serial HV in-core (large B, reuse preload)
 ):
     pid = tl.program_id(0)
     num_jobs = tl.num_programs(0)
-    # num_hv = tl.cdiv(HV, BLOCK_HV)
     num_v = tl.cdiv(V, BLOCK_V)
+    num_hv = tl.cdiv(HV, BLOCK_HV)
     N = B
-    TOTAL_BLOCKS = num_v * N
+    # SPLIT_HV: small B includes the HV-block dim in flat space (high), splitting across cores to fill them;
+    # large B falls back to splitting only N+V (HV iterates serially in-core, reusing scalar preload of the same n-group, faster).
+    if SPLIT_HV:
+        TOTAL_BLOCKS = num_v * num_hv * N
+    else:
+        TOTAL_BLOCKS = num_v * N
 
-    rangeB = tl.arange(0, BLOCK_B)
-    maskB = rangeB < B
-    state_idxs = tl.load(ssm_state_indices + rangeB * stride_indices_seq, mask=maskB).to(tl.int32)
     A_log_vals = tl.load(A_log + tl.arange(0,HV)).to(tl.float32)
     dt_bias_vals = tl.load(dt_bias + tl.arange(0,HV)).to(tl.float32)
-    a_vals = tl.load(a + (rangeB * stride_a_tok)[:, None] + tl.arange(0,HV)[None, :], mask=maskB[:, None])
-    b_vals = tl.load(b + (rangeB * stride_b_tok)[:, None] + tl.arange(0,HV)[None, :], mask=maskB[:, None]).to(tl.float32)
 
-
-    xs = a_vals + dt_bias_vals[None, :]
-    softplus_xs = tl.where(xs <= SOFTPLUS_THRESHOLD, tl.log(1.0 + tl.exp(xs)), xs)
-    g_vals = -tl.exp(A_log_vals)[None, :] * softplus_xs  # [MAX_N, HV]
-    beta_vals = tl.sigmoid(b_vals)  # [MAX_N, HV]
-    exp_g_vals = tl.exp(g_vals)
+    HEADS_PER_Q: tl.constexpr = HV // H
+    BH: tl.constexpr = (BLOCK_HV+HEADS_PER_Q-1) // HEADS_PER_Q
 
     ones = tl.full((1,BLOCK_K),1,tl.float32)
     neg_ones = tl.full((1,BLOCK_K),-1,tl.float32)
 
-
+    # Split N into per-core segments (persistent loop); last core takes the remainder.
     num_percore = TOTAL_BLOCKS // num_jobs
     num_acturepercore = num_percore
     if pid == num_jobs - 1:
@@ -88,225 +83,152 @@ def tmo_fused_recurrent_gated_delta_rule_packed_decode_kernel(
     o_k = tl.arange(0, BLOCK_K)
     mask_k = o_k < K
 
-    o_h = tl.arange(0, H)
-    o_hv = tl.arange(0, HV)
     o_N_blk = tl.arange(0, BLOCK_N)
 
-    b_os = tl.empty((BLOCK_N,HV,BLOCK_V), dtype=tl.float32)
     zeros = tl.zeros((BLOCK_V,), dtype=tl.float32).to(o.dtype.element_ty)
-    for id in range(0, num_acturepercore, BLOCK_N):
-        flat_pid = id + num_percore * pid
-        i_v = flat_pid % num_v
-        i_n = flat_pid // num_v
-
-
-        if pid == num_jobs - 1 and num_acturepercore % BLOCK_N != 0 and num_acturepercore // BLOCK_N == id:
-            end_N = i_n + num_acturepercore % BLOCK_N
+    # SPLIT_HV: compute this core's HV-block range [lo, hi) for the outer for i_hv_blk;
+    # non-SPLIT_HV: outer i_hv_blk runs once (hv_blk_hi=1), HV driven by inner for hv_start over full range (reuse scalar preload).
+    if SPLIT_HV:
+        lo = num_percore * pid
+        hi = lo + num_acturepercore
+        hv_blk_lo = lo // (num_v * N)
+        hv_blk_hi = tl.cdiv(hi, num_v * N)
+    else:
+        hv_blk_lo = 0
+        hv_blk_hi = 1
+    # This core's flat range [start, end). Variable-step while replaced by fixed-step nested for (better software pipelining).
+    # N low, V-tile higher, HV-tile higher (SPLIT_HV): within one (i_hv_blk, i_v) tile, BLOCK_N consecutive work items
+    # never cross a V-tile/HV-block boundary (preserves the C3 invariant).
+    start = num_percore * pid
+    end = start + num_acturepercore
+    # Outer for i_hv_blk: SPLIT_HV iterates this core's HV-block range (each flat item handles its own 1 HV block,
+    # fixing the old while-version bug "iterate all-core HV → state updated in-place multiple times across HV blocks");
+    # non-SPLIT_HV runs range(0,1) once, HV driven by inner for hv_start over full range (reuse scalar preload).
+    for i_hv_blk in range(hv_blk_lo, hv_blk_hi, 1):
+        # This i_hv_blk's flat sub-range [seg_lo, seg_hi):
+        #   non-split: the whole core range [start, end) (i_hv_blk not involved);
+        #   split: intersection of core range with i_hv_blk slice [i_hv_blk*(num_v*N), (i_hv_blk+1)*(num_v*N)).
+        if SPLIT_HV:
+            seg_lo = tl.maximum(start, i_hv_blk * num_v * N)
+            seg_hi = tl.minimum(end, (i_hv_blk + 1) * num_v * N)
         else:
-            end_N = i_n + BLOCK_N
+            seg_lo = start
+            seg_hi = end
+        # V-tile sub-range (N low, i_v high).
+        i_v_start = seg_lo // N
+        i_v_end = (seg_hi - 1) // N
+        for i_v in range(i_v_start, i_v_end + 1, 1):
+            # First segment's n_lo may be != 0 (core/slice start lands mid V-tile); later segments have n_lo = 0.
+            n_lo = tl.where(i_v == i_v_start, seg_lo - i_v_start * N, 0)
+            # N upper bound: min of V-tile boundary N and this sub-range remainder (seg_hi - i_v*N).
+            n_hi = tl.minimum(N, seg_hi - i_v * N)
+            for i_n_base in range(n_lo, n_hi, BLOCK_N):
+                i_n = i_n_base  # this segment's N start (body uses n_blk = i_n + o_N_blk as base address)
+                numN = tl.minimum(BLOCK_N, n_hi - i_n_base)
+                end_N = i_n + numN
+                n_blk = i_n + o_N_blk
+                mask_n_blk = (n_blk < end_N) & (n_blk < N)
 
-        o_v = i_v * BLOCK_V + tl.arange(0, BLOCK_V)
-        mask_v = o_v < V
-        mask_h = mask_v[:, None] & mask_k[None, :]
-
-
-        n_blk = i_n + o_N_blk
-        mask_n_blk = n_blk < end_N
-        p_qs = mixed_qkv + n_blk[:, None, None] * stride_mixed_qkv_tok + o_h[None, :, None] * K + o_k[None, None, :]
-        p_ks = mixed_qkv + n_blk[:, None, None] * stride_mixed_qkv_tok + (H * K) + o_h[None, :, None] * K + o_k[None, None, :]
-        p_vs = mixed_qkv + n_blk[:, None, None] * stride_mixed_qkv_tok + (2 * H * K) + o_hv[None, :, None] * V + o_v[None, None, :]
-        mask_qs = mask_n_blk[:, None, None] & (o_k[None, None, :] < K)
-        mask_vs_blk = mask_n_blk[:, None, None] & (o_v[None, None, :] < V)
-        qs = tl.load(p_qs, mask=mask_qs, other=0).to(tl.float32)  # [BLOCK_N, H, BK]
-        ks = tl.load(p_ks, mask=mask_qs, other=0).to(tl.float32)  # [BLOCK_N, H, BK]
-        vs = tl.load(p_vs, mask=mask_vs_blk, other=0).to(tl.float32)  # [BLOCK_N, HV, BV]
-        if USE_QK_L2NORM_IN_KERNEL:
-            qs = qs * (tl.rsqrt(tl.sum(qs * qs, axis=-1, keep_dims=True) + 1e-6))
-            ks = ks * (tl.rsqrt(tl.sum(ks * ks, axis=-1, keep_dims=True) + 1e-6))
-        qs = qs * scale
-
-        i_n_start = i_n
-
-        for i_n in range(i_n, end_N, 1):
-            state_idx = state_idxs[i_n]
-            i_n_off = i_n - i_n_start
-
-            for i_hv in range(0, HV, 1):
-                i_h = i_hv // (HV // H)  # h(0-1)
-
-                output_offsets = (i_n * HV + i_hv) * V + o_v
-                state_base_offset = i_hv * V * K
-                state_offsets = state_base_offset + o_v[:, None] * K + o_k[None, :]
-
-                # Invalid state index (NULL_BLOCK_ID=0) only writes zero for this block.
-                if state_idx <= 0:
-                    b_os[i_n_off,i_hv,:] = zeros
-                    # zero = tl.zeros((BLOCK_V,), dtype=tl.float32).to(p_o.dtype.element_ty)
-                    # tl.store(p_o, zero, mask=mask_v)
+                # o_v needs the LOCAL V-tile index within this HV slice: non-split i_v is local;
+                # split i_v is the global flat V index (= i_hv_blk*num_v + local i_v), must strip i_hv_blk*num_v,
+                # else o_v exceeds V → mask_v all False → vs/state read 0, wrong output.
+                if SPLIT_HV:
+                    i_v_local = i_v - i_hv_blk * num_v
                 else:
-                    p_h0 = h0 + state_idx * stride_init_state_token
-                    p_h0 = p_h0 + state_offsets
-                    b_h = tl.load(p_h0, mask=mask_h, other=0).to(tl.float32)
+                    i_v_local = i_v
+                o_v = i_v_local * BLOCK_V + tl.arange(0, BLOCK_V)
+                mask_v = o_v < V
+                mask_h = mask_v[:, None] & mask_k[None, :]
 
-                    b_q = qs[i_n_off, i_h, :]
-                    b_k = ks[i_n_off, i_h, :]
-                    b_v = vs[i_n_off, i_hv, :]
+                # state_idxs stays int32: ssm_state_indices is an int32 tensor and the values are cache-slot
+                # indices that fit int32. (Upstream uses int64; int32 is the xllm convention and halves the
+                # per-element load width of the [BLOCK_N, HV] scalar tables.)
+                state_idxs = tl.load(ssm_state_indices + n_blk * stride_indices_seq, mask=mask_n_blk).to(tl.int32)
+                a_vals = tl.load(a + (n_blk * stride_a_tok)[:, None] + tl.arange(0,HV)[None, :], mask=mask_n_blk[:, None])
+                b_vals = tl.load(b + (n_blk * stride_b_tok)[:, None] + tl.arange(0,HV)[None, :], mask=mask_n_blk[:, None]).to(tl.float32)
 
-                    b_h *= exp_g_vals[i_n, i_hv]
-                    b_v += tl.dot(neg_ones,(b_h * b_k[None, :]).trans(), allow_tf32=False)
-                    b_v *= beta_vals[i_n, i_hv]
-                    b_h += tl.dot(b_v.reshape([BLOCK_V,1]),ones,allow_tf32=False) * b_k[None, :]
-                    b_os[i_n_off,i_hv,:] = (tl.dot(ones,(b_h * b_q[None, :]).trans(),allow_tf32=False)).reshape([BLOCK_V,])
-                    # b_o = (tl.dot(ones,(b_h * b_q[None, :]).trans(),allow_tf32=False)).reshape([BLOCK_V,])
-                    # tl.store(p_o, b_o.to(p_o.dtype.element_ty), mask=mask_v)
+                # Precompute scalar tables [BLOCK_N, HV]; inner loop indexes [i_n, i_hv] (aligned with fused_sigmoid_gating's b_gs/b_beta)
+                xs = a_vals + dt_bias_vals[None, :]
+                softplus_xs = tl.where(xs <= SOFTPLUS_THRESHOLD, tl.log(1.0 + tl.exp(xs)), xs)
+                g_vals = -tl.exp(A_log_vals)[None, :] * softplus_xs  # [BLOCK_N, HV]
+                beta_vals = tl.sigmoid(b_vals)  # [BLOCK_N, HV]
+                exp_g_vals = tl.exp(g_vals)  # [BLOCK_N, HV], inner b_h *= exp_g_vals
 
-                    p_ht = ht + state_idx * stride_final_state_token
-                    p_ht = p_ht + state_offsets
-                    tl.store(p_ht, b_h.to(p_ht.dtype.element_ty), mask=mask_h)
+                # HV blocking: load BLOCK_HV V-heads + their BH Q/K heads each iter; inner loop is scalar over local_i_hv.
+                # Scalar tables (a/b/g/beta/exp_g/state_idxs) load all HV and are reused outside hv_start; inner uses gi_hv.
+                # for hv_start range depends on SPLIT_HV:
+                #   non-split: full [0, HV) — reuse the preload above (1 load serves num_hv blocks).
+                #   split: only this i_hv_blk's 1 block [i_hv_blk*BLOCK_HV, +BLOCK_HV) — avoid cross-HV-block recounting.
+                if SPLIT_HV:
+                    hv_start_lo = i_hv_blk * BLOCK_HV
+                    hv_start_hi = i_hv_blk * BLOCK_HV + BLOCK_HV
+                else:
+                    hv_start_lo = 0
+                    hv_start_hi = HV
+                for hv_start in range(hv_start_lo, hv_start_hi, BLOCK_HV):
+                    o_hv_block = tl.arange(0, BLOCK_HV) + hv_start  # [BLOCK_HV] global V-head offset
+                    mask_hvb = o_hv_block < HV
+                    o_h_block = tl.arange(0, BH) + (hv_start // HEADS_PER_Q)  # [BH] global Q/K head offset
+                    mask_hb = o_h_block < H
+                    p_qs = mixed_qkv + n_blk[:, None, None] * stride_mixed_qkv_tok + o_h_block[None, :, None] * K + o_k[None, None, :]
+                    p_ks = mixed_qkv + n_blk[:, None, None] * stride_mixed_qkv_tok + (H * K) + o_h_block[None, :, None] * K + o_k[None, None, :]
+                    mask_qks = mask_n_blk[:, None, None] & (o_k[None, None, :] < K) & mask_hb[None, :, None]
+                    qs = tl.load(p_qs, mask=mask_qks, other=0).to(tl.float32)  # [BLOCK_N, BH, BK]
+                    ks = tl.load(p_ks, mask=mask_qks, other=0).to(tl.float32)  # [BLOCK_N, BH, BK]
+                    if USE_QK_L2NORM_IN_KERNEL:
+                        # L2-normalize q/k over the K dim via a single 2D reshape+dot (aligned with fused_sigmoid_gating L193-196).
+                        qs = qs.reshape((BLOCK_N * BH, BLOCK_K))
+                        qs_mean = tl.rsqrt(tl.dot(ones, (qs * qs).trans(), allow_tf32=False) + 1e-6)
+                        qs = qs * tl.dot(qs_mean.reshape((BLOCK_N * BH, 1)), ones, allow_tf32=False)
+                        ks = ks.reshape((BLOCK_N * BH, BLOCK_K))
+                        ks_mean = tl.rsqrt(tl.dot(ones, (ks * ks).trans(), allow_tf32=False) + 1e-6)
+                        ks = ks * tl.dot(ks_mean.reshape((BLOCK_N * BH, 1)), ones, allow_tf32=False)
+                        qs = qs.reshape((BLOCK_N, BH, BLOCK_K))
+                        ks = ks.reshape((BLOCK_N, BH, BLOCK_K))
+                    qs = qs * scale
+                    p_vs = mixed_qkv + n_blk[:, None, None] * stride_mixed_qkv_tok + (2 * H * K) + o_hv_block[None, :, None] * V + o_v[None, None, :]
+                    mask_vs_blk = mask_n_blk[:, None, None] & (o_v[None, None, :] < V) & mask_hvb[None, :, None]
+                    vs = tl.load(p_vs, mask=mask_vs_blk, other=0).to(tl.float32)  # [BLOCK_N, BLOCK_HV, BLOCK_V]
+                    b_os = tl.empty((BLOCK_N, BLOCK_HV, BLOCK_V), dtype=tl.float32)
 
+                    # Inner loop processes all i_hv of the same N segment consecutively; mixed_qkv[i_n] rows stay cached.
+                    for i_n_off in range(0, numN, 1):
+                        state_idx = state_idxs[i_n_off]
+                        for local_i_hv in range(0, BLOCK_HV, 1):
+                            gi_hv = hv_start + local_i_hv  # global V-head index (indexes full-HV scalar tables / state ptr)
+                            i_h = local_i_hv // HEADS_PER_Q  # Q/K head index within block, [0,BH) (matches qs/ks BH dim)
 
-        p_os = o + n_blk[:,None,None]*(HV*V) + o_hv[None,:,None]*V + o_v[None,None,:]
-        tl.store(p_os, b_os.to(p_os.dtype.element_ty), mask=mask_vs_blk)
+                            if gi_hv < HV:
+                                # output_offsets = (i_n * HV + i_hv) * V + o_v
+                                state_base_offset = gi_hv * V * K
+                                state_offsets = state_base_offset + o_v[:, None] * K + o_k[None, :]
 
+                                # Invalid state index (NULL_BLOCK_ID=0) only writes zero for this block.
+                                if state_idx <= 0:
+                                    b_os[i_n_off, local_i_hv, :] = zeros
+                                else:
+                                    p_h0 = h0 + state_idx * stride_init_state_token
+                                    p_h0 = p_h0 + state_offsets
+                                    b_h = tl.load(p_h0, mask=mask_h, other=0).to(tl.float32)
 
-def fused_recurrent_gated_delta_rule_packed_decode(
-    mixed_qkv: torch.Tensor,
-    a: torch.Tensor,
-    b: torch.Tensor,
-    A_log: torch.Tensor,
-    dt_bias: torch.Tensor,
-    scale: float,
-    initial_state: torch.Tensor,
-    out: torch.Tensor,
-    ssm_state_indices: torch.Tensor,
-    use_qk_l2norm_in_kernel: bool = False,
-) -> tuple[torch.Tensor, torch.Tensor]:
-    if mixed_qkv.ndim != 2:
-        raise ValueError(
-            f"`mixed_qkv` must be a 2D tensor (got ndim={mixed_qkv.ndim})."
-        )
-    if mixed_qkv.stride(-1) != 1:
-        raise ValueError("`mixed_qkv` must be contiguous in the last dim.")
-    if a.ndim != 2 or b.ndim != 2:
-        raise ValueError(
-            f"`a` and `b` must be 2D tensors (got a.ndim={a.ndim}, b.ndim={b.ndim})."
-        )
-    if a.stride(-1) != 1 or b.stride(-1) != 1:
-        raise ValueError("`a`/`b` must be contiguous in the last dim.")
-    if A_log.ndim != 1 or dt_bias.ndim != 1:
-        raise ValueError("`A_log`/`dt_bias` must be 1D tensors.")
-    if A_log.stride(0) != 1 or dt_bias.stride(0) != 1:
-        raise ValueError("`A_log`/`dt_bias` must be contiguous.")
-    if ssm_state_indices.ndim != 1:
-        raise ValueError(
-            f"`ssm_state_indices` must be 1D for packed decode (got ndim={ssm_state_indices.ndim})."
-        )
-    if not out.is_contiguous():
-        raise ValueError("`out` must be contiguous.")
+                                    b_q = qs[i_n_off, i_h, :]
+                                    b_k = ks[i_n_off, i_h, :]
+                                    b_v = vs[i_n_off, local_i_hv, :]
 
-    dev = mixed_qkv.device
-    if (
-        a.device != dev
-        or b.device != dev
-        or A_log.device != dev
-        or dt_bias.device != dev
-        or initial_state.device != dev
-        or out.device != dev
-        or ssm_state_indices.device != dev
-    ):
-        raise ValueError("All inputs must be on the same device.")
+                                    b_h *= exp_g_vals[i_n_off, gi_hv]
+                                    b_v += tl.dot(neg_ones,(b_h * b_k[None, :]).trans(), allow_tf32=False)
+                                    b_v *= beta_vals[i_n_off, gi_hv]
+                                    b_h += tl.dot(b_v.reshape([BLOCK_V,1]),ones,allow_tf32=False) * b_k[None, :]
+                                    b_os[i_n_off, local_i_hv, :] = (tl.dot(ones,(b_h * b_q[None, :]).trans(),allow_tf32=False)).reshape([BLOCK_V,])
 
-    B = mixed_qkv.shape[0]
-    if a.shape[0] != B or b.shape[0] != B:
-        raise ValueError(
-            "Mismatched batch sizes: "
-            f"mixed_qkv.shape[0]={B}, a.shape[0]={a.shape[0]}, b.shape[0]={b.shape[0]}."
-        )
-    if ssm_state_indices.shape[0] != B:
-        raise ValueError(
-            f"`ssm_state_indices` must have shape [B] (got {tuple(ssm_state_indices.shape)}; expected ({B},))."
-        )
+                                    p_ht = ht + state_idx * stride_final_state_token
+                                    p_ht = p_ht + state_offsets
+                                    tl.store(p_ht, b_h.to(p_ht.dtype.element_ty), mask=mask_h)
+                            else:
+                                b_os[i_n_off, local_i_hv, :] = zeros
 
-    if initial_state.ndim != 4:
-        raise ValueError(
-            f"`initial_state` must be a 4D tensor (got ndim={initial_state.ndim})."
-        )
-    if initial_state.stride(-1) != 1:
-        raise ValueError("`initial_state` must be contiguous in the last dim.")
-    HV, V, K = initial_state.shape[-3:]
-    if a.shape[1] != HV or b.shape[1] != HV:
-        raise ValueError(
-            f"`a`/`b` must have shape [B, HV] with HV={HV} (got a.shape={tuple(a.shape)}, b.shape={tuple(b.shape)})."
-        )
-    if A_log.numel() != HV or dt_bias.numel() != HV:
-        raise ValueError(
-            f"`A_log` and `dt_bias` must have {HV} elements (got A_log.numel()={A_log.numel()}, dt_bias.numel()={dt_bias.numel()})."
-        )
-    if out.shape != (B, 1, HV, V):
-        raise ValueError(
-            f"`out` must have shape {(B, 1, HV, V)} (got out.shape={tuple(out.shape)})."
-        )
-
-    qkv_dim = mixed_qkv.shape[1]
-    qk_dim = qkv_dim - HV * V
-    if qk_dim <= 0 or qk_dim % 2 != 0:
-        raise ValueError(
-            f"Invalid packed `mixed_qkv` last dim={qkv_dim} for HV={HV}, V={V}."
-        )
-    q_dim = qk_dim // 2
-    if q_dim % K != 0:
-        raise ValueError(f"Invalid packed Q size {q_dim}: must be divisible by K={K}.")
-    H = q_dim // K
-    if H <= 0 or HV % H != 0:
-        raise ValueError(
-            f"Invalid head config inferred from mixed_qkv: H={H}, HV={HV}."
-        )
+                    # n_blk * (HV*V) + o_hv_block * V + i_v*BLOCK_V + o_v_block
+                    p_os = o + n_blk[:,None,None]*(HV*V) + o_hv_block[None,:,None]*V + o_v[None,None,:]
+                    tl.store(p_os, b_os.to(p_os.dtype.element_ty), mask=mask_vs_blk)
 
 
-    stride_mixed_qkv_tok = mixed_qkv.stride(0)
-    stride_a_tok = a.stride(0)
-    stride_b_tok = b.stride(0)
-    stride_init_state_token = initial_state.stride(0)
-    stride_final_state_token = initial_state.stride(0)
-    stride_indices_seq = ssm_state_indices.stride(0)
-
-    _devprob = driver.BangUtils().get_device_properties(torch.mlu.current_device())
-    TOTAL_CORE_NUM = _devprob.get("cluster_num") * _devprob.get("core_num_per_cluster")
-    grid = lambda META: (
-        min(
-            triton.cdiv(V, META["BLOCK_V"]) * B,
-            TOTAL_CORE_NUM // META.get("num_warps", 1),
-        ),
-    )
-    tmo_fused_recurrent_gated_delta_rule_packed_decode_kernel[grid](
-        mixed_qkv=mixed_qkv,
-        a=a,
-        b=b,
-        A_log=A_log,
-        dt_bias=dt_bias,
-        o=out,
-        h0=initial_state,
-        ht=initial_state,
-        ssm_state_indices=ssm_state_indices,
-        scale=scale,
-        stride_mixed_qkv_tok=stride_mixed_qkv_tok,
-        stride_a_tok=stride_a_tok,
-        stride_b_tok=stride_b_tok,
-        stride_init_state_token=stride_init_state_token,
-        stride_final_state_token=stride_final_state_token,
-        stride_indices_seq=stride_indices_seq,
-        B=B,
-        H=H,
-        HV=HV,
-        K=K,
-        V=V,
-        SOFTPLUS_THRESHOLD=20.0,
-        USE_QK_L2NORM_IN_KERNEL=use_qk_l2norm_in_kernel,
-        BLOCK_N= 4,
-        BLOCK_HV= 1,
-        BLOCK_V=128,
-        BLOCK_K=K,
-        num_stages=2,
-        num_warps=1,
-    )
-    return out, initial_state


### PR DESCRIPTION
## Description

fix qwen35 mlu fused recurrent pack accuracy issue.

## Change Type

- [x] Bug fix
- [ ] New feature
- [ ] Performance improvement
- [ ] Refactor
- [ ] Documentation
- [ ] Test
- [ ] Build or CI

## Pull Request Checklist

Thank you for contributing to xLLM. Before requesting review, please make sure the following items are complete.

### PR Title and Commit Messages

- [x] The PR title and each commit message follow the xLLM commit format: `<type>: <subject>`.

> Allowed types: feat, bugfix, docs, test, refactor, chore, style, revert, perf, model, build, release.
> The subject should use clear English, start with a verb, include at least 4 words, and end with `.`.

### Pre-commit Checks

- [x] I have installed `pre-commit` by running `pip install pre-commit` or an equivalent command.
- [x] I have installed the hooks with `pre-commit install`.
- [x] I have run `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

### Self Review

- [x] I have self-reviewed the code according to `.agents/skills/code-review/references/custom-code-style.md`, especially code written or assisted by AI.
- [x] I have rebased this PR onto the latest `main` branch.

### Build and Test Coverage

- [x] Tests have been added or updated as needed.
- [ ] CUDA: `python setup.py build test` has passed on a CUDA machine.
- [x] NPU: `python setup.py build test` has passed on an NPU machine.
- [x] MLU: `python setup.py build test` has passed on an MLU machine.

## Reviewer Notes

<!-- Optional: anything reviewers should focus on, known risks, follow-ups, or validation gaps. -->
