### PR TITLE
feat: add residual-aware SJF scheduling policy for PD prefill.

### DIFF
--- a/docs/src/content/docs/zh/cli_reference.md
+++ b/docs/src/content/docs/zh/cli_reference.md
@@ -113,7 +113,8 @@ xLLM 使用 gflags 管理服务启动参数。`--model <PATH>` 是唯一必填�
 | `chunked_match_frequency` | `int32` | `2` | sequence prefix cache 匹配频率。 |
 | `use_zero_evict` | `bool` | `false` | 是否使用 ZeroEvictionScheduler；详见 [Zero Evict Scheduler](/zh/features/zero_evict_scheduler/)。 |
 | `max_decode_token_per_sequence` | `int32` | `256` | ZeroEvictionScheduler 中每个 sequence 的最大 decode token 数。 |
-| `priority_strategy` | `string` | `"fcfs"` | 请求优先级策略，例如 `fcfs`、`priority`、`deadline`。 |
+| `priority_strategy` | `string` | `"fcfs"` | 请求优先级策略，例如 `fcfs`、`priority`、`deadline`；PD prefill 下支持 `residual_sjf`（按剩余本地 prefill 成本排序）。 |
+| `residual_sjf_max_wait_ms` | `int32` | `10000` | `residual_sjf` 下的 aging 阈值（毫秒）：等待超过该值的请求按 FCFS 提前；`0` 退化为 FCFS。 |
 | `use_mix_scheduler` | `bool` | `false` | 是否使用 MixScheduler 统一处理 prefill 和 decode。 |
 | `enable_online_preempt_offline` | `bool` | `true` | 是否允许在线请求抢占离线请求。 |
 | `aggressive_coeff` | `double` | `1.0` | MixScheduler 紧急度判断的激进系数。 |

--- a/tests/core/framework/config/config_json_test.cpp
+++ b/tests/core/framework/config/config_json_test.cpp
@@ -38,6 +38,7 @@ inline constexpr std::string_view kInlineConfig = R"json({
   "enable_prefix_cache": false,
   "max_tokens_per_batch": 8192,
   "max_seqs_per_batch": 64,
+  "residual_sjf_max_wait_ms": 12345,
   "model_impl": "py",
   "python_graph_backend": "cudagraphs"
 })json";
@@ -236,6 +237,7 @@ TEST(ConfigJsonTest, FromJsonUsesParsedOverrides) {
   EXPECT_EQ(kv_cache_config.kv_cache_dtype(), "auto");
   EXPECT_EQ(kv_cache_config.indexer_cache_dtype(), "auto");
   EXPECT_EQ(scheduler_config.max_decode_token_per_sequence(), 256);
+  EXPECT_EQ(scheduler_config.residual_sjf_max_wait_ms(), 12345);
 }
 
 TEST(KVCacheConfigValidationTest, AcceptsSupportedIndexerCacheDtypes) {

--- a/tests/core/scheduler/CMakeLists.txt
+++ b/tests/core/scheduler/CMakeLists.txt
@@ -10,6 +10,7 @@ cc_test(
     continuous_scheduler_test.cpp
     fixed_steps_scheduler_test.cpp
     scheduler_policy_test.cpp
+    residual_sjf_policy_test.cpp
   DEPS
     :config
     :scheduler

--- a/tests/core/scheduler/residual_sjf_policy_test.cpp
+++ b/tests/core/scheduler/residual_sjf_policy_test.cpp
@@ -1,0 +1,262 @@
+/* Copyright 2026 The xLLM Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://github.com/jd-opensource/xllm/blob/main/LICENSE
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include <absl/time/clock.h>
+#include <absl/time/time.h>
+#include <gtest/gtest.h>
+
+#include <cstdint>
+#include <map>
+#include <memory>
+#include <string>
+#include <vector>
+
+#include "continuous_scheduler.h"
+#include "core/framework/block/block_manager_pool.h"
+#include "framework/request/priority_comparator.h"
+#include "framework/request/request.h"
+#include "framework/request/request_state.h"
+#include "scheduler/request_priority_queue.h"
+#include "scheduler/scheduler_policy.h"
+
+namespace xllm {
+namespace {
+
+std::shared_ptr<Request> make_request(const std::string& request_id,
+                                      size_t prompt_tokens,
+                                      int32_t token_id = 1) {
+  std::vector<int32_t> prompt_token_ids(prompt_tokens, token_id);
+  RequestSamplingParam sampling_param;
+  SchedulerParam scheduler_param;
+
+  StoppingChecker stopping_checker;
+  stopping_checker.set_max_generated_tokens(4);
+  stopping_checker.set_max_context_len(4096);
+  stopping_checker.set_ignore_eos(true);
+
+  RequestState state("prompt",
+                     prompt_token_ids,
+                     sampling_param,
+                     scheduler_param,
+                     stopping_checker,
+                     prompt_token_ids.size() + 8,
+                     /*n=*/1,
+                     /*best_of=*/1,
+                     /*logprobs=*/false,
+                     /*stream=*/false,
+                     /*echo=*/false,
+                     /*skip_special_tokens=*/false,
+                     /*enable_schedule_overlap=*/false,
+                     /*output_func=*/nullptr,
+                     /*outputs_func=*/nullptr);
+  return std::make_shared<Request>(
+      request_id, "x-request-id", "x-request-time", state);
+}
+
+std::vector<std::string> collect_ids(const RequestPriorityQueue& queue) {
+  std::vector<std::string> request_ids;
+  for (auto it = queue.begin(); it != queue.end(); ++it) {
+    request_ids.emplace_back((*it)->request_id());
+  }
+  return request_ids;
+}
+
+ResidualSJFComparator::ResidualCostFn cost_from_map(
+    const std::map<std::string, size_t>& cost_by_id) {
+  return [&cost_by_id](const std::shared_ptr<Request>& request) -> size_t {
+    const auto found = cost_by_id.find(request->request_id());
+    return found == cost_by_id.end() ? 0 : found->second;
+  };
+}
+
+void sort_residual_sjf(DequeQueue& queue,
+                       const std::map<std::string, size_t>& cost_by_id,
+                       int32_t max_wait_ms,
+                       absl::Time now) {
+  queue.sort(
+      ResidualSJFComparator(cost_from_map(cost_by_id), max_wait_ms, now));
+}
+
+TEST(ResidualSJFPolicyTest, QuantizesResidualCostToBlocks) {
+  EXPECT_EQ(residual_sjf_cost_blocks(1024, 4, 128), 4);
+  EXPECT_EQ(residual_sjf_cost_blocks(1024, 0, 128), 8);
+  EXPECT_EQ(residual_sjf_cost_blocks(1024, 8, 128), 0);
+  EXPECT_EQ(residual_sjf_cost_blocks(1024, 16, 128), 0);
+  EXPECT_EQ(residual_sjf_cost_blocks(1024, 4, 0), 0);
+}
+
+TEST(ResidualSJFPolicyTest, SortsFreshRequestsByResidualCostThenArrival) {
+  DequeQueue queue;
+  queue.push(make_request("cold-short", 256), /*if_back=*/false);
+  queue.push(make_request("warm-long", 2048), /*if_back=*/false);
+  queue.push(make_request("cold-long", 2048), /*if_back=*/false);
+  queue.push(make_request("warm-short", 256), /*if_back=*/false);
+
+  sort_residual_sjf(queue,
+                    {{"warm-long", 1},
+                     {"cold-short", 2},
+                     {"warm-short", 2},
+                     {"cold-long", 16}},
+                    /*max_wait_ms=*/60000,
+                    absl::Now());
+
+  // warm-long has the smallest residual cost; the two cost-2 requests
+  // tie-break by arrival (cold-short was created before warm-short).
+  const std::vector<std::string> expected = {
+      "warm-long", "cold-short", "warm-short", "cold-long"};
+  EXPECT_EQ(collect_ids(queue), expected);
+}
+
+TEST(ResidualSJFPolicyTest, AgedRequestsPrecedeFreshInFcfsOrder) {
+  std::shared_ptr<Request> old_long = make_request("old-long", 2048);
+  // Give the first request a real age so it crosses the max-wait threshold
+  // while the second one stays fresh.
+  absl::SleepFor(absl::Milliseconds(20));
+  std::shared_ptr<Request> new_short = make_request("new-short", 256);
+  DequeQueue queue;
+  queue.push(old_long, /*if_back=*/false);
+  queue.push(new_short, /*if_back=*/false);
+
+  // The aged request is promoted ahead of the fresh one in FCFS order,
+  // ignoring residual cost (old-long cost 100 > new-short cost 1).
+  sort_residual_sjf(queue,
+                    {{"old-long", 100}, {"new-short", 1}},
+                    /*max_wait_ms=*/10,
+                    absl::Now());
+
+  const std::vector<std::string> expected = {"old-long", "new-short"};
+  EXPECT_EQ(collect_ids(queue), expected);
+}
+
+TEST(ResidualSJFPolicyTest, ZeroMaxWaitBehavesLikeFcfs) {
+  DequeQueue queue;
+  queue.push(make_request("first-expensive", 2048), /*if_back=*/false);
+  queue.push(make_request("second-cheap", 256), /*if_back=*/false);
+
+  // max_wait_ms=0 ages every request immediately, so cost is ignored and the
+  // earlier arrival wins.
+  sort_residual_sjf(queue,
+                    {{"first-expensive", 100}, {"second-cheap", 1}},
+                    /*max_wait_ms=*/0,
+                    absl::Now());
+
+  const std::vector<std::string> expected = {"first-expensive", "second-cheap"};
+  EXPECT_EQ(collect_ids(queue), expected);
+}
+
+TEST(ResidualSJFPolicyTest, RecoveryPrecedesAgedAndFresh) {
+  std::shared_ptr<Request> aged = make_request("aged", 256);
+  absl::SleepFor(absl::Milliseconds(20));
+  std::shared_ptr<Request> fresh = make_request("fresh", 256);
+  std::shared_ptr<Request> recovery = make_request("recovery", 256);
+  recovery->set_preempted();
+  DequeQueue queue;
+  queue.push(fresh, /*if_back=*/false);
+  queue.push(recovery, /*if_back=*/false);
+  queue.push(aged, /*if_back=*/false);
+
+  sort_residual_sjf(queue,
+                    {{"fresh", 1}, {"recovery", 1}, {"aged", 1}},
+                    /*max_wait_ms=*/10,
+                    absl::Now());
+
+  const std::vector<std::string> expected = {"recovery", "aged", "fresh"};
+  EXPECT_EQ(collect_ids(queue), expected);
+}
+
+TEST(ResidualSJFPolicyTest, ReadOnlyProbeReportsLocalPrefixHit) {
+  BlockManagerPool::Options opt;
+  opt.num_blocks_ = 4096;
+  opt.block_size_ = 128;
+  opt.max_seqs_per_batch_ = 1024;
+  opt.enable_prefix_cache_ = true;
+  BlockManagerPool pool(opt, /*dp_size=*/1);
+
+  std::shared_ptr<Request> warm = make_request("warm", 1024);
+  Sequence* warm_seq = warm->sequences()[0].get();
+  EXPECT_EQ(pool.get_num_local_computed_blocks(warm_seq), 0);
+  ASSERT_TRUE(pool.allocate(warm_seq));
+  // Simulate a completed prefill so the final cache flush covers the prompt.
+  warm_seq->kv_state().set_kv_cache_tokens_num(1024);
+  pool.cache(warm_seq);
+
+  std::shared_ptr<Request> hit = make_request("hit", 1024);
+  Sequence* hit_seq = hit->sequences()[0].get();
+  // All 8 full blocks are locally cached: the read-only probe reports the
+  // hit block count without allocating or mutating state.
+  EXPECT_EQ(pool.get_num_local_computed_blocks(hit_seq), 8);
+
+  std::shared_ptr<Request> miss = make_request("miss", 1024, /*token_id=*/2);
+  Sequence* miss_seq = miss->sequences()[0].get();
+  EXPECT_EQ(pool.get_num_local_computed_blocks(miss_seq), 0);
+
+  // A second probe on the same sequence stays stable (no state mutation).
+  EXPECT_EQ(pool.get_num_local_computed_blocks(hit_seq), 8);
+}
+
+TEST(ResidualSJFPolicyTest, ProbeIsZeroWhenPrefixCacheDisabled) {
+  BlockManagerPool::Options opt;
+  opt.num_blocks_ = 4096;
+  opt.block_size_ = 128;
+  opt.max_seqs_per_batch_ = 1024;
+  opt.enable_prefix_cache_ = false;
+  BlockManagerPool pool(opt, /*dp_size=*/1);
+
+  std::shared_ptr<Request> request = make_request("cold", 1024);
+  EXPECT_EQ(pool.get_num_local_computed_blocks(request->sequences()[0].get()),
+            0);
+}
+
+TEST(ResidualSJFPolicyTest, FactorySelectsResidualSJFPolicy) {
+  ContinuousScheduler::Options options;
+  options.enable_disagg_pd(true).enable_chunked_prefill(true);
+  options.instance_role(InstanceRole::PREFILL);
+  BatchMode mode;
+  mode.priority_strategy = "residual_sjf";
+  std::unique_ptr<SchedulerPolicy> policy =
+      create_scheduler_policy(mode, options);
+  EXPECT_NE(dynamic_cast<ResidualSJFPolicy*>(policy.get()), nullptr);
+}
+
+TEST(ResidualSJFPolicyTest, FactoryDefaultsToPrefillFirstForFcfs) {
+  ContinuousScheduler::Options options;
+  options.enable_disagg_pd(true).enable_chunked_prefill(true);
+  options.instance_role(InstanceRole::PREFILL);
+  BatchMode mode;
+  mode.priority_strategy = "fcfs";
+  std::unique_ptr<SchedulerPolicy> policy =
+      create_scheduler_policy(mode, options);
+  EXPECT_NE(dynamic_cast<PrefillFirstPolicy*>(policy.get()), nullptr);
+}
+
+TEST(ResidualSJFPolicyTest, FactoryRejectsResidualSJfWithoutDisaggPd) {
+  ContinuousScheduler::Options options;
+  BatchMode mode;
+  mode.priority_strategy = "residual_sjf";
+  EXPECT_DEATH(create_scheduler_policy(mode, options), "enable_disagg_pd");
+}
+
+TEST(ResidualSJFPolicyTest, FactoryRejectsResidualSJfWithMixBatch) {
+  ContinuousScheduler::Options options;
+  options.enable_disagg_pd(true).enable_chunked_prefill(true);
+  options.instance_role(InstanceRole::PREFILL);
+  BatchMode mode;
+  mode.priority_strategy = "residual_sjf";
+  mode.enable_mix_batch = true;
+  EXPECT_DEATH(create_scheduler_policy(mode, options), "enable_mix_batch");
+}
+
+}  // namespace
+}  // namespace xllm

--- a/xllm/core/framework/block/block_manager.h
+++ b/xllm/core/framework/block/block_manager.h
@@ -133,6 +133,24 @@ class BlockManager {
                      const Slice<XXH3Key>& block_hashes = {}) = 0;
   virtual void cache(const std::vector<Block>& blocks) = 0;
 
+  // Read-only local prefix-cache hit length in full KV blocks for the caller's
+  // precomputed chained block hashes. Unlike allocate_shared(), this never
+  // creates blocks, mutates LRU order, or touches usage accounting. The
+  // scheduler uses it to estimate residual prefill work; the caller is
+  // responsible for ensuring the sequence's block hashes exist first (see
+  // CompositeBlockManager::get_num_local_computed_blocks, which memoizes them
+  // on the sequence).
+  //
+  // Thread-safety: the underlying hash walk is unsynchronized, so this must
+  // only run under the leaf's ConcurrentBlockManagerImpl lock (PD / kvcache
+  // store leaves are wrapped) or in a single-threaded context.
+  // Returns 0 when the prefix cache is disabled. Default no-op for managers
+  // without a prefix cache (e.g. xtensor / embedding leaves).
+  virtual size_t get_num_local_computed_blocks(
+      const Slice<XXH3Key>& block_hashes) const {
+    return 0;
+  }
+
   virtual size_t num_blocks_in_prefix_cache() const = 0;
   virtual size_t num_free_blocks() const = 0;
   virtual size_t num_used_blocks() const = 0;

--- a/xllm/core/framework/block/block_manager_impl.cpp
+++ b/xllm/core/framework/block/block_manager_impl.cpp
@@ -186,6 +186,20 @@ std::vector<Block> BlockManagerImpl::allocate_shared(
   return {};
 }
 
+size_t BlockManagerImpl::get_num_local_computed_blocks(
+    const Slice<XXH3Key>& block_hashes) const {
+  if (!options_.enable_prefix_cache()) {
+    return 0;
+  }
+  size_t matched_blocks = 0;
+  for (; matched_blocks < block_hashes.size(); ++matched_blocks) {
+    if (!prefix_cache_->contains(block_hashes[matched_blocks])) {
+      break;
+    }
+  }
+  return matched_blocks;
+}
+
 void BlockManagerImpl::cache(const Slice<int32_t>& token_ids,
                              std::vector<Block>& blocks,
                              size_t existed_shared_blocks_num,

--- a/xllm/core/framework/block/block_manager_impl.h
+++ b/xllm/core/framework/block/block_manager_impl.h
@@ -53,6 +53,12 @@ class BlockManagerImpl : public BlockManager {
       const MMData& mm_data = MMData(),
       const Slice<XXH3Key>& block_hashes = {}) override;
 
+  // Read-only prefix-cache probe: solid-prefix walk over precomputed chained
+  // block hashes using the LRU-neutral contains() lookup, returning the count
+  // of full hit blocks.
+  size_t get_num_local_computed_blocks(
+      const Slice<XXH3Key>& block_hashes) const override;
+
   // cache blocks when enable prefix cache
   void cache(const Slice<int32_t>& token_ids,
              std::vector<Block>& blocks,

--- a/xllm/core/framework/block/block_manager_pool.cpp
+++ b/xllm/core/framework/block/block_manager_pool.cpp
@@ -291,6 +291,15 @@ void BlockManagerPool::allocate_shared(Sequence* sequence) {
       ->allocate_shared_for_sequence(sequence);
 }
 
+size_t BlockManagerPool::get_num_local_computed_blocks(Sequence* sequence) {
+  if (sequence == nullptr || !options_.enable_prefix_cache()) {
+    return 0;
+  }
+  int32_t dp_rank = get_dp_rank(sequence);
+  return static_cast<CompositeBlockManager*>(block_managers_[dp_rank].get())
+      ->get_num_local_computed_blocks(sequence);
+}
+
 void BlockManagerPool::cache(Sequence* sequence) {
   if (!options_.enable_prefix_cache()) {
     return;

--- a/xllm/core/framework/block/block_manager_pool.h
+++ b/xllm/core/framework/block/block_manager_pool.h
@@ -92,6 +92,7 @@ class BlockManagerPool : public KVCacheManager {
   void deallocate_without_cache(Sequence* sequence);
 
   void allocate_shared(Sequence* sequence) override;
+  size_t get_num_local_computed_blocks(Sequence* sequence) override;
   void cache(Sequence* sequence) override;
   void cache(Sequence* sequence, size_t num_tokens) override;
 

--- a/xllm/core/framework/block/composite_block_manager.cpp
+++ b/xllm/core/framework/block/composite_block_manager.cpp
@@ -732,6 +732,24 @@ void CompositeBlockManager::allocate_shared_for_sequence(Sequence* seq) {
   }
 }
 
+size_t CompositeBlockManager::get_num_local_computed_blocks(Sequence* seq) {
+  if (seq == nullptr || combination_ == LeafCombination::UNSUPPORTED) {
+    return 0;
+  }
+  const auto kv_leaf_it = leaves_.find(BlockType::KV);
+  if (kv_leaf_it == leaves_.end() ||
+      !kv_leaf_it->second.supports_prefix_cache) {
+    return 0;
+  }
+  BlockManager& kv_leaf = *kv_leaf_it->second.leaf;
+  if (!kv_leaf.options().enable_prefix_cache()) {
+    return 0;
+  }
+  seq->update_block_hashes(static_cast<uint32_t>(kv_leaf.block_size()),
+                           kv_leaf.options().hasher_type());
+  return kv_leaf.get_num_local_computed_blocks(seq->block_hashes());
+}
+
 void CompositeBlockManager::cache_for_sequence(Sequence* seq) {
   // Final flush at deallocate. KV shapes flush the tail via leaf->cache();
   // SWA_COMPRESSED re-runs the pre-grow hook (cursor-guarded, idempotent) so

--- a/xllm/core/framework/block/composite_block_manager.h
+++ b/xllm/core/framework/block/composite_block_manager.h
@@ -78,6 +78,16 @@ class CompositeBlockManager : public BlockManager {
   void release_out_of_window_for_sequence(Sequence* seq);
   void deallocate_for_sequence(Sequence* seq);
   void allocate_shared_for_sequence(Sequence* seq);
+  // Read-only KV prefix-cache hit length in full KV blocks for a waiting
+  // request.
+  // Mirrors the allocate_shared_for_sequence() KV probe without creating
+  // blocks or mutating LRU/usage accounting, so the scheduler can compute
+  // residual prefill cost. Returns 0 when the composite has no prefix-capable
+  // KV leaf or the prefix cache is disabled. Note: for FLAT_KV_LINEAR
+  // composites the probe reports the raw KV hit without applying the LINEAR
+  // restore clamp, so the residual estimate can be optimistic for GDN models;
+  // SWA_COMPRESSED composites have no KV leaf and fall back to raw length.
+  size_t get_num_local_computed_blocks(Sequence* seq);
   void cache_for_sequence(Sequence* seq);
   void cache_for_sequence(Sequence* seq, size_t num_tokens);
   void cache_full_blocks_for_sequence(Sequence* seq);

--- a/xllm/core/framework/block/concurrent_block_manager_impl.cpp
+++ b/xllm/core/framework/block/concurrent_block_manager_impl.cpp
@@ -68,6 +68,12 @@ std::vector<Block> ConcurrentBlockManagerImpl::allocate_shared(
   return blocks;
 }
 
+size_t ConcurrentBlockManagerImpl::get_num_local_computed_blocks(
+    const Slice<XXH3Key>& block_hashes) const {
+  std::lock_guard<std::recursive_mutex> lock(mutex_);
+  return inner_->get_num_local_computed_blocks(block_hashes);
+}
+
 void ConcurrentBlockManagerImpl::cache(const Slice<int32_t>& token_ids,
                                        std::vector<Block>& blocks,
                                        size_t existed_shared_blocks_num,

--- a/xllm/core/framework/block/concurrent_block_manager_impl.h
+++ b/xllm/core/framework/block/concurrent_block_manager_impl.h
@@ -48,6 +48,9 @@ class ConcurrentBlockManagerImpl : public BlockManager {
       const MMData& mm_data = MMData(),
       const Slice<XXH3Key>& block_hashes = {}) override;
 
+  size_t get_num_local_computed_blocks(
+      const Slice<XXH3Key>& block_hashes) const override;
+
   void cache(const Slice<int32_t>& token_ids,
              std::vector<Block>& blocks,
              size_t existed_shared_blocks_num = 0,

--- a/xllm/core/framework/block/kv_cache_manager.h
+++ b/xllm/core/framework/block/kv_cache_manager.h
@@ -79,6 +79,12 @@ class KVCacheManager {
 
   virtual uint32_t num_blocks() const = 0;
   virtual int32_t block_size() const = 0;
+  // Read-only local prefix-cache hit length in full KV blocks for a sequence,
+  // without creating blocks or mutating the prefix cache (the sequence's block
+  // hashes may be memoized on first use). Used by residual-aware SJF to
+  // estimate remaining prefill work. Must only be called on scheduler-owned
+  // waiting requests. Default 0 for managers without a prefix cache.
+  virtual size_t get_num_local_computed_blocks(Sequence* sequence) { return 0; }
   // Drop all prefix-cache entries (RL sleep/wakeup: discarded KV would make
   // cached prefixes point to garbage). Default no-op for managers without a
   // prefix cache.

--- a/xllm/core/framework/config/scheduler_config.cpp
+++ b/xllm/core/framework/config/scheduler_config.cpp
@@ -58,6 +58,12 @@ DEFINE_string(priority_strategy,
               "fcfs",
               "Priority strategy for requests(e.g. fcfs, priority, deadline).");
 
+DEFINE_int32(residual_sjf_max_wait_ms,
+             10000,
+             "Max wait in milliseconds before a PD-prefill waiting request is "
+             "promoted ahead of residual-cost ordering under residual_sjf. "
+             "Larger values favor mean latency; 0 behaves like FCFS.");
+
 DEFINE_bool(enable_online_preempt_offline,
             true,
             "Whether to enable online preempt offline.");
@@ -87,6 +93,7 @@ void SchedulerConfig::from_flags() {
   XLLM_CONFIG_ASSIGN_FROM_FLAG(use_zero_evict);
   XLLM_CONFIG_ASSIGN_FROM_FLAG(max_decode_token_per_sequence);
   XLLM_CONFIG_ASSIGN_FROM_FLAG(priority_strategy);
+  XLLM_CONFIG_ASSIGN_FROM_FLAG(residual_sjf_max_wait_ms);
   XLLM_CONFIG_ASSIGN_FROM_FLAG(enable_mix_batch);
   XLLM_CONFIG_ASSIGN_FROM_FLAG(enable_online_preempt_offline);
   XLLM_CONFIG_ASSIGN_FROM_FLAG(aggressive_coeff);
@@ -105,6 +112,7 @@ void SchedulerConfig::from_json(const JsonReader& json) {
   XLLM_CONFIG_ASSIGN_FROM_JSON(use_zero_evict);
   XLLM_CONFIG_ASSIGN_FROM_JSON(max_decode_token_per_sequence);
   XLLM_CONFIG_ASSIGN_FROM_JSON(priority_strategy);
+  XLLM_CONFIG_ASSIGN_FROM_JSON(residual_sjf_max_wait_ms);
   XLLM_CONFIG_ASSIGN_FROM_JSON(enable_mix_batch);
   XLLM_CONFIG_ASSIGN_FROM_JSON(enable_online_preempt_offline);
   XLLM_CONFIG_ASSIGN_FROM_JSON(aggressive_coeff);
@@ -135,6 +143,8 @@ void SchedulerConfig::append_config_json(
       config_json, default_config, max_decode_token_per_sequence);
   APPEND_CONFIG_JSON_VALUE_IF_NOT_DEFAULT(
       config_json, default_config, priority_strategy);
+  APPEND_CONFIG_JSON_VALUE_IF_NOT_DEFAULT(
+      config_json, default_config, residual_sjf_max_wait_ms);
   APPEND_CONFIG_JSON_VALUE_IF_NOT_DEFAULT(
       config_json, default_config, enable_mix_batch);
   APPEND_CONFIG_JSON_VALUE_IF_NOT_DEFAULT(

--- a/xllm/core/framework/config/scheduler_config.h
+++ b/xllm/core/framework/config/scheduler_config.h
@@ -51,6 +51,7 @@ class SchedulerConfig final {
          "use_zero_evict",
          "max_decode_token_per_sequence",
          "priority_strategy",
+         "residual_sjf_max_wait_ms",
          "enable_mix_batch",
          "enable_online_preempt_offline",
          "aggressive_coeff",
@@ -78,6 +79,8 @@ class SchedulerConfig final {
   PROPERTY(int32_t, max_decode_token_per_sequence) = 256;
 
   PROPERTY(std::string, priority_strategy) = "fcfs";
+
+  PROPERTY(int32_t, residual_sjf_max_wait_ms) = 10000;
 
   PROPERTY(bool, enable_mix_batch) = true;
 

--- a/xllm/core/framework/request/priority_comparator.cpp
+++ b/xllm/core/framework/request/priority_comparator.cpp
@@ -15,6 +15,8 @@ limitations under the License.
 
 #include "priority_comparator.h"
 
+#include <utility>
+
 #include "glog/logging.h"
 
 namespace xllm {
@@ -100,6 +102,65 @@ bool SJFComparator::operator()(const std::shared_ptr<Request>& a,
   // For sorting, '<' puts smaller first; for priority_queue, '<' puts larger
   // first.
   return density_a < density_b;
+}
+
+size_t residual_sjf_cost_blocks(size_t num_prompt_tokens,
+                                size_t num_local_computed_blocks,
+                                size_t block_size) {
+  if (block_size == 0) {
+    // Cannot quantize without a KV block size: treat as zero residual so the
+    // ordering degrades to FCFS. Production always supplies a real block size.
+    return 0;
+  }
+  const size_t prompt_blocks = num_prompt_tokens / block_size;
+  return prompt_blocks > num_local_computed_blocks
+             ? prompt_blocks - num_local_computed_blocks
+             : 0;
+}
+
+ResidualSJFComparator::ResidualSJFComparator(
+    ResidualCostFn residual_cost_blocks,
+    int32_t max_wait_ms,
+    absl::Time now)
+    : residual_cost_blocks_(std::move(residual_cost_blocks)),
+      max_wait_ms_(max_wait_ms),
+      now_(now) {}
+
+ResidualSJFRequestClass ResidualSJFComparator::rank(
+    const std::shared_ptr<Request>& request) const {
+  CHECK(!request->sequences().empty());
+  Sequence* sequence = request->sequences()[0].get();
+  CHECK(sequence != nullptr);
+  if (request->preempted() ||
+      sequence->kv_state().num_cached_blocks(BlockType::KV) > 0) {
+    return ResidualSJFRequestClass::RECOVERY;
+  }
+  // Aging uses the request creation time as the arrival proxy (the same
+  // convention as the FCFS/SRF comparators). Unlike vLLM's queue-entry
+  // arrival_time this includes service-side routing latency, which is
+  // negligible in the PD path but documented for exactness.
+  if (now_ - request->created_time() >= absl::Milliseconds(max_wait_ms_)) {
+    return ResidualSJFRequestClass::AGED;
+  }
+  return ResidualSJFRequestClass::FRESH;
+}
+
+bool ResidualSJFComparator::operator()(
+    const std::shared_ptr<Request>& a,
+    const std::shared_ptr<Request>& b) const {
+  const ResidualSJFRequestClass rank_a = rank(a);
+  const ResidualSJFRequestClass rank_b = rank(b);
+  if (rank_a != rank_b) {
+    return static_cast<int8_t>(rank_a) < static_cast<int8_t>(rank_b);
+  }
+  if (rank_a == ResidualSJFRequestClass::FRESH) {
+    const size_t cost_a = residual_cost_blocks_(a);
+    const size_t cost_b = residual_cost_blocks_(b);
+    if (cost_a != cost_b) {
+      return cost_a < cost_b;
+    }
+  }
+  return a->created_time() < b->created_time();
 }
 
 // decode-first, then deadline-first

--- a/xllm/core/framework/request/priority_comparator.h
+++ b/xllm/core/framework/request/priority_comparator.h
@@ -14,6 +14,9 @@ limitations under the License.
 ==============================================================================*/
 
 #pragma once
+#include <absl/time/time.h>
+
+#include <cstdint>
 #include <functional>
 #include <memory>
 #include <string>
@@ -52,6 +55,48 @@ struct DeadlineComparator : public PriorityComparator {
 struct SJFComparator : public PriorityComparator {
   bool operator()(const std::shared_ptr<Request>& a,
                   const std::shared_ptr<Request>& b) const override;
+};
+
+// Residual-aware SJF request class for PD-prefill waiting requests. Mirrors
+// the vLLM residual_sjf policy ordering: recovery requests first, then
+// max-wait aged requests in FCFS order, then fresh requests by residual local
+// prefill cost (prompt tokens minus local cached tokens, quantized to KV
+// blocks).
+enum class ResidualSJFRequestClass : int8_t {
+  RECOVERY = 0,
+  AGED = 1,
+  FRESH = 2,
+};
+
+// Residual local prefill cost in KV blocks: floor(prompt tokens / block_size)
+// minus the locally cached full blocks, matching the vLLM residual_sjf cost so
+// equal residual block counts tie-break by arrival. When block_size is
+// unavailable (0) the cost degrades to 0 (FCFS by arrival); production always
+// supplies a real KV block size.
+size_t residual_sjf_cost_blocks(size_t num_prompt_tokens,
+                                size_t num_local_computed_blocks,
+                                size_t block_size);
+
+// Residual-aware SJF ordering for PD-prefill waiting requests:
+// RECOVERY first, then AGED (max-wait) requests in FCFS order, then FRESH
+// requests by residual cost with arrival-time tie-break.
+class ResidualSJFComparator final : public PriorityComparator {
+ public:
+  using ResidualCostFn = std::function<size_t(const std::shared_ptr<Request>&)>;
+
+  ResidualSJFComparator(ResidualCostFn residual_cost_blocks,
+                        int32_t max_wait_ms,
+                        absl::Time now);
+
+  bool operator()(const std::shared_ptr<Request>& a,
+                  const std::shared_ptr<Request>& b) const override;
+
+ private:
+  ResidualSJFRequestClass rank(const std::shared_ptr<Request>& request) const;
+
+  ResidualCostFn residual_cost_blocks_;
+  int32_t max_wait_ms_;
+  absl::Time now_;
 };
 
 struct DecodeDeadlineComparator : public PriorityComparator {

--- a/xllm/core/scheduler/CMakeLists.txt
+++ b/xllm/core/scheduler/CMakeLists.txt
@@ -22,6 +22,7 @@ cc_library(
   SRCS
     scheduler_policy.cpp
     prefill_first_policy.cpp
+    residual_sjf_policy.cpp
     decode_first_policy.cpp
     unified_policy.cpp
     zero_eviction_scheduler.cpp

--- a/xllm/core/scheduler/continuous_scheduler.cpp
+++ b/xllm/core/scheduler/continuous_scheduler.cpp
@@ -188,7 +188,8 @@ bool ContinuousScheduler::add_request(std::shared_ptr<Request>& request) {
 
 void ContinuousScheduler::create_queues(const Options& options) {
   if (options.priority_strategy() == "multi_slo_and_prio" ||
-      options.priority_strategy() == "fcfs") {
+      options.priority_strategy() == "fcfs" ||
+      options.priority_strategy() == "residual_sjf") {
     prefill_queue_ = std::make_unique<DequeQueue>();
     chunk_queue_ = std::make_unique<DequeQueue>();
     decode_queue_ = std::make_unique<DequeQueue>();

--- a/xllm/core/scheduler/prefill_first_policy.cpp
+++ b/xllm/core/scheduler/prefill_first_policy.cpp
@@ -19,6 +19,7 @@ limitations under the License.
 #include <limits>
 
 #include "core/framework/config/scheduler_config.h"
+#include "core/util/verbose_trace_logger.h"
 #include "framework/request/priority_comparator.h"
 #include "scheduler/scheduler_policy.h"
 
@@ -104,6 +105,21 @@ void PrefillFirstPolicy::schedule(
   schedule_prefill_from_queue(
       &state.chunk_queue, state, budget, finished, reserved_full_footprint);
   // Then new prefill requests.
+  // Opt-in dispatch-order trace: the fresh prefill queue order this step will
+  // drain (recovery requests and chunked continuations live in chunk_queue and
+  // are not listed). Enabled only via --enable_verbose_trace_log, so the hot
+  // path carries no cost unless a validation run asks for it.
+  int32_t queue_rank = 0;
+  for (auto it = state.prefill_queue.begin(); it != state.prefill_queue.end();
+       ++it) {
+    CHECK(!(*it)->sequences().empty());
+    Sequence* sequence = (*it)->sequences()[0].get();
+    CHECK(sequence != nullptr);
+    XLLM_VERBOSE_TRACE() << "event=prefill_queue_order rank=" << queue_rank
+                         << " req=" << (*it)->request_id() << " prompt_tokens="
+                         << static_cast<int64_t>(sequence->num_prompt_tokens());
+    ++queue_rank;
+  }
   schedule_prefill_from_queue(
       &state.prefill_queue, state, budget, finished, reserved_full_footprint);
 

--- a/xllm/core/scheduler/residual_sjf_policy.cpp
+++ b/xllm/core/scheduler/residual_sjf_policy.cpp
@@ -1,0 +1,101 @@
+/* Copyright 2026 The xLLM Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://github.com/jd-opensource/xllm/blob/main/LICENSE
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include <absl/time/clock.h>
+#include <glog/logging.h>
+
+#include <algorithm>
+#include <cstdint>
+#include <memory>
+#include <unordered_map>
+#include <vector>
+
+#include "core/framework/config/scheduler_config.h"
+#include "core/util/verbose_trace_logger.h"
+#include "framework/request/priority_comparator.h"
+#include "scheduler/scheduler_policy.h"
+
+namespace xllm {
+
+namespace {
+
+// Residual local prefill cost in KV blocks for a waiting PD-prefill request:
+// floor(prompt tokens / block size) minus the locally cached full blocks.
+// Without a KV manager the cost degrades to 0 (FCFS by arrival).
+size_t get_residual_sjf_cost_blocks(KVCacheManager* kv_cache_manager,
+                                    const std::shared_ptr<Request>& request) {
+  CHECK(!request->sequences().empty());
+  Sequence* sequence = request->sequences()[0].get();
+  CHECK(sequence != nullptr);
+  const size_t num_cached_blocks =
+      kv_cache_manager == nullptr
+          ? 0
+          : kv_cache_manager->get_num_local_computed_blocks(sequence);
+  const int32_t block_size =
+      kv_cache_manager == nullptr ? 0 : kv_cache_manager->block_size();
+  return residual_sjf_cost_blocks(sequence->num_prompt_tokens(),
+                                  num_cached_blocks,
+                                  static_cast<size_t>(std::max(block_size, 0)));
+}
+
+}  // namespace
+
+void ResidualSJFPolicy::schedule(
+    SchedulerState& state,
+    ScheduleBudget& budget,
+    std::vector<std::shared_ptr<Request>>& finished) {
+  const SchedulerConfig& scheduler_config = SchedulerConfig::get_instance();
+
+  // Compute the residual cost once per waiting request per step so the sort
+  // comparator stays cheap: the prefix-cache probe walks prompt-length block
+  // hashes, and block hashes are memoized on the sequence after the first
+  // computation.
+  std::unordered_map<const Request*, size_t> residual_cost_blocks;
+  residual_cost_blocks.reserve(state.prefill_queue.size());
+  for (auto it = state.prefill_queue.begin(); it != state.prefill_queue.end();
+       ++it) {
+    residual_cost_blocks.emplace(
+        (*it).get(), get_residual_sjf_cost_blocks(state.kv_cache_manager, *it));
+  }
+
+  const ResidualSJFComparator comparator(
+      [&residual_cost_blocks](
+          const std::shared_ptr<Request>& request) -> size_t {
+        const auto found = residual_cost_blocks.find(request.get());
+        return found == residual_cost_blocks.end() ? 0 : found->second;
+      },
+      scheduler_config.residual_sjf_max_wait_ms(),
+      absl::Now());
+  state.prefill_queue.sort(comparator);
+
+  // Opt-in dispatch-order trace: one entry per waiting request, in the order
+  // this step will drain the prefill queue, with its residual cost in blocks.
+  // Enabled only via --enable_verbose_trace_log, so the hot path stays free
+  // unless a validation run asks for it.
+  int32_t queue_rank = 0;
+  for (auto it = state.prefill_queue.begin(); it != state.prefill_queue.end();
+       ++it) {
+    const auto found = residual_cost_blocks.find((*it).get());
+    const size_t cost = found == residual_cost_blocks.end() ? 0 : found->second;
+    XLLM_VERBOSE_TRACE() << "event=residual_sjf_order rank=" << queue_rank
+                         << " req=" << (*it)->request_id()
+                         << " cost_blocks=" << static_cast<int64_t>(cost);
+    ++queue_rank;
+  }
+
+  PrefillFirstPolicy::schedule(state, budget, finished);
+}
+
+}  // namespace xllm

--- a/xllm/core/scheduler/scheduler_policy.cpp
+++ b/xllm/core/scheduler/scheduler_policy.cpp
@@ -89,6 +89,29 @@ size_t get_sequence_free_blocks_for_rank(KVCacheManager* kv_cache_manager,
   return util::max(free_blocks);
 }
 
+void validate_residual_sjf_options(
+    const BatchMode& mode,
+    const ContinuousScheduler::Options& options) {
+  if (!options.enable_disagg_pd()) {
+    LOG(FATAL) << "residual_sjf requires enable_disagg_pd=true.";
+  }
+  if (mode.enable_mix_batch) {
+    LOG(FATAL) << "residual_sjf requires enable_mix_batch=false "
+                  "(exclusive prefill-first batching).";
+  }
+  if (!options.enable_chunked_prefill()) {
+    LOG(FATAL) << "residual_sjf requires enable_chunked_prefill=true.";
+  }
+  if (options.instance_role() == InstanceRole::DECODE) {
+    LOG(FATAL) << "residual_sjf is only supported on PD prefill or mix "
+               << "instances, not decode instances.";
+  }
+  if (SchedulerConfig::get_instance().residual_sjf_max_wait_ms() < 0) {
+    LOG(FATAL) << "residual_sjf_max_wait_ms must be >= 0, got "
+               << SchedulerConfig::get_instance().residual_sjf_max_wait_ms();
+  }
+}
+
 }  // namespace
 
 // =============================================================================
@@ -862,13 +885,19 @@ void SchedulerPolicy::clear_mtp_bootstrap(Request* request,
 std::unique_ptr<SchedulerPolicy> create_scheduler_policy(
     const BatchMode& mode,
     const ContinuousScheduler::Options& options) {
+  if (mode.priority_strategy == "residual_sjf") {
+    validate_residual_sjf_options(mode, options);
+    LOG(INFO) << "Enable PD-prefill residual-aware SJF scheduling: "
+              << "residual_sjf_max_wait_ms="
+              << SchedulerConfig::get_instance().residual_sjf_max_wait_ms();
+    return std::make_unique<ResidualSJFPolicy>(mode, options);
+  }
   if (mode.enable_mix_batch && mode.priority_strategy == "multi_slo_and_prio") {
     return std::make_unique<UnifiedPolicy>(mode, options);
   } else if (mode.enable_mix_batch) {
     return std::make_unique<DecodeFirstPolicy>(mode, options);
-  } else {
-    return std::make_unique<PrefillFirstPolicy>(mode, options);
   }
+  return std::make_unique<PrefillFirstPolicy>(mode, options);
 }
 
 }  // namespace xllm

--- a/xllm/core/scheduler/scheduler_policy.h
+++ b/xllm/core/scheduler/scheduler_policy.h
@@ -217,6 +217,19 @@ class PrefillFirstPolicy : public SchedulerPolicy {
                                          const SchedulerState& state) override;
 };
 
+// ResidualSJFPolicy: PrefillFirstPolicy with residual-aware SJF ordering.
+// Sorts the fresh prefill queue with the residual_sjf comparator (recovery
+// first, max-wait aged requests in FCFS order, then fresh requests by residual
+// local prefill cost) and then delegates to PrefillFirstPolicy.
+class ResidualSJFPolicy final : public PrefillFirstPolicy {
+ public:
+  using PrefillFirstPolicy::PrefillFirstPolicy;
+
+  void schedule(SchedulerState& state,
+                ScheduleBudget& budget,
+                std::vector<std::shared_ptr<Request>>& finished) override;
+};
+
 // DecodeFirstPolicy: mixed batch mode with fcfs/priority/deadline.
 // Decode requests fill the batch first ("decode-maximal batching"),
 // remaining token budget goes to chunked prefill.


### PR DESCRIPTION
## Description

Add a residual-aware SJF scheduling policy for the xLLM PD prefill scheduler. Waiting prefill requests are now ordered by residual local prefill cost in KV blocks — `floor(prompt_tokens / block_size) - local_cached_blocks` — instead of raw prompt length, so cache-warm long prompts are no longer misclassified as expensive.

Ordering semantics: recovery requests first, max-wait aged requests in FCFS order, then fresh requests by residual cost with arrival-time tie-break. `residual_sjf_max_wait_ms` (default 10000) configures the aging threshold; `0` degrades to FCFS.

Key changes:
- `priority_strategy=residual_sjf` selects `ResidualSJFPolicy` on PD prefill/mix instances (requires `enable_disagg_pd` + chunked prefill; rejects mixed batching and decode roles).
- Add a side-effect-free local prefix-cache hit probe (`get_num_local_computed_blocks`) at full-KV-block granularity across `KVCacheManager`/`BlockManager`, without block allocation, LRU mutation, or usage accounting.
- Opt-in dispatch-order trace (`--enable_verbose_trace_log`) records the fresh prefill queue order each step for validation.
- Unit tests cover cost quantization, comparator ordering, FCFS fallback, factory selection/validation, config parsing, and the probe.

Measured on the shared A3 host (Qwen2.5-7B, TP1+TP1, Open-SWE 160-session steady 6 req/s / 120 s / 64 output tokens, 2 rounds per group): FCFS baseline TTFT mean 14.7 s; residual_sjf mw10 TTFT mean -10.9% / E2E -9.8% with flat P95/P99; mw20 TTFT mean -46.5% / E2E -41.1% / throughput +31.5% at the cost of P95/P99 +18%. Results are workload-scoped.

## Related Issues

None.

## Change Type

- [ ] Bug fix
- [x] New feature
- [x] Performance improvement
- [ ] Refactor
- [ ] Documentation
- [ ] Test
- [ ] Build or CI

## Pull Request Checklist

- [x] The PR title and each commit message follow the xLLM commit format: `<type>: <subject>.`
- [x] Pre-commit hooks installed and clang-format passed on all changed files.
- [x] Self-reviewed per `custom-code-style.md`; branch based on the latest `origin/main` at submission time (`5b514d57`; rebase again if main has advanced).
- [x] Tests added/updated; NPU build + tests passed on the A3 host (`scheduler_test` 11/11, `config_json_test` 10/10, 6-round Open-SWE benchmark all green).
- [ ] CUDA: not run (feature is NPU PD-specific).
- [ ] MLU: not run.

## Reviewer Notes

- Aging uses the request creation time as the arrival proxy (same convention as the existing FCFS/SRF comparators), a documented deviation from vLLM's queue-entry arrival time.
- The probe reports the KV-block hit only; FLAT_KV_LINEAR (GDN) models get an optimistic residual estimate, and SWA_COMPRESSED models fall back to raw length.
- Client TTFT/E2E/throughput are measured; xLLM has no Prometheus `/metrics`, so server-side queue-wait/TPOT are not included.