### PR TITLE
bugfix: fix control-reaches-end in profile start and stop.

### DIFF
--- a/xllm/core/runtime/worker_impl.cpp
+++ b/xllm/core/runtime/worker_impl.cpp
@@ -1255,12 +1255,13 @@ bool WorkerImpl::update_weights(const std::string& weights_path) {
 bool WorkerImpl::start_profile() {
   const auto& cfg = ProfileConfig::get_instance();
   LOG(INFO) << "Starting profiling with backend: " << cfg.profile_backend();
+#if defined(USE_CUDA) || defined(USE_DCU) || defined(USE_MUSA)
 #if defined(USE_CUDA)
   if (cfg.profile_backend() == "cuda") {
     // Capture-range only; requires the server to run under nsys.
     return CudaProfiler::get_instance().start();
   }
-#elif defined(USE_DCU) || defined(USE_MUSA)
+#endif
   // Default "torch" backend records in-process via Kineto. CPU-op capture uses
   // thread-local callbacks, so enable it on the compute thread that runs the
   // forward pass rather than on the RPC handler thread.
@@ -1279,11 +1280,12 @@ bool WorkerImpl::start_profile() {
 bool WorkerImpl::stop_profile() {
   const auto& cfg = ProfileConfig::get_instance();
   LOG(INFO) << "Stopping profiling with backend: " << cfg.profile_backend();
+#if defined(USE_CUDA) || defined(USE_DCU) || defined(USE_MUSA)
 #if defined(USE_CUDA)
   if (cfg.profile_backend() == "cuda") {
     return CudaProfiler::get_instance().stop();
   }
-#elif defined(USE_DCU) || defined(USE_MUSA)
+#endif
   const std::string profile_dir = cfg.profile_dir();
   const int32_t rank = parallel_args_.rank();
   folly::Promise<bool> promise;


### PR DESCRIPTION


## Description

Under `USE_CUDA` with a non-"cuda" backend, the CUDA branch did not return and control fell off the end of `start_profile()/stop_profile()`, which `-Werror=return-type` rejected. Nest the CUDA nsys check inside the shared torch-backend block so `CUDA/DCU/MUSA` all fall through to the default Kineto TorchProfiler.

<!-- What does this PR do? Briefly describe the changes and why they are needed. -->

## Related Issues

<!-- Link related issues here. Use "Fixes #123" when this PR closes an issue. -->

## Change Type

- [x] Bug fix
- [ ] New feature
- [ ] Performance improvement
- [ ] Refactor
- [ ] Documentation
- [ ] Test
- [ ] Build or CI

## Pull Request Checklist

Thank you for contributing to xLLM. Before requesting review, please make sure the following items are complete.

### PR Title and Commit Messages

- [x] The PR title and each commit message follow the xLLM commit format: `<type>: <subject>`.

> Allowed types: feat, bugfix, docs, test, refactor, chore, style, revert, perf, model, build, release.
> The subject should use clear English, start with a verb, include at least 4 words, and end with `.`.

### Pre-commit Checks

- [x] I have installed `pre-commit` by running `pip install pre-commit` or an equivalent command.
- [x] I have installed the hooks with `pre-commit install`.
- [x] I have run `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

### Self Review

- [x] I have self-reviewed the code according to `.agents/skills/code-review/references/custom-code-style.md`, especially code written or assisted by AI.
- [x] I have rebased this PR onto the latest `main` branch.

### Build and Test Coverage

- [ ] Tests have been added or updated as needed.
- [x] CUDA: `python setup.py build test` has passed on a CUDA machine.
- [ ] NPU: `python setup.py build test` has passed on an NPU machine.
- [ ] MLU: `python setup.py build test` has passed on an MLU machine.

## Reviewer Notes

<!-- Optional: anything reviewers should focus on, known risks, follow-ups, or validation gaps. -->
