### PR TITLE
feat: fix prefix-cache prefill attention in Python graph path.

### DIFF
--- a/xllm/python/attention/npu_paged_attention.py
+++ b/xllm/python/attention/npu_paged_attention.py
@@ -40,6 +40,16 @@ from xllm.python.model_executor.forward_context import (
 if TYPE_CHECKING:
     from xllm.python.layers.attention import Attention
 
+# Ascend FIA sparse_mode values (see CANN aclnnFusedInferAttentionScore docs).
+# 0: no compressed mask; used for single-query decode where no causal mask is
+#    needed.
+# 3: rightDownCausal; the causal mask is right-aligned to the KV tail, for the
+#    prefix-cache / chunked-prefill case where q_len < kv_len so the new queries
+#    attend the full cached prefix plus their own tokens (mode 2, leftUpCausal,
+#    only aligns when q_len == kv_len and would misalign on a cache hit).
+_SPARSE_MODE_NONE = 0
+_SPARSE_MODE_RIGHT_DOWN_CAUSAL = 3
+
 
 class NpuPagedAttentionBackend(AttentionBackend):
     """NPU attention backend dispatching to npu_fused_infer_attention_score."""
@@ -154,7 +164,7 @@ class NpuPagedAttentionBackend(AttentionBackend):
                         actual_seq_lengths_kv=self._actual_seq_kv,
                         num_key_value_heads=self.num_kv_heads,
                         num_heads=self.num_heads,
-                        sparse_mode=0,
+                        sparse_mode=_SPARSE_MODE_NONE,
                         scale=self.scale,
                         softmax_lse_flag=False,
                     )
@@ -216,7 +226,9 @@ class NpuPagedAttentionBackend(AttentionBackend):
         q_3d = q.view(num_tokens, self.num_heads, self.head_dim).contiguous()
 
         if metadata.is_prefill or metadata.is_chunked_prefill:
-            return self._prefill(q_3d, k_3d, v_3d, metadata, num_tokens)
+            return self._prefill(
+                q_3d, k_3d, v_3d, k_cache, v_cache, metadata, num_tokens
+            )
         return self._decode(q_3d, k_cache, v_cache, metadata, num_tokens)
 
     def execute_mla(
@@ -283,9 +295,37 @@ class NpuPagedAttentionBackend(AttentionBackend):
 
     def _prefill(
         self, q_3d: torch.Tensor, k_3d: torch.Tensor, v_3d: torch.Tensor,
+        k_cache: torch.Tensor, v_cache: torch.Tensor,
         metadata: AttentionMetadata, num_tokens: int,
     ) -> torch.Tensor:
         actual_seq = self._cumulative_seq_lens(metadata, num_tokens)
+
+        # Prefix-cache hit (or chunked prefill with prior context): part of the
+        # KV already lives in the paged cache, so this forward only carries the
+        # new tokens (q_len < kv_len). Attend over the full paged KV via
+        # block_table, mirroring _decode. Without this, the new query tokens
+        # would only see their own KV (actual_seq_lengths_kv == q_len) and never
+        # the cached prefix, diverging from a full recompute.
+        if metadata.block_table is not None:
+            block_size = k_cache.size(1)
+            k_flat = k_cache.view(k_cache.size(0), block_size, -1)
+            v_flat = v_cache.view(v_cache.size(0), block_size, -1)
+            output, _ = torch.ops.npu.npu_fused_infer_attention_score(
+                q_3d, k_flat, v_flat,
+                pse_shift=None,
+                atten_mask=self._causal_mask,
+                block_table=self._block_table_i32,
+                actual_seq_lengths=actual_seq,
+                actual_seq_lengths_kv=self._actual_seq_kv,
+                num_heads=self.num_heads,
+                scale=self.scale,
+                input_layout="TND",
+                num_key_value_heads=self.num_kv_heads,
+                block_size=block_size,
+                sparse_mode=_SPARSE_MODE_RIGHT_DOWN_CAUSAL,
+                softmax_lse_flag=False,
+            )
+            return output.reshape(num_tokens, self.num_heads * self.head_dim)
 
         output, _ = torch.ops.npu.npu_fused_infer_attention_score(
             q_3d, k_3d, v_3d,
@@ -297,7 +337,7 @@ class NpuPagedAttentionBackend(AttentionBackend):
             scale=self.scale,
             input_layout="TND",
             num_key_value_heads=self.num_kv_heads,
-            sparse_mode=3,
+            sparse_mode=_SPARSE_MODE_RIGHT_DOWN_CAUSAL,
             softmax_lse_flag=False,
         )
         return output.reshape(num_tokens, self.num_heads * self.head_dim)
@@ -321,7 +361,7 @@ class NpuPagedAttentionBackend(AttentionBackend):
             scale=self.scale,
             input_layout="TND",
             num_key_value_heads=self.num_kv_heads,
-            sparse_mode=0,
+            sparse_mode=_SPARSE_MODE_NONE,
             block_size=block_size,
             softmax_lse_flag=False,
             workspace=self._graph_workspace,
@@ -373,7 +413,7 @@ class NpuPagedAttentionBackend(AttentionBackend):
             scale=self.scale,
             input_layout="TND",
             num_key_value_heads=self.num_kv_heads,
-            sparse_mode=0,
+            sparse_mode=_SPARSE_MODE_NONE,
             block_size=block_size,
             softmax_lse_flag=False,
         )


### PR DESCRIPTION
The Python model executor's _prefill computed attention only over the tokens carried in the current forward, with actual_seq_lengths_kv equal to the query length and no block_table. On a prefix-cache hit the cached prefix KV already lives in the paged cache and only the new tokens are fed in, so the new queries never attended to the cached prefix and the output diverged from a full recompute.

Add a hit branch in _prefill: when block_table is present, attend over the full paged KV via block_table with actual_seq_lengths_kv set to the complete sequence length (prefix + new) and sparse_mode=3, mirroring the decode path. GSM8K accuracy with prefix cache now matches the no-cache baseline (0.94 == 0.94 at 50 samples).

## Description

<!-- What does this PR do? Briefly describe the changes and why they are needed. -->

## Related Issues

<!-- Link related issues here. Use "Fixes #123" when this PR closes an issue. -->

## Change Type

- [ ] Bug fix
- [ ] New feature
- [ ] Performance improvement
- [ ] Refactor
- [ ] Documentation
- [ ] Test
- [ ] Build or CI

## Pull Request Checklist

Thank you for contributing to xLLM. Before requesting review, please make sure the following items are complete.

### PR Title and Commit Messages

- [ ] The PR title and each commit message follow the xLLM commit format: `<type>: <subject>`.

> Allowed types: feat, bugfix, docs, test, refactor, chore, style, revert, perf, model, build, release.
> The subject should use clear English, start with a verb, include at least 4 words, and end with `.`.

### Pre-commit Checks

- [ ] I have installed `pre-commit` by running `pip install pre-commit` or an equivalent command.
- [ ] I have installed the hooks with `pre-commit install`.
- [ ] I have run `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

### Self Review

- [ ] I have self-reviewed the code according to `.agents/skills/code-review/references/custom-code-style.md`, especially code written or assisted by AI.
- [ ] I have rebased this PR onto the latest `main` branch.

### Build and Test Coverage

- [ ] Tests have been added or updated as needed.
- [ ] CUDA: `python setup.py build test` has passed on a CUDA machine.
- [ ] NPU: `python setup.py build test` has passed on an NPU machine.
- [ ] MLU: `python setup.py build test` has passed on an MLU machine.

## Reviewer Notes

<!-- Optional: anything reviewers should focus on, known risks, follow-ups, or validation gaps. -->
