### PR TITLE
refactor: consolidate platform typing into single torch-based module.

### DIFF
--- a/tests/python/test_kernels_import.py
+++ b/tests/python/test_kernels_import.py
@@ -72,7 +72,7 @@ _NPU_SCHEMAS = (
 )
 
 _PLATFORM_REQUIRED = pytest.mark.skipif(
-    not (platform.is_gpu() or platform.is_npu()),
+    not (platform.current_platform.is_cuda() or platform.current_platform.is_npu()),
     reason="no kernel package for this platform",
 )
 
@@ -132,15 +132,20 @@ def _run_isolated_python(
 
 
 def test_platform_queries_are_no_argument(monkeypatch: pytest.MonkeyPatch) -> None:
-    monkeypatch.setattr(platform, "current_platform", lambda: "npu")
-    assert platform.is_npu() and not platform.is_gpu()
-    monkeypatch.setattr(platform, "current_platform", lambda: "cuda")
-    assert platform.is_gpu() and not platform.is_npu()
+    current_platform = platform.current_platform
+    monkeypatch.setattr(
+        type(current_platform), "enum", classmethod(lambda cls: platform.PlatformEnum.NPU)
+    )
+    assert current_platform.is_npu() and not current_platform.is_cuda()
+    monkeypatch.setattr(
+        type(current_platform), "enum", classmethod(lambda cls: platform.PlatformEnum.CUDA)
+    )
+    assert current_platform.is_cuda() and not current_platform.is_npu()
 
 
 @_PLATFORM_REQUIRED
 def test_binding_import_contract() -> None:
-    schemas = _CUDA_SCHEMAS if platform.is_gpu() else _NPU_SCHEMAS
+    schemas = _CUDA_SCHEMAS if platform.current_platform.is_cuda() else _NPU_SCHEMAS
     _run_isolated_python(
         """
         import sys
@@ -149,12 +154,12 @@ def test_binding_import_contract() -> None:
         from xllm.python import kernels
         import xllm.python.kernels
         from xllm.python.kernels import rms_norm
-        from xllm.python import platform
+        from xllm.python.platform import current_platform
 
-        selected = f"xllm.python.kernels_{'cuda' if platform.is_gpu() else 'npu'}"
+        selected = f"xllm.python.kernels_{'cuda' if current_platform.is_cuda() else 'npu'}"
         peer = (
             "xllm.python.kernels_npu"
-            if platform.is_gpu()
+            if current_platform.is_cuda()
             else "xllm.python.kernels_cuda"
         )
         assert kernels is sys.modules[selected]

--- a/tests/python/test_model_executor.py
+++ b/tests/python/test_model_executor.py
@@ -126,7 +126,10 @@ class _FakeModelNoAttention(nn.Module):
 
 
 class TestNpuGraphBackendResolution:
-    @patch("xllm.python.model_executor.executor.platform.is_npu", return_value=True)
+    @patch(
+        "xllm.python.model_executor.executor.current_platform.is_npu",
+        return_value=True,
+    )
     def test_enable_graph_selects_aclgraph_on_npu(self, _mock_is_npu):
         config = {"enable_graph": True, "python_graph_backend": "off"}
         assert _resolve_graph_backend(config) == "aclgraph"
@@ -139,7 +142,8 @@ class TestNpuGraphBackendResolution:
 
 class TestCreateAttentionBackend:
     @patch(
-        "xllm.python.model_executor.executor.platform.is_npu", return_value=True
+        "xllm.python.model_executor.executor.current_platform.is_npu",
+        return_value=True,
     )
     @patch(
         "xllm.python.attention.npu_paged_attention.NpuPagedAttentionBackend",
@@ -155,10 +159,16 @@ class TestCreateAttentionBackend:
         assert backend.init_kwargs["num_kv_heads"] == 2
         assert backend.init_kwargs["head_dim"] == 64
 
-    @patch("xllm.python.model_executor.executor.platform.is_npu", return_value=False)
-    @patch("xllm.python.model_executor.executor.platform.is_gpu", return_value=True)
+    @patch(
+        "xllm.python.model_executor.executor.current_platform.is_npu",
+        return_value=False,
+    )
+    @patch(
+        "xllm.python.model_executor.executor.current_platform.is_cuda",
+        return_value=True,
+    )
     def test_cuda_device_creates_flashinfer_backend(
-        self, _mock_is_gpu, _mock_is_npu
+        self, _mock_is_cuda, _mock_is_npu
     ):
         attn = _make_attention_layer()
         module = types.ModuleType("xllm.python.attention.flashinfer")

--- a/tests/python/test_python_kernel_layout.py
+++ b/tests/python/test_python_kernel_layout.py
@@ -141,7 +141,7 @@ def test_platform_queries_stay_in_the_owning_layers() -> None:
             if not isinstance(node, ast.Call):
                 continue
             name = _qualified_name(node.func)
-            if not name.endswith(("platform.is_gpu", "platform.is_npu")):
+            if not name.endswith(("platform.is_cuda", "platform.is_npu")):
                 continue
             if relative != binding and not relative.is_relative_to(executor_root):
                 violations.append(f"{relative}:{node.lineno}: {name}")

--- a/xllm/auto_config/utils.py
+++ b/xllm/auto_config/utils.py
@@ -13,357 +13,64 @@
 # limitations under the License.
 # ==============================================================================
 
-"""Hardware typing for xLLM auto-tuning.
+"""Auto-tuning machinery for `xllm serve`.
 
-A slimmed-down Python `Platform`, modeled on sglang's
-`multimodal_gen/runtime/platforms/interface.py`, that answers "what hardware is
-this?" for the auto_config tuning profiles. It runs inside the `xllm serve`
-launcher process, which has no hard `torch` dependency, so detection is
-layered and torch-optional:
+Hosts the per-model tuning base class (`BaseTuner`) and the launcher helpers
+that resolve a model's tuning profile and generate its tuned config.
 
-1. Prefer the framework runtime (`torch` / `torch_npu` / `torch_mlu` / ...)
-   when it is importable and reports an available device -- the most accurate
-   signal, matching `scripts/build_support/utils.py::get_device_type`.
-2. Otherwise fall back to visible-device env masks, then `npu-smi` for the
-   Ascend chip name, neither of which requires torch.
-
-Nothing here raises: an undetectable environment resolves to
-`PlatformEnum.UNSPECIFIED` / `CpuArchEnum.UNSPECIFIED` / `"unknown"` so callers
-can always read a value.
+Hardware typing (`Platform`, `PlatformEnum`, `CpuArchEnum`, `detect_hardware`)
+lives in `xllm/python/platform.py`, the single home shared with the C++ worker.
+The launcher has no hard `torch` dependency and cannot `import
+xllm.python.platform` normally -- that would execute `xllm/python/__init__.py`,
+which imports `torch` and binds a kernel package. So this module loads that one
+file by path (the same technique `load_tuning_module` uses for tuning profiles)
+and re-exports the symbols, keeping the tuning profiles' imports unchanged.
 """
 
 from __future__ import annotations
 
 import copy
-import enum
-import functools
 import importlib.util
 import json
 import os
-import platform as platform_module
-import re
-import subprocess
-from abc import ABC, abstractmethod
 from types import ModuleType
 from typing import Any, Dict, Optional, Sequence
 
 from scripts.logger import logger
 
 
-class PlatformEnum(enum.Enum):
-    CUDA = enum.auto()
-    NPU = enum.auto()
-    MLU = enum.auto()
-    MUSA = enum.auto()
-    DCU = enum.auto()
-    ILU = enum.auto()
-    CPU = enum.auto()
-    UNSPECIFIED = enum.auto()
+def _load_platform_module() -> ModuleType:
+    """Load `xllm/python/platform.py` by file path, dodging its package init.
 
-
-class CpuArchEnum(enum.Enum):
-    X86 = enum.auto()
-    ARM = enum.auto()
-    UNSPECIFIED = enum.auto()
-
-
-# Visible-device env masks per backend, mirroring the CLI reference's
-# device-selection note. Order matches the accelerator detection precedence.
-_VISIBLE_DEVICE_ENV_VARS = {
-    PlatformEnum.NPU: "ASCEND_RT_VISIBLE_DEVICES",
-    PlatformEnum.CUDA: "CUDA_VISIBLE_DEVICES",
-    PlatformEnum.MLU: "MLU_VISIBLE_DEVICES",
-    PlatformEnum.DCU: "HIP_VISIBLE_DEVICES",
-    PlatformEnum.MUSA: "MUSA_VISIBLE_DEVICES",
-}
-
-
-def _torch_device_type() -> Optional[PlatformEnum]:
-    """Detect the accelerator via the framework runtime, or None if absent.
-
-    Follows the same probing order as
-    `scripts/build_support/utils.py::get_device_type`. Every import is guarded:
-    the launcher must not fail just because a framework wheel is missing.
+    `platform.py` only imports the stdlib and the shared logger, so it loads
+    cleanly here without pulling in `torch` or a kernel package. A private
+    module name keeps it from clashing with the worker's real
+    `xllm.python.platform`.
     """
-    try:
-        import torch
-    except ImportError:
-        return None
-
-    try:
-        if torch.cuda.is_available():
-            try:
-                from torch.utils.cpp_extension import HIP_HOME
-
-                if HIP_HOME and "dtk" in HIP_HOME.lower():
-                    return PlatformEnum.DCU
-            except ImportError:
-                pass
-            try:
-                import ixformer  # noqa: F401
-
-                return PlatformEnum.ILU
-            except ImportError:
-                return PlatformEnum.CUDA
-    except Exception:
-        pass
-
-    for module_name, attr, enum_value in (
-        ("torch_musa", "musa", PlatformEnum.MUSA),
-        ("torch_mlu", "mlu", PlatformEnum.MLU),
-        ("torch_npu", "npu", PlatformEnum.NPU),
-    ):
-        try:
-            __import__(module_name)
-            device_module = getattr(torch, attr, None)
-            if device_module is not None and device_module.is_available():
-                return enum_value
-        except ImportError:
-            continue
-        except Exception:
-            continue
-
-    return None
+    platform_path = os.path.join(
+        os.path.dirname(os.path.dirname(os.path.realpath(__file__))),
+        "python",
+        "platform.py",
+    )
+    spec = importlib.util.spec_from_file_location(
+        "xllm.auto_config._platform", platform_path
+    )
+    if spec is None or spec.loader is None:
+        raise ImportError(f"failed to load platform module: {platform_path}")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
 
 
-def _env_device_type() -> Optional[PlatformEnum]:
-    """Detect the accelerator from visible-device env masks, or None."""
-    for enum_value, env_var in _VISIBLE_DEVICE_ENV_VARS.items():
-        if os.environ.get(env_var) is not None:
-            return enum_value
-    return None
+_platform_module = _load_platform_module()
 
-
-def _npu_chip_from_smi() -> Optional[str]:
-    """Best-effort lowercase Ascend chip name from `npu-smi info`, or None.
-
-    `npu-smi` may be absent or permission-blocked, so this never raises. The
-    chip appears in the per-device rows (e.g. `910B2C`).
-    """
-    try:
-        completed = subprocess.run(
-            ["npu-smi", "info"],
-            capture_output=True,
-            text=True,
-            timeout=15,
-            check=False,
-        )
-    except (OSError, subprocess.SubprocessError):
-        return None
-
-    match = re.search(r"910[A-Za-z0-9]*", completed.stdout)
-    if match is None:
-        return None
-    return match.group(0).lower()
-
-
-def _npu_chip_from_acl() -> Optional[str]:
-    """Best-effort lowercase Ascend chip name via `acl`, or None.
-
-    `acl` is often unavailable in the launcher's import path and may already be
-    initialized by torch_npu, so failures are swallowed and this is only a
-    supplement to `npu-smi`.
-    """
-    try:
-        import acl
-    except ImportError:
-        return None
-    try:
-        soc_name = acl.get_soc_name()
-    except Exception:
-        return None
-    if not soc_name:
-        return None
-    match = re.search(r"910[A-Za-z0-9]*", soc_name)
-    if match is None:
-        return None
-    return match.group(0).lower()
-
-
-class Platform:
-    """Streamlined hardware-typing facade for auto-tuning profiles.
-
-    All methods are classmethods so profiles can call `Platform.is_npu()`
-    without holding an instance. Detection results are cached for the process
-    lifetime.
-    """
-
-    @classmethod
-    @functools.lru_cache(maxsize=1)
-    def enum(cls) -> PlatformEnum:
-        detected = _torch_device_type()
-        if detected is not None:
-            return detected
-
-        detected = _env_device_type()
-        if detected is not None:
-            return detected
-
-        # No framework runtime and no visible-device mask, but a readable
-        # Ascend chip still means this is an NPU host.
-        if cls.get_npu_chip() != "unknown":
-            return PlatformEnum.NPU
-
-        logger.warning(
-            "Platform: could not detect an accelerator; treating host as CPU."
-        )
-        return PlatformEnum.CPU
-
-    @classmethod
-    def is_cuda(cls) -> bool:
-        return cls.enum() == PlatformEnum.CUDA
-
-    @classmethod
-    def is_npu(cls) -> bool:
-        return cls.enum() == PlatformEnum.NPU
-
-    @classmethod
-    def is_mlu(cls) -> bool:
-        return cls.enum() == PlatformEnum.MLU
-
-    @classmethod
-    def is_musa(cls) -> bool:
-        return cls.enum() == PlatformEnum.MUSA
-
-    @classmethod
-    def is_dcu(cls) -> bool:
-        return cls.enum() == PlatformEnum.DCU
-
-    @classmethod
-    def is_ilu(cls) -> bool:
-        return cls.enum() == PlatformEnum.ILU
-
-    @classmethod
-    def is_cpu(cls) -> bool:
-        return cls.enum() == PlatformEnum.CPU
-
-    @classmethod
-    def device_type(cls) -> str:
-        """Lowercase device-type string, aligned with build-time detection."""
-        return cls.enum().name.lower()
-
-    @classmethod
-    @functools.lru_cache(maxsize=1)
-    def get_cpu_architecture(cls) -> CpuArchEnum:
-        arch = platform_module.machine().lower()
-        if "x86" in arch or "amd64" in arch:
-            return CpuArchEnum.X86
-        if "arm" in arch or "aarch64" in arch:
-            return CpuArchEnum.ARM
-        return CpuArchEnum.UNSPECIFIED
-
-    @classmethod
-    def get_cpu_arch_str(cls) -> str:
-        """Raw CPU machine string, e.g. `x86_64` or `aarch64`."""
-        return platform_module.machine() or "unknown"
-
-    @classmethod
-    @functools.lru_cache(maxsize=1)
-    def get_npu_chip(cls) -> str:
-        """Lowercase NPU chip identifier (e.g. `910b2c`), or `"unknown"`.
-
-        Prefers `npu-smi` (reliable in the launcher) and falls back to `acl`.
-        """
-        chip = _npu_chip_from_smi()
-        if chip is not None:
-            return chip
-        chip = _npu_chip_from_acl()
-        if chip is not None:
-            return chip
-        return "unknown"
-
-    @classmethod
-    @functools.lru_cache(maxsize=1)
-    def get_ascend_soc_generation(cls) -> Optional[str]:
-        """Ascend SoC generation (`a2`/`a3`/`a5`), or None if not an NPU host.
-
-        Derived from the chip name so it does not require a second `acl.init`.
-        Mapping matches `scripts/build_support/utils.py::get_ascend_platform`:
-        910B -> a2, 910C / 910_93 -> a3, 950 -> a5, other 910 -> a2.
-        """
-        chip = cls.get_npu_chip()
-        if chip == "unknown":
-            return None
-        if chip.startswith("910b"):
-            return "a2"
-        if chip.startswith("910c") or "910_93" in chip:
-            return "a3"
-        if chip.startswith("950"):
-            return "a5"
-        if chip.startswith("910"):
-            return "a2"
-        return None
-
-    @classmethod
-    def get_device_count(cls) -> Optional[int]:
-        """Number of usable devices, or None if undetectable.
-
-        Prefers the framework runtime's device count; falls back to counting
-        entries in the platform's visible-device env mask.
-        """
-        try:
-            import torch
-        except ImportError:
-            torch = None
-
-        if torch is not None:
-            try:
-                if cls.is_cuda() or cls.is_dcu() or cls.is_ilu():
-                    return torch.cuda.device_count()
-                device_module = getattr(torch, cls.device_type(), None)
-                if device_module is not None and hasattr(
-                    device_module, "device_count"
-                ):
-                    return device_module.device_count()
-            except Exception:
-                pass
-
-        env_var = _VISIBLE_DEVICE_ENV_VARS.get(cls.enum())
-        if env_var is not None:
-            value = os.environ.get(env_var)
-            if value is not None:
-                entries = [
-                    entry for entry in value.split(",") if entry.strip() != ""
-                ]
-                return len(entries)
-        return None
-
-    @classmethod
-    def get_device_name(cls, device_id: int = 0) -> str:
-        """Human-readable device name, best-effort.
-
-        Uses the framework runtime when available; otherwise composes a name
-        from the device type and (for NPU) the chip.
-        """
-        try:
-            import torch
-
-            if cls.is_cuda() or cls.is_dcu() or cls.is_ilu():
-                return torch.cuda.get_device_name(device_id)
-            device_module = getattr(torch, cls.device_type(), None)
-            if device_module is not None and hasattr(
-                device_module, "get_device_name"
-            ):
-                return device_module.get_device_name(device_id)
-        except Exception:
-            pass
-
-        if cls.is_npu():
-            return f"npu:{cls.get_npu_chip()}"
-        return cls.device_type()
-
-
-def detect_hardware() -> Dict[str, str]:
-    """Return the current hardware descriptor: CPU arch, device type, NPU chip.
-
-    Backed by `Platform` so detection stays consistent across profiles. Every
-    field falls back gracefully so the caller can always rely on the keys.
-    """
-    return {
-        "arch": Platform.get_cpu_arch_str(),
-        "device_type": Platform.device_type(),
-        "chip": Platform.get_npu_chip(),
-    }
+# Re-export the shared hardware-typing surface so tuning profiles keep importing
+# it from `xllm.auto_config.utils` while the definitions live in one place.
+Platform = _platform_module.Platform
+PlatformEnum = _platform_module.PlatformEnum
+CpuArchEnum = _platform_module.CpuArchEnum
+current_platform = _platform_module.current_platform
+detect_hardware = _platform_module.detect_hardware
 
 
 def check_device_count(
@@ -410,7 +117,7 @@ def check_device_count(
     return True
 
 
-class BaseTuner(ABC):
+class BaseTuner:
     """Base class for per-model auto-tuning profiles.
 
     A profile subclasses this, sets `MODEL_TYPE`, and implements the two

--- a/xllm/launch_server.py
+++ b/xllm/launch_server.py
@@ -290,8 +290,7 @@ def _detect_device_count(parser: argparse.ArgumentParser) -> int:
     """Number of local nodes (cards) on this machine, from the device count.
 
     Each machine hosts one node per visible device (matching multi_machine.md),
-    and the visible set is controlled by the accelerator's *_VISIBLE_DEVICES
-    env mask, which Platform.get_device_count() honors.
+    reported by Platform.get_device_count() via the framework runtime.
     """
     # Imported lazily so the common launch path keeps a light import surface
     # and only touches the auto_config package (and its device probing) when a
@@ -302,9 +301,9 @@ def _detect_device_count(parser: argparse.ArgumentParser) -> int:
     if device_count is None or device_count < 1:
         parser.error(
             "could not detect the local device count for a multi-machine "
-            "launch (--machine-rank is set); set the accelerator's "
-            "*_VISIBLE_DEVICES env mask (e.g. ASCEND_RT_VISIBLE_DEVICES / "
-            "CUDA_VISIBLE_DEVICES) so the device count is discoverable."
+            "launch (--machine-rank is set); this requires the framework "
+            "runtime (torch) to be importable so the device count is "
+            "discoverable."
         )
     return device_count
 

--- a/xllm/python/README.md
+++ b/xllm/python/README.md
@@ -37,9 +37,9 @@ The peers share no code and never import each other. `xllm/python/__init__.py`
 binds the one matching the active platform:
 
 ```python
-if platform.is_gpu():
+if current_platform.is_cuda():
     from xllm.python import kernels_cuda as kernels
-elif platform.is_npu():
+elif current_platform.is_npu():
     from xllm.python import kernels_npu as kernels
 ```
 
@@ -143,7 +143,8 @@ up the change.
    implementation.
 3. Add `_custom_op.py` with the FakeTensor implementations of the platform's
    C++ operators.
-4. Teach `platform.current_platform()` to report `<device>` and add the matching
+4. Teach `Platform` in `xllm/python/platform.py` to report `<device>` (extend
+   `PlatformEnum` and the detection in `Platform.enum`) and add the matching
    branch to the import in `xllm/python/__init__.py`.
 5. `setup.py --device <device>` then ships it. Before that, a build for the
    device logs the packages that do exist and ships none of them.

--- a/xllm/python/__init__.py
+++ b/xllm/python/__init__.py
@@ -43,18 +43,18 @@ from __future__ import annotations
 
 import sys
 
-from xllm.python import platform
+from xllm.python.platform import current_platform
 
 # Bound before anything else in the package so that a module reached from here
 # already finds ``xllm.python.kernels`` in place.
-if platform.is_gpu():
+if current_platform.is_cuda():
     from xllm.python import kernels_cuda as kernels
-elif platform.is_npu():
+elif current_platform.is_npu():
     from xllm.python import kernels_npu as kernels
 else:
     raise ImportError(
-        f"no kernel package for platform '{platform.current_platform()}'; add "
-        f"xllm/python/kernels_{platform.current_platform()}/ exporting the same "
+        f"no kernel package for platform '{current_platform.device_type()}'; add "
+        f"xllm/python/kernels_{current_platform.device_type()}/ exporting the same "
         "names as its peers, and import it here"
     )
 

--- a/xllm/python/model_executor/executor.py
+++ b/xllm/python/model_executor/executor.py
@@ -21,14 +21,14 @@ from xllm.python.attention.backend import AttentionBackend, AttentionMetadata, K
 from xllm.python.layers.attention import Attention
 from xllm.python.model_executor.forward_context import LayerSynchronizer
 from xllm.python.model_executor.runners.eager import EagerRunner
-from xllm.python import platform
+from xllm.python.platform import current_platform
 
 
 def _resolve_graph_backend(config: dict) -> str:
     graph_backend = str(config.get("python_graph_backend", "off")).lower()
     graph_disabled = graph_backend in ("", "off", "none", "0")
     if graph_disabled and config.get("enable_graph", False):
-        if platform.is_npu():
+        if current_platform.is_npu():
             return "aclgraph"
     return graph_backend
 
@@ -38,7 +38,7 @@ def _create_attention_backend(
     device: torch.device,
     dtype: torch.dtype,
 ) -> AttentionBackend:
-    if platform.is_npu():
+    if current_platform.is_npu():
         from xllm.python.attention.npu_paged_attention import (
             NpuPagedAttentionBackend,
         )
@@ -51,7 +51,7 @@ def _create_attention_backend(
             device=device,
             dtype=dtype,
         )
-    if platform.is_gpu():
+    if current_platform.is_cuda():
         from xllm.python.attention.flashinfer import FlashInferBackend
         return FlashInferBackend(
             num_heads=first_attention.num_heads,

--- a/xllm/python/platform.py
+++ b/xllm/python/platform.py
@@ -12,34 +12,333 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Active platform state for the Python model executor."""
+"""Hardware typing for xLLM -- the single home for ``Platform``.
+
+Modeled on sglang's platform interface (``sglang/srt/platforms/interface.py``):
+callers reach a process-wide ``current_platform`` singleton and ask it
+``current_platform.is_npu()`` / ``current_platform.is_cuda()`` rather than
+branching on a raw string.
+
+This module runs in two processes with opposite ``torch`` guarantees, so every
+``torch`` access is guarded:
+
+* The C++ worker's embedded CPython, where ``torch`` is always present. It
+  imports this module through ``xllm.python`` to pick the kernel package.
+* The ``xllm serve`` launcher, which has no hard ``torch`` dependency. It has no
+  access to ``xllm.python`` (importing that package pulls in ``torch`` and a
+  kernel package), so ``xllm.auto_config.utils`` loads this file by path and
+  re-exports the symbols for the auto-tuning profiles.
+
+Device-type detection comes solely from the framework runtime
+(``torch`` / ``torch_npu`` / ``torch_mlu`` / ...), matching
+``scripts/build_support/utils.py``. When ``torch`` is absent -- as in the
+launcher -- or reports no accelerator, the platform resolves to
+``PlatformEnum.CPU``.
+
+Nothing here raises: an undetectable environment resolves to
+``PlatformEnum.CPU`` / ``CpuArchEnum.UNSPECIFIED`` / ``"unknown"`` so callers can
+always read a value.
+"""
 
 from __future__ import annotations
 
-from functools import cache
+import enum
+import functools
+import platform as platform_module
+import re
+import subprocess
+from typing import Dict, Optional
 
-import torch
+from scripts.logger import logger
 
 
-@cache
-def current_platform() -> str:
-    """Detect the active runtime using the same priority as ``setup.py``."""
-    if torch.cuda.is_available():
-        return "cuda"
+class PlatformEnum(enum.Enum):
+    CUDA = enum.auto()
+    NPU = enum.auto()
+    MLU = enum.auto()
+    MUSA = enum.auto()
+    DCU = enum.auto()
+    ILU = enum.auto()
+    CPU = enum.auto()
+    UNSPECIFIED = enum.auto()
+
+
+class CpuArchEnum(enum.Enum):
+    X86 = enum.auto()
+    ARM = enum.auto()
+    UNSPECIFIED = enum.auto()
+
+
+# CUDA-like backends that share the CUDA kernel package and the ``torch.cuda``
+# runtime API. Detection maps DCU and ILU onto this group; the executor binds
+# the CUDA kernel package for all three (see ``xllm/python/__init__.py``).
+_CUDA_LIKE = (PlatformEnum.CUDA, PlatformEnum.DCU, PlatformEnum.ILU)
+
+
+def _torch_device_type() -> Optional[PlatformEnum]:
+    """Detect the accelerator via the framework runtime, or None if absent.
+
+    Follows the same probing order as
+    ``scripts/build_support/utils.py::get_device_type``. Every import is
+    guarded: neither process may fail just because a framework wheel is missing.
+    """
     try:
-        import torch_npu  # noqa: F401
+        import torch
     except ImportError:
-        return "cpu"
-    if torch.npu.is_available():
-        return "npu"
-    return "cpu"
+        return None
+
+    try:
+        if torch.cuda.is_available():
+            try:
+                from torch.utils.cpp_extension import HIP_HOME
+
+                if HIP_HOME and "dtk" in HIP_HOME.lower():
+                    return PlatformEnum.DCU
+            except ImportError:
+                pass
+            try:
+                import ixformer  # noqa: F401
+
+                return PlatformEnum.ILU
+            except ImportError:
+                return PlatformEnum.CUDA
+    except Exception:
+        pass
+
+    for module_name, attr, enum_value in (
+        ("torch_musa", "musa", PlatformEnum.MUSA),
+        ("torch_mlu", "mlu", PlatformEnum.MLU),
+        ("torch_npu", "npu", PlatformEnum.NPU),
+    ):
+        try:
+            __import__(module_name)
+            device_module = getattr(torch, attr, None)
+            if device_module is not None and device_module.is_available():
+                return enum_value
+        except ImportError:
+            continue
+        except Exception:
+            continue
+
+    return None
 
 
-def is_npu() -> bool:
-    """Return whether the active executor platform is NPU."""
-    return current_platform() == "npu"
+def _npu_chip_from_smi() -> Optional[str]:
+    """Best-effort lowercase Ascend chip name from ``npu-smi info``, or None.
+
+    ``npu-smi`` may be absent or permission-blocked, so this never raises. The
+    chip appears in the per-device rows (e.g. ``910B2C``).
+    """
+    try:
+        completed = subprocess.run(
+            ["npu-smi", "info"],
+            capture_output=True,
+            text=True,
+            timeout=15,
+            check=False,
+        )
+    except (OSError, subprocess.SubprocessError):
+        return None
+
+    match = re.search(r"910[A-Za-z0-9]*", completed.stdout)
+    if match is None:
+        return None
+    return match.group(0).lower()
 
 
-def is_gpu() -> bool:
-    """Return whether the active executor platform is CUDA GPU."""
-    return current_platform() == "cuda"
+def _npu_chip_from_acl() -> Optional[str]:
+    """Best-effort lowercase Ascend chip name via ``acl``, or None.
+
+    ``acl`` is often unavailable in the launcher's import path and may already
+    be initialized by torch_npu, so failures are swallowed and this is only a
+    supplement to ``npu-smi``.
+    """
+    try:
+        import acl
+    except ImportError:
+        return None
+    try:
+        soc_name = acl.get_soc_name()
+    except Exception:
+        return None
+    if not soc_name:
+        return None
+    match = re.search(r"910[A-Za-z0-9]*", soc_name)
+    if match is None:
+        return None
+    return match.group(0).lower()
+
+
+class Platform:
+    """Streamlined hardware-typing facade shared by the worker and launcher.
+
+    All methods are classmethods, so the launcher's auto-tuning profiles call
+    ``Platform.is_npu()`` on the class while worker code reaches the same
+    queries through the ``current_platform`` singleton -- the sglang usage
+    idiom. Detection results are cached for the process lifetime.
+    """
+
+    @classmethod
+    @functools.lru_cache(maxsize=1)
+    def enum(cls) -> PlatformEnum:
+        detected = _torch_device_type()
+        if detected is not None:
+            return detected
+
+        logger.warning(
+            "Platform: could not detect an accelerator; treating host as CPU."
+        )
+        return PlatformEnum.CPU
+
+    @classmethod
+    def is_cuda(cls) -> bool:
+        return cls.enum() == PlatformEnum.CUDA
+
+    @classmethod
+    def is_npu(cls) -> bool:
+        return cls.enum() == PlatformEnum.NPU
+
+    @classmethod
+    def is_mlu(cls) -> bool:
+        return cls.enum() == PlatformEnum.MLU
+
+    @classmethod
+    def is_musa(cls) -> bool:
+        return cls.enum() == PlatformEnum.MUSA
+
+    @classmethod
+    def is_dcu(cls) -> bool:
+        return cls.enum() == PlatformEnum.DCU
+
+    @classmethod
+    def is_ilu(cls) -> bool:
+        return cls.enum() == PlatformEnum.ILU
+
+    @classmethod
+    def is_cpu(cls) -> bool:
+        return cls.enum() == PlatformEnum.CPU
+
+    @classmethod
+    def device_type(cls) -> str:
+        """Lowercase device-type string, aligned with build-time detection."""
+        return cls.enum().name.lower()
+
+    @classmethod
+    @functools.lru_cache(maxsize=1)
+    def get_cpu_architecture(cls) -> CpuArchEnum:
+        arch = platform_module.machine().lower()
+        if "x86" in arch or "amd64" in arch:
+            return CpuArchEnum.X86
+        if "arm" in arch or "aarch64" in arch:
+            return CpuArchEnum.ARM
+        return CpuArchEnum.UNSPECIFIED
+
+    @classmethod
+    def get_cpu_arch_str(cls) -> str:
+        """Raw CPU machine string, e.g. ``x86_64`` or ``aarch64``."""
+        return platform_module.machine() or "unknown"
+
+    @classmethod
+    @functools.lru_cache(maxsize=1)
+    def get_npu_chip(cls) -> str:
+        """Lowercase NPU chip identifier (e.g. ``910b2c``), or ``"unknown"``.
+
+        Prefers ``npu-smi`` (reliable in the launcher) and falls back to
+        ``acl``.
+        """
+        chip = _npu_chip_from_smi()
+        if chip is not None:
+            return chip
+        chip = _npu_chip_from_acl()
+        if chip is not None:
+            return chip
+        return "unknown"
+
+    @classmethod
+    @functools.lru_cache(maxsize=1)
+    def get_ascend_soc_generation(cls) -> Optional[str]:
+        """Ascend SoC generation (``a2``/``a3``/``a5``), or None if not an NPU.
+
+        Derived from the chip name so it does not require a second ``acl.init``.
+        Mapping matches ``scripts/build_support/utils.py::get_ascend_platform``:
+        910B -> a2, 910C / 910_93 -> a3, 950 -> a5, other 910 -> a2.
+        """
+        chip = cls.get_npu_chip()
+        if chip == "unknown":
+            return None
+        if chip.startswith("910b"):
+            return "a2"
+        if chip.startswith("910c") or "910_93" in chip:
+            return "a3"
+        if chip.startswith("950"):
+            return "a5"
+        if chip.startswith("910"):
+            return "a2"
+        return None
+
+    @classmethod
+    def get_device_count(cls) -> Optional[int]:
+        """Number of usable devices from the framework runtime, or None.
+
+        Returns None when ``torch`` is absent (as in the launcher) or reports no
+        device.
+        """
+        try:
+            import torch
+        except ImportError:
+            return None
+
+        try:
+            if cls.enum() in _CUDA_LIKE:
+                return torch.cuda.device_count()
+            device_module = getattr(torch, cls.device_type(), None)
+            if device_module is not None and hasattr(
+                device_module, "device_count"
+            ):
+                return device_module.device_count()
+        except Exception:
+            pass
+        return None
+
+    @classmethod
+    def get_device_name(cls, device_id: int = 0) -> str:
+        """Human-readable device name, best-effort.
+
+        Uses the framework runtime when available; otherwise composes a name
+        from the device type and (for NPU) the chip.
+        """
+        try:
+            import torch
+
+            if cls.enum() in _CUDA_LIKE:
+                return torch.cuda.get_device_name(device_id)
+            device_module = getattr(torch, cls.device_type(), None)
+            if device_module is not None and hasattr(
+                device_module, "get_device_name"
+            ):
+                return device_module.get_device_name(device_id)
+        except Exception:
+            pass
+
+        if cls.is_npu():
+            return f"npu:{cls.get_npu_chip()}"
+        return cls.device_type()
+
+
+# Process-wide singleton, the sglang-style entry point:
+# ``from xllm.python.platform import current_platform``. Construction is cheap;
+# detection is deferred to the first query via ``Platform.enum``'s cache.
+current_platform = Platform()
+
+
+def detect_hardware() -> Dict[str, str]:
+    """Return the current hardware descriptor: CPU arch, device type, NPU chip.
+
+    Backed by ``Platform`` so detection stays consistent across profiles. Every
+    field falls back gracefully so the caller can always rely on the keys.
+    """
+    return {
+        "arch": Platform.get_cpu_arch_str(),
+        "device_type": Platform.device_type(),
+        "chip": Platform.get_npu_chip(),
+    }


### PR DESCRIPTION


## Description

- move `Platform/PlatformEnum/CpuArchEnum/detect_hardware` into `xllm/python/platform.py` as the single home; auto_config loads it by path and re-exports for the torchless launcher
- adopt sglang-style `current_platform` singleton; rename `is_gpu` to `is_cuda`
- detect device type solely from the framework runtime, dropping the visible-device env-mask and npu-smi fallbacks
- drop unused ABC base from BaseTuner
- 
<!-- What does this PR do? Briefly describe the changes and why they are needed. -->

## Related Issues

<!-- Link related issues here. Use "Fixes #123" when this PR closes an issue. -->

## Change Type

- [ ] Bug fix
- [ ] New feature
- [ ] Performance improvement
- [ ] Refactor
- [ ] Documentation
- [ ] Test
- [ ] Build or CI

## Pull Request Checklist

Thank you for contributing to xLLM. Before requesting review, please make sure the following items are complete.

### PR Title and Commit Messages

- [ ] The PR title and each commit message follow the xLLM commit format: `<type>: <subject>`.

> Allowed types: feat, bugfix, docs, test, refactor, chore, style, revert, perf, model, build, release.
> The subject should use clear English, start with a verb, include at least 4 words, and end with `.`.

### Pre-commit Checks

- [ ] I have installed `pre-commit` by running `pip install pre-commit` or an equivalent command.
- [ ] I have installed the hooks with `pre-commit install`.
- [ ] I have run `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

### Self Review

- [ ] I have self-reviewed the code according to `.agents/skills/code-review/references/custom-code-style.md`, especially code written or assisted by AI.
- [ ] I have rebased this PR onto the latest `main` branch.

### Build and Test Coverage

- [ ] Tests have been added or updated as needed.
- [ ] CUDA: `python setup.py build test` has passed on a CUDA machine.
- [ ] NPU: `python setup.py build test` has passed on an NPU machine.
- [ ] MLU: `python setup.py build test` has passed on an MLU machine.

## Reviewer Notes

<!-- Optional: anything reviewers should focus on, known risks, follow-ups, or validation gaps. -->
