### PR TITLE
refactor: unify linear state validity metadata.

### DIFF
--- a/tests/core/framework/kv_cache/linear_state_restore_test.cpp
+++ b/tests/core/framework/kv_cache/linear_state_restore_test.cpp
@@ -63,40 +63,6 @@ TEST(LinearStateRestoreTest, RejectsNonDivisibleActiveRows) {
                "logical rows must evenly divide active rows");
 }
 
-TEST(LinearStateRestoreTest, MaterializesExplicitValidityMask) {
-  const std::vector<int64_t> validity_mask = {0, 1, 1, 0, 0, 1};
-
-  torch::Tensor tensor =
-      materialize_linear_state_mask(validity_mask,
-                                    /*metadata_rows=*/6,
-                                    /*is_dummy=*/false,
-                                    torch::Device(torch::kCPU));
-
-  EXPECT_EQ(tensor.scalar_type(), torch::kBool);
-  EXPECT_EQ(tensor.device(), torch::Device(torch::kCPU));
-  EXPECT_TRUE(torch::equal(
-      tensor, torch::tensor({false, true, true, false, false, true})));
-}
-
-TEST(LinearStateRestoreTest, MaterializesColdMaskForEmptyDataParallelShard) {
-  torch::Tensor tensor = materialize_linear_state_mask(
-      /*validity_mask=*/{},
-      /*metadata_rows=*/1,
-      /*is_dummy=*/true,
-      torch::Device(torch::kCPU));
-
-  EXPECT_TRUE(torch::equal(tensor, torch::tensor({false})));
-}
-
-TEST(LinearStateRestoreTest, RejectsValidityMaskMetadataRowMismatch) {
-  EXPECT_DEATH(materialize_linear_state_mask(/*validity_mask=*/{0, 1},
-                                             /*metadata_rows=*/3,
-                                             /*is_dummy=*/false,
-                                             torch::Device(torch::kCPU)),
-               "linear state mask row count mismatch.*mask_rows=2.*"
-               "metadata_rows=3");
-}
-
 TEST(LinearStateRestoreTest, ModelInputConversionPreservesValidityMask) {
   ModelInputParams input_params;
   input_params.linear_state_validity_mask = {0, 1, 1, 0};

--- a/tests/core/layers/CMakeLists.txt
+++ b/tests/core/layers/CMakeLists.txt
@@ -14,6 +14,18 @@ cc_test(
 
 cc_test(
   NAME
+    attention_metadata_builder_test
+  SRCS
+    attention_metadata_builder_test.cpp
+  DEPS
+    :common_layers
+    GTest::gtest_main
+)
+
+target_link_libraries(attention_metadata_builder_test PUBLIC Python::Python)
+
+cc_test(
+  NAME
     rotary_embedding_util_test
   SRCS
     rotary_embedding_util_test.cpp

--- a/tests/core/layers/attention_metadata_builder_test.cpp
+++ b/tests/core/layers/attention_metadata_builder_test.cpp
@@ -1,0 +1,116 @@
+/* Copyright 2026 The xLLM Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://github.com/jd-opensource/xllm/blob/main/LICENSE
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include "core/layers/common/attention_metadata_builder.h"
+
+#include <gtest/gtest.h>
+#include <torch/torch.h>
+
+#include "core/framework/batch/batch_forward_type.h"
+#include "core/framework/model/model_input_params.h"
+#include "core/layers/common/attention_metadata.h"
+
+namespace xllm::layer {
+namespace {
+
+ModelInputParams make_params() {
+  ModelInputParams params;
+  params.meta.batch_forward_type = BatchForwardType::PREFILL;
+  params.meta.num_sequences = 3;
+  params.meta.q_max_seq_len = 1;
+  params.meta.kv_max_seq_len = 8;
+  const torch::TensorOptions options =
+      torch::TensorOptions().dtype(torch::kInt32).device(torch::kCPU);
+  params.attention.device.q_seq_lens = torch::tensor({1, 1, 1}, options);
+  params.attention.device.kv_seq_lens = torch::tensor({1, 4, 8}, options);
+  params.attention.device.q_cu_seq_lens = torch::tensor({1, 2, 3}, options);
+  params.attention.device.kv_cache_tokens_nums =
+      torch::tensor({7, 0, 5}, options);
+  params.embedding.linear_state_ids = {4, 2, 9};
+  params.embedding.linear_state_indices = torch::tensor({4, 2, 9}, options);
+  params.linear_state_validity_mask = {0, 1, 0};
+  return params;
+}
+
+TEST(AttentionMetadataBuilderTest, MaterializesCanonicalInitialStateMask) {
+  ModelInputParams params = make_params();
+
+  AttentionMetadata metadata =
+      AttentionMetadataBuilder::build(params, /*enable_mla=*/false);
+
+  ASSERT_TRUE(metadata.has_initial_states.defined());
+  EXPECT_EQ(metadata.has_initial_states.scalar_type(), torch::kBool);
+  EXPECT_EQ(metadata.has_initial_states.device(), torch::Device(torch::kCPU));
+  EXPECT_TRUE(torch::equal(metadata.has_initial_states,
+                           torch::tensor({false, true, false}, torch::kBool)));
+}
+
+TEST(AttentionMetadataBuilderTest, DoesNotDeriveValidityFromContextOrSlot) {
+  ModelInputParams params = make_params();
+  params.embedding.linear_state_indices = torch::tensor({0, 0, 0}, torch::kInt);
+  params.attention.device.kv_cache_tokens_nums =
+      torch::tensor({9, 0, 11}, torch::kInt);
+  params.linear_state_validity_mask = {0, 1, 0};
+
+  AttentionMetadata metadata =
+      AttentionMetadataBuilder::build(params, /*enable_mla=*/false);
+
+  EXPECT_TRUE(torch::equal(metadata.has_initial_states,
+                           torch::tensor({false, true, false}, torch::kBool)));
+}
+
+TEST(AttentionMetadataBuilderTest, MaterializesChunkedPrefillMask) {
+  ModelInputParams params = make_params();
+  params.meta.batch_forward_type = BatchForwardType::CHUNKED_PREFILL;
+
+  AttentionMetadata metadata =
+      AttentionMetadataBuilder::build(params, /*enable_mla=*/false);
+
+  ASSERT_TRUE(metadata.has_initial_states.defined());
+  EXPECT_TRUE(torch::equal(metadata.has_initial_states,
+                           torch::tensor({false, true, false}, torch::kBool)));
+}
+
+TEST(AttentionMetadataBuilderTest, DecodeDoesNotMaterializeInitialStateMask) {
+  ModelInputParams params = make_params();
+  params.meta.batch_forward_type = BatchForwardType::DECODE;
+
+  AttentionMetadata metadata =
+      AttentionMetadataBuilder::build(params, /*enable_mla=*/false);
+
+  EXPECT_FALSE(metadata.has_initial_states.defined());
+}
+
+TEST(AttentionMetadataBuilderTest, MaterializesColdMaskForDummyShard) {
+  ModelInputParams params;
+  params.meta.batch_forward_type = BatchForwardType::CHUNKED_PREFILL;
+  params.meta.num_sequences = 0;
+  params.meta.q_max_seq_len = 0;
+  params.meta.kv_max_seq_len = 0;
+
+  AttentionMetadata metadata =
+      AttentionMetadataBuilder::build(params,
+                                      /*enable_mla=*/false,
+                                      /*attn_mask=*/{},
+                                      torch::Device(torch::kCPU));
+
+  ASSERT_TRUE(metadata.is_dummy);
+  ASSERT_TRUE(metadata.has_initial_states.defined());
+  EXPECT_TRUE(
+      torch::equal(metadata.has_initial_states, torch::tensor({false})));
+}
+
+}  // namespace
+}  // namespace xllm::layer

--- a/tests/core/runtime/acl_graph_executor_test.cpp
+++ b/tests/core/runtime/acl_graph_executor_test.cpp
@@ -918,7 +918,7 @@ TEST_F(AclGraphExecutorTest, BatchInputCarriesLinearStateIds) {
   EXPECT_EQ(forward_input.input_params.embedding.embedding_ids[0],
             expected_embedding_id);
 
-  forward_input.input_params.linear_state_validity_mask = {0};
+  forward_input.input_params.linear_state_validity_mask = {1};
   forward_input = forward_input.to(*device_, torch::kFloat32);
   npu::GraphPersistentParam persistent_param(model_args_, *device_, options_);
   std::optional<ModelInputParams> params_for_capture = persistent_param.update(
@@ -935,7 +935,7 @@ TEST_F(AclGraphExecutorTest, BatchInputCarriesLinearStateIds) {
       params_for_capture->embedding.linear_state_ids,
       std::vector<int32_t>({expected_linear_state_id, kPaddingLinearStateId}));
   ASSERT_EQ(params_for_capture->linear_state_validity_mask.size(), 2);
-  EXPECT_EQ(params_for_capture->linear_state_validity_mask[0], 0);
+  EXPECT_EQ(params_for_capture->linear_state_validity_mask[0], 1);
   EXPECT_EQ(params_for_capture->linear_state_validity_mask[1], 0);
 }
 

--- a/xllm/core/framework/kv_cache/linear_state_restore.h
+++ b/xllm/core/framework/kv_cache/linear_state_restore.h
@@ -15,9 +15,6 @@ limitations under the License.
 
 #pragma once
 
-#include <glog/logging.h>
-#include <torch/torch.h>
-
 #include <cstdint>
 #include <vector>
 
@@ -32,25 +29,6 @@ namespace xllm {
 LinearStateValidityMask build_linear_state_mask(
     const std::vector<int32_t>& cached_tokens,
     int64_t active_rows);
-
-// Materialize the worker-produced linear-state validity result for a backend
-// kernel that consumes a device bool tensor. Empty data-parallel shards have
-// one synthetic, always-cold dummy metadata row.
-inline torch::Tensor materialize_linear_state_mask(
-    const LinearStateValidityMask& validity_mask,
-    int64_t metadata_rows,
-    bool is_dummy,
-    const torch::Device& device) {
-  const int64_t mask_rows = static_cast<int64_t>(validity_mask.size());
-  if (is_dummy && mask_rows == 0 && metadata_rows == 1) {
-    return torch::zeros({1}, torch::dtype(torch::kBool).device(device));
-  }
-  CHECK_EQ(mask_rows, metadata_rows)
-      << "linear state mask row count mismatch: mask_rows=" << mask_rows
-      << ", metadata_rows=" << metadata_rows;
-  return torch::tensor(validity_mask,
-                       torch::dtype(torch::kBool).device(device));
-}
 
 // Apply each op's restore plan in-place: copy `restore_src_slot_id` into
 // `linear_state_id` across every linear-attention layer present in

--- a/xllm/core/layers/common/attention_metadata_builder.cpp
+++ b/xllm/core/layers/common/attention_metadata_builder.cpp
@@ -43,6 +43,57 @@ torch::TensorOptions int32_options_like(const torch::Tensor& preferred,
   return torch::TensorOptions().dtype(torch::kInt32).device(torch::kCPU);
 }
 
+void materialize_linear_state_validity(
+    const ModelInputParams& params,
+    const std::optional<torch::Device>& device,
+    AttentionMetadata& attn_metadata) {
+  const bool needs_initial_states =
+      attn_metadata.is_prefill || attn_metadata.is_chunked_prefill;
+  if (!needs_initial_states) {
+    return;
+  }
+
+  const int64_t mask_rows =
+      static_cast<int64_t>(params.linear_state_validity_mask.size());
+  const bool has_linear_state_rows =
+      !params.embedding.linear_state_ids.empty() ||
+      params.embedding.linear_state_indices.defined();
+  if (!attn_metadata.is_dummy && mask_rows == 0) {
+    CHECK(!has_linear_state_rows)
+        << "linear-state metadata requires a canonical validity mask";
+    return;
+  }
+
+  if (!(attn_metadata.is_dummy && mask_rows == 0)) {
+    int64_t metadata_rows = mask_rows;
+    if (!params.embedding.linear_state_ids.empty()) {
+      metadata_rows =
+          static_cast<int64_t>(params.embedding.linear_state_ids.size());
+    } else if (params.embedding.linear_state_indices.defined()) {
+      metadata_rows = params.embedding.linear_state_indices.numel();
+    }
+    CHECK_EQ(mask_rows, metadata_rows)
+        << "linear state mask row count mismatch: mask_rows=" << mask_rows
+        << ", metadata_rows=" << metadata_rows;
+  }
+
+  torch::TensorOptions options;
+  if (params.embedding.linear_state_indices.defined()) {
+    options = params.embedding.linear_state_indices.options();
+  } else if (params.attention.device.q_seq_lens.defined()) {
+    options = params.attention.device.q_seq_lens.options();
+  } else {
+    CHECK(device.has_value())
+        << "linear state metadata requires a target device";
+    options = torch::TensorOptions().device(device.value());
+  }
+  options = options.dtype(torch::kBool);
+  attn_metadata.has_initial_states =
+      attn_metadata.is_dummy && mask_rows == 0
+          ? torch::zeros({1}, options)
+          : torch::tensor(params.linear_state_validity_mask, options);
+}
+
 AttentionMetadata build_attention_metadata(
     const ModelInputParams& params,
     bool enable_mla,
@@ -240,6 +291,7 @@ AttentionMetadata build_attention_metadata(
     attn_metadata.max_query_len = 1;
     attn_metadata.max_seq_len = std::max<int64_t>(attn_metadata.max_seq_len, 1);
   }
+  materialize_linear_state_validity(params, device, attn_metadata);
 
   // Set is_causal: true for prefill (causal attention), false for decode
   // (non-causal) Default to true (causal) if not explicitly set

--- a/xllm/core/runtime/worker_impl.cpp
+++ b/xllm/core/runtime/worker_impl.cpp
@@ -234,24 +234,11 @@ LinearStateInputRows get_npu_linear_state_rows(ModelInputParams& input_params) {
         input_params.parallel.query_start_loc[i] + seq_len;
   }
 
-  const std::vector<int32_t>& host_kv_cache_tokens_nums =
+  const std::vector<int32_t>& cached_tokens =
       input_params.attention.host.kv_cache_tokens_nums;
-  std::vector<int32_t> cached_tokens;
-  if (!host_kv_cache_tokens_nums.empty()) {
-    cached_tokens = host_kv_cache_tokens_nums;
-  } else {
-    // Compatibility fallback for inputs that only carry the device view.
-    torch::Tensor cached_tokens_tensor =
-        input_params.attention.device.kv_cache_tokens_nums > 0;
-    torch::Tensor cached_tokens_cpu = cached_tokens_tensor.contiguous()
-                                          .view({-1})
-                                          .to(torch::kCPU)
-                                          .to(torch::kInt32);
-    cached_tokens.assign(
-        cached_tokens_cpu.data_ptr<int32_t>(),
-        cached_tokens_cpu.data_ptr<int32_t>() + cached_tokens_cpu.numel());
-  }
-  return {std::move(cached_tokens), batch_size, /*empty_shard=*/false};
+  CHECK(!cached_tokens.empty())
+      << "NPU linear-state input requires host kv cache token counts";
+  return {cached_tokens, batch_size, /*empty_shard=*/false};
 }
 #endif
 

--- a/xllm/models/vlm/qwen3_5.h
+++ b/xllm/models/vlm/qwen3_5.h
@@ -15,7 +15,6 @@ limitations under the License.
 
 #pragma once
 
-#include "core/framework/kv_cache/linear_state_restore.h"
 #include "core/framework/model/model_output.h"
 #include "core/layers/common/lm_head.h"
 #include "core/layers/common/rotary_embedding_util.h"
@@ -215,23 +214,6 @@ class Qwen3_5ModelImpl final
       attn_metadata.tot = tot;
       attn_metadata.batch = batch_ptr;
       attn_metadata.token_block_offset = token_block_offset_ptr;
-#if defined(USE_MLU)
-      attn_metadata.has_initial_states =
-          materialize_linear_state_mask(params.linear_state_validity_mask,
-                                        attn_metadata.q_cu_seq_lens.size(0) - 1,
-                                        attn_metadata.is_dummy,
-                                        h.device());
-#else
-      if (params.attention.device.kv_cache_tokens_nums.defined() &&
-          params.attention.device.kv_cache_tokens_nums.numel() > 0) {
-        attn_metadata.has_initial_states =
-            (params.attention.device.kv_cache_tokens_nums > 0).to(torch::kBool);
-      } else {
-        attn_metadata.has_initial_states =
-            torch::zeros({seqlens.size(0)},
-                         torch::dtype(torch::kBool).device(seqlens.device()));
-      }
-#endif
     }
     return attn_metadata;
   }


### PR DESCRIPTION
## 中文说明

### 重构目的

本 PR 将 Qwen3.5 linear-state validity metadata 统一到唯一的 host 侧权威来源：

```cpp
ModelInputParams::linear_state_validity_mask
```

这次重构要解决的核心问题是：**物理 slot 的地址和该 slot 中历史 recurrent state 的可用性是两个不同属性，不能互相推导。**

- `linear_state_indices` 只回答 conv/SSM state **存在哪里**。
- `linear_state_validity_mask` 只回答该地址中的历史 state **能否被当前序列读取**。
- `kv_cache_tokens_nums > 0` 只能说明存在 KV 历史，不能证明对应的 conv/SSM checkpoint 已成功恢复。

二者必须分离，因为 slot 的分配生命周期与 state 的有效生命周期不同：

```text
同一个物理 slot S
  新请求刚分配到 S                     -> validity 0
  当前请求在 S 中连续执行               -> validity 1
  prefix checkpoint 成功恢复到 S        -> validity 1
  KV prefix 命中但 recurrent restore 失败 -> validity 0
  ACL Graph / DP synthetic padding row   -> validity 0
```

因此：

```text
state/cache index = 存储地址
has-initial-state = 是否允许消费该地址中的历史状态
```

这种分离可以避免三类问题：

1. slot 复用后把其他请求遗留的 stale conv/SSM state 当成当前请求的历史状态；
2. prefix KV 命中但 recurrent checkpoint 恢复失败时，仍根据 KV token 数误判为 warm；
3. 空 DP shard 或 ACL Graph padding row 因为携带占位 slot 而被误判为有效状态。

### 与 vLLM、SGLang 的设计关系

本 PR 遵循 vLLM 和 SGLang 已采用的共同设计原则，但不会机械照搬它们的 validity 来源：

- **vLLM** 从 Mamba block table 的 `block_table_tensor[:, 0]` 独立取得 state slot，并从 request context length 独立构造 `has_initial_state`。GDN prefill 同时向 causal convolution 传递 `cache_indices` 和 `has_initial_state`；SSM state 按 index gather 后，再把 validity 为 false 的行清零。参考 `vllm/v1/attention/backends/gdn_attn.py` 与 `vllm/model_executor/layers/mamba/gdn/qwen_gdn_linear_attn.py`。
- **SGLang** 从 `mamba_cache_indices` 取得物理地址，从 `extend_prefix_lens > 0` 独立构造 `has_initial_states`，并把 `cache_indices` 与 `has_initial_state` 作为两个参数传给 `causal_conv1d_fn`。参考 `python/sglang/srt/layers/attention/linear/gdn_backend.py`。

vLLM、SGLang 与本 PR 的共同点是：**slot/index 负责寻址，validity 负责控制是否读取历史状态。**

xLLM 不能只照搬 `context_len > 0` 或 `prefix_len > 0`，因为 xLLM 的 linear prefix cache 会显式执行 physical conv/SSM checkpoint restore，而 restore 可能 miss、越界或失败。最终 validity 必须反映实际 restore 结果。因此 worker 生成 canonical mask，`restore_linear_state_slots()` 根据实际结果修正同一份 mask，所有 backend 再从这份 mask 派生执行 metadata。

### 统一后的数据流

```text
scheduler/batch host metadata
        |
        v
prepare_input_params_for_linear_attention()
        |
        v
ModelInputParams::linear_state_validity_mask   （唯一 host 权威来源）
        |
        +-- restore_linear_state_slots() 修正同一份 mask
        |      restore 成功 -> warm (1)
        |      restore 未解析/失败 -> cold (0)
        |
        +-- NPU GDN 直接消费 canonical mask
        +-- ACL Graph 复制 mask，synthetic padding row 补 0
        +-- AttentionMetadataBuilder 转成 device bool tensor
                   |
                   v
        AttentionMetadata::has_initial_states
        （派生的执行 metadata，不是第二个 validity 来源）
```

### 主要修改

- 将 `has_initial_states` materialization 放到公共 `AttentionMetadataBuilder` owning path。
- 删除 Qwen3.5 model/backend 从 `kv_cache_tokens_nums` 重新推导 validity 的逻辑。
- 删除从 device token-count tensor 反向重建 host validity 的运行时 fallback。
- 保留 physical conv/SSM slot clear/copy/restore，并用真实 restore 结果更新同一份 canonical mask。
- 保持 slot identity 与 state validity 独立。
- 空 DP shard 和 ACL Graph padding row 固定为 cold。
- 增加测试，证明 context/token count 和 slot index 都不能覆盖 canonical mask。

从 `linear_state_restore.h` 移出的 helper 只负责把 canonical host mask 转换成 `AttentionMetadata::has_initial_states`，不负责判断 warm/cold。这样，KV-cache restore 层只负责物理状态恢复及其结果，attention metadata builder 只负责构造 device 侧执行 metadata。

---

## Description

This PR unifies Qwen3.5 linear-state validity metadata around one canonical host-side source:

```cpp
ModelInputParams::linear_state_validity_mask
```

### Purpose

A physical linear-state slot and the validity of the recurrent state stored in that slot are separate concepts:

- `linear_state_indices` identifies **where** the conv/SSM state is stored.
- `linear_state_validity_mask` identifies **whether** that slot contains historical recurrent state that is valid for the current sequence.
- A positive KV-cache token count does not by itself prove that the corresponding recurrent state was restored successfully.

The separation is necessary because allocation and state validity have different lifecycles. A newly allocated request, a reused slot, and a padding row can all carry a physical slot index while still being cold. Conversely, a slot becomes warm only after the current sequence has continued from, or successfully restored, the matching recurrent state. Keeping these properties independent lets restore failure change a row from warm to cold without changing its storage address, and prevents padding or reused storage from being mistaken for usable history.

For example:

```text
same physical slot S
  fresh request assigned S                 -> validity 0
  current request continues in S           -> validity 1
  prefix checkpoint restored into S        -> validity 1
  prefix matched but recurrent restore failed -> validity 0
  synthetic graph/DP padding row           -> validity 0
```

Encoding validity in the slot index, or inferring it from KV-cache length, cannot represent these transitions reliably. Slot identity answers an addressing question; validity answers an ownership and initialization question.

Before this change, the Qwen3.5 NPU path could independently derive `AttentionMetadata::has_initial_states` from `kv_cache_tokens_nums > 0`, while other paths used `linear_state_validity_mask`. These two sources could disagree after slot reuse, a prefix-cache miss, or a failed linear-state restore. In that situation, a cold or stale conv/SSM slot could incorrectly be treated as warm.

### Alignment with vLLM and SGLang

This separation follows the same design principle used by the local vLLM and SGLang implementations, without copying their validity source mechanically:

- **vLLM** obtains the recurrent-state location independently from the Mamba block table (`block_table_tensor[:, 0]`) and builds `has_initial_state` separately from the request context length. Its GDN prefill path passes both `cache_indices` and `has_initial_state` to causal convolution, then gathers SSM state by the state indices and zeroes rows for which `prefill_has_initial_state` is false. See `vllm/v1/attention/backends/gdn_attn.py` and `vllm/model_executor/layers/mamba/gdn/qwen_gdn_linear_attn.py`.
- **SGLang** reads the physical state location from `mamba_cache_indices`, derives `has_initial_states` independently from `extend_prefix_lens > 0`, and passes `cache_indices` and `has_initial_state` as separate arguments to `causal_conv1d_fn`. See `python/sglang/srt/layers/attention/linear/gdn_backend.py`.

The shared design rule is therefore:

```text
state/cache index = storage address
has-initial-state = permission to consume the stored history
```

xLLM needs a stronger canonical validity source than simply checking context or KV-cache length because its linear prefix-cache path performs an explicit physical conv/SSM checkpoint restore that can miss or fail. `linear_state_validity_mask` captures the actual worker-side restore outcome, while still preserving the same slot/validity separation used by vLLM and SGLang.

This refactor removes that duplicate derivation. The worker constructs the canonical mask, `restore_linear_state_slots()` updates the same mask according to the actual restore outcome, and all downstream representations are derived from it.

### Canonical data flow

```text
scheduler/batch host metadata
        |
        v
prepare_input_params_for_linear_attention()
        |
        v
ModelInputParams::linear_state_validity_mask   (canonical host authority)
        |
        +-- restore_linear_state_slots() updates the same mask
        |      restored -> warm (1)
        |      unresolved/failed restore -> cold (0)
        |
        +-- NPU GDN consumes the canonical mask directly
        +-- ACL Graph copies it and pads synthetic rows with 0
        +-- AttentionMetadataBuilder materializes it as a device bool tensor
                   |
                   v
        AttentionMetadata::has_initial_states
        (derived execution metadata, not a second validity source)
```

### Changes

- Move `has_initial_states` materialization to the common `AttentionMetadataBuilder` owning path.
- Remove Qwen3.5 backend/model validity derivation from `kv_cache_tokens_nums`.
- Remove the runtime fallback that reconstructed host validity from the device token-count tensor.
- Preserve physical conv/SSM slot restore/copy behavior and update the same canonical mask with restore results.
- Keep slot identity and state validity independent.
- Materialize empty data-parallel shards and ACL Graph padding rows as cold.
- Add tests proving that context/token counts and slot indices cannot override the canonical mask.

The helper moved out of `linear_state_restore.h` only converts the canonical host mask into `AttentionMetadata::has_initial_states`; it does not decide whether a row is warm or cold. This placement keeps cache restore responsible for physical state restoration and keeps attention metadata construction responsible for device metadata materialization.

## Related Issues

N/A

## Change Type

- [ ] Bug fix
- [ ] New feature
- [ ] Performance improvement
- [x] Refactor
- [ ] Documentation
- [x] Test
- [ ] Build or CI

## Pull Request Checklist

Thank you for contributing to xLLM. Before requesting review, please make sure the following items are complete.

### PR Title and Commit Messages

- [ ] The PR title and each commit message follow the xLLM commit format: `<type>: <subject>`.

> Allowed types: feat, bugfix, docs, test, refactor, chore, style, revert, perf, model, build, release.
> The subject should use clear English, start with a verb, include at least 4 words, and end with `.`.

### Pre-commit Checks

- [ ] I have installed `pre-commit` by running `pip install pre-commit` or an equivalent command.
- [ ] I have installed the hooks with `pre-commit install`.
- [ ] I have run `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

### Self Review

- [x] I have self-reviewed the code according to `.agents/skills/code-review/references/custom-code-style.md`, especially code written or assisted by AI.
- [ ] I have rebased this PR onto the latest `main` branch.

### Build and Test Coverage

- [x] Tests have been added or updated as needed.
- [ ] NPU: `python setup.py build test` has passed on an NPU machine.

### NPU validation performed

- `python setup.py build --device npu`: passed.
- `attention_metadata_builder_test`: 5/5 passed.
- Complete `linear_state_restore_test` binary: 8/8 passed, including the three pre-existing death tests.
- Complete `acl_graph_executor_test` binary: 24/24 passed.
- `causal_conv1d_decode_wrapper_test`: passed, including the Qwen3.5 decode case with `max_diff=0`.
- Qwen3.5-4B service smoke tests passed for eager execution, ACL Graph execution, cold start, and chunked prefill.
- Linear prefix-cache restore was exercised with a shared long prompt; the second request reported `num_prefix_cache_tokens=1152`.
- A deterministic completion request (`temperature=0`, `logprobs=5`) returned HTTP 200 with eight API token IDs and eight token logprobs; re-encoding the generated text with the model tokenizer produced the same token IDs.

## Reviewer Notes

Please focus on the ownership boundary:

- `linear_state_validity_mask` is the only host-side validity authority.
- `linear_state_indices` remains a physical slot identifier only.
- `AttentionMetadata::has_initial_states` is a device-side representation derived only from the canonical mask.
- Restore failure must force the corresponding canonical row cold before model execution.

Validation covers the affected NPU paths, including the complete targeted restore and ACL Graph test binaries listed above. Backend-specific follow-up should preserve the same canonical-mask contract rather than introduce another validity source.
